### PR TITLE
feat(meetings): add the Meetings surface over the existing API

### DIFF
--- a/apps/web/e2e/flow-meetings-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-meetings-ui-journey.spec.ts
@@ -1,0 +1,650 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { API_BASE, authedHeaders } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+import { clickAndExpectUrl, clickUntil } from './helpers/nav';
+
+/**
+ * flow-meetings-ui-journey — the `/meetings` DASHBOARD UI, end-to-end.
+ *
+ * `flow-meetings-crud-contract.spec.ts` drives the `/api/meetings` REST surface
+ * with fresh registered users. This file is the DISTINCT, additive UI angle: it
+ * seeds meetings through the API as the SEEDED storageState user (so they render
+ * for the authenticated browser session) and then asserts the real rendered
+ * Next.js pages:
+ *   - `/meetings`        list catalog          (MeetingsList + MeetingCard)
+ *   - `/meetings/new`    capture form          (MeetingForm + createMeetingAction)
+ *   - `/meetings/[id]`   detail + mutations    (MeetingDetailClient)
+ *
+ * The Meetings surface is a server component that fetches with the seeded user's
+ * Better-Auth session cookie, so a meeting created via the JWT API for that same
+ * user shows up on a fresh navigation with no client cache to fight — the same
+ * idiom `flow-goals-ui-journey.spec.ts` uses.
+ *
+ * Contract pinned from apps/api/src/meetings/meetings.controller.ts:
+ *   - POST   /api/meetings                → 201 MeetingView; `source` defaults
+ *     to 'manual', `participants` to [], `hasTranscript` false, and `dedupeKey`
+ *     never leaves the API.
+ *   - GET    /api/meetings                → 200 MeetingView[]; list rows OMIT
+ *     `transcriptText` and carry `hasTranscript` instead — which is exactly what
+ *     the card's Transcript / No transcript chip reads.
+ *   - GET    /api/meetings/:id            → 200 INCLUDING `transcriptText`; 404
+ *     for unknown AND for another owner's row (no existence leak) → the web
+ *     detail page calls notFound().
+ *   - PATCH  /api/meetings/:id            → 200; a whitespace-only title is
+ *     refused by the SERVICE with "title cannot be empty".
+ *   - DELETE /api/meetings/:id            → 204, then GET is 404.
+ *   - POST   /api/meetings/:id/transcript → 200 { meeting, summary?,
+ *     memorySaved, envelopeEmitted }.
+ *
+ * Environment note: the transcript pipeline's enrichment half (AI summary →
+ * Memory observation → ingest envelope) is BEST EFFORT by design, so on a
+ * key-less CI stack `summary` is absent and both booleans are false. The UI
+ * therefore must NOT claim a summary exists — the spec asserts the honest
+ * "attached" outcome and tolerates either toast wording, and the Summary
+ * section's empty copy is what gets pinned.
+ *
+ * Rendered copy pinned from apps/web/messages/en.json (dashboard.meetingsPage /
+ * .meetingNew / .meetingDetail).
+ *
+ * Robustness: unique title suffixes; meeting identity asserted via the card's
+ * `/meetings/:id` href (toHaveCount / not.toContainText), never global counts;
+ * mutations proven via persisted API reads rather than transient toasts; a fresh
+ * seeded bearer token per test; `loadSeededTestUser()` is called INSIDE helpers
+ * (never at module scope — that reddens whole shards at collection time).
+ */
+
+// ---- API helpers (seeded storageState user, so the UI can read them) ----
+
+async function seededToken(request: APIRequestContext): Promise<string> {
+    const seeded = loadSeededTestUser();
+    const res = await request.post(`${API_BASE}/api/auth/login`, {
+        data: { email: seeded.email, password: seeded.password },
+    });
+    expect(res.status(), 'seeded login').toBe(200);
+    return (await res.json()).access_token;
+}
+
+function suffix(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+interface SeedMeeting {
+    title?: string;
+    startedAt?: string;
+    endedAt?: string;
+    source?: 'zoom' | 'google-meet' | 'manual' | 'import';
+    participants?: Array<{ name: string; email?: string }>;
+    sourceUrl?: string;
+    transcriptText?: string;
+}
+
+async function createMeeting(request: APIRequestContext, token: string, o: SeedMeeting = {}) {
+    const res = await request.post(`${API_BASE}/api/meetings`, {
+        headers: authedHeaders(token),
+        data: {
+            title: o.title ?? `UI Meeting ${suffix()}`,
+            startedAt: o.startedAt ?? new Date().toISOString(),
+            ...(o.endedAt ? { endedAt: o.endedAt } : {}),
+            ...(o.source ? { source: o.source } : {}),
+            ...(o.participants ? { participants: o.participants } : {}),
+            ...(o.sourceUrl ? { sourceUrl: o.sourceUrl } : {}),
+            ...(o.transcriptText ? { transcriptText: o.transcriptText } : {}),
+        },
+    });
+    expect(res.status(), `create meeting body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+async function getMeetingStatus(
+    request: APIRequestContext,
+    token: string,
+    id: string,
+): Promise<number> {
+    const res = await request.get(`${API_BASE}/api/meetings/${id}`, {
+        headers: authedHeaders(token),
+    });
+    return res.status();
+}
+
+async function readMeeting(
+    request: APIRequestContext,
+    token: string,
+    id: string,
+): Promise<Record<string, unknown>> {
+    const res = await request.get(`${API_BASE}/api/meetings/${id}`, {
+        headers: authedHeaders(token),
+    });
+    expect(res.status(), 'get meeting').toBe(200);
+    return res.json();
+}
+
+/** Card locator for one meeting id (the whole card is a `/meetings/:id` link). */
+function cardFor(page: Page, id: string) {
+    return page.locator(`a[href*="/meetings/${id}"]`);
+}
+
+// ============================================================================
+// A. /meetings list catalog
+// ============================================================================
+
+test.describe('Meetings — /meetings list catalog (UI)', () => {
+    test('list shell renders header, subtitle, connect hint and New meeting CTA', async ({
+        page,
+    }) => {
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await expect(page).not.toHaveURL(/\/login/);
+        await expect(page.getByRole('heading', { name: 'Meetings', level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(
+            page.getByText('Every meeting the platform captured', { exact: false }),
+        ).toBeVisible();
+
+        // The connect affordance points at the connector catalog rather than
+        // pretending this form is where provider sync is configured.
+        const hint = page.getByTestId('meetings-connect-hint');
+        await expect(hint).toBeVisible();
+        await expect(hint).toContainText('Zoom recordings and Google Meet transcripts');
+        await expect(hint.getByRole('link', { name: 'Manage connectors' })).toHaveAttribute(
+            'href',
+            /\/plugins/,
+        );
+
+        const cta = page.getByRole('link', { name: /New meeting/i }).first();
+        await expect(cta).toBeVisible();
+        await expect(cta).toHaveAttribute('href', /\/meetings\/new/);
+    });
+
+    test('filter bar exposes the Source control, Apply and Reset', async ({ page }) => {
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByRole('heading', { name: 'Meetings', level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(page.getByTestId('meetings-source-filter')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
+        const reset = page.getByRole('link', { name: 'Reset' });
+        await expect(reset).toBeVisible();
+        await expect(reset).toHaveAttribute('href', /\/meetings$/);
+    });
+
+    test('a seeded meeting renders as a card with source, transcript chip and roster', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const title = `Card Basics ${suffix()}`;
+        const meeting = await createMeeting(request, token, {
+            title,
+            participants: [{ name: 'Ada Lovelace', email: 'ada@example.com' }, { name: 'Grace' }],
+        });
+
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        const card = cardFor(page, meeting.id);
+        await expect(card).toBeVisible({ timeout: 30_000 });
+        await expect(card).toContainText(title);
+        // `source` defaults to 'manual' → the Manual chip.
+        await expect(card).toContainText('Manual');
+        // No transcript was supplied → hasTranscript false → the neutral chip.
+        await expect(card).toContainText('No transcript');
+        await expect(card).toContainText('2 participants');
+        // No endedAt → the duration line reads the open-meeting copy.
+        await expect(card).toContainText('Still open');
+    });
+
+    test('a meeting captured with a transcript shows the Transcript chip and duration', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const startedAt = new Date(Date.now() - 90 * 60_000).toISOString();
+        const endedAt = new Date(Date.now() - 30 * 60_000).toISOString();
+        const meeting = await createMeeting(request, token, {
+            title: `Card Transcript ${suffix()}`,
+            startedAt,
+            endedAt,
+            transcriptText: 'Ada: the gate is green. Grace: merging the task branch.',
+        });
+
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        const card = cardFor(page, meeting.id);
+        await expect(card).toBeVisible({ timeout: 30_000 });
+        // The list projection omits the transcript BODY but keeps the flag —
+        // the chip is driven by `hasTranscript`, never by `transcriptText`.
+        // (The transcript body's absence from the list payload is pinned in
+        // flow-meetings-crud-contract.spec.ts; asserting on rendered transcript
+        // text here would be env-dependent, since an AI-enabled stack renders a
+        // summary line on the card.)
+        await expect(card.getByTestId('meeting-transcript-badge')).toHaveText('Transcript');
+        // 90 → 30 minutes ago = a 1h span rendered by formatDuration.
+        await expect(card).toContainText('1h');
+    });
+
+    test('offset beyond the last page renders the deterministic empty state', async ({ page }) => {
+        // ?offset=480 always overshoots the seeded user's meeting count → API []
+        // → the empty-state block AND the "No results on this page" nav. This is
+        // deterministic regardless of how many meetings the shared seed owns.
+        await page.goto('/en/meetings?offset=480', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByTestId('meetings-empty')).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByText('No meetings yet.')).toBeVisible();
+        await expect(
+            page.getByText('Capture a meeting by hand and paste its transcript', { exact: false }),
+        ).toBeVisible();
+        await expect(page.getByText('No results on this page')).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Previous' })).toBeVisible();
+    });
+
+    test('the source filter narrows the list to matching meetings', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const zoom = await createMeeting(request, token, {
+            title: `Filter Zoom ${suffix()}`,
+            source: 'zoom',
+        });
+        const manual = await createMeeting(request, token, {
+            title: `Filter Manual ${suffix()}`,
+            source: 'manual',
+        });
+
+        await page.goto('/en/meetings?source=zoom', { waitUntil: 'domcontentloaded' });
+        await expect(cardFor(page, zoom.id)).toBeVisible({ timeout: 30_000 });
+        // The manual meeting must be filtered OUT of the zoom view.
+        await expect(cardFor(page, manual.id)).toHaveCount(0);
+    });
+
+    test('an unknown source filter is ignored (no error alert, list still renders)', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const meeting = await createMeeting(request, token, { title: `Bogus Source ${suffix()}` });
+
+        await page.goto('/en/meetings?source=telepathy', { waitUntil: 'domcontentloaded' });
+        // The page whitelists `source` against the closed set → drops the bogus
+        // value → unfiltered list, and the load-error alert never renders.
+        await expect(cardFor(page, meeting.id)).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByTestId('meetings-load-error')).toHaveCount(0);
+    });
+
+    test('a non-uuid workId filter is dropped before it reaches the API', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const meeting = await createMeeting(request, token, { title: `Bogus Work ${suffix()}` });
+
+        // `workId` is compared straight against a uuid column server-side, so an
+        // arbitrary string would be a cast error (500). The page must drop it.
+        await page.goto('/en/meetings?workId=not-a-uuid', { waitUntil: 'domcontentloaded' });
+        await expect(cardFor(page, meeting.id)).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByTestId('meetings-load-error')).toHaveCount(0);
+    });
+
+    test('clicking a meeting card navigates to its detail page', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const title = `Click Through ${suffix()}`;
+        const meeting = await createMeeting(request, token, { title });
+
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        const card = cardFor(page, meeting.id);
+        await expect(card).toBeVisible({ timeout: 30_000 });
+        // The card is a client <Link>: a click landing before hydration is
+        // silently swallowed (and a soft nav never re-fires `load`, so
+        // waitForURL would hang) — clickAndExpectUrl polls the URL instead.
+        await clickAndExpectUrl(page, card, new RegExp(`/meetings/${meeting.id}`));
+        await expect(page.getByRole('heading', { name: title, level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+    });
+});
+
+// ============================================================================
+// B. /meetings/:id detail
+// ============================================================================
+
+test.describe('Meetings — /meetings/:id detail (UI)', () => {
+    test('detail renders the section scaffold, provenance rows and roster', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const title = `Detail Scaffold ${suffix()}`;
+        const meeting = await createMeeting(request, token, {
+            title,
+            participants: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+            sourceUrl: 'https://example.com/recording/1',
+        });
+
+        await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByRole('heading', { name: title, level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(page.getByRole('link', { name: 'Back to Meetings' })).toBeVisible();
+
+        await expect(page.getByRole('heading', { name: 'Summary' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Transcript' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Edit meeting' })).toBeVisible();
+
+        // No transcript yet → the Summary section says so instead of implying a
+        // failed summary.
+        await expect(page.getByText('Attach a transcript to generate a summary.')).toBeVisible();
+
+        // Provenance rows + roster.
+        await expect(page.getByTestId('meeting-participants')).toContainText('Ada Lovelace');
+        await expect(page.getByTestId('meeting-participants')).toContainText('ada@example.com');
+        // "Org-wide" is also a substring of the edit card's "Org-wide (no Work)"
+        // Work-picker placeholder, so scope to the first match.
+        await expect(page.getByText('Org-wide').first()).toBeVisible();
+        await expect(page.getByText('Still open').first()).toBeVisible();
+
+        // The recording deep link opens in a new tab with the anti-tabnabbing rel.
+        const recording = page.getByTestId('meeting-recording-link');
+        await expect(recording).toHaveAttribute('href', 'https://example.com/recording/1');
+        await expect(recording).toHaveAttribute('rel', /noopener/);
+    });
+
+    test('a stored transcript renders in the body and hides the composer behind Replace', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const marker = `gate-is-green-${suffix()}`;
+        const meeting = await createMeeting(request, token, {
+            title: `Detail Transcript ${suffix()}`,
+            transcriptText: `Ada: ${marker}. Grace: merging the task branch.`,
+        });
+
+        await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const body = page.getByTestId('meeting-transcript-body');
+        await expect(body).toBeVisible({ timeout: 30_000 });
+        await expect(body).toContainText(marker);
+        // With a transcript present the composer is collapsed behind Replace.
+        await expect(page.getByTestId('meeting-transcript-composer')).toHaveCount(0);
+        const toggle = page.getByTestId('meeting-replace-transcript-toggle');
+        await expect(toggle).toBeVisible();
+        await clickUntil(toggle, () =>
+            page
+                .getByTestId('meeting-transcript-composer')
+                .isVisible()
+                .catch(() => false),
+        );
+        await expect(page.getByTestId('meeting-transcript-composer')).toBeVisible();
+    });
+
+    test('attaching a transcript from the UI stores it and degrades honestly with no AI provider', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const meeting = await createMeeting(request, token, { title: `UI Attach ${suffix()}` });
+        const marker = `shipping-the-gate-${suffix()}`;
+
+        await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const composer = page.getByTestId('meeting-transcript-composer');
+        await expect(composer).toBeVisible({ timeout: 30_000 });
+
+        const attach = page.getByTestId('meeting-attach-transcript');
+        // BOTH halves are swallowable pre-hydration: a fill that never reaches
+        // setState is wiped by the next render, and a click before onClick is
+        // wired does nothing. The post-condition is the PERSISTED write, so a
+        // click that did land is never repeated.
+        const landed = async () =>
+            (await readMeeting(request, token, meeting.id).catch(() => null))?.hasTranscript ===
+            true;
+        await expect(async () => {
+            if (!(await landed())) {
+                if ((await composer.inputValue().catch(() => '')) !== `Ada: ${marker}.`) {
+                    await composer.fill(`Ada: ${marker}.`).catch(() => undefined);
+                }
+                await attach.click({ timeout: 5_000, noWaitAfter: true }).catch(() => undefined);
+            }
+            expect(await landed()).toBe(true);
+        }).toPass({ timeout: 60_000 });
+
+        // Persisted truth: the transcript body really landed server-side.
+        const persisted = await readMeeting(request, token, meeting.id);
+        expect(String(persisted.transcriptText)).toContain(marker);
+
+        // Rendered truth: the transcript body now shows on the page.
+        await expect(page.getByTestId('meeting-transcript-body')).toContainText(marker, {
+            timeout: 30_000,
+        });
+
+        // The enrichment half is BEST EFFORT. On a key-less stack no summary is
+        // produced, and the UI must say so rather than render a fake summary.
+        if (!persisted.summary) {
+            await expect(
+                page.getByText('No summary was generated for this transcript', { exact: false }),
+            ).toBeVisible({ timeout: 30_000 });
+        }
+    });
+
+    test('the edit card renames the meeting and the change persists', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const meeting = await createMeeting(request, token, { title: `Before Rename ${suffix()}` });
+        const renamed = `After Rename ${suffix()}`;
+
+        await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const titleInput = page.getByLabel('Title');
+        await expect(titleInput).toBeVisible({ timeout: 30_000 });
+        const save = page.getByTestId('meeting-save');
+
+        // Post-condition = the PERSISTED title. Re-fill only the field that
+        // actually lost its value, and stop as soon as the write lands.
+        await expect(async () => {
+            const current = await readMeeting(request, token, meeting.id).catch(() => null);
+            if (current?.title !== renamed) {
+                if ((await titleInput.inputValue().catch(() => '')) !== renamed) {
+                    await titleInput.fill(renamed).catch(() => undefined);
+                }
+                await save.click({ timeout: 5_000, noWaitAfter: true }).catch(() => undefined);
+            }
+            expect((await readMeeting(request, token, meeting.id)).title).toBe(renamed);
+        }).toPass({ timeout: 60_000 });
+
+        // …and the catalog shows the new title on the same card.
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await expect(cardFor(page, meeting.id)).toContainText(renamed, { timeout: 30_000 });
+    });
+
+    test('UI Delete removes the meeting and returns to the catalog', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const meeting = await createMeeting(request, token, { title: `UI Delete ${suffix()}` });
+
+        await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const del = page.getByTestId('meeting-delete');
+        await expect(del).toBeVisible({ timeout: 30_000 });
+        // The delete flow guards with window.confirm().
+        page.on('dialog', (dialog) => dialog.accept());
+        // Post-condition: the client `router.push('/meetings')` landed us back on
+        // the catalog. A click before hydration never even raises the confirm,
+        // and re-clicking is safe because we stop as soon as the URL matches.
+        await clickAndExpectUrl(page, del, /\/meetings$/);
+        await expect(cardFor(page, meeting.id)).toHaveCount(0);
+        // Cascade confirmed at the API: the row is gone.
+        expect(await getMeetingStatus(request, token, meeting.id)).toBe(404);
+    });
+
+    test('an unknown meeting id renders the not-found surface, not a detail page', async ({
+        page,
+    }) => {
+        const bogus = '11111111-1111-1111-1111-111111111111';
+        const resp = await page.goto(`/en/meetings/${bogus}`, { waitUntil: 'domcontentloaded' });
+        // Handled cleanly (no 5xx). Next dev may echo 200 with the not-found body.
+        expect(resp?.status(), 'no server error for unknown meeting').toBeLessThan(500);
+        await expect(
+            page
+                .getByText('404')
+                .or(page.getByRole('heading', { name: 'Page not found' }))
+                .first(),
+            `expected not-found copy on ${page.url()}`,
+        ).toBeVisible({ timeout: 30_000 });
+        // Meaningful invariant: the meeting detail chrome must NOT render.
+        await expect(page.getByTestId('meeting-detail')).toHaveCount(0);
+        await expect(page.getByRole('heading', { name: 'Edit meeting' })).toHaveCount(0);
+    });
+});
+
+// ============================================================================
+// C. /meetings/new capture form
+// ============================================================================
+
+test.describe('Meetings — /meetings/new capture form (UI)', () => {
+    test('the capture form renders its sections, fields and actions', async ({ page }) => {
+        await page.goto('/en/meetings/new', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByRole('heading', { name: 'New meeting', level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(page.getByRole('heading', { name: 'Where it came from' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Participants' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Transcript' })).toBeVisible();
+
+        await expect(page.getByLabel('Title')).toBeVisible();
+        await expect(page.getByTestId('meeting-started-at')).toBeVisible();
+        await expect(page.getByTestId('meeting-ended-at')).toBeVisible();
+        await expect(page.getByTestId('meeting-source-select')).toBeVisible();
+        await expect(page.getByTestId('meeting-participants-input')).toBeVisible();
+        await expect(page.getByTestId('meeting-transcript-input')).toBeVisible();
+
+        await expect(page.getByTestId('meeting-create-submit')).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Cancel' })).toBeVisible();
+    });
+
+    test('client-side validation blocks a titleless submission', async ({ page }) => {
+        await page.goto('/en/meetings/new', { waitUntil: 'domcontentloaded' });
+        const create = page.getByTestId('meeting-create-submit');
+        await expect(create).toBeVisible({ timeout: 30_000 });
+
+        // Empty title → title-required toast, still on the form. The whole
+        // validation lives in a client onClick, so a click before hydration is
+        // swallowed and no toast is ever raised — hence clickUntil.
+        // (`.first()` — retries can stack duplicate toasts of the same text.)
+        const titleRequired = page.getByText('Title is required.').first();
+        await clickUntil(create, () => titleRequired.isVisible().catch(() => false));
+        await expect(titleRequired).toBeVisible({ timeout: 10_000 });
+        await expect(page).toHaveURL(/\/meetings\/new/);
+    });
+
+    test('a title-only capture defaults the start time and lands on the detail page', async ({
+        page,
+        request,
+    }) => {
+        const title = `Captured In UI ${suffix()}`;
+        await page.goto('/en/meetings/new', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByRole('heading', { name: 'New meeting', level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+
+        const titleInput = page.getByLabel('Title');
+        await expect(titleInput).toBeVisible({ timeout: 30_000 });
+
+        // `startedAt` is REQUIRED by the API; leaving the field empty means
+        // "now", so a title alone is a complete capture.
+        const detailUrl = /\/meetings\/[0-9a-f]{8}-[0-9a-f]{4}-/;
+        const create = page.getByTestId('meeting-create-submit');
+        await expect(async () => {
+            if (!detailUrl.test(page.url())) {
+                if ((await titleInput.inputValue().catch(() => '')) !== title) {
+                    await titleInput.fill(title).catch(() => undefined);
+                }
+                await create.click({ timeout: 5_000, noWaitAfter: true }).catch(() => undefined);
+            }
+            // toHaveURL polls the URL only — `load` never re-fires on a soft nav.
+            await expect(page).toHaveURL(detailUrl, { timeout: 5_000 });
+        }).toPass({ timeout: 60_000 });
+
+        await expect(page.getByRole('heading', { name: title, level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+        // Fresh capture: manual source, org-wide, no transcript yet.
+        await expect(page.getByText('Attach a transcript to generate a summary.')).toBeVisible({
+            timeout: 30_000,
+        });
+
+        // And it now appears back in the catalog.
+        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(title, { exact: true }).first()).toBeVisible({
+            timeout: 30_000,
+        });
+
+        // Persisted truth via the API: the row really exists for this owner.
+        const token = await seededToken(request);
+        const list = await request.get(`${API_BASE}/api/meetings?limit=100`, {
+            headers: authedHeaders(token),
+        });
+        expect(list.status()).toBe(200);
+        const rows = (await list.json()) as Array<{ title: string; source: string }>;
+        const created = rows.find((r) => r.title === title);
+        expect(created, 'the UI-captured meeting is in my list').toBeTruthy();
+        expect(created?.source).toBe('manual');
+    });
+
+    test('a pasted roster round-trips through the participant parser', async ({
+        page,
+        request,
+    }) => {
+        const title = `Roster In UI ${suffix()}`;
+        await page.goto('/en/meetings/new', { waitUntil: 'domcontentloaded' });
+        const titleInput = page.getByLabel('Title');
+        await expect(titleInput).toBeVisible({ timeout: 30_000 });
+        const roster = page.getByTestId('meeting-participants-input');
+        const create = page.getByTestId('meeting-create-submit');
+
+        const detailUrl = /\/meetings\/[0-9a-f]{8}-[0-9a-f]{4}-/;
+        await expect(async () => {
+            if (!detailUrl.test(page.url())) {
+                if ((await titleInput.inputValue().catch(() => '')) !== title) {
+                    await titleInput.fill(title).catch(() => undefined);
+                }
+                if ((await roster.inputValue().catch(() => '')) === '') {
+                    await roster
+                        .fill('Ada Lovelace <ada@example.com>\nGrace Hopper')
+                        .catch(() => undefined);
+                }
+                await create.click({ timeout: 5_000, noWaitAfter: true }).catch(() => undefined);
+            }
+            await expect(page).toHaveURL(detailUrl, { timeout: 5_000 });
+        }).toPass({ timeout: 60_000 });
+
+        // `Name <email>` becomes { name, email }; a bare name becomes { name }.
+        const participants = page.getByTestId('meeting-participants');
+        await expect(participants).toContainText('Ada Lovelace', { timeout: 30_000 });
+        await expect(participants).toContainText('ada@example.com');
+        await expect(participants).toContainText('Grace Hopper');
+
+        // Persisted truth: the API stored two roster entries, only one of which
+        // carries an email.
+        const token = await seededToken(request);
+        const id = page.url().split('/meetings/')[1];
+        const persisted = (await readMeeting(request, token, id)) as {
+            participants: Array<{ name: string; email?: string }>;
+        };
+        expect(persisted.participants.length).toBe(2);
+        expect(persisted.participants[0]).toMatchObject({
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+        });
+        expect(persisted.participants[1].name).toBe('Grace Hopper');
+        expect(persisted.participants[1].email).toBeUndefined();
+    });
+});
+
+// ============================================================================
+// D. Navigation
+// ============================================================================
+
+test.describe('Meetings — dashboard navigation', () => {
+    test('the sidebar Meetings link routes to the catalog', async ({ page }) => {
+        await page.goto('/en', { waitUntil: 'domcontentloaded' });
+        const link = page.locator('a[href$="/meetings"], a[href*="/meetings?"]').first();
+        if (!(await link.isVisible({ timeout: 10_000 }).catch(() => false))) {
+            test.skip(true, 'no Meetings nav link surfaced in this build');
+        }
+        // Post-condition: the catalog URL. Sidebar entries are client <Link>s —
+        // a pre-hydration click never starts the soft nav, and `load` never
+        // re-fires on one either, so waitForURL would time out regardless.
+        await clickAndExpectUrl(page, link, /\/meetings(\?|$)/);
+        await expect(page.getByRole('heading', { name: 'Meetings', level: 1 })).toBeVisible({
+            timeout: 30_000,
+        });
+    });
+});

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -453,6 +453,102 @@
                     "successDefault": "تم التحقق من اتصال SIM AI."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -744,7 +840,8 @@
                 "instructions": "التعليمات",
                 "skills": "المهارات",
                 "budgets": "الميزانيات",
-                "settings": "الإعدادات"
+                "settings": "الإعدادات",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "وكيل جديد",
@@ -827,6 +924,65 @@
                 "saveSuccess": "تم حفظ الضوابط",
                 "saveError": "تعذر حفظ الضوابط",
                 "resetSuccess": "تمت إعادة الضوابط إلى الوضع الافتراضي"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -881,7 +1037,11 @@
                 "priorityP4": "P4 — منخفض",
                 "createError": "فشل إنشاء المهمة",
                 "cancel": "إلغاء",
-                "create": "إنشاء"
+                "create": "إنشاء",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "نقل إلى",
@@ -914,7 +1074,27 @@
                 "updated": "آخر تحديث",
                 "scopeWork": "العمل",
                 "scopeMission": "المهمة",
-                "scopeIdea": "الفكرة"
+                "scopeIdea": "الفكرة",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "جدول متكرر",
@@ -945,6 +1125,94 @@
                 "p2": "متوسطة",
                 "p3": "عادية",
                 "p4": "منخفضة"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -1020,7 +1288,36 @@
                 "mission": "المهمة",
                 "idea": "الفكرة",
                 "work": "العمل",
-                "tenant": "المستأجر"
+                "tenant": "المستأجر",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
             },
             "newPage": {
                 "title": "مهارة جديدة",
@@ -1593,7 +1890,9 @@
                 "gitProviders": "مزودو Git",
                 "dangerZone": "منطقة الخطر",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "تثبيتات تطبيق GitHub",
@@ -2089,6 +2388,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -2270,11 +2748,13 @@
                     "kb": "قاعدة المعرفة",
                     "generator": "توليد الـWork مرة واحدة أو وفق جدول",
                     "deploy": "نشر الـWork",
-                    "tasks": "مهام هذا العمل"
+                    "tasks": "مهام هذا العمل",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "المهام",
                 "posts": "المقالات",
-                "pages": "الصفحات"
+                "pages": "الصفحات",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "أعضاء الفريق",
@@ -3627,7 +4107,81 @@
                 "providerRepoEnabled": "تم تفعيل إنشاء مستودع {provider}",
                 "providerRepoDisabled": "تم إيقاف إنشاء مستودع {provider}",
                 "providerRepoUpdateFailed": "تعذّر تحديث إعداد المستودع",
-                "providerRepoDisabledNote": "الإنشاء متوقف. يبقى المستودع الحالي كما هو — يتوقف تحديثه فقط."
+                "providerRepoDisabledNote": "الإنشاء متوقف. يبقى المستودع الحالي كما هو — يتوقف تحديثه فقط.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3775,6 +4329,26 @@
                     "dnsName": "الاسم:",
                     "dnsValue": "القيمة:",
                     "copyButton": "نسخ"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3809,7 +4383,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "إشعار مستند موروث",
@@ -3830,7 +4405,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -4013,6 +4589,299 @@
                     "errorFallback": "تعذّر الحذف. حاول مرة أخرى.",
                     "errorBusy": "جارٍ الحذف…",
                     "errorPartial": "تم حذف {ok}، فشل {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -4451,6 +5320,34 @@
                     "description": "توجد مستودعات بهذا الاسم بالفعل في حسابك. يمكنك استخدام اسم مختلف أو قبول الاقتراح.",
                     "useSuggestion": "استخدم \"{slug}\" بدلاً من ذلك"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4777,7 +5674,8 @@
                 "skills": "المهارات",
                 "templates": "القوالب",
                 "settings": "الإعدادات",
-                "teams": "الفرق"
+                "teams": "الفرق",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "توسيع الشريط الجانبي",
@@ -5390,7 +6288,24 @@
                 "removeMember": "إزالة",
                 "roleLead": "قائد",
                 "roleMember": "عضو",
-                "emptyRoster": "لا يوجد أعضاء بعد — أضف وكلاء أو زملاء إلى هذا الفريق."
+                "emptyRoster": "لا يوجد أعضاء بعد — أضف وكلاء أو زملاء إلى هذا الفريق.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "إعدادات الفريق",
@@ -5412,7 +6327,9 @@
                 "updateFailed": "تعذّر تحديث الفريق",
                 "deleteFailed": "تعذّر حذف الفريق",
                 "memberAddFailed": "تعذّر إضافة العضو",
-                "memberRemoveFailed": "تعذّر إزالة العضو"
+                "memberRemoveFailed": "تعذّر إزالة العضو",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5493,6 +6410,207 @@
             "company": "Company",
             "campaign": "حملة",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5582,7 +6700,8 @@
             "pluginSettings": "إعدادات الإضافة",
             "discover": "اكتشف",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -453,6 +453,102 @@
                     "successDefault": "Връзка към SIM AI проверена."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -744,7 +840,8 @@
                 "instructions": "Инструкции",
                 "skills": "Умения",
                 "budgets": "Бюджети",
-                "settings": "Настройки"
+                "settings": "Настройки",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Нов Агент",
@@ -827,6 +924,65 @@
                 "saveSuccess": "Предпазните механизми са запазени",
                 "saveError": "Предпазните механизми не можаха да бъдат запазени",
                 "resetSuccess": "Предпазните механизми са възстановени по подразбиране"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -881,7 +1037,11 @@
                 "priorityP4": "P4 — нисък",
                 "createError": "Неуспешно създаване на задачата",
                 "cancel": "Отказ",
-                "create": "Създай"
+                "create": "Създай",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Премести в",
@@ -914,7 +1074,27 @@
                 "updated": "Актуализирано",
                 "scopeWork": "Работа",
                 "scopeMission": "Мисия",
-                "scopeIdea": "Идея"
+                "scopeIdea": "Идея",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Повтарящ се график",
@@ -945,6 +1125,94 @@
                 "p2": "Среден",
                 "p3": "Нормален",
                 "p4": "Нисък"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -1020,7 +1288,36 @@
                 "mission": "Мисия",
                 "idea": "Идея",
                 "work": "Работа",
-                "tenant": "Tenant"
+                "tenant": "Tenant",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
             },
             "newPage": {
                 "title": "Ново умение",
@@ -1593,7 +1890,9 @@
                 "gitProviders": "Git доставчици",
                 "dangerZone": "Опасна зона",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Инсталации на GitHub App",
@@ -2089,6 +2388,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -2270,11 +2748,13 @@
                     "kb": "База знания",
                     "generator": "Генериране на Work — еднократно или по график",
                     "deploy": "Разгръщане на Work",
-                    "tasks": "Задачи за тази работа"
+                    "tasks": "Задачи за тази работа",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Задачи",
                 "posts": "Публикации",
-                "pages": "Страници"
+                "pages": "Страници",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Членове на екипа",
@@ -3627,7 +4107,81 @@
                 "providerRepoEnabled": "Генерирането на репозитория в {provider} е включено",
                 "providerRepoDisabled": "Генерирането на репозитория в {provider} е изключено",
                 "providerRepoUpdateFailed": "Настройката на репозитория не можа да бъде обновена",
-                "providerRepoDisabledNote": "Генерирането е изключено. Съществуващият репозиторий остава непроменен — просто спира да се обновява."
+                "providerRepoDisabledNote": "Генерирането е изключено. Съществуващият репозиторий остава непроменен — просто спира да се обновява.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3775,6 +4329,26 @@
                     "dnsName": "Име:",
                     "dnsValue": "Стойност:",
                     "copyButton": "Копирай"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3809,7 +4383,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Известие за наследен документ",
@@ -3830,7 +4405,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -4013,6 +4589,299 @@
                     "errorFallback": "Изтриването е неуспешно. Опитайте отново.",
                     "errorBusy": "Изтриване…",
                     "errorPartial": "Изтрити: {ok}, неуспешни: {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -4451,6 +5320,34 @@
                     "description": "Хранилища с това име вече съществуват във вашата сметка. Можете да използвате различно име или да приемете предложението.",
                     "useSuggestion": "Използвай \"{slug}\" вместо това"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4777,7 +5674,8 @@
                 "skills": "Умения",
                 "templates": "Шаблони",
                 "settings": "Настройки",
-                "teams": "Екипи"
+                "teams": "Екипи",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Разшири страничното меню",
@@ -5390,7 +6288,24 @@
                 "removeMember": "Премахване",
                 "roleLead": "Ръководител",
                 "roleMember": "Член",
-                "emptyRoster": "Все още няма членове — добавете Агенти или колеги към този екип."
+                "emptyRoster": "Все още няма членове — добавете Агенти или колеги към този екип.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Настройки на екипа",
@@ -5412,7 +6327,9 @@
                 "updateFailed": "Екипът не можа да бъде актуализиран",
                 "deleteFailed": "Екипът не можа да бъде изтрит",
                 "memberAddFailed": "Членът не можа да бъде добавен",
-                "memberRemoveFailed": "Членът не можа да бъде премахнат"
+                "memberRemoveFailed": "Членът не можа да бъде премахнат",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5493,6 +6410,207 @@
             "company": "Company",
             "campaign": "Кампания",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5582,7 +6700,8 @@
             "pluginSettings": "Настройки на приставките",
             "discover": "Открийте",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI-Verbindung überprüft."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -744,7 +840,8 @@
                 "instructions": "Anweisungen",
                 "skills": "Fähigkeiten",
                 "budgets": "Budgets",
-                "settings": "Einstellungen"
+                "settings": "Einstellungen",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Neuer Agent",
@@ -827,6 +924,65 @@
                 "saveSuccess": "Guardrails gespeichert",
                 "saveError": "Guardrails konnten nicht gespeichert werden",
                 "resetSuccess": "Guardrails auf Standard zurückgesetzt"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -881,7 +1037,11 @@
                 "priorityP4": "P4 — niedrig",
                 "createError": "Aufgabe konnte nicht erstellt werden",
                 "cancel": "Abbrechen",
-                "create": "Erstellen"
+                "create": "Erstellen",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Verschieben nach",
@@ -914,7 +1074,27 @@
                 "updated": "Aktualisiert",
                 "scopeWork": "Arbeit",
                 "scopeMission": "Mission",
-                "scopeIdea": "Idee"
+                "scopeIdea": "Idee",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Wiederkehrender Zeitplan",
@@ -945,6 +1125,94 @@
                 "p2": "Mittel",
                 "p3": "Normal",
                 "p4": "Niedrig"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -1020,7 +1288,36 @@
                 "mission": "Mission",
                 "idea": "Idee",
                 "work": "Aufgabe",
-                "tenant": "Mandant"
+                "tenant": "Mandant",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
             },
             "newPage": {
                 "title": "Neuer Skill",
@@ -1593,7 +1890,9 @@
                 "gitProviders": "Git-Anbieter",
                 "dangerZone": "Gefahrenzone",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub-App-Installationen",
@@ -2089,6 +2388,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -2270,11 +2748,13 @@
                     "kb": "Wissensdatenbank",
                     "generator": "Work generieren – einmalig oder nach Zeitplan",
                     "deploy": "Work bereitstellen",
-                    "tasks": "Aufgaben für diese Arbeit"
+                    "tasks": "Aufgaben für diese Arbeit",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Aufgaben",
                 "posts": "Beiträge",
-                "pages": "Seiten"
+                "pages": "Seiten",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Teammitglieder",
@@ -3627,7 +4107,81 @@
                 "providerRepoEnabled": "Generierung des {provider}-Repositorys aktiviert",
                 "providerRepoDisabled": "Generierung des {provider}-Repositorys deaktiviert",
                 "providerRepoUpdateFailed": "Repository-Einstellung konnte nicht aktualisiert werden",
-                "providerRepoDisabledNote": "Die Generierung ist aus. Das vorhandene Repository bleibt unverändert — es wird lediglich nicht mehr aktualisiert."
+                "providerRepoDisabledNote": "Die Generierung ist aus. Das vorhandene Repository bleibt unverändert — es wird lediglich nicht mehr aktualisiert.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3775,6 +4329,26 @@
                     "dnsName": "Name:",
                     "dnsValue": "Wert:",
                     "copyButton": "Kopieren"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3809,7 +4383,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Hinweis zu geerbtem Dokument",
@@ -3830,7 +4405,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -4013,6 +4589,299 @@
                     "errorFallback": "Löschen fehlgeschlagen. Bitte erneut versuchen.",
                     "errorBusy": "Wird gelöscht…",
                     "errorPartial": "Gelöscht: {ok}, fehlgeschlagen: {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -4451,6 +5320,34 @@
                     "description": "Repositories mit diesem Namen existieren bereits in Ihrem Konto. Sie können einen anderen Namen verwenden oder den Vorschlag akzeptieren.",
                     "useSuggestion": "Verwenden Sie „{slug}“ stattdessen"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4777,7 +5674,8 @@
                 "skills": "Fähigkeiten",
                 "templates": "Vorlagen",
                 "settings": "Einstellungen",
-                "teams": "Teams"
+                "teams": "Teams",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Sidebar erweitern",
@@ -5390,7 +6288,24 @@
                 "removeMember": "Entfernen",
                 "roleLead": "Leitung",
                 "roleMember": "Mitglied",
-                "emptyRoster": "Noch keine Mitglieder – fügen Sie diesem Team Agenten oder Teamkollegen hinzu."
+                "emptyRoster": "Noch keine Mitglieder – fügen Sie diesem Team Agenten oder Teamkollegen hinzu.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Team-Einstellungen",
@@ -5412,7 +6327,9 @@
                 "updateFailed": "Team konnte nicht aktualisiert werden",
                 "deleteFailed": "Team konnte nicht gelöscht werden",
                 "memberAddFailed": "Mitglied konnte nicht hinzugefügt werden",
-                "memberRemoveFailed": "Mitglied konnte nicht entfernt werden"
+                "memberRemoveFailed": "Mitglied konnte nicht entfernt werden",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5493,6 +6410,207 @@
             "company": "Company",
             "campaign": "Kampagne",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5582,7 +6700,8 @@
             "pluginSettings": "Plugin-Einstellungen",
             "discover": "Entdecken",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5728,6 +5728,164 @@
                 "delete": "Delete this Goal? Its observation history and Mission links will be removed. This cannot be undone."
             }
         },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
         "sidebar": {
             "menu": "Menu",
             "aiChat": "AI Chat",
@@ -5744,6 +5902,7 @@
                 "tasks": "Tasks",
                 "agents": "Agents",
                 "memory": "Memory",
+                "meetings": "Meetings",
                 "plugins": "Plugins",
                 "skills": "Skills",
                 "templates": "Templates",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -453,6 +453,102 @@
                     "successDefault": "Conexión de SIM AI verificada."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -744,7 +840,8 @@
                 "instructions": "Instrucciones",
                 "skills": "Habilidades",
                 "budgets": "Presupuestos",
-                "settings": "Configuración"
+                "settings": "Configuración",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Nuevo Agente",
@@ -827,6 +924,65 @@
                 "saveSuccess": "Salvaguardas guardadas",
                 "saveError": "No se pudieron guardar las salvaguardas",
                 "resetSuccess": "Salvaguardas restablecidas a los valores predeterminados"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -881,7 +1037,11 @@
                 "priorityP4": "P4 — baja",
                 "createError": "No se pudo crear la tarea",
                 "cancel": "Cancelar",
-                "create": "Crear"
+                "create": "Crear",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Mover a",
@@ -914,7 +1074,27 @@
                 "updated": "Actualizado",
                 "scopeWork": "Trabajo",
                 "scopeMission": "Misión",
-                "scopeIdea": "Idea"
+                "scopeIdea": "Idea",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Programación recurrente",
@@ -945,6 +1125,94 @@
                 "p2": "Media",
                 "p3": "Normal",
                 "p4": "Baja"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -1020,7 +1288,36 @@
                 "mission": "Misión",
                 "idea": "Idea",
                 "work": "Trabajo",
-                "tenant": "Inquilino"
+                "tenant": "Inquilino",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
             },
             "newPage": {
                 "title": "Nueva habilidad",
@@ -1593,7 +1890,9 @@
                 "gitProviders": "Proveedores de Git",
                 "dangerZone": "Zona de peligro",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Instalaciones de GitHub App",
@@ -2089,6 +2388,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -2270,11 +2748,13 @@
                     "kb": "Base de conocimiento",
                     "generator": "Generar Work, una vez o según programación",
                     "deploy": "Desplegar Work",
-                    "tasks": "Tareas de este Work"
+                    "tasks": "Tareas de este Work",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Tareas",
                 "posts": "Publicaciones",
-                "pages": "Páginas"
+                "pages": "Páginas",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Miembros del equipo",
@@ -3627,7 +4107,81 @@
                 "providerRepoEnabled": "Generación del repositorio de {provider} activada",
                 "providerRepoDisabled": "Generación del repositorio de {provider} desactivada",
                 "providerRepoUpdateFailed": "No se pudo actualizar el ajuste del repositorio",
-                "providerRepoDisabledNote": "La generación está desactivada. El repositorio existente se conserva intacto: simplemente deja de actualizarse."
+                "providerRepoDisabledNote": "La generación está desactivada. El repositorio existente se conserva intacto: simplemente deja de actualizarse.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3775,6 +4329,26 @@
                     "dnsName": "Nombre:",
                     "dnsValue": "Valor:",
                     "copyButton": "Copiar"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3809,7 +4383,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Aviso de documento heredado",
@@ -3830,7 +4405,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -4013,6 +4589,299 @@
                     "errorFallback": "No se pudo eliminar. Inténtalo de nuevo.",
                     "errorBusy": "Eliminando…",
                     "errorPartial": "Eliminados {ok}, fallidos {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -4451,6 +5320,34 @@
                     "description": "Ya existen repositorios con este nombre en tu cuenta. Puedes usar un nombre diferente o aceptar la sugerencia.",
                     "useSuggestion": "Usa \"{slug}\" en su lugar"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4777,7 +5674,8 @@
                 "skills": "Habilidades",
                 "templates": "Plantillas",
                 "settings": "Configuración",
-                "teams": "Equipos"
+                "teams": "Equipos",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Expandir barra lateral",
@@ -5390,7 +6288,24 @@
                 "removeMember": "Quitar",
                 "roleLead": "Líder",
                 "roleMember": "Miembro",
-                "emptyRoster": "Aún no hay miembros: añade Agentes o compañeros a este equipo."
+                "emptyRoster": "Aún no hay miembros: añade Agentes o compañeros a este equipo.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Configuración del equipo",
@@ -5412,7 +6327,9 @@
                 "updateFailed": "No se pudo actualizar el equipo",
                 "deleteFailed": "No se pudo eliminar el equipo",
                 "memberAddFailed": "No se pudo añadir el miembro",
-                "memberRemoveFailed": "No se pudo quitar el miembro"
+                "memberRemoveFailed": "No se pudo quitar el miembro",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5493,6 +6410,207 @@
             "company": "Company",
             "campaign": "Campaña",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5582,7 +6700,8 @@
             "pluginSettings": "Configuración de complementos",
             "discover": "Descubrir",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -453,6 +453,102 @@
                     "successDefault": "Connexion SIM AI vérifiée."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -744,7 +840,8 @@
                 "instructions": "Instructions",
                 "skills": "Compétences",
                 "budgets": "Budgets",
-                "settings": "Paramètres"
+                "settings": "Paramètres",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Nouvel Agent",
@@ -827,6 +924,65 @@
                 "saveSuccess": "Garde-fous enregistrés",
                 "saveError": "Impossible d'enregistrer les garde-fous",
                 "resetSuccess": "Garde-fous réinitialisés par défaut"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -881,7 +1037,11 @@
                 "priorityP4": "P4 — faible",
                 "createError": "Échec de la création de la tâche",
                 "cancel": "Annuler",
-                "create": "Créer"
+                "create": "Créer",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Déplacer vers",
@@ -914,7 +1074,27 @@
                 "updated": "Mis à jour",
                 "scopeWork": "Travail",
                 "scopeMission": "Mission",
-                "scopeIdea": "Idée"
+                "scopeIdea": "Idée",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Calendrier récurrent",
@@ -945,6 +1125,94 @@
                 "p2": "Moyenne",
                 "p3": "Normale",
                 "p4": "Basse"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -1020,7 +1288,36 @@
                 "mission": "Mission",
                 "idea": "Idée",
                 "work": "Work",
-                "tenant": "Locataire"
+                "tenant": "Locataire",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
             },
             "newPage": {
                 "title": "Nouvelle compétence",
@@ -1593,7 +1890,9 @@
                 "gitProviders": "Fournisseurs Git",
                 "dangerZone": "Zone de danger",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Installations GitHub App",
@@ -2089,6 +2388,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -2270,11 +2748,13 @@
                     "kb": "Base de connaissances",
                     "generator": "Générer le Work, ponctuellement ou planifié",
                     "deploy": "Déployer le Work",
-                    "tasks": "Tâches de ce Work"
+                    "tasks": "Tâches de ce Work",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Tâches",
                 "posts": "Articles",
-                "pages": "Pages"
+                "pages": "Pages",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Membres de l'équipe",
@@ -3627,7 +4107,81 @@
                 "providerRepoEnabled": "Génération du dépôt {provider} activée",
                 "providerRepoDisabled": "Génération du dépôt {provider} désactivée",
                 "providerRepoUpdateFailed": "Impossible de mettre à jour le paramètre du dépôt",
-                "providerRepoDisabledNote": "La génération est désactivée. Le dépôt existant reste intact — il cesse simplement d’être mis à jour."
+                "providerRepoDisabledNote": "La génération est désactivée. Le dépôt existant reste intact — il cesse simplement d’être mis à jour.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3775,6 +4329,26 @@
                     "dnsName": "Nom :",
                     "dnsValue": "Valeur :",
                     "copyButton": "Copier"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3809,7 +4383,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Notification de document hérité",
@@ -3830,7 +4405,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -4013,6 +4589,299 @@
                     "errorFallback": "Suppression impossible. Réessayez.",
                     "errorBusy": "Suppression…",
                     "errorPartial": "Supprimés {ok}, échec {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -4451,6 +5320,34 @@
                     "description": "Des dépôts portant ce nom existent déjà dans votre compte. Vous pouvez utiliser un nom différent ou accepter la suggestion.",
                     "useSuggestion": "Utiliser « {slug} » à la place"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4777,7 +5674,8 @@
                 "skills": "Compétences",
                 "templates": "Modèles",
                 "settings": "Paramètres",
-                "teams": "Équipes"
+                "teams": "Équipes",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Développer la barre latérale",
@@ -5390,7 +6288,24 @@
                 "removeMember": "Retirer",
                 "roleLead": "Responsable",
                 "roleMember": "Membre",
-                "emptyRoster": "Aucun membre pour le moment — ajoutez des Agents ou des collègues à cette équipe."
+                "emptyRoster": "Aucun membre pour le moment — ajoutez des Agents ou des collègues à cette équipe.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Paramètres de l’équipe",
@@ -5412,7 +6327,9 @@
                 "updateFailed": "Impossible de mettre à jour l’équipe",
                 "deleteFailed": "Impossible de supprimer l’équipe",
                 "memberAddFailed": "Impossible d’ajouter le membre",
-                "memberRemoveFailed": "Impossible de retirer le membre"
+                "memberRemoveFailed": "Impossible de retirer le membre",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5493,6 +6410,207 @@
             "company": "Company",
             "campaign": "Campagne",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5582,7 +6700,8 @@
             "pluginSettings": "Paramètres des plugins",
             "discover": "Découvrir",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -453,6 +453,102 @@
                     "successDefault": "חיבור SIM AI אומת."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -744,7 +840,8 @@
                 "instructions": "הוראות",
                 "skills": "מיומנויות",
                 "budgets": "תקציבים",
-                "settings": "הגדרות"
+                "settings": "הגדרות",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "סוכן חדש",
@@ -827,6 +924,65 @@
                 "saveSuccess": "מעקות הבטיחות נשמרו",
                 "saveError": "לא ניתן לשמור את מעקות הבטיחות",
                 "resetSuccess": "מעקות הבטיחות אופסו לברירת מחדל"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -881,7 +1037,11 @@
                 "priorityP4": "P4 — נמוך",
                 "createError": "יצירת המשימה נכשלה",
                 "cancel": "בטל",
-                "create": "צור"
+                "create": "צור",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "העבר אל",
@@ -914,7 +1074,27 @@
                 "updated": "עודכן",
                 "scopeWork": "עבודה",
                 "scopeMission": "משימה",
-                "scopeIdea": "רעיון"
+                "scopeIdea": "רעיון",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "תדירות חוזרת",
@@ -945,6 +1125,94 @@
                 "p2": "בינוני",
                 "p3": "רגיל",
                 "p4": "נמוך"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -1020,7 +1288,36 @@
                 "mission": "משימה",
                 "idea": "רעיון",
                 "work": "עבודה",
-                "tenant": "דייר"
+                "tenant": "דייר",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
             },
             "newPage": {
                 "title": "כישור חדש",
@@ -1593,7 +1890,9 @@
                 "gitProviders": "ספקי Git",
                 "dangerZone": "אזור סכנה",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "התקנות GitHub App",
@@ -2089,6 +2388,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -2270,11 +2748,13 @@
                     "kb": "מאגר ידע",
                     "generator": "צור Work, חד-פעמי או על פי לוח זמנים",
                     "deploy": "פרוס Work",
-                    "tasks": "משימות עבור Work זה"
+                    "tasks": "משימות עבור Work זה",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "משימות",
                 "posts": "פוסטים",
-                "pages": "עמודים"
+                "pages": "עמודים",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "חברי צוות",
@@ -3627,7 +4107,81 @@
                 "providerRepoEnabled": "יצירת מאגר {provider} הופעלה",
                 "providerRepoDisabled": "יצירת מאגר {provider} כובתה",
                 "providerRepoUpdateFailed": "עדכון הגדרת המאגר נכשל",
-                "providerRepoDisabledNote": "היצירה כבויה. המאגר הקיים נשאר כפי שהוא — הוא פשוט מפסיק להתעדכן."
+                "providerRepoDisabledNote": "היצירה כבויה. המאגר הקיים נשאר כפי שהוא — הוא פשוט מפסיק להתעדכן.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3775,6 +4329,26 @@
                     "dnsName": "שם:",
                     "dnsValue": "ערך:",
                     "copyButton": "העתק"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3809,7 +4383,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "הודעת מסמך בירושה",
@@ -3830,7 +4405,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -4013,6 +4589,299 @@
                     "errorFallback": "המחיקה נכשלה. נסה שוב.",
                     "errorBusy": "מוחק…",
                     "errorPartial": "נמחקו {ok}, נכשלו {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -4451,6 +5320,34 @@
                     "description": "מאגרים עם שם זה כבר קיימים בחשבונך. ניתן להשתמש בשם אחר או לקבל את ההצעה.",
                     "useSuggestion": "השתמש ב-\"{slug}\" במקום"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4777,7 +5674,8 @@
                 "skills": "מיומנויות",
                 "templates": "תבניות",
                 "settings": "הגדרות",
-                "teams": "צוותים"
+                "teams": "צוותים",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "הרחב צד",
@@ -5390,7 +6288,24 @@
                 "removeMember": "הסר",
                 "roleLead": "מוביל",
                 "roleMember": "חבר",
-                "emptyRoster": "אין חברים עדיין — הוסף סוכנים או עמיתים לצוות הזה."
+                "emptyRoster": "אין חברים עדיין — הוסף סוכנים או עמיתים לצוות הזה.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "הגדרות צוות",
@@ -5412,7 +6327,9 @@
                 "updateFailed": "לא ניתן היה לעדכן את הצוות",
                 "deleteFailed": "לא ניתן היה למחוק את הצוות",
                 "memberAddFailed": "לא ניתן היה להוסיף את החבר",
-                "memberRemoveFailed": "לא ניתן היה להסיר את החבר"
+                "memberRemoveFailed": "לא ניתן היה להסיר את החבר",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5493,6 +6410,207 @@
             "company": "Company",
             "campaign": "קמפיין",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5582,7 +6700,8 @@
             "pluginSettings": "הגדרות תוסף",
             "discover": "גלה",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI कनेक्शन सत्यापित।"
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "विवरण कम से कम 10 अक्षरों का होना चाहिए।",
                 "error": "मिशन नहीं बनाया जा सका। कृपया पुनः प्रयास करें।",
                 "chatUnavailable": "चैट अभी उपलब्ध नहीं है — इसके बजाय \"मैन्युअल रूप से बनाएँ\" का उपयोग करें।"
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "निर्देश",
                 "skills": "कौशल",
                 "budgets": "बजट",
-                "settings": "सेटिंग्स"
+                "settings": "सेटिंग्स",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "नए एजेंट",
@@ -716,7 +829,17 @@
                 "teamLabel": "टीम",
                 "teamNone": "कोई टीम नहीं",
                 "reportsToLabel": "किसे रिपोर्ट करता है",
-                "reportsToNone": "कोई प्रबंधक नहीं"
+                "reportsToNone": "कोई प्रबंधक नहीं",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "गार्डरेल सहेजे गए",
                 "saveError": "गार्डरेल सहेजे नहीं जा सके",
                 "resetSuccess": "गार्डरेल डिफ़ॉल्ट पर रीसेट हो गए"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — निम्न",
                 "createError": "कार्य बनाने में विफल",
                 "cancel": "रद्द करें",
-                "create": "बनाएं"
+                "create": "बनाएं",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "इसमें स्थानांतरित करें",
@@ -840,7 +1043,27 @@
                 "updated": "अपडेट किया गया",
                 "scopeWork": "काम",
                 "scopeMission": "मिशन",
-                "scopeIdea": "विचार"
+                "scopeIdea": "विचार",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "पुनरावर्ती अनुसूची",
@@ -871,6 +1094,94 @@
                 "p2": "मध्यम",
                 "p3": "सामान्य",
                 "p4": "निम्न"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "मिशन",
                 "idea": "विचार",
                 "work": "काम",
-                "tenant": "टेनेंट"
+                "tenant": "टेनेंट",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "विफल",
                     "cancelled": "रद्द"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "सेटिंग्स",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Git प्रदाता",
                 "dangerZone": "खतरे का क्षेत्र",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub ऐप इंस्टॉलेशन",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "सक्रिय वेबसाइटें",
             "monthSpend": "Month Spend",
             "fromLastMonth": "पिछले महीने से",
-            "teams": "टीमें"
+            "teams": "टीमें",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "ध्यान देने की आवश्यकता",
@@ -2068,11 +2680,13 @@
                     "kb": "ज्ञान आधार",
                     "generator": "Work उत्पन्न करें, एक बार या निर्धारित समय पर",
                     "deploy": "Work परिनियोजित करें",
-                    "tasks": "इस Work के कार्य"
+                    "tasks": "इस Work के कार्य",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "कार्य",
                 "posts": "पोस्ट",
-                "pages": "पृष्ठ"
+                "pages": "पृष्ठ",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "टीम सदस्य",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "{provider} रिपॉजिटरी निर्माण सक्षम",
                 "providerRepoDisabled": "{provider} रिपॉजिटरी निर्माण अक्षम",
                 "providerRepoUpdateFailed": "रिपॉजिटरी सेटिंग अपडेट नहीं हो सकी",
-                "providerRepoDisabledNote": "निर्माण बंद है। मौजूदा रिपॉजिटरी अछूती रहती है — बस उसका अपडेट होना रुक जाता है।"
+                "providerRepoDisabledNote": "निर्माण बंद है। मौजूदा रिपॉजिटरी अछूती रहती है — बस उसका अपडेट होना रुक जाता है।",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "नाम:",
                     "dnsValue": "मान:",
                     "copyButton": "कॉपी करें"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "विरासत में मिले दस्तावेज़ की सूचना",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "हटाया नहीं जा सका. कृपया पुनः प्रयास करें.",
                     "errorBusy": "हटा रहा है…",
                     "errorPartial": "{ok} हटाए गए, {failed} विफल."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "नई कार्य बनाएँ",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "अपने व्यक्तिगत खाते के बजाय संगठन के अंतर्गत रिपॉजिटरी बनाएँ",
                 "organizationNameLabel": "संगठन का नाम",
                 "organizationNamePlaceholder": "संगठन का नाम दर्ज करें",
-                "websiteTemplateHelperText": "वह कार्य टेम्प्लेट चुनें जो कार्य रिपॉज़िटरी पहली बार बनाए जाने पर उपयोग किया जाएगा।"
+                "websiteTemplateHelperText": "वह कार्य टेम्प्लेट चुनें जो कार्य रिपॉज़िटरी पहली बार बनाए जाने पर उपयोग किया जाएगा।",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "मैन्युअल रूप से बनाएँ",
@@ -4218,6 +5229,58 @@
                     "description": "इस नाम वाली रिपॉजिटरीज़ पहले से आपके खाते में मौजूद हैं। आप अलग नाम उपयोग कर सकते हैं या सुझाव स्वीकार करें।",
                     "useSuggestion": "\"{slug}\" का उपयोग करें"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "कौशल",
                 "templates": "टेम्प्लेट",
                 "settings": "सेटिंग्स",
-                "teams": "टीमें"
+                "teams": "टीमें",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "साइडबार विस्तारित करें",
@@ -5161,7 +6225,24 @@
                 "removeMember": "हटाएं",
                 "roleLead": "लीड",
                 "roleMember": "सदस्य",
-                "emptyRoster": "अभी कोई सदस्य नहीं — इस टीम में एजेंट या सहकर्मी जोड़ें।"
+                "emptyRoster": "अभी कोई सदस्य नहीं — इस टीम में एजेंट या सहकर्मी जोड़ें।",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "टीम सेटिंग्स",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "टीम अपडेट नहीं की जा सकी",
                 "deleteFailed": "टीम हटाई नहीं जा सकी",
                 "memberAddFailed": "सदस्य जोड़ा नहीं जा सका",
-                "memberRemoveFailed": "सदस्य हटाया नहीं जा सका"
+                "memberRemoveFailed": "सदस्य हटाया नहीं जा सका",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "अभियान",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "प्लगइन सेटिंग्स",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "निजी",
             "public": "सार्वजनिक"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -453,6 +453,102 @@
                     "successDefault": "Koneksi SIM AI diverifikasi."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "Deskripsi harus minimal 10 karakter.",
                 "error": "Tidak dapat membuat Misi. Silakan coba lagi.",
                 "chatUnavailable": "Chat sedang tidak tersedia — gunakan \"Buat manual\"."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Petunjuk",
                 "skills": "Keterampilan",
                 "budgets": "Anggaran",
-                "settings": "Pengaturan"
+                "settings": "Pengaturan",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Agen Baru",
@@ -716,7 +829,17 @@
                 "teamLabel": "Tim",
                 "teamNone": "Tanpa tim",
                 "reportsToLabel": "Melapor kepada",
-                "reportsToNone": "Tanpa manajer"
+                "reportsToNone": "Tanpa manajer",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Pagar pengaman disimpan",
                 "saveError": "Tidak dapat menyimpan pagar pengaman",
                 "resetSuccess": "Pagar pengaman diatur ulang ke bawaan"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — rendah",
                 "createError": "Gagal membuat tugas",
                 "cancel": "Batal",
-                "create": "Buat"
+                "create": "Buat",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Pindahkan ke",
@@ -840,7 +1043,27 @@
                 "updated": "Diperbarui",
                 "scopeWork": "Karya",
                 "scopeMission": "Misi",
-                "scopeIdea": "Ide"
+                "scopeIdea": "Ide",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Jadwal berulang",
@@ -871,6 +1094,94 @@
                 "p2": "Sedang",
                 "p3": "Normal",
                 "p4": "Rendah"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Misi",
                 "idea": "Ide",
                 "work": "Karya",
-                "tenant": "Penyewa"
+                "tenant": "Penyewa",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Gagal",
                     "cancelled": "Dibatalkan"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Pengaturan",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Penyedia Git",
                 "dangerZone": "Zona Berbahaya",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Instalasi GitHub App",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Situs Web Aktif",
             "monthSpend": "Month Spend",
             "fromLastMonth": "dari bulan lalu",
-            "teams": "Tim"
+            "teams": "Tim",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Perlu perhatian",
@@ -2068,11 +2680,13 @@
                     "kb": "Basis Pengetahuan",
                     "generator": "Buat Work, sekali atau terjadwal",
                     "deploy": "Deploy Work",
-                    "tasks": "Tugas untuk Work ini"
+                    "tasks": "Tugas untuk Work ini",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Tugas",
                 "posts": "Postingan",
-                "pages": "Halaman"
+                "pages": "Halaman",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Anggota Tim",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Pembuatan repositori {provider} diaktifkan",
                 "providerRepoDisabled": "Pembuatan repositori {provider} dinonaktifkan",
                 "providerRepoUpdateFailed": "Gagal memperbarui pengaturan repositori",
-                "providerRepoDisabledNote": "Pembuatan dimatikan. Repositori yang ada dibiarkan apa adanya — hanya berhenti diperbarui."
+                "providerRepoDisabledNote": "Pembuatan dimatikan. Repositori yang ada dibiarkan apa adanya — hanya berhenti diperbarui.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Nama:",
                     "dnsValue": "Nilai:",
                     "copyButton": "Salin"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Pemberitahuan dokumen warisan",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Tidak dapat menghapus. Silakan coba lagi.",
                     "errorBusy": "Menghapus…",
                     "errorPartial": "Terhapus {ok}, gagal {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Buat Karya Baru",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Buat repositori di bawah organisasi bukan akun pribadi Anda",
                 "organizationNameLabel": "Nama Organisasi",
                 "organizationNamePlaceholder": "Masukkan nama organisasi",
-                "websiteTemplateHelperText": "Pilih template Karya yang akan digunakan saat repositori Karya pertama kali dibuat."
+                "websiteTemplateHelperText": "Pilih template Karya yang akan digunakan saat repositori Karya pertama kali dibuat.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Buat Secara Manual",
@@ -4218,6 +5229,58 @@
                     "description": "Repositori dengan nama ini sudah ada di akun Anda. Anda bisa gunakan nama berbeda atau terima saran.",
                     "useSuggestion": "Gunakan \"{slug}\" sebagai gantinya"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Keterampilan",
                 "templates": "Template",
                 "settings": "Pengaturan",
-                "teams": "Tim"
+                "teams": "Tim",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Lebarkan bilah sisi",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Hapus",
                 "roleLead": "Ketua",
                 "roleMember": "Anggota",
-                "emptyRoster": "Belum ada anggota — tambahkan Agen atau rekan kerja ke tim ini."
+                "emptyRoster": "Belum ada anggota — tambahkan Agen atau rekan kerja ke tim ini.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Pengaturan Tim",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Tidak dapat memperbarui tim",
                 "deleteFailed": "Tidak dapat menghapus tim",
                 "memberAddFailed": "Tidak dapat menambahkan anggota",
-                "memberRemoveFailed": "Tidak dapat menghapus anggota"
+                "memberRemoveFailed": "Tidak dapat menghapus anggota",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Kampanye",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Pengaturan Plugin",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Pribadi",
             "public": "Publik"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -453,6 +453,102 @@
                     "successDefault": "Connessione SIM AI verificata."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "La descrizione deve contenere almeno 10 caratteri.",
                 "error": "Impossibile creare la missione. Riprova.",
                 "chatUnavailable": "La chat non è disponibile — usa «Crea manualmente»."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Istruzioni",
                 "skills": "Competenze",
                 "budgets": "Budget",
-                "settings": "Impostazioni"
+                "settings": "Impostazioni",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Nuovo Agente",
@@ -716,7 +829,17 @@
                 "teamLabel": "Team",
                 "teamNone": "Nessun team",
                 "reportsToLabel": "Riporta a",
-                "reportsToNone": "Nessun manager"
+                "reportsToNone": "Nessun manager",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Guardrail salvati",
                 "saveError": "Impossibile salvare i guardrail",
                 "resetSuccess": "Guardrail ripristinati ai valori predefiniti"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — bassa",
                 "createError": "Creazione dell'attività non riuscita",
                 "cancel": "Annulla",
-                "create": "Crea"
+                "create": "Crea",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Sposta in",
@@ -840,7 +1043,27 @@
                 "updated": "Aggiornato",
                 "scopeWork": "Lavoro",
                 "scopeMission": "Missione",
-                "scopeIdea": "Idea"
+                "scopeIdea": "Idea",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Programma ricorrente",
@@ -871,6 +1094,94 @@
                 "p2": "Media",
                 "p3": "Normale",
                 "p4": "Bassa"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Missione",
                 "idea": "Idea",
                 "work": "Lavoro",
-                "tenant": "Tenant"
+                "tenant": "Tenant",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Fallito",
                     "cancelled": "Annullato"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Impostazioni",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Fornitori Git",
                 "dangerZone": "Zona di pericolo",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Installazioni GitHub App",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Siti web attivi",
             "monthSpend": "Month Spend",
             "fromLastMonth": "rispetto al mese scorso",
-            "teams": "Team"
+            "teams": "Team",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Richiede attenzione",
@@ -2068,11 +2680,13 @@
                     "kb": "Base di conoscenza",
                     "generator": "Genera Work, una tantum o pianificato",
                     "deploy": "Distribuisci Work",
-                    "tasks": "Attività di questo Work"
+                    "tasks": "Attività di questo Work",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Attività",
                 "posts": "Articoli",
-                "pages": "Pagine"
+                "pages": "Pagine",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Membri del team",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Generazione del repository {provider} attivata",
                 "providerRepoDisabled": "Generazione del repository {provider} disattivata",
                 "providerRepoUpdateFailed": "Impossibile aggiornare l’impostazione del repository",
-                "providerRepoDisabledNote": "La generazione è disattivata. Il repository esistente resta intatto: smette semplicemente di essere aggiornato."
+                "providerRepoDisabledNote": "La generazione è disattivata. Il repository esistente resta intatto: smette semplicemente di essere aggiornato.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Nome:",
                     "dnsValue": "Valore:",
                     "copyButton": "Copia"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Notifica documento ereditato",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Eliminazione non riuscita. Riprova.",
                     "errorBusy": "Eliminazione…",
                     "errorPartial": "Eliminati {ok}, falliti {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Crea Nuova Lavori",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Crea repository sotto un'organizzazione invece del tuo account personale",
                 "organizationNameLabel": "Nome Organizzazione",
                 "organizationNamePlaceholder": "Inserisci il nome dell'organizzazione",
-                "websiteTemplateHelperText": "Scegli il modello Lavori che verrà utilizzato quando il repository Lavori viene creato per la prima volta."
+                "websiteTemplateHelperText": "Scegli il modello Lavori che verrà utilizzato quando il repository Lavori viene creato per la prima volta.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Crea Manualmente",
@@ -4218,6 +5229,58 @@
                     "description": "Repository con questo nome esistono già nel tuo account. Puoi usare un nome diverso o accettare il suggerimento.",
                     "useSuggestion": "Usa \"{slug}\" invece"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Competenze",
                 "templates": "Modelli",
                 "settings": "Impostazioni",
-                "teams": "Team"
+                "teams": "Team",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Espandi barra laterale",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Rimuovi",
                 "roleLead": "Responsabile",
                 "roleMember": "Membro",
-                "emptyRoster": "Ancora nessun membro: aggiungi Agenti o colleghi a questo team."
+                "emptyRoster": "Ancora nessun membro: aggiungi Agenti o colleghi a questo team.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Impostazioni del team",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Impossibile aggiornare il team",
                 "deleteFailed": "Impossibile eliminare il team",
                 "memberAddFailed": "Impossibile aggiungere il membro",
-                "memberRemoveFailed": "Impossibile rimuovere il membro"
+                "memberRemoveFailed": "Impossibile rimuovere il membro",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Campagna",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Impostazioni plugin",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Privato",
             "public": "Pubblico"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI 接続が検証されました。"
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -625,6 +722,13 @@
                 "minLength": "説明は 10 文字以上で入力してください。",
                 "error": "ミッションを作成できませんでした。もう一度お試しください。",
                 "chatUnavailable": "チャットは現在利用できません。「手動で作成」をご利用ください。"
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
             }
         },
         "memoryPage": {
@@ -705,7 +809,8 @@
                 "instructions": "指示",
                 "skills": "スキル",
                 "budgets": "予算",
-                "settings": "設定"
+                "settings": "設定",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "新しいエージェント",
@@ -724,7 +829,17 @@
                 "teamLabel": "チーム",
                 "teamNone": "チームなし",
                 "reportsToLabel": "報告先",
-                "reportsToNone": "マネージャーなし"
+                "reportsToNone": "マネージャーなし",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -761,6 +876,82 @@
                 "saveSuccess": "ガードレールを保存しました",
                 "saveError": "ガードレールを保存できませんでした",
                 "resetSuccess": "ガードレールをデフォルトに戻しました"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -815,7 +1006,11 @@
                 "priorityP4": "P4 — 低",
                 "createError": "タスクの作成に失敗しました",
                 "cancel": "キャンセル",
-                "create": "作成"
+                "create": "作成",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "移動先",
@@ -848,7 +1043,27 @@
                 "updated": "更新日",
                 "scopeWork": "作業",
                 "scopeMission": "ミッション",
-                "scopeIdea": "アイデア"
+                "scopeIdea": "アイデア",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "定期的なスケジュール",
@@ -879,6 +1094,94 @@
                 "p2": "中",
                 "p3": "通常",
                 "p4": "低"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -907,7 +1210,120 @@
                 "mission": "ミッション",
                 "idea": "アイデア",
                 "work": "作業",
-                "tenant": "テナント"
+                "tenant": "テナント",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1075,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1388,7 +1805,8 @@
                     "failed": "失敗",
                     "cancelled": "キャンセル"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "設定",
@@ -1404,7 +1822,9 @@
                 "gitProviders": "Git プロバイダー",
                 "dangerZone": "危険ゾーン",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub App インストール",
@@ -1900,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1910,7 +2509,12 @@
             "activeWebsites": "アクティブなウェブサイト",
             "monthSpend": "Month Spend",
             "fromLastMonth": "先月から",
-            "teams": "チーム"
+            "teams": "チーム",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "要対応",
@@ -2076,11 +2680,13 @@
                     "kb": "ナレッジベース",
                     "generator": "Work を 1 回またはスケジュールで生成",
                     "deploy": "Work をデプロイ",
-                    "tasks": "このワークのタスク"
+                    "tasks": "このワークのタスク",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "タスク",
                 "posts": "投稿",
-                "pages": "ページ"
+                "pages": "ページ",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "チームメンバー",
@@ -3433,7 +4039,81 @@
                 "providerRepoEnabled": "{provider} リポジトリの生成を有効にしました",
                 "providerRepoDisabled": "{provider} リポジトリの生成を無効にしました",
                 "providerRepoUpdateFailed": "リポジトリ設定を更新できませんでした",
-                "providerRepoDisabledNote": "生成はオフです。既存のリポジトリはそのまま残り、更新されなくなるだけです。"
+                "providerRepoDisabledNote": "生成はオフです。既存のリポジトリはそのまま残り、更新されなくなるだけです。",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3581,6 +4261,26 @@
                     "dnsName": "名前：",
                     "dnsValue": "値：",
                     "copyButton": "コピー"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3615,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "継承ドキュメントの通知",
@@ -3636,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3819,6 +4521,299 @@
                     "errorFallback": "削除できませんでした。再試行してください。",
                     "errorBusy": "削除中…",
                     "errorPartial": "削除 {ok} 件、失敗 {failed} 件。"
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3836,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3859,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3877,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "新しいワークを作成",
@@ -3990,7 +4990,10 @@
                 "organizationHelp": "個人アカウントではなく組織の下にリポジトリを作成",
                 "organizationNameLabel": "組織名",
                 "organizationNamePlaceholder": "組織名を入力",
-                "websiteTemplateHelperText": "ワークリポジトリが最初に作成されるときに使用されるワークテンプレートを選択してください。"
+                "websiteTemplateHelperText": "ワークリポジトリが最初に作成されるときに使用されるワークテンプレートを選択してください。",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "手動で作成",
@@ -4226,6 +5229,58 @@
                     "description": "この名前のリポジトリがアカウントに既に存在します。別の名前を使用するか提案を受け入れてください。",
                     "useSuggestion": "代わりに「{slug}」を使用"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4552,7 +5607,8 @@
                 "skills": "スキル",
                 "templates": "テンプレート",
                 "settings": "設定",
-                "teams": "チーム"
+                "teams": "チーム",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "サイドバーを展開",
@@ -5169,7 +6225,24 @@
                 "removeMember": "削除",
                 "roleLead": "リード",
                 "roleMember": "メンバー",
-                "emptyRoster": "メンバーはまだいません。このチームにエージェントや同僚を追加しましょう。"
+                "emptyRoster": "メンバーはまだいません。このチームにエージェントや同僚を追加しましょう。",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "チーム設定",
@@ -5191,7 +6264,9 @@
                 "updateFailed": "チームを更新できませんでした",
                 "deleteFailed": "チームを削除できませんでした",
                 "memberAddFailed": "メンバーを追加できませんでした",
-                "memberRemoveFailed": "メンバーを削除できませんでした"
+                "memberRemoveFailed": "メンバーを削除できませんでした",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5305,6 +6380,238 @@
             "company": "Company",
             "campaign": "キャンペーン",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5394,7 +6701,8 @@
             "pluginSettings": "プラグイン設定",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5568,6 +6876,11 @@
         "visibility": {
             "private": "非公開",
             "public": "公開"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5665,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI 연결 확인됨."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -625,6 +722,13 @@
                 "minLength": "설명은 최소 10자 이상이어야 합니다.",
                 "error": "미션을 생성하지 못했습니다. 다시 시도해 주세요.",
                 "chatUnavailable": "채팅을 사용할 수 없습니다 — \"직접 만들기\"를 이용하세요."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
             }
         },
         "memoryPage": {
@@ -705,7 +809,8 @@
                 "instructions": "지시사항",
                 "skills": "기술",
                 "budgets": "예산",
-                "settings": "설정"
+                "settings": "설정",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "새 에이전트",
@@ -724,7 +829,17 @@
                 "teamLabel": "팀",
                 "teamNone": "팀 없음",
                 "reportsToLabel": "보고 대상",
-                "reportsToNone": "관리자 없음"
+                "reportsToNone": "관리자 없음",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -761,6 +876,82 @@
                 "saveSuccess": "가드레일이 저장되었습니다",
                 "saveError": "가드레일을 저장할 수 없습니다",
                 "resetSuccess": "가드레일이 기본값으로 재설정되었습니다"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -815,7 +1006,11 @@
                 "priorityP4": "P4 — 낮음",
                 "createError": "작업을 만들지 못했습니다",
                 "cancel": "취소",
-                "create": "생성"
+                "create": "생성",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "이동 대상",
@@ -848,7 +1043,27 @@
                 "updated": "수정일",
                 "scopeWork": "작업",
                 "scopeMission": "임무",
-                "scopeIdea": "아이디어"
+                "scopeIdea": "아이디어",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "반복 일정",
@@ -879,6 +1094,94 @@
                 "p2": "보통",
                 "p3": "일반",
                 "p4": "낮음"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -907,7 +1210,120 @@
                 "mission": "임무",
                 "idea": "아이디어",
                 "work": "작업",
-                "tenant": "테넌트"
+                "tenant": "테넌트",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1075,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1388,7 +1805,8 @@
                     "failed": "실패",
                     "cancelled": "취소됨"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "설정",
@@ -1404,7 +1822,9 @@
                 "gitProviders": "Git 공급자",
                 "dangerZone": "위험 영역",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub 앱 설치",
@@ -1900,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1910,7 +2509,12 @@
             "activeWebsites": "활성 웹사이트",
             "monthSpend": "Month Spend",
             "fromLastMonth": "전월 대비",
-            "teams": "팀"
+            "teams": "팀",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "주의 필요",
@@ -2076,11 +2680,13 @@
                     "kb": "지식 베이스",
                     "generator": "Work를 일회성 또는 예약된 일정으로 생성",
                     "deploy": "Work 배포",
-                    "tasks": "이 워크의 작업"
+                    "tasks": "이 워크의 작업",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "작업",
                 "posts": "게시물",
-                "pages": "페이지"
+                "pages": "페이지",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "팀 멤버",
@@ -3433,7 +4039,81 @@
                 "providerRepoEnabled": "{provider} 리포지토리 생성을 켰습니다",
                 "providerRepoDisabled": "{provider} 리포지토리 생성을 껐습니다",
                 "providerRepoUpdateFailed": "리포지토리 설정을 업데이트하지 못했습니다",
-                "providerRepoDisabledNote": "생성이 꺼져 있습니다. 기존 리포지토리는 그대로 남고 업데이트만 중단됩니다."
+                "providerRepoDisabledNote": "생성이 꺼져 있습니다. 기존 리포지토리는 그대로 남고 업데이트만 중단됩니다.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3581,6 +4261,26 @@
                     "dnsName": "이름:",
                     "dnsValue": "값:",
                     "copyButton": "복사"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3615,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "상속된 문서 알림",
@@ -3636,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3819,6 +4521,299 @@
                     "errorFallback": "삭제할 수 없습니다. 다시 시도하세요.",
                     "errorBusy": "삭제 중…",
                     "errorPartial": "삭제 {ok}개, 실패 {failed}개."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3836,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3859,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3877,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "새 워크 생성",
@@ -3990,7 +4990,10 @@
                 "organizationHelp": "개인 계정 대신 조직 아래에 저장소 생성",
                 "organizationNameLabel": "조직 이름",
                 "organizationNamePlaceholder": "조직 이름 입력",
-                "websiteTemplateHelperText": "워크 저장소가 처음 생성될 때 사용될 워크 템플릿을 선택하세요."
+                "websiteTemplateHelperText": "워크 저장소가 처음 생성될 때 사용될 워크 템플릿을 선택하세요.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "수동 생성",
@@ -4226,6 +5229,58 @@
                     "description": "이 이름의 저장소가 계정에 이미 존재합니다. 다른 이름 사용하거나 제안을 수락하세요.",
                     "useSuggestion": "\"{slug}\" 대신 사용"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4552,7 +5607,8 @@
                 "skills": "기술",
                 "templates": "템플릿",
                 "settings": "설정",
-                "teams": "팀"
+                "teams": "팀",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "사이드바 확장",
@@ -5169,7 +6225,24 @@
                 "removeMember": "제거",
                 "roleLead": "리드",
                 "roleMember": "구성원",
-                "emptyRoster": "아직 구성원이 없습니다. 이 팀에 에이전트나 동료를 추가하세요."
+                "emptyRoster": "아직 구성원이 없습니다. 이 팀에 에이전트나 동료를 추가하세요.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "팀 설정",
@@ -5191,7 +6264,9 @@
                 "updateFailed": "팀을 업데이트하지 못했습니다",
                 "deleteFailed": "팀을 삭제하지 못했습니다",
                 "memberAddFailed": "구성원을 추가하지 못했습니다",
-                "memberRemoveFailed": "구성원을 제거하지 못했습니다"
+                "memberRemoveFailed": "구성원을 제거하지 못했습니다",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5305,6 +6380,238 @@
             "company": "Company",
             "campaign": "캠페인",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5394,7 +6701,8 @@
             "pluginSettings": "플러그인 설정",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5568,6 +6876,11 @@
         "visibility": {
             "private": "비공개",
             "public": "공개"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5665,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI-verbinding geverifieerd."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -625,6 +722,13 @@
                 "minLength": "De beschrijving moet minstens 10 tekens bevatten.",
                 "error": "Kon de missie niet aanmaken. Probeer het opnieuw.",
                 "chatUnavailable": "Chat is momenteel niet beschikbaar — gebruik \"Handmatig aanmaken\"."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
             }
         },
         "memoryPage": {
@@ -705,7 +809,8 @@
                 "instructions": "Instructies",
                 "skills": "Vaardigheden",
                 "budgets": "Budgetten",
-                "settings": "Instellingen"
+                "settings": "Instellingen",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Nieuwe Agent",
@@ -724,7 +829,17 @@
                 "teamLabel": "Team",
                 "teamNone": "Geen team",
                 "reportsToLabel": "Rapporteert aan",
-                "reportsToNone": "Geen manager"
+                "reportsToNone": "Geen manager",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -761,6 +876,82 @@
                 "saveSuccess": "Vangrails opgeslagen",
                 "saveError": "Kon vangrails niet opslaan",
                 "resetSuccess": "Vangrails teruggezet naar standaard"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -815,7 +1006,11 @@
                 "priorityP4": "P4 — laag",
                 "createError": "Taak aanmaken mislukt",
                 "cancel": "Annuleren",
-                "create": "Maken"
+                "create": "Maken",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Verplaats naar",
@@ -848,7 +1043,27 @@
                 "updated": "Bijgewerkt",
                 "scopeWork": "Werk",
                 "scopeMission": "Missie",
-                "scopeIdea": "Idee"
+                "scopeIdea": "Idee",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Terugkerend schema",
@@ -879,6 +1094,94 @@
                 "p2": "Gemiddeld",
                 "p3": "Normaal",
                 "p4": "Laag"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -907,7 +1210,120 @@
                 "mission": "Missie",
                 "idea": "Idee",
                 "work": "Work",
-                "tenant": "Tenant"
+                "tenant": "Tenant",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1075,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1388,7 +1805,8 @@
                     "failed": "Mislukt",
                     "cancelled": "Geannuleerd"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Instellingen",
@@ -1404,7 +1822,9 @@
                 "gitProviders": "Git-providers",
                 "dangerZone": "Gevaarzone",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub App-installaties",
@@ -1900,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1910,7 +2509,12 @@
             "activeWebsites": "Actieve websites",
             "monthSpend": "Month Spend",
             "fromLastMonth": "van afgelopen maand",
-            "teams": "Teams"
+            "teams": "Teams",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Vereist aandacht",
@@ -2076,11 +2680,13 @@
                     "kb": "Kennisbank",
                     "generator": "Work genereren — eenmalig of volgens planning",
                     "deploy": "Work uitrollen",
-                    "tasks": "Taken voor deze Work"
+                    "tasks": "Taken voor deze Work",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Taken",
                 "posts": "Berichten",
-                "pages": "Pagina's"
+                "pages": "Pagina's",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Teamleden",
@@ -3433,7 +4039,81 @@
                 "providerRepoEnabled": "Genereren van de {provider}-repository ingeschakeld",
                 "providerRepoDisabled": "Genereren van de {provider}-repository uitgeschakeld",
                 "providerRepoUpdateFailed": "Kan de repository-instelling niet bijwerken",
-                "providerRepoDisabledNote": "Genereren staat uit. De bestaande repository blijft ongemoeid — die wordt alleen niet meer bijgewerkt."
+                "providerRepoDisabledNote": "Genereren staat uit. De bestaande repository blijft ongemoeid — die wordt alleen niet meer bijgewerkt.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3581,6 +4261,26 @@
                     "dnsName": "Naam:",
                     "dnsValue": "Waarde:",
                     "copyButton": "Kopiëren"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3615,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Melding voor overgenomen document",
@@ -3636,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3819,6 +4521,299 @@
                     "errorFallback": "Verwijderen mislukt. Probeer opnieuw.",
                     "errorBusy": "Bezig met verwijderen…",
                     "errorPartial": "{ok} verwijderd, {failed} mislukt."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3836,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3859,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3877,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Nieuwe werk aanmaken",
@@ -3990,7 +4990,10 @@
                 "organizationHelp": "Maak repositories aan onder een organisatie in plaats van je persoonlijke account",
                 "organizationNameLabel": "Organisatienaam",
                 "organizationNamePlaceholder": "Voer organisatienaam in",
-                "websiteTemplateHelperText": "Kies de Work-template die wordt gebruikt wanneer de Work-repository voor het eerst wordt aangemaakt."
+                "websiteTemplateHelperText": "Kies de Work-template die wordt gebruikt wanneer de Work-repository voor het eerst wordt aangemaakt.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Handmatig aanmaken",
@@ -4226,6 +5229,58 @@
                     "description": "Repositories met deze naam bestaan al in je account. Gebruik een andere naam of accepteer de suggestie.",
                     "useSuggestion": "Gebruik \"{slug}\" in plaats daarvan"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4552,7 +5607,8 @@
                 "skills": "Vaardigheden",
                 "templates": "Sjablonen",
                 "settings": "Instellingen",
-                "teams": "Teams"
+                "teams": "Teams",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Zijbalk uitklappen",
@@ -5169,7 +6225,24 @@
                 "removeMember": "Verwijderen",
                 "roleLead": "Lead",
                 "roleMember": "Lid",
-                "emptyRoster": "Nog geen leden — voeg Agenten of teamgenoten toe aan dit team."
+                "emptyRoster": "Nog geen leden — voeg Agenten of teamgenoten toe aan dit team.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Teaminstellingen",
@@ -5191,7 +6264,9 @@
                 "updateFailed": "Kon het team niet bijwerken",
                 "deleteFailed": "Kon het team niet verwijderen",
                 "memberAddFailed": "Kon het lid niet toevoegen",
-                "memberRemoveFailed": "Kon het lid niet verwijderen"
+                "memberRemoveFailed": "Kon het lid niet verwijderen",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5305,6 +6380,238 @@
             "company": "Company",
             "campaign": "Campagne",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5394,7 +6701,8 @@
             "pluginSettings": "Plug-ininstellingen",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5568,6 +6876,11 @@
         "visibility": {
             "private": "Privé",
             "public": "Openbaar"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5665,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -453,6 +453,102 @@
                     "successDefault": "Połączenie SIM AI zweryfikowane."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "Opis musi mieć co najmniej 10 znaków.",
                 "error": "Nie udało się utworzyć misji. Spróbuj ponownie.",
                 "chatUnavailable": "Czat jest niedostępny — użyj „Utwórz ręcznie”."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Instrukcje",
                 "skills": "Umiejętności",
                 "budgets": "Budżety",
-                "settings": "Ustawienia"
+                "settings": "Ustawienia",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Nowy Agent",
@@ -716,7 +829,17 @@
                 "teamLabel": "Zespół",
                 "teamNone": "Brak zespołu",
                 "reportsToLabel": "Podlega",
-                "reportsToNone": "Brak menedżera"
+                "reportsToNone": "Brak menedżera",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Bariery zapisane",
                 "saveError": "Nie udało się zapisać barier",
                 "resetSuccess": "Przywrócono domyślne bariery"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — niskie",
                 "createError": "Nie udało się utworzyć zadania",
                 "cancel": "Anuluj",
-                "create": "Utwórz"
+                "create": "Utwórz",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Przenieś do",
@@ -840,7 +1043,27 @@
                 "updated": "Zaktualizowano",
                 "scopeWork": "Praca",
                 "scopeMission": "Misja",
-                "scopeIdea": "Pomysł"
+                "scopeIdea": "Pomysł",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Cykliczne harmonogramy",
@@ -871,6 +1094,94 @@
                 "p2": "Średni",
                 "p3": "Normalny",
                 "p4": "Niski"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Misja",
                 "idea": "Pomysł",
                 "work": "Praca",
-                "tenant": "Organizacja"
+                "tenant": "Organizacja",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Nieudane",
                     "cancelled": "Anulowane"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Ustawienia",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Dostawcy Git",
                 "dangerZone": "Strefa niebezpieczeństwa",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Instalacje aplikacji GitHub",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Aktywne witryny",
             "monthSpend": "Month Spend",
             "fromLastMonth": "z ostatniego miesiąca",
-            "teams": "Zespoły"
+            "teams": "Zespoły",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Wymaga uwagi",
@@ -2068,11 +2680,13 @@
                     "kb": "Baza wiedzy",
                     "generator": "Wygeneruj Work — jednorazowo lub według harmonogramu",
                     "deploy": "Wdróż Work",
-                    "tasks": "Zadania dla tego Work"
+                    "tasks": "Zadania dla tego Work",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Zadania",
                 "posts": "Wpisy",
-                "pages": "Strony"
+                "pages": "Strony",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Członkowie zespołu",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Generowanie repozytorium {provider} włączone",
                 "providerRepoDisabled": "Generowanie repozytorium {provider} wyłączone",
                 "providerRepoUpdateFailed": "Nie udało się zaktualizować ustawienia repozytorium",
-                "providerRepoDisabledNote": "Generowanie jest wyłączone. Istniejące repozytorium pozostaje nietknięte — przestaje być tylko aktualizowane."
+                "providerRepoDisabledNote": "Generowanie jest wyłączone. Istniejące repozytorium pozostaje nietknięte — przestaje być tylko aktualizowane.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Nazwa:",
                     "dnsValue": "Wartość:",
                     "copyButton": "Kopiuj"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Powiadomienie o odziedziczonym dokumencie",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Nie udało się usunąć. Spróbuj ponownie.",
                     "errorBusy": "Usuwanie…",
                     "errorPartial": "Usunięto {ok}, nie udało się {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Utwórz nowy praca",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Twórz repozytoria w organizacji zamiast na koncie osobistym",
                 "organizationNameLabel": "Nazwa organizacji",
                 "organizationNamePlaceholder": "Wprowadź nazwę organizacji",
-                "websiteTemplateHelperText": "Wybierz szablon Pracy, który zostanie użyty przy pierwszym utworzeniu repozytorium Pracy."
+                "websiteTemplateHelperText": "Wybierz szablon Pracy, który zostanie użyty przy pierwszym utworzeniu repozytorium Pracy.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Utwórz ręcznie",
@@ -4218,6 +5229,58 @@
                     "description": "Repozytoria o tej nazwie już istnieją na Twoim koncie. Możesz użyć innej nazwy lub zaakceptować sugestię.",
                     "useSuggestion": "Użyj \"{slug}\" zamiast"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Umiejętności",
                 "templates": "Szablony",
                 "settings": "Ustawienia",
-                "teams": "Zespoły"
+                "teams": "Zespoły",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Rozwiń pasek boczny",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Usuń",
                 "roleLead": "Lider",
                 "roleMember": "Członek",
-                "emptyRoster": "Brak członków — dodaj Agentów lub współpracowników do tego zespołu."
+                "emptyRoster": "Brak członków — dodaj Agentów lub współpracowników do tego zespołu.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Ustawienia zespołu",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Nie udało się zaktualizować zespołu",
                 "deleteFailed": "Nie udało się usunąć zespołu",
                 "memberAddFailed": "Nie udało się dodać członka",
-                "memberRemoveFailed": "Nie udało się usunąć członka"
+                "memberRemoveFailed": "Nie udało się usunąć członka",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Kampania",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Ustawienia wtyczek",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Prywatny",
             "public": "Publiczny"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -453,6 +453,102 @@
                     "successDefault": "Conexão do SIM AI verificada"
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "A descrição deve ter pelo menos 10 caracteres.",
                 "error": "Não foi possível criar a missão. Tente novamente.",
                 "chatUnavailable": "O chat está indisponível — use «Criar manualmente»."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Instruções",
                 "skills": "Habilidades",
                 "budgets": "Orçamentos",
-                "settings": "Configurações"
+                "settings": "Configurações",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Novo Agente",
@@ -716,7 +829,17 @@
                 "teamLabel": "Equipe",
                 "teamNone": "Sem equipe",
                 "reportsToLabel": "Reporta-se a",
-                "reportsToNone": "Sem gerente"
+                "reportsToNone": "Sem gerente",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Salvaguardas salvas",
                 "saveError": "Não foi possível salvar as salvaguardas",
                 "resetSuccess": "Salvaguardas redefinidas para o padrão"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — baixa",
                 "createError": "Falha ao criar a tarefa",
                 "cancel": "Cancelar",
-                "create": "Criar"
+                "create": "Criar",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Mover para",
@@ -840,7 +1043,27 @@
                 "updated": "Atualizado",
                 "scopeWork": "Trabalho",
                 "scopeMission": "Missão",
-                "scopeIdea": "Ideia"
+                "scopeIdea": "Ideia",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Agenda recorrente",
@@ -871,6 +1094,94 @@
                 "p2": "Média",
                 "p3": "Normal",
                 "p4": "Baixa"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Missão",
                 "idea": "Ideia",
                 "work": "Trabalho",
-                "tenant": "Inquilino"
+                "tenant": "Inquilino",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Falhou",
                     "cancelled": "Cancelado"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Configurações",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Provedores Git",
                 "dangerZone": "Zona de Perigo",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Instalações do GitHub App",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Sites Ativos",
             "monthSpend": "Month Spend",
             "fromLastMonth": "do último mês",
-            "teams": "Equipes"
+            "teams": "Equipes",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Requer atenção",
@@ -2068,11 +2680,13 @@
                     "kb": "Base de conhecimento",
                     "generator": "Gerar Work, uma vez ou em agenda",
                     "deploy": "Implantar Work",
-                    "tasks": "Tarefas deste Work"
+                    "tasks": "Tarefas deste Work",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Tarefas",
                 "posts": "Publicações",
-                "pages": "Páginas"
+                "pages": "Páginas",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Membros da Equipe",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Geração do repositório do {provider} ativada",
                 "providerRepoDisabled": "Geração do repositório do {provider} desativada",
                 "providerRepoUpdateFailed": "Não foi possível atualizar a definição do repositório",
-                "providerRepoDisabledNote": "A geração está desativada. O repositório existente fica intacto — apenas deixa de ser atualizado."
+                "providerRepoDisabledNote": "A geração está desativada. O repositório existente fica intacto — apenas deixa de ser atualizado.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Nome:",
                     "dnsValue": "Valor:",
                     "copyButton": "Copiar"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Aviso de documento herdado",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Não foi possível excluir. Tente novamente.",
                     "errorBusy": "Excluindo…",
                     "errorPartial": "Excluídos {ok}, falharam {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Criar Novo Trabalho",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Criar repositórios sob uma organização em vez da sua conta pessoal",
                 "organizationNameLabel": "Nome da Organização",
                 "organizationNamePlaceholder": "Digite o nome da organização",
-                "websiteTemplateHelperText": "Escolha o modelo de Trabalho que será usado quando o repositório do Trabalho for criado pela primeira vez."
+                "websiteTemplateHelperText": "Escolha o modelo de Trabalho que será usado quando o repositório do Trabalho for criado pela primeira vez.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Criar Manualmente",
@@ -4218,6 +5229,58 @@
                     "description": "Repositórios com este nome já existem em sua conta. Você pode usar um nome diferente ou aceitar a sugestão.",
                     "useSuggestion": "Use \"{slug}\" em vez disso"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Habilidades",
                 "templates": "Modelos",
                 "settings": "Configurações",
-                "teams": "Equipes"
+                "teams": "Equipes",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Expandir barra lateral",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Remover",
                 "roleLead": "Líder",
                 "roleMember": "Membro",
-                "emptyRoster": "Nenhum membro ainda — adicione Agentes ou colegas a esta equipe."
+                "emptyRoster": "Nenhum membro ainda — adicione Agentes ou colegas a esta equipe.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Configurações da equipe",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Não foi possível atualizar a equipe",
                 "deleteFailed": "Não foi possível excluir a equipe",
                 "memberAddFailed": "Não foi possível adicionar o membro",
-                "memberRemoveFailed": "Não foi possível remover o membro"
+                "memberRemoveFailed": "Não foi possível remover o membro",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Campanha",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Configurações de Plugin",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Privado",
             "public": "Público"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -453,6 +453,102 @@
                     "successDefault": "Соединение с SIM AI проверено."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "Описание должно содержать не менее 10 символов.",
                 "error": "Не удалось создать миссию. Попробуйте ещё раз.",
                 "chatUnavailable": "Чат сейчас недоступен — воспользуйтесь «Создать вручную»."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Инструкции",
                 "skills": "Навыки",
                 "budgets": "Бюджеты",
-                "settings": "Настройки"
+                "settings": "Настройки",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Новый агент",
@@ -716,7 +829,17 @@
                 "teamLabel": "Команда",
                 "teamNone": "Без команды",
                 "reportsToLabel": "Подчиняется",
-                "reportsToNone": "Без менеджера"
+                "reportsToNone": "Без менеджера",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Ограничители сохранены",
                 "saveError": "Не удалось сохранить ограничители",
                 "resetSuccess": "Ограничители сброшены к настройкам по умолчанию"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — низкий",
                 "createError": "Не удалось создать задачу",
                 "cancel": "Отмена",
-                "create": "Создать"
+                "create": "Создать",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Переместить в",
@@ -840,7 +1043,27 @@
                 "updated": "Обновлено",
                 "scopeWork": "Работа",
                 "scopeMission": "Миссия",
-                "scopeIdea": "Идея"
+                "scopeIdea": "Идея",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Повторяющееся расписание",
@@ -871,6 +1094,94 @@
                 "p2": "Средний",
                 "p3": "Обычный",
                 "p4": "Низкий"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Миссия",
                 "idea": "Идея",
                 "work": "Работа",
-                "tenant": "Арендатор"
+                "tenant": "Арендатор",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Ошибка",
                     "cancelled": "Отменено"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Настройки",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Провайдеры Git",
                 "dangerZone": "Опасная зона",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Установки GitHub App",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Активные веб-сайты",
             "monthSpend": "Month Spend",
             "fromLastMonth": "за последний месяц",
-            "teams": "Команды"
+            "teams": "Команды",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Требует внимания",
@@ -2068,11 +2680,13 @@
                     "kb": "База знаний",
                     "generator": "Сгенерировать Work — разово или по расписанию",
                     "deploy": "Развернуть Work",
-                    "tasks": "Задачи этой работы"
+                    "tasks": "Задачи этой работы",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Задачи",
                 "posts": "Публикации",
-                "pages": "Страницы"
+                "pages": "Страницы",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Участники команды",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Создание репозитория {provider} включено",
                 "providerRepoDisabled": "Создание репозитория {provider} отключено",
                 "providerRepoUpdateFailed": "Не удалось обновить настройку репозитория",
-                "providerRepoDisabledNote": "Создание отключено. Существующий репозиторий остаётся нетронутым — он просто перестаёт обновляться."
+                "providerRepoDisabledNote": "Создание отключено. Существующий репозиторий остаётся нетронутым — он просто перестаёт обновляться.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Имя:",
                     "dnsValue": "Значение:",
                     "copyButton": "Копировать"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Уведомление о унаследованном документе",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Не удалось удалить. Попробуйте снова.",
                     "errorBusy": "Удаление…",
                     "errorPartial": "Удалено {ok}, не удалось {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Создать новый работа",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Создавать репозитории в организации вместо личного аккаунта",
                 "organizationNameLabel": "Название организации",
                 "organizationNamePlaceholder": "Введите название организации",
-                "websiteTemplateHelperText": "Выберите шаблон работы, который будет использоваться при первом создании репозитория работы."
+                "websiteTemplateHelperText": "Выберите шаблон работы, который будет использоваться при первом создании репозитория работы.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Создать вручную",
@@ -4218,6 +5229,58 @@
                     "description": "Репозитории с таким именем уже существуют в вашем аккаунте. Можно использовать другое имя или принять предложение.",
                     "useSuggestion": "Использовать \"{slug}\" вместо"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Навыки",
                 "templates": "Шаблоны",
                 "settings": "Настройки",
-                "teams": "Команды"
+                "teams": "Команды",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Развернуть боковую панель",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Удалить",
                 "roleLead": "Лид",
                 "roleMember": "Участник",
-                "emptyRoster": "Участников пока нет — добавьте в эту команду Агентов или коллег."
+                "emptyRoster": "Участников пока нет — добавьте в эту команду Агентов или коллег.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Настройки команды",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Не удалось обновить команду",
                 "deleteFailed": "Не удалось удалить команду",
                 "memberAddFailed": "Не удалось добавить участника",
-                "memberRemoveFailed": "Не удалось удалить участника"
+                "memberRemoveFailed": "Не удалось удалить участника",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Кампания",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Настройки плагинов",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Приватный",
             "public": "Публичный"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -453,6 +453,102 @@
                     "successDefault": "ยืนยันการเชื่อมต่อ SIM AI แล้ว"
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "คำอธิบายต้องมีอย่างน้อย 10 ตัวอักษร",
                 "error": "ไม่สามารถสร้างภารกิจได้ กรุณาลองใหม่อีกครั้ง",
                 "chatUnavailable": "แชทไม่พร้อมใช้งานขณะนี้ — ใช้ \"สร้างด้วยตนเอง\" แทน"
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "คำแนะนำ",
                 "skills": "ทักษะ",
                 "budgets": "งบประมาณ",
-                "settings": "การตั้งค่า"
+                "settings": "การตั้งค่า",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "เอเจนต์ใหม่",
@@ -716,7 +829,17 @@
                 "teamLabel": "ทีม",
                 "teamNone": "ไม่มีทีม",
                 "reportsToLabel": "รายงานต่อ",
-                "reportsToNone": "ไม่มีผู้จัดการ"
+                "reportsToNone": "ไม่มีผู้จัดการ",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "บันทึกการ์ดเรลแล้ว",
                 "saveError": "ไม่สามารถบันทึกการ์ดเรลได้",
                 "resetSuccess": "รีเซ็ตการ์ดเรลเป็นค่าเริ่มต้นแล้ว"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — ต่ำ",
                 "createError": "สร้างงานไม่สำเร็จ",
                 "cancel": "ยกเลิก",
-                "create": "สร้าง"
+                "create": "สร้าง",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "ย้ายไปยัง",
@@ -840,7 +1043,27 @@
                 "updated": "อัปเดตเมื่อ",
                 "scopeWork": "งาน",
                 "scopeMission": "ภารกิจ",
-                "scopeIdea": "ความคิด"
+                "scopeIdea": "ความคิด",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "กำหนดการทำซ้ำ",
@@ -871,6 +1094,94 @@
                 "p2": "ปานกลาง",
                 "p3": "ปกติ",
                 "p4": "ต่ำ"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "ภารกิจ",
                 "idea": "ความคิด",
                 "work": "งาน",
-                "tenant": "เจ้าของบริษัท"
+                "tenant": "เจ้าของบริษัท",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "ล้มเหลว",
                     "cancelled": "ยกเลิก"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "การตั้งค่า",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "ผู้ให้บริการ Git",
                 "dangerZone": "โซนอันตราย",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "การติดตั้ง GitHub App",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "เว็บไซต์ที่ใช้งานอยู่",
             "monthSpend": "Month Spend",
             "fromLastMonth": "จากเดือนที่แล้ว",
-            "teams": "ทีม"
+            "teams": "ทีม",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "ต้องการความสนใจ",
@@ -2068,11 +2680,13 @@
                     "kb": "ฐานความรู้",
                     "generator": "สร้าง Work ครั้งเดียวหรือตามตารางเวลา",
                     "deploy": "ปรับใช้ Work",
-                    "tasks": "งานสำหรับ Work นี้"
+                    "tasks": "งานสำหรับ Work นี้",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "งาน",
                 "posts": "โพสต์",
-                "pages": "หน้า"
+                "pages": "หน้า",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "สมาชิกทีม",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "เปิดการสร้างคลัง {provider} แล้ว",
                 "providerRepoDisabled": "ปิดการสร้างคลัง {provider} แล้ว",
                 "providerRepoUpdateFailed": "อัปเดตการตั้งค่าคลังไม่สำเร็จ",
-                "providerRepoDisabledNote": "การสร้างถูกปิดอยู่ คลังที่มีอยู่ยังคงเดิม เพียงแต่จะไม่ถูกอัปเดตอีก"
+                "providerRepoDisabledNote": "การสร้างถูกปิดอยู่ คลังที่มีอยู่ยังคงเดิม เพียงแต่จะไม่ถูกอัปเดตอีก",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "ชื่อ:",
                     "dnsValue": "ค่า:",
                     "copyButton": "คัดลอก"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "การแจ้งเตือนเอกสารที่รับช่วงต่อ",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "ไม่สามารถลบได้ โปรดลองอีกครั้ง",
                     "errorBusy": "กำลังลบ…",
                     "errorPartial": "ลบสำเร็จ {ok}, ล้มเหลว {failed}"
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "สร้างงานใหม่",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "สร้าง repository ภายใต้องค์กรแทนบัญชีส่วนตัวของคุณ",
                 "organizationNameLabel": "ชื่อองค์กร",
                 "organizationNamePlaceholder": "ป้อนชื่อองค์กร",
-                "websiteTemplateHelperText": "เลือกเทมเพลตงานที่จะใช้เมื่อสร้างคลังงานครั้งแรก"
+                "websiteTemplateHelperText": "เลือกเทมเพลตงานที่จะใช้เมื่อสร้างคลังงานครั้งแรก",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "สร้างด้วยตนเอง",
@@ -4218,6 +5229,58 @@
                     "description": "Repository ชื่อนี้มีอยู่แล้วในบัญชีของคุณ คุณสามารถใช้ชื่ออื่นหรือยอมรับข้อเสนอแนะ",
                     "useSuggestion": "ใช้ \"{slug}\" แทน"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "ทักษะ",
                 "templates": "เทมเพลต",
                 "settings": "การตั้งค่า",
-                "teams": "ทีม"
+                "teams": "ทีม",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "ขยายแถบด้านข้าง",
@@ -5161,7 +6225,24 @@
                 "removeMember": "นำออก",
                 "roleLead": "หัวหน้าทีม",
                 "roleMember": "สมาชิก",
-                "emptyRoster": "ยังไม่มีสมาชิก — เพิ่มเอเจนต์หรือเพื่อนร่วมทีมในทีมนี้"
+                "emptyRoster": "ยังไม่มีสมาชิก — เพิ่มเอเจนต์หรือเพื่อนร่วมทีมในทีมนี้",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "การตั้งค่าทีม",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "ไม่สามารถอัปเดตทีมได้",
                 "deleteFailed": "ไม่สามารถลบทีมได้",
                 "memberAddFailed": "ไม่สามารถเพิ่มสมาชิกได้",
-                "memberRemoveFailed": "ไม่สามารถนำสมาชิกออกได้"
+                "memberRemoveFailed": "ไม่สามารถนำสมาชิกออกได้",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "แคมเปญ",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "การตั้งค่าปลั๊กอิน",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "ส่วนตัว",
             "public": "สาธารณะ"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI bağlantısı doğrulandı."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "Açıklama en az 10 karakter olmalıdır.",
                 "error": "Görev oluşturulamadı. Lütfen tekrar deneyin.",
                 "chatUnavailable": "Sohbet şu anda kullanılamıyor — \"Elle oluştur\" seçeneğini kullanın."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Talimatlar",
                 "skills": "Yetenekler",
                 "budgets": "Bütçeler",
-                "settings": "Ayarlar"
+                "settings": "Ayarlar",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Yeni Ajan",
@@ -716,7 +829,17 @@
                 "teamLabel": "Ekip",
                 "teamNone": "Ekip yok",
                 "reportsToLabel": "Bağlı olduğu yönetici",
-                "reportsToNone": "Yönetici yok"
+                "reportsToNone": "Yönetici yok",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Korkuluklar kaydedildi",
                 "saveError": "Korkuluklar kaydedilemedi",
                 "resetSuccess": "Korkuluklar varsayılana sıfırlandı"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — düşük",
                 "createError": "Görev oluşturulamadı",
                 "cancel": "İptal",
-                "create": "Oluştur"
+                "create": "Oluştur",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Taşı",
@@ -840,7 +1043,27 @@
                 "updated": "Güncellenme",
                 "scopeWork": "İş",
                 "scopeMission": "Görev",
-                "scopeIdea": "Fikir"
+                "scopeIdea": "Fikir",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Tekrarlayan zamanlama",
@@ -871,6 +1094,94 @@
                 "p2": "Orta",
                 "p3": "Normal",
                 "p4": "Düşük"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Görev",
                 "idea": "Fikir",
                 "work": "İş",
-                "tenant": "Kiracı"
+                "tenant": "Kiracı",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Başarısız",
                     "cancelled": "İptal edildi"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Ayarlar",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Git Sağlayıcıları",
                 "dangerZone": "Tehlike Alanı",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub App Kurulumları",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Aktif Web Siteleri",
             "monthSpend": "Month Spend",
             "fromLastMonth": "geçen aydan",
-            "teams": "Takımlar"
+            "teams": "Takımlar",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Dikkat gerektiriyor",
@@ -2068,11 +2680,13 @@
                     "kb": "Bilgi Tabanı",
                     "generator": "Work'i tek seferlik veya zamanlanmış üret",
                     "deploy": "Work'i dağıt",
-                    "tasks": "Bu Work için görevler"
+                    "tasks": "Bu Work için görevler",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Görevler",
                 "posts": "Gönderiler",
-                "pages": "Sayfalar"
+                "pages": "Sayfalar",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Takım Üyeleri",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "{provider} deposu oluşturma açıldı",
                 "providerRepoDisabled": "{provider} deposu oluşturma kapatıldı",
                 "providerRepoUpdateFailed": "Depo ayarı güncellenemedi",
-                "providerRepoDisabledNote": "Oluşturma kapalı. Mevcut depoya dokunulmaz — yalnızca güncellenmesi durur."
+                "providerRepoDisabledNote": "Oluşturma kapalı. Mevcut depoya dokunulmaz — yalnızca güncellenmesi durur.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Ad:",
                     "dnsValue": "Değer:",
                     "copyButton": "Kopyala"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Devralınan belge bildirimi",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Silinemedi. Lütfen tekrar deneyin.",
                     "errorBusy": "Siliniyor…",
                     "errorPartial": "{ok} silindi, {failed} başarısız."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Yeni İş Oluştur",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Kişisel hesabınız yerine bir kuruluş altında depolar oluşturun",
                 "organizationNameLabel": "Kuruluş Adı",
                 "organizationNamePlaceholder": "Kuruluş adını girin",
-                "websiteTemplateHelperText": "İş deposu ilk oluşturulduğunda kullanılacak iş şablonunu seçin."
+                "websiteTemplateHelperText": "İş deposu ilk oluşturulduğunda kullanılacak iş şablonunu seçin.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Manuel Oluştur",
@@ -4218,6 +5229,58 @@
                     "description": "Bu adlı depolar hesabınızda zaten var. Farklı bir ad kullanabilir veya öneriyi kabul edebilirsiniz.",
                     "useSuggestion": "Bunun yerine \"{slug}\" kullanın"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Yetenekler",
                 "templates": "Şablonlar",
                 "settings": "Ayarlar",
-                "teams": "Ekipler"
+                "teams": "Ekipler",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Kenar çubuğunu genişlet",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Kaldır",
                 "roleLead": "Lider",
                 "roleMember": "Üye",
-                "emptyRoster": "Henüz üye yok — bu ekibe Ajanlar veya ekip arkadaşları ekleyin."
+                "emptyRoster": "Henüz üye yok — bu ekibe Ajanlar veya ekip arkadaşları ekleyin.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Ekip Ayarları",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Ekip güncellenemedi",
                 "deleteFailed": "Ekip silinemedi",
                 "memberAddFailed": "Üye eklenemedi",
-                "memberRemoveFailed": "Üye kaldırılamadı"
+                "memberRemoveFailed": "Üye kaldırılamadı",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Kampanya",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Eklenti Ayarları",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Özel",
             "public": "Genel"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -453,6 +453,102 @@
                     "successDefault": "З'єднання SIM AI перевірено."
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "Опис має містити щонайменше 10 символів.",
                 "error": "Не вдалося створити місію. Спробуйте ще раз.",
                 "chatUnavailable": "Чат зараз недоступний — скористайтеся «Створити вручну»."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Інструкції",
                 "skills": "Навички",
                 "budgets": "Бюджети",
-                "settings": "Налаштування"
+                "settings": "Налаштування",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Новий Агент",
@@ -716,7 +829,17 @@
                 "teamLabel": "Команда",
                 "teamNone": "Без команди",
                 "reportsToLabel": "Підпорядковується",
-                "reportsToNone": "Без менеджера"
+                "reportsToNone": "Без менеджера",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Обмежувачі збережено",
                 "saveError": "Не вдалося зберегти обмежувачі",
                 "resetSuccess": "Обмежувачі скинуто до типових"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — низький",
                 "createError": "Не вдалося створити завдання",
                 "cancel": "Скасувати",
-                "create": "Створити"
+                "create": "Створити",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Перемістити до",
@@ -840,7 +1043,27 @@
                 "updated": "Оновлено",
                 "scopeWork": "Робота",
                 "scopeMission": "Місія",
-                "scopeIdea": "Ідея"
+                "scopeIdea": "Ідея",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Повторюване розкладання",
@@ -871,6 +1094,94 @@
                 "p2": "Середній",
                 "p3": "Звичайний",
                 "p4": "Низький"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Місія",
                 "idea": "Ідея",
                 "work": "Робота",
-                "tenant": "Тенант"
+                "tenant": "Тенант",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Помилка",
                     "cancelled": "Скасовано"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Налаштування",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Постачальники Git",
                 "dangerZone": "Небезпечна зона",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Інсталяції GitHub App",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Активні вебсайти",
             "monthSpend": "Month Spend",
             "fromLastMonth": "за останній місяць",
-            "teams": "Команди"
+            "teams": "Команди",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Потребує уваги",
@@ -2068,11 +2680,13 @@
                     "kb": "База знань",
                     "generator": "Згенерувати Work — разово або за розкладом",
                     "deploy": "Розгорнути Work",
-                    "tasks": "Завдання цієї роботи"
+                    "tasks": "Завдання цієї роботи",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Завдання",
                 "posts": "Дописи",
-                "pages": "Сторінки"
+                "pages": "Сторінки",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Учасники команди",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Створення репозиторію {provider} увімкнено",
                 "providerRepoDisabled": "Створення репозиторію {provider} вимкнено",
                 "providerRepoUpdateFailed": "Не вдалося оновити налаштування репозиторію",
-                "providerRepoDisabledNote": "Створення вимкнено. Наявний репозиторій залишається недоторканим — він просто перестає оновлюватися."
+                "providerRepoDisabledNote": "Створення вимкнено. Наявний репозиторій залишається недоторканим — він просто перестає оновлюватися.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Ім'я:",
                     "dnsValue": "Значення:",
                     "copyButton": "Копіювати"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Сповіщення про успадкований документ",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Не вдалося видалити. Спробуйте знову.",
                     "errorBusy": "Видалення…",
                     "errorPartial": "Видалено {ok}, не вдалося {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Створити новий робота",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Створюйте репозиторії в організації замість особистого облікового запису",
                 "organizationNameLabel": "Назва організації",
                 "organizationNamePlaceholder": "Введіть назву організації",
-                "websiteTemplateHelperText": "Виберіть шаблон Роботи, який буде використано під час першого створення репозиторію Роботи."
+                "websiteTemplateHelperText": "Виберіть шаблон Роботи, який буде використано під час першого створення репозиторію Роботи.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Створити вручну",
@@ -4218,6 +5229,58 @@
                     "description": "Репозиторії з цією назвою вже існують у вашому обліковому записі. Ви можете використати іншу назву або прийняти пропозицію.",
                     "useSuggestion": "Використати \"{slug}\" замість"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Навички",
                 "templates": "Шаблони",
                 "settings": "Налаштування",
-                "teams": "Команди"
+                "teams": "Команди",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Розгорнути бічну панель",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Видалити",
                 "roleLead": "Лід",
                 "roleMember": "Учасник",
-                "emptyRoster": "Учасників поки немає — додайте до цієї команди Агентів або колег."
+                "emptyRoster": "Учасників поки немає — додайте до цієї команди Агентів або колег.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Налаштування команди",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Не вдалося оновити команду",
                 "deleteFailed": "Не вдалося видалити команду",
                 "memberAddFailed": "Не вдалося додати учасника",
-                "memberRemoveFailed": "Не вдалося видалити учасника"
+                "memberRemoveFailed": "Не вдалося видалити учасника",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Кампанія",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Налаштування плагінів",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Приватний",
             "public": "Публічний"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -453,6 +453,102 @@
                     "successDefault": "Kết nối SIM AI đã được xác minh"
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "Mô tả phải có ít nhất 10 ký tự.",
                 "error": "Không thể tạo nhiệm vụ. Vui lòng thử lại.",
                 "chatUnavailable": "Trò chuyện hiện không khả dụng — hãy dùng \"Tạo thủ công\"."
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "Hướng dẫn",
                 "skills": "Kỹ năng",
                 "budgets": "Ngân sách",
-                "settings": "Cài đặt"
+                "settings": "Cài đặt",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "Agent mới",
@@ -716,7 +829,17 @@
                 "teamLabel": "Nhóm",
                 "teamNone": "Không có nhóm",
                 "reportsToLabel": "Báo cáo cho",
-                "reportsToNone": "Không có quản lý"
+                "reportsToNone": "Không có quản lý",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "Đã lưu rào chắn",
                 "saveError": "Không thể lưu rào chắn",
                 "resetSuccess": "Đã đặt lại rào chắn về mặc định"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — thấp",
                 "createError": "Không thể tạo nhiệm vụ",
                 "cancel": "Hủy",
-                "create": "Tạo"
+                "create": "Tạo",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Di chuyển đến",
@@ -840,7 +1043,27 @@
                 "updated": "Đã cập nhật",
                 "scopeWork": "Công việc",
                 "scopeMission": "Nhiệm vụ",
-                "scopeIdea": "Ý tưởng"
+                "scopeIdea": "Ý tưởng",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Lên lịch định kỳ",
@@ -871,6 +1094,94 @@
                 "p2": "Trung bình",
                 "p3": "Bình thường",
                 "p4": "Thấp"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "Nhiệm vụ",
                 "idea": "Ý tưởng",
                 "work": "Công việc",
-                "tenant": "Tenant"
+                "tenant": "Tenant",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "Thất bại",
                     "cancelled": "Đã hủy"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "Cài đặt",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Nhà cung cấp Git",
                 "dangerZone": "Vùng nguy hiểm",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "Cài đặt Ứng dụng GitHub",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "Trang web hoạt động",
             "monthSpend": "Month Spend",
             "fromLastMonth": "từ tháng trước",
-            "teams": "Nhóm"
+            "teams": "Nhóm",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "Cần chú ý",
@@ -2068,11 +2680,13 @@
                     "kb": "Cơ sở tri thức",
                     "generator": "Tạo Work một lần hoặc theo lịch",
                     "deploy": "Triển khai Work",
-                    "tasks": "Nhiệm vụ cho Work này"
+                    "tasks": "Nhiệm vụ cho Work này",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "Nhiệm vụ",
                 "posts": "Bài viết",
-                "pages": "Trang"
+                "pages": "Trang",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "Thành viên đội ngũ",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "Đã bật tạo kho {provider}",
                 "providerRepoDisabled": "Đã tắt tạo kho {provider}",
                 "providerRepoUpdateFailed": "Không thể cập nhật cài đặt kho",
-                "providerRepoDisabledNote": "Việc tạo đang tắt. Kho hiện có được giữ nguyên — chỉ là không còn được cập nhật."
+                "providerRepoDisabledNote": "Việc tạo đang tắt. Kho hiện có được giữ nguyên — chỉ là không còn được cập nhật.",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "Tên:",
                     "dnsValue": "Giá trị:",
                     "copyButton": "Sao chép"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "Thông báo tài liệu được kế thừa",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "Không thể xóa. Vui lòng thử lại.",
                     "errorBusy": "Đang xóa…",
                     "errorPartial": "Đã xóa {ok}, thất bại {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "Tạo Công Việc Mới",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "Tạo kho lưu trữ dưới tổ chức thay vì tài khoản cá nhân của bạn",
                 "organizationNameLabel": "Tên Tổ Chức",
                 "organizationNamePlaceholder": "Nhập tên tổ chức",
-                "websiteTemplateHelperText": "Chọn mẫu Công việc sẽ được dùng khi kho Công việc được tạo lần đầu."
+                "websiteTemplateHelperText": "Chọn mẫu Công việc sẽ được dùng khi kho Công việc được tạo lần đầu.",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "Tạo Thủ Công",
@@ -4218,6 +5229,58 @@
                     "description": "Các kho với tên này đã tồn tại trong tài khoản của bạn. Bạn có thể dùng tên khác hoặc chấp nhận gợi ý.",
                     "useSuggestion": "Sử dụng \"{slug}\" thay thế"
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "Skills",
                 "templates": "Mẫu",
                 "settings": "Cài đặt",
-                "teams": "Nhóm"
+                "teams": "Nhóm",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "Mở rộng thanh bên",
@@ -5161,7 +6225,24 @@
                 "removeMember": "Xóa",
                 "roleLead": "Trưởng nhóm",
                 "roleMember": "Thành viên",
-                "emptyRoster": "Chưa có thành viên nào — hãy thêm Agent hoặc đồng nghiệp vào nhóm này."
+                "emptyRoster": "Chưa có thành viên nào — hãy thêm Agent hoặc đồng nghiệp vào nhóm này.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Cài đặt nhóm",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "Không thể cập nhật nhóm",
                 "deleteFailed": "Không thể xóa nhóm",
                 "memberAddFailed": "Không thể thêm thành viên",
-                "memberRemoveFailed": "Không thể xóa thành viên"
+                "memberRemoveFailed": "Không thể xóa thành viên",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "Chiến dịch",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "Cài đặt Plugin",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "Riêng tư",
             "public": "Công khai"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -453,6 +453,102 @@
                     "successDefault": "SIM AI 连接已验证。"
                 }
             }
+        },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
     },
     "dashboard": {
@@ -580,7 +676,8 @@
             "newMission": "+ New Mission",
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -617,6 +714,21 @@
                 "minLength": "描述至少需要 10 个字符。",
                 "error": "无法创建 Mission，请重试。",
                 "chatUnavailable": "聊天当前不可用——请改用“手动创建”。"
+            },
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "memoryPage": {
@@ -697,7 +809,8 @@
                 "instructions": "指令",
                 "skills": "技能",
                 "budgets": "预算",
-                "settings": "设置"
+                "settings": "设置",
+                "terminal": "Terminal"
             },
             "newDialog": {
                 "title": "新代理",
@@ -716,7 +829,17 @@
                 "teamLabel": "团队",
                 "teamNone": "无团队",
                 "reportsToLabel": "汇报对象",
-                "reportsToNone": "无管理者"
+                "reportsToNone": "无管理者",
+                "parentLabel": "Pick a {scope}",
+                "parentPlaceholder": "Select…",
+                "parentRequired": "Pick a parent to continue.",
+                "noMissions": "You don't have any Missions yet — create one to scope an Agent here.",
+                "noWorks": "You don't have any Works yet — create one to scope an Agent here.",
+                "noIdeas": "You don't have any Ideas yet — add one to scope an Agent here.",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
             },
             "settings": {
                 "orgCard": {
@@ -753,6 +876,82 @@
                 "saveSuccess": "护栏已保存",
                 "saveError": "无法保存护栏",
                 "resetSuccess": "护栏已重置为默认"
+            },
+            "scorecard": {
+                "title": "Scorecard",
+                "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
+                "addMetric": "Add metric",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save scorecard",
+                "statuses": {
+                    "exceeded": "Exceeded",
+                    "onTrack": "On track",
+                    "behind": "Behind",
+                    "critical": "Critical"
+                },
+                "fields": {
+                    "label": "Metric",
+                    "target": "Target",
+                    "current": "Current",
+                    "floor": "Floor",
+                    "stretch": "Stretch",
+                    "period": "Period"
+                },
+                "periods": {
+                    "weekly": "Weekly",
+                    "monthly": "Monthly",
+                    "quarterly": "Quarterly"
+                },
+                "saved": "Scorecard saved",
+                "errors": {
+                    "labelRequired": "Every metric needs a label",
+                    "numbersRequired": "Targets and values must be numbers",
+                    "saveFailed": "Could not save scorecard"
+                }
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -807,7 +1006,11 @@
                 "priorityP4": "P4 — 低",
                 "createError": "创建任务失败",
                 "cancel": "取消",
-                "create": "创建"
+                "create": "创建",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "移动到",
@@ -840,7 +1043,27 @@
                 "updated": "更新时间",
                 "scopeWork": "工作",
                 "scopeMission": "任务",
-                "scopeIdea": "想法"
+                "scopeIdea": "想法",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "重复计划",
@@ -871,6 +1094,94 @@
                 "p2": "中",
                 "p3": "普通",
                 "p4": "低"
+            },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
+            "branch": {
+                "section": "Branch",
+                "branch": "Branch",
+                "copy": "Copy branch name",
+                "copied": "Copied",
+                "baseSha": "Base",
+                "state": "State",
+                "pullRequest": "Pull request",
+                "openPr": "Open PR",
+                "conflictTitle": "This branch has merge conflicts",
+                "resolve": "Resolve conflicts",
+                "resolving": "Resolving…",
+                "resolveError": "Failed to resolve conflicts",
+                "discard": "Discard branch",
+                "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardError": "Failed to discard branch",
+                "isolationLabel": "Task isolation",
+                "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",
+                "isolationInherit": "Inherit from Work",
+                "isolationOn": "On — isolated branch",
+                "isolationOff": "Off — work directly",
+                "isolationSaveError": "Failed to update isolation override"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -899,7 +1210,120 @@
                 "mission": "任务",
                 "idea": "想法",
                 "work": "工作",
-                "tenant": "租户"
+                "tenant": "租户",
+                "backToSkills": "Back to Skills",
+                "body": {
+                    "write": "Write",
+                    "preview": "Preview",
+                    "saving": "Saving…",
+                    "saved": "Saved",
+                    "saveFailed": "Save failed",
+                    "placeholder": "# What this Skill does\n\nDescribe the steps, conventions, and examples the Agent should follow when this Skill is pulled into a run.",
+                    "emptyPreview": "Nothing to preview yet — click here to start writing.",
+                    "clickToEdit": "Click to edit",
+                    "markdownHint": "Markdown supported, including tables and task lists (GFM).",
+                    "words": "{count, plural, =1 {1 word} other {# words}}",
+                    "characters": "{count, plural, =1 {1 character} other {# characters}}"
+                },
+                "addBindingTitle": "Add binding",
+                "noBindings": "No bindings yet — attach this Skill to a target below.",
+                "target": "Target",
+                "picker": {
+                    "searchPlaceholder": "Search by name…",
+                    "workspaceWide": "Applies to the entire workspace",
+                    "pasteUuid": "Options unavailable — paste a UUID",
+                    "noOptionsPasteUuid": "Nothing to pick yet — paste a UUID",
+                    "loading": "Loading…",
+                    "noMatches": "No matches"
+                },
+                "agentOff": "Agent: off",
+                "generatorOn": "Generator: on",
+                "add": "Add",
+                "adding": "Adding…"
+            },
+            "tabs": {
+                "label": "Skill sections",
+                "installed": "Installed",
+                "available": "Available",
+                "custom": "Custom"
+            },
+            "search": {
+                "label": "Search skills",
+                "placeholder": "Search skills by title, slug, or description",
+                "submit": "Search",
+                "clear": "Clear"
+            },
+            "errors": {
+                "installed": "Installed skills could not be loaded. Try refreshing the page.",
+                "catalog": "The skills catalog could not be loaded. Installed and custom skills are still available."
+            },
+            "catalog": {
+                "emptyTitle": "No catalog Skills available.",
+                "emptySubtitle": "Enable a skills-provider plugin or adjust the search.",
+                "install": "Install",
+                "installing": "Installing...",
+                "installed": "Installed",
+                "installFailed": "Install failed"
+            },
+            "custom": {
+                "summary": "{count, plural, =0 {No hand-authored Skills yet.} =1 {1 hand-authored Skill.} other {# hand-authored Skills.}}",
+                "new": "New Skill",
+                "formTitle": "New custom Skill",
+                "title": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "description": "Description (optional)",
+                "descriptionPlaceholder": "One-liner. Body goes on the detail page.",
+                "create": "Create",
+                "creating": "Creating...",
+                "cancel": "Cancel",
+                "titleRequired": "Title is required.",
+                "createFailed": "Failed to create Skill"
+            },
+            "card": {
+                "fromCatalog": "from catalog"
+            },
+            "pagination": {
+                "showing": "Showing {start}-{end} of {total}",
+                "emptyPage": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "newPage": {
+                "title": "New Skill",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "scopeStepTitle": "Where should this Skill live?",
+                "scopeTenantLabel": "Workspace",
+                "scopeTenantDesc": "Available across your whole workspace.",
+                "scopeMissionDesc": "Scoped to a single Mission.",
+                "scopeWorkDesc": "Scoped to a single Work.",
+                "scopeIdeaDesc": "Scoped to a single Idea.",
+                "scopeAgentDesc": "Owned by a single Agent.",
+                "noMissions": "No Missions yet — create one first, or pick another scope.",
+                "noWorks": "No Works yet — create one first, or pick another scope.",
+                "noIdeas": "No Ideas yet — create one first, or pick another scope.",
+                "noAgents": "No Agents yet — create one first, or pick another scope.",
+                "parentLabel": "Which {scope}?",
+                "parentPlaceholder": "Select…",
+                "pickParentHint": "Pick a {scope} to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Select a parent to continue",
+                "scopeSuffix": "scope —",
+                "detailsStepTitle": "Describe the Skill",
+                "titleLabel": "Title",
+                "titlePlaceholder": "e.g. Code review checklist",
+                "descriptionLabel": "Description (optional)",
+                "descriptionPlaceholder": "One-line summary Agents see when deciding to load this Skill.",
+                "instructionsLabel": "Instructions (Markdown, optional)",
+                "instructionsPlaceholder": "# My Skill\n\nWhat should the Agent know or do?",
+                "instructionsHint": "You can refine the body later on the Skill detail page.",
+                "back": "Back",
+                "next": "Next",
+                "cancel": "Cancel",
+                "create": "Create Skill",
+                "creating": "Creating...",
+                "titleRequired": "Title is required.",
+                "parentRequired": "Pick a parent for this scope.",
+                "createFailed": "Failed to create Skill"
             }
         },
         "templatesPage": {
@@ -1067,7 +1491,8 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
-                "minLength": "Description must be at least 10 characters."
+                "minLength": "Description must be at least 10 characters.",
+                "submitTitle": "Add Idea"
             },
             "toggles": {
                 "showAccepted": "Show accepted",
@@ -1380,7 +1805,8 @@
                     "failed": "失败",
                     "cancelled": "已取消"
                 }
-            }
+            },
+            "add": "Add"
         },
         "settings": {
             "title": "设置",
@@ -1396,7 +1822,9 @@
                 "gitProviders": "Git 提供商",
                 "dangerZone": "危险区域",
                 "billing": "Billing",
-                "usageCredits": "Usage & Credits"
+                "usageCredits": "Usage & Credits",
+                "fleet": "Fleet",
+                "jobRuntime": "Job Runtime"
             },
             "githubApp": {
                 "title": "GitHub App 安装",
@@ -1892,6 +2320,185 @@
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
                 }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen",
+                    "load": "Load"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
+                },
+                "load": {
+                    "idle": "Idle",
+                    "busy": "{count} running",
+                    "currentJob": "Current job: {kind}"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "requiredFieldsMissing": "Required credential fields are empty: {fields}",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
             }
         },
         "stats": {
@@ -1902,7 +2509,12 @@
             "activeWebsites": "活动网站",
             "monthSpend": "Month Spend",
             "fromLastMonth": "上月",
-            "teams": "团队"
+            "teams": "团队",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers"
         },
         "attention": {
             "title": "需要关注",
@@ -2068,11 +2680,13 @@
                     "kb": "知识库",
                     "generator": "生成 Work，一次性或按计划",
                     "deploy": "部署 Work",
-                    "tasks": "此 Work 的任务"
+                    "tasks": "此 Work 的任务",
+                    "pullRequests": "Open pull requests across this Work's repositories, with the agent's review"
                 },
                 "tasks": "任务",
                 "posts": "文章",
-                "pages": "页面"
+                "pages": "页面",
+                "pullRequests": "Pull requests"
             },
             "members": {
                 "title": "团队成员",
@@ -3425,7 +4039,81 @@
                 "providerRepoEnabled": "已开启 {provider} 仓库生成",
                 "providerRepoDisabled": "已关闭 {provider} 仓库生成",
                 "providerRepoUpdateFailed": "更新仓库设置失败",
-                "providerRepoDisabledNote": "生成已关闭。现有仓库保持不变，只是不再更新。"
+                "providerRepoDisabledNote": "生成已关闭。现有仓库保持不变，只是不再更新。",
+                "taskIsolation": {
+                    "title": "Task isolation",
+                    "subtitle": "Run each isolated Task on its own branch instead of the Work's main line.",
+                    "enableLabel": "Isolate Tasks in worktree branches",
+                    "enableDescription": "When off, agents work directly against the Work's repositories. When on, each Task gets its own branch forked from the base branch.",
+                    "baseBranchLabel": "Base branch",
+                    "baseBranchDescription": "Branch Task branches fork from. Leave empty to use the repository's default branch.",
+                    "baseBranchPlaceholder": "Repository default branch",
+                    "baseBranchSave": "Save",
+                    "targetRepoLabel": "Target repository",
+                    "targetRepoWorkOutput": "Work output repository",
+                    "targetRepoLinked": "Linked repository (coming soon)",
+                    "cleanupLabel": "Branch cleanup",
+                    "cleanupOnMerge": "Delete branch when merged",
+                    "cleanupManual": "Keep branches (clean up manually)",
+                    "saved": "Task isolation settings updated",
+                    "saveFailed": "Failed to update task isolation settings"
+                },
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
+                }
             },
             "deploy": {
                 "progress": {
@@ -3573,6 +4261,26 @@
                     "dnsName": "名称：",
                     "dnsValue": "值：",
                     "copyButton": "复制"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {
@@ -3607,7 +4315,8 @@
                     "personas": "Personas",
                     "research": "Research",
                     "output": "Outputs",
-                    "freeform": "Freeform"
+                    "freeform": "Freeform",
+                    "decision": "Decision"
                 },
                 "inherited": {
                     "bannerLabel": "继承文档通知",
@@ -3628,7 +4337,8 @@
                     "additions-only": "Additions only"
                 },
                 "document": {
-                    "emptyBody": "This document has no body yet."
+                    "emptyBody": "This document has no body yet.",
+                    "tagsLabel": "Tags"
                 },
                 "editor": {
                     "save": "Save",
@@ -3811,6 +4521,299 @@
                     "errorFallback": "无法删除。请重试。",
                     "errorBusy": "删除中…",
                     "errorPartial": "已删除 {ok}，失败 {failed}。"
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
+                },
+                "workbench": {
+                    "title": "Knowledge Base workbench",
+                    "metaTitle": "Knowledge Base workbench",
+                    "empty": "Select a document from the tree, or upload a file via drag-and-drop (coming in slice C).",
+                    "tab": {
+                        "kb": "KB",
+                        "originals": "Originals"
+                    },
+                    "originals": {
+                        "placeholder": "Drag-and-drop upload of original files lands in slice C. Use the KB tab to browse documents in the meantime."
+                    },
+                    "editor": {
+                        "preview": "Preview",
+                        "savedAt": "Saved {seconds}s ago",
+                        "saving": "Saving…",
+                        "placeholder": "Start writing…"
+                    },
+                    "wikilink": {
+                        "searching": "Searching documents…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Wikilink suggestions"
+                    },
+                    "mention": {
+                        "searching": "Searching…",
+                        "noMatches": "No matches — type more.",
+                        "listLabel": "Mention suggestions",
+                        "label": {
+                            "doc": "Doc",
+                            "agent": "Agent"
+                        }
+                    },
+                    "conflict": "This document was edited elsewhere. Reload to see the latest.",
+                    "reload": "Reload",
+                    "locked": "This document is locked.",
+                    "upload": {
+                        "dropPrompt": "Drop files here to upload",
+                        "modal": {
+                            "title": "Upload to Knowledge Base",
+                            "targetClass": "Target class",
+                            "tags": "Tags",
+                            "tagsPlaceholder": "Type a tag and press Enter",
+                            "description": "Description",
+                            "descriptionPlaceholder": "Short summary of the file(s) you are uploading",
+                            "autoClassify": "Let the agent reclassify after extraction",
+                            "upload": "Upload",
+                            "cancel": "Cancel"
+                        },
+                        "progress": {
+                            "uploading": "Uploading",
+                            "done": "Done",
+                            "failed": "Failed"
+                        }
+                    },
+                    "metadata": {
+                        "title": "Metadata",
+                        "class": "Class",
+                        "tags": {
+                            "label": "Tags",
+                            "add": "Add tag",
+                            "placeholder": "Type a tag and press Enter",
+                            "remove": "Remove tag {tag}"
+                        },
+                        "description": "Description",
+                        "descriptionPlaceholder": "Short summary of this document",
+                        "status": "Status",
+                        "statusActive": "Active",
+                        "statusArchived": "Archived",
+                        "statusDraft": "Draft",
+                        "lock": {
+                            "toggle": "Locked",
+                            "mode": "Lock mode",
+                            "modeFull": "Full lock",
+                            "modeAdditionsOnly": "Additions only"
+                        },
+                        "language": "Language",
+                        "languagePlaceholder": "BCP-47 code (e.g. en, en-US)",
+                        "source": "Source",
+                        "history": "View Git history",
+                        "historyComingSoon": "Coming in slice E",
+                        "saveFailed": "Save failed",
+                        "lockedBanner": "This document is locked."
+                    },
+                    "viewer": {
+                        "sizeBlocked": {
+                            "title": "Preview unavailable — file too large",
+                            "description": "This file is {size} which exceeds the inline preview cap of {cap}. Download it to view locally.",
+                            "download": "Download original"
+                        },
+                        "unsupported": {
+                            "title": "Preview unavailable for this format",
+                            "description": "No inline viewer is available for {mime}. Download the file to open it in a native application.",
+                            "download": "Download original"
+                        }
+                    },
+                    "contextMenu": {
+                        "rename": "Rename",
+                        "duplicate": "Duplicate",
+                        "lock": "Lock",
+                        "lockFull": "Full lock",
+                        "lockAdditionsOnly": "Additions-only lock",
+                        "unlock": "Unlock",
+                        "archive": "Archive",
+                        "delete": "Delete",
+                        "copyPath": "Copy path",
+                        "copyWikilink": "Copy wikilink",
+                        "lockedDisabledTooltip": "Unlock the document to perform this action.",
+                        "deleteConfirmTitle": "Delete document?",
+                        "deleteConfirmInstruction": "Type \"{name}\" to confirm. This cannot be undone.",
+                        "deleteConfirmInput": "Document name",
+                        "deleteCancel": "Cancel",
+                        "deleteConfirm": "Delete"
+                    },
+                    "search": {
+                        "placeholder": "Search Knowledge Base documents…",
+                        "empty": "Type to search KB documents.",
+                        "noResults": "No documents matched your search.",
+                        "searching": "Searching…",
+                        "filter": {
+                            "class": "Class",
+                            "tags": "Tags",
+                            "status": "Status",
+                            "locked": "Locked only",
+                            "language": "Language"
+                        }
+                    },
+                    "history": {
+                        "title": "Document Git history",
+                        "placeholder": "No commits yet for this document.",
+                        "placeholderDescription": "The Git-mirror background job will populate this list after the next edit lands. If this persists, the backend endpoint may still be rolling out — track follow-up at EW-732.",
+                        "restore": "Restore",
+                        "restored": "Restored",
+                        "failed": "Restore failed",
+                        "close": "Close"
+                    }
+                },
+                "facets": {
+                    "searchLabel": "Search memory",
+                    "searchPlaceholder": "Search titles and content…",
+                    "clear": "Clear filters",
+                    "typeLabel": "Type",
+                    "sourceLabel": "Source",
+                    "noMatches": "No documents match these filters.",
+                    "activeCount": "{count} matching",
+                    "badge": {
+                        "human": "Human",
+                        "agent": "Agent",
+                        "synthesized": "Synthesized",
+                        "connector": "Connector"
+                    },
+                    "badgeAria": {
+                        "human": "Written by a person",
+                        "agent": "Written by an agent run",
+                        "synthesized": "Merged by memory consolidation",
+                        "connector": "Came from a connected tool: {source}"
+                    }
+                },
+                "health": {
+                    "title": "Memory health",
+                    "subtitle": "How well the Knowledge Base is answering the questions agents actually ask.",
+                    "loading": "Measuring memory health…",
+                    "error": "Could not load memory health.",
+                    "retry": "Try again",
+                    "window": "Last {days} days",
+                    "notMeasurable": "Not measurable yet",
+                    "recall": {
+                        "label": "Recall hit rate",
+                        "explainer": "Of the documents we put in front of an agent, how many did it actually use. Low means we are injecting the wrong things.",
+                        "detail": "{cited} of {retrieved} injected documents were cited.",
+                        "noSignal": "Nothing has cited a document yet, so this cannot be measured — a 0% here would be a guess, not a fact."
+                    },
+                    "stale": {
+                        "label": "Stale decisions",
+                        "explainer": "Settled decisions nobody has touched in {days} days. High means the decision log is drifting from how the team actually works.",
+                        "detail": "{stale} of {accepted} accepted decisions are stale.",
+                        "none": "No accepted decisions yet."
+                    },
+                    "backlog": {
+                        "label": "Awaiting review",
+                        "explainer": "Agent-written notes stay out of agent context until a human accepts them. A growing backlog means learning is being captured and then discarded.",
+                        "detail": "Oldest has waited {oldest} days; average {average} days.",
+                        "none": "Nothing is waiting for review."
+                    },
+                    "gaps": {
+                        "label": "Questions we could not answer",
+                        "explainer": "Searches that returned nothing. These are fed into the next consolidation pass as synthesis candidates.",
+                        "occurrences": "asked {count}x",
+                        "none": "Every question in this window returned something."
+                    },
+                    "uncited": {
+                        "label": "Injected but never used",
+                        "retrievals": "injected {count}x",
+                        "none": "Everything injected has been used."
+                    }
+                },
+                "askWhy": {
+                    "trigger": "Ask why",
+                    "title": "Why this document showed up",
+                    "subtitle": "The recorded retrieval trail — no AI, no guessing.",
+                    "loading": "Loading the retrieval trail…",
+                    "error": "Could not load the retrieval trail.",
+                    "empty": "This document has not been retrieved in the last {days} days.",
+                    "alwaysInjected": "Always injected (no query)",
+                    "resultCount": "{count} documents returned",
+                    "citations": "Cited {count}x",
+                    "total": "{count} retrievals in the last {days} days",
+                    "close": "Close"
+                }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
+            },
+            "pullRequests": {
+                "title": "Pull requests",
+                "subtitle": "{count} open across this Work’s repositories",
+                "loading": "Loading pull requests…",
+                "noOpen": "No open pull requests in this repository.",
+                "repoError": "Could not list pull requests: {message}",
+                "openExternal": "Open pull request #{number} on the git provider",
+                "empty": {
+                    "title": "No open pull requests",
+                    "body": "Pull requests opened on this Work’s repositories show up here, together with the agent’s review."
+                },
+                "roles": {
+                    "work": "main repo",
+                    "website": "website repo",
+                    "data": "data repo"
+                },
+                "states": {
+                    "open": "Open",
+                    "merged": "Merged",
+                    "closed": "Closed"
+                },
+                "pills": {
+                    "reviewed": "Reviewed ({count})",
+                    "notReviewed": "Not reviewed"
+                },
+                "detail": {
+                    "loading": "Loading the diff…",
+                    "refresh": "Refresh",
+                    "requestReview": "Request agent review",
+                    "reviews": "Agent reviews",
+                    "noReviews": "No agent review recorded for this pull request yet.",
+                    "fileNotes": "{count} file notes",
+                    "notPosted": "not posted to the pull request",
+                    "diff": "Diff",
+                    "noDiff": "No file changes to show.",
+                    "truncated": "Diff truncated",
+                    "fileTruncated": "truncated"
+                },
+                "errors": {
+                    "list": "Failed to load pull requests",
+                    "diff": "Failed to load the diff",
+                    "review": "Failed to run the agent review"
+                }
+            },
+            "externalEvents": {
+                "title": "External activity",
+                "subtitle": "Events ingested from the connectors for this Work — repos, trackers, docs, chat and meetings.",
+                "loading": "Loading external activity…",
+                "empty": "No external events for this Work yet. Connect a connector and claim its channel, repository or project on this Work.",
+                "emptyFiltered": "No external events from {source} for this Work.",
+                "error": "Failed to load external events",
+                "untitled": "Untitled event",
+                "openSource": "Open the original in the source system",
+                "filters": {
+                    "all": "All sources"
                 }
             }
         },
@@ -3828,7 +4831,9 @@
                 "blog": "Blog",
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo",
-                "company": "Company"
+                "company": "Company",
+                "agent": "Agent",
+                "task": "Task"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3851,7 +4856,9 @@
             "toasts": {
                 "missionCreated": "Mission created",
                 "ideaCreated": "Idea added",
-                "submitError": "Couldn't create. Please try again."
+                "submitError": "Couldn't create. Please try again.",
+                "agentDraft": "Opening Agent setup — finish to create.",
+                "taskDraft": "Opening Task setup — finish to create."
             },
             "cards": {
                 "ai": {
@@ -3869,7 +4876,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }
+            },
+            "submitTitle": "Create"
         },
         "workCreation": {
             "title": "创建新作品",
@@ -3982,7 +4990,10 @@
                 "organizationHelp": "在组织下创建仓库，而不是个人账户",
                 "organizationNameLabel": "组织名称",
                 "organizationNamePlaceholder": "输入组织名称",
-                "websiteTemplateHelperText": "选择首次创建作品仓库时将使用的作品模板。"
+                "websiteTemplateHelperText": "选择首次创建作品仓库时将使用的作品模板。",
+                "slugLabel": "Work Slug",
+                "slugPlaceholder": "awesome-ai-tools",
+                "slugHelp": "URL-friendly identifier. Auto-generated from the name — edit to override."
             },
             "manual": {
                 "title": "手动创建",
@@ -4218,6 +5229,58 @@
                     "description": "您的账户中已存在此名称的仓库。您可以使用不同的名称或接受建议。",
                     "useSuggestion": "改用 \"{slug}\""
                 }
+            },
+            "promptLabel": "What kind of Work do you want to build?",
+            "or": "or",
+            "kinds": {
+                "website": "Website",
+                "landing-page": "Landing Page",
+                "blog": "Blog",
+                "directory": "Directory",
+                "awesome-repo": "Awesome Repo"
+            },
+            "kindDescriptions": {
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
+            "promptHints": {
+                "minLength": "Add a description (at least 10 characters) to start.",
+                "submitTitle": "Create with AI"
+            },
+            "buttons": {
+                "manual": "Create Work Manually",
+                "import": "Import Existing Work"
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {
@@ -4544,7 +5607,8 @@
                 "skills": "技能",
                 "templates": "模板",
                 "settings": "设置",
-                "teams": "团队"
+                "teams": "团队",
+                "meetings": "Meetings"
             },
             "tooltips": {
                 "expandSidebar": "展开侧边栏",
@@ -5161,7 +6225,24 @@
                 "removeMember": "移除",
                 "roleLead": "负责人",
                 "roleMember": "成员",
-                "emptyRoster": "暂无成员 — 请向该团队添加代理或同事。"
+                "emptyRoster": "暂无成员 — 请向该团队添加代理或同事。",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "团队设置",
@@ -5183,7 +6264,9 @@
                 "updateFailed": "无法更新团队",
                 "deleteFailed": "无法删除团队",
                 "memberAddFailed": "无法添加成员",
-                "memberRemoveFailed": "无法移除成员"
+                "memberRemoveFailed": "无法移除成员",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {
@@ -5297,6 +6380,238 @@
             "company": "Company",
             "campaign": "营销活动",
             "default": "Work"
+        },
+        "meetingsPage": {
+            "title": "Meetings",
+            "subtitle": "Every meeting the platform captured, newest first. Attach a transcript and it is summarized, remembered, and posted to your activity feed.",
+            "newMeeting": "New meeting",
+            "connectHint": "Zoom recordings and Google Meet transcripts sync automatically once their connector is enabled.",
+            "connectHintLink": "Manage connectors",
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "badges": {
+                "transcript": "Transcript",
+                "noTranscript": "No transcript"
+            },
+            "filterBar": {
+                "source": "Source",
+                "anySource": "Any source",
+                "work": "Work",
+                "anyWork": "Any Work",
+                "apply": "Apply",
+                "reset": "Reset"
+            },
+            "loadError": {
+                "title": "Could not load meetings."
+            },
+            "empty": {
+                "title": "No meetings yet.",
+                "subtitle": "Capture a meeting by hand and paste its transcript, or enable a meetings connector so recordings sync on their own."
+            },
+            "pagination": {
+                "showing": "Showing {from}-{to}",
+                "noResults": "No results on this page",
+                "previous": "Previous",
+                "next": "Next"
+            },
+            "card": {
+                "participants": "{count, plural, =0 {No participants} one {# participant} other {# participants}}",
+                "durationPrefix": "Duration:",
+                "durationUnknown": "Still open"
+            }
+        },
+        "meetingNew": {
+            "title": "New meeting",
+            "subtitle": "Capture a meeting the platform did not sync for you. Paste the transcript now and it is summarized, saved to Memory and posted to your activity feed in one step.",
+            "backToMeetings": "Back to Meetings",
+            "created": "Meeting captured",
+            "sections": {
+                "provenance": "Where it came from",
+                "participants": "Participants",
+                "transcript": "Transcript"
+            },
+            "sources": {
+                "manual": "Manual",
+                "import": "Import",
+                "zoom": "Zoom",
+                "google-meet": "Google Meet"
+            },
+            "fields": {
+                "title": "Title",
+                "titlePlaceholder": "e.g. Weekly roadmap review",
+                "startedAt": "Started at",
+                "startedAtHint": "Leave empty to use the current time.",
+                "endedAt": "Ended at (optional)",
+                "source": "Source",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)",
+                "workHint": "Route the meeting to one Work, or leave it org-wide.",
+                "sourceUrl": "Recording link (optional)",
+                "externalId": "Provider meeting ID (optional)",
+                "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "transcript": "Transcript (optional)",
+                "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
+                "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "createFailed": "Couldn't capture the meeting. Please try again."
+            },
+            "actions": {
+                "create": "Capture meeting",
+                "cancel": "Cancel"
+            }
+        },
+        "meetingDetail": {
+            "backToMeetings": "Back to Meetings",
+            "actions": {
+                "openRecording": "Open recording",
+                "delete": "Delete",
+                "attachTranscript": "Attach transcript",
+                "replaceTranscript": "Replace transcript",
+                "cancelReplace": "Cancel replace",
+                "save": "Save changes"
+            },
+            "sections": {
+                "summary": "Summary",
+                "transcript": "Transcript",
+                "details": "Details",
+                "edit": "Edit meeting"
+            },
+            "summary": {
+                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
+                "noTranscript": "Attach a transcript to generate a summary."
+            },
+            "transcript": {
+                "composerLabel": "Transcript text",
+                "composerPlaceholder": "Paste the meeting transcript here.",
+                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
+                "storedElsewhere": "The transcript is stored but was not returned with this view."
+            },
+            "details": {
+                "source": "Source",
+                "startedAt": "Started",
+                "endedAt": "Ended",
+                "openEnded": "Still open",
+                "duration": "Duration",
+                "work": "Work",
+                "orgWide": "Org-wide",
+                "externalId": "Provider ID",
+                "createdAt": "Captured",
+                "participants": "Participants",
+                "noParticipants": "No participants recorded."
+            },
+            "edit": {
+                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+            },
+            "fields": {
+                "title": "Title",
+                "endedAt": "Ended at",
+                "sourceUrl": "Recording link",
+                "work": "Work",
+                "workNone": "Org-wide (no Work)"
+            },
+            "errors": {
+                "titleRequired": "Title is required.",
+                "endedAtInvalid": "End time is not a valid date.",
+                "endedBeforeStarted": "End time cannot be before the start time.",
+                "transcriptRequired": "Transcript text is required."
+            },
+            "toasts": {
+                "transcriptSaved": "Transcript attached",
+                "transcriptSummarized": "Transcript attached and summarized",
+                "transcriptError": "Couldn't attach the transcript.",
+                "saved": "Meeting updated",
+                "saveError": "Couldn't update the meeting.",
+                "deleted": "Meeting deleted",
+                "deleteError": "Couldn't delete the meeting."
+            },
+            "confirm": {
+                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            }
+        },
+        "agentsPreview": {
+            "title": "Agents",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Agents yet.",
+                "subtitleLink": "Create your first Agent",
+                "subtitleSuffix": "to delegate recurring work."
+            },
+            "scope": {
+                "tenant": "Workspace",
+                "mission": "Mission",
+                "work": "Work",
+                "idea": "Idea"
+            },
+            "cadence": "every {cadence}"
+        },
+        "recentTasks": {
+            "title": "Tasks",
+            "add": "Add",
+            "viewAll": "View all ({n}) →",
+            "empty": {
+                "title": "No Tasks yet.",
+                "subtitle": "Create one to start tracking work."
+            },
+            "view": {
+                "label": "Switch task view",
+                "list": "List view",
+                "cards": "Card view"
+            }
+        },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
+        "terminal": {
+            "stateStarting": "Connecting…",
+            "stateAttached": "Live",
+            "stateEnded": "Session ended ({reason})",
+            "stateCannotConnect": "Cannot connect — terminal streaming is not available for this run.",
+            "stateRefused": "You do not have access to this terminal.",
+            "readOnly": "read-only",
+            "reconnect": "Reconnect",
+            "waitingForOutput": "Waiting for output…",
+            "noRuns": "No runs yet — terminals attach to agent runs.",
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {
@@ -5386,7 +6701,8 @@
             "pluginSettings": "插件设置",
             "discover": "Discover",
             "billing": "Billing",
-            "usage": "Usage & Credits"
+            "usage": "Usage & Credits",
+            "jobRuntime": "Job Runtime"
         }
     },
     "api": {
@@ -5560,6 +6876,11 @@
         "visibility": {
             "private": "私有",
             "public": "公开"
+        },
+        "footer": {
+            "build": "Build",
+            "web": "Web",
+            "api": "API"
         }
     },
     "organizations": {
@@ -5657,6 +6978,109 @@
             "title": "Create your first Organization",
             "description": "Organize your work, share with teammates, and collaborate as a team.",
             "cta": "Create Organization"
+        }
+    },
+    "notifications-v2": {
+        "emails": {
+            "title": "Email Addresses",
+            "subtitle": "Tenant-managed inbound + outbound addresses for agents.",
+            "addAddress": "Add address",
+            "empty": "No email addresses yet. Click Add address to register a Postmark / Resend / Mailgun / Sendgrid / Mailchimp inbox.",
+            "columns": {
+                "address": "Address",
+                "direction": "Direction",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove",
+                "verify": "Resend verification"
+            }
+        },
+        "channels": {
+            "title": "Notification Channels",
+            "subtitle": "Connect Discord, Slack, Telegram, WhatsApp or Novu for multi-channel notification delivery.",
+            "addChannel": "Add channel",
+            "empty": "No channels yet. Add a Discord webhook, Slack incoming webhook, Telegram bot, or Novu workflow to start fanning notifications out beyond in-app.",
+            "columns": {
+                "name": "Name",
+                "provider": "Provider",
+                "verified": "Verified"
+            },
+            "actions": {
+                "test": "Test",
+                "edit": "Edit",
+                "disable": "Disable",
+                "remove": "Remove"
+            },
+            "testResult": {
+                "delivered": "Test delivered ✓",
+                "failed": "Test failed"
+            }
+        },
+        "preferences": {
+            "title": "Notification Preferences",
+            "subtitle": "Pick which channels deliver each event. In-app delivery is always on.",
+            "empty": "No event types registered yet. Producers will populate the registry on first emission.",
+            "columns": {
+                "event": "Event",
+                "inApp": "In-app"
+            },
+            "quietHours": {
+                "title": "Quiet hours",
+                "start": "Start",
+                "end": "End",
+                "timezone": "Timezone"
+            },
+            "mute": {
+                "title": "Mute category",
+                "until": "Mute until",
+                "muted": "Muted",
+                "unmute": "Unmute"
+            }
+        },
+        "inbox": {
+            "title": "Inbox",
+            "subtitleCount": "Inbound + outbound email for this agent. {count} messages.",
+            "compose": "Compose",
+            "empty": "No messages yet. Assign an inbound email address to this agent under Settings → Integrations → Emails to start receiving mail.",
+            "columns": {
+                "direction": "Direction",
+                "from": "From",
+                "subject": "Subject",
+                "when": "When",
+                "status": "Status"
+            },
+            "directionIn": "in",
+            "directionOut": "out",
+            "back": "← Back to inbox"
+        },
+        "detail": {
+            "from": "From",
+            "to": "To",
+            "cc": "Cc",
+            "inbound": "inbound",
+            "outbound": "outbound"
+        },
+        "composer": {
+            "title": "Compose",
+            "to": "To",
+            "toPlaceholder": "recipient@example.com, another@example.com",
+            "cc": "Cc",
+            "ccOptional": "(optional)",
+            "subject": "Subject",
+            "message": "Message",
+            "send": "Send",
+            "sending": "Sending…",
+            "sent": "Sent ✓",
+            "errors": {
+                "recipientRequired": "At least one recipient is required.",
+                "subjectRequired": "Subject is required.",
+                "bodyRequired": "Message body is required.",
+                "sendFailed": "Send failed."
+            }
         }
     }
 }

--- a/apps/web/scripts/sync-locale-parity.mjs
+++ b/apps/web/scripts/sync-locale-parity.mjs
@@ -27,8 +27,13 @@
 
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const messagesDir = new URL('../messages', import.meta.url).pathname.replace(/^\//, '');
+// `fileURLToPath` (not `.pathname`): a URL pathname is percent-encoded, so a
+// checkout under a directory with a space in it resolved to a literal
+// `...Ever%20Works...` path and the script died with ENOENT before reading
+// en.json. It also strips the Windows leading-slash drive prefix correctly.
+const messagesDir = fileURLToPath(new URL('../messages', import.meta.url));
 
 // Deep walk en.json. Returns the count of leaves added. Mutates
 // `target` in place. Treats arrays as opaque leaves — we do not

--- a/apps/web/src/app/[locale]/(dashboard)/meetings/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/meetings/[id]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { meetingsAPI } from '@/lib/api/meetings';
+import { workAPI } from '@/lib/api/work';
+import { MeetingDetailClient, type MeetingWorkOption } from '@/components/meetings';
+
+/**
+ * Meetings — `/meetings/[id]` detail page. Server-fetches the meeting
+ * (the single-meeting projection is the one that INCLUDES the
+ * transcript body). Unknown ids, other owners' rows and fetch failures
+ * all resolve to `null` — the API 404s identically for missing and
+ * not-mine, deliberately leaking no existence — so the page renders the
+ * standard 404 surface instead of a half-built detail view.
+ *
+ * The Work options are a best-effort side fetch (`.catch(() => [])`)
+ * used only to name the routed Work and power the re-route picker.
+ */
+type Params = Promise<{ id: string; locale: string }>;
+
+const WORK_OPTIONS_LIMIT = 100;
+
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+    const { id } = await params;
+    const meeting = await meetingsAPI.get(id);
+    if (!meeting) {
+        const t = await getTranslations('dashboard.meetingsPage');
+        return { title: t('title') };
+    }
+    return { title: meeting.title };
+}
+
+export default async function MeetingDetailPage({ params }: { params: Params }) {
+    const { id } = await params;
+    const meeting = await meetingsAPI.get(id);
+    if (!meeting) {
+        notFound();
+    }
+
+    const works: MeetingWorkOption[] = await workAPI
+        .getAll({ limit: WORK_OPTIONS_LIMIT })
+        .then((res) => (res?.works ?? []).map((work) => ({ id: work.id, name: work.name })))
+        .catch(() => []);
+
+    return <MeetingDetailClient meeting={meeting} works={works} />;
+}

--- a/apps/web/src/app/[locale]/(dashboard)/meetings/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/meetings/new/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { workAPI } from '@/lib/api/work';
+import { MeetingForm, type MeetingWorkOption } from '@/components/meetings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.meetingNew');
+    return { title: t('title') };
+}
+
+const WORK_OPTIONS_LIMIT = 100;
+
+/**
+ * Meetings — `/meetings/new` capture form. The Work options are a
+ * best-effort side fetch (`.catch(() => [])`): routing a meeting to a
+ * Work is optional (meetings are org-wide by default), so a flaky works
+ * endpoint must degrade to "no Work picker" rather than blocking
+ * capture entirely.
+ */
+export default async function NewMeetingPage() {
+    const works: MeetingWorkOption[] = await workAPI
+        .getAll({ limit: WORK_OPTIONS_LIMIT })
+        .then((res) => (res?.works ?? []).map((work) => ({ id: work.id, name: work.name })))
+        .catch(() => []);
+
+    return <MeetingForm works={works} />;
+}

--- a/apps/web/src/app/[locale]/(dashboard)/meetings/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/meetings/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { meetingsAPI, type Meeting } from '@/lib/api/meetings';
+import { MEETING_SOURCES, type MeetingSource } from '@/lib/api/meetings.shared';
+import { workAPI } from '@/lib/api/work';
+import { MeetingsList, type MeetingWorkOption } from '@/components/meetings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.meetingsPage');
+    return { title: t('title') };
+}
+
+const PAGE_SIZE = 24;
+const WORK_OPTIONS_LIMIT = 100;
+
+/** Canonical uuid shape — anything else is dropped before it reaches the API. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type MeetingsSearchParams = Promise<{
+    source?: string | string[];
+    workId?: string | string[];
+    offset?: string | string[];
+}>;
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function buildMeetingsHref(input: {
+    source?: MeetingSource;
+    workId?: string;
+    offset?: number;
+}): string {
+    const params = new URLSearchParams();
+    if (input.source) params.set('source', input.source);
+    if (input.workId) params.set('workId', input.workId);
+    if (input.offset && input.offset > 0) params.set('offset', String(input.offset));
+    const qs = params.toString();
+    return qs ? `/meetings?${qs}` : '/meetings';
+}
+
+/**
+ * Meetings — `/meetings` catalog page. Server-fetches the user's
+ * meetings with bounded pagination and hands load errors to the client
+ * so a flaky API doesn't masquerade as an empty meeting history (same
+ * contract as the Goals catalog).
+ *
+ * Both filters are whitelisted here before they reach the API:
+ *   - `source` must be one of the closed `MeetingSource` set — the API
+ *     silently ignores unknown values, so dropping it locally keeps the
+ *     rendered filter chip and the actual query in agreement.
+ *   - `workId` must look like a uuid. The API compares it straight
+ *     against a uuid column, so an arbitrary string would be a Postgres
+ *     cast error (a 500) rather than an empty result.
+ *
+ * The Work options powering the "routed to" filter are a best-effort
+ * side fetch (`.catch(() => [])`) — the meetings list must render even
+ * when the works endpoint is unhappy.
+ */
+export default async function MeetingsPage({
+    searchParams,
+}: {
+    searchParams: MeetingsSearchParams;
+}) {
+    const params = await searchParams;
+    const sourceParam = firstParam(params.source);
+    const source = MEETING_SOURCES.includes(sourceParam as MeetingSource)
+        ? (sourceParam as MeetingSource)
+        : undefined;
+    const workIdParam = firstParam(params.workId);
+    const workId = workIdParam && UUID_RE.test(workIdParam) ? workIdParam : undefined;
+    const offset = Math.max(0, parseInt(firstParam(params.offset) ?? '0', 10) || 0);
+
+    const worksPromise = workAPI
+        .getAll({ limit: WORK_OPTIONS_LIMIT })
+        .then<MeetingWorkOption[]>((res) =>
+            (res?.works ?? []).map((work) => ({ id: work.id, name: work.name })),
+        )
+        .catch<MeetingWorkOption[]>(() => []);
+
+    let meetings: Meeting[] = [];
+    let loadError: string | null = null;
+    try {
+        meetings = await meetingsAPI.list({
+            source,
+            workId,
+            offset,
+            limit: PAGE_SIZE + 1,
+        });
+    } catch (err) {
+        loadError = err instanceof Error ? err.message : 'Failed to load meetings.';
+    }
+
+    const works = await worksPromise;
+
+    const hasNext = meetings.length > PAGE_SIZE;
+    const pageMeetings = hasNext ? meetings.slice(0, PAGE_SIZE) : meetings;
+    const prevOffset = Math.max(0, offset - PAGE_SIZE);
+    const nextOffset = offset + PAGE_SIZE;
+
+    return (
+        <MeetingsList
+            meetings={pageMeetings}
+            works={works}
+            loadError={loadError}
+            filters={{ source, workId }}
+            pagination={{
+                offset,
+                hasPrevious: offset > 0,
+                hasNext,
+                previousHref: buildMeetingsHref({ source, workId, offset: prevOffset }),
+                nextHref: buildMeetingsHref({ source, workId, offset: nextOffset }),
+            }}
+        />
+    );
+}

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -32,6 +32,7 @@ import {
     Users,
     CreditCard,
     BarChart3,
+    Video,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
@@ -137,6 +138,11 @@ export function DashboardSidebar({
         // active Organization knows, aggregated across all its Works' KB.
         // Sits directly below Agents per spec §4.1.
         { name: t('navigation.memory'), href: ROUTES.DASHBOARD_MEMORY, icon: Brain },
+        // Meetings (Wave 8, feature a) — captured meetings, transcripts
+        // and their AI summaries. Sits right after Memory: a meeting
+        // transcript is one of the richest things the platform learns
+        // from, and its ingest writes straight into Memory + Activity.
+        { name: t('navigation.meetings'), href: ROUTES.DASHBOARD_MEETINGS, icon: Video },
         // Teams & Prebuilt Companies (teams-and-companies spec §4.1).
         { name: t('navigation.teams'), href: ROUTES.DASHBOARD_TEAMS, icon: Users },
         { name: t('navigation.templates'), href: ROUTES.DASHBOARD_TEMPLATES, icon: LayoutTemplate },

--- a/apps/web/src/components/meetings/MeetingCard.tsx
+++ b/apps/web/src/components/meetings/MeetingCard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { CalendarClock, ChevronRight, Users, Video } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import type { Meeting } from '@/lib/api/meetings';
+import {
+    SourceBadge,
+    TranscriptBadge,
+    durationMinutes,
+    formatDateTime,
+    formatDuration,
+} from './meeting-ui';
+
+/**
+ * Meetings — read-only summary card for a single meeting in the
+ * `/meetings` list grid. The whole card links to the meeting detail
+ * page. Surfaces when it started (+ duration when it ended), the
+ * producing surface, whether a transcript landed, the roster size, and
+ * the first line of the AI summary when one exists.
+ *
+ * List rows deliberately carry NO transcript body (the API's list
+ * projection omits it), so the card reads `hasTranscript` rather than
+ * probing `transcriptText`.
+ */
+export function MeetingCard({ meeting }: { meeting: Meeting }) {
+    const t = useTranslations('dashboard.meetingsPage.card');
+    const minutes = durationMinutes(meeting.startedAt, meeting.endedAt);
+    const participantCount = meeting.participants?.length ?? 0;
+    const summaryLine = meeting.summary?.trim().split(/\r?\n/)[0] ?? '';
+
+    return (
+        <Link
+            href={`/meetings/${meeting.id}`}
+            data-testid="meeting-card"
+            className={cn(
+                'group relative flex min-h-[12rem] flex-col overflow-hidden rounded-lg p-4 shadow-xs',
+                'bg-card dark:bg-card-primary-dark/70',
+                'border border-card-border dark:border-white/9',
+                'hover:border-primary-500/50 dark:hover:border-white/20',
+                'transition-colors',
+                'no-underline',
+            )}
+        >
+            <div className="mb-3 flex min-w-0 items-start gap-3 pr-6">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-info/20 bg-info/10">
+                    <Video strokeWidth={1.4} className="h-4 w-4 text-info" />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <h3 className="line-clamp-2 text-sm font-semibold leading-snug text-text dark:text-text-dark">
+                        {meeting.title}
+                    </h3>
+                    {summaryLine ? (
+                        <p className="mt-1 line-clamp-2 text-xs text-text-muted dark:text-text-muted-dark">
+                            {summaryLine}
+                        </p>
+                    ) : null}
+                </div>
+                <ChevronRight className="mt-1 h-4 w-4 shrink-0 text-text-muted opacity-0 transition-opacity group-hover:opacity-100 dark:text-text-muted-dark" />
+            </div>
+
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-border/50 bg-surface/40 px-3 py-2 dark:border-border-dark/50 dark:bg-surface-dark/30">
+                <CalendarClock className="h-3.5 w-3.5 shrink-0 text-text-muted dark:text-text-muted-dark" />
+                <time
+                    dateTime={meeting.startedAt}
+                    suppressHydrationWarning
+                    className="truncate text-xs font-medium text-text dark:text-text-dark"
+                >
+                    {formatDateTime(meeting.startedAt)}
+                </time>
+            </div>
+
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+                <SourceBadge source={meeting.source} />
+                <TranscriptBadge hasTranscript={meeting.hasTranscript} />
+            </div>
+
+            <div className="mt-auto space-y-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                <div className="flex items-center gap-1.5">
+                    <Users className="h-3 w-3 shrink-0" />
+                    <span>{t('participants', { count: participantCount })}</span>
+                </div>
+                <div>
+                    <span className="font-medium text-text-secondary dark:text-text-secondary-dark">
+                        {t('durationPrefix')}
+                    </span>{' '}
+                    {minutes !== null ? formatDuration(minutes) : t('durationUnknown')}
+                </div>
+            </div>
+        </Link>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -1,0 +1,502 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import {
+    CalendarClock,
+    ChevronLeft,
+    ExternalLink,
+    FileText,
+    Save,
+    Sparkles,
+    Trash2,
+    Upload,
+    Users,
+    Video,
+} from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Link, useRouter } from '@/i18n/navigation';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { cn } from '@/lib/utils/cn';
+import {
+    MEETING_SOURCE_URL_MAX_CHARS,
+    MEETING_TITLE_MAX_CHARS,
+    MEETING_TRANSCRIPT_MAX_CHARS,
+} from '@/lib/api/meetings.shared';
+import type { Meeting } from '@/lib/api/meetings';
+import type { MeetingWorkOption } from './MeetingsList';
+import {
+    SourceBadge,
+    TranscriptBadge,
+    durationMinutes,
+    formatDateTime,
+    formatDuration,
+    isoToLocalInput,
+    localInputToIso,
+} from './meeting-ui';
+import { deleteMeetingAction, ingestMeetingTranscriptAction, updateMeetingAction } from './actions';
+
+export interface MeetingDetailClientProps {
+    meeting: Meeting;
+    works?: MeetingWorkOption[];
+}
+
+const btn =
+    'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-border dark:border-border-dark text-text dark:text-text-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed';
+
+const btnDanger =
+    'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-danger/30 dark:border-danger/20 text-danger hover:bg-danger/5 dark:hover:bg-danger/10 transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed';
+
+const sectionCard =
+    'rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5';
+
+const fieldLabel = 'block text-xs font-medium text-text dark:text-text-dark mb-2';
+
+const dateInput = cn(
+    'w-full text-sm rounded-lg transition-colors outline-none px-4 py-2',
+    'bg-card dark:bg-card-primary-dark',
+    'border border-card-border dark:border-white/9',
+    'text-text dark:text-text-dark',
+    'focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20',
+);
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex items-baseline justify-between gap-3 py-1.5">
+            <span className="shrink-0 text-xs text-text-muted dark:text-text-muted-dark">
+                {label}
+            </span>
+            <span className="min-w-0 truncate text-right text-xs font-medium text-text dark:text-text-dark">
+                {children}
+            </span>
+        </div>
+    );
+}
+
+/**
+ * Meetings — `/meetings/:id` detail client.
+ *
+ * Renders the AI summary, the captured transcript, the roster and the
+ * provenance rows, and hosts the three mutations the API supports for a
+ * single meeting: attach/replace transcript, patch the editable fields,
+ * and delete.
+ *
+ * The transcript panel is deliberately honest about the pipeline's
+ * BEST-EFFORT half: the API stores the transcript and only then tries
+ * the AI summary → Memory observation → ingest envelope. On a stack
+ * with no AI provider the write still succeeds with no summary, so the
+ * toast reports what actually happened instead of promising a summary
+ * that never arrives.
+ */
+export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDetailClientProps) {
+    const t = useTranslations('dashboard.meetingDetail');
+    const router = useRouter();
+
+    const [meeting, setMeeting] = useState<Meeting>(initial);
+    const [pendingTranscript, startTranscript] = useTransition();
+    const [pendingSave, startSave] = useTransition();
+    const [pendingDelete, startDelete] = useTransition();
+
+    const [transcriptDraft, setTranscriptDraft] = useState('');
+    const [replacing, setReplacing] = useState(false);
+
+    const [title, setTitle] = useState(initial.title);
+    const [sourceUrl, setSourceUrl] = useState(initial.sourceUrl ?? '');
+    const [endedAt, setEndedAt] = useState(isoToLocalInput(initial.endedAt));
+    const [workId, setWorkId] = useState(initial.workId ?? '');
+
+    const minutes = useMemo(
+        () => durationMinutes(meeting.startedAt, meeting.endedAt),
+        [meeting.startedAt, meeting.endedAt],
+    );
+    const transcript = meeting.transcriptText ?? '';
+    const hasTranscript = meeting.hasTranscript || transcript.length > 0;
+    const showComposer = !hasTranscript || replacing;
+
+    const attachTranscript = () => {
+        const text = transcriptDraft.trim();
+        if (!text) {
+            toast.error(t('errors.transcriptRequired'));
+            return;
+        }
+        startTranscript(async () => {
+            try {
+                const result = await ingestMeetingTranscriptAction(
+                    meeting.id,
+                    text.slice(0, MEETING_TRANSCRIPT_MAX_CHARS),
+                );
+                setMeeting(result.meeting);
+                setTranscriptDraft('');
+                setReplacing(false);
+                // Honest reporting: the summary leg is best-effort and is
+                // simply absent on a stack with no AI provider.
+                toast.success(
+                    result.summary ? t('toasts.transcriptSummarized') : t('toasts.transcriptSaved'),
+                );
+                router.refresh();
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : t('toasts.transcriptError'));
+            }
+        });
+    };
+
+    const saveDetails = () => {
+        const trimmedTitle = title.trim();
+        if (!trimmedTitle) {
+            toast.error(t('errors.titleRequired'));
+            return;
+        }
+
+        let endedIso: string | null = null;
+        if (endedAt) {
+            endedIso = localInputToIso(endedAt);
+            if (!endedIso) {
+                toast.error(t('errors.endedAtInvalid'));
+                return;
+            }
+            if (Date.parse(endedIso) < Date.parse(meeting.startedAt)) {
+                toast.error(t('errors.endedBeforeStarted'));
+                return;
+            }
+        }
+
+        startSave(async () => {
+            try {
+                const updated = await updateMeetingAction(meeting.id, {
+                    title: trimmedTitle.slice(0, MEETING_TITLE_MAX_CHARS),
+                    // `null` clears the field; on `workId` it re-routes the
+                    // meeting back to org-wide. class-validator's
+                    // @IsOptional() skips validation for an explicit null,
+                    // and the service treats `!== undefined` as "patch it".
+                    endedAt: endedIso,
+                    workId: workId ? workId : null,
+                    sourceUrl: sourceUrl.trim()
+                        ? sourceUrl.trim().slice(0, MEETING_SOURCE_URL_MAX_CHARS)
+                        : null,
+                });
+                setMeeting(updated);
+                toast.success(t('toasts.saved'));
+                router.refresh();
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : t('toasts.saveError'));
+            }
+        });
+    };
+
+    const handleDelete = () => {
+        if (!window.confirm(t('confirm.delete'))) return;
+        startDelete(async () => {
+            try {
+                await deleteMeetingAction(meeting.id);
+                toast.success(t('toasts.deleted'));
+                router.push('/meetings');
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : t('toasts.deleteError'));
+            }
+        });
+    };
+
+    return (
+        <div className="mx-auto w-full max-w-screen-2xl space-y-6 p-6" data-testid="meeting-detail">
+            {/* Header */}
+            <div>
+                <Link
+                    href="/meetings"
+                    className="inline-flex items-center gap-1 text-xs text-text-muted transition-colors hover:text-text dark:text-text-muted-dark dark:hover:text-text-dark"
+                >
+                    <ChevronLeft className="h-3.5 w-3.5" />
+                    {t('backToMeetings')}
+                </Link>
+
+                <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
+                    <div className="flex min-w-0 flex-1 items-start gap-3">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-info/20 bg-info/10">
+                            <Video className="h-5 w-5 text-info" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                            <h1 className="text-2xl font-semibold leading-tight text-text dark:text-text-dark">
+                                {meeting.title}
+                            </h1>
+                            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                                <SourceBadge source={meeting.source} />
+                                <TranscriptBadge hasTranscript={hasTranscript} />
+                            </div>
+                            <p className="mt-2.5 flex flex-wrap items-center gap-1.5 text-sm text-text-secondary dark:text-text-secondary-dark">
+                                <CalendarClock className="h-3.5 w-3.5 shrink-0" />
+                                <time dateTime={meeting.startedAt} suppressHydrationWarning>
+                                    {formatDateTime(meeting.startedAt)}
+                                </time>
+                                <span aria-hidden="true">·</span>
+                                <span>{formatDuration(minutes)}</span>
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="flex shrink-0 flex-wrap items-center gap-2">
+                        {meeting.sourceUrl ? (
+                            <a
+                                href={meeting.sourceUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={btn}
+                                data-testid="meeting-recording-link"
+                            >
+                                <ExternalLink className="h-3.5 w-3.5" />
+                                {t('actions.openRecording')}
+                            </a>
+                        ) : null}
+                        <button
+                            type="button"
+                            onClick={handleDelete}
+                            disabled={pendingDelete}
+                            className={btnDanger}
+                            data-testid="meeting-delete"
+                        >
+                            <Trash2 className="h-3.5 w-3.5" />
+                            {t('actions.delete')}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {/* Summary */}
+            <section className={sectionCard} data-testid="meeting-summary">
+                <div className="mb-4 flex items-center gap-2.5">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-info/20 bg-info/10">
+                        <Sparkles className="h-3.5 w-3.5 text-info" />
+                    </div>
+                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('sections.summary')}
+                    </h2>
+                </div>
+                {meeting.summary ? (
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed text-text dark:text-text-dark">
+                        {meeting.summary}
+                    </p>
+                ) : (
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                        {hasTranscript ? t('summary.notGenerated') : t('summary.noTranscript')}
+                    </p>
+                )}
+            </section>
+
+            {/* Transcript */}
+            <section className={sectionCard} data-testid="meeting-transcript">
+                <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2.5">
+                        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-info/20 bg-info/10">
+                            <FileText className="h-3.5 w-3.5 text-info" />
+                        </div>
+                        <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                            {t('sections.transcript')}
+                        </h2>
+                    </div>
+                    {hasTranscript ? (
+                        <button
+                            type="button"
+                            onClick={() => setReplacing((v) => !v)}
+                            className={btn}
+                            data-testid="meeting-replace-transcript-toggle"
+                        >
+                            <Upload className="h-3.5 w-3.5" />
+                            {replacing
+                                ? t('actions.cancelReplace')
+                                : t('actions.replaceTranscript')}
+                        </button>
+                    ) : null}
+                </div>
+
+                {hasTranscript ? (
+                    <pre
+                        data-testid="meeting-transcript-body"
+                        className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-surface/40 p-4 font-mono text-xs leading-relaxed text-text dark:border-border-dark/50 dark:bg-surface-dark/30 dark:text-text-dark"
+                    >
+                        {transcript || t('transcript.storedElsewhere')}
+                    </pre>
+                ) : null}
+
+                {showComposer ? (
+                    <div className={hasTranscript ? 'mt-4' : ''}>
+                        <label className={fieldLabel} htmlFor="meeting-transcript-draft">
+                            {t('transcript.composerLabel')}
+                        </label>
+                        <Textarea
+                            id="meeting-transcript-draft"
+                            data-testid="meeting-transcript-composer"
+                            value={transcriptDraft}
+                            onChange={(e) => setTranscriptDraft(e.target.value)}
+                            rows={8}
+                            maxLength={MEETING_TRANSCRIPT_MAX_CHARS}
+                            placeholder={t('transcript.composerPlaceholder')}
+                            className="font-mono text-xs"
+                        />
+                        <div className="mt-3 flex items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={attachTranscript}
+                                disabled={pendingTranscript}
+                                className={btn}
+                                data-testid="meeting-attach-transcript"
+                            >
+                                <Upload className="h-3.5 w-3.5" />
+                                {t('actions.attachTranscript')}
+                            </button>
+                            <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
+                                {t('transcript.pipelineHint')}
+                            </p>
+                        </div>
+                    </div>
+                ) : null}
+            </section>
+
+            <div className="grid gap-5 @3xl/main:grid-cols-2">
+                {/* Details */}
+                <section className={sectionCard} data-testid="meeting-details">
+                    <h2 className="mb-3 text-sm font-semibold text-text dark:text-text-dark">
+                        {t('sections.details')}
+                    </h2>
+                    <div className="divide-y divide-border/50 dark:divide-border-dark/50">
+                        <DetailRow label={t('details.source')}>
+                            <SourceBadge source={meeting.source} />
+                        </DetailRow>
+                        <DetailRow label={t('details.startedAt')}>
+                            <time dateTime={meeting.startedAt} suppressHydrationWarning>
+                                {formatDateTime(meeting.startedAt)}
+                            </time>
+                        </DetailRow>
+                        <DetailRow label={t('details.endedAt')}>
+                            {meeting.endedAt ? (
+                                <time dateTime={meeting.endedAt} suppressHydrationWarning>
+                                    {formatDateTime(meeting.endedAt)}
+                                </time>
+                            ) : (
+                                t('details.openEnded')
+                            )}
+                        </DetailRow>
+                        <DetailRow label={t('details.duration')}>
+                            {formatDuration(minutes)}
+                        </DetailRow>
+                        <DetailRow label={t('details.work')}>
+                            {meeting.workId ? (
+                                <Link
+                                    href={`/works/${meeting.workId}`}
+                                    className="text-info hover:underline"
+                                >
+                                    {works.find((w) => w.id === meeting.workId)?.name ??
+                                        meeting.workId}
+                                </Link>
+                            ) : (
+                                t('details.orgWide')
+                            )}
+                        </DetailRow>
+                        <DetailRow label={t('details.externalId')}>
+                            {meeting.externalId ?? '—'}
+                        </DetailRow>
+                        <DetailRow label={t('details.createdAt')}>
+                            <time dateTime={meeting.createdAt} suppressHydrationWarning>
+                                {formatDateTime(meeting.createdAt)}
+                            </time>
+                        </DetailRow>
+                    </div>
+
+                    <div className="mt-4">
+                        <div className="mb-2 flex items-center gap-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                            <Users className="h-3 w-3 shrink-0" />
+                            <span>{t('details.participants')}</span>
+                        </div>
+                        {meeting.participants.length > 0 ? (
+                            <ul className="space-y-1" data-testid="meeting-participants">
+                                {meeting.participants.map((p, i) => (
+                                    <li
+                                        key={`${p.name}-${p.email ?? ''}-${i}`}
+                                        className="truncate text-xs text-text dark:text-text-dark"
+                                    >
+                                        {p.name}
+                                        {p.email ? (
+                                            <span className="text-text-muted dark:text-text-muted-dark">
+                                                {' '}
+                                                &lt;{p.email}&gt;
+                                            </span>
+                                        ) : null}
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('details.noParticipants')}
+                            </p>
+                        )}
+                    </div>
+                </section>
+
+                {/* Edit */}
+                <section className={sectionCard} data-testid="meeting-edit">
+                    <h2 className="mb-1 text-sm font-semibold text-text dark:text-text-dark">
+                        {t('sections.edit')}
+                    </h2>
+                    <p className="mb-3 text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('edit.hint')}
+                    </p>
+                    <div className="space-y-4">
+                        <Input
+                            label={t('fields.title')}
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            maxLength={MEETING_TITLE_MAX_CHARS}
+                        />
+                        <div>
+                            <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
+                                {t('fields.endedAt')}
+                            </label>
+                            <input
+                                id="meeting-edit-ended-at"
+                                data-testid="meeting-edit-ended-at"
+                                type="datetime-local"
+                                value={endedAt}
+                                onChange={(e) => setEndedAt(e.target.value)}
+                                className={dateInput}
+                            />
+                        </div>
+                        <Input
+                            label={t('fields.sourceUrl')}
+                            value={sourceUrl}
+                            onChange={(e) => setSourceUrl(e.target.value)}
+                            maxLength={MEETING_SOURCE_URL_MAX_CHARS}
+                            placeholder="https://example.com/recordings/123"
+                        />
+                        {works.length > 0 ? (
+                            <div>
+                                <label className={fieldLabel}>{t('fields.work')}</label>
+                                <Select
+                                    value={workId}
+                                    onValueChange={setWorkId}
+                                    placeholder={t('fields.workNone')}
+                                    data-testid="meeting-edit-work"
+                                >
+                                    <option value="">{t('fields.workNone')}</option>
+                                    {works.map((work) => (
+                                        <option key={work.id} value={work.id}>
+                                            {work.name}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </div>
+                        ) : null}
+                        <button
+                            type="button"
+                            onClick={saveDetails}
+                            disabled={pendingSave}
+                            className={btn}
+                            data-testid="meeting-save"
+                        >
+                            <Save className="h-3.5 w-3.5" />
+                            {t('actions.save')}
+                        </button>
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingForm.tsx
+++ b/apps/web/src/components/meetings/MeetingForm.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { ChevronLeft, Video } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Link, useRouter } from '@/i18n/navigation';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils/cn';
+import {
+    MEETING_CREATABLE_SOURCES,
+    MEETING_EXTERNAL_ID_MAX_CHARS,
+    MEETING_SOURCE_URL_MAX_CHARS,
+    MEETING_TITLE_MAX_CHARS,
+    MEETING_TRANSCRIPT_MAX_CHARS,
+    parseParticipants,
+    type MeetingSource,
+} from '@/lib/api/meetings.shared';
+import type { MeetingWorkOption } from './MeetingsList';
+import { localInputToIso } from './meeting-ui';
+import { createMeetingAction } from './actions';
+
+const sectionCard =
+    'rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4';
+
+const fieldLabel = 'block text-xs font-medium text-text dark:text-text-dark mb-2';
+
+const dateInput = cn(
+    'w-full text-sm rounded-lg transition-colors outline-none px-4 py-2',
+    'bg-card dark:bg-card-primary-dark',
+    'border border-card-border dark:border-white/9',
+    'text-text dark:text-text-dark',
+    'focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20',
+);
+
+/**
+ * Meetings — capture form backing `/meetings/new`.
+ *
+ * Collects everything `POST /api/meetings` accepts: title, start/end,
+ * producing source, the Work to route the meeting to (org-wide when
+ * omitted), the recording deep link, the provider meeting id, a roster
+ * and — optionally — the transcript itself. Supplying the transcript
+ * here runs the SAME best-effort pipeline as attaching it later
+ * (summary → Memory observation → `meeting.transcript` envelope), so
+ * capture-and-summarize is a single round trip.
+ *
+ * Validation mirrors the API so obvious mistakes never cost a request;
+ * the API re-validates everything regardless (it is the source of
+ * truth).
+ */
+export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
+    const t = useTranslations('dashboard.meetingNew');
+    const router = useRouter();
+    const [pending, startSubmit] = useTransition();
+
+    const [title, setTitle] = useState('');
+    const [startedAt, setStartedAt] = useState('');
+    const [endedAt, setEndedAt] = useState('');
+    const [source, setSource] = useState<MeetingSource>('manual');
+    const [workId, setWorkId] = useState('');
+    const [sourceUrl, setSourceUrl] = useState('');
+    const [externalId, setExternalId] = useState('');
+    const [participantsText, setParticipantsText] = useState('');
+    const [transcriptText, setTranscriptText] = useState('');
+
+    const submit = () => {
+        const trimmedTitle = title.trim();
+        if (trimmedTitle.length < 1) {
+            toast.error(t('errors.titleRequired'));
+            return;
+        }
+
+        // `startedAt` is REQUIRED by the API. An empty field means "now",
+        // which is the honest default for a meeting you are capturing as
+        // it happens — the field is pre-fillable for anything historical.
+        const startedIso = startedAt ? localInputToIso(startedAt) : new Date().toISOString();
+        if (!startedIso) {
+            toast.error(t('errors.startedAtInvalid'));
+            return;
+        }
+
+        let endedIso: string | undefined;
+        if (endedAt) {
+            const parsed = localInputToIso(endedAt);
+            if (!parsed) {
+                toast.error(t('errors.endedAtInvalid'));
+                return;
+            }
+            if (Date.parse(parsed) < Date.parse(startedIso)) {
+                toast.error(t('errors.endedBeforeStarted'));
+                return;
+            }
+            endedIso = parsed;
+        }
+
+        const participants = parseParticipants(participantsText);
+        const trimmedTranscript = transcriptText.trim();
+
+        startSubmit(async () => {
+            try {
+                const meeting = await createMeetingAction({
+                    title: trimmedTitle.slice(0, MEETING_TITLE_MAX_CHARS),
+                    startedAt: startedIso,
+                    ...(endedIso ? { endedAt: endedIso } : {}),
+                    source,
+                    ...(workId ? { workId } : {}),
+                    ...(sourceUrl.trim()
+                        ? { sourceUrl: sourceUrl.trim().slice(0, MEETING_SOURCE_URL_MAX_CHARS) }
+                        : {}),
+                    ...(externalId.trim()
+                        ? { externalId: externalId.trim().slice(0, MEETING_EXTERNAL_ID_MAX_CHARS) }
+                        : {}),
+                    ...(participants.length > 0 ? { participants } : {}),
+                    ...(trimmedTranscript
+                        ? {
+                              transcriptText: trimmedTranscript.slice(
+                                  0,
+                                  MEETING_TRANSCRIPT_MAX_CHARS,
+                              ),
+                          }
+                        : {}),
+                });
+                toast.success(t('created'));
+                router.push(`/meetings/${meeting.id}`);
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : t('errors.createFailed'));
+            }
+        });
+    };
+
+    return (
+        <div className="mx-auto w-full max-w-3xl space-y-6 p-6" data-testid="meeting-form">
+            <div>
+                <Link
+                    href="/meetings"
+                    className="inline-flex items-center gap-1 text-xs text-text-muted transition-colors hover:text-text dark:text-text-muted-dark dark:hover:text-text-dark"
+                >
+                    <ChevronLeft className="h-3.5 w-3.5" />
+                    {t('backToMeetings')}
+                </Link>
+                <div className="mt-3 flex items-start gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-info/20 bg-info/10">
+                        <Video className="h-5 w-5 text-info" />
+                    </div>
+                    <div className="min-w-0">
+                        <h1 className="text-2xl font-semibold leading-tight text-text dark:text-text-dark">
+                            {t('title')}
+                        </h1>
+                        <p className="mt-1 max-w-2xl text-sm text-text-secondary dark:text-text-secondary-dark">
+                            {t('subtitle')}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            {/* Basics */}
+            <section className={sectionCard}>
+                <Input
+                    label={t('fields.title')}
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    maxLength={MEETING_TITLE_MAX_CHARS}
+                    placeholder={t('fields.titlePlaceholder')}
+                />
+                <div className="grid gap-4 @lg/main:grid-cols-2">
+                    <div>
+                        <label className={fieldLabel} htmlFor="meeting-started-at">
+                            {t('fields.startedAt')}
+                        </label>
+                        <input
+                            id="meeting-started-at"
+                            data-testid="meeting-started-at"
+                            type="datetime-local"
+                            value={startedAt}
+                            onChange={(e) => setStartedAt(e.target.value)}
+                            className={dateInput}
+                        />
+                        <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('fields.startedAtHint')}
+                        </p>
+                    </div>
+                    <div>
+                        <label className={fieldLabel} htmlFor="meeting-ended-at">
+                            {t('fields.endedAt')}
+                        </label>
+                        <input
+                            id="meeting-ended-at"
+                            data-testid="meeting-ended-at"
+                            type="datetime-local"
+                            value={endedAt}
+                            onChange={(e) => setEndedAt(e.target.value)}
+                            className={dateInput}
+                        />
+                    </div>
+                </div>
+            </section>
+
+            {/* Provenance */}
+            <section className={sectionCard}>
+                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('sections.provenance')}
+                </h2>
+                <div className="grid gap-4 @lg/main:grid-cols-2">
+                    <div>
+                        <label className={fieldLabel}>{t('fields.source')}</label>
+                        <Select
+                            value={source}
+                            onValueChange={(v) => setSource(v as MeetingSource)}
+                            data-testid="meeting-source-select"
+                        >
+                            {MEETING_CREATABLE_SOURCES.map((s) => (
+                                <option key={s} value={s}>
+                                    {t(`sources.${s}`)}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+                    <div>
+                        <label className={fieldLabel}>{t('fields.work')}</label>
+                        <Select
+                            value={workId}
+                            onValueChange={setWorkId}
+                            placeholder={t('fields.workNone')}
+                            data-testid="meeting-work-select"
+                        >
+                            <option value="">{t('fields.workNone')}</option>
+                            {works.map((work) => (
+                                <option key={work.id} value={work.id}>
+                                    {work.name}
+                                </option>
+                            ))}
+                        </Select>
+                        <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('fields.workHint')}
+                        </p>
+                    </div>
+                </div>
+                <Input
+                    label={t('fields.sourceUrl')}
+                    value={sourceUrl}
+                    onChange={(e) => setSourceUrl(e.target.value)}
+                    maxLength={MEETING_SOURCE_URL_MAX_CHARS}
+                    placeholder="https://example.com/recordings/123"
+                />
+                <Input
+                    label={t('fields.externalId')}
+                    value={externalId}
+                    onChange={(e) => setExternalId(e.target.value)}
+                    maxLength={MEETING_EXTERNAL_ID_MAX_CHARS}
+                    helperText={t('fields.externalIdHint')}
+                />
+            </section>
+
+            {/* Roster */}
+            <section className={sectionCard}>
+                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('sections.participants')}
+                </h2>
+                <div>
+                    <label className={fieldLabel} htmlFor="meeting-participants">
+                        {t('fields.participants')}
+                    </label>
+                    <Textarea
+                        id="meeting-participants"
+                        data-testid="meeting-participants-input"
+                        value={participantsText}
+                        onChange={(e) => setParticipantsText(e.target.value)}
+                        rows={4}
+                        placeholder={'Ada Lovelace <ada@example.com>\nGrace Hopper'}
+                        className="font-mono text-xs"
+                    />
+                    <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('fields.participantsHint')}
+                    </p>
+                </div>
+            </section>
+
+            {/* Transcript */}
+            <section className={sectionCard}>
+                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('sections.transcript')}
+                </h2>
+                <div>
+                    <label className={fieldLabel} htmlFor="meeting-transcript">
+                        {t('fields.transcript')}
+                    </label>
+                    <Textarea
+                        id="meeting-transcript"
+                        data-testid="meeting-transcript-input"
+                        value={transcriptText}
+                        onChange={(e) => setTranscriptText(e.target.value)}
+                        rows={8}
+                        maxLength={MEETING_TRANSCRIPT_MAX_CHARS}
+                        placeholder={t('fields.transcriptPlaceholder')}
+                        className="font-mono text-xs"
+                    />
+                    <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('fields.transcriptHint')}
+                    </p>
+                </div>
+            </section>
+
+            <div className="flex items-center gap-2">
+                <Button
+                    onClick={submit}
+                    loading={pending}
+                    disabled={pending}
+                    size="md"
+                    data-testid="meeting-create-submit"
+                >
+                    {t('actions.create')}
+                </Button>
+                <Button href="/meetings" variant="ghost" size="md">
+                    {t('actions.cancel')}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingsList.tsx
+++ b/apps/web/src/components/meetings/MeetingsList.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Plus, Video } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Link } from '@/i18n/navigation';
+import { PageHeader } from '@/components/common/PageHeader';
+import { MEETING_SOURCES, type MeetingSource } from '@/lib/api/meetings.shared';
+import type { Meeting } from '@/lib/api/meetings';
+import { MeetingCard } from './MeetingCard';
+
+/** Minimal Work reference used by the "routed to" filter. */
+export interface MeetingWorkOption {
+    id: string;
+    name: string;
+}
+
+interface MeetingsListProps {
+    meetings: Meeting[];
+    works?: MeetingWorkOption[];
+    loadError?: string | null;
+    filters?: {
+        source?: MeetingSource;
+        workId?: string;
+    };
+    pagination?: {
+        offset: number;
+        hasPrevious: boolean;
+        hasNext: boolean;
+        previousHref: string;
+        nextHref: string;
+    };
+}
+
+/**
+ * Meetings — `/meetings` catalog list client. Grid of MeetingCards with
+ * source + Work filters and a "+ New meeting" CTA routing to the
+ * dedicated capture form. Load failures are surfaced explicitly so a
+ * flaky API never masquerades as an empty meeting history (same
+ * contract as `GoalsList`).
+ *
+ * The filter form is a plain GET form (no client router push), so the
+ * filtered view is a real, shareable URL and works before hydration.
+ */
+export function MeetingsList({
+    meetings,
+    works = [],
+    loadError = null,
+    filters,
+    pagination,
+}: MeetingsListProps) {
+    const t = useTranslations('dashboard.meetingsPage');
+    const [sourceFilter, setSourceFilter] = useState<string>(filters?.source ?? '');
+    const [workFilter, setWorkFilter] = useState<string>(filters?.workId ?? '');
+
+    useEffect(() => {
+        setSourceFilter(filters?.source ?? '');
+    }, [filters?.source]);
+    useEffect(() => {
+        setWorkFilter(filters?.workId ?? '');
+    }, [filters?.workId]);
+
+    return (
+        <div className="w-full" data-testid="meetings-shell">
+            <PageHeader
+                icon={Video}
+                title={t('title')}
+                subtitle={t('subtitle')}
+                tone="info"
+                actions={
+                    <Button href="/meetings/new" size="sm">
+                        <Plus className="h-4 w-4" />
+                        <span className="font-medium">{t('newMeeting')}</span>
+                    </Button>
+                }
+            />
+
+            {/*
+                Connect affordance: provider-synced meetings (Zoom
+                recordings, Google Meet transcripts picked up by the
+                Workspace connector) land through the ingest spine, not
+                this form — point at the connector catalog rather than
+                inventing a second sync surface here.
+            */}
+            <p
+                className="mb-5 rounded-lg border border-dashed border-border/70 bg-surface/40 px-4 py-3 text-xs text-text-muted dark:border-border-dark/70 dark:bg-surface-dark/30 dark:text-text-muted-dark"
+                data-testid="meetings-connect-hint"
+            >
+                {t('connectHint')}{' '}
+                <Link href="/plugins" className="font-medium text-info hover:underline">
+                    {t('connectHintLink')}
+                </Link>
+            </p>
+
+            <form className="mb-5 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end">
+                <div className="min-w-40">
+                    <span className="mb-1 block text-xs text-text-secondary dark:text-text-secondary-dark">
+                        {t('filterBar.source')}
+                    </span>
+                    <input type="hidden" name="source" value={sourceFilter} />
+                    <Select
+                        value={sourceFilter}
+                        onValueChange={setSourceFilter}
+                        placeholder={t('filterBar.anySource')}
+                        size="xs"
+                        data-testid="meetings-source-filter"
+                    >
+                        <option value="">{t('filterBar.anySource')}</option>
+                        {MEETING_SOURCES.map((source) => (
+                            <option key={source} value={source}>
+                                {t(`sources.${source}`)}
+                            </option>
+                        ))}
+                    </Select>
+                </div>
+
+                {works.length > 0 ? (
+                    <div className="min-w-40">
+                        <span className="mb-1 block text-xs text-text-secondary dark:text-text-secondary-dark">
+                            {t('filterBar.work')}
+                        </span>
+                        <input type="hidden" name="workId" value={workFilter} />
+                        <Select
+                            value={workFilter}
+                            onValueChange={setWorkFilter}
+                            placeholder={t('filterBar.anyWork')}
+                            size="xs"
+                            data-testid="meetings-work-filter"
+                        >
+                            <option value="">{t('filterBar.anyWork')}</option>
+                            {works.map((work) => (
+                                <option key={work.id} value={work.id}>
+                                    {work.name}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+                ) : null}
+
+                <div className="flex items-center gap-2">
+                    <Button type="submit" size="sm">
+                        {t('filterBar.apply')}
+                    </Button>
+                    <Button href="/meetings" size="sm" variant="ghost">
+                        {t('filterBar.reset')}
+                    </Button>
+                </div>
+            </form>
+
+            {loadError ? (
+                <div
+                    role="alert"
+                    data-testid="meetings-load-error"
+                    className="mb-5 rounded-lg border border-danger/30 bg-danger/5 p-4"
+                >
+                    <p className="text-sm font-medium text-danger">{t('loadError.title')}</p>
+                    <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark">
+                        {loadError}
+                    </p>
+                </div>
+            ) : null}
+
+            {!loadError ? (
+                meetings.length === 0 ? (
+                    <div
+                        data-testid="meetings-empty"
+                        className="rounded-lg border border-dashed border-border/70 bg-surface/40 p-8 text-center dark:border-border-dark/70 dark:bg-surface-dark/30"
+                    >
+                        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-info/20 bg-info/10">
+                            <Video className="h-4 w-4 text-info" />
+                        </div>
+                        <p className="text-sm font-medium text-text dark:text-text-dark">
+                            {t('empty.title')}
+                        </p>
+                        <p className="mx-auto mt-1 max-w-2xl text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('empty.subtitle')}
+                        </p>
+                        <div className="mt-4">
+                            <Button href="/meetings/new" size="sm">
+                                <Plus className="h-4 w-4" />
+                                <span className="font-medium">{t('newMeeting')}</span>
+                            </Button>
+                        </div>
+                    </div>
+                ) : (
+                    <div
+                        data-testid="meetings-grid"
+                        className="grid grid-cols-1 gap-4 @lg/main:grid-cols-2 @3xl/main:grid-cols-3"
+                    >
+                        {meetings.map((meeting) => (
+                            <MeetingCard key={meeting.id} meeting={meeting} />
+                        ))}
+                    </div>
+                )
+            ) : null}
+
+            {!loadError && pagination && (pagination.hasPrevious || pagination.hasNext) ? (
+                <nav className="mt-5 flex items-center justify-between gap-3 text-xs text-text-muted dark:text-text-muted-dark">
+                    {meetings.length > 0 ? (
+                        <span>
+                            {t('pagination.showing', {
+                                from: pagination.offset + 1,
+                                to: pagination.offset + meetings.length,
+                            })}
+                        </span>
+                    ) : (
+                        <span>{t('pagination.noResults')}</span>
+                    )}
+                    <div className="flex items-center gap-2">
+                        {pagination.hasPrevious ? (
+                            <Link
+                                href={pagination.previousHref}
+                                className="rounded-md border border-border/60 px-3 py-1.5 text-text hover:bg-surface-secondary dark:border-border-dark/60 dark:text-text-dark dark:hover:bg-surface-secondary-dark"
+                            >
+                                {t('pagination.previous')}
+                            </Link>
+                        ) : null}
+                        {pagination.hasNext ? (
+                            <Link
+                                href={pagination.nextHref}
+                                className="rounded-md border border-border/60 px-3 py-1.5 text-text hover:bg-surface-secondary dark:border-border-dark/60 dark:text-text-dark dark:hover:bg-surface-secondary-dark"
+                            >
+                                {t('pagination.next')}
+                            </Link>
+                        ) : null}
+                    </div>
+                </nav>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/web/src/components/meetings/actions.ts
+++ b/apps/web/src/components/meetings/actions.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { meetingsAPI, type CreateMeetingInput, type UpdateMeetingInput } from '@/lib/api/meetings';
+import { getAuthFromCookie } from '@/lib/auth';
+import { ROUTES } from '@/lib/constants';
+
+/**
+ * Meetings — server actions backing the Meetings UI. Each one forwards
+ * to the JWT-protected `/api/meetings` surface and busts the relevant
+ * page caches, mirroring `components/goals/actions.ts`. Lives alongside
+ * the Meetings components so the whole surface ships in one directory.
+ */
+
+// Security: defense-in-depth auth guard at the web layer. Every Meeting
+// server action forwards straight to the JWT-protected API; this rejects
+// unauthenticated callers before any request is issued, matching the
+// Goals actions. Authenticated callers are unaffected
+// (getAuthFromCookie is cache()d).
+async function requireMeetingAuth() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+}
+
+const MEETINGS_LIST_PATH = '/[locale]/(dashboard)/meetings';
+
+function revalidateMeetingDetail(id: string) {
+    revalidatePath(`/[locale]/(dashboard)/meetings/${id}`, 'page');
+}
+
+export async function createMeetingAction(input: CreateMeetingInput) {
+    await requireMeetingAuth();
+    const meeting = await meetingsAPI.create(input);
+    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    return meeting;
+}
+
+export async function updateMeetingAction(id: string, input: UpdateMeetingInput) {
+    await requireMeetingAuth();
+    const meeting = await meetingsAPI.update(id, input);
+    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidateMeetingDetail(id);
+    return meeting;
+}
+
+export async function deleteMeetingAction(id: string) {
+    await requireMeetingAuth();
+    await meetingsAPI.remove(id);
+    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    return { deleted: true as const };
+}
+
+/**
+ * Attach (or replace) the transcript. The API stores it and then runs
+ * the BEST-EFFORT fan-out (AI summary → Memory observation → ingest
+ * envelope), so the result's `summary` may be absent and both booleans
+ * false on a stack with no AI provider — the caller surfaces that
+ * honestly instead of pretending a summary was produced.
+ */
+export async function ingestMeetingTranscriptAction(id: string, transcriptText: string) {
+    await requireMeetingAuth();
+    const result = await meetingsAPI.ingestTranscript(id, transcriptText);
+    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidateMeetingDetail(id);
+    return result;
+}

--- a/apps/web/src/components/meetings/index.ts
+++ b/apps/web/src/components/meetings/index.ts
@@ -1,0 +1,16 @@
+// Meetings — public surface of the web-side meetings/ directory: the
+// catalog list, the capture form, and the detail client, plus the
+// shared presentational helpers.
+export { MeetingsList, type MeetingWorkOption } from './MeetingsList';
+export { MeetingCard } from './MeetingCard';
+export { MeetingForm } from './MeetingForm';
+export { MeetingDetailClient } from './MeetingDetailClient';
+export {
+    SourceBadge,
+    TranscriptBadge,
+    durationMinutes,
+    formatDateTime,
+    formatDuration,
+    isoToLocalInput,
+    localInputToIso,
+} from './meeting-ui';

--- a/apps/web/src/components/meetings/meeting-ui.tsx
+++ b/apps/web/src/components/meetings/meeting-ui.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { MeetingSource } from '@/lib/api/meetings.shared';
+
+/**
+ * Meetings — shared presentational helpers for the surface (list card +
+ * detail page), so the source badge, timestamps and durations render
+ * identically everywhere. Mirrors `components/goals/goal-ui.tsx`.
+ */
+
+const SOURCE_STYLES: Record<string, string> = {
+    zoom: 'bg-info/10 text-info border-info/20',
+    'google-meet': 'bg-success/10 text-success border-success/20',
+    manual: 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark border-border/70 dark:border-border-dark/70',
+    import: 'bg-accent-indigo/10 text-accent-indigo border-accent-indigo/20',
+};
+
+const UNKNOWN_SOURCE_STYLE =
+    'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark border-border/70 dark:border-border-dark/70';
+
+/** Sources the UI has a translated label for. */
+const KNOWN_SOURCES: readonly string[] = ['zoom', 'google-meet', 'manual', 'import'];
+
+/**
+ * Format an ISO timestamp for display. Locale/timezone formatting
+ * differs between the server and client render, so callers wrap the
+ * output in an element with `suppressHydrationWarning`.
+ */
+export function formatDateTime(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (!Number.isFinite(ms)) return '—';
+    return new Date(ms).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+
+/**
+ * Meeting length in whole minutes, or `null` when the meeting has no
+ * end (still running / never closed) or the pair does not parse.
+ */
+export function durationMinutes(
+    startedAt: string | null | undefined,
+    endedAt: string | null | undefined,
+): number | null {
+    if (!startedAt || !endedAt) return null;
+    const from = Date.parse(startedAt);
+    const to = Date.parse(endedAt);
+    if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+    const minutes = Math.round((to - from) / 60_000);
+    return minutes >= 0 ? minutes : null;
+}
+
+/** `95` → `1h 35m`, `35` → `35m`, `0` → `0m`. */
+export function formatDuration(minutes: number | null): string {
+    if (minutes === null) return '—';
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const rest = minutes % 60;
+    return rest === 0 ? `${hours}h` : `${hours}h ${rest}m`;
+}
+
+/**
+ * Convert a `datetime-local` input value into an ISO instant, or `null`
+ * when the field is empty / unparseable. The API validates
+ * `@IsDateString()`, so the form never posts a raw local string.
+ */
+export function localInputToIso(value: string): string | null {
+    if (!value) return null;
+    const ms = Date.parse(value);
+    if (!Number.isFinite(ms)) return null;
+    return new Date(ms).toISOString();
+}
+
+/**
+ * Inverse of {@link localInputToIso} — an ISO instant rendered as the
+ * `YYYY-MM-DDTHH:mm` string a `datetime-local` input expects, in the
+ * viewer's own timezone. Returns '' for missing/unparseable input so
+ * the control stays empty rather than showing `Invalid Date`.
+ */
+export function isoToLocalInput(iso: string | null | undefined): string {
+    if (!iso) return '';
+    const ms = Date.parse(iso);
+    if (!Number.isFinite(ms)) return '';
+    const d = new Date(ms);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Producing-surface pill (Zoom / Google Meet / Manual / Import). The
+ * API's source set is closed, but an unrecognized value still renders
+ * verbatim in a neutral chip rather than crashing on a missing
+ * translation key.
+ */
+export function SourceBadge({ source, className }: { source: string; className?: string }) {
+    const t = useTranslations('dashboard.meetingsPage');
+    const known = KNOWN_SOURCES.includes(source);
+    return (
+        <span
+            data-testid="meeting-source-badge"
+            className={cn(
+                'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                SOURCE_STYLES[source] ?? UNKNOWN_SOURCE_STYLE,
+                className,
+            )}
+        >
+            {known ? t(`sources.${source as MeetingSource}`) : source}
+        </span>
+    );
+}
+
+/** "Transcript" / "No transcript" chip driven by `hasTranscript`. */
+export function TranscriptBadge({
+    hasTranscript,
+    className,
+}: {
+    hasTranscript: boolean;
+    className?: string;
+}) {
+    const t = useTranslations('dashboard.meetingsPage');
+    return (
+        <span
+            data-testid="meeting-transcript-badge"
+            className={cn(
+                'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                hasTranscript
+                    ? 'bg-success/10 text-success border-success/20'
+                    : 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark border-border/70 dark:border-border-dark/70',
+                className,
+            )}
+        >
+            {hasTranscript ? t('badges.transcript') : t('badges.noTranscript')}
+        </span>
+    );
+}

--- a/apps/web/src/lib/api/meetings.shared.ts
+++ b/apps/web/src/lib/api/meetings.shared.ts
@@ -1,0 +1,105 @@
+/**
+ * Meetings — client-safe contract values.
+ *
+ * Pure unions and numeric bounds with NO server dependency, so they
+ * live apart from `meetings.ts` (which is `server-only`). `'use client'`
+ * components (`MeetingForm`, `MeetingDetailClient`) import them from
+ * here directly; `meetings.ts` re-exports them so server-side callers
+ * keep a single import site. Importing a VALUE (not just a type) from
+ * `meetings.ts` in a client component pulls its `server-only` guard
+ * into the client bundle and fails `next build` — this split avoids
+ * that while keeping one canonical definition (same idiom as
+ * `goals.shared.ts`).
+ *
+ * Mirrors of the API-side bounds:
+ *   - sources          `MeetingSource` in packages/agent/src/entities/meeting.entity.ts
+ *   - transcript cap   `MEETING_TRANSCRIPT_MAX_CHARS` in packages/agent/src/meetings/meetings.service.ts
+ *   - field lengths    `apps/api/src/meetings/dto/meeting.dto.ts`
+ */
+
+/** Where a meeting row came from (closed set — the API 400s on others). */
+export type MeetingSource = 'zoom' | 'google-meet' | 'manual' | 'import';
+
+/** Every accepted source, in the order the pickers render them. */
+export const MEETING_SOURCES: MeetingSource[] = ['manual', 'import', 'zoom', 'google-meet'];
+
+/**
+ * Sources a human can pick when capturing a meeting by hand.
+ * Provider-synced meetings (`zoom`, `google-meet`) normally arrive
+ * through the connector → ingest-spine path, but the API accepts them
+ * on create too (e.g. pasting a transcript from a recording you already
+ * have), so they stay selectable rather than being hidden.
+ */
+export const MEETING_CREATABLE_SOURCES: MeetingSource[] = MEETING_SOURCES;
+
+/** Service-level transcript cap; the DTO enforces the same MaxLength. */
+export const MEETING_TRANSCRIPT_MAX_CHARS = 200_000;
+
+/** `CreateMeetingDto.title` / `UpdateMeetingDto.title` MaxLength. */
+export const MEETING_TITLE_MAX_CHARS = 500;
+
+/** `sourceUrl` MaxLength (recording / provider deep link). */
+export const MEETING_SOURCE_URL_MAX_CHARS = 2048;
+
+/** `externalId` MaxLength (provider meeting id / dedupe key). */
+export const MEETING_EXTERNAL_ID_MAX_CHARS = 200;
+
+/** `MeetingParticipantDto.name` MaxLength. */
+export const MEETING_PARTICIPANT_NAME_MAX_CHARS = 200;
+
+/** `MeetingParticipantDto.email` MaxLength. */
+export const MEETING_PARTICIPANT_EMAIL_MAX_CHARS = 320;
+
+/**
+ * Defensive roster cap for the client-side parser. The API has no
+ * explicit array bound, so the form refuses to post an unbounded
+ * roster pasted from a spreadsheet.
+ */
+export const MEETING_PARTICIPANTS_MAX = 200;
+
+/** One roster entry, matching the API's `MeetingParticipantDto`. */
+export interface MeetingParticipant {
+    name: string;
+    email?: string;
+}
+
+/**
+ * Parse a human-typed roster into `MeetingParticipant[]`.
+ *
+ * One participant per line, in any of:
+ *   `Ada Lovelace <ada@example.com>`  → { name, email }
+ *   `ada@example.com`                 → { name: email, email }
+ *   `Grace`                           → { name }
+ *
+ * Blank lines are dropped and every field is truncated to the API's
+ * MaxLength so a paste can never be rejected for length alone. Shared
+ * with the unit spec, which is why it lives in the client-safe module.
+ */
+export function parseParticipants(raw: string): MeetingParticipant[] {
+    const lines = raw
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .slice(0, MEETING_PARTICIPANTS_MAX);
+
+    return lines.map((line) => {
+        const angled = /^(.*?)\s*<\s*([^>]+?)\s*>$/.exec(line);
+        if (angled) {
+            const email = angled[2].trim().slice(0, MEETING_PARTICIPANT_EMAIL_MAX_CHARS);
+            const name = (angled[1].trim() || email).slice(0, MEETING_PARTICIPANT_NAME_MAX_CHARS);
+            return { name, email };
+        }
+        if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(line)) {
+            const email = line.slice(0, MEETING_PARTICIPANT_EMAIL_MAX_CHARS);
+            return { name: email.slice(0, MEETING_PARTICIPANT_NAME_MAX_CHARS), email };
+        }
+        return { name: line.slice(0, MEETING_PARTICIPANT_NAME_MAX_CHARS) };
+    });
+}
+
+/** Render a roster back into the textarea format `parseParticipants` reads. */
+export function formatParticipants(participants: MeetingParticipant[]): string {
+    return participants
+        .map((p) => (p.email && p.email !== p.name ? `${p.name} <${p.email}>` : p.name))
+        .join('\n');
+}

--- a/apps/web/src/lib/api/meetings.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/meetings.shared.unit.spec.ts
@@ -1,0 +1,88 @@
+// Meetings — pure-helper spec for the roster parser shared by the
+// capture form and the detail page.
+
+import { describe, expect, it } from 'vitest';
+import {
+    MEETING_PARTICIPANTS_MAX,
+    MEETING_PARTICIPANT_EMAIL_MAX_CHARS,
+    MEETING_PARTICIPANT_NAME_MAX_CHARS,
+    MEETING_SOURCES,
+    formatParticipants,
+    parseParticipants,
+} from './meetings.shared';
+
+describe('MEETING_SOURCES', () => {
+    it('mirrors the API closed set exactly', () => {
+        expect([...MEETING_SOURCES].sort()).toEqual(
+            ['google-meet', 'import', 'manual', 'zoom'].sort(),
+        );
+    });
+});
+
+describe('parseParticipants', () => {
+    it('reads "Name <email>" into a name + email pair', () => {
+        expect(parseParticipants('Ada Lovelace <ada@example.com>')).toEqual([
+            { name: 'Ada Lovelace', email: 'ada@example.com' },
+        ]);
+    });
+
+    it('treats a bare address as both the name and the email', () => {
+        expect(parseParticipants('grace@example.com')).toEqual([
+            { name: 'grace@example.com', email: 'grace@example.com' },
+        ]);
+    });
+
+    it('keeps a bare name email-less rather than inventing an address', () => {
+        const parsed = parseParticipants('Grace Hopper');
+        expect(parsed).toEqual([{ name: 'Grace Hopper' }]);
+        expect(parsed[0].email).toBeUndefined();
+    });
+
+    it('parses one participant per line and drops blank lines', () => {
+        expect(parseParticipants('Ada Lovelace <ada@example.com>\n\n  \nGrace Hopper\n')).toEqual([
+            { name: 'Ada Lovelace', email: 'ada@example.com' },
+            { name: 'Grace Hopper' },
+        ]);
+    });
+
+    it('falls back to the address when the display name is empty', () => {
+        expect(parseParticipants('<ada@example.com>')).toEqual([
+            { name: 'ada@example.com', email: 'ada@example.com' },
+        ]);
+    });
+
+    it('truncates to the API MaxLength so a paste is never rejected for length', () => {
+        const longName = 'n'.repeat(MEETING_PARTICIPANT_NAME_MAX_CHARS + 50);
+        const longLocal = 'e'.repeat(MEETING_PARTICIPANT_EMAIL_MAX_CHARS + 50);
+        const [parsed] = parseParticipants(`${longName} <${longLocal}@example.com>`);
+        expect(parsed.name.length).toBe(MEETING_PARTICIPANT_NAME_MAX_CHARS);
+        expect((parsed.email ?? '').length).toBe(MEETING_PARTICIPANT_EMAIL_MAX_CHARS);
+    });
+
+    it('caps an unbounded paste at the defensive roster limit', () => {
+        const pasted = Array.from({ length: MEETING_PARTICIPANTS_MAX + 25 }, (_, i) => `P${i}`);
+        expect(parseParticipants(pasted.join('\n')).length).toBe(MEETING_PARTICIPANTS_MAX);
+    });
+
+    it('returns nothing for an empty or whitespace-only roster', () => {
+        expect(parseParticipants('')).toEqual([]);
+        expect(parseParticipants('   \n\t\n')).toEqual([]);
+    });
+
+    it('handles CRLF line endings (pasted from a Windows client)', () => {
+        expect(parseParticipants('Ada\r\nGrace')).toEqual([{ name: 'Ada' }, { name: 'Grace' }]);
+    });
+});
+
+describe('formatParticipants', () => {
+    it('round-trips a parsed roster back into the textarea format', () => {
+        const raw = 'Ada Lovelace <ada@example.com>\nGrace Hopper';
+        expect(formatParticipants(parseParticipants(raw))).toBe(raw);
+    });
+
+    it('does not duplicate an address that is also the display name', () => {
+        expect(formatParticipants([{ name: 'ada@example.com', email: 'ada@example.com' }])).toBe(
+            'ada@example.com',
+        );
+    });
+});

--- a/apps/web/src/lib/api/meetings.ts
+++ b/apps/web/src/lib/api/meetings.ts
@@ -1,0 +1,179 @@
+import 'server-only';
+import { serverFetch, serverMutation } from './server-api';
+
+/**
+ * Meetings — server-only client for the owner-scoped meetings surface
+ * (`apps/api/src/meetings/meetings.controller.ts`).
+ *
+ *   GET    /api/meetings                 list mine (workId/source/limit/offset)
+ *   POST   /api/meetings                 create (manual/import)
+ *   GET    /api/meetings/:id             get one (INCLUDES transcriptText)
+ *   PATCH  /api/meetings/:id             partial update
+ *   DELETE /api/meetings/:id             204
+ *   POST   /api/meetings/:id/transcript  attach transcript (summary fan-out)
+ *
+ * Web-side mirror of the API's `MeetingView` wire shape, kept in
+ * lockstep manually so `apps/web` needs no runtime dependency on the
+ * agent package for a small projection — the same idiom
+ * `lib/api/goals.ts` and `lib/api/missions.ts` use. Date fields are
+ * ISO strings on the wire and stay strings until a renderer formats
+ * them.
+ *
+ * `dedupeKey` deliberately never appears here: the API's `toView` is an
+ * explicit projection that drops it, and the contract spec asserts it
+ * never leaves the API.
+ */
+
+// Pure contract values/types shared with `'use client'` components live in
+// a `server-only`-free module so forms can import them without pulling
+// this module into the client bundle. Re-exported for server callers.
+export {
+    MEETING_SOURCES,
+    MEETING_CREATABLE_SOURCES,
+    MEETING_TRANSCRIPT_MAX_CHARS,
+    MEETING_TITLE_MAX_CHARS,
+    MEETING_SOURCE_URL_MAX_CHARS,
+    MEETING_EXTERNAL_ID_MAX_CHARS,
+    MEETING_PARTICIPANT_NAME_MAX_CHARS,
+    MEETING_PARTICIPANT_EMAIL_MAX_CHARS,
+    MEETING_PARTICIPANTS_MAX,
+    parseParticipants,
+    formatParticipants,
+    type MeetingSource,
+    type MeetingParticipant,
+} from './meetings.shared';
+import type { MeetingSource, MeetingParticipant } from './meetings.shared';
+
+/**
+ * One meeting as the API projects it. `transcriptText` is present ONLY
+ * on the single-meeting reads (detail / create / update / transcript
+ * ingest) — list rows carry `hasTranscript` instead, which is why the
+ * field is optional here rather than nullable.
+ */
+export interface Meeting {
+    id: string;
+    title: string;
+    startedAt: string;
+    endedAt: string | null;
+    source: string;
+    externalId: string | null;
+    workId: string | null;
+    organizationId: string | null;
+    participants: MeetingParticipant[];
+    sourceUrl: string | null;
+    summary: string | null;
+    hasTranscript: boolean;
+    transcriptText?: string | null;
+    createdAt: string;
+}
+
+export interface CreateMeetingInput {
+    title: string;
+    startedAt: string;
+    endedAt?: string;
+    source?: MeetingSource;
+    externalId?: string;
+    workId?: string;
+    participants?: MeetingParticipant[];
+    sourceUrl?: string;
+    /** Optional transcript captured at creation — runs the full pipeline. */
+    transcriptText?: string;
+}
+
+export interface UpdateMeetingInput {
+    title?: string;
+    startedAt?: string;
+    endedAt?: string | null;
+    /** `null` re-routes the meeting back to org-wide. */
+    workId?: string | null;
+    participants?: MeetingParticipant[];
+    /** `null` clears the recording link. */
+    sourceUrl?: string | null;
+}
+
+/**
+ * `POST /:id/transcript` result. The transcript WRITE is the only part
+ * that can fail the call — `summary` is absent and both booleans are
+ * false whenever the best-effort enrichment legs (AI summary → memory
+ * observation → ingest envelope) could not run.
+ */
+export interface IngestTranscriptResult {
+    meeting: Meeting;
+    summary?: string;
+    memorySaved: boolean;
+    envelopeEmitted: boolean;
+}
+
+export interface ListMeetingsInput {
+    workId?: string;
+    source?: MeetingSource;
+    /** The API clamps to 1–100 and defaults to 20. */
+    limit?: number;
+    offset?: number;
+}
+
+function buildListEndpoint(input?: ListMeetingsInput): string {
+    const params = new URLSearchParams();
+    if (input?.workId) params.set('workId', input.workId);
+    if (input?.source) params.set('source', input.source);
+    if (input?.limit) params.set('limit', String(input.limit));
+    if (input?.offset && input.offset > 0) params.set('offset', String(input.offset));
+    const qs = params.toString();
+    return qs ? `/meetings?${qs}` : '/meetings';
+}
+
+export const meetingsAPI = {
+    async list(input?: ListMeetingsInput): Promise<Meeting[]> {
+        return serverFetch<Meeting[]>(buildListEndpoint(input), { method: 'GET' });
+    },
+
+    /**
+     * `null` for a missing meeting AND for another owner's row — the API
+     * 404s identically in both cases (no existence leak), and the detail
+     * page turns that into `notFound()`.
+     */
+    async get(id: string): Promise<Meeting | null> {
+        try {
+            return await serverFetch<Meeting>(`/meetings/${id}`, { method: 'GET' });
+        } catch {
+            return null;
+        }
+    },
+
+    async create(input: CreateMeetingInput): Promise<Meeting> {
+        return serverMutation<Meeting>({
+            endpoint: '/meetings',
+            data: input,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async update(id: string, input: UpdateMeetingInput): Promise<Meeting> {
+        return serverMutation<Meeting>({
+            endpoint: `/meetings/${id}`,
+            data: input,
+            method: 'PATCH',
+            wrapInData: false,
+        });
+    },
+
+    /** 204 No Content — `serverFetch` resolves to undefined on an empty body. */
+    async remove(id: string): Promise<void> {
+        await serverMutation<void>({
+            endpoint: `/meetings/${id}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+
+    async ingestTranscript(id: string, transcriptText: string): Promise<IngestTranscriptResult> {
+        return serverMutation<IngestTranscriptResult>({
+            endpoint: `/meetings/${id}/transcript`,
+            data: { transcriptText },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+};

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -117,6 +117,13 @@ export const ROUTES = {
     // documents. Sits BELOW Agents in the sidebar. Session-scoped
     // (`/memory`); the org is resolved from the active scope context.
     DASHBOARD_MEMORY: '/memory',
+    // Meetings (Wave 8, feature a) — owner-scoped captured meetings with
+    // their transcripts + AI summaries. Provider-synced recordings land
+    // through the ingest spine; these routes are the human surface over
+    // the same rows (`/api/meetings`).
+    DASHBOARD_MEETINGS: '/meetings',
+    DASHBOARD_MEETINGS_NEW: '/meetings/new',
+    DASHBOARD_MEETING: (id: string) => `/meetings/${id}`,
     // Templates
     DASHBOARD_TEMPLATES: '/templates',
     // Agents (Agents/Skills/Tasks PR #1017 — Phase 5)


### PR DESCRIPTION
## The problem

Meetings had a full backend — owner-scoped rows, transcripts, AI summaries,
provider-synced recordings landing through the ingest spine — and **zero user
interface**. None of it was reachable.

## What changed

- `/meetings` list, `/meetings/new`, and `/meetings/[id]` detail showing the
  transcript and summary the backend already exposes
- `meetings.ts` / `meetings.shared.ts` split so the client component never
  value-imports a server-only module (the house `.shared.ts` rule)
- A `DashboardSidebar` entry plus `ROUTES.DASHBOARD_MEETINGS*` — three route
  files nobody can navigate to would not be a surface
- `flow-meetings-ui-journey.spec.ts`, in the style of the existing
  `flow-*.spec.ts` e2e specs

## No invented endpoints

Every call maps onto a route that already existed on
`apps/api/src/meetings/meetings.controller.ts`:

| Client call | Controller |
|---|---|
| `GET /meetings` | `@Get()` (line 64) |
| `POST /meetings` | `@Post()` (line 85) |
| `GET /meetings/:id` | `@Get(':id')` (line 97) |
| `PATCH /meetings/:id` | `@Patch(':id')` (line 108) |
| `DELETE /meetings/:id` | `@Delete(':id')` (line 121) |
| `POST /meetings/:id/transcript` | `@Post(':id/transcript')` (line 132) |

## i18n

Strings added across all 21 locales. Verified **zero duplicate keys** in every
locale file — the recurring landmine in this repo.

## Unrelated bug fixed on the way

`scripts/sync-locale-parity.mjs` derived the messages directory from
`new URL(...).pathname`, which is percent-encoded. Any checkout under a path
containing a space — such as this repo's own `C:\Coding\Ever Works\` — resolved
to a literal `...Ever%20Works...` and the script died with `ENOENT` before it
could read `en.json`. Now uses `fileURLToPath`, which also strips the Windows
leading-slash drive prefix correctly.

## Gates

| Gate | Result |
|---|---|
| `node scripts/sync-locale-parity.mjs` | green (21 locales) |
| duplicate-key scan, all locales | green — 0 duplicates |
| `apps/web` vitest (`meetings.shared.unit.spec.ts`) | green |
| `apps/web` tsc --noEmit | green |
| `pnpm build --filter=ever-works-web` | green |
| prettier | clean |

API-side gates not run: this branch touches no API, agent or tasks code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Meetings area with catalog, filtering, pagination, and navigation from the dashboard sidebar.
  * Added meeting creation with title, timestamps, source details, participants, transcript, and optional work routing.
  * Added meeting detail views with summaries, transcripts, editing, transcript replacement, renaming, and deletion.
  * Added localized interface text across supported languages.

* **Bug Fixes**
  * Improved locale synchronization for project paths containing spaces.

* **Tests**
  * Added comprehensive end-to-end and unit coverage for meeting workflows, validation, navigation, and participant handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->