### PR TITLE
feat(billing): add paid-plan checkout so a tier can actually be purchased (B24)

### DIFF
--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -1,24 +1,37 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '@src/auth';
 import { SubscriptionsModule as AgentSubscriptionsModule } from '@ever-works/agent/subscriptions';
+import { OrganizationsModule } from '@src/organizations/organizations.module';
 import { BillingController, CreditsCheckoutController } from './billing.controller';
 import { BillingWebhookController } from './billing-webhook.controller';
+import { PlanCheckoutController } from './plan-checkout.controller';
 
 /**
  * The money path (billing PRD B5) — thin API module over the agent-side
  * `BillingService` / `BillingProvider` seam.
  *
- * Three controllers, two auth postures:
- *   - `BillingController` + `CreditsCheckoutController`: session-guarded,
- *     owner-scoped (overview, invoices, auto-recharge, packs, checkout).
+ * Four controllers, two auth postures:
+ *   - `BillingController` + `CreditsCheckoutController` +
+ *     `PlanCheckoutController`: session-guarded, owner-scoped (overview,
+ *     invoices, auto-recharge, packs, credit checkout, plan checkout).
  *   - `BillingWebhookController`: @Public, authenticated by the provider
  *     request signature and fail-closed when unconfigured.
+ *
+ * `OrganizationsModule` is imported for the ONE audited implementation of
+ * the tenant-ownership check (`OrganizationMembershipService`), so a plan
+ * checkout naming an `organizationId` outside the caller's tenant is
+ * rejected the same way every other raw-`orgId` route rejects it.
  *
  * Additive: the existing read-only `CreditsController` (balance, ledger,
  * usage-summary) in `subscriptions/` is untouched.
  */
 @Module({
-    imports: [AuthModule, AgentSubscriptionsModule],
-    controllers: [BillingController, CreditsCheckoutController, BillingWebhookController],
+    imports: [AuthModule, AgentSubscriptionsModule, OrganizationsModule],
+    controllers: [
+        BillingController,
+        CreditsCheckoutController,
+        PlanCheckoutController,
+        BillingWebhookController,
+    ],
 })
 export class BillingApiModule {}

--- a/apps/api/src/billing/dto/plan-checkout.dto.ts
+++ b/apps/api/src/billing/dto/plan-checkout.dto.ts
@@ -1,0 +1,39 @@
+import { IsEnum, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+import { SubscriptionPlanCode } from '@ever-works/agent/entities';
+
+/**
+ * Paid-plan checkout request (audit B24).
+ *
+ * The body names a PLAN CODE and, optionally, the organization the
+ * subscription is being bought for. It can never name a price: the
+ * global ValidationPipe runs `whitelist` + `forbidNonWhitelisted`, so a
+ * body carrying `priceCents`/`amount`/`monthlyPrice` is rejected with a
+ * 400 rather than silently stripped, and the service reads the recurring
+ * amount from the `subscription_plans` row regardless.
+ *
+ * `organizationId` is NOT an authorization — the controller resolves it
+ * through `OrganizationMembershipService`, which 404s any org outside the
+ * caller's tenant. Supplying someone else's org id buys nothing.
+ */
+export class CreatePlanCheckoutDto {
+    @IsEnum(SubscriptionPlanCode)
+    planCode: SubscriptionPlanCode;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(64)
+    organizationId?: string;
+}
+
+/**
+ * Return-route query (audit B24). `sessionId` is provider-opaque and
+ * arrives from a redirect, so it is length- and charset-constrained
+ * before it is ever handed to the provider SDK. It is NOT a credential:
+ * the service authorizes on the user id stored in the session metadata.
+ */
+export class PlanCheckoutReturnQueryDto {
+    @IsString()
+    @MaxLength(255)
+    @Matches(/^[A-Za-z0-9_-]+$/, { message: 'sessionId has an unexpected format' })
+    sessionId: string;
+}

--- a/apps/api/src/billing/plan-checkout.controller.spec.ts
+++ b/apps/api/src/billing/plan-checkout.controller.spec.ts
@@ -1,0 +1,391 @@
+// Paid-plan checkout's HTTP boundary (audit B24). Mirrors
+// billing.controller.spec.ts: the agent barrels are stubbed so the spec
+// never drags in @ever-works/agent/database, and the DTOs are validated
+// with the same class-validator pipeline the global ValidationPipe runs.
+//
+// What these specs exist to pin is AUTH SCOPING:
+//   - the routes are session-guarded, so an unauthenticated caller never
+//     reaches the handler at all;
+//   - the buyer is always the session user — no body field can name
+//     another one;
+//   - an `organizationId` outside the caller's tenant is rejected BEFORE
+//     the payment provider is ever contacted;
+//   - a checkout session belonging to another account cannot be
+//     finalized, and is answered the same as one that does not exist.
+class FakeBillingProviderNotConfiguredError extends Error {
+    constructor(message = 'Payment provider is not configured on this deployment') {
+        super(message);
+        this.name = 'BillingProviderNotConfiguredError';
+    }
+}
+class FakeBillingProviderError extends Error {
+    constructor(
+        message: string,
+        public readonly code?: string,
+    ) {
+        super(message);
+        this.name = 'BillingProviderError';
+    }
+}
+class FakeUnknownSubscriptionPlanError extends Error {
+    constructor(planCode: string) {
+        super(`Unknown subscription plan: ${planCode}`);
+        this.name = 'UnknownSubscriptionPlanError';
+    }
+}
+class FakePlanNotPurchasableError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PlanNotPurchasableError';
+    }
+}
+class FakeCheckoutSessionNotFoundError extends Error {
+    constructor() {
+        super('Checkout session not found');
+        this.name = 'CheckoutSessionNotFoundError';
+    }
+}
+
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    BillingProviderNotConfiguredError: FakeBillingProviderNotConfiguredError,
+    BillingProviderError: FakeBillingProviderError,
+    UnknownSubscriptionPlanError: FakeUnknownSubscriptionPlanError,
+    PlanNotPurchasableError: FakePlanNotPurchasableError,
+    CheckoutSessionNotFoundError: FakeCheckoutSessionNotFoundError,
+    PlanSubscriptionService: class PlanSubscriptionService {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({
+    SubscriptionPlanCode: { FREE: 'free', STANDARD: 'standard', PREMIUM: 'premium' },
+}));
+jest.mock('../auth', () => ({
+    AuthSessionGuard: class AuthSessionGuard {},
+    CurrentUser: () => () => undefined,
+}));
+jest.mock('../organizations/organization-membership.service', () => ({
+    OrganizationMembershipService: class OrganizationMembershipService {},
+}));
+
+import {
+    BadRequestException,
+    ConflictException,
+    NotFoundException,
+    ServiceUnavailableException,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { PlanCheckoutController } from './plan-checkout.controller';
+import { CreatePlanCheckoutDto, PlanCheckoutReturnQueryDto } from './dto/plan-checkout.dto';
+import { AuthSessionGuard } from '../auth';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+const auth: AuthenticatedUser = {
+    userId: 'user-1',
+    email: 'u@e.test',
+    username: 'u',
+    provider: 'local',
+    emailVerified: true,
+} as AuthenticatedUser;
+
+const otherAuth: AuthenticatedUser = { ...auth, userId: 'user-2' } as AuthenticatedUser;
+
+function makeService(overrides: Record<string, unknown> = {}) {
+    return {
+        startPlanCheckout: jest.fn().mockResolvedValue({
+            url: 'https://pay.example/cs_plan_1',
+            sessionId: 'cs_plan_1',
+            planCode: 'standard',
+            priceCents: 2900,
+            currency: 'usd',
+        }),
+        syncCheckoutReturn: jest.fn().mockResolvedValue({
+            status: 'active',
+            activated: true,
+            planCode: 'standard',
+        }),
+        ...overrides,
+    } as any;
+}
+
+function makeMembership(overrides: Record<string, unknown> = {}) {
+    return {
+        ensureMember: jest.fn().mockResolvedValue({ id: 'org-1', tenantId: 'tenant-1' }),
+        ...overrides,
+    } as any;
+}
+
+beforeAll(() => {
+    process.env.WEB_URL = 'https://app.test';
+});
+
+describe('PlanCheckoutController — route auth posture', () => {
+    it('is session-guarded, so an unauthenticated request never reaches the handler', () => {
+        const guards = Reflect.getMetadata('__guards__', PlanCheckoutController) ?? [];
+        expect(guards).toContain(AuthSessionGuard);
+    });
+});
+
+describe('POST /api/billing/checkout/plan — owner scoping', () => {
+    it('starts the checkout for the AUTHENTICATED user, never a caller-supplied one', async () => {
+        const service = makeService();
+        const controller = new PlanCheckoutController(service, makeMembership());
+
+        await controller.createPlanCheckout(auth, { planCode: 'standard' } as never);
+        expect(service.startPlanCheckout).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 'user-1', planCode: 'standard' }),
+        );
+
+        // A second caller cannot subscribe on behalf of the first.
+        await controller.createPlanCheckout(otherAuth, { planCode: 'standard' } as never);
+        expect(service.startPlanCheckout).toHaveBeenLastCalledWith(
+            expect.objectContaining({ userId: 'user-2' }),
+        );
+    });
+
+    it('builds the return URLs server-side (no client-supplied redirect)', async () => {
+        const service = makeService();
+        const controller = new PlanCheckoutController(service, makeMembership());
+
+        await controller.createPlanCheckout(auth, { planCode: 'premium' } as never);
+
+        const passed = service.startPlanCheckout.mock.calls[0][0];
+        expect(passed.successUrl).toBe('https://app.test/settings/billing?plan=success');
+        expect(passed.cancelUrl).toBe('https://app.test/settings/billing?plan=cancelled');
+    });
+
+    it('omits org scope entirely when the body names no organization', async () => {
+        const service = makeService();
+        const membership = makeMembership();
+        const controller = new PlanCheckoutController(service, membership);
+
+        await controller.createPlanCheckout(auth, { planCode: 'standard' } as never);
+
+        expect(membership.ensureMember).not.toHaveBeenCalled();
+        expect(service.startPlanCheckout).toHaveBeenCalledWith(
+            expect.objectContaining({ organizationId: null, tenantId: null }),
+        );
+    });
+
+    it('CANNOT start a checkout for another org — the membership check runs first', async () => {
+        const service = makeService();
+        // `ensureMember` answers 404 for any org outside the caller's
+        // tenant (existence-leak contract).
+        const membership = makeMembership({
+            ensureMember: jest
+                .fn()
+                .mockRejectedValue(new NotFoundException('Organization org-other not found')),
+        });
+        const controller = new PlanCheckoutController(service, membership);
+
+        await expect(
+            controller.createPlanCheckout(auth, {
+                planCode: 'standard',
+                organizationId: 'org-other',
+            } as never),
+        ).rejects.toBeInstanceOf(NotFoundException);
+
+        expect(membership.ensureMember).toHaveBeenCalledWith('org-other', 'user-1');
+        // The payment provider is never contacted for a foreign org.
+        expect(service.startPlanCheckout).not.toHaveBeenCalled();
+    });
+
+    it('authorizes the caller against the SESSION user, not a body-supplied one', async () => {
+        const service = makeService();
+        const membership = makeMembership();
+        const controller = new PlanCheckoutController(service, membership);
+
+        await controller.createPlanCheckout(otherAuth, {
+            planCode: 'standard',
+            organizationId: 'org-1',
+            // Even if a smuggled userId survived validation, nothing reads it.
+            userId: 'user-1',
+        } as never);
+
+        expect(membership.ensureMember).toHaveBeenCalledWith('org-1', 'user-2');
+        expect(service.startPlanCheckout).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 'user-2', organizationId: 'org-1' }),
+        );
+    });
+
+    it('passes the RESOLVED org + tenant, never the raw request values', async () => {
+        const service = makeService();
+        const membership = makeMembership({
+            ensureMember: jest
+                .fn()
+                .mockResolvedValue({ id: 'org-canonical', tenantId: 'tenant-canonical' }),
+        });
+        const controller = new PlanCheckoutController(service, membership);
+
+        await controller.createPlanCheckout(auth, {
+            planCode: 'standard',
+            organizationId: 'org-1',
+        } as never);
+
+        expect(service.startPlanCheckout).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationId: 'org-canonical',
+                tenantId: 'tenant-canonical',
+            }),
+        );
+    });
+
+    it('maps provider-not-configured to 503 so the UI can degrade', async () => {
+        const service = makeService({
+            startPlanCheckout: jest
+                .fn()
+                .mockRejectedValue(new FakeBillingProviderNotConfiguredError()),
+        });
+        const controller = new PlanCheckoutController(service, makeMembership());
+
+        await expect(
+            controller.createPlanCheckout(auth, { planCode: 'standard' } as never),
+        ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    });
+
+    it('maps an unknown plan and a free plan to 400', async () => {
+        const unknown = new PlanCheckoutController(
+            makeService({
+                startPlanCheckout: jest
+                    .fn()
+                    .mockRejectedValue(new FakeUnknownSubscriptionPlanError('enterprise')),
+            }),
+            makeMembership(),
+        );
+        await expect(
+            unknown.createPlanCheckout(auth, { planCode: 'standard' } as never),
+        ).rejects.toBeInstanceOf(BadRequestException);
+
+        const free = new PlanCheckoutController(
+            makeService({
+                startPlanCheckout: jest
+                    .fn()
+                    .mockRejectedValue(new FakePlanNotPurchasableError('Free plans')),
+            }),
+            makeMembership(),
+        );
+        await expect(
+            free.createPlanCheckout(auth, { planCode: 'free' } as never),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('maps a provider-side failure to 409 rather than an unmapped 500', async () => {
+        const controller = new PlanCheckoutController(
+            makeService({
+                startPlanCheckout: jest
+                    .fn()
+                    .mockRejectedValue(new FakeBillingProviderError('provider said no')),
+            }),
+            makeMembership(),
+        );
+
+        await expect(
+            controller.createPlanCheckout(auth, { planCode: 'standard' } as never),
+        ).rejects.toBeInstanceOf(ConflictException);
+    });
+});
+
+describe('GET /api/billing/checkout/plan/return — session ownership', () => {
+    it('finalizes only for the authenticated user', async () => {
+        const service = makeService();
+        const controller = new PlanCheckoutController(service, makeMembership());
+
+        const result = await controller.completePlanCheckout(auth, { sessionId: 'cs_plan_1' });
+
+        expect(service.syncCheckoutReturn).toHaveBeenCalledWith('user-1', 'cs_plan_1');
+        // The route returns `PlanCheckoutReturn` verbatim. Its `status` is
+        // the SUBSCRIPTION state (`active` | `pending` | `ignored`), not a
+        // `{ status: 'success' }` transport envelope — wrapping it in one
+        // would collide on the key and destroy the domain value.
+        expect(result).toEqual(
+            expect.objectContaining({ status: 'active', activated: true, planCode: 'standard' }),
+        );
+    });
+
+    it('CANNOT finalize another account’s checkout session (404, not 403)', async () => {
+        // The service refuses when the session metadata names a
+        // different user; the controller must not soften that into a
+        // "does this session exist?" oracle.
+        const service = makeService({
+            syncCheckoutReturn: jest.fn().mockRejectedValue(new FakeCheckoutSessionNotFoundError()),
+        });
+        const controller = new PlanCheckoutController(service, makeMembership());
+
+        await expect(
+            controller.completePlanCheckout(otherAuth, { sessionId: 'cs_plan_1' }),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(service.syncCheckoutReturn).toHaveBeenCalledWith('user-2', 'cs_plan_1');
+    });
+
+    it('maps provider-not-configured to 503', async () => {
+        const controller = new PlanCheckoutController(
+            makeService({
+                syncCheckoutReturn: jest
+                    .fn()
+                    .mockRejectedValue(new FakeBillingProviderNotConfiguredError()),
+            }),
+            makeMembership(),
+        );
+
+        await expect(
+            controller.completePlanCheckout(auth, { sessionId: 'cs_plan_1' }),
+        ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    });
+});
+
+describe('CreatePlanCheckoutDto — the client can never name a price', () => {
+    async function validateBody(body: Record<string, unknown>) {
+        const dto = plainToInstance(CreatePlanCheckoutDto, body, {
+            // Same options as the global ValidationPipe in main.ts.
+            excludeExtraneousValues: false,
+        });
+        return validate(dto as object, { whitelist: true, forbidNonWhitelisted: true });
+    }
+
+    it('accepts a known plan code', async () => {
+        expect(await validateBody({ planCode: 'standard' })).toHaveLength(0);
+        expect(await validateBody({ planCode: 'premium', organizationId: 'org-1' })).toHaveLength(
+            0,
+        );
+    });
+
+    it('rejects an unknown plan code', async () => {
+        expect(await validateBody({ planCode: 'enterprise' })).not.toHaveLength(0);
+    });
+
+    it('rejects a body carrying a client-supplied amount (forbidNonWhitelisted)', async () => {
+        for (const field of ['priceCents', 'monthlyPrice', 'amount', 'credits']) {
+            const errors = await validateBody({ planCode: 'standard', [field]: 1 });
+            expect(errors.map((e) => e.property)).toContain(field);
+        }
+    });
+
+    it('rejects a body trying to name another buyer', async () => {
+        const errors = await validateBody({ planCode: 'standard', userId: 'user-9' });
+        expect(errors.map((e) => e.property)).toContain('userId');
+    });
+
+    it('rejects a missing plan code', async () => {
+        expect(await validateBody({})).not.toHaveLength(0);
+    });
+});
+
+describe('PlanCheckoutReturnQueryDto', () => {
+    async function validateQuery(query: Record<string, unknown>) {
+        const dto = plainToInstance(PlanCheckoutReturnQueryDto, query);
+        return validate(dto as object, { whitelist: true, forbidNonWhitelisted: true });
+    }
+
+    it('accepts a provider-shaped session id', async () => {
+        expect(await validateQuery({ sessionId: 'cs_test_a1B2-c3_d4' })).toHaveLength(0);
+    });
+
+    it('rejects a session id carrying path or query characters', async () => {
+        for (const value of ['../../etc', 'cs_1?x=1', 'cs 1', 'https://evil.test/cs_1']) {
+            expect(await validateQuery({ sessionId: value })).not.toHaveLength(0);
+        }
+    });
+
+    it('rejects a smuggled userId on the query string', async () => {
+        const errors = await validateQuery({ sessionId: 'cs_1', userId: 'user-9' });
+        expect(errors.map((e) => e.property)).toContain('userId');
+    });
+});

--- a/apps/api/src/billing/plan-checkout.controller.ts
+++ b/apps/api/src/billing/plan-checkout.controller.ts
@@ -1,0 +1,183 @@
+import {
+    BadRequestException,
+    Body,
+    ConflictException,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    NotFoundException,
+    Post,
+    Query,
+    ServiceUnavailableException,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { AuthSessionGuard, CurrentUser } from '@src/auth';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { config } from '@src/config/constants';
+import {
+    BillingProviderError,
+    BillingProviderNotConfiguredError,
+    CheckoutSessionNotFoundError,
+    PlanNotPurchasableError,
+    PlanSubscriptionService,
+    UnknownSubscriptionPlanError,
+} from '@ever-works/agent/subscriptions';
+import { OrganizationMembershipService } from '@src/organizations/organization-membership.service';
+import { CreatePlanCheckoutDto, PlanCheckoutReturnQueryDto } from './dto/plan-checkout.dto';
+
+/**
+ * Paid-plan purchase (audit B24) — the surface that was missing for a
+ * paid tier to be buyable at all.
+ *
+ * Two routes, one auth posture (session-guarded, owner-scoped):
+ *
+ *   - `POST /api/billing/checkout/plan` — creates the hosted checkout
+ *     session and returns the provider redirect URL.
+ *   - `GET  /api/billing/checkout/plan/return` — finalizes the browser's
+ *     return so the buyer sees the new tier without waiting on the
+ *     asynchronous webhook. The webhook remains the authority; both
+ *     paths funnel into the same idempotent activation.
+ *
+ * ## Scoping rules
+ *
+ * 1. The buyer is ALWAYS `@CurrentUser().userId`. There is no body field
+ *    that can name another user, and nothing here reads one.
+ * 2. `organizationId`, when supplied, is authorized through
+ *    `OrganizationMembershipService` — which resolves org→tenant and
+ *    caller→tenant and answers 404 for anything outside the caller's
+ *    tenant. A cross-org checkout is therefore impossible: it never
+ *    reaches the payment provider.
+ * 3. The return URLs are built server-side from `WEB_URL`; a
+ *    client-supplied redirect would turn checkout into an open redirect.
+ * 4. The return route treats the session id as UNTRUSTED input. Ownership
+ *    is decided by the user id the provider stored in our session
+ *    metadata, and a session belonging to someone else is answered the
+ *    same as one that does not exist.
+ */
+@ApiTags('Billing')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/billing')
+@UseGuards(AuthSessionGuard)
+export class PlanCheckoutController {
+    constructor(
+        private readonly planSubscriptionService: PlanSubscriptionService,
+        private readonly organizationMembership: OrganizationMembershipService,
+    ) {}
+
+    @Post('checkout/plan')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Start a paid-plan checkout',
+        description:
+            'Creates a recurring hosted checkout session for one active subscription plan and returns the ' +
+            'redirect URL. The body accepts a planCode (and optionally an organizationId the caller belongs ' +
+            'to) — a client-supplied price is rejected with 400. Free plans are not purchasable here; use the ' +
+            'self-service plan endpoint.',
+    })
+    @ApiResponse({ status: 200, description: 'Checkout session created' })
+    @ApiResponse({
+        status: 400,
+        description: 'Unknown plan, free plan, or a non-whitelisted field',
+    })
+    @ApiResponse({ status: 404, description: 'Organization is not the caller’s' })
+    @ApiResponse({ status: 503, description: 'Payment provider not configured' })
+    // Checkout creates an object at the provider on every call — keep the
+    // per-user rate well below anything that could be used to spam them.
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async createPlanCheckout(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: CreatePlanCheckoutDto,
+    ) {
+        // Cross-org guard FIRST: a caller must not be able to make the
+        // platform talk to the payment provider about an org they cannot
+        // see. `ensureMember` answers 404 (not 403) so org ids in other
+        // tenants stay opaque.
+        let organizationId: string | null = null;
+        let tenantId: string | null = null;
+        if (body.organizationId) {
+            const organization = await this.organizationMembership.ensureMember(
+                body.organizationId,
+                auth.userId,
+            );
+            organizationId = organization.id;
+            tenantId = organization.tenantId ?? null;
+        }
+
+        const base = config.webAppUrl().replace(/\/+$/, '');
+        try {
+            const session = await this.planSubscriptionService.startPlanCheckout({
+                userId: auth.userId,
+                planCode: body.planCode,
+                // The provider appends its own session identifier — see
+                // the `successUrl` contract on `PlanCheckoutRequest`.
+                successUrl: `${base}/settings/billing?plan=success`,
+                cancelUrl: `${base}/settings/billing?plan=cancelled`,
+                organizationId,
+                tenantId,
+            });
+            return { status: 'success', ...session };
+        } catch (error) {
+            throw mapPlanBillingError(error);
+        }
+    }
+
+    @Get('checkout/plan/return')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Finalize a returning paid-plan checkout',
+        description:
+            'Reads the hosted checkout session back from the provider and activates the plan when it has ' +
+            'settled, so the buyer does not have to wait for the webhook. Idempotent, and scoped to the ' +
+            'authenticated user: a session belonging to another account answers 404.',
+    })
+    @ApiResponse({ status: 200, description: 'Return processed' })
+    @ApiResponse({ status: 404, description: 'No such checkout session for this account' })
+    @ApiResponse({ status: 503, description: 'Payment provider not configured' })
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async completePlanCheckout(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: PlanCheckoutReturnQueryDto,
+    ) {
+        try {
+            // Returned as-is, NOT wrapped in the `{ status: 'success' }`
+            // envelope the sibling routes use. `PlanCheckoutReturn.status`
+            // is a meaningful tri-state (`active` | `pending` | `ignored`)
+            // and is NOT redundant with `activated`: `ignored` is how a
+            // CREDIT TOP-UP session that returned through this plan route
+            // reports back — not an error, it just activates no plan.
+            // Spreading the result under an envelope key of the same name
+            // silently clobbered that value, which is what this prevents.
+            return await this.planSubscriptionService.syncCheckoutReturn(
+                auth.userId,
+                query.sessionId,
+            );
+        } catch (error) {
+            throw mapPlanBillingError(error);
+        }
+    }
+}
+
+/**
+ * Stable-name error mapping — the money path must never surface an
+ * unmapped 500 (billing PRD §6).
+ */
+export function mapPlanBillingError(error: unknown): unknown {
+    if (error instanceof BillingProviderNotConfiguredError) {
+        return new ServiceUnavailableException(error.message);
+    }
+    if (error instanceof UnknownSubscriptionPlanError || error instanceof PlanNotPurchasableError) {
+        return new BadRequestException(error.message);
+    }
+    if (error instanceof CheckoutSessionNotFoundError) {
+        // Existence-leak contract: "not yours" is indistinguishable from
+        // "does not exist".
+        return new NotFoundException(error.message);
+    }
+    if (error instanceof BillingProviderError) {
+        return new ConflictException(error.message);
+    }
+    return error;
+}

--- a/apps/api/src/migrations/1784700000000-AddUserSubscriptionProviderRef.ts
+++ b/apps/api/src/migrations/1784700000000-AddUserSubscriptionProviderRef.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+/**
+ * Paid-plan checkout (audit B24) — the one column `user_subscriptions`
+ * was missing to be driven by a payment provider.
+ *
+ *  - `providerSubscriptionId` — the provider's own subscription id,
+ *    stamped when a hosted plan checkout completes. It is what lets a
+ *    later `customer.subscription.updated` / `.deleted` delivery update
+ *    or revoke exactly the row that checkout created, instead of
+ *    guessing from the customer mapping. Opaque reference, never a
+ *    secret; NULL on every pre-existing (manually granted) row, which
+ *    reads correctly as "not provider-managed".
+ *
+ * A non-unique index because a re-subscribe legitimately produces a new
+ * provider subscription while the cancelled row is still on file —
+ * uniqueness here would reject the second sale.
+ *
+ * Forward-only with per-step guards (house pattern, mirrors
+ * `1784400000000-AddRunAttentionColumns`). No backfill: there is nothing
+ * to backfill, and no existing behavior changes.
+ */
+export class AddUserSubscriptionProviderRef1784700000000 implements MigrationInterface {
+    name = 'AddUserSubscriptionProviderRef1784700000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('user_subscriptions');
+        if (!table) return;
+
+        if (!table.findColumnByName('providerSubscriptionId')) {
+            await queryRunner.query(
+                `ALTER TABLE "user_subscriptions" ADD COLUMN "providerSubscriptionId" varchar(128)`,
+            );
+        }
+
+        const refreshed = await queryRunner.getTable('user_subscriptions');
+        const hasIndex = refreshed?.indices.some(
+            (index) => index.name === 'idx_user_subscriptions_provider_subscription',
+        );
+        if (!hasIndex) {
+            await queryRunner.createIndex(
+                'user_subscriptions',
+                new TableIndex({
+                    name: 'idx_user_subscriptions_provider_subscription',
+                    columnNames: ['providerSubscriptionId'],
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('user_subscriptions');
+        if (!table) return;
+
+        const hasIndex = table.indices.some(
+            (index) => index.name === 'idx_user_subscriptions_provider_subscription',
+        );
+        if (hasIndex) {
+            await queryRunner.dropIndex(
+                'user_subscriptions',
+                'idx_user_subscriptions_provider_subscription',
+            );
+        }
+        if (table.findColumnByName('providerSubscriptionId')) {
+            await queryRunner.query(
+                `ALTER TABLE "user_subscriptions" DROP COLUMN "providerSubscriptionId"`,
+            );
+        }
+    }
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/billing/page.tsx
@@ -26,7 +26,26 @@ export async function generateMetadata(): Promise<Metadata> {
  * ledger paging/filtering through the `/api/credits/ledger` proxy.
  * Static page by design — no polling; refresh on navigation.
  */
-export default async function BillingSettingsPage() {
+interface BillingSettingsPageProps {
+    /** `session_id` is appended by the payment provider on return. */
+    searchParams: Promise<{ session_id?: string; plan?: string }>;
+}
+
+export default async function BillingSettingsPage({ searchParams }: BillingSettingsPageProps) {
+    // Paid-plan checkout return (audit B24). The provider redirects here
+    // with its session id; finalizing BEFORE the snapshot fetch means the
+    // page renders the new tier immediately instead of the old one.
+    //
+    // This is a convenience, not the source of truth — the
+    // signature-verified webhook activates the plan regardless, and both
+    // paths funnel into the same idempotent activation. The API scopes
+    // the call to the session user, so a session id pasted from another
+    // account's redirect resolves to a 404 and is swallowed here.
+    const params = await searchParams;
+    if (params.session_id) {
+        await billingAPI.completePlanCheckout(params.session_id).catch(() => null);
+    }
+
     // Each fetch degrades independently: a failed call renders that
     // section's error/empty state instead of failing the whole page.
     const [plan, plans, balance, ledger, overview, invoices] = await Promise.all([

--- a/apps/web/src/app/actions/dashboard/billing.ts
+++ b/apps/web/src/app/actions/dashboard/billing.ts
@@ -80,6 +80,42 @@ export async function startCreditCheckoutAction(packId: string) {
     }
 }
 
+/**
+ * Start a paid-plan checkout (audit B24).
+ *
+ * The client sends a PLAN CODE and nothing else; the API prices it from
+ * `subscription_plans`, refuses free plans, builds the return URLs
+ * itself and scopes everything to the session user. Returns the provider
+ * redirect URL as a discriminated union so the caller can render the
+ * failure branch inline (production redacts thrown server-action
+ * messages).
+ */
+export async function startPlanCheckoutAction(planCode: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const result = await billingAPI.startPlanCheckout(planCode);
+        return { success: true as const, url: result.url, error: null };
+    } catch (error) {
+        // Security: log full error server-side; return a generic client-safe message.
+        console.error('[startPlanCheckoutAction]', error);
+        let message = 'Could not start checkout';
+        if (error instanceof ApiResponseError) {
+            if (error.statusCode === 503) {
+                message = 'Card payments are not enabled on this deployment yet.';
+            } else if (error.statusCode === 400) {
+                message = 'That plan is not available for purchase.';
+            } else if (error.statusCode === 404) {
+                message = 'Plan not found.';
+            }
+        }
+        return { success: false as const, url: null, error: message };
+    }
+}
+
 /** Update threshold-triggered auto-recharge (billing PRD §3.4). */
 export async function updateAutoRechargeAction(settings: {
     enabled: boolean;

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -10,6 +10,7 @@ import { Select } from '@/components/ui/select';
 import {
     changePlanAction,
     startCreditCheckoutAction,
+    startPlanCheckoutAction,
     updateAutoRechargeAction,
 } from '@/app/actions/dashboard/billing';
 import {
@@ -29,6 +30,7 @@ import {
 import {
     canBuyCredits,
     canConfigureAutoRecharge,
+    canUpgradePlan,
     formatCardExpiry,
     formatPaymentMethod,
     invoiceStatusTone,
@@ -126,6 +128,12 @@ export function BillingSettings({
     const [selectedPackId, setSelectedPackId] = useState<string | null>(packs[0]?.id ?? null);
     const [checkoutPending, setCheckoutPending] = useState(false);
 
+    // Paid-tier purchase (audit B24). Same two gates as buying credits,
+    // plus subscriptions being enabled — an upgrade the deployment can't
+    // apply must not be offered as a live button.
+    const upgradeEnabled = canUpgradePlan(overview, paymentsEnabled, subscriptionsEnabled);
+    const [upgradingPlanCode, setUpgradingPlanCode] = useState<string | null>(null);
+
     const [autoRechargeOn, setAutoRechargeOn] = useState(overview?.autoRecharge.enabled ?? false);
     const [autoRechargeThreshold, setAutoRechargeThreshold] = useState(
         overview?.autoRecharge.thresholdCredits != null
@@ -158,6 +166,30 @@ export function BillingSettings({
             setCheckoutPending(false);
         }
     }, [selectedPackId, t]);
+
+    const handleUpgradePlan = useCallback(
+        async (plan: SubscriptionPlanListItem) => {
+            if (!upgradeEnabled) {
+                // Degraded deployment: keep the pre-payments affordance
+                // rather than a button that always errors.
+                toast.info(t('plans.upgradeHint'));
+                return;
+            }
+            setUpgradingPlanCode(plan.code);
+            try {
+                // Only a PLAN CODE crosses the wire — the server prices it.
+                const result = await startPlanCheckoutAction(plan.code);
+                if (result.success && result.url) {
+                    window.location.assign(result.url);
+                    return;
+                }
+                toast.error(result.error ?? t('credits.checkoutError'));
+            } finally {
+                setUpgradingPlanCode(null);
+            }
+        },
+        [upgradeEnabled, t],
+    );
 
     const handleSaveAutoRecharge = useCallback(async () => {
         setAutoRechargeSaving(true);
@@ -363,14 +395,19 @@ export function BillingSettings({
                                     </Button>
                                 ) : (
                                     // Paid tiers activate through a billing-verified
-                                    // path only (EW-711 #23) — until the payment
-                                    // provider lands this is a contact affordance.
+                                    // path only (EW-711 #23): this starts a hosted
+                                    // plan checkout (audit B24). On a deployment
+                                    // without payments it degrades to the original
+                                    // coming-soon hint rather than erroring.
                                     <Button
                                         className="text-xs w-full"
                                         data-testid={`billing-plan-upgrade-${plan.code}`}
-                                        onClick={() => toast.info(t('plans.upgradeHint'))}
+                                        disabled={upgradingPlanCode !== null}
+                                        onClick={() => void handleUpgradePlan(plan)}
                                     >
-                                        {t('plans.upgrade')}
+                                        {upgradingPlanCode === plan.code
+                                            ? t('credits.redirecting')
+                                            : t('plans.upgrade')}
                                     </Button>
                                 )}
                             </div>

--- a/apps/web/src/lib/api/billing.shared.ts
+++ b/apps/web/src/lib/api/billing.shared.ts
@@ -79,6 +79,29 @@ export interface CreditCheckoutResponse {
     credits: number;
 }
 
+/** Paid-plan checkout (audit B24). Prices are echoed FROM the server. */
+export interface PlanCheckoutResponse {
+    status: string;
+    url: string;
+    sessionId: string;
+    planCode: string;
+    priceCents: number;
+    currency: string;
+}
+
+/** Result of finalizing the browser's return from a plan checkout. */
+export interface PlanCheckoutReturnResponse {
+    /**
+     * `active` once the tier is in force; `pending` while money settles;
+     * `ignored` when a credit top-up session returned through this plan
+     * route — not an error, it simply activates no plan.
+     */
+    status: 'active' | 'pending' | 'ignored';
+    /** True once the plan is actually in force for the owner. */
+    activated: boolean;
+    planCode: string | null;
+}
+
 // ── Pure helpers (unit-tested in billing.shared.unit.spec.ts) ───────
 
 /** Bonus credits a pack grants over the 1 credit = 1¢ par rate. */
@@ -138,4 +161,18 @@ export function canConfigureAutoRecharge(
     paymentsEnabled: boolean,
 ): boolean {
     return canBuyCredits(overview, paymentsEnabled) && Boolean(overview?.paymentMethod);
+}
+
+/**
+ * A paid tier is purchasable only when the deployment's master switch is
+ * on, the provider is wired AND subscriptions are enabled (an upgrade
+ * that cannot be applied must not be offered). Same single-testable-place
+ * rule as {@link canBuyCredits} — audit B24.
+ */
+export function canUpgradePlan(
+    overview: BillingOverview | null,
+    paymentsEnabled: boolean,
+    subscriptionsEnabled: boolean,
+): boolean {
+    return canBuyCredits(overview, paymentsEnabled) && subscriptionsEnabled;
 }

--- a/apps/web/src/lib/api/billing.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/billing.shared.unit.spec.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import {
     canBuyCredits,
     canConfigureAutoRecharge,
+    canUpgradePlan,
     formatCardExpiry,
     formatPaymentMethod,
     invoiceStatusTone,
@@ -117,5 +118,29 @@ describe('canConfigureAutoRecharge', () => {
 
     it('is false whenever buying is off', () => {
         expect(canConfigureAutoRecharge(withCard, false)).toBe(false);
+    });
+});
+
+describe('canUpgradePlan — a tier is only sellable when it can also be applied', () => {
+    const configured = overview({ providerConfigured: true });
+
+    it('needs the payments master switch', () => {
+        expect(canUpgradePlan(configured, false, true)).toBe(false);
+    });
+
+    it('needs a configured provider', () => {
+        expect(canUpgradePlan(overview({ providerConfigured: false }), true, true)).toBe(false);
+    });
+
+    it('needs subscriptions to be enabled — an upgrade that cannot apply is not offered', () => {
+        expect(canUpgradePlan(configured, true, false)).toBe(false);
+    });
+
+    it('is false when the overview could not be loaded at all', () => {
+        expect(canUpgradePlan(null, true, true)).toBe(false);
+    });
+
+    it('is true only when all three gates pass', () => {
+        expect(canUpgradePlan(configured, true, true)).toBe(true);
     });
 });

--- a/apps/web/src/lib/api/billing.ts
+++ b/apps/web/src/lib/api/billing.ts
@@ -1,8 +1,20 @@
 import 'server-only';
 import { serverFetch } from './server-api';
-import type { BillingOverview, CreditCheckoutResponse, InvoiceListPage } from './billing.shared';
+import type {
+    BillingOverview,
+    CreditCheckoutResponse,
+    InvoiceListPage,
+    PlanCheckoutResponse,
+    PlanCheckoutReturnResponse,
+} from './billing.shared';
 
-export type { BillingOverview, CreditCheckoutResponse, InvoiceListPage };
+export type {
+    BillingOverview,
+    CreditCheckoutResponse,
+    InvoiceListPage,
+    PlanCheckoutResponse,
+    PlanCheckoutReturnResponse,
+};
 
 /**
  * The money path (billing PRD B5) — server-side wrappers over
@@ -42,6 +54,39 @@ export const billingAPI = {
             method: 'POST',
             body: JSON.stringify({ packId }),
         });
+    },
+
+    /**
+     * Start a paid-plan checkout (audit B24). The body carries a PLAN
+     * CODE (and optionally an org the caller belongs to) — the API prices
+     * it from `subscription_plans` and rejects any price field. The
+     * return URLs are built by the API from `WEB_URL`, never here.
+     */
+    async startPlanCheckout(
+        planCode: string,
+        organizationId?: string | null,
+    ): Promise<PlanCheckoutResponse> {
+        const body: { planCode: string; organizationId?: string } = { planCode };
+        if (organizationId) {
+            body.organizationId = organizationId;
+        }
+        return serverFetch<PlanCheckoutResponse>('/billing/checkout/plan', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+    },
+
+    /**
+     * Finalize the browser's return from a plan checkout so the new tier
+     * shows immediately. The webhook is still the authority; this call is
+     * idempotent and scoped to the session user by the API.
+     */
+    async completePlanCheckout(sessionId: string): Promise<PlanCheckoutReturnResponse> {
+        const search = new URLSearchParams({ sessionId });
+        return serverFetch<PlanCheckoutReturnResponse>(
+            `/billing/checkout/plan/return?${search.toString()}`,
+            { method: 'GET' },
+        );
     },
 
     /** Enable/disable threshold-triggered top-ups. */

--- a/packages/agent/src/database/repositories/user-subscription.repository.ts
+++ b/packages/agent/src/database/repositories/user-subscription.repository.ts
@@ -17,6 +17,21 @@ export class UserSubscriptionRepository {
         });
     }
 
+    /**
+     * Look a subscription up by the PROVIDER's id (audit B24 — plan
+     * checkout). This is how a later `customer.subscription.*` delivery
+     * finds exactly the row the hosted checkout created, without
+     * trusting anything the browser could have supplied.
+     */
+    async findByProviderSubscriptionId(
+        providerSubscriptionId: string,
+    ): Promise<UserSubscription | null> {
+        return this.repository.findOne({
+            where: { providerSubscriptionId },
+            relations: ['plan'],
+        });
+    }
+
     async listByUser(userId: string): Promise<UserSubscription[]> {
         return this.repository.find({
             where: { userId },

--- a/packages/agent/src/entities/user-subscription.entity.ts
+++ b/packages/agent/src/entities/user-subscription.entity.ts
@@ -58,6 +58,16 @@ export class UserSubscription {
     @Column({ type: 'varchar', default: SubscriptionBillingProvider.STRIPE })
     billingProvider: SubscriptionBillingProvider;
 
+    /**
+     * Provider subscription id (audit B24 — plan checkout). Opaque
+     * reference, NEVER a secret: it is what lets a later
+     * `customer.subscription.*` delivery update or revoke exactly the row
+     * the hosted checkout created, and what a future manage/cancel
+     * surface would address. NULL on manually-granted rows.
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    providerSubscriptionId?: string | null;
+
     @TimestampColumn()
     currentPeriodEnd?: Date | null;
 

--- a/packages/agent/src/subscriptions/billing/billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.ts
@@ -77,6 +77,84 @@ export interface CreditCheckoutSession {
     readonly customerId: string;
 }
 
+/**
+ * A subscription plan, priced by the SERVER from `subscription_plans`.
+ *
+ * The seam deliberately takes a flat descriptor rather than the TypeORM
+ * entity: a provider implementation must never reach into our schema,
+ * and the caller must be the one that decided what this plan costs.
+ */
+export interface BillingPlanDescriptor {
+    /** `subscription_plans.code` — echoed back on the provider event. */
+    readonly code: string;
+    /** Display label shown on the hosted checkout page. */
+    readonly label: string;
+    /** Recurring price in cents, from the server plan row. */
+    readonly priceCents: number;
+    readonly currency: string;
+    /** Only monthly today; widened here so the seam does not need a bump. */
+    readonly interval: 'month' | 'year';
+}
+
+/**
+ * Who is subscribing, and to what (audit B24). Same trust posture as
+ * {@link CreditCheckoutRequest}: the caller names a PLAN CODE, never a
+ * price, and the return URLs are built server-side.
+ */
+export interface PlanCheckoutRequest {
+    readonly userId: string;
+    readonly userEmail?: string | null;
+    readonly customerId?: string | null;
+    /** The server-resolved plan — never client-supplied numbers. */
+    readonly plan: BillingPlanDescriptor;
+    /**
+     * Where the provider returns the buyer after a successful payment.
+     *
+     * The IMPLEMENTATION is responsible for appending its own session
+     * identifier to this URL (providers use different template tokens);
+     * the caller supplies a clean, server-built URL and stays
+     * vendor-neutral. The return route needs that identifier to read the
+     * session back — see {@link CheckoutSessionSnapshot}.
+     */
+    readonly successUrl: string;
+    readonly cancelUrl: string;
+    /** `{userId}:{planCode}` — echoed back on the signed provider event. */
+    readonly referenceId: string;
+}
+
+export interface PlanCheckoutSession {
+    /** Redirect the browser here. */
+    readonly url: string;
+    readonly sessionId: string;
+    readonly customerId: string;
+}
+
+/**
+ * A read-back of a hosted checkout session, used by the RETURN route so
+ * a buyer who lands back on the Billing page sees their plan immediately
+ * instead of waiting for the asynchronous webhook.
+ *
+ * `userId` is the value WE stamped into the session metadata at creation
+ * time, so the return route can prove the session belongs to the caller
+ * before acting on it — a session id in a URL is not an authorization.
+ */
+export interface CheckoutSessionSnapshot {
+    readonly sessionId: string;
+    readonly status: 'complete' | 'open' | 'expired';
+    /** True when the provider settled the money (or none was required). */
+    readonly paid: boolean;
+    /** What the session was created for. */
+    readonly purpose: 'plan' | 'credits' | 'other';
+    /** Platform user id from OUR metadata — the ownership check. */
+    readonly userId: string | null;
+    readonly planCode: string | null;
+    readonly packId: string | null;
+    readonly customerId: string | null;
+    /** Provider subscription id, for plan sessions. */
+    readonly subscriptionId: string | null;
+    readonly currentPeriodEnd: Date | null;
+}
+
 /** Off-session charge for auto-recharge (PRD §3.4). */
 export interface OffSessionChargeRequest {
     readonly customerId: string;
@@ -144,6 +222,14 @@ export type BillingWebhookEventKind =
     | 'invoice.updated'
     /** The customer's default payment method changed. */
     | 'payment_method.updated'
+    /**
+     * A paid plan is now in force (audit B24) — first checkout, renewal,
+     * or a provider-side change back to an active/trialing state. The
+     * ONLY billing-verified path that may grant a paid tier.
+     */
+    | 'subscription.activated'
+    /** A paid plan lapsed (cancelled, unpaid, or deleted). */
+    | 'subscription.canceled'
     /** Recognized envelope, no action for us. */
     | 'ignored';
 
@@ -168,6 +254,18 @@ export interface BillingWebhookEvent {
     readonly paymentId: string | null;
     /** Raw provider event type, for logging/diagnostics. Never a secret. */
     readonly providerType: string;
+    /**
+     * Plan code echoed from OUR subscription metadata. Populated for
+     * `subscription.*` kinds only. Optional so the existing credit-path
+     * event literals stay valid.
+     */
+    readonly planCode?: string | null;
+    /** Provider subscription id, for `subscription.*` kinds. */
+    readonly subscriptionId?: string | null;
+    /** End of the paid period currently in force. */
+    readonly currentPeriodEnd?: Date | null;
+    /** The provider will not renew at `currentPeriodEnd`. */
+    readonly cancelAtPeriodEnd?: boolean | null;
 }
 
 export abstract class BillingProvider {
@@ -213,6 +311,24 @@ export abstract class BillingProvider {
     async createCreditCheckoutSession(
         _request: CreditCheckoutRequest,
     ): Promise<CreditCheckoutSession> {
+        throw new BillingProviderNotConfiguredError();
+    }
+
+    /**
+     * Hosted checkout for a recurring PLAN subscription (audit B24).
+     * Same posture as the credit checkout: the caller hands over a
+     * server-priced plan descriptor, never a client number.
+     */
+    async createPlanCheckoutSession(_request: PlanCheckoutRequest): Promise<PlanCheckoutSession> {
+        throw new BillingProviderNotConfiguredError();
+    }
+
+    /**
+     * Read one hosted checkout session back, for the return route. The
+     * snapshot carries the metadata WE stamped at creation time so the
+     * caller can verify ownership before acting on it.
+     */
+    async retrieveCheckoutSession(_sessionId: string): Promise<CheckoutSessionSnapshot> {
         throw new BillingProviderNotConfiguredError();
     }
 

--- a/packages/agent/src/subscriptions/billing/billing.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.spec.ts
@@ -96,6 +96,9 @@ function build(parts: Partial<Record<string, any>> = {}) {
     const ledgerRepo = parts.ledgerRepo ?? makeLedgerRepository();
     const ledgerService = parts.ledgerService ?? makeLedgerService();
     const users = parts.users ?? makeUserRepository();
+    // Paid-plan lifecycle collaborator (audit B24) — OPTIONAL, so the
+    // credit-path specs keep the original 6-argument construction.
+    const plans = parts.plans;
     const service = new BillingService(
         provider,
         profiles,
@@ -103,8 +106,9 @@ function build(parts: Partial<Record<string, any>> = {}) {
         ledgerRepo,
         ledgerService,
         users,
+        plans,
     );
-    return { service, provider, profiles, invoices, ledgerRepo, ledgerService, users };
+    return { service, provider, profiles, invoices, ledgerRepo, ledgerService, users, plans };
 }
 
 const CHECKOUT = {
@@ -682,5 +686,56 @@ describe('BillingService — overview, invoices and auto-recharge settings', () 
             autoRechargeThresholdCredits: 500,
             autoRechargePackId: 'credits-5500',
         });
+    });
+});
+
+describe('handleWebhook — paid-plan lifecycle is delegated, not duplicated (audit B24)', () => {
+    function planEvent(kind: 'subscription.activated' | 'subscription.canceled') {
+        return event({
+            id: 'evt_plan_1',
+            kind,
+            customerId: 'cus_1',
+            planCode: 'standard',
+            subscriptionId: 'sub_1',
+            providerType: 'checkout.session.completed',
+        });
+    }
+
+    it('hands a subscription event to the plan service and echoes its action', async () => {
+        const plans = { applyWebhook: jest.fn().mockResolvedValue('subscription-activated') };
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(planEvent('subscription.activated')),
+        });
+        const { service, ledgerService } = build({ provider, plans });
+
+        const outcome = await service.handleWebhook('{}', 'sig');
+
+        expect(plans.applyWebhook).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: 'subscription.activated', planCode: 'standard' }),
+        );
+        expect(outcome.action).toBe('subscription-activated');
+        // A plan sale must never touch the credits ledger.
+        expect(ledgerService.record).not.toHaveBeenCalled();
+    });
+
+    it('echoes a revocation action', async () => {
+        const plans = { applyWebhook: jest.fn().mockResolvedValue('subscription-canceled') };
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(planEvent('subscription.canceled')),
+        });
+        const { service } = build({ provider, plans });
+
+        expect((await service.handleWebhook('{}', 'sig')).action).toBe('subscription-canceled');
+    });
+
+    it('acknowledges (never 500s) when plan handling is not wired', async () => {
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(planEvent('subscription.activated')),
+        });
+        const { service } = build({ provider });
+
+        // A 5xx here would make the provider retry a delivery we can
+        // never resolve.
+        expect((await service.handleWebhook('{}', 'sig')).action).toBe('ignored');
     });
 });

--- a/packages/agent/src/subscriptions/billing/billing.service.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { BillingProfileRepository } from '@src/database/repositories/billing-profile.repository';
 import { CreditLedgerRepository } from '@src/database/repositories/credit-ledger.repository';
 import { InvoiceRepository } from '@src/database/repositories/invoice.repository';
@@ -14,6 +14,7 @@ import {
     type BillingWebhookEvent,
 } from './billing.provider';
 import { CREDIT_PACKS, findCreditPack, type CreditPack } from './credit-packs';
+import { PlanSubscriptionService } from './plan-subscription.service';
 
 /** Correlation refType stamped on every purchase/refund ledger movement. */
 export const BILLING_PAYMENT_REF_TYPE = 'billing-payment';
@@ -76,6 +77,10 @@ export interface WebhookOutcome {
         | 'reversed-idempotent'
         | 'invoice-mirrored'
         | 'payment-method-updated'
+        // Paid-plan lifecycle (audit B24) — delegated to
+        // `PlanSubscriptionService`, which owns the tier grant/revoke.
+        | 'subscription-activated'
+        | 'subscription-canceled'
         | 'ignored'
         | 'unattributed';
     creditsDelta?: number;
@@ -114,6 +119,14 @@ export class BillingService {
         private readonly creditLedgerRepository: CreditLedgerRepository,
         private readonly creditLedgerService: CreditLedgerService,
         private readonly userRepository: UserRepository,
+        /**
+         * Paid-plan lifecycle (audit B24). Appended LAST so every
+         * existing positional construction in the specs keeps working;
+         * `@Optional()` so a caller that only needs the credits path can
+         * still build the service without the plan collaborator.
+         */
+        @Optional()
+        private readonly planSubscriptionService?: PlanSubscriptionService,
     ) {}
 
     /** Server-side pack table — the only source of prices. */
@@ -276,10 +289,30 @@ export class BillingService {
                 return this.mirrorInvoice(event);
             case 'payment_method.updated':
                 return this.applyPaymentMethod(event);
+            case 'subscription.activated':
+            case 'subscription.canceled':
+                return this.applySubscription(event);
             case 'ignored':
             default:
                 return { eventId: event.id, kind: event.kind, action: 'ignored' };
         }
+    }
+
+    /**
+     * Paid-plan lifecycle (audit B24). Delegated whole — the tier grant
+     * lives with the plan repositories, not with the credits ledger. A
+     * deployment that somehow lacks the collaborator acknowledges the
+     * delivery rather than 500-ing it into an infinite provider retry.
+     */
+    private async applySubscription(event: BillingWebhookEvent): Promise<WebhookOutcome> {
+        if (!this.planSubscriptionService) {
+            this.logger.warn(
+                `Billing webhook ${event.id}: subscription event received but plan handling is not wired — acknowledged`,
+            );
+            return { eventId: event.id, kind: event.kind, action: 'ignored' };
+        }
+        const action = await this.planSubscriptionService.applyWebhook(event);
+        return { eventId: event.id, kind: event.kind, action };
     }
 
     private async applyPurchase(event: BillingWebhookEvent): Promise<WebhookOutcome> {

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -1,0 +1,531 @@
+import {
+    CheckoutSessionNotFoundError,
+    PlanNotPurchasableError,
+    PlanSubscriptionService,
+    UnknownSubscriptionPlanError,
+} from './plan-subscription.service';
+import { BillingProviderNotConfiguredError, type BillingWebhookEvent } from './billing.provider';
+import { SubscriptionStatus } from '@src/entities/user-subscription.entity';
+
+/**
+ * Paid-plan purchase (audit B24). No DB, no Nest container, no vendor
+ * SDK — the `BillingProvider` seam is a jest.fn() shell.
+ *
+ * What these specs pin:
+ *   - checkout is priced from the SERVER plan row, never by the caller;
+ *   - a free plan is not purchasable (that path stays self-service);
+ *   - the return route authorizes on the user id the PROVIDER holds in
+ *     our session metadata — a session id in a URL is not an
+ *     authorization, and someone else's session is a 404-shaped error;
+ *   - only a billing-verified path reaches the privileged plan grant;
+ *   - activation is idempotent, so a webhook replay (or a webhook racing
+ *     the return route) grants the same tier once.
+ */
+
+const STANDARD_PLAN = {
+    id: 'plan-standard',
+    code: 'standard',
+    displayName: 'Standard',
+    monthlyPrice: '29',
+    currency: 'usd',
+    active: true,
+};
+
+const FREE_PLAN = {
+    id: 'plan-free',
+    code: 'free',
+    displayName: 'Free',
+    monthlyPrice: '0',
+    currency: 'usd',
+    active: true,
+};
+
+function makeProvider(overrides: Record<string, unknown> = {}) {
+    return {
+        getProviderId: jest.fn().mockReturnValue('stripe'),
+        getDefaultCurrency: jest.fn().mockReturnValue('usd'),
+        isConfigured: jest.fn().mockReturnValue(true),
+        ensureCustomer: jest.fn().mockResolvedValue('cus_1'),
+        createPlanCheckoutSession: jest.fn().mockResolvedValue({
+            url: 'https://pay.example/cs_plan_1',
+            sessionId: 'cs_plan_1',
+            customerId: 'cus_1',
+        }),
+        retrieveCheckoutSession: jest.fn(),
+        ...overrides,
+    } as any;
+}
+
+function makePlanRepository(overrides: Record<string, unknown> = {}) {
+    return {
+        findByCode: jest.fn().mockImplementation(async (code: string) => {
+            if (code === 'standard') return STANDARD_PLAN;
+            if (code === 'free') return FREE_PLAN;
+            return null;
+        }),
+        ...overrides,
+    } as any;
+}
+
+function makeSubscriptionRepository(overrides: Record<string, unknown> = {}) {
+    return {
+        createOrUpdate: jest.fn().mockResolvedValue({ id: 'sub-row-1' }),
+        findByProviderSubscriptionId: jest.fn().mockResolvedValue(null),
+        findActiveByUser: jest.fn().mockResolvedValue(null),
+        cancel: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+    } as any;
+}
+
+function makeProfileRepository(overrides: Record<string, unknown> = {}) {
+    return {
+        findByUserId: jest.fn().mockResolvedValue(null),
+        findByCustomerId: jest.fn().mockResolvedValue(null),
+        ensure: jest.fn().mockResolvedValue({ userId: 'u1', providerCustomerId: 'cus_1' }),
+        ...overrides,
+    } as any;
+}
+
+function makeUserRepository(overrides: Record<string, unknown> = {}) {
+    return {
+        findById: jest.fn().mockResolvedValue({ id: 'u1', email: 'buyer@example.test' }),
+        ...overrides,
+    } as any;
+}
+
+function makeSubscriptionService(overrides: Record<string, unknown> = {}) {
+    return {
+        isEnabled: jest.fn().mockReturnValue(true),
+        assignPlanToUser: jest.fn().mockResolvedValue(STANDARD_PLAN),
+        changePlanSelfService: jest.fn().mockResolvedValue(FREE_PLAN),
+        ...overrides,
+    } as any;
+}
+
+function build(
+    overrides: {
+        provider?: any;
+        planRepository?: any;
+        subscriptionRepository?: any;
+        profileRepository?: any;
+        userRepository?: any;
+        subscriptionService?: any;
+    } = {},
+) {
+    const provider = overrides.provider ?? makeProvider();
+    const planRepository = overrides.planRepository ?? makePlanRepository();
+    const subscriptionRepository = overrides.subscriptionRepository ?? makeSubscriptionRepository();
+    const profileRepository = overrides.profileRepository ?? makeProfileRepository();
+    const userRepository = overrides.userRepository ?? makeUserRepository();
+    const subscriptionService = overrides.subscriptionService ?? makeSubscriptionService();
+    const service = new PlanSubscriptionService(
+        provider,
+        planRepository,
+        subscriptionRepository,
+        profileRepository,
+        userRepository,
+        subscriptionService,
+    );
+    return {
+        service,
+        provider,
+        planRepository,
+        subscriptionRepository,
+        profileRepository,
+        userRepository,
+        subscriptionService,
+    };
+}
+
+const checkoutOptions = {
+    userId: 'u1',
+    planCode: 'standard',
+    successUrl: 'https://app.test/settings/billing?plan=success',
+    cancelUrl: 'https://app.test/settings/billing?plan=cancelled',
+};
+
+describe('startPlanCheckout — the server prices everything', () => {
+    it('prices the checkout from the SERVER plan row', async () => {
+        const { service, provider } = build();
+
+        const started = await service.startPlanCheckout(checkoutOptions);
+
+        expect(started).toEqual({
+            url: 'https://pay.example/cs_plan_1',
+            sessionId: 'cs_plan_1',
+            planCode: 'standard',
+            priceCents: 2900,
+            currency: 'usd',
+        });
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        // $29.00 → 2900 cents, straight from `subscription_plans`.
+        expect(request.plan).toEqual(
+            expect.objectContaining({ code: 'standard', priceCents: 2900, interval: 'month' }),
+        );
+        // Server-authored correlation id, echoed back on the signed event.
+        expect(request.referenceId).toBe('u1:standard');
+    });
+
+    it('lazily creates the provider customer + billing profile', async () => {
+        const { service, provider, profileRepository } = build();
+
+        await service.startPlanCheckout(checkoutOptions);
+
+        expect(provider.ensureCustomer).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 'u1', existingCustomerId: null }),
+        );
+        expect(profileRepository.ensure).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 'u1', provider: 'stripe' }),
+        );
+    });
+
+    it('refuses a free plan — that move stays on the self-service path', async () => {
+        const { service, provider } = build();
+
+        await expect(
+            service.startPlanCheckout({ ...checkoutOptions, planCode: 'free' }),
+        ).rejects.toBeInstanceOf(PlanNotPurchasableError);
+        expect(provider.createPlanCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('refuses an unknown or inactive plan', async () => {
+        const { service } = build();
+        await expect(
+            service.startPlanCheckout({ ...checkoutOptions, planCode: 'enterprise' }),
+        ).rejects.toBeInstanceOf(UnknownSubscriptionPlanError);
+
+        const inactive = build({
+            planRepository: makePlanRepository({
+                findByCode: jest.fn().mockResolvedValue({ ...STANDARD_PLAN, active: false }),
+            }),
+        });
+        await expect(inactive.service.startPlanCheckout(checkoutOptions)).rejects.toBeInstanceOf(
+            UnknownSubscriptionPlanError,
+        );
+    });
+
+    it('fails closed when the provider is not configured', async () => {
+        const { service } = build({
+            provider: makeProvider({ isConfigured: jest.fn().mockReturnValue(false) }),
+        });
+
+        await expect(service.startPlanCheckout(checkoutOptions)).rejects.toBeInstanceOf(
+            BillingProviderNotConfiguredError,
+        );
+    });
+
+    it('fails closed when subscriptions are disabled on the deployment', async () => {
+        const { service, provider } = build({
+            subscriptionService: makeSubscriptionService({
+                isEnabled: jest.fn().mockReturnValue(false),
+            }),
+        });
+
+        await expect(service.startPlanCheckout(checkoutOptions)).rejects.toBeInstanceOf(
+            PlanNotPurchasableError,
+        );
+        expect(provider.createPlanCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('treats a malformed plan price as not sellable rather than charging it', async () => {
+        const { service } = build({
+            planRepository: makePlanRepository({
+                findByCode: jest.fn().mockResolvedValue({ ...STANDARD_PLAN, monthlyPrice: 'abc' }),
+            }),
+        });
+
+        await expect(service.startPlanCheckout(checkoutOptions)).rejects.toBeInstanceOf(
+            PlanNotPurchasableError,
+        );
+    });
+});
+
+describe('syncCheckoutReturn — a session id is not an authorization', () => {
+    function paidPlanSnapshot(overrides: Record<string, unknown> = {}) {
+        return {
+            sessionId: 'cs_plan_1',
+            status: 'complete',
+            paid: true,
+            purpose: 'plan',
+            userId: 'u1',
+            planCode: 'standard',
+            packId: null,
+            customerId: 'cus_1',
+            subscriptionId: 'sub_1',
+            currentPeriodEnd: new Date('2026-09-01T00:00:00Z'),
+            ...overrides,
+        };
+    }
+
+    it('activates the plan for the owning user', async () => {
+        const { service, provider, subscriptionRepository, subscriptionService } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest.fn().mockResolvedValue(paidPlanSnapshot()),
+            }),
+        });
+
+        const result = await service.syncCheckoutReturn('u1', 'cs_plan_1');
+
+        expect(result).toEqual({ status: 'active', activated: true, planCode: 'standard' });
+        expect(provider.retrieveCheckoutSession).toHaveBeenCalledWith('cs_plan_1');
+        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({
+                planCode: 'standard',
+                planId: 'plan-standard',
+                status: SubscriptionStatus.ACTIVE,
+                providerSubscriptionId: 'sub_1',
+            }),
+        );
+        // The PRIVILEGED grant — the only path allowed to set a paid tier.
+        expect(subscriptionService.assignPlanToUser).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'u1' }),
+            'standard',
+        );
+    });
+
+    it('REFUSES a session belonging to another account, without leaking existence', async () => {
+        const { service, subscriptionRepository, subscriptionService } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest
+                    .fn()
+                    .mockResolvedValue(paidPlanSnapshot({ userId: 'someone-else' })),
+            }),
+        });
+
+        await expect(service.syncCheckoutReturn('u1', 'cs_plan_1')).rejects.toBeInstanceOf(
+            CheckoutSessionNotFoundError,
+        );
+        expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES a session with no owner metadata at all', async () => {
+        const { service } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest
+                    .fn()
+                    .mockResolvedValue(paidPlanSnapshot({ userId: null })),
+            }),
+        });
+
+        await expect(service.syncCheckoutReturn('u1', 'cs_plan_1')).rejects.toBeInstanceOf(
+            CheckoutSessionNotFoundError,
+        );
+    });
+
+    it('grants nothing while the payment is still settling', async () => {
+        const { service, subscriptionService } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest
+                    .fn()
+                    .mockResolvedValue(paidPlanSnapshot({ status: 'open', paid: false })),
+            }),
+        });
+
+        const result = await service.syncCheckoutReturn('u1', 'cs_plan_1');
+
+        expect(result).toEqual({ status: 'pending', activated: false, planCode: 'standard' });
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('grants nothing for a credit top-up session returning through this route', async () => {
+        const { service, subscriptionService } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest.fn().mockResolvedValue(
+                    paidPlanSnapshot({
+                        purpose: 'credits',
+                        planCode: null,
+                        packId: 'credits-1000',
+                    }),
+                ),
+            }),
+        });
+
+        const result = await service.syncCheckoutReturn('u1', 'cs_plan_1');
+
+        expect(result).toEqual({ status: 'ignored', activated: false, planCode: null });
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the provider is not configured', async () => {
+        const { service } = build({
+            provider: makeProvider({ isConfigured: jest.fn().mockReturnValue(false) }),
+        });
+
+        await expect(service.syncCheckoutReturn('u1', 'cs_plan_1')).rejects.toBeInstanceOf(
+            BillingProviderNotConfiguredError,
+        );
+    });
+});
+
+describe('applyWebhook — activation and revocation', () => {
+    function event(overrides: Partial<BillingWebhookEvent> = {}): BillingWebhookEvent {
+        return {
+            id: 'evt_1',
+            kind: 'subscription.activated',
+            customerId: 'cus_1',
+            referenceId: 'u1:standard',
+            packId: null,
+            amountCents: 2900,
+            currency: 'usd',
+            paymentId: null,
+            providerType: 'checkout.session.completed',
+            planCode: 'standard',
+            subscriptionId: 'sub_1',
+            currentPeriodEnd: new Date('2026-09-01T00:00:00Z'),
+            cancelAtPeriodEnd: false,
+            ...overrides,
+        };
+    }
+
+    it('activates the plan, attributing by provider customer id', async () => {
+        const { service, subscriptionService, profileRepository } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(service.applyWebhook(event())).resolves.toBe('subscription-activated');
+        expect(profileRepository.findByCustomerId).toHaveBeenCalledWith('stripe', 'cus_1');
+        expect(subscriptionService.assignPlanToUser).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'u1' }),
+            'standard',
+        );
+    });
+
+    it('is idempotent — a replayed delivery re-asserts the same tier', async () => {
+        const { service, subscriptionRepository, subscriptionService } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await service.applyWebhook(event());
+        await service.applyWebhook(event());
+
+        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalledTimes(2);
+        expect(subscriptionRepository.createOrUpdate.mock.calls[0][1]).toEqual(
+            subscriptionRepository.createOrUpdate.mock.calls[1][1],
+        );
+        expect(subscriptionService.assignPlanToUser).toHaveBeenCalledTimes(2);
+        expect(subscriptionService.assignPlanToUser).toHaveBeenLastCalledWith(
+            expect.objectContaining({ id: 'u1' }),
+            'standard',
+        );
+    });
+
+    it('acknowledges an unattributable event instead of throwing', async () => {
+        const { service, subscriptionService } = build();
+
+        await expect(
+            service.applyWebhook(event({ customerId: null, referenceId: null })),
+        ).resolves.toBe('unattributed');
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('ignores an activation naming a plan we do not sell', async () => {
+        const { service, subscriptionService } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(service.applyWebhook(event({ planCode: 'enterprise' }))).resolves.toBe(
+            'ignored',
+        );
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('revokes a cancelled subscription back to the free tier', async () => {
+        const { service, subscriptionRepository, subscriptionService } = build({
+            subscriptionRepository: makeSubscriptionRepository({
+                findByProviderSubscriptionId: jest
+                    .fn()
+                    .mockResolvedValue({ id: 'sub-row-1', userId: 'u1' }),
+            }),
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(
+            service.applyWebhook(
+                event({
+                    kind: 'subscription.canceled',
+                    providerType: 'customer.subscription.deleted',
+                }),
+            ),
+        ).resolves.toBe('subscription-canceled');
+        expect(subscriptionRepository.cancel).toHaveBeenCalledWith('sub-row-1');
+        expect(subscriptionService.changePlanSelfService).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'u1' }),
+            'free',
+        );
+    });
+
+    it('never revokes a DIFFERENT live subscription when the named one is not on file', async () => {
+        // The owner may legitimately hold a second, active subscription
+        // this event says nothing about — "cancel whatever is active" is
+        // exactly the wrong fallback.
+        const { service, subscriptionRepository, subscriptionService } = build({
+            subscriptionRepository: makeSubscriptionRepository({
+                findByProviderSubscriptionId: jest.fn().mockResolvedValue(null),
+                findActiveByUser: jest
+                    .fn()
+                    .mockResolvedValue({ id: 'sub-row-other', userId: 'u1' }),
+            }),
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(
+            service.applyWebhook(
+                event({ kind: 'subscription.canceled', subscriptionId: 'sub_unknown' }),
+            ),
+        ).resolves.toBe('ignored');
+        expect(subscriptionRepository.cancel).not.toHaveBeenCalled();
+        expect(subscriptionService.changePlanSelfService).not.toHaveBeenCalled();
+    });
+
+    it('prefers the subscription row over the customer mapping when attributing', async () => {
+        const { service, subscriptionService } = build({
+            subscriptionRepository: makeSubscriptionRepository({
+                findByProviderSubscriptionId: jest
+                    .fn()
+                    .mockResolvedValue({ id: 'sub-row-1', userId: 'owner-of-record' }),
+            }),
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'stale-mapping' }),
+            }),
+            userRepository: makeUserRepository({
+                findById: jest.fn().mockResolvedValue({ id: 'owner-of-record' }),
+            }),
+        });
+
+        await service.applyWebhook(event());
+
+        expect(subscriptionService.assignPlanToUser).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'owner-of-record' }),
+            'standard',
+        );
+    });
+
+    it('still records the provider truth when subscriptions are flag-disabled', async () => {
+        const { service, subscriptionRepository, subscriptionService } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+            subscriptionService: makeSubscriptionService({
+                isEnabled: jest.fn().mockReturnValue(false),
+            }),
+        });
+
+        await expect(service.applyWebhook(event())).resolves.toBe('subscription-activated');
+        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalled();
+        // …but the privileged grant is not attempted on a deploy that
+        // has subscriptions switched off (it would throw by contract).
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -1,0 +1,434 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { BillingProfileRepository } from '@src/database/repositories/billing-profile.repository';
+import { SubscriptionPlanRepository } from '@src/database/repositories/subscription-plan.repository';
+import { UserRepository } from '@src/database/repositories/user.repository';
+import { UserSubscriptionRepository } from '@src/database/repositories/user-subscription.repository';
+import { SubscriptionPlan } from '@src/entities/subscription-plan.entity';
+import { SubscriptionPlanCode } from '@src/entities/types';
+import {
+    SubscriptionBillingProvider,
+    SubscriptionStatus,
+} from '@src/entities/user-subscription.entity';
+import { SubscriptionService } from '../subscription.service';
+import {
+    BillingProvider,
+    BillingProviderNotConfiguredError,
+    type BillingWebhookEvent,
+} from './billing.provider';
+
+/** A checkout was asked for with a plan code that is not sellable. */
+export class UnknownSubscriptionPlanError extends Error {
+    constructor(planCode: string) {
+        super(`Unknown subscription plan: ${planCode}`);
+        this.name = 'UnknownSubscriptionPlanError';
+    }
+}
+
+/**
+ * The plan exists but there is nothing to buy — a free tier, or a plan
+ * row whose price is missing/malformed. Free moves stay on the existing
+ * self-service path (`POST /api/subscriptions/plan`).
+ */
+export class PlanNotPurchasableError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PlanNotPurchasableError';
+    }
+}
+
+/**
+ * The caller asked to finalize a checkout session that is not theirs (or
+ * does not exist). Deliberately ONE error for both, so a session id in a
+ * URL cannot be used to probe other accounts' checkouts — the API maps it
+ * to 404, matching `OrganizationMembershipService`'s existence-leak rule.
+ */
+export class CheckoutSessionNotFoundError extends Error {
+    constructor() {
+        super('Checkout session not found');
+        this.name = 'CheckoutSessionNotFoundError';
+    }
+}
+
+export interface StartPlanCheckoutOptions {
+    userId: string;
+    planCode: string;
+    successUrl: string;
+    cancelUrl: string;
+    organizationId?: string | null;
+    tenantId?: string | null;
+}
+
+export interface PlanCheckoutStarted {
+    url: string;
+    sessionId: string;
+    planCode: string;
+    /** Echoed for the UI's confirmation copy — from the SERVER plan row. */
+    priceCents: number;
+    currency: string;
+}
+
+export interface PlanCheckoutReturn {
+    /** `active` once the plan is in force; `pending` while money settles. */
+    status: 'active' | 'pending' | 'ignored';
+    activated: boolean;
+    planCode: string | null;
+}
+
+/** What `applyWebhook` did, mirrored into the BillingService outcome. */
+export type PlanWebhookAction =
+    | 'subscription-activated'
+    | 'subscription-canceled'
+    | 'ignored'
+    | 'unattributed';
+
+/**
+ * Paid-plan purchase (audit B24).
+ *
+ * Before this service existed the platform had a credit top-up checkout
+ * but **no way to actually buy a tier**: `POST /api/subscriptions/plan`
+ * refuses paid plans by design (EW-711 #23) and `assignPlanToUser` — the
+ * privileged grant — had no caller. This is that caller.
+ *
+ * Three invariants, mirroring {@link BillingService}:
+ *
+ * 1. **The server prices everything.** Checkout takes a plan CODE; the
+ *    recurring amount is read from the `subscription_plans` row. A client
+ *    never supplies a price (the DTO rejects extra fields outright).
+ *
+ * 2. **Only a billing-verified path grants a paid tier.** Activation
+ *    happens from the signature-verified webhook, or from a return-route
+ *    read-back of the session straight from the provider. Neither trusts
+ *    the browser: the return route authorizes on the `userId` WE stamped
+ *    into the session metadata, not on the session id in the URL.
+ *
+ * 3. **Entitlements are untouched.** Activation writes the plan the user
+ *    is on; every limit/lever continues to resolve through
+ *    `EntitlementsService` keyed by plan code. Nothing here grants
+ *    credits or bypasses a gate.
+ */
+@Injectable()
+export class PlanSubscriptionService {
+    private readonly logger = new Logger(PlanSubscriptionService.name);
+
+    constructor(
+        private readonly billingProvider: BillingProvider,
+        private readonly planRepository: SubscriptionPlanRepository,
+        private readonly userSubscriptionRepository: UserSubscriptionRepository,
+        private readonly billingProfileRepository: BillingProfileRepository,
+        private readonly userRepository: UserRepository,
+        private readonly subscriptionService: SubscriptionService,
+    ) {}
+
+    /**
+     * Start a hosted checkout for a recurring plan.
+     *
+     * Fails closed on every axis: subscriptions off, provider not wired,
+     * unknown/inactive plan, or a plan with no positive price.
+     */
+    async startPlanCheckout(options: StartPlanCheckoutOptions): Promise<PlanCheckoutStarted> {
+        if (!this.subscriptionService.isEnabled()) {
+            throw new PlanNotPurchasableError('Subscriptions are disabled on this deployment');
+        }
+        if (!this.billingProvider.isConfigured()) {
+            throw new BillingProviderNotConfiguredError();
+        }
+
+        const plan = await this.resolveSellablePlan(options.planCode);
+        const priceCents = planPriceCents(plan);
+
+        const user = await this.userRepository.findById(options.userId);
+        const existing = await this.billingProfileRepository.findByUserId(options.userId);
+
+        const customerId = await this.billingProvider.ensureCustomer({
+            userId: options.userId,
+            email: user?.email ?? null,
+            existingCustomerId: existing?.providerCustomerId ?? null,
+        });
+
+        const profile = await this.billingProfileRepository.ensure({
+            userId: options.userId,
+            provider: this.billingProvider.getProviderId(),
+            providerCustomerId: customerId,
+            organizationId: options.organizationId ?? null,
+            tenantId: options.tenantId ?? null,
+        });
+
+        const session = await this.billingProvider.createPlanCheckoutSession({
+            userId: options.userId,
+            userEmail: user?.email ?? null,
+            customerId: profile.providerCustomerId,
+            plan: {
+                code: plan.code,
+                label: `${plan.displayName} plan`,
+                priceCents,
+                currency: plan.currency || this.billingProvider.getDefaultCurrency(),
+                interval: 'month',
+            },
+            successUrl: options.successUrl,
+            cancelUrl: options.cancelUrl,
+            referenceId: `${options.userId}:${plan.code}`,
+        });
+
+        return {
+            url: session.url,
+            sessionId: session.sessionId,
+            planCode: plan.code,
+            priceCents,
+            currency: plan.currency,
+        };
+    }
+
+    /**
+     * Finalize the browser's return from a hosted checkout.
+     *
+     * The webhook is still the authority — this exists so a buyer who
+     * lands back on the Billing page sees the new tier immediately
+     * instead of waiting on an asynchronous delivery. It is safe to run
+     * alongside the webhook: both funnel into the same idempotent
+     * {@link activate}.
+     *
+     * SECURITY: `sessionId` is attacker-controllable (it comes back in a
+     * query string). Authorization is the `userId` the PROVIDER stored in
+     * our session metadata — a session belonging to anyone else is
+     * indistinguishable from one that does not exist.
+     */
+    async syncCheckoutReturn(userId: string, sessionId: string): Promise<PlanCheckoutReturn> {
+        if (!this.billingProvider.isConfigured()) {
+            throw new BillingProviderNotConfiguredError();
+        }
+
+        const snapshot = await this.billingProvider.retrieveCheckoutSession(sessionId);
+        if (!snapshot.userId || snapshot.userId !== userId) {
+            throw new CheckoutSessionNotFoundError();
+        }
+        if (snapshot.purpose !== 'plan') {
+            // A credit top-up session returning through this route is not
+            // an error — it simply activates no plan.
+            return { status: 'ignored', activated: false, planCode: null };
+        }
+        if (snapshot.status !== 'complete' || !snapshot.paid) {
+            return { status: 'pending', activated: false, planCode: snapshot.planCode };
+        }
+
+        const activated = await this.activate({
+            userId,
+            planCode: snapshot.planCode,
+            providerSubscriptionId: snapshot.subscriptionId,
+            currentPeriodEnd: snapshot.currentPeriodEnd,
+            cancelAtPeriodEnd: false,
+        });
+
+        return {
+            status: activated ? 'active' : 'pending',
+            activated,
+            planCode: snapshot.planCode,
+        };
+    }
+
+    // ── Webhook ──────────────────────────────────────────────────────
+
+    /**
+     * Apply one verified `subscription.*` delivery. Called by
+     * {@link BillingService.handleWebhook}; never reached for an
+     * unverified payload.
+     */
+    async applyWebhook(event: BillingWebhookEvent): Promise<PlanWebhookAction> {
+        const userId = await this.resolveUserId(event);
+        if (!userId) {
+            this.logger.warn(
+                `Billing webhook ${event.id} (${event.providerType}) — subscription event could not be attributed to an owner; acknowledged`,
+            );
+            return 'unattributed';
+        }
+
+        if (event.kind === 'subscription.activated') {
+            const activated = await this.activate({
+                userId,
+                planCode: event.planCode ?? null,
+                providerSubscriptionId: event.subscriptionId ?? null,
+                currentPeriodEnd: event.currentPeriodEnd ?? null,
+                cancelAtPeriodEnd: event.cancelAtPeriodEnd ?? false,
+            });
+            return activated ? 'subscription-activated' : 'ignored';
+        }
+
+        const canceled = await this.cancel(userId, event.subscriptionId ?? null);
+        return canceled ? 'subscription-canceled' : 'ignored';
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────
+
+    /**
+     * Put a user on a paid plan. Idempotent: re-running for the same
+     * plan rewrites the same row and re-asserts the same default plan, so
+     * a webhook replay (or a webhook racing the return route) moves
+     * nothing twice.
+     */
+    private async activate(input: {
+        userId: string;
+        planCode: string | null;
+        providerSubscriptionId: string | null;
+        currentPeriodEnd: Date | null;
+        cancelAtPeriodEnd: boolean;
+    }): Promise<boolean> {
+        const plan = input.planCode ? await this.findPlanByCode(input.planCode) : null;
+        if (!plan) {
+            this.logger.warn(
+                `Plan activation skipped — unknown plan code '${input.planCode ?? 'none'}'`,
+            );
+            return false;
+        }
+
+        await this.userSubscriptionRepository.createOrUpdate(input.userId, {
+            planCode: plan.code,
+            planId: plan.id,
+            status: SubscriptionStatus.ACTIVE,
+            billingProvider: providerEnum(this.billingProvider.getProviderId()),
+            currentPeriodEnd: input.currentPeriodEnd ?? null,
+            cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+            providerSubscriptionId: input.providerSubscriptionId ?? null,
+        });
+
+        // THE privileged grant (`assignPlanToUser`) — documented as
+        // "call only from a billing-verified path", which is exactly here.
+        // The `user_subscriptions` row above is written regardless so the
+        // provider's truth is recorded even on a deployment where the
+        // subscriptions flag was switched off after the sale.
+        if (this.subscriptionService.isEnabled()) {
+            const user = await this.userRepository.findById(input.userId);
+            if (user) {
+                await this.subscriptionService.assignPlanToUser(user, plan.code);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Revoke a lapsed plan: mark the subscription canceled and drop the
+     * account back to the free tier through the existing self-service
+     * downgrade path (which permits free plans by design).
+     */
+    private async cancel(userId: string, providerSubscriptionId: string | null): Promise<boolean> {
+        let subscription = null;
+        if (providerSubscriptionId) {
+            subscription =
+                await this.userSubscriptionRepository.findByProviderSubscriptionId(
+                    providerSubscriptionId,
+                );
+            if (!subscription) {
+                // The provider named a subscription we never recorded.
+                // Do NOT fall back to "cancel whatever is active on this
+                // account" — an owner can legitimately hold a second,
+                // live subscription that this event says nothing about.
+                this.logger.warn(
+                    'Subscription cancel skipped — provider subscription is not on file',
+                );
+                return false;
+            }
+        } else {
+            subscription = await this.userSubscriptionRepository.findActiveByUser(userId);
+        }
+
+        if (!subscription) {
+            return false;
+        }
+        // Belt and braces: never cancel a row belonging to someone else,
+        // whatever the attribution path decided.
+        if (subscription.userId !== userId) {
+            this.logger.warn(
+                'Subscription cancel skipped — provider subscription belongs to another owner',
+            );
+            return false;
+        }
+        await this.userSubscriptionRepository.cancel(subscription.id);
+
+        if (this.subscriptionService.isEnabled()) {
+            const user = await this.userRepository.findById(userId);
+            if (user) {
+                // Free plans are exactly what `changePlanSelfService`
+                // permits (sign-up default / downgrade / cancel).
+                await this.subscriptionService.changePlanSelfService(
+                    user,
+                    SubscriptionPlanCode.FREE,
+                );
+            }
+        }
+        return Boolean(subscription);
+    }
+
+    // ── Resolution helpers ───────────────────────────────────────────
+
+    private async resolveSellablePlan(planCode: string): Promise<SubscriptionPlan> {
+        const plan = await this.findPlanByCode(planCode);
+        if (!plan || !plan.active) {
+            throw new UnknownSubscriptionPlanError(String(planCode));
+        }
+        if (planPriceCents(plan) <= 0) {
+            throw new PlanNotPurchasableError(
+                'Free plans do not require checkout — switch to them directly',
+            );
+        }
+        return plan;
+    }
+
+    private async findPlanByCode(planCode: string): Promise<SubscriptionPlan | null> {
+        const normalized = String(planCode ?? '').toLowerCase();
+        if (!Object.values(SubscriptionPlanCode).includes(normalized as SubscriptionPlanCode)) {
+            return null;
+        }
+        return this.planRepository.findByCode(normalized as SubscriptionPlanCode);
+    }
+
+    /**
+     * Attribute a verified subscription event to an owner. Provider
+     * customer id first (the mapping we control), then the `referenceId`
+     * WE stamped at checkout — both are server-authored values echoed
+     * back inside a SIGNED event, never client input.
+     */
+    private async resolveUserId(event: BillingWebhookEvent): Promise<string | null> {
+        if (event.subscriptionId) {
+            const existing = await this.userSubscriptionRepository.findByProviderSubscriptionId(
+                event.subscriptionId,
+            );
+            if (existing) {
+                return existing.userId;
+            }
+        }
+        if (event.customerId) {
+            const profile = await this.billingProfileRepository.findByCustomerId(
+                this.billingProvider.getProviderId(),
+                event.customerId,
+            );
+            if (profile) {
+                return profile.userId;
+            }
+        }
+        if (event.referenceId) {
+            const [userId] = event.referenceId.split(':');
+            if (userId) {
+                return userId;
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * `subscription_plans.monthlyPrice` is a DECIMAL string. Fail closed:
+ * anything that does not parse to a finite, positive number prices at 0
+ * (i.e. "not sellable") rather than silently charging something odd.
+ */
+function planPriceCents(plan: SubscriptionPlan): number {
+    const price = Number(plan.monthlyPrice);
+    if (!Number.isFinite(price) || price <= 0) {
+        return 0;
+    }
+    return Math.round(price * 100);
+}
+
+/** Map the provider id onto the entity's closed billing-provider set. */
+function providerEnum(providerId: string): SubscriptionBillingProvider {
+    return providerId === SubscriptionBillingProvider.STRIPE
+        ? SubscriptionBillingProvider.STRIPE
+        : SubscriptionBillingProvider.MANUAL;
+}

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -46,6 +46,7 @@ function fakeClient(overrides: Record<string, unknown> = {}) {
                 create: jest
                     .fn()
                     .mockResolvedValue({ id: 'cs_1', url: 'https://pay.example/cs_1' }),
+                retrieve: jest.fn(),
             },
         },
         paymentIntents: {
@@ -520,5 +521,312 @@ describe('StripeBillingProvider — event normalization', () => {
 
         expect(normalized.customerId).toBe('cus_expanded');
         expect(normalized.paymentId).toBe('pi_expanded');
+    });
+});
+
+describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
+    beforeEach(() => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+    });
+
+    const planRequest = {
+        userId: 'u1',
+        customerId: 'cus_1',
+        plan: {
+            code: 'standard',
+            label: 'Standard plan',
+            priceCents: 2900,
+            currency: 'usd',
+            interval: 'month' as const,
+        },
+        successUrl: 'https://app.test/settings/billing?plan=success',
+        cancelUrl: 'https://app.test/settings/billing?plan=cancelled',
+        referenceId: 'u1:standard',
+    };
+
+    it('creates a recurring session priced from the SERVER plan descriptor', async () => {
+        const { provider, client } = build();
+
+        const session = await provider.createPlanCheckoutSession(planRequest);
+
+        expect(session).toEqual({
+            url: 'https://pay.example/cs_1',
+            sessionId: 'cs_1',
+            customerId: 'cus_1',
+        });
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('subscription');
+        expect(params.line_items[0].price_data.unit_amount).toBe(2900);
+        expect(params.line_items[0].price_data.recurring).toEqual({ interval: 'month' });
+    });
+
+    it('mirrors the plan metadata onto the SUBSCRIPTION so renewals stay attributable', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession(planRequest);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.metadata[STRIPE_METADATA_KEYS.kind]).toBe(
+            STRIPE_PURCHASE_KINDS.planSubscription,
+        );
+        expect(params.metadata[STRIPE_METADATA_KEYS.planCode]).toBe('standard');
+        // Unlike the credit path, the lifecycle events are a DIFFERENT
+        // decision and must carry the plan themselves.
+        expect(params.subscription_data.metadata).toEqual(params.metadata);
+    });
+
+    it('appends its own session-id token to the caller’s clean success URL', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession(planRequest);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.success_url).toBe(
+            'https://app.test/settings/billing?plan=success&session_id={CHECKOUT_SESSION_ID}',
+        );
+        // The cancel URL is passed through untouched.
+        expect(params.cancel_url).toBe('https://app.test/settings/billing?plan=cancelled');
+    });
+
+    it('fails closed with no secret key', async () => {
+        delete process.env.STRIPE_SECRET_KEY;
+        const { provider } = build();
+
+        await expect(provider.createPlanCheckoutSession(planRequest)).rejects.toBeInstanceOf(
+            BillingProviderNotConfiguredError,
+        );
+    });
+
+    it('reads a session back with the metadata WE stamped (the ownership check)', async () => {
+        const client = fakeClient();
+        client.checkout.sessions.retrieve = jest.fn().mockResolvedValue({
+            id: 'cs_plan_1',
+            status: 'complete',
+            payment_status: 'paid',
+            customer: 'cus_1',
+            subscription: { id: 'sub_1', current_period_end: 1790000000 },
+            metadata: {
+                [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
+                [STRIPE_METADATA_KEYS.userId]: 'u1',
+                [STRIPE_METADATA_KEYS.planCode]: 'standard',
+            },
+        });
+        const { provider } = build(client);
+
+        const snapshot = await provider.retrieveCheckoutSession('cs_plan_1');
+
+        expect(snapshot).toEqual(
+            expect.objectContaining({
+                sessionId: 'cs_plan_1',
+                status: 'complete',
+                paid: true,
+                purpose: 'plan',
+                userId: 'u1',
+                planCode: 'standard',
+                customerId: 'cus_1',
+                subscriptionId: 'sub_1',
+            }),
+        );
+        expect(snapshot.currentPeriodEnd).toEqual(new Date(1790000000 * 1000));
+    });
+
+    it('treats a trial session (no payment required) as settled', async () => {
+        const client = fakeClient();
+        client.checkout.sessions.retrieve = jest.fn().mockResolvedValue({
+            id: 'cs_plan_2',
+            status: 'complete',
+            payment_status: 'no_payment_required',
+            metadata: {
+                [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
+                [STRIPE_METADATA_KEYS.userId]: 'u1',
+                [STRIPE_METADATA_KEYS.planCode]: 'standard',
+            },
+        });
+        const { provider } = build(client);
+
+        expect((await provider.retrieveCheckoutSession('cs_plan_2')).paid).toBe(true);
+    });
+
+    it('labels a credit session read through this route as `credits`, not `plan`', async () => {
+        const client = fakeClient();
+        client.checkout.sessions.retrieve = jest.fn().mockResolvedValue({
+            id: 'cs_1',
+            status: 'complete',
+            payment_status: 'paid',
+            metadata: {
+                [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.checkout,
+                [STRIPE_METADATA_KEYS.userId]: 'u1',
+                [STRIPE_METADATA_KEYS.packId]: 'credits-1000',
+            },
+        });
+        const { provider } = build(client);
+
+        const snapshot = await provider.retrieveCheckoutSession('cs_1');
+        expect(snapshot.purpose).toBe('credits');
+        expect(snapshot.planCode).toBeNull();
+    });
+
+    it('never echoes the provider message when a session cannot be read', async () => {
+        const client = fakeClient();
+        client.checkout.sessions.retrieve = jest
+            .fn()
+            .mockRejectedValue(new Error('No such checkout.session: cs_secret; req_123'));
+        const { provider } = build(client);
+
+        await expect(provider.retrieveCheckoutSession('cs_missing')).rejects.toMatchObject({
+            name: 'BillingProviderError',
+            message: 'Checkout session could not be read',
+        });
+    });
+});
+
+describe('StripeBillingProvider — subscription event normalization (audit B24)', () => {
+    beforeEach(() => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+        process.env.STRIPE_WEBHOOK_SECRET = 'whsec_x';
+    });
+
+    function parse(raw: any) {
+        const client = fakeClient({
+            webhooks: { constructEvent: jest.fn().mockReturnValue(raw) },
+        });
+        const { provider } = build(client);
+        return provider.verifyAndParseWebhook('{}', 'sig');
+    }
+
+    const planMeta = {
+        [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
+        [STRIPE_METADATA_KEYS.userId]: 'u1',
+        [STRIPE_METADATA_KEYS.planCode]: 'standard',
+        [STRIPE_METADATA_KEYS.referenceId]: 'u1:standard',
+    };
+
+    it('normalizes a paid plan checkout to subscription.activated', async () => {
+        const normalized = await parse({
+            id: 'evt_p1',
+            type: 'checkout.session.completed',
+            data: {
+                object: {
+                    payment_status: 'paid',
+                    customer: 'cus_1',
+                    client_reference_id: 'u1:standard',
+                    subscription: 'sub_1',
+                    amount_total: 2900,
+                    currency: 'usd',
+                    metadata: planMeta,
+                },
+            },
+        });
+
+        expect(normalized).toEqual(
+            expect.objectContaining({
+                kind: 'subscription.activated',
+                planCode: 'standard',
+                subscriptionId: 'sub_1',
+                customerId: 'cus_1',
+                referenceId: 'u1:standard',
+            }),
+        );
+    });
+
+    it('never activates a plan from an unpaid checkout session', async () => {
+        const normalized = await parse({
+            id: 'evt_p2',
+            type: 'checkout.session.completed',
+            data: { object: { payment_status: 'unpaid', metadata: planMeta } },
+        });
+
+        expect(normalized.kind).toBe('ignored');
+    });
+
+    it('does not confuse a plan checkout with a credit top-up', async () => {
+        const normalized = await parse({
+            id: 'evt_p3',
+            type: 'checkout.session.completed',
+            data: {
+                object: { payment_status: 'paid', amount_total: 2900, metadata: planMeta },
+            },
+        });
+
+        // A plan sale must NEVER credit the usage ledger.
+        expect(normalized.kind).not.toBe('credits.purchased');
+        expect(normalized.packId).toBeNull();
+    });
+
+    it('normalizes an active subscription update to subscription.activated', async () => {
+        const normalized = await parse({
+            id: 'evt_p4',
+            type: 'customer.subscription.updated',
+            data: {
+                object: {
+                    id: 'sub_1',
+                    status: 'active',
+                    customer: 'cus_1',
+                    cancel_at_period_end: true,
+                    current_period_end: 1790000000,
+                    metadata: planMeta,
+                },
+            },
+        });
+
+        expect(normalized).toEqual(
+            expect.objectContaining({
+                kind: 'subscription.activated',
+                subscriptionId: 'sub_1',
+                planCode: 'standard',
+                cancelAtPeriodEnd: true,
+            }),
+        );
+        expect(normalized.currentPeriodEnd).toEqual(new Date(1790000000 * 1000));
+    });
+
+    it('reads the period end from the subscription ITEM when the root field is absent', async () => {
+        const normalized = await parse({
+            id: 'evt_p5',
+            type: 'customer.subscription.updated',
+            data: {
+                object: {
+                    id: 'sub_1',
+                    status: 'trialing',
+                    metadata: planMeta,
+                    items: { data: [{ current_period_end: 1790000001 }] },
+                },
+            },
+        });
+
+        expect(normalized.kind).toBe('subscription.activated');
+        expect(normalized.currentPeriodEnd).toEqual(new Date(1790000001 * 1000));
+    });
+
+    it('normalizes a deleted subscription to subscription.canceled', async () => {
+        const normalized = await parse({
+            id: 'evt_p6',
+            type: 'customer.subscription.deleted',
+            data: { object: { id: 'sub_1', status: 'canceled', metadata: planMeta } },
+        });
+
+        expect(normalized.kind).toBe('subscription.canceled');
+        expect(normalized.subscriptionId).toBe('sub_1');
+    });
+
+    it('does NOT revoke a plan on a transient dunning state', async () => {
+        for (const status of ['past_due', 'incomplete']) {
+            const normalized = await parse({
+                id: `evt_p7_${status}`,
+                type: 'customer.subscription.updated',
+                data: { object: { id: 'sub_1', status, metadata: planMeta } },
+            });
+            expect(normalized.kind).toBe('ignored');
+        }
+    });
+
+    it('ignores a subscription that is not one of ours', async () => {
+        const normalized = await parse({
+            id: 'evt_p8',
+            type: 'customer.subscription.updated',
+            data: { object: { id: 'sub_other', status: 'active', metadata: {} } },
+        });
+
+        expect(normalized.kind).toBe('ignored');
     });
 });

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -14,11 +14,14 @@ import {
     type BillingInvoiceSnapshot,
     type BillingWebhookEvent,
     type BillingWebhookEventKind,
+    type CheckoutSessionSnapshot,
     type CreditCheckoutRequest,
     type CreditCheckoutSession,
     type OffSessionChargeRequest,
     type OffSessionChargeResult,
     type PaymentMethodSummary,
+    type PlanCheckoutRequest,
+    type PlanCheckoutSession,
 } from './billing.provider';
 
 /**
@@ -32,12 +35,21 @@ export const STRIPE_METADATA_KEYS = {
     userId: 'ever_works_user_id',
     packId: 'ever_works_pack_id',
     referenceId: 'ever_works_reference_id',
+    /**
+     * Plan checkout (audit B24). Stamped on the checkout session AND
+     * mirrored onto `subscription_data.metadata`, so the later
+     * `customer.subscription.*` events still carry the plan we sold —
+     * without it a renewal could not be attributed to a tier.
+     */
+    planCode: 'ever_works_plan_code',
 } as const;
 
-/** `kind` metadata values — the two ways a credit purchase can originate. */
+/** `kind` metadata values — how a purchase at the provider originated. */
 export const STRIPE_PURCHASE_KINDS = {
     checkout: 'credit-topup',
     autoRecharge: 'credit-auto-recharge',
+    /** A recurring plan subscription (audit B24). */
+    planSubscription: 'plan-subscription',
 } as const;
 
 export type StripeClientFactory = (secretKey: string) => Stripe;
@@ -187,6 +199,111 @@ export class StripeBillingProvider extends BillingProvider {
         return { url: session.url, sessionId: session.id, customerId };
     }
 
+    /**
+     * Recurring plan checkout (audit B24) — `mode: 'subscription'`.
+     *
+     * Two metadata stamps, deliberately:
+     *   - on the SESSION, so `checkout.session.completed` is attributable
+     *     and the return route can prove ownership;
+     *   - mirrored onto `subscription_data.metadata`, so every later
+     *     `customer.subscription.*` (renewal, cancel, dunning) still
+     *     names the plan. Unlike the credit path — where mirroring onto
+     *     the payment intent would double-credit — a subscription's
+     *     lifecycle events are a DIFFERENT decision than the checkout, so
+     *     they must carry the plan code themselves.
+     */
+    async createPlanCheckoutSession(request: PlanCheckoutRequest): Promise<PlanCheckoutSession> {
+        const stripe = this.requireClient();
+        const customerId = await this.ensureCustomer({
+            userId: request.userId,
+            email: request.userEmail,
+            existingCustomerId: request.customerId,
+        });
+
+        const metadata = {
+            [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
+            [STRIPE_METADATA_KEYS.userId]: request.userId,
+            [STRIPE_METADATA_KEYS.planCode]: request.plan.code,
+            [STRIPE_METADATA_KEYS.referenceId]: request.referenceId,
+        };
+
+        const session = await stripe.checkout.sessions.create({
+            mode: 'subscription',
+            customer: customerId,
+            client_reference_id: request.referenceId,
+            // The seam leaves the session-identifier token to the
+            // implementation; this one is Stripe's.
+            success_url: withSessionIdTemplate(request.successUrl),
+            cancel_url: request.cancelUrl,
+            line_items: [
+                {
+                    quantity: 1,
+                    price_data: {
+                        // Price comes from the SERVER plan row.
+                        currency: request.plan.currency,
+                        unit_amount: request.plan.priceCents,
+                        recurring: { interval: request.plan.interval },
+                        product_data: { name: request.plan.label },
+                    },
+                },
+            ],
+            metadata,
+            subscription_data: { metadata },
+        });
+
+        if (!session.url) {
+            throw new BillingProviderError('Checkout session did not return a redirect URL');
+        }
+        return { url: session.url, sessionId: session.id, customerId };
+    }
+
+    /**
+     * Read one hosted checkout session back for the RETURN route.
+     *
+     * Everything the caller authorizes on (`userId`, `planCode`) comes
+     * from the metadata WE wrote at creation time and the provider stored
+     * server-side — the browser only ever supplies the session id.
+     */
+    async retrieveCheckoutSession(sessionId: string): Promise<CheckoutSessionSnapshot> {
+        const stripe = this.requireClient();
+        let session: Stripe.Checkout.Session;
+        try {
+            session = await stripe.checkout.sessions.retrieve(sessionId, {
+                expand: ['subscription'],
+            });
+        } catch {
+            // Never echo the provider message — it can quote request params.
+            throw new BillingProviderError('Checkout session could not be read');
+        }
+
+        const meta = session.metadata ?? {};
+        const kind = meta[STRIPE_METADATA_KEYS.kind];
+        const subscription = session.subscription;
+        return {
+            sessionId: session.id,
+            status: normalizeSessionStatus(session.status),
+            // A subscription with a trial settles with `no_payment_required`.
+            paid:
+                session.payment_status === 'paid' ||
+                session.payment_status === 'no_payment_required',
+            purpose:
+                kind === STRIPE_PURCHASE_KINDS.planSubscription
+                    ? 'plan'
+                    : kind === STRIPE_PURCHASE_KINDS.checkout
+                      ? 'credits'
+                      : 'other',
+            userId: meta[STRIPE_METADATA_KEYS.userId] ?? null,
+            planCode: meta[STRIPE_METADATA_KEYS.planCode] ?? null,
+            packId: meta[STRIPE_METADATA_KEYS.packId] ?? null,
+            customerId: asId(session.customer),
+            subscriptionId: asId(subscription),
+            currentPeriodEnd:
+                subscription && typeof subscription === 'object'
+                    ? readCurrentPeriodEnd(subscription as Stripe.Subscription)
+                    : null,
+        };
+    }
+
     async chargeOffSession(request: OffSessionChargeRequest): Promise<OffSessionChargeResult> {
         const stripe = this.requireClient();
         try {
@@ -270,6 +387,30 @@ export class StripeBillingProvider extends BillingProvider {
             case 'checkout.session.completed': {
                 const session = event.data.object as Stripe.Checkout.Session;
                 const meta = session.metadata ?? {};
+                // A plan checkout activates a tier; it never touches the
+                // credits ledger. Handled before the credit branch so the
+                // two purchase kinds can never be confused.
+                if (meta[STRIPE_METADATA_KEYS.kind] === STRIPE_PURCHASE_KINDS.planSubscription) {
+                    // A subscription with a trial settles as
+                    // `no_payment_required` — still a live plan.
+                    if (
+                        session.payment_status !== 'paid' &&
+                        session.payment_status !== 'no_payment_required'
+                    ) {
+                        return { ...base, kind: 'ignored' };
+                    }
+                    return {
+                        ...base,
+                        kind: 'subscription.activated',
+                        customerId: asId(session.customer),
+                        referenceId: session.client_reference_id ?? null,
+                        planCode: meta[STRIPE_METADATA_KEYS.planCode] ?? null,
+                        subscriptionId: asId(session.subscription),
+                        amountCents: session.amount_total ?? null,
+                        currency: session.currency ?? null,
+                        cancelAtPeriodEnd: false,
+                    };
+                }
                 // Only OUR credit top-ups credit the ledger.
                 if (meta[STRIPE_METADATA_KEYS.kind] !== STRIPE_PURCHASE_KINDS.checkout) {
                     return { ...base, kind: 'ignored' };
@@ -347,6 +488,44 @@ export class StripeBillingProvider extends BillingProvider {
                 };
             }
 
+            case 'customer.subscription.created':
+            case 'customer.subscription.updated':
+            case 'customer.subscription.deleted': {
+                const subscription = event.data.object as Stripe.Subscription;
+                const meta = subscription.metadata ?? {};
+                // Only subscriptions WE sold carry a plan code. Anything
+                // else on this account is not ours to act on.
+                if (meta[STRIPE_METADATA_KEYS.kind] !== STRIPE_PURCHASE_KINDS.planSubscription) {
+                    return { ...base, kind: 'ignored' };
+                }
+                const live =
+                    event.type !== 'customer.subscription.deleted' &&
+                    (subscription.status === 'active' || subscription.status === 'trialing');
+                const shared = {
+                    ...base,
+                    customerId: asId(subscription.customer),
+                    planCode: meta[STRIPE_METADATA_KEYS.planCode] ?? null,
+                    referenceId: meta[STRIPE_METADATA_KEYS.referenceId] ?? null,
+                    subscriptionId: subscription.id,
+                    currentPeriodEnd: readCurrentPeriodEnd(subscription),
+                    cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
+                };
+                if (live) {
+                    return { ...shared, kind: 'subscription.activated' };
+                }
+                // `incomplete` / `past_due` are transient dunning states —
+                // the plan is not revoked until the provider says it is.
+                if (
+                    event.type === 'customer.subscription.deleted' ||
+                    subscription.status === 'canceled' ||
+                    subscription.status === 'unpaid' ||
+                    subscription.status === 'incomplete_expired'
+                ) {
+                    return { ...shared, kind: 'subscription.canceled' };
+                }
+                return { ...shared, kind: 'ignored' };
+            }
+
             case 'payment_method.attached': {
                 const method = event.data.object as Stripe.PaymentMethod;
                 return {
@@ -394,6 +573,49 @@ function asId(value: unknown): string | null {
         return (value as { id: string }).id;
     }
     return null;
+}
+
+/**
+ * `current_period_end` moved from the subscription root onto each
+ * subscription ITEM in recent API versions. Read both shapes so the
+ * period end survives a provider API-version bump (it is display/renewal
+ * metadata — a missing value degrades to `null`, never an error).
+ */
+function readCurrentPeriodEnd(subscription: Stripe.Subscription): Date | null {
+    const raw = subscription as unknown as Record<string, unknown>;
+    const root = raw['current_period_end'];
+    if (typeof root === 'number') {
+        return toUnixDate(root);
+    }
+    const firstItem = subscription.items?.data?.[0] as unknown as
+        | Record<string, unknown>
+        | undefined;
+    const itemEnd = firstItem?.['current_period_end'];
+    return typeof itemEnd === 'number' ? toUnixDate(itemEnd) : null;
+}
+
+/**
+ * Append Stripe's `{CHECKOUT_SESSION_ID}` template to the caller's clean
+ * success URL. The provider substitutes it at redirect time, which is
+ * how the return route learns which session to read back. Kept in this
+ * file because the token is vendor-specific.
+ */
+function withSessionIdTemplate(successUrl: string): string {
+    if (successUrl.includes('{CHECKOUT_SESSION_ID}')) {
+        return successUrl;
+    }
+    const separator = successUrl.includes('?') ? '&' : '?';
+    return `${successUrl}${separator}session_id={CHECKOUT_SESSION_ID}`;
+}
+
+/** Provider session status → our closed set. Unknown ⇒ still `open`. */
+function normalizeSessionStatus(
+    status: Stripe.Checkout.Session['status'],
+): CheckoutSessionSnapshot['status'] {
+    if (status === 'complete' || status === 'expired') {
+        return status;
+    }
+    return 'open';
 }
 
 function toUnixDate(seconds: number | null | undefined): Date | null {

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -8,6 +8,8 @@ export * from './billing/credit-packs';
 export * from './billing/stripe-billing.provider';
 export * from './billing/billing.service';
 export * from './billing/auto-recharge.service';
+// Paid-plan purchase: checkout, return-route sync, activation (audit B24)
+export * from './billing/plan-subscription.service';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)
 export * from './credits/credit-ledger.service';
 export * from './credits/entitlements.service';

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -11,6 +11,12 @@ import {
 import { StripeBillingProvider, STRIPE_METADATA_KEYS } from './billing/stripe-billing.provider';
 import { BillingService, UnknownCreditPackError } from './billing/billing.service';
 import { AutoRechargeService } from './billing/auto-recharge.service';
+import {
+    CheckoutSessionNotFoundError,
+    PlanNotPurchasableError,
+    PlanSubscriptionService,
+    UnknownSubscriptionPlanError,
+} from './billing/plan-subscription.service';
 import { CREDIT_PACKS, CREDIT_PACK_IDS } from './billing/credit-packs';
 import { CreditLedgerService, InsufficientCreditsError } from './credits/credit-ledger.service';
 import { ENTITLEMENT_KEYS, EntitlementsService } from './credits/entitlements.service';
@@ -84,6 +90,17 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.BillingProviderError).toBe(BillingProviderError);
         });
 
+        it('re-exports the paid-plan purchase path (audit B24)', () => {
+            expect(subscriptionsBarrel.PlanSubscriptionService).toBe(PlanSubscriptionService);
+            expect(subscriptionsBarrel.UnknownSubscriptionPlanError).toBe(
+                UnknownSubscriptionPlanError,
+            );
+            expect(subscriptionsBarrel.PlanNotPurchasableError).toBe(PlanNotPurchasableError);
+            expect(subscriptionsBarrel.CheckoutSessionNotFoundError).toBe(
+                CheckoutSessionNotFoundError,
+            );
+        });
+
         it('exposes the documented runtime symbols only (no extras silently appearing)', () => {
             const runtimeKeys = Object.keys(subscriptionsBarrel).sort();
             expect(runtimeKeys).toEqual(
@@ -108,6 +125,11 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'BILLING_PAYMENT_REF_TYPE',
                     'UnknownCreditPackError',
                     'AutoRechargeService',
+                    // Paid-plan purchase (audit B24)
+                    'PlanSubscriptionService',
+                    'UnknownSubscriptionPlanError',
+                    'PlanNotPurchasableError',
+                    'CheckoutSessionNotFoundError',
                     // Credits ledger + plan entitlements (pricing Wave 9 M1)
                     'CreditLedgerService',
                     'InsufficientCreditsError',
@@ -194,6 +216,11 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(exports).toContain(AutoRechargeService);
         });
 
+        it('declares + exports PlanSubscriptionService (audit B24 — paid-plan checkout)', () => {
+            expect(getMeta('providers')).toContain(PlanSubscriptionService);
+            expect(getMeta('exports')).toContain(PlanSubscriptionService);
+        });
+
         it('pins the credit-pack table to the packs published on the website', () => {
             expect(CREDIT_PACK_IDS).toEqual(['credits-1000', 'credits-5500', 'credits-25000']);
             expect(CREDIT_PACKS.map((p) => [p.priceCents, p.credits])).toEqual([
@@ -209,6 +236,9 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                 userId: 'ever_works_user_id',
                 packId: 'ever_works_pack_id',
                 referenceId: 'ever_works_reference_id',
+                // Audit B24 — mirrored onto subscription_data.metadata so
+                // renewals/cancels stay attributable to a tier.
+                planCode: 'ever_works_plan_code',
             });
         });
 

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -7,6 +7,7 @@ import { BillingProvider, ManualBillingProvider } from './billing/billing.provid
 import { StripeBillingProvider } from './billing/stripe-billing.provider';
 import { BillingService } from './billing/billing.service';
 import { AutoRechargeService } from './billing/auto-recharge.service';
+import { PlanSubscriptionService } from './billing/plan-subscription.service';
 import { CreditLedgerService } from './credits/credit-ledger.service';
 import { EntitlementsService } from './credits/entitlements.service';
 import { RunCostSettlementService } from './credits/run-cost-settlement.service';
@@ -37,6 +38,10 @@ import { UsageSummaryService } from './credits/usage-summary.service';
         // auto-recharge. Additive beside the read-only credits surface.
         BillingService,
         AutoRechargeService,
+        // Paid-plan purchase (audit B24) — the checkout + return + webhook
+        // path that actually puts an account on a paid tier. Additive
+        // beside the credit top-up path; shares the same provider seam.
+        PlanSubscriptionService,
         // Both provider implementations are instantiable; the factory
         // below picks one PER DEPLOYMENT from configuration. Keeping
         // ManualBillingProvider as a real provider means the fallback is
@@ -63,6 +68,7 @@ import { UsageSummaryService } from './credits/usage-summary.service';
         UsageSummaryService,
         BillingService,
         AutoRechargeService,
+        PlanSubscriptionService,
         BillingProvider,
     ],
 })


### PR DESCRIPTION
## The problem

There was **no plan/subscription checkout route**, so no paid tier could be
purchased at all. The Billing page could list plans and nothing more.

## What changed

- `POST /api/billing/checkout/plan` — creates the hosted checkout session and
  returns the provider redirect URL.
- `GET /api/billing/checkout/plan/return` — finalizes the browser's return so
  the buyer sees the new tier without waiting on the webhook. The webhook
  remains the authority; both paths funnel into the same idempotent activation.
- The web action wiring it to the existing Billing settings page.
- `providerSubscriptionId` column + migration `1784700000000`.

Everything goes through the existing Stripe billing provider via the
established facade/plugin seam — **no hand-written Stripe REST calls**.

## Security posture

| Rule | How |
|---|---|
| Buyer is always the session user | `@CurrentUser().userId`; no body field can name another, and nothing reads one |
| No caller-supplied price | Only a **plan code** crosses the wire; the server prices it |
| No cross-org checkout | `organizationId` goes through `OrganizationMembershipService` — the one audited tenant-ownership check — **before** the provider is contacted |
| No open redirect | Return URLs built server-side from `WEB_URL` |
| No existence oracle | The return route treats the session id as untrusted; ownership is the userId the *provider* stored in session metadata, and someone else's session answers **404, not 403** |
| No unmapped 500 | Every failure maps to a typed status (the money path rule, billing PRD §6) |

## A bug found and fixed in this change's own code

The return handler was:

```ts
return { status: 'success', ...result };
```

The spread comes **after** the literal key, so `result.status` overwrote
`'success'`. That matters more than it first looks:
`PlanCheckoutReturn.status` is a meaningful tri-state —
`'active' | 'pending' | 'ignored'` — and it is **not** redundant with
`activated`. `'ignored'` is how a *credit top-up* session that returned through
this plan route reports back (not an error — it simply activates no plan). The
envelope and the domain field were fighting over one key, and information was
lost whichever won.

`status: 'success'` **is** a real convention in this repo
(`account.controller.ts:188`, `works.controller.ts:296`, data-sync) — but it is
used by endpoints that return nothing else meaningful. Here there is a real
payload, and the web-side `PlanCheckoutReturnResponse` type already described
`{ status, activated, planCode }`. So the envelope was the mistake. The route
now returns the service result verbatim, matching the declared web type exactly.

The sibling `POST` route keeps its envelope — its payload has no `status` key,
so there is no collision there.

### On the test change

The branch's own spec asserted `status: 'success'`, a value the domain type can
**never** produce; it could only pass by destroying the tri-state. It now
asserts the true contract. This is a correction, not a weakening — the
security assertion beside it (another account's session → 404, not 403) is
untouched, as is every other test in the file.

Also tightened `PlanCheckoutReturnResponse.status` from `string` to the real
union, and moved a JSDoc that documented `status` while sitting on `activated`.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 439 suites, 7951 tests |
| `apps/api` jest | green — 228 suites, 3702 tests |
| `apps/web` tsc --noEmit | green |
| `pnpm build --filter=ever-works-web` | green (clears the `'use client'` server-only-import trap) |
| prettier | clean |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paid subscription-plan checkout with server-controlled pricing.
  * Added hosted checkout redirects and return-status handling.
  * Added organization authorization during checkout.
  * Added automatic subscription activation, cancellation, and plan entitlement updates from payment events.
  * Added billing settings controls for upgrading to eligible paid plans.

* **Bug Fixes**
  * Improved checkout ownership validation and safe handling of pending, invalid, or unconfigured payment sessions.
  * Prevented duplicate upgrade requests and unintended subscription changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->