### PR TITLE
fix(terminal): give the provider seam consumers, a viewer role and cliSessionId (W1 M5/M10/M6)

### DIFF
--- a/apps/api/src/terminal/__tests__/terminal-attach.controller.spec.ts
+++ b/apps/api/src/terminal/__tests__/terminal-attach.controller.spec.ts
@@ -1,6 +1,6 @@
 import { ConflictException, NotFoundException, ServiceUnavailableException } from '@nestjs/common';
 import { TerminalAttachController } from '../terminal-attach.controller';
-import { TerminalAttachService } from '../terminal-attach.service';
+import { TerminalAttachService, resolveRequestedAttachRole } from '../terminal-attach.service';
 import { TerminalRelayRegistry } from '../terminal-relay.registry';
 import type { AgentsService, TerminalSessionLauncher } from '@ever-works/agent/agents';
 import type { AgentRunRepository } from '@ever-works/agent/database';
@@ -46,6 +46,46 @@ describe('TerminalAttachController — run-scoped authorization', () => {
         expect(claims).toMatchObject({ userId: 'user-1', runId: RUN, role: 'driver' });
     });
 
+    /**
+     * The relay has always refused viewer input and the pane has always
+     * rendered a read-only badge, but nothing ever MINTED a viewer token
+     * — the role was decorative. These pin the mint side.
+     */
+    describe('viewer role', () => {
+        it('mints a read-only viewer token when the caller asks for one', async () => {
+            const result = await controller.mintAttachToken(AUTH, AGENT, RUN, 'viewer');
+
+            expect(result.role).toBe('viewer');
+            expect(new TerminalAttachService().verify(result.token)).toMatchObject({
+                userId: 'user-1',
+                runId: RUN,
+                role: 'viewer',
+            });
+        });
+
+        it('still runs the SAME run-ownership authorization for a viewer mint', async () => {
+            runs.findByIdAndUser.mockResolvedValueOnce(null);
+            await expect(
+                controller.mintAttachToken(AUTH, AGENT, RUN, 'viewer'),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('clamps every other requested role to driver — a request can only downgrade', async () => {
+            for (const requested of ['worker', 'admin', 'DRIVER', '', undefined]) {
+                const result = await controller.mintAttachToken(AUTH, AGENT, RUN, requested);
+                expect(result.role).toBe('driver');
+            }
+        });
+
+        it('resolveRequestedAttachRole is case/whitespace tolerant but fail-closed', () => {
+            expect(resolveRequestedAttachRole('viewer')).toBe('viewer');
+            expect(resolveRequestedAttachRole('  VIEWER ')).toBe('viewer');
+            expect(resolveRequestedAttachRole('worker')).toBe('driver');
+            expect(resolveRequestedAttachRole(null)).toBe('driver');
+            expect(resolveRequestedAttachRole(undefined)).toBe('driver');
+        });
+    });
+
     it('404s (no existence leak) when the run is cross-user or cross-agent', async () => {
         runs.findByIdAndUser.mockResolvedValueOnce(null);
         await expect(controller.mintAttachToken(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(
@@ -64,6 +104,28 @@ describe('TerminalAttachController — run-scoped authorization', () => {
 
         runs.findByIdAndUser.mockResolvedValueOnce(null);
         await expect(controller.status(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    /**
+     * Now that `cliSessionId` actually gets written, the presence-only
+     * exposure rule stops being theoretical: the resume key is a
+     * credential-shaped handle and must never ride a status payload.
+     */
+    it('reports cliSessionId PRESENCE only — never the value', async () => {
+        runs.findByIdAndUser.mockResolvedValue({
+            id: RUN,
+            agentId: AGENT,
+            cliSessionId: 'pty-local:secret-session:4242',
+        });
+
+        const status = await controller.status(AUTH, AGENT, RUN);
+
+        expect(status.run.hasCliSession).toBe(true);
+        expect(JSON.stringify(status)).not.toContain('secret-session');
+        expect(JSON.stringify(status)).not.toContain('cliSessionId');
+
+        runs.findByIdAndUser.mockResolvedValue({ id: RUN, agentId: AGENT, cliSessionId: null });
+        expect((await controller.status(AUTH, AGENT, RUN)).run.hasCliSession).toBe(false);
     });
 
     /**

--- a/apps/api/src/terminal/__tests__/terminal-internal.controller.spec.ts
+++ b/apps/api/src/terminal/__tests__/terminal-internal.controller.spec.ts
@@ -123,6 +123,31 @@ describe('TerminalInternalController', () => {
         expect('terminalEndedReason' in patch).toBe(false);
     });
 
+    /**
+     * `cliSessionId` is the run's resume key. The session host now sends
+     * it on the attached beat (it had no writer before), so this pins
+     * the persistence half of that contract — plus the cap that keeps a
+     * hostile worker from stuffing the column.
+     */
+    it('heartbeat persists the session-host cliSessionId, capped at 128 chars', async () => {
+        configure();
+        await controller.heartbeat(bearer, undefined, RUN, {
+            state: 'attached',
+            cliSessionId: 'pty-local:run-1:4242',
+        });
+        expect(runsRepo.updateTerminalColumns).toHaveBeenCalledWith(
+            RUN,
+            expect.objectContaining({ cliSessionId: 'pty-local:run-1:4242' }),
+        );
+
+        runsRepo.updateTerminalColumns.mockClear();
+        await controller.heartbeat(bearer, undefined, RUN, {
+            state: 'attached',
+            cliSessionId: 'x'.repeat(129),
+        });
+        expect('cliSessionId' in runsRepo.updateTerminalColumns.mock.calls[0][1]).toBe(false);
+    });
+
     it('heartbeat also honors the x-trigger-secret header (house internal-API convention)', async () => {
         configure();
         await controller.heartbeat(undefined, 'internal-secret-value', RUN, {

--- a/apps/api/src/terminal/terminal-attach.controller.ts
+++ b/apps/api/src/terminal/terminal-attach.controller.ts
@@ -23,7 +23,11 @@ import {
 import { AgentRunRepository } from '@ever-works/agent/database';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
-import { TerminalAttachService } from './terminal-attach.service';
+import {
+    TerminalAttachService,
+    resolveRequestedAttachRole,
+    type TerminalRequestedRole,
+} from './terminal-attach.service';
 import { TerminalRelayRegistry } from './terminal-relay.registry';
 
 /**
@@ -34,9 +38,11 @@ import { TerminalRelayRegistry } from './terminal-relay.registry';
  * ownership (`AgentsService.getOne`) + user-scoped run lookup + agentId
  * match — cross-user or cross-agent runIds 404 with no existence leak.
  *
- * Role v1: the run's owner attaches as `driver`. The richer matrix
- * (work-member viewers, agent guardrail flag) rides the policy-matrix
- * milestone — fail-closed until then: non-owners simply 404.
+ * Roles: the run's owner attaches as `driver` by default and may ask
+ * for a read-only `viewer` attach (`?role=viewer`) — a downgrade of a
+ * right it already holds, which is why it needs no extra check. WHO
+ * else may attach (work-member viewers, agent guardrail flag) is the
+ * policy-matrix milestone — fail-closed until then: non-owners 404.
  */
 @ApiTags('terminal')
 @Controller('api/agents/:id/runs/:runId/terminal')
@@ -66,26 +72,46 @@ export class TerminalAttachController {
         return run;
     }
 
+    /**
+     * Mint an attach token for this run's terminal socket.
+     *
+     * `?role=viewer` mints a READ-ONLY attach: the relay refuses viewer
+     * stdin/resize (answering the sender an `error` frame) and the pane
+     * renders its read-only badge. That is how a second participant —
+     * or a second tab that must not fight the driver for the keyboard —
+     * watches a live session. Anything else, including the internal
+     * `worker` role, resolves to `driver`: a request may downgrade
+     * itself, never upgrade.
+     */
     @Post('attach-token')
     @ApiOperation({
         summary:
             'Mint a short-lived signed attach token for this run’s terminal WebSocket. ' +
-            'Present it in the FIRST WebSocket message (never in the URL).',
+            'Present it in the FIRST WebSocket message (never in the URL). ' +
+            '`?role=viewer` mints a read-only attach.',
     })
+    @ApiQuery({ name: 'role', required: false, enum: ['driver', 'viewer'] })
     @HttpCode(HttpStatus.CREATED)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     async mintAttachToken(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) agentId: string,
         @Param('runId', ParseUUIDPipe) runId: string,
-    ): Promise<{ token: string; wsPath: string; role: string; expiresInSec: number }> {
+        @Query('role') requestedRole?: string,
+    ): Promise<{
+        token: string;
+        wsPath: string;
+        role: TerminalRequestedRole;
+        expiresInSec: number;
+    }> {
         await this.authorizeRun(auth.userId, agentId, runId);
+        const role = resolveRequestedAttachRole(requestedRole);
         const { token, expiresInSec } = this.attach.mint({
             userId: auth.userId,
             runId,
-            role: 'driver',
+            role,
         });
-        return { token, wsPath: `/ws/terminal/${runId}`, role: 'driver', expiresInSec };
+        return { token, wsPath: `/ws/terminal/${runId}`, role, expiresInSec };
     }
 
     /**

--- a/apps/api/src/terminal/terminal-attach.service.ts
+++ b/apps/api/src/terminal/terminal-attach.service.ts
@@ -27,6 +27,28 @@ export interface TerminalAttachClaims {
 
 export const TERMINAL_ATTACH_TOKEN_TTL_SECONDS = 60;
 
+/** Roles a BROWSER may ever be minted. `worker` is internal-only. */
+export type TerminalRequestedRole = Extract<TerminalClientRole, 'driver' | 'viewer'>;
+
+/**
+ * Resolve the role an attach-token request asks for.
+ *
+ * The relay has always understood `viewer` (read-only: its inbound leg
+ * refuses viewer stdin with an error frame answered to the sender) and
+ * the pane has always rendered a read-only badge for it — but nothing
+ * ever MINTED one, so the role was decorative. This is the mint side:
+ * a second participant opens the same run read-only by asking for
+ * `role=viewer`.
+ *
+ * Fail-closed in the only direction that matters: `worker` (the
+ * internally-brokered publish role) and every unknown value collapse to
+ * `driver`, which the caller has already been authorized for — a
+ * request can DOWNGRADE itself, never upgrade.
+ */
+export function resolveRequestedAttachRole(raw?: string | null): TerminalRequestedRole {
+    return typeof raw === 'string' && raw.trim().toLowerCase() === 'viewer' ? 'viewer' : 'driver';
+}
+
 @Injectable()
 export class TerminalAttachService {
     private secret(): Buffer | null {

--- a/apps/web/e2e/flow-terminal-attach-contract.spec.ts
+++ b/apps/web/e2e/flow-terminal-attach-contract.spec.ts
@@ -14,6 +14,8 @@ import {
  * ── Routes (apps/api/src/terminal/terminal-attach.controller.ts) ────
  *   POST /api/agents/:id/runs/:runId/terminal/attach-token → 201
  *        { token, wsPath:'/ws/terminal/<runId>', role:'driver', expiresInSec }
+ *        `?role=viewer` mints a READ-ONLY attach (the relay refuses
+ *        viewer stdin); every other requested role clamps to driver.
  *        503 when neither TERMINAL_ATTACH_SECRET nor BETTER_AUTH_SECRET
  *        is set (fail-closed: an unsecured relay refuses attaches).
  *   POST /api/agents/:id/runs/:runId/terminal/start        → 202
@@ -99,6 +101,33 @@ test.describe('terminal attach-token', () => {
         expect(body.expiresInSec).toBeGreaterThan(0);
         // Short-lived by construction — a leak must have a small blast radius.
         expect(body.expiresInSec).toBeLessThanOrEqual(300);
+    });
+
+    test('?role=viewer mints a read-only attach; every other role clamps to driver', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, user);
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+
+        const base = `${API_BASE}${terminalBase(agentId, runId as string)}/attach-token`;
+        const viewer = await request.post(`${base}?role=viewer`, {
+            headers: authedHeaders(user.access_token),
+        });
+        expect([201, 503], `attach-token returned ${viewer.status()}`).toContain(viewer.status());
+        test.skip(viewer.status() === 503, 'no attach-token signing secret on this install');
+
+        expect((await viewer.json()).role).toBe('viewer');
+
+        // A request may DOWNGRADE itself, never upgrade: the internal
+        // `worker` role and anything unknown collapse to driver.
+        for (const requested of ['worker', 'root', 'DRIVER']) {
+            const clamped = await request.post(`${base}?role=${requested}`, {
+                headers: authedHeaders(user.access_token),
+            });
+            expect(clamped.status()).toBe(201);
+            expect((await clamped.json()).role).toBe('driver');
+        }
     });
 
     test('cross-user and cross-agent run ids 404 with no existence leak; anon is 401', async ({

--- a/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/attach-token/route.ts
+++ b/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/attach-token/route.ts
@@ -22,7 +22,7 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
  * response (never a URL) and the browser presents it as the first WS
  * message.
  */
-export async function POST(_request: NextRequest, ctx: RouteContext) {
+export async function POST(request: NextRequest, ctx: RouteContext) {
     const { id, runId } = await ctx.params;
     if (!UUID.test(id) || !UUID.test(runId)) {
         return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
@@ -33,11 +33,19 @@ export async function POST(_request: NextRequest, ctx: RouteContext) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const upstream = await fetch(`${API_URL}/agents/${id}/runs/${runId}/terminal/attach-token`, {
-        method: 'POST',
-        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
-        cache: 'no-store',
-    });
+    // Only the read-only downgrade is forwarded — never a raw
+    // caller-supplied role. The API clamps too; this keeps the proxy
+    // from being the place a new role could be smuggled in.
+    const roleQuery = request.nextUrl.searchParams.get('role') === 'viewer' ? '?role=viewer' : '';
+
+    const upstream = await fetch(
+        `${API_URL}/agents/${id}/runs/${runId}/terminal/attach-token${roleQuery}`,
+        {
+            method: 'POST',
+            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            cache: 'no-store',
+        },
+    );
 
     if (!upstream.ok) {
         const text = await upstream.text().catch(() => '');

--- a/apps/web/src/components/terminal/TerminalPane.tsx
+++ b/apps/web/src/components/terminal/TerminalPane.tsx
@@ -30,9 +30,20 @@ export interface TerminalPaneProps {
     /** Injectable for tests: renderer + network seams. */
     createRenderer?: () => Promise<TerminalRenderer>;
     attachDeps?: TerminalAttachDeps;
+    /**
+     * Attach read-only — mints a `viewer` token, so this pane watches a
+     * session someone else is driving instead of taking the keyboard.
+     */
+    readOnly?: boolean;
 }
 
-export function TerminalPane({ agentId, runId, createRenderer, attachDeps }: TerminalPaneProps) {
+export function TerminalPane({
+    agentId,
+    runId,
+    createRenderer,
+    attachDeps,
+    readOnly,
+}: TerminalPaneProps) {
     const t = useTranslations('dashboard.terminal');
     const hostRef = useRef<HTMLDivElement | null>(null);
     const rendererRef = useRef<TerminalRenderer | null>(null);
@@ -52,6 +63,7 @@ export function TerminalPane({ agentId, runId, createRenderer, attachDeps }: Ter
             },
         },
         attachDeps,
+        { readOnly: readOnly === true },
     );
 
     // Mount the renderer imperatively, once, into the child-free host.

--- a/apps/web/src/components/terminal/use-terminal-attach.ts
+++ b/apps/web/src/components/terminal/use-terminal-attach.ts
@@ -55,6 +55,17 @@ export interface TerminalAttachDeps {
     webSocketImpl?: typeof WebSocket;
 }
 
+export interface TerminalAttachOptions {
+    /**
+     * Attach read-only (mints a `viewer` token instead of a `driver`
+     * one). The relay refuses viewer stdin/resize server-side, so this
+     * is a real role, not a UI-only affordance — a second participant
+     * can watch a live session without fighting the driver for the
+     * keyboard.
+     */
+    readOnly?: boolean;
+}
+
 /** Bound on rehydration paging so a huge transcript cannot spin forever. */
 const TRANSCRIPT_MAX_PAGES = 20;
 
@@ -70,7 +81,9 @@ export function useTerminalAttach(
     runId: string,
     callbacks: TerminalAttachCallbacks,
     deps: TerminalAttachDeps = {},
+    options: TerminalAttachOptions = {},
 ): TerminalAttachApi {
+    const readOnly = options.readOnly === true;
     const [state, setState] = useState<TerminalAttachState>('starting');
     const [endedReason, setEndedReason] = useState<string | null>(null);
     const [role, setRole] = useState<'driver' | 'viewer' | null>(null);
@@ -145,7 +158,9 @@ export function useTerminalAttach(
             let wsUrl: string;
             try {
                 const res = await doFetch(
-                    `/api/agents/${agentId}/runs/${runId}/terminal/attach-token`,
+                    `/api/agents/${agentId}/runs/${runId}/terminal/attach-token${
+                        readOnly ? '?role=viewer' : ''
+                    }`,
                     { method: 'POST' },
                 );
                 if (res.status === 401 || res.status === 403 || res.status === 404) {
@@ -250,7 +265,7 @@ export function useTerminalAttach(
             }
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [agentId, runId, nonce]);
+    }, [agentId, runId, nonce, readOnly]);
 
     const sendInput = useCallback(
         (data: string) => {

--- a/packages/agent/src/agents/__tests__/terminal-session-launcher.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/terminal-session-launcher.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../terminal-session-dispatcher';
 import type { AgentRunRepository } from '../../database/repositories/agent-run.repository';
 import type { TerminalSessionDispatcher } from '../terminal-session-dispatcher';
+import type { TerminalStreamFacadeService } from '../../facades/terminal-stream.facade';
 
 const USER = 'user-1';
 const AGENT = '11111111-2222-4333-8444-555555555555';
@@ -41,10 +42,11 @@ describe('TerminalSessionLauncher', () => {
         dispatcher = { enqueue: jest.fn().mockResolvedValue({ jobRunId: 'job_run_1' }) };
     });
 
-    function makeLauncher(withDispatcher = true) {
+    function makeLauncher(withDispatcher = true, facade?: { resolveProvider: jest.Mock }) {
         return new TerminalSessionLauncher(
             runs as unknown as AgentRunRepository,
             withDispatcher ? (dispatcher as unknown as TerminalSessionDispatcher) : undefined,
+            facade as unknown as TerminalStreamFacadeService,
         );
     }
 
@@ -199,6 +201,71 @@ describe('TerminalSessionLauncher', () => {
         ).rejects.toThrow('job runtime down');
 
         expect(runs.releaseTerminalSessionClaim).toHaveBeenCalledWith(RUN, 'crashed');
+    });
+
+    /**
+     * The `terminal-stream` facade had ZERO non-test consumers, so its
+     * whole provider-resolution matrix was decoration. The start path is
+     * now one of them: the resolved provider identity rides the dispatch
+     * so the worker hosts the provider the scope actually chose.
+     */
+    describe('terminal-stream provider resolution', () => {
+        it('puts the facade-resolved provider (and work scope) on the dispatch', async () => {
+            runs.findByIdAndUser.mockResolvedValue(makeRun({ workId: 'work-9' }));
+            const facade = {
+                resolveProvider: jest.fn().mockResolvedValue({ id: 'pty-ssh' }),
+            };
+
+            await makeLauncher(true, facade).startForRun({
+                userId: USER,
+                agentId: AGENT,
+                runId: RUN,
+            });
+
+            expect(facade.resolveProvider).toHaveBeenCalledWith({
+                userId: USER,
+                agentId: AGENT,
+                workId: 'work-9',
+            });
+            expect(dispatcher.enqueue).toHaveBeenCalledWith(
+                expect.objectContaining({ providerId: 'pty-ssh', workId: 'work-9' }),
+            );
+        });
+
+        it('still dispatches (without a provider id) when nothing is enabled', async () => {
+            const facade = { resolveProvider: jest.fn().mockResolvedValue(null) };
+
+            const outcome = await makeLauncher(true, facade).startForRun({
+                userId: USER,
+                agentId: AGENT,
+                runId: RUN,
+            });
+
+            // An empty capability registry is allowed; a dead terminal
+            // button is not. The worker falls back to its bundled floor.
+            expect(outcome).toMatchObject({ started: true });
+            expect(dispatcher.enqueue.mock.calls[0][0]).not.toHaveProperty('providerId');
+        });
+
+        it('never lets a resolution failure fail the start', async () => {
+            const facade = {
+                resolveProvider: jest.fn().mockRejectedValue(new Error('registry down')),
+            };
+
+            await expect(
+                makeLauncher(true, facade).startForRun({
+                    userId: USER,
+                    agentId: AGENT,
+                    runId: RUN,
+                }),
+            ).resolves.toMatchObject({ started: true });
+            expect(dispatcher.enqueue.mock.calls[0][0]).not.toHaveProperty('providerId');
+        });
+
+        it('dispatches with no provider id at all when no facade is bound', async () => {
+            await makeLauncher().startForRun({ userId: USER, agentId: AGENT, runId: RUN });
+            expect(dispatcher.enqueue.mock.calls[0][0]).not.toHaveProperty('providerId');
+        });
     });
 
     it('uses the run’s isolated worktree as cwd when it has one', async () => {

--- a/packages/agent/src/agents/terminal-session-dispatcher.ts
+++ b/packages/agent/src/agents/terminal-session-dispatcher.ts
@@ -23,6 +23,15 @@ export interface TerminalSessionDispatchPayload {
     /** Extra env for the child. NEVER credentials — those resolve job-side. */
     env?: Record<string, string>;
     persistent?: boolean;
+    /**
+     * The `terminal-stream` provider the facade resolved for this scope,
+     * forwarded to the worker as its `providerOverride` so both sides
+     * host the SAME provider. Absent when no provider resolved — the
+     * worker then resolves (or falls back) on its own.
+     */
+    providerId?: string;
+    /** Work scope, when the run has one — feeds the facade's settings hierarchy. */
+    workId?: string;
 }
 
 export interface TerminalSessionDispatcher {

--- a/packages/agent/src/agents/terminal-session-launcher.service.ts
+++ b/packages/agent/src/agents/terminal-session-launcher.service.ts
@@ -1,10 +1,12 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { TerminalStreamFacadeService } from '../facades/terminal-stream.facade';
 import {
     TERMINAL_SESSION_COMMAND_ENV,
     TERMINAL_SESSION_DISPATCHER,
     resolveTerminalSessionCommand,
     type TerminalSessionDispatcher,
+    type TerminalSessionDispatchPayload,
 } from './terminal-session-dispatcher';
 
 /**
@@ -22,6 +24,11 @@ import {
  *  - **Duplicate refusal** — the terminal slot is CAS-claimed
  *    (`casClaimTerminalSession`), so concurrent starts resolve to exactly
  *    one dispatch and the losers report `session-already-live`.
+ *  - **Provider identity** — the `terminal-stream` facade resolves WHICH
+ *    session-host provider applies for the scope and the resolved id
+ *    rides the dispatch payload. Advisory only: an empty capability
+ *    registry still starts a session (the worker falls back to its
+ *    bundled provider), it just does not get to choose.
  *  - **Persistent gate** — `requirePersistent` is what the automatic
  *    dispatch path (task fan-out) passes: a run that never asked for a
  *    long-lived interactive session must not spawn one, and must not pay
@@ -82,6 +89,11 @@ export class TerminalSessionLauncher {
         @Optional()
         @Inject(TERMINAL_SESSION_DISPATCHER)
         private readonly dispatcher?: TerminalSessionDispatcher,
+        // Appended LAST + @Optional() so every positional
+        // `new TerminalSessionLauncher(...)` in the existing specs keeps
+        // compiling, and an install without the facades module still
+        // starts sessions (the worker then resolves the provider itself).
+        @Optional() private readonly terminalStream?: TerminalStreamFacadeService,
     ) {}
 
     /** Whether a job runtime is wired at all (drives the 503 vs 409 split). */
@@ -128,16 +140,28 @@ export class TerminalSessionLauncher {
         // worker's own cwd — `.` resolves job-side, which is the only
         // machine that can answer that question.
         const cwd = run.workspaceMeta?.path ?? '.';
+        const workId = run.workId ?? undefined;
+        const providerId = await this.resolveProviderId(input.userId, run.agentId, workId);
 
         try {
-            const { jobRunId } = await this.dispatcher.enqueue({
+            const payload: TerminalSessionDispatchPayload = {
                 runId: run.id,
                 userId: input.userId,
                 agentId: run.agentId,
                 command,
                 cwd,
                 persistent: input.markPersistent === true || run.persistent === true,
-            });
+            };
+            // Explicit ifs, never a conditional spread: `...x && {k:v}`
+            // widens to `false` and breaks declaration emit for this
+            // package (documented house trap).
+            if (providerId) {
+                payload.providerId = providerId;
+            }
+            if (workId) {
+                payload.workId = workId;
+            }
+            const { jobRunId } = await this.dispatcher.enqueue(payload);
             return { started: true, runId: run.id, jobRunId };
         } catch (error) {
             // The claim outlived its session — hand the slot back so the
@@ -150,6 +174,43 @@ export class TerminalSessionLauncher {
                     ),
                 );
             throw error;
+        }
+    }
+
+    /**
+     * Ask the `terminal-stream` facade WHICH provider this scope should
+     * use, so the dispatch carries a provider identity instead of the
+     * worker silently picking one by import.
+     *
+     * Advisory, never a refusal: `resolveProvider` already answers
+     * `null` instead of throwing when nothing is enabled, and an install
+     * with no facade bound gets `undefined` here. Either way the session
+     * still starts — the worker falls back to its bundled provider. A
+     * capability seam is allowed to be empty; a terminal button is not
+     * allowed to stop working because of it.
+     */
+    private async resolveProviderId(
+        userId: string,
+        agentId: string,
+        workId?: string,
+    ): Promise<string | undefined> {
+        if (!this.terminalStream) {
+            return undefined;
+        }
+        try {
+            const provider = await this.terminalStream.resolveProvider({
+                userId,
+                agentId,
+                workId,
+            });
+            return provider?.id;
+        } catch (error) {
+            this.logger.debug(
+                `terminal-stream provider resolution skipped: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return undefined;
         }
     }
 }

--- a/packages/plugin/src/contracts/capabilities/terminal-stream.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/terminal-stream.interface.ts
@@ -53,6 +53,17 @@ export interface TerminalSessionHandle {
 	/** True PTY (resizable) vs `child_process` pipe floor (no resize —
 	 *  the UI renders an honest `isPty:false` banner). */
 	readonly isPty: boolean;
+	/**
+	 * Provider-minted identifier for THIS hosted session — the value the
+	 * platform persists on the run as `cliSessionId` (its resume key).
+	 *
+	 * Optional by design: a provider with no addressable session concept
+	 * simply omits it and nothing is written. It is an INTERNAL handle —
+	 * API responses expose its PRESENCE only (`hasCliSession`), never the
+	 * value, so a leaked status payload can never be replayed into
+	 * somebody else's session.
+	 */
+	readonly sessionId?: string;
 	write(data: Uint8Array): void;
 	resize(cols: number, rows: number): void;
 	kill(signal?: string): void;

--- a/packages/plugins/pty-local/src/__tests__/pty-local.plugin.spec.ts
+++ b/packages/plugins/pty-local/src/__tests__/pty-local.plugin.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TerminalFrame, TerminalTransport } from '@ever-works/plugin';
-import { PtyLocalPlugin } from '../pty-local.plugin.js';
+import { PtyLocalPlugin, makePtyLocalSessionId } from '../pty-local.plugin.js';
 
 /**
  * The suite exercises the full pump contract against PLAIN child
@@ -105,6 +105,39 @@ describe('PtyLocalPlugin', () => {
 			.map((f) => f.seq);
 		expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
 		expect(seqs[0]).toBe(0);
+	});
+
+	/**
+	 * The handle's `sessionId` is what the platform persists as the run's
+	 * `cliSessionId` — the column had no writer at all before this, so a
+	 * provider that mints nothing leaves the whole resume story dead.
+	 */
+	it('mints a provider-scoped session id on the handle (the run’s resume key)', async () => {
+		const plugin = new PtyLocalPlugin();
+		const h = makeTransport();
+		const runId = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
+
+		const handle = await plugin.spawn(
+			{
+				runId,
+				command: [NODE, '-e', 'process.exit(0)'],
+				cwd: process.cwd(),
+				env: {}
+			},
+			h.transport
+		);
+
+		expect(handle.sessionId).toMatch(new RegExp(`^pty-local:${runId}:(\\d+|no-pid)$`));
+		// Stays inside the API's 128-char whitelist cap, so it is never
+		// silently dropped on the heartbeat.
+		expect(handle.sessionId!.length).toBeLessThanOrEqual(128);
+		await handle.exited;
+	});
+
+	it('makePtyLocalSessionId is provider-prefixed and honest about a missing pid', () => {
+		expect(makePtyLocalSessionId('run-1', 4242)).toBe('pty-local:run-1:4242');
+		expect(makePtyLocalSessionId('run-1', undefined)).toBe('pty-local:run-1:no-pid');
+		expect(makePtyLocalSessionId('run-1', Number.NaN)).toBe('pty-local:run-1:no-pid');
 	});
 
 	it('a non-zero exit is reported as crashed', async () => {

--- a/packages/plugins/pty-local/src/index.ts
+++ b/packages/plugins/pty-local/src/index.ts
@@ -1,4 +1,4 @@
-import { PtyLocalPlugin } from './pty-local.plugin.js';
+import { PtyLocalPlugin, makePtyLocalSessionId } from './pty-local.plugin.js';
 
-export { PtyLocalPlugin };
+export { PtyLocalPlugin, makePtyLocalSessionId };
 export default PtyLocalPlugin;

--- a/packages/plugins/pty-local/src/pty-local.plugin.ts
+++ b/packages/plugins/pty-local/src/pty-local.plugin.ts
@@ -26,6 +26,8 @@ interface PtyProcessLike {
 	write(data: string): void;
 	resize(cols: number, rows: number): void;
 	kill(signal?: string): void;
+	/** node-pty exposes the child pid; typed optional so a stub without it still compiles. */
+	readonly pid?: number;
 }
 
 interface PtyModuleLike {
@@ -44,6 +46,21 @@ interface PtyModuleLike {
 
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
+
+/**
+ * Mint the provider-scoped session id reported on the handle (persisted
+ * by the platform as the run's `cliSessionId`).
+ *
+ * `pty-local:<runId>:<pid>` — provider-prefixed so a value minted by a
+ * DIFFERENT terminal-stream provider can never be mistaken for one of
+ * ours, and pid-scoped so two sessions for the same run (a resume after
+ * a worker restart) are distinguishable. `no-pid` when the platform
+ * reported none rather than pretending to know it.
+ */
+export function makePtyLocalSessionId(runId: string, pid?: number): string {
+	const suffix = typeof pid === 'number' && Number.isFinite(pid) ? String(pid) : 'no-pid';
+	return `pty-local:${runId}:${suffix}`;
+}
 
 /**
  * `pty-local` — first-party `terminal-stream` provider.
@@ -194,6 +211,7 @@ export class PtyLocalPlugin implements IPlugin, ITerminalStreamPlugin {
 		return {
 			runId: input.runId,
 			isPty: true,
+			sessionId: makePtyLocalSessionId(input.runId, proc.pid),
 			write: (data) => proc.write(Buffer.from(data).toString('latin1')),
 			resize: (c, r) => proc.resize(c, r),
 			kill: (signal) => {
@@ -272,6 +290,7 @@ export class PtyLocalPlugin implements IPlugin, ITerminalStreamPlugin {
 		return {
 			runId: input.runId,
 			isPty: false,
+			sessionId: makePtyLocalSessionId(input.runId, child.pid),
 			write: (data) => void child.stdin?.write(Buffer.from(data)),
 			resize: () => undefined,
 			kill: (signal) => {

--- a/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
+++ b/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
@@ -135,6 +135,12 @@ export const terminalSessionTriggerAdapter: TerminalSessionDispatcher = {
                 cwd: payload.cwd,
                 env: payload.env,
                 persistent: payload.persistent,
+                // Provider identity resolved by the API-side
+                // `terminal-stream` facade; the worker facade takes it as
+                // its `providerOverride` so both processes host the same
+                // provider (see TerminalSessionLauncher).
+                providerId: payload.providerId,
+                workId: payload.workId,
             } satisfies TerminalSessionPayload,
             { idempotencyKey: `terminal-session:${payload.runId}` },
         );

--- a/packages/tasks/src/tasks/trigger/terminal-session.task.ts
+++ b/packages/tasks/src/tasks/trigger/terminal-session.task.ts
@@ -1,12 +1,16 @@
 import { task } from '@trigger.dev/sdk';
 import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
 import { AgentRunRepository } from '@ever-works/agent/database';
+import { TerminalStreamFacadeService } from '@ever-works/agent/facades';
 import { PtyLocalPlugin } from '@ever-works/pty-local-plugin';
-import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { TriggerTerminalModule } from '../../trigger/worker/modules/trigger-terminal.module';
+import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
 import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
 import { assertUuid } from '../../trigger/worker/utils/task-context.utils';
 import { TerminalTransportClient } from '../../trigger/worker/services/terminal-transport.client';
 import { TerminalSessionHost } from '../../trigger/worker/services/terminal-session-host';
+import { resolveTerminalSessionSpawner } from '../../trigger/worker/services/terminal-provider.resolver';
 
 export interface TerminalSessionPayload {
     /** The AgentRun whose id doubles as the relay channel id. */
@@ -20,6 +24,15 @@ export interface TerminalSessionPayload {
      *  job-side by the facades at spawn time (see plan §7). */
     env?: Record<string, string>;
     persistent?: boolean;
+    /**
+     * `terminal-stream` provider the API's facade resolved for this
+     * scope, forwarded as the worker facade's `providerOverride` so both
+     * processes agree on WHICH provider hosts the session. Absent = let
+     * the worker resolve it itself.
+     */
+    providerId?: string;
+    /** Work scope for the facade's settings hierarchy, when the run has one. */
+    workId?: string;
 }
 
 /**
@@ -28,6 +41,13 @@ export interface TerminalSessionPayload {
  * Hosts one live terminal session for an AgentRun: PTY (or pipe floor)
  * in THIS worker process, bytes relayed through the API gateway, kept
  * alive by heartbeats, reaped by the sweeper on heartbeat loss.
+ *
+ * The provider is resolved through `TerminalStreamFacadeService` rather
+ * than imported: this task used to construct the `pty-local` plugin
+ * directly, which left the capability seam with no consumer at all. The
+ * bundled plugin is now only the FLOOR — used when the facade resolves
+ * nothing (no enabled provider, hydration failure), so an install that
+ * enables a different `terminal-stream` provider actually gets it.
  *
  * This is the building block the run orchestration composes: today it
  * is dispatched explicitly (persistent/interactive runs); the
@@ -50,8 +70,9 @@ export const terminalSessionTask = task<'terminal-session', TerminalSessionPaylo
             return { status: 'skipped' as const, reason: 'empty-command' };
         }
 
-        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+        const appContext = await NestFactory.createApplicationContext(TriggerTerminalModule);
         appContext.useLogger(createTriggerLogger('TerminalSession'));
+        const logger = new Logger('TerminalSession');
         try {
             // Ownership guard mirroring agent-task-execute: the run must
             // belong to the payload's user + agent; forged payloads skip
@@ -62,8 +83,44 @@ export const terminalSessionTask = task<'terminal-session', TerminalSessionPaylo
                 return { status: 'skipped' as const, reason: 'run-not-found' };
             }
 
+            // Plugin hydration is what gives the facade a registry to
+            // resolve against. Best-effort by design: a hydration failure
+            // degrades to the bundled provider below instead of denying
+            // the user a terminal.
+            try {
+                await appContext.get(TriggerPluginHydratorService).initialize();
+            } catch (error) {
+                logger.warn(
+                    `Plugin hydration failed; terminal falls back to the bundled provider: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+
             const client = new TerminalTransportClient();
-            const host = new TerminalSessionHost(new PtyLocalPlugin(), client);
+            // `.get` THROWS for an unbound token — a context assembled
+            // without the facade must degrade, not crash the session.
+            let facade: TerminalStreamFacadeService | null = null;
+            try {
+                facade = appContext.get(TerminalStreamFacadeService, { strict: false });
+            } catch {
+                facade = null;
+            }
+
+            const { spawner, source, degradedReason } = await resolveTerminalSessionSpawner({
+                facade,
+                facadeOptions: {
+                    userId: payload.userId,
+                    workId: payload.workId,
+                    providerOverride: payload.providerId,
+                    agentId: payload.agentId,
+                },
+                bundledFallback: () => new PtyLocalPlugin(),
+            });
+            if (source === 'bundled' && degradedReason) {
+                logger.warn(`terminal-stream facade did not resolve a provider: ${degradedReason}`);
+            }
+            const host = new TerminalSessionHost(spawner, client);
 
             const outcome = await host.run({
                 runId: payload.runId,

--- a/packages/tasks/src/trigger/worker/modules/trigger-terminal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-terminal.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { TerminalStreamFacadeService } from '@ever-works/agent/facades';
+import { TriggerInternalModule } from './trigger-internal.module';
+import { TriggerPluginsModule } from './trigger-plugins.module';
+
+/**
+ * Worker scope for the `terminal-session` task.
+ *
+ * The task used to bootstrap `TriggerInternalModule` alone and construct
+ * ONE hardcoded provider, which is why `TerminalStreamFacadeService` had
+ * zero non-test consumers. Binding the facade here is what turns the
+ * capability seam on for the live session path: the registry (from the
+ * @Global `TriggerPluginsModule`) answers WHICH `terminal-stream`
+ * provider applies for the scope, and the task spawns through the
+ * facade rather than through an import.
+ *
+ * Same shape as `TriggerFacadesModule`: the facade itself is a LOCAL
+ * provider (it must run in the process that hosts the PTY), while every
+ * repository underneath it is a remote proxy to the API. Its three
+ * dependencies — `PluginRegistryService`, `PluginSettingsService` and
+ * the `@Optional() WorkPluginRepository` — all come from the @Global
+ * plugins module, so no extra provider is needed here.
+ *
+ * `TriggerInternalModule` is imported (and re-exported) because the task
+ * also resolves `AgentRunRepository` from this context for its ownership
+ * guard.
+ */
+@Module({
+    imports: [TriggerPluginsModule.forRoot(), TriggerInternalModule],
+    providers: [TerminalStreamFacadeService],
+    exports: [TerminalStreamFacadeService, TriggerInternalModule],
+})
+export class TriggerTerminalModule {}

--- a/packages/tasks/src/trigger/worker/services/terminal-provider.resolver.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-provider.resolver.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FacadeOptions } from '@ever-works/plugin';
+import { resolveTerminalSessionSpawner } from './terminal-provider.resolver';
+import type { TerminalSessionSpawner } from './terminal-session-host';
+
+const FACADE_OPTIONS = {
+    userId: '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f',
+    workId: 'work-1',
+} as FacadeOptions;
+
+function bundled(): TerminalSessionSpawner {
+    return {
+        providerName: 'pty-local',
+        spawn: vi.fn(async () => ({ runId: 'r1', isPty: true }) as never),
+    };
+}
+
+describe('resolveTerminalSessionSpawner (the facade seam, made load-bearing)', () => {
+    it('spawns THROUGH the facade when it resolves a provider', async () => {
+        const handle = { runId: 'r1', isPty: true };
+        const facade = {
+            resolveProvider: vi.fn(async () => ({ id: 'pty-ssh', providerName: 'pty-ssh' })),
+            spawn: vi.fn(async () => handle as never),
+        };
+
+        const resolution = await resolveTerminalSessionSpawner({
+            facade: facade as never,
+            facadeOptions: FACADE_OPTIONS,
+            bundledFallback: bundled,
+        });
+
+        expect(resolution.source).toBe('facade');
+        // Provider identity comes from the RESOLVED provider — this is
+        // what the lifecycle beat reports and what makes a swap visible.
+        expect(resolution.spawner.providerName).toBe('pty-ssh');
+
+        const transport = { publish: vi.fn(), inbound: vi.fn(), close: vi.fn() };
+        const input = { runId: 'r1', command: ['/bin/bash'], cwd: '/w', env: {} };
+        await expect(resolution.spawner.spawn(input, transport as never)).resolves.toBe(handle);
+
+        // The facade (not the plugin) is what spawns: it injects the
+        // scope's resolved settings and owns the error contract.
+        expect(facade.spawn).toHaveBeenCalledWith(input, transport, FACADE_OPTIONS);
+        expect(facade.resolveProvider).toHaveBeenCalledWith(FACADE_OPTIONS);
+    });
+
+    it('falls back to the bundled floor when no provider is enabled for the scope', async () => {
+        const facade = {
+            resolveProvider: vi.fn(async () => null),
+            spawn: vi.fn(),
+        };
+
+        const resolution = await resolveTerminalSessionSpawner({
+            facade: facade as never,
+            facadeOptions: FACADE_OPTIONS,
+            bundledFallback: bundled,
+        });
+
+        expect(resolution.source).toBe('bundled');
+        expect(resolution.spawner.providerName).toBe('pty-local');
+        expect(resolution.degradedReason).toContain('no enabled terminal-stream provider');
+        expect(facade.spawn).not.toHaveBeenCalled();
+    });
+
+    it('falls back (never throws) when resolution itself explodes', async () => {
+        const facade = {
+            resolveProvider: vi.fn(async () => {
+                throw new Error('registry down');
+            }),
+            spawn: vi.fn(),
+        };
+
+        const resolution = await resolveTerminalSessionSpawner({
+            facade: facade as never,
+            facadeOptions: FACADE_OPTIONS,
+            bundledFallback: bundled,
+        });
+
+        expect(resolution.source).toBe('bundled');
+        expect(resolution.degradedReason).toContain('registry down');
+    });
+
+    it('falls back when no facade is bound in this worker context at all', async () => {
+        const resolution = await resolveTerminalSessionSpawner({
+            facade: null,
+            facadeOptions: FACADE_OPTIONS,
+            bundledFallback: bundled,
+        });
+
+        expect(resolution.source).toBe('bundled');
+        expect(resolution.degradedReason).toContain('no terminal-stream facade');
+    });
+
+    it('honours the provider override the API-side facade already resolved', async () => {
+        const facade = {
+            resolveProvider: vi.fn(async () => ({ id: 'k8s-exec', providerName: 'k8s-exec' })),
+            spawn: vi.fn(),
+        };
+        const withOverride = { ...FACADE_OPTIONS, providerOverride: 'k8s-exec' } as FacadeOptions;
+
+        const resolution = await resolveTerminalSessionSpawner({
+            facade: facade as never,
+            facadeOptions: withOverride,
+            bundledFallback: bundled,
+        });
+
+        expect(facade.resolveProvider).toHaveBeenCalledWith(
+            expect.objectContaining({ providerOverride: 'k8s-exec' }),
+        );
+        expect(resolution.spawner.providerName).toBe('k8s-exec');
+    });
+});

--- a/packages/tasks/src/trigger/worker/services/terminal-provider.resolver.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-provider.resolver.ts
@@ -1,0 +1,84 @@
+import type { FacadeOptions, ITerminalStreamFacade } from '@ever-works/plugin';
+import type { TerminalSessionSpawner } from './terminal-session-host.js';
+
+/**
+ * Streaming-terminal — the provider seam, made load-bearing.
+ *
+ * `TerminalStreamFacadeService` existed with the full capability
+ * resolution matrix behind it (provider override → work default → user
+ * default → first enabled, plus the 4-level settings hierarchy) and NO
+ * non-test caller: the session task constructed one hardcoded provider,
+ * so "a different terminal provider can be swapped in" was a claim the
+ * code did not honour. This resolver is the consumer that makes it
+ * true — the live session path asks the facade WHICH provider applies
+ * and then spawns THROUGH it.
+ *
+ * Degradation is deliberate and quiet-but-reported: an install whose
+ * registry has no enabled `terminal-stream` plugin (or whose plugin
+ * hydration failed) still gets a working terminal from the bundled
+ * floor. Losing the seam must never mean losing the session.
+ */
+export type TerminalProviderSource = 'facade' | 'bundled';
+
+export interface TerminalProviderResolution {
+    spawner: TerminalSessionSpawner;
+    source: TerminalProviderSource;
+    /** Why the bundled floor was used (empty for `source: 'facade'`). */
+    degradedReason?: string;
+}
+
+export interface ResolveTerminalSessionSpawnerInput {
+    /** Absent when the worker context has no facade bound at all. */
+    facade?: ITerminalStreamFacade | null;
+    facadeOptions: FacadeOptions;
+    /** The in-bundle provider used when the facade resolves nothing. */
+    bundledFallback: () => TerminalSessionSpawner;
+}
+
+export async function resolveTerminalSessionSpawner(
+    input: ResolveTerminalSessionSpawnerInput,
+): Promise<TerminalProviderResolution> {
+    const { facade, facadeOptions, bundledFallback } = input;
+
+    if (!facade || typeof facade.resolveProvider !== 'function') {
+        return {
+            spawner: bundledFallback(),
+            source: 'bundled',
+            degradedReason: 'no terminal-stream facade bound in this worker context',
+        };
+    }
+
+    let provider: { id?: string; providerName?: string } | null = null;
+    try {
+        provider = await facade.resolveProvider(facadeOptions);
+    } catch (error) {
+        return {
+            spawner: bundledFallback(),
+            source: 'bundled',
+            degradedReason: `terminal-stream provider resolution failed: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        };
+    }
+
+    if (!provider) {
+        return {
+            spawner: bundledFallback(),
+            source: 'bundled',
+            degradedReason: 'no enabled terminal-stream provider for this scope',
+        };
+    }
+
+    const providerName = provider.providerName ?? provider.id ?? 'terminal-stream';
+    return {
+        source: 'facade',
+        spawner: {
+            providerName,
+            // Spawn through the FACADE, not the resolved plugin: the
+            // facade is what injects the scope's resolved settings and
+            // what passes `TerminalNotProvisionedError` through
+            // un-wrapped (the UI's cannot-connect signal).
+            spawn: (spawnInput, transport) => facade.spawn(spawnInput, transport, facadeOptions),
+        },
+    };
+}

--- a/packages/tasks/src/trigger/worker/services/terminal-session-host.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-session-host.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { TerminalFrame } from '@ever-works/contracts';
 import { PtyLocalPlugin } from '@ever-works/pty-local-plugin';
-import { TerminalSessionHost } from './terminal-session-host';
+import {
+    MAX_CLI_SESSION_ID_LENGTH,
+    TerminalSessionHost,
+    normalizeCliSessionId,
+} from './terminal-session-host';
 import type { TerminalTransportClient } from './terminal-transport.client';
 
 const RUN = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
@@ -120,6 +124,57 @@ describe('TerminalSessionHost (loopback, real processes)', () => {
         });
     });
 
+    /**
+     * `cliSessionId` is the run's resume key. It had a column, an API
+     * whitelist entry and a presence-only status field — and no writer
+     * anywhere, so it was permanently null. The session host is where a
+     * session comes into existence, so it is where the key is written.
+     */
+    it('writes the provider-minted session id on the attached beat', async () => {
+        const { client, heartbeats } = makeLoopbackClient();
+        const host = new TerminalSessionHost(new PtyLocalPlugin(), client, 5000);
+
+        await host.run({
+            runId: RUN,
+            command: [NODE, '-e', 'process.stdout.write("x")'],
+            cwd: process.cwd(),
+            env: {},
+        });
+
+        const attached = heartbeats.find((h) => h.state === 'attached');
+        expect(attached).toBeDefined();
+        expect(typeof attached?.cliSessionId).toBe('string');
+        expect(String(attached?.cliSessionId)).toMatch(new RegExp(`^pty-local:${RUN}:`));
+        expect(String(attached?.cliSessionId).length).toBeLessThanOrEqual(
+            MAX_CLI_SESSION_ID_LENGTH,
+        );
+
+        // The `starting` beat cannot know it yet — the provider mints it
+        // during spawn — so it must not pretend to.
+        expect(heartbeats[0]).not.toHaveProperty('cliSessionId');
+    });
+
+    it('sends NO cliSessionId when the provider mints none', async () => {
+        const { client, heartbeats } = makeLoopbackClient();
+        const sessionless = {
+            providerName: 'sessionless',
+            spawn: vi.fn(async () => ({
+                runId: RUN,
+                isPty: false,
+                write: () => undefined,
+                resize: () => undefined,
+                kill: () => undefined,
+                exited: Promise.resolve({ code: 0, reason: 'completed' as const }),
+            })),
+        };
+        const host = new TerminalSessionHost(sessionless as never, client, 5000);
+
+        await host.run({ runId: RUN, command: ['/bin/true'], cwd: '/', env: {} });
+
+        const attached = heartbeats.find((h) => h.state === 'attached');
+        expect(attached).toEqual({ state: 'attached' });
+    });
+
     it('heartbeats repeat while the session lives', async () => {
         const { client, heartbeats } = makeLoopbackClient();
         const host = new TerminalSessionHost(new PtyLocalPlugin(), client, 40);
@@ -134,5 +189,23 @@ describe('TerminalSessionHost (loopback, real processes)', () => {
 
         const attachedBeats = heartbeats.filter((h) => h.state === 'attached').length;
         expect(attachedBeats).toBeGreaterThanOrEqual(3);
+    });
+});
+
+describe('normalizeCliSessionId', () => {
+    it('accepts a trimmed non-empty id within the API whitelist cap', () => {
+        expect(normalizeCliSessionId('  pty-local:run:42  ')).toBe('pty-local:run:42');
+        expect(normalizeCliSessionId('x'.repeat(MAX_CLI_SESSION_ID_LENGTH))).toHaveLength(
+            MAX_CLI_SESSION_ID_LENGTH,
+        );
+    });
+
+    it('rejects anything the API would silently drop — never truncates', () => {
+        // A truncated resume key is worse than an absent one: it looks
+        // present (hasCliSession: true) and resolves to nothing.
+        expect(normalizeCliSessionId('x'.repeat(MAX_CLI_SESSION_ID_LENGTH + 1))).toBeNull();
+        expect(normalizeCliSessionId('   ')).toBeNull();
+        expect(normalizeCliSessionId(undefined)).toBeNull();
+        expect(normalizeCliSessionId(42)).toBeNull();
     });
 });

--- a/packages/tasks/src/trigger/worker/services/terminal-session-host.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-session-host.ts
@@ -1,4 +1,8 @@
-import type { ITerminalStreamPlugin, TerminalSessionHandle } from '@ever-works/plugin';
+import type {
+    TerminalSessionHandle,
+    TerminalSpawnInput,
+    TerminalTransport,
+} from '@ever-works/plugin';
 import { makeTerminalErrorFrame } from '@ever-works/contracts';
 import type { TerminalTransportClient } from './terminal-transport.client.js';
 
@@ -11,8 +15,10 @@ import type { TerminalTransportClient } from './terminal-transport.client.js';
  *
  *   1. lifecycle → `starting` (+ provider id, persistent flag)
  *   2. transport up (worker token + WS inbound + batched publish)
- *   3. preamble banner, then `plugin.spawn(...)` pumps the process
- *   4. heartbeat every {@link HEARTBEAT_INTERVAL_MS} while live
+ *   3. preamble banner, then `spawner.spawn(...)` pumps the process
+ *   4. lifecycle → `attached`, carrying the provider-minted session id
+ *      (persisted as the run's `cliSessionId` resume key) when there is
+ *      one, then heartbeat every {@link HEARTBEAT_INTERVAL_MS} while live
  *   5. on exit: lifecycle → `ended` with the mapped reason (the plugin
  *      already published the pinned exit frame BEFORE resolving)
  *
@@ -21,6 +27,42 @@ import type { TerminalTransportClient } from './terminal-transport.client.js';
  * still transitions the lifecycle to `ended/crashed`.
  */
 const HEARTBEAT_INTERVAL_MS = 60_000;
+
+/** The API's whitelist caps `cliSessionId` at 128 chars; longer is dropped. */
+export const MAX_CLI_SESSION_ID_LENGTH = 128;
+
+/**
+ * What the host needs to start a session — deliberately NARROWER than
+ * `ITerminalStreamPlugin`.
+ *
+ * A raw plugin satisfies it structurally (that is what the loopback
+ * suite uses), and so does a `TerminalStreamFacadeService`-backed
+ * adapter with its `FacadeOptions` bound. That is the whole point of
+ * the port: the host stops naming ONE provider, so swapping the
+ * terminal-stream provider is a facade-resolution question rather than
+ * an edit to this file.
+ */
+export interface TerminalSessionSpawner {
+    /** Provider identity reported on the `starting` lifecycle beat. */
+    readonly providerName: string;
+    spawn(
+        input: Omit<TerminalSpawnInput, 'settings'>,
+        transport: TerminalTransport,
+    ): Promise<TerminalSessionHandle>;
+}
+
+/**
+ * Accept a provider-minted session id only when it is actually usable:
+ * a non-empty string within the API's whitelist cap. Anything else
+ * yields `null` and NOTHING is written — a truncated resume key is
+ * worse than an absent one.
+ */
+export function normalizeCliSessionId(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_CLI_SESSION_ID_LENGTH) return null;
+    return trimmed;
+}
 
 export interface TerminalSessionSpec {
     runId: string;
@@ -40,7 +82,7 @@ export interface TerminalSessionResult {
 
 export class TerminalSessionHost {
     constructor(
-        private readonly plugin: ITerminalStreamPlugin,
+        private readonly plugin: TerminalSessionSpawner,
         private readonly client: TerminalTransportClient,
         private readonly heartbeatIntervalMs: number = HEARTBEAT_INTERVAL_MS,
     ) {}
@@ -82,7 +124,17 @@ export class TerminalSessionHost {
             throw error;
         }
 
-        await this.client.heartbeat(spec.runId, { state: 'attached' });
+        // The session EXISTS now, so this is where its resume key is
+        // written: the provider minted it during spawn, and the first
+        // `attached` beat is the earliest moment it can be known. The
+        // API whitelist persists it to `AgentRun.cliSessionId`; nothing
+        // is sent when the provider minted nothing.
+        const cliSessionId = normalizeCliSessionId(handle.sessionId);
+        if (cliSessionId) {
+            await this.client.heartbeat(spec.runId, { state: 'attached', cliSessionId });
+        } else {
+            await this.client.heartbeat(spec.runId, { state: 'attached' });
+        }
 
         const beat = setInterval(() => {
             void this.client.heartbeat(spec.runId, { state: 'attached' });


### PR DESCRIPTION
Three related terminal gaps from the audit, fixed together because they touch
the same path.

## (a) `TerminalStreamFacadeService` had zero non-test consumers — W1 M5

The capability interface, the facade and its settings all existed, but the real
terminal start/stream path went straight to one hardcoded provider. The seam
could not actually swap anything; it was decoration.

The launcher and the worker-side session host now resolve the provider
**through the facade**. That is what makes a different terminal provider
installable rather than theoretical.

**Who calls it in production now?**

| File | Role |
|---|---|
| `packages/agent/src/agents/terminal-session-launcher.service.ts:96` | injected `@Optional()` |
| `packages/tasks/src/tasks/trigger/terminal-session.task.ts` | resolves the provider through it |
| `packages/tasks/src/trigger/worker/modules/trigger-terminal.module.ts:30` | provides it worker-side |

## (b) No viewer role — W1 M10

The terminal hardcoded `role: 'driver'`, so a second participant could never
attach read-only; there was no viewer role to mint. Viewer-role minting is now
real end to end.

**Explicitly out of scope:** a Redis fanout bus. The transport is unchanged.
What changes is that the role is a real, enforced value instead of a constant —
so this closes the role gap, not the multi-subscriber-transport gap.

## (c) `cliSessionId` was never written — W1 M6

Now written where the session is created. The existing exposure rule is
preserved **exactly**: API responses report *presence only*, never the value.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `pnpm build --filter=@ever-works/trigger-tasks --filter=@ever-works/plugin` | green |
| `packages/agent` jest | green — 442 suites, 8008 tests |
| `apps/api` jest | green — 230 suites, 3733 tests |
| `packages/tasks` vitest | green — 28 files |
| `packages/plugins/pty-local` vitest | green |
| `apps/web` tsc --noEmit | green |
| prettier | clean |

No existing test was weakened or removed; no existing surface was replaced.