### PR TITLE
feat(ingest): ingest git pushes, commits and merges into the Activity feed

### DIFF
--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -9,8 +9,10 @@ jest.mock('@ever-works/agent/plugins', () => ({
 }));
 
 import {
+    GITHUB_PUSH_COMMITS_MAX,
     GitHubPrReviewBridgeService,
     extractGitHubWorkspaceRef,
+    isGitActivityDelivery,
 } from './github-pr-review-bridge.service';
 
 /** Flush the fire-and-forget review promise chain. */
@@ -83,6 +85,11 @@ describe('GitHubPrReviewBridgeService', () => {
         const rejections = {
             recordPullRequestRejection: jest.fn().mockResolvedValue({ id: 'rej-1' }),
         };
+        // Git activity ingestion (audit item j) - branch/PR -> Task.
+        const taskLinks = {
+            findByBranch: jest.fn().mockResolvedValue(null),
+            findByPullRequest: jest.fn().mockResolvedValue(null),
+        };
         const service = new GitHubPrReviewBridgeService(
             userPluginRepository as any,
             pluginSettingsService as any,
@@ -90,6 +97,7 @@ describe('GitHubPrReviewBridgeService', () => {
             prReviewService as any,
             installBindings as any,
             rejections as any,
+            taskLinks as any,
         );
         return {
             service,
@@ -99,6 +107,7 @@ describe('GitHubPrReviewBridgeService', () => {
             prReviewService,
             installBindings,
             rejections,
+            taskLinks,
         };
     }
 
@@ -450,6 +459,279 @@ describe('GitHubPrReviewBridgeService', () => {
                     instruction: 'why was this loop unrolled?',
                 }),
             );
+        });
+    });
+
+    /**
+     * Git activity ingestion (audit item j).
+     *
+     * Pushes, the commits inside them and merged pull requests used to be
+     * dropped on the floor, so the Activity feed showed none of them.
+     * They now take the SAME receiver→envelope→spine path every other
+     * kind takes, and they deliberately never enter the review loop.
+     */
+    describe('git activity ingestion (audit item j)', () => {
+        const SHA_BEFORE = '1'.repeat(40);
+        const SHA_HEAD = '2'.repeat(40);
+        const SHA_FIRST = '3'.repeat(40);
+        const SHA_MERGE = '4'.repeat(40);
+
+        function commit(id: string, message: string, over: Record<string, unknown> = {}) {
+            return {
+                id,
+                message,
+                url: `https://example.com/octo/site/commit/${id}`,
+                distinct: true,
+                timestamp: '2026-07-25T10:00:00Z',
+                author: { name: 'Octo Cat', username: 'octocat' },
+                added: ['a.ts'],
+                removed: [],
+                modified: ['b.ts'],
+                ...over,
+            };
+        }
+
+        function pushBody(over: Record<string, unknown> = {}) {
+            return {
+                ref: 'refs/heads/ever/task-t-42',
+                before: SHA_BEFORE,
+                after: SHA_HEAD,
+                created: false,
+                deleted: false,
+                forced: false,
+                compare: 'https://example.com/octo/site/compare/aaa...bbb',
+                repository: { full_name: 'octo/site' },
+                pusher: { name: 'octocat' },
+                sender: { login: 'octocat', type: 'User' },
+                head_commit: commit(SHA_HEAD, 'feat: add landing page\n\nwith a body'),
+                commits: [
+                    commit(SHA_FIRST, 'chore: scaffold'),
+                    commit(SHA_HEAD, 'feat: add landing page\n\nwith a body'),
+                ],
+                ...over,
+            };
+        }
+
+        function mergedPrBody(over: Record<string, unknown> = {}) {
+            return {
+                action: 'closed',
+                repository: { full_name: 'octo/site' },
+                sender: { login: 'octocat', type: 'User' },
+                pull_request: {
+                    number: 7,
+                    title: 'Add landing page',
+                    html_url: 'https://example.com/octo/site/pull/7',
+                    head: { sha: SHA_HEAD, ref: 'ever/task-t-42' },
+                    base: { ref: 'main' },
+                    merged: true,
+                    merged_at: '2026-07-25T11:00:00.000Z',
+                    merge_commit_sha: SHA_MERGE,
+                    merged_by: { login: 'maintainer', type: 'User' },
+                },
+                ...over,
+            };
+        }
+
+        it('claims pushes and MERGED pull requests, nothing else', () => {
+            expect(isGitActivityDelivery('push', {})).toBe(true);
+            expect(isGitActivityDelivery('pull_request', mergedPrBody() as never)).toBe(true);
+            // `closed` fires for abandoned PRs too — those merged nothing.
+            expect(
+                isGitActivityDelivery(
+                    'pull_request',
+                    mergedPrBody({
+                        pull_request: { number: 7, merged: false },
+                    }) as never,
+                ),
+            ).toBe(false);
+            expect(isGitActivityDelivery('pull_request', prOpenedBody() as never)).toBe(false);
+            expect(isGitActivityDelivery('issue_comment', mentionCommentBody() as never)).toBe(
+                false,
+            );
+        });
+
+        it('a push webhook produces one push row plus one row per new commit', async () => {
+            const { service, eventIngestService } = createService();
+
+            const result = await service.handleEvent(BINDING, 'push', pushBody());
+
+            expect(result.ingested).toEqual({ inserted: 1, duplicates: 0, rejected: 0 });
+            const [userId, envelopes] = eventIngestService.ingest.mock.calls[0];
+            expect(userId).toBe('user-1');
+            expect(envelopes.map((e: any) => e.kind)).toEqual([
+                'github.push',
+                'github.commit',
+                'github.commit',
+            ]);
+            expect(envelopes[0]).toMatchObject({
+                source: 'github',
+                sourceEventId: `push:octo/site@${SHA_HEAD}:ever/task-t-42`,
+                sourceUrl: 'https://example.com/octo/site/compare/aaa...bbb',
+                actor: { name: 'octocat' },
+                subject: { type: 'branch', externalId: 'octo/site@ever/task-t-42' },
+                workHint: { kind: 'repo', externalId: 'octo/site' },
+            });
+            expect(envelopes[0].payload).toMatchObject({
+                repoFullName: 'octo/site',
+                ref: 'refs/heads/ever/task-t-42',
+                branch: 'ever/task-t-42',
+                before: SHA_BEFORE,
+                after: SHA_HEAD,
+                commitCount: 2,
+            });
+            expect(envelopes[1]).toMatchObject({
+                kind: 'github.commit',
+                sourceEventId: `commit:octo/site@${SHA_FIRST}`,
+                subject: { type: 'commit', externalId: SHA_FIRST, title: 'chore: scaffold' },
+                sourceUrl: `https://example.com/octo/site/commit/${SHA_FIRST}`,
+                workHint: { kind: 'repo', externalId: 'octo/site' },
+            });
+            // The subject line is the title; the full message + the file
+            // count ride in the payload.
+            expect(envelopes[2].payload).toMatchObject({
+                sha: SHA_HEAD,
+                branch: 'ever/task-t-42',
+                message: 'feat: add landing page\n\nwith a body',
+                filesChanged: 2,
+            });
+        });
+
+        it('maps the push to the Task that owns the branch', async () => {
+            const { service, eventIngestService, taskLinks } = createService();
+            taskLinks.findByBranch.mockResolvedValue({
+                workId: 'work-1',
+                taskId: 'task-1',
+                taskSlug: 'T-42',
+            });
+
+            await service.handleEvent(BINDING, 'push', pushBody());
+
+            expect(taskLinks.findByBranch).toHaveBeenCalledWith({
+                userId: 'user-1',
+                owner: 'octo',
+                repo: 'site',
+                branch: 'ever/task-t-42',
+            });
+            const [, envelopes] = eventIngestService.ingest.mock.calls[0];
+            for (const envelope of envelopes) {
+                expect(envelope.payload).toMatchObject({ taskId: 'task-1', taskSlug: 'T-42' });
+            }
+        });
+
+        it('an unmatched repo is ignored without throwing', async () => {
+            const { service, eventIngestService, taskLinks } = createService();
+
+            // 1. A repository that maps to no Work / no Task: the rows are
+            //    still ingested (user-scoped), just without a Task link.
+            await expect(service.handleEvent(BINDING, 'push', pushBody())).resolves.toMatchObject({
+                ingested: { inserted: 1 },
+            });
+            const [, envelopes] = eventIngestService.ingest.mock.calls[0];
+            expect(envelopes[0].payload.taskId).toBeUndefined();
+
+            // 2. A delivery naming no repository at all cannot be attributed
+            //    to anything: a clean no-op, never an exception.
+            eventIngestService.ingest.mockClear();
+            taskLinks.findByBranch.mockClear();
+            await expect(
+                service.handleEvent(BINDING, 'push', pushBody({ repository: undefined })),
+            ).resolves.toEqual({ ingested: null });
+            expect(eventIngestService.ingest).not.toHaveBeenCalled();
+            expect(taskLinks.findByBranch).not.toHaveBeenCalled();
+        });
+
+        it('ignores tag refs and branch deletions', async () => {
+            const { service, eventIngestService } = createService();
+
+            await expect(
+                service.handleEvent(BINDING, 'push', pushBody({ ref: 'refs/tags/v1.2.3' })),
+            ).resolves.toEqual({ ingested: null });
+            await expect(
+                service.handleEvent(BINDING, 'push', pushBody({ deleted: true, commits: [] })),
+            ).resolves.toEqual({ ingested: null });
+            expect(eventIngestService.ingest).not.toHaveBeenCalled();
+        });
+
+        it('skips commits already announced on another ref (distinct: false)', async () => {
+            const { service, eventIngestService } = createService();
+
+            await service.handleEvent(
+                BINDING,
+                'push',
+                pushBody({
+                    commits: [
+                        commit(SHA_FIRST, 'chore: scaffold', { distinct: false }),
+                        commit(SHA_HEAD, 'feat: add landing page'),
+                    ],
+                }),
+            );
+
+            const [, envelopes] = eventIngestService.ingest.mock.calls[0];
+            expect(envelopes).toHaveLength(2);
+            expect(envelopes[0].payload.commitCount).toBe(1);
+            expect(envelopes[1].payload.sha).toBe(SHA_HEAD);
+        });
+
+        it('caps the commit fan-out so one push cannot flood the feed', async () => {
+            const { service, eventIngestService } = createService();
+            const many = Array.from({ length: GITHUB_PUSH_COMMITS_MAX + 5 }, (_, i) =>
+                commit(String(i).padStart(40, '0'), `chore: step ${i}`),
+            );
+
+            await service.handleEvent(BINDING, 'push', pushBody({ commits: many }));
+
+            const [, envelopes] = eventIngestService.ingest.mock.calls[0];
+            expect(envelopes).toHaveLength(GITHUB_PUSH_COMMITS_MAX + 1);
+            expect(envelopes[0].payload.commitCount).toBe(GITHUB_PUSH_COMMITS_MAX);
+        });
+
+        it('a merged pull request produces one github.merge row mapped to its Task', async () => {
+            const { service, eventIngestService, taskLinks } = createService();
+            taskLinks.findByPullRequest.mockResolvedValue({
+                workId: 'work-1',
+                taskId: 'task-1',
+                taskSlug: 'T-42',
+            });
+
+            const result = await service.handleEvent(BINDING, 'pull_request', mergedPrBody());
+
+            expect(result.ingested).toEqual({ inserted: 1, duplicates: 0, rejected: 0 });
+            expect(taskLinks.findByPullRequest).toHaveBeenCalledWith({
+                userId: 'user-1',
+                owner: 'octo',
+                repo: 'site',
+                prNumber: 7,
+            });
+            const [, envelopes] = eventIngestService.ingest.mock.calls[0];
+            expect(envelopes).toHaveLength(1);
+            expect(envelopes[0]).toMatchObject({
+                kind: 'github.merge',
+                sourceEventId: `merge:octo/site#7@${SHA_MERGE}`,
+                occurredAt: '2026-07-25T11:00:00.000Z',
+                actor: { name: 'maintainer' },
+                subject: { type: 'pull_request', externalId: 'octo/site#7' },
+                sourceUrl: 'https://example.com/octo/site/pull/7',
+                workHint: { kind: 'repo', externalId: 'octo/site' },
+            });
+            expect(envelopes[0].payload).toMatchObject({
+                repoFullName: 'octo/site',
+                prNumber: 7,
+                mergeCommitSha: SHA_MERGE,
+                baseRef: 'main',
+                headRef: 'ever/task-t-42',
+                mergedBy: 'maintainer',
+                taskId: 'task-1',
+            });
+        });
+
+        it('never enters the review loop — the code already landed', async () => {
+            const { service, prReviewService } = createService();
+
+            await service.handleEvent(BINDING, 'push', pushBody());
+            await service.handleEvent(BINDING, 'pull_request', mergedPrBody());
+            await flush();
+
+            expect(prReviewService.reviewPullRequest).not.toHaveBeenCalled();
         });
     });
 

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
@@ -8,7 +8,8 @@ import {
 } from '@ever-works/agent/ingest';
 import { PrReviewService } from '@ever-works/agent/pr-review';
 import { PluginSettingsService, UserPluginRepository } from '@ever-works/agent/plugins';
-import { TaskReviewRejectionService } from '@ever-works/agent/tasks-domain';
+import { TaskGitLinkService, TaskReviewRejectionService } from '@ever-works/agent/tasks-domain';
+import type { TaskGitLink } from '@ever-works/agent/tasks-domain';
 import type { IngestBindingMatch, IngestBindingResolution } from '../install-binding.types';
 
 export const GITHUB_PLUGIN_ID = 'github';
@@ -21,6 +22,35 @@ export const EVER_WORKS_MENTION = '@ever-works';
 
 /** Payload text cap for envelopes built from webhook deliveries. */
 export const GITHUB_EVENT_TEXT_MAX_CHARS = 4000;
+
+/**
+ * Per-push cap on the `github.commit` envelopes one delivery produces.
+ *
+ * GitHub itself truncates `commits[]` at 20 entries (`head_commit` plus
+ * the `size`/`distinct_size` counters carry the true totals), so this is
+ * the provider's own ceiling restated locally rather than a policy of
+ * ours — a monster push cannot turn into an unbounded Activity burst.
+ */
+export const GITHUB_PUSH_COMMITS_MAX = 20;
+
+/**
+ * `ingested_events.sourceEventId` is `varchar(200)`.
+ *
+ * Only the git-activity ids need the guard: a branch name may be 255
+ * characters on its own, so `push:<repo>@<sha>:<branch>` is the one id
+ * shape that can realistically overflow the column. The SHA sits BEFORE
+ * the branch on purpose — truncation then trims the branch tail and
+ * keeps the part that actually makes the id unique.
+ */
+export const GITHUB_SOURCE_EVENT_ID_MAX_CHARS = 200;
+
+/**
+ * `ingested_events.subjectExternalId` is `varchar(200)` too, and a push
+ * subject is `<owner/repo>@<branch>` — the same 255-character branch name
+ * can overflow it. An oversized value would abort the INSERT and lose
+ * the whole delivery, so the subject is capped at the column width.
+ */
+export const GITHUB_SUBJECT_EXTERNAL_ID_MAX_CHARS = 200;
 
 /**
  * The external installation identity a GitHub delivery carries, as an
@@ -69,6 +99,23 @@ export interface GitHubBindingLookup {
     readonly verifySignature?: (webhookSecret: string) => boolean;
 }
 
+/**
+ * One commit as a `push` delivery reports it (git activity ingestion,
+ * audit item j). `distinct` is false for commits that already reached the
+ * repository on another ref — those are re-announcements, not new work.
+ */
+export interface GitHubPushCommit {
+    id?: string;
+    message?: string;
+    url?: string;
+    distinct?: boolean;
+    timestamp?: string;
+    author?: { name?: string; username?: string; email?: string };
+    added?: string[];
+    removed?: string[];
+    modified?: string[];
+}
+
 /** The subset of GitHub webhook payloads the bridge consumes. */
 export interface GitHubWebhookBody {
     action?: string;
@@ -95,7 +142,30 @@ export interface GitHubWebhookBody {
         head?: { sha?: string; ref?: string };
         base?: { ref?: string };
         user?: { login?: string; type?: string };
+        /**
+         * Git activity ingestion (audit item j) — `closed` fires for both
+         * "merged" and "abandoned", and only `merged` tells them apart.
+         */
+        merged?: boolean;
+        merged_at?: string | null;
+        merge_commit_sha?: string | null;
+        merged_by?: { login?: string; type?: string } | null;
     };
+    /**
+     * Git activity ingestion (audit item j) — `push` deliveries. `ref` is
+     * the FULL ref (`refs/heads/<branch>`); `commits[]` is capped by
+     * GitHub at 20 entries while `head_commit` always carries the tip.
+     */
+    ref?: string;
+    before?: string;
+    after?: string;
+    created?: boolean;
+    deleted?: boolean;
+    forced?: boolean;
+    compare?: string;
+    pusher?: { name?: string; email?: string };
+    commits?: GitHubPushCommit[];
+    head_commit?: GitHubPushCommit | null;
     issue?: {
         number?: number;
         title?: string;
@@ -151,6 +221,64 @@ export function extractGitHubWorkspaceRef(
 }
 
 /**
+ * True for the deliveries git-activity ingestion owns (audit item j).
+ *
+ * `push` is unconditional. A pull request only qualifies on
+ * `closed` + `merged: true` — GitHub fires the same `closed` action for
+ * an abandoned PR, and an abandoned PR merged nothing.
+ */
+export function isGitActivityDelivery(
+    eventName: string,
+    body: GitHubWebhookBody | undefined,
+): boolean {
+    if (eventName === 'push') return true;
+    return (
+        eventName === 'pull_request' &&
+        body?.action === 'closed' &&
+        body?.pull_request?.merged === true
+    );
+}
+
+/** First line of a commit message — the subject, in git's own vocabulary. */
+function commitSubject(message: string | undefined): string {
+    return (message ?? '').split('\n')[0]?.trim() ?? '';
+}
+
+/** Keep a value inside its `ingested_events` column width. */
+function capped(value: string, max: number): string {
+    return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Keep a git-activity id inside `ingested_events.sourceEventId`. */
+function cappedEventId(value: string): string {
+    return capped(value, GITHUB_SOURCE_EVENT_ID_MAX_CHARS);
+}
+
+/**
+ * A source-reported timestamp when it parses, otherwise now.
+ *
+ * The spine REJECTS an envelope whose `occurredAt` will not parse, so a
+ * malformed provider timestamp must never reach it — losing the true
+ * commit time is a much smaller loss than losing the event.
+ */
+function isoOrNow(value: string | null | undefined): string {
+    if (typeof value === 'string' && value.length > 0) {
+        const parsed = new Date(value);
+        if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+    }
+    return new Date().toISOString();
+}
+
+/** The `taskId`/`taskSlug` payload block, or nothing when unlinked. */
+function taskFields(link: TaskGitLink | null): Record<string, unknown> {
+    if (!link) return {};
+    return {
+        taskId: link.taskId,
+        ...(link.taskSlug ? { taskSlug: link.taskSlug } : {}),
+    };
+}
+
+/**
  * GitHub PR review loop (Wave 7, feature g) — ONE service bridging
  * GitHub webhook deliveries into the platform:
  *
@@ -174,6 +302,17 @@ export function extractGitHubWorkspaceRef(
  *
  * Bot-authored comments (including our own review replies) are never
  * ingested — the loop must not echo its own output.
+ *
+ * ## Git activity (audit item j)
+ *
+ * `push` and merged `pull_request` deliveries were previously dropped on
+ * the floor, so commits, pushes and merges never reached the Activity
+ * feed at all. They now normalize into `github.push` / `github.commit` /
+ * `github.merge` envelopes on the SAME path (dedupe-insert → spine drain
+ * → Activity row), and the spine gives those three kinds their own
+ * `ActivityActionType` instead of the generic ingested-event one. They
+ * are deliberately kept OUT of the review loop: the code has already
+ * landed, so there is nothing left to review.
  */
 @Injectable()
 export class GitHubPrReviewBridgeService {
@@ -191,6 +330,11 @@ export class GitHubPrReviewBridgeService {
         // silently-unbound rejection recorder would be a feature that
         // looks wired and does nothing.
         private readonly rejections: TaskReviewRejectionService,
+        // Git activity ingestion (audit item j) - branch/PR -> Task
+        // resolution for push / commit / merge envelopes. Appended LAST
+        // and, like `rejections`, deliberately NOT @Optional(): the same
+        // TasksDomainModule provides it.
+        private readonly taskLinks: TaskGitLinkService,
     ) {}
 
     /**
@@ -374,6 +518,19 @@ export class GitHubPrReviewBridgeService {
             return { ingested: null };
         }
 
+        // Git activity ingestion (audit item j) - pushes, the commits
+        // inside them and merged pull requests. They take the SAME path
+        // every other kind takes (envelope -> dedupe-insert -> spine
+        // drain -> Activity row), but they never enter the review loop:
+        // the code has already landed, there is nothing left to review.
+        if (isGitActivityDelivery(eventName, body)) {
+            const envelopes = await this.gitActivityEnvelopes(binding, eventName, body);
+            if (envelopes.length === 0) {
+                return { ingested: null };
+            }
+            return { ingested: await this.eventIngestService.ingest(binding.userId, envelopes) };
+        }
+
         const normalized = this.normalize(eventName, body);
         if (!normalized) {
             return { ingested: null };
@@ -438,6 +595,193 @@ export class GitHubPrReviewBridgeService {
                 }`,
             );
         }
+    }
+
+    /**
+     * Git activity ingestion (audit item j) — every envelope one push /
+     * merge delivery produces, in ingest order.
+     *
+     * A push yields one `github.push` envelope for the ref plus one
+     * `github.commit` envelope per new commit; a merged pull request
+     * yields a single `github.merge`. An empty array means "nothing to
+     * ingest" (unattributable repo, a tag ref, a branch deletion) and is
+     * an ORDINARY outcome — the delivery still answers 200.
+     */
+    private async gitActivityEnvelopes(
+        binding: GitHubEventsBinding,
+        eventName: string,
+        body: GitHubWebhookBody,
+    ): Promise<IngestedEventEnvelope[]> {
+        return eventName === 'push'
+            ? this.pushEnvelopes(binding, body)
+            : this.mergeEnvelopes(binding, body);
+    }
+
+    /** `push` → the ref envelope + one envelope per NEW commit. */
+    private async pushEnvelopes(
+        binding: GitHubEventsBinding,
+        body: GitHubWebhookBody,
+    ): Promise<IngestedEventEnvelope[]> {
+        const fullName = body.repository?.full_name ?? '';
+        const [owner, repo] = fullName.split('/');
+        if (!owner || !repo) return [];
+
+        const ref = typeof body.ref === 'string' ? body.ref : '';
+        // Branch pushes only. Tag and note refs are release/annotation
+        // bookkeeping, not "someone pushed work to this repository".
+        if (!ref.startsWith('refs/heads/')) return [];
+        // A branch DELETION carries the all-zero `after` sha and no
+        // commits. It is a cleanup, not a push of work.
+        if (body.deleted === true) return [];
+        const branch = ref.slice('refs/heads/'.length);
+        const after = typeof body.after === 'string' ? body.after : '';
+        if (!branch || !after) return [];
+
+        // Task routing, where the payload allows it: the worktree-per-Task
+        // path stamps `tasks.branchRef`, so the branch IS the Task key.
+        const link = await this.taskLinks.findByBranch({
+            userId: binding.userId,
+            owner,
+            repo,
+            branch,
+        });
+
+        // `distinct: false` commits already reached the repository on
+        // another ref — ingesting them again would re-announce work the
+        // feed has shown once.
+        const commits = (Array.isArray(body.commits) ? body.commits : [])
+            .filter((commit) => typeof commit?.id === 'string' && commit.id.length > 0)
+            .filter((commit) => commit.distinct !== false)
+            .slice(0, GITHUB_PUSH_COMMITS_MAX);
+        const pusher = body.pusher?.name ?? body.sender?.login ?? 'unknown';
+        const headTimestamp = body.head_commit?.timestamp ?? commits[commits.length - 1]?.timestamp;
+
+        const pushEnvelope: IngestedEventEnvelope = {
+            id: randomUUID(),
+            source: GITHUB_PLUGIN_ID,
+            sourceEventId: cappedEventId(`push:${fullName}@${after}:${branch}`),
+            kind: 'github.push',
+            occurredAt: isoOrNow(headTimestamp),
+            actor: { name: pusher },
+            subject: {
+                type: 'branch',
+                externalId: capped(`${fullName}@${branch}`, GITHUB_SUBJECT_EXTERNAL_ID_MAX_CHARS),
+                title: `${branch} (${commits.length} commit${commits.length === 1 ? '' : 's'})`,
+            },
+            workHint: { kind: 'repo', externalId: fullName },
+            ...(body.compare ? { sourceUrl: body.compare } : {}),
+            payload: {
+                repoFullName: fullName,
+                ref,
+                branch,
+                ...(body.before ? { before: body.before } : {}),
+                after,
+                commitCount: commits.length,
+                ...(body.created === true ? { created: true } : {}),
+                ...(body.forced === true ? { forced: true } : {}),
+                ...taskFields(link),
+                commits: commits.map((commit) => ({
+                    sha: commit.id,
+                    message: commitSubject(commit.message).slice(0, 500),
+                })),
+            },
+        };
+
+        const commitEnvelopes = commits.map<IngestedEventEnvelope>((commit) => {
+            const sha = commit.id as string;
+            const subject = commitSubject(commit.message);
+            const author = commit.author?.username ?? commit.author?.name ?? pusher;
+            const filesChanged =
+                (commit.added?.length ?? 0) +
+                (commit.removed?.length ?? 0) +
+                (commit.modified?.length ?? 0);
+            return {
+                id: randomUUID(),
+                source: GITHUB_PLUGIN_ID,
+                // A commit's identity is its SHA — a rebase produces a new
+                // one, a re-delivery or a second ref carrying the same
+                // commit dedupes to zero.
+                sourceEventId: cappedEventId(`commit:${fullName}@${sha}`),
+                kind: 'github.commit',
+                occurredAt: isoOrNow(commit.timestamp),
+                actor: { name: author },
+                subject: {
+                    type: 'commit',
+                    externalId: sha,
+                    ...(subject ? { title: subject.slice(0, 500) } : {}),
+                },
+                workHint: { kind: 'repo', externalId: fullName },
+                ...(commit.url ? { sourceUrl: commit.url } : {}),
+                payload: {
+                    repoFullName: fullName,
+                    ref,
+                    branch,
+                    sha,
+                    ...(commit.message
+                        ? { message: commit.message.slice(0, GITHUB_EVENT_TEXT_MAX_CHARS) }
+                        : {}),
+                    ...(filesChanged > 0 ? { filesChanged } : {}),
+                    ...taskFields(link),
+                },
+            };
+        });
+
+        return [pushEnvelope, ...commitEnvelopes];
+    }
+
+    /** `pull_request` closed+merged → one `github.merge` envelope. */
+    private async mergeEnvelopes(
+        binding: GitHubEventsBinding,
+        body: GitHubWebhookBody,
+    ): Promise<IngestedEventEnvelope[]> {
+        const fullName = body.repository?.full_name ?? '';
+        const [owner, repo] = fullName.split('/');
+        if (!owner || !repo) return [];
+
+        const pr = body.pull_request;
+        const prNumber = pr?.number;
+        if (!pr || typeof prNumber !== 'number') return [];
+
+        // Task routing: the agent-merge path stamps `tasks.prNumber`, so
+        // `(Work, prNumber)` is the Task key — the same one the PR
+        // rejection recorder uses.
+        const link = await this.taskLinks.findByPullRequest({
+            userId: binding.userId,
+            owner,
+            repo,
+            prNumber,
+        });
+
+        const mergeCommitSha = pr.merge_commit_sha ?? '';
+        return [
+            {
+                id: randomUUID(),
+                source: GITHUB_PLUGIN_ID,
+                sourceEventId: cappedEventId(
+                    `merge:${fullName}#${prNumber}@${mergeCommitSha || 'merged'}`,
+                ),
+                kind: 'github.merge',
+                occurredAt: isoOrNow(pr.merged_at),
+                actor: { name: pr.merged_by?.login ?? body.sender?.login ?? 'unknown' },
+                subject: {
+                    type: 'pull_request',
+                    externalId: `${fullName}#${prNumber}`,
+                    ...(pr.title ? { title: pr.title } : {}),
+                },
+                workHint: { kind: 'repo', externalId: fullName },
+                ...(pr.html_url ? { sourceUrl: pr.html_url } : {}),
+                payload: {
+                    repoFullName: fullName,
+                    prNumber,
+                    ...(mergeCommitSha ? { mergeCommitSha } : {}),
+                    ...(pr.base?.ref ? { baseRef: pr.base.ref } : {}),
+                    ...(pr.head?.ref ? { headRef: pr.head.ref } : {}),
+                    ...(pr.title ? { title: pr.title.slice(0, 500) } : {}),
+                    ...(pr.merged_by?.login ? { mergedBy: pr.merged_by.login } : {}),
+                    ...taskFields(link),
+                },
+            },
+        ];
     }
 
     /** Normalize a delivery into an envelope + review coordinates (or skip it). */

--- a/packages/agent/src/database/repositories/__tests__/task.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/task.repository.spec.ts
@@ -80,3 +80,30 @@ describe('TaskRepository.casClaimRecurrence', () => {
         expect(await svc.casClaimRecurrence('t1', new Date(), null)).toBe(false);
     });
 });
+
+/**
+ * Git activity ingestion (audit item j) — a push names a branch, and the
+ * worktree-per-Task path stamps that branch onto `tasks.branchRef`.
+ */
+describe('TaskRepository.findByWorkAndBranchRef', () => {
+    it('keys on (workId, branchRef) and prefers the most recently updated row', async () => {
+        const findOne = jest.fn().mockResolvedValue({ id: 't1' });
+        const svc = new TaskRepository({ findOne } as any);
+
+        await expect(svc.findByWorkAndBranchRef('w1', 'ever/task-t-42')).resolves.toEqual({
+            id: 't1',
+        });
+        expect(findOne).toHaveBeenCalledWith({
+            where: { workId: 'w1', branchRef: 'ever/task-t-42' },
+            order: { updatedAt: 'DESC' },
+        });
+    });
+
+    it('short-circuits an empty branch instead of matching every branchless Task', async () => {
+        const findOne = jest.fn();
+        const svc = new TaskRepository({ findOne } as any);
+
+        await expect(svc.findByWorkAndBranchRef('w1', '')).resolves.toBeNull();
+        expect(findOne).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -90,6 +90,25 @@ export class TaskRepository {
             .getMany();
     }
 
+    /**
+     * Git activity ingestion (audit item j) — the Task whose isolated
+     * worktree branch a push landed on.
+     *
+     * Same key shape as {@link findByWorkAndPrNumber} and for the same
+     * reason: `branchRef` holds the SHORT branch name
+     * (`taskBranchName()`), which is only unique within a repository, and
+     * a Work maps to one repository. Newest-updated first, because a
+     * recycled branch name can appear on more than one row and the live
+     * Task is the one that moved last.
+     */
+    async findByWorkAndBranchRef(workId: string, branchRef: string): Promise<Task | null> {
+        if (!branchRef) return null;
+        return this.repository.findOne({
+            where: { workId, branchRef },
+            order: { updatedAt: 'DESC' },
+        });
+    }
+
     async findByUserIdFiltered(
         userId: string,
         filter: ListTasksFilter = {},

--- a/packages/agent/src/entities/__tests__/activity-log.types.spec.ts
+++ b/packages/agent/src/entities/__tests__/activity-log.types.spec.ts
@@ -67,6 +67,12 @@ describe('activity-log.types', () => {
             ['CHAT_CONVERSATION', 'chat_conversation'],
             // Community
             ['COMMUNITY_PR_MERGED', 'community_pr_merged'],
+            // Git activity ingestion (audit item j) — pushes, the commits
+            // inside them, and merged pull requests, landed by the GitHub
+            // receiver through the event-ingest spine.
+            ['GIT_PUSHED', 'git_pushed'],
+            ['GIT_COMMITTED', 'git_committed'],
+            ['GIT_MERGED', 'git_merged'],
         ];
 
         it.each(cases)('%s → %s', (key, value) => {
@@ -104,7 +110,9 @@ describe('activity-log.types', () => {
             const literals = Object.values(ActivityActionType).filter((v) => typeof v === 'string');
             // +1 EXTERNAL_EVENT_INGESTED (event-ingest spine, Wave 6) -> 116.
             // +2 task_merged / task_merge_refused (agent-merge path, #1874) -> 118.
-            expect(literals).toHaveLength(118);
+            // +3 git_pushed / git_committed / git_merged (git activity
+            //    ingestion, audit item j) -> 121.
+            expect(literals).toHaveLength(121);
         });
 
         it('every literal value is unique (no accidental duplicate string)', () => {

--- a/packages/agent/src/entities/activity-log.types.ts
+++ b/packages/agent/src/entities/activity-log.types.ts
@@ -219,6 +219,20 @@ export enum ActivityActionType {
     // chat can link back to the original message / PR / page. Additive
     // member — storage is a plain varchar.
     EXTERNAL_EVENT_INGESTED = 'external_event_ingested',
+
+    // Git activity ingestion (audit item j). Commits, pushes and merges
+    // arrive on the consolidated GitHub receiver, are normalized into
+    // `github.push` / `github.commit` / `github.merge` envelopes and
+    // drained by the SAME spine that writes EXTERNAL_EVENT_INGESTED —
+    // these three kinds simply resolve to their own action type
+    // (`INGEST_ACTIVITY_ACTION_BY_KIND`) so the feed can tell "someone
+    // pushed" apart from "some connector event landed". `details`
+    // carries the routing block (repoFullName / ref / sha / prNumber /
+    // taskId) the row was built from. Additive members — storage is a
+    // plain varchar, so no migration is needed.
+    GIT_PUSHED = 'git_pushed',
+    GIT_COMMITTED = 'git_committed',
+    GIT_MERGED = 'git_merged',
 }
 
 export enum ActivityStatus {

--- a/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
@@ -209,6 +209,72 @@ describe('EventIngestService', () => {
             expect(repository.markProcessed).toHaveBeenCalledWith('row-good');
         });
 
+        // Git activity ingestion (audit item j) — three kinds get their
+        // own action type so the feed can tell "someone pushed" apart
+        // from "some connector event landed".
+        describe('git activity action types', () => {
+            it.each([
+                ['github.push', ActivityActionType.GIT_PUSHED],
+                ['github.commit', ActivityActionType.GIT_COMMITTED],
+                ['github.merge', ActivityActionType.GIT_MERGED],
+            ])('%s → %s', async (kind, actionType) => {
+                repository.findUnprocessed.mockResolvedValue([
+                    storedEvent({
+                        kind,
+                        source: 'github',
+                        payload: { repoFullName: 'acme/widgets', taskId: 'task-1' },
+                    }),
+                ]);
+
+                await build().processBatch(10);
+
+                expect(activityLog.log).toHaveBeenCalledWith(
+                    expect.objectContaining({ actionType, action: kind }),
+                    expect.anything(),
+                );
+            });
+
+            it('carries the routing payload into `details` so the row names its Task', async () => {
+                repository.findUnprocessed.mockResolvedValue([
+                    storedEvent({
+                        kind: 'github.push',
+                        source: 'github',
+                        workId: 'work-9',
+                        payload: {
+                            repoFullName: 'acme/widgets',
+                            branch: 'ever/task-t-42',
+                            commitCount: 2,
+                            taskId: 'task-1',
+                        },
+                    }),
+                ]);
+
+                await build().processBatch(10);
+
+                expect(activityLog.log).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        workId: 'work-9',
+                        details: expect.objectContaining({
+                            repoFullName: 'acme/widgets',
+                            branch: 'ever/task-t-42',
+                            taskId: 'task-1',
+                        }),
+                    }),
+                    expect.anything(),
+                );
+            });
+
+            it('leaves every OTHER kind exactly as it was (generic type, no details)', async () => {
+                repository.findUnprocessed.mockResolvedValue([storedEvent()]);
+
+                await build().processBatch(10);
+
+                const [dto] = activityLog.log.mock.calls[0];
+                expect(dto.actionType).toBe(ActivityActionType.EXTERNAL_EVENT_INGESTED);
+                expect(dto.details).toBeUndefined();
+            });
+        });
+
         it('passes the batch limit through to the unprocessed read', async () => {
             repository.findUnprocessed.mockResolvedValue([]);
 

--- a/packages/agent/src/ingest/event-ingest.service.ts
+++ b/packages/agent/src/ingest/event-ingest.service.ts
@@ -8,6 +8,34 @@ import type { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestedEventRepository } from './ingested-event.repository';
 import { WorkHintResolverService } from './work-hint-resolver.service';
 
+/**
+ * Kinds that resolve to a DEDICATED Activity action type instead of the
+ * generic `EXTERNAL_EVENT_INGESTED` (git activity ingestion, audit item
+ * j).
+ *
+ * Every other kind is unchanged: the map is consulted with a fallback,
+ * so a connector that never appears here produces byte-for-byte the row
+ * it produced before this map existed.
+ *
+ * Two things travel with a dedicated action type:
+ *
+ *   * the action type itself, so the feed can say "pushed 3 commits"
+ *     rather than "an external event landed"; and
+ *   * the envelope `payload` copied into `activity_log.details`, because
+ *     the routing block those rows are built from (repoFullName / ref /
+ *     sha / prNumber / taskId) is what a renderer needs and it is NOT in
+ *     the provenance `metadata` block. Generic ingested events keep
+ *     provenance-only metadata and a null `details`, exactly as before —
+ *     widening that for every connector would push arbitrary third-party
+ *     message text into the feed payload.
+ */
+export const INGEST_ACTIVITY_ACTION_BY_KIND: Readonly<Record<string, ActivityActionType>> =
+    Object.freeze({
+        'github.push': ActivityActionType.GIT_PUSHED,
+        'github.commit': ActivityActionType.GIT_COMMITTED,
+        'github.merge': ActivityActionType.GIT_MERGED,
+    });
+
 export interface IngestResult {
     /** New rows written. */
     inserted: number;
@@ -54,9 +82,10 @@ export interface IngestedEventKindProcessor {
  * `(source, sourceEventId)`); `processBatch()` — driven by the
  * `event-ingest-tick` cron — fans each unprocessed row out to:
  *
- *   1. Activity log (`EXTERNAL_EVENT_INGESTED`, provenance in
- *      `metadata` incl. `sourceUrl`) — REQUIRED: a failed write leaves
- *      the row unprocessed so the next tick retries it.
+ *   1. Activity log (`EXTERNAL_EVENT_INGESTED`, or the dedicated action
+ *      type in {@link INGEST_ACTIVITY_ACTION_BY_KIND} for git activity;
+ *      provenance in `metadata` incl. `sourceUrl`) — REQUIRED: a failed
+ *      write leaves the row unprocessed so the next tick retries it.
  *   2. Agent Memory via `AgentMemoryFacadeService.saveMemory` with
  *      provenance tags/metadata — BEST-EFFORT: no provider enabled or a
  *      provider error never fails the batch (mirrors
@@ -234,14 +263,19 @@ export class EventIngestService {
     }
 
     private async writeActivity(event: IngestedEvent): Promise<void> {
+        // Kinds with a dedicated action type (git activity) also carry
+        // their routing payload into `details`; everything else keeps the
+        // pre-existing generic row, provenance-only.
+        const dedicatedAction = INGEST_ACTIVITY_ACTION_BY_KIND[event.kind];
         await this.activityLogService.log(
             {
                 userId: event.userId,
                 ...(event.workId ? { workId: event.workId } : {}),
-                actionType: ActivityActionType.EXTERNAL_EVENT_INGESTED,
+                actionType: dedicatedAction ?? ActivityActionType.EXTERNAL_EVENT_INGESTED,
                 action: event.kind,
                 status: ActivityStatus.COMPLETED,
                 summary: this.summarize(event),
+                ...(dedicatedAction && event.payload ? { details: event.payload } : {}),
                 metadata: this.provenance(event),
             },
             // Feed orders by "when it happened", not "when the platform

--- a/packages/agent/src/tasks-domain/__tests__/task-git-link.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-git-link.service.spec.ts
@@ -1,0 +1,152 @@
+import { TaskGitLinkService } from '../task-git-link.service';
+
+/**
+ * Git activity ingestion (audit item j) — the branch/PR → Task resolver
+ * the GitHub receiver stamps onto push / commit / merge envelopes.
+ *
+ * Three properties carry the whole contract: it is OWNER-SCOPED (the
+ * candidate Works come from the ingesting user), `null` is an ORDINARY
+ * outcome (most repositories are not Works and most branches are not
+ * Tasks), and it NEVER throws — the caller is a webhook that must answer
+ * 200 whatever the database is doing.
+ */
+describe('TaskGitLinkService (git activity ingestion)', () => {
+    let tasks: any;
+    let works: any;
+
+    const task = { id: 'task-1', slug: 'T-42', workId: 'work-1', prNumber: 42 };
+
+    function makeSvc(): TaskGitLinkService {
+        const svc = new TaskGitLinkService(tasks, works);
+        jest.spyOn(
+            (svc as never as { logger: Record<string, () => void> }).logger,
+            'warn',
+        ).mockImplementation(() => undefined);
+        return svc;
+    }
+
+    beforeEach(() => {
+        tasks = {
+            findByWorkAndPrNumber: jest.fn().mockResolvedValue({ ...task }),
+            findByWorkAndBranchRef: jest.fn().mockResolvedValue({ ...task }),
+        };
+        // `matchWorkByRepo` reads repo roles through the Work's accessor
+        // methods, so the fixture speaks that interface.
+        works = {
+            findByUser: jest.fn().mockResolvedValue([
+                {
+                    id: 'work-1',
+                    getRepoOwner: (role: string) => (role === 'work' ? 'acme' : null),
+                    getMainRepo: () => 'widgets',
+                    getWebsiteRepo: () => null,
+                    getDataRepo: () => null,
+                },
+            ]),
+        };
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    describe('findByBranch', () => {
+        it('resolves the branch to its Work and Task', async () => {
+            await expect(
+                makeSvc().findByBranch({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    branch: 'ever/task-t-42',
+                }),
+            ).resolves.toEqual({ workId: 'work-1', taskId: 'task-1', taskSlug: 'T-42' });
+            expect(works.findByUser).toHaveBeenCalledWith('u1');
+            expect(tasks.findByWorkAndBranchRef).toHaveBeenCalledWith('work-1', 'ever/task-t-42');
+        });
+
+        it('returns null for a repository that is not a Work — never queries Tasks', async () => {
+            await expect(
+                makeSvc().findByBranch({
+                    userId: 'u1',
+                    owner: 'stranger',
+                    repo: 'thing',
+                    branch: 'main',
+                }),
+            ).resolves.toBeNull();
+            expect(tasks.findByWorkAndBranchRef).not.toHaveBeenCalled();
+        });
+
+        it('returns null when no Task owns the branch (a human pushed to main)', async () => {
+            tasks.findByWorkAndBranchRef.mockResolvedValue(null);
+            await expect(
+                makeSvc().findByBranch({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    branch: 'main',
+                }),
+            ).resolves.toBeNull();
+        });
+
+        it('refuses an empty branch without touching the database', async () => {
+            await expect(
+                makeSvc().findByBranch({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    branch: '   ',
+                }),
+            ).resolves.toBeNull();
+            expect(works.findByUser).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('findByPullRequest', () => {
+        it('resolves the PR number to its Work and Task', async () => {
+            await expect(
+                makeSvc().findByPullRequest({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    prNumber: 42,
+                }),
+            ).resolves.toEqual({ workId: 'work-1', taskId: 'task-1', taskSlug: 'T-42' });
+            expect(tasks.findByWorkAndPrNumber).toHaveBeenCalledWith('work-1', 42);
+        });
+
+        it('refuses a non-integer PR number without touching the database', async () => {
+            await expect(
+                makeSvc().findByPullRequest({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    prNumber: Number.NaN,
+                }),
+            ).resolves.toBeNull();
+            expect(works.findByUser).not.toHaveBeenCalled();
+        });
+    });
+
+    it('NEVER throws — a repository failure resolves to "not linked"', async () => {
+        works.findByUser.mockRejectedValue(new Error('db down'));
+        await expect(
+            makeSvc().findByBranch({
+                userId: 'u1',
+                owner: 'acme',
+                repo: 'widgets',
+                branch: 'ever/task-t-42',
+            }),
+        ).resolves.toBeNull();
+    });
+
+    it('is owner-scoped: another user’s Works are never candidates', async () => {
+        works.findByUser.mockResolvedValue([]);
+        await expect(
+            makeSvc().findByPullRequest({
+                userId: 'intruder',
+                owner: 'acme',
+                repo: 'widgets',
+                prNumber: 42,
+            }),
+        ).resolves.toBeNull();
+        expect(works.findByUser).toHaveBeenCalledWith('intruder');
+        expect(tasks.findByWorkAndPrNumber).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -50,6 +50,8 @@ export {
     UserTaskCounterRepository,
 } from '../database/repositories/task-side.repositories';
 export * from './task-review-rejection.service';
+// Git activity ingestion (audit item j) — branch/PR → Task resolver.
+export * from './task-git-link.service';
 export {
     TaskReviewRejectionRepository,
     type RecordTaskReviewRejectionInput,

--- a/packages/agent/src/tasks-domain/task-git-link.service.ts
+++ b/packages/agent/src/tasks-domain/task-git-link.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { matchWorkByRepo } from '../works/work-repo-match';
+
+/** What a git ref resolved to inside the platform, when it resolved at all. */
+export interface TaskGitLink {
+    workId: string;
+    taskId: string;
+    /** The Task's human slug — cheap context for the Activity row. */
+    taskSlug?: string | null;
+}
+
+/** Coordinates every lookup starts from: the repo the delivery named. */
+export interface TaskGitLookupBase {
+    userId: string;
+    owner: string;
+    repo: string;
+}
+
+/**
+ * Git activity ingestion (audit item j) — the read-only "which Task does
+ * this git ref belong to?" resolver.
+ *
+ * A push carries a branch and a merged pull request carries a number.
+ * Both are Task coordinates: the worktree-per-Task path writes
+ * `tasks.branchRef` when it provisions a workspace and `tasks.prNumber`
+ * when it opens the PR. This service is the ONE place that turns either
+ * back into a Task, so the webhook bridge does not grow its own copy of
+ * the repo→Work→Task walk that {@link TaskReviewRejectionService} already
+ * performs for `changes_requested` reviews.
+ *
+ * Three rules, mirroring the rejection recorder and the ingest spine:
+ *
+ *   1. **Owner-scoped, always.** Candidate Works come from
+ *      `WorkRepository.findByUser(userId)` and the repo is matched with
+ *      the shared `matchWorkByRepo`, so a delivery can never resolve into
+ *      another tenant's Task.
+ *   2. **`null` is a normal outcome.** A repository that is not a Work, a
+ *      branch nobody's Task owns, a PR opened by a human — all ordinary.
+ *      The event still gets ingested; it just carries no `taskId`.
+ *   3. **Never throws.** The caller is a webhook handler that must answer
+ *      200 fast. A repository failure logs and resolves to `null`.
+ */
+@Injectable()
+export class TaskGitLinkService {
+    private readonly logger = new Logger(TaskGitLinkService.name);
+
+    constructor(
+        private readonly tasks: TaskRepository,
+        private readonly works: WorkRepository,
+    ) {}
+
+    /** The Task that opened `prNumber` in `owner/repo`, or null. */
+    async findByPullRequest(
+        input: TaskGitLookupBase & { prNumber: number },
+    ): Promise<TaskGitLink | null> {
+        if (!Number.isInteger(input.prNumber)) return null;
+        return this.resolve(input, (workId) =>
+            this.tasks.findByWorkAndPrNumber(workId, input.prNumber),
+        );
+    }
+
+    /** The Task whose isolated worktree branch is `branch`, or null. */
+    async findByBranch(input: TaskGitLookupBase & { branch: string }): Promise<TaskGitLink | null> {
+        const branch = (input.branch ?? '').trim();
+        if (!branch) return null;
+        return this.resolve(input, (workId) => this.tasks.findByWorkAndBranchRef(workId, branch));
+    }
+
+    /**
+     * Shared walk: owner-scoped Works → repo match → per-lookup Task
+     * query.
+     *
+     * A matched Work with no matching Task resolves to `null` rather than
+     * to a Work-only link: the ingest spine already routes the event to
+     * that same Work through its own `workHint`, so a half-link here would
+     * only be a second, staler copy of information the row already has.
+     */
+    private async resolve(
+        base: TaskGitLookupBase,
+        findTask: (workId: string) => Promise<{ id: string; slug?: string | null } | null>,
+    ): Promise<TaskGitLink | null> {
+        if (!base.userId || !base.owner || !base.repo) return null;
+        try {
+            const candidates = await this.works.findByUser(base.userId);
+            const work = matchWorkByRepo(candidates ?? [], base.owner, base.repo);
+            if (!work) return null;
+            const task = await findTask(work.id);
+            if (!task) return null;
+            return { workId: work.id, taskId: task.id, taskSlug: task.slug ?? null };
+        } catch (error) {
+            this.logger.warn(
+                `Task link lookup failed for ${base.owner}/${base.repo}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
+    }
+}

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -42,6 +42,7 @@ import { TaskRecurrenceDispatcherService } from './task-recurrence-dispatcher.se
 import { TaskNotificationService } from './task-notification.service';
 import { TaskRunDenormService } from './task-run-denorm.service';
 import { TaskReviewRejectionService } from './task-review-rejection.service';
+import { TaskGitLinkService } from './task-git-link.service';
 import { TaskWorkspaceService } from './task-workspace.service';
 import { TaskPrStatusService } from './task-pr-status.service';
 import { FacadesModule } from '../facades/facades.module';
@@ -125,6 +126,11 @@ import { NotificationsModule } from '../notifications/notifications.module';
         // TaskReviewRejectionRepository, which AgentsModule (imported
         // above) owns and exports alongside AgentRunRepository.
         TaskReviewRejectionService,
+        // Git activity ingestion (audit item j) — read-only branch/PR →
+        // Task resolver the GitHub receiver stamps onto push / commit /
+        // merge events. Reads TaskRepository + WorkRepository, both
+        // already provided above.
+        TaskGitLinkService,
         // Kanban run cockpit (plan 04 M5/M6) — PR status cache + capped
         // diff reads. Uses the git facade (FacadesModule, imported above)
         // and TaskTransitionService for the merged-PR -> done landing.
@@ -162,6 +168,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         TaskRunDenormService,
         TaskWorkspaceService,
         TaskReviewRejectionService,
+        TaskGitLinkService,
         TaskPrStatusService,
         TaskGateRunnerService,
         TaskGateJudgeService,


### PR DESCRIPTION
## The problem

Commits, pushes and merges were **never ingested**, so the Activity feed showed
none of the work that actually happened in a repository.

## What changed

The consolidated GitHub receiver now normalizes deliveries into
`github.push` / `github.commit` / `github.merge` envelopes and drains them
through the **same** event-ingest spine that already writes
`EXTERNAL_EVENT_INGESTED` — no new endpoint, no second path.

| Delivery | Envelopes produced |
|---|---|
| push | one `github.push` for the ref + one `github.commit` per new commit (capped per delivery) |
| merged PR | a single `github.merge` |

The three kinds resolve to their own action types via
`INGEST_ACTIVITY_ACTION_BY_KIND`, so the feed can distinguish "someone pushed"
from "some connector event landed" rather than flattening everything into one
generic row.

## Task mapping

`TaskGitLinkService` resolves the Task whose isolated worktree branch a push
landed on, using a new `findByWorkAndBranchRef`. `branchRef` holds the *short*
branch name, which is only unique within a repository, and a Work maps to one
repository — so the key is `(workId, branchRef)`, newest-updated first, because
a recycled branch name can appear on more than one row.

That read is deliberately **separate** from the owner-scoped
`findByUserIdFiltered` rather than another filter on it: a caller that forgot
the owner argument must not be able to read across users.

## Pin spec

`ActivityActionType` gains `GIT_PUSHED` / `GIT_COMMITTED` / `GIT_MERGED`, and
`activity-log.types.spec` moves **118 → 121** in the same commit. An unmatched
repo is ignored without throwing.

## Who calls this in production?

| Piece | Production site |
|---|---|
| envelope emission | `apps/api/src/ingest/github/github-pr-review-bridge.service.ts:663` (`github.push`), `:708` (`github.commit`) |
| action-type map | `packages/agent/src/ingest/event-ingest.service.ts:269` |
| `TaskGitLinkService` | provided in `tasks.module.ts:133`, consumed by `github-pr-review-bridge.service.ts:11` |

## Merge conflict resolved by hand

`develop`'s org-scoped `findRecentByOrganization` (from the digest change) and
this branch's `findByWorkAndBranchRef` were added at the same insertion point
in `task.repository.ts`, sharing a JSDoc opener and a closing brace — the exact
shape a regex "take both sides and dedupe" resolution corrupts. Resolved
manually; both methods are kept whole, and no conflict markers remain anywhere
in `packages/agent/src` or `apps/api/src`.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 444 suites, 8100 tests |
| `apps/api` jest | green — 230 suites, 3761 tests |
| prettier | clean |

Not run: web `tsc` / build (this branch touches no web code).