### PR TITLE
feat(onboarding): connect communication in place and persist the org profile

### DIFF
--- a/apps/api/src/migrations/1784750000000-CreateOrganizationOnboardingProfiles.ts
+++ b/apps/api/src/migrations/1784750000000-CreateOrganizationOnboardingProfiles.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+/**
+ * Audit item A53 — organization-scoped onboarding profile.
+ *
+ * `organization_onboarding_profiles` mirrors the onboarding wizard's
+ * "What do you do" answers (roles multi-select + team size) at the
+ * organization level. Until now they only ever landed on
+ * `users.onboarding_state`, which is per-user and therefore invisible to
+ * every other member of the same organization.
+ *
+ * Single row per organization (`organizationId` is the PK), cascading
+ * delete from `organizations` — same shape as
+ * `organization_notification_defaults` (see
+ * [`1780000000000-AddNotificationsV2Tables`](./1780000000000-AddNotificationsV2Tables.ts)).
+ *
+ * `roles` is the entity's `simple-json` column, which maps to `text` on
+ * Postgres and on the better-sqlite3 test/CLI driver alike — so a plain
+ * nullable `text` column is the portable spelling.
+ *
+ * Entity: `packages/agent/src/entities/organization-onboarding-profile.entity.ts`.
+ *
+ * Purely additive: no backfill, and every column is nullable, so
+ * existing organizations are unaffected until someone answers the step.
+ * Forward-only and idempotent (`hasTable` guarded), matching the house
+ * migration pattern.
+ */
+export class CreateOrganizationOnboardingProfiles1784750000000 implements MigrationInterface {
+    name = 'CreateOrganizationOnboardingProfiles1784750000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('organization_onboarding_profiles')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'organization_onboarding_profiles',
+                columns: [
+                    { name: 'organizationId', type: 'uuid', isPrimary: true, isNullable: false },
+                    { name: 'roles', type: 'text', isNullable: true },
+                    { name: 'teamSize', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'updatedByUserId', type: 'uuid', isNullable: true },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()', isNullable: false },
+                ],
+                foreignKeys: [
+                    {
+                        name: 'fk_organization_onboarding_profiles_organization',
+                        columnNames: ['organizationId'],
+                        referencedTableName: 'organizations',
+                        referencedColumnNames: ['id'],
+                        onDelete: 'CASCADE',
+                    },
+                ],
+            }),
+            true,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('organization_onboarding_profiles')) {
+            await queryRunner.dropTable('organization_onboarding_profiles', true);
+        }
+    }
+}

--- a/apps/api/src/onboarding/dto/onboarding-state.dto.ts
+++ b/apps/api/src/onboarding/dto/onboarding-state.dto.ts
@@ -17,6 +17,7 @@ import type {
     OnboardingAiChoice,
     OnboardingDbChoice,
     OnboardingDeployChoice,
+    OnboardingProfile,
     OnboardingStorageChoice,
     OnboardingWizardStateV2,
     OnboardingCatalogResponse,
@@ -180,6 +181,12 @@ export class OnboardingStateResponseDto {
 
     @ApiProperty()
     state!: OnboardingWizardStateV2;
+
+    // Audit item A53 — organization-level mirror of `state.profile`,
+    // read from `organization_onboarding_profiles`. `null` when the
+    // request resolved no organization scope or nobody has answered yet.
+    @ApiPropertyOptional({ nullable: true })
+    organizationProfile?: OnboardingProfile | null;
 }
 
 export class OnboardingCatalogResponseDto implements OnboardingCatalogResponse {

--- a/apps/api/src/onboarding/onboarding-catalog.service.spec.ts
+++ b/apps/api/src/onboarding/onboarding-catalog.service.spec.ts
@@ -4,7 +4,7 @@ jest.mock('@ever-works/agent/plugins', () => ({
 
 import { Test } from '@nestjs/testing';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
-import { OnboardingCatalogService } from './onboarding-catalog.service';
+import { COMMUNICATION_PLUGIN_IDS, OnboardingCatalogService } from './onboarding-catalog.service';
 
 interface FakeRegisteredPlugin {
     manifest: {
@@ -173,6 +173,41 @@ describe('OnboardingCatalogService', () => {
             const cat = svc.getCatalog();
             const ids = cat.plugins.map((p) => p.pluginId);
             expect(ids).toEqual(['make', 'zapier']);
+        });
+
+        // Audit item (b) — the Communication step now connects Slack /
+        // Discord IN PLACE, so those connectors must not also show up as
+        // generic "Plugins & Integrations" cards.
+        it('excludes the Communication-step connectors even when they opt into onboarding', async () => {
+            const svc = await makeSvc([
+                {
+                    manifest: {
+                        id: 'slack-connector',
+                        name: 'Slack Connector',
+                        category: 'connector',
+                        uiHints: { includeInOnboarding: true, onboardingPriority: 1 },
+                    },
+                },
+                {
+                    manifest: {
+                        id: 'discord-connector',
+                        name: 'Discord Connector',
+                        category: 'connector',
+                        uiHints: { includeInOnboarding: true, onboardingPriority: 1 },
+                    },
+                },
+                {
+                    manifest: {
+                        id: 'zapier',
+                        name: 'Zapier',
+                        category: 'pipeline',
+                        uiHints: { includeInOnboarding: true, onboardingPriority: 2 },
+                    },
+                },
+            ]);
+
+            expect(svc.getCatalog().plugins.map((p) => p.pluginId)).toEqual(['zapier']);
+            expect(COMMUNICATION_PLUGIN_IDS).toEqual(['slack-connector', 'discord-connector']);
         });
 
         it('sorts plugins by onboardingPriority ascending', async () => {

--- a/apps/api/src/onboarding/onboarding-catalog.service.ts
+++ b/apps/api/src/onboarding/onboarding-catalog.service.ts
@@ -12,6 +12,18 @@ import type {
 } from '@ever-works/contracts/api';
 
 /**
+ * Audit item (b) — connector plugins the dedicated "Communication"
+ * wizard step owns. The step now connects them IN PLACE (settings form
+ * + enable) instead of linking out to Settings → Plugins, so they are
+ * reserved out of the generic "Plugins & Integrations" list below; a
+ * user should never be offered the same connector twice in one wizard.
+ *
+ * Exported so the reservation is assertable from a spec rather than
+ * being an invisible literal inside `getCatalog`.
+ */
+export const COMMUNICATION_PLUGIN_IDS: readonly string[] = ['slack-connector', 'discord-connector'];
+
+/**
  * Builds the catalog payload the web wizard renders:
  *
  *  - AI choice cards (Ever Works AI default + 5 BYOK options)
@@ -194,6 +206,7 @@ export class OnboardingCatalogService {
                 ...storage.map((c) => c.pluginId),
                 ...db.map((c) => c.pluginId),
                 ...deploy.map((c) => c.pluginId),
+                ...COMMUNICATION_PLUGIN_IDS,
             ].filter((id): id is string => Boolean(id)),
         );
 

--- a/apps/api/src/onboarding/onboarding-state.service.spec.ts
+++ b/apps/api/src/onboarding/onboarding-state.service.spec.ts
@@ -1,11 +1,18 @@
 jest.mock('@ever-works/agent/database', () => ({
     UserRepository: class {},
+    // A53 — the org-level mirror repository is a real DI token on the
+    // service constructor now, so the mocked barrel must expose it too.
+    OrganizationOnboardingProfileRepository: class {},
 }));
 
 import { Test } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
-import { UserRepository } from '@ever-works/agent/database';
+import {
+    OrganizationOnboardingProfileRepository,
+    UserRepository,
+} from '@ever-works/agent/database';
 import { ONBOARDING_DEFAULT_STATE } from '@ever-works/contracts/api';
+import { ScopeContextService } from '../scope/scope-context.service';
 import { OnboardingStateService, __test__ } from './onboarding-state.service';
 
 interface FakeUser {
@@ -13,6 +20,46 @@ interface FakeUser {
     onboardingCompletedAt?: Date | null;
     onboardingDismissedAt?: Date | null;
     onboardingState?: unknown;
+}
+
+interface FakeOrgProfileRow {
+    organizationId: string;
+    roles?: string[] | null;
+    teamSize?: string | null;
+    updatedByUserId?: string | null;
+}
+
+/**
+ * In-memory stand-in for `OrganizationOnboardingProfileRepository` with
+ * the same field-level upsert semantics as the real one (an omitted
+ * field keeps the persisted value; an explicit `null` clears it).
+ */
+function buildOrgProfileRepository() {
+    const rows = new Map<string, FakeOrgProfileRow>();
+    return {
+        findByOrg: jest.fn(async (organizationId: string) => rows.get(organizationId) ?? null),
+        upsert: jest.fn(
+            async (
+                organizationId: string,
+                input: {
+                    roles?: readonly string[] | null;
+                    teamSize?: string | null;
+                    updatedByUserId?: string | null;
+                },
+            ) => {
+                const existing = rows.get(organizationId) ?? { organizationId };
+                const next: FakeOrgProfileRow = { ...existing };
+                if (input.roles !== undefined) next.roles = input.roles ? [...input.roles] : null;
+                if (input.teamSize !== undefined) next.teamSize = input.teamSize ?? null;
+                if (input.updatedByUserId !== undefined) {
+                    next.updatedByUserId = input.updatedByUserId ?? null;
+                }
+                rows.set(organizationId, next);
+                return next;
+            },
+        ),
+        _peek: (organizationId: string) => rows.get(organizationId) ?? null,
+    };
 }
 
 function buildUserRepository(initial: FakeUser | null) {
@@ -162,6 +209,134 @@ describe('OnboardingStateService', () => {
                 state: { profile: { roles: ['engineering'] } },
             });
             expect(third.state.profile).toEqual({ roles: ['engineering'], teamSize: 'solo' });
+        });
+    });
+
+    // ─── A53: organization-level mirror ─────────────────────────────────
+
+    describe('organization-scoped profile mirror (A53)', () => {
+        let orgRepo: ReturnType<typeof buildOrgProfileRepository>;
+
+        async function makeScopedSvc(organizationId: string | null) {
+            repo = buildUserRepository({ id: 'u1' });
+            orgRepo = buildOrgProfileRepository();
+            const moduleRef = await Test.createTestingModule({
+                providers: [
+                    OnboardingStateService,
+                    { provide: UserRepository, useValue: repo },
+                    {
+                        provide: ScopeContextService,
+                        useValue: { getOrganizationId: () => organizationId },
+                    },
+                    { provide: OrganizationOnboardingProfileRepository, useValue: orgRepo },
+                ],
+            }).compile();
+            svc = moduleRef.get(OnboardingStateService);
+        }
+
+        it('persists the answers on the active organization and echoes them back', async () => {
+            await makeScopedSvc('org-1');
+
+            const res = await svc.patchState('u1', {
+                state: { profile: { roles: ['marketing', 'sales'], teamSize: 'small-2-10' } },
+            });
+
+            expect(orgRepo.upsert).toHaveBeenCalledWith('org-1', {
+                roles: ['marketing', 'sales'],
+                teamSize: 'small-2-10',
+                updatedByUserId: 'u1',
+            });
+            expect(orgRepo._peek('org-1')).toMatchObject({
+                organizationId: 'org-1',
+                roles: ['marketing', 'sales'],
+                teamSize: 'small-2-10',
+                updatedByUserId: 'u1',
+            });
+            expect(res.organizationProfile).toEqual({
+                roles: ['marketing', 'sales'],
+                teamSize: 'small-2-10',
+            });
+        });
+
+        it('mirrors the MERGED profile, so a roles-only patch keeps the org team size', async () => {
+            await makeScopedSvc('org-1');
+            await svc.patchState('u1', {
+                state: { profile: { roles: ['sales'], teamSize: 'mid-11-50' } },
+            });
+
+            const res = await svc.patchState('u1', {
+                state: { profile: { roles: ['engineering'] } },
+            });
+
+            expect(res.organizationProfile).toEqual({
+                roles: ['engineering'],
+                teamSize: 'mid-11-50',
+            });
+        });
+
+        it('does NOT re-stamp the org row for a patch that carries no profile', async () => {
+            await makeScopedSvc('org-1');
+            await svc.patchState('u1', { state: { profile: { roles: ['product'] } } });
+            expect(orgRepo.upsert).toHaveBeenCalledTimes(1);
+
+            await svc.patchState('u1', { state: { lastStep: 4 } });
+            expect(orgRepo.upsert).toHaveBeenCalledTimes(1);
+        });
+
+        it('getState reads the org row back for the active scope', async () => {
+            await makeScopedSvc('org-1');
+            await svc.patchState('u1', {
+                state: { profile: { roles: ['founder-ceo'], teamSize: 'solo' } },
+            });
+
+            const res = await svc.getState('u1');
+            expect(res.organizationProfile).toEqual({ roles: ['founder-ceo'], teamSize: 'solo' });
+        });
+
+        it('is a no-op (organizationProfile null) when no organization scope is resolved', async () => {
+            await makeScopedSvc(null);
+
+            const res = await svc.patchState('u1', {
+                state: { profile: { roles: ['legal'], teamSize: 'solo' } },
+            });
+
+            expect(orgRepo.upsert).not.toHaveBeenCalled();
+            // The per-user answers still persist — the org mirror is additive.
+            expect(res.state.profile).toEqual({ roles: ['legal'], teamSize: 'solo' });
+            expect(res.organizationProfile).toBeNull();
+        });
+
+        it('never fails the save when the org write throws', async () => {
+            await makeScopedSvc('org-1');
+            orgRepo.upsert.mockRejectedValueOnce(new Error('db down'));
+
+            const res = await svc.patchState('u1', {
+                state: { profile: { roles: ['support'] } },
+            });
+
+            expect(res.state.profile).toEqual({ roles: ['support'] });
+            expect(res.organizationProfile).toBeNull();
+        });
+
+        it('skips the mirror entirely when the repository is not wired', async () => {
+            repo = buildUserRepository({ id: 'u1' });
+            const moduleRef = await Test.createTestingModule({
+                providers: [
+                    OnboardingStateService,
+                    { provide: UserRepository, useValue: repo },
+                    {
+                        provide: ScopeContextService,
+                        useValue: { getOrganizationId: () => 'org-1' },
+                    },
+                ],
+            }).compile();
+            svc = moduleRef.get(OnboardingStateService);
+
+            const res = await svc.patchState('u1', {
+                state: { profile: { roles: ['research'] } },
+            });
+            expect(res.state.profile).toEqual({ roles: ['research'] });
+            expect(res.organizationProfile).toBeNull();
         });
     });
 

--- a/apps/api/src/onboarding/onboarding-state.service.ts
+++ b/apps/api/src/onboarding/onboarding-state.service.ts
@@ -1,5 +1,8 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { UserRepository } from '@ever-works/agent/database';
+import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
+import {
+    OrganizationOnboardingProfileRepository,
+    UserRepository,
+} from '@ever-works/agent/database';
 import {
     ONBOARDING_DEFAULT_STATE,
     ROLE_OPTIONS,
@@ -9,6 +12,11 @@ import {
     type OnboardingStatePatchRequest,
     type OnboardingWizardStateV2,
 } from '@ever-works/contracts/api';
+// Concrete path (not the `../scope` barrel): the barrel re-exports
+// `ScopeModule`, and pulling a module into a service's import graph is
+// how circular-module init bugs start. The service itself is provided
+// globally, so only the class is needed here.
+import { ScopeContextService } from '../scope/scope-context.service';
 
 /**
  * Owns reads + writes for the v2 onboarding wizard's server-side state.
@@ -17,12 +25,28 @@ import {
  * timestamp columns (`onboardingCompletedAt`, `onboardingDismissedAt`). All
  * three default to NULL — `getState` synthesises the version-2 default
  * payload until the user makes their first choice.
+ *
+ * Audit item A53 — the "What do you do" answers (`state.profile`) are
+ * ALSO mirrored onto `organization_onboarding_profiles` whenever the
+ * request resolves an organization scope, so the answers are visible to
+ * the whole organization instead of being trapped on one user row. The
+ * user blob stays the source of truth for the wizard UI; the org row is
+ * a read model surfaced back as `organizationProfile`.
  */
 @Injectable()
 export class OnboardingStateService {
     private readonly logger = new Logger(OnboardingStateService.name);
 
-    constructor(private readonly userRepository: UserRepository) {}
+    constructor(
+        private readonly userRepository: UserRepository,
+        // Both @Optional(): the org mirror is a best-effort enrichment, and
+        // keeping them optional lets unit specs construct the service with
+        // just the user repository (and keeps non-HTTP callers — CLI,
+        // workers — working outside any request scope).
+        @Optional() private readonly scopeContext?: ScopeContextService,
+        @Optional()
+        private readonly orgProfileRepository?: OrganizationOnboardingProfileRepository,
+    ) {}
 
     async getState(userId: string): Promise<OnboardingStateResponse> {
         const user = await this.userRepository.findById(userId);
@@ -37,6 +61,7 @@ export class OnboardingStateService {
                 ? user.onboardingDismissedAt.toISOString()
                 : null,
             state: normaliseState(user.onboardingState),
+            organizationProfile: await this.readOrganizationProfile(),
         };
     }
 
@@ -52,7 +77,11 @@ export class OnboardingStateService {
         const current = normaliseState(user.onboardingState);
         const next = mergeState(current, patch.state ?? {});
 
-        // Idempotent: skip the write if nothing actually changed.
+        // Idempotent: skip the USER write if nothing actually changed. The
+        // org mirror still runs when the patch carried a profile — another
+        // member may have overwritten the org row since, and this request
+        // is an explicit re-statement of this user's answers (last writer
+        // inside the organization wins).
         if (deepEqual(current, next)) {
             return {
                 completedAt: user.onboardingCompletedAt
@@ -62,12 +91,22 @@ export class OnboardingStateService {
                     ? user.onboardingDismissedAt.toISOString()
                     : null,
                 state: current,
+                organizationProfile: patch.state?.profile
+                    ? await this.mirrorOrganizationProfile(userId, current.profile)
+                    : await this.readOrganizationProfile(),
             };
         }
 
         const updated = await this.userRepository.update(userId, {
             onboardingState: next,
         });
+
+        // A53 — mirror the answers at org level. Only when the patch
+        // actually carried a `profile` (an unrelated step transition must
+        // not re-stamp the org row) and only inside a resolved org scope.
+        const organizationProfile = patch.state?.profile
+            ? await this.mirrorOrganizationProfile(userId, next.profile)
+            : await this.readOrganizationProfile();
 
         return {
             completedAt: updated?.onboardingCompletedAt
@@ -77,7 +116,78 @@ export class OnboardingStateService {
                 ? updated.onboardingDismissedAt.toISOString()
                 : null,
             state: next,
+            organizationProfile,
         };
+    }
+
+    // ─── Organization-scoped mirror (A53) ───────────────────────────────
+
+    /**
+     * Resolve the organization the current request runs in, or `null`
+     * when there is none (no scope service wired, called outside a
+     * request, or a user who has not created an Organization yet).
+     */
+    private currentOrganizationId(): string | null {
+        if (!this.scopeContext || !this.orgProfileRepository) return null;
+        return this.scopeContext.getOrganizationId();
+    }
+
+    /** Read the org-level profile for the active scope; `null` when absent. */
+    private async readOrganizationProfile(): Promise<OnboardingProfile | null> {
+        const organizationId = this.currentOrganizationId();
+        if (!organizationId) return null;
+        try {
+            const row = await this.orgProfileRepository!.findByOrg(organizationId);
+            if (!row) return null;
+            return (
+                normaliseProfile({
+                    roles: row.roles ?? undefined,
+                    teamSize: row.teamSize ?? undefined,
+                }) ?? null
+            );
+        } catch (error) {
+            // Best-effort enrichment — a read failure must never turn a
+            // successful onboarding save into a 500.
+            this.logger.warn(
+                `Failed to read organization onboarding profile for ${organizationId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Persist the merged profile onto the active organization. Values are
+     * already id-validated by `OnboardingStatePatchInnerDto` and merged by
+     * `mergeProfile`, so the row simply follows the user's latest answers.
+     */
+    private async mirrorOrganizationProfile(
+        userId: string,
+        profile: OnboardingProfile | undefined,
+    ): Promise<OnboardingProfile | null> {
+        const organizationId = this.currentOrganizationId();
+        if (!organizationId) return null;
+        try {
+            const row = await this.orgProfileRepository!.upsert(organizationId, {
+                roles: profile?.roles ? [...profile.roles] : null,
+                teamSize: profile?.teamSize ?? null,
+                updatedByUserId: userId,
+            });
+            return (
+                normaliseProfile({
+                    roles: row.roles ?? undefined,
+                    teamSize: row.teamSize ?? undefined,
+                }) ?? null
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Failed to persist organization onboarding profile for ${organizationId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
     }
 
     async markCompleted(userId: string): Promise<OnboardingStateResponse> {
@@ -104,6 +214,7 @@ export class OnboardingStateService {
                 ? updated.onboardingDismissedAt.toISOString()
                 : null,
             state: normaliseState(updated?.onboardingState),
+            organizationProfile: await this.readOrganizationProfile(),
         };
     }
 
@@ -128,6 +239,7 @@ export class OnboardingStateService {
                 : null,
             dismissedAt: now.toISOString(),
             state: normaliseState(updated?.onboardingState),
+            organizationProfile: await this.readOrganizationProfile(),
         };
     }
 }

--- a/apps/web/e2e/onboarding-communication-connect.spec.ts
+++ b/apps/web/e2e/onboarding-communication-connect.spec.ts
@@ -1,0 +1,253 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, apiUrl, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { createOrganizationViaAPI } from './helpers/organizations';
+
+/**
+ * Onboarding — Communication step connects IN PLACE + the wizard's
+ * "What do you do" answers persist at ORGANIZATION level.
+ *
+ * Audit items (b) and A53.
+ *
+ * (b) The Slack card used to be a link OUT to `/plugins/slack-connector`,
+ *     which threw the user out of the wizard mid-flow. It now expands an
+ *     inline panel carrying the connector's own settings form plus an
+ *     Enable action wired to the existing `enablePlugin` server action.
+ *
+ * A53 `PATCH /api/onboarding/state { state: { profile } }` now mirrors the
+ *     answers onto `organization_onboarding_profiles` for the request's
+ *     resolved organization scope and echoes them back as
+ *     `organizationProfile`.
+ *
+ * Environment-adaptive by design (house rule): `slack-connector` ships
+ * with `distribution: "registry"`, so a given image may or may not have
+ * it loaded. The UI test asserts the in-place panel when the connector is
+ * present and the (still-supported) settings link when it is not — what
+ * it never tolerates is a navigation away from the wizard.
+ */
+
+const SLACK_PLUGIN_ID = 'slack-connector';
+const DISCORD_PLUGIN_ID = 'discord-connector';
+
+interface CatalogResponse {
+    plugins: Array<{ pluginId: string }>;
+}
+
+interface StateResponse {
+    completedAt: string | null;
+    dismissedAt: string | null;
+    state: { profile?: { roles?: string[]; teamSize?: string } };
+    organizationProfile?: { roles?: string[]; teamSize?: string } | null;
+}
+
+async function getState(
+    request: APIRequestContext,
+    token: string,
+    scopeSlug?: string,
+): Promise<StateResponse> {
+    const headers: Record<string, string> = { ...authedHeaders(token) };
+    if (scopeSlug) headers['X-Scope-Slug'] = scopeSlug;
+    const res = await request.get(apiUrl('/api/onboarding/state'), { headers });
+    expect(res.status(), `GET state body=${await res.text().catch(() => '')}`).toBe(200);
+    return res.json();
+}
+
+async function patchProfile(
+    request: APIRequestContext,
+    token: string,
+    profile: { roles?: string[]; teamSize?: string },
+    scopeSlug?: string,
+): Promise<StateResponse> {
+    const headers: Record<string, string> = { ...authedHeaders(token) };
+    if (scopeSlug) headers['X-Scope-Slug'] = scopeSlug;
+    const res = await request.patch(apiUrl('/api/onboarding/state'), {
+        headers,
+        data: { state: { profile } },
+    });
+    expect(res.status(), `PATCH state body=${await res.text().catch(() => '')}`).toBe(200);
+    return res.json();
+}
+
+test.describe('Onboarding — Communication step connects in place (audit item b)', () => {
+    let token: string;
+
+    test.beforeAll(async ({ playwright }) => {
+        const ctx = await playwright.request.newContext();
+        try {
+            const user = await registerUserViaAPI(ctx, {});
+            token = user.access_token;
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('the connectors owned by the Communication step are not ALSO offered as generic plugin cards', async ({
+        request,
+    }) => {
+        const res = await request.get(apiUrl('/api/onboarding/catalog'), {
+            headers: authedHeaders(token),
+        });
+        expect(res.status()).toBe(200);
+        const catalog = (await res.json()) as CatalogResponse;
+
+        const ids = (catalog.plugins ?? []).map((p) => p.pluginId);
+        expect(ids).not.toContain(SLACK_PLUGIN_ID);
+        expect(ids).not.toContain(DISCORD_PLUGIN_ID);
+    });
+
+    test('UI: the Slack card connects inside the wizard instead of navigating to Settings', async ({
+        page,
+    }) => {
+        // The standalone /onboarding route force-opens the wizard for an
+        // authenticated user (onboarding-page-client.tsx), which is far more
+        // deterministic than the dashboard's auto-open heuristics.
+        await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText('Get started with Ever Works')).toBeVisible({
+            timeout: 45_000,
+        });
+
+        // Jump to the Communication step via its SideNav entry. Retry-to-open
+        // rides out the dev-mode hydration race (the first click can land
+        // before the dialog is interactive).
+        const communicationNav = page.getByRole('button', { name: 'Communication' });
+        const connectAction = page.getByTestId('onboarding-communication-connect-slack');
+        await expect(async () => {
+            await communicationNav.click();
+            await expect(connectAction).toBeVisible({ timeout: 3_000 });
+        }).toPass({ timeout: 45_000 });
+
+        // The Discord coming-soon chip still renders — the step is additive.
+        await expect(page.getByTestId('onboarding-communication-discord-soon')).toBeVisible();
+
+        const urlBefore = page.url();
+        const isInPlace = (await connectAction.evaluate((el) => el.tagName)) === 'BUTTON';
+
+        if (isInPlace) {
+            // Connector present in this image → connect WITHOUT leaving the wizard.
+            await expect(connectAction).toHaveAttribute('aria-expanded', 'false');
+            await connectAction.click();
+
+            const panel = page.getByTestId('onboarding-communication-slack-panel');
+            await expect(panel).toBeVisible({ timeout: 15_000 });
+            // The enable affordance lives inside the panel (or the "already
+            // connected" badge when the plugin is enabled for this user).
+            await expect(
+                page
+                    .getByTestId('onboarding-communication-slack-enable')
+                    .or(page.getByTestId('onboarding-communication-slack-enabled'))
+                    .first(),
+            ).toBeVisible({ timeout: 15_000 });
+            // The advanced-settings escape hatch is kept, as a secondary link.
+            await expect(
+                page.getByTestId('onboarding-communication-slack-settings-link'),
+            ).toHaveAttribute('href', new RegExp(`/plugins/${SLACK_PLUGIN_ID}$`));
+
+            // Collapsing puts the card back — still no navigation.
+            await connectAction.click();
+            await expect(panel).toBeHidden({ timeout: 10_000 });
+        } else {
+            // Connector absent (registry-distributed) → the pre-existing
+            // degraded path: a link to the plugin's settings page.
+            await expect(connectAction).toHaveAttribute(
+                'href',
+                new RegExp(`/plugins/${SLACK_PLUGIN_ID}$`),
+            );
+        }
+
+        // Either way the wizard stayed put: no step ever navigates the browser.
+        expect(page.url()).toBe(urlBefore);
+        await expect(page.getByText('Get started with Ever Works')).toBeVisible();
+    });
+});
+
+test.describe('Onboarding profile persists at organization level (A53)', () => {
+    test('PATCH mirrors the answers onto the request-scoped organization', async ({ request }) => {
+        const user = await registerUserViaAPI(request, {});
+        const org = await createOrganizationViaAPI(
+            request,
+            user.access_token,
+            `Comms Org ${Date.now().toString(36)}`,
+        );
+
+        const patched = await patchProfile(
+            request,
+            user.access_token,
+            { roles: ['marketing', 'sales'], teamSize: 'small-2-10' },
+            org.slug,
+        );
+
+        // Per-user answers still persist (unchanged behaviour) …
+        expect(patched.state.profile).toEqual({
+            roles: ['marketing', 'sales'],
+            teamSize: 'small-2-10',
+        });
+        // … and are now ALSO readable at organization level.
+        expect(patched.organizationProfile).toEqual({
+            roles: ['marketing', 'sales'],
+            teamSize: 'small-2-10',
+        });
+
+        const reread = await getState(request, user.access_token, org.slug);
+        expect(reread.organizationProfile).toEqual({
+            roles: ['marketing', 'sales'],
+            teamSize: 'small-2-10',
+        });
+    });
+
+    test('a roles-only patch keeps the organization team size (field-level merge)', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request, {});
+        const org = await createOrganizationViaAPI(
+            request,
+            user.access_token,
+            `Comms Org ${Date.now().toString(36)}b`,
+        );
+
+        await patchProfile(
+            request,
+            user.access_token,
+            { roles: ['product'], teamSize: 'mid-11-50' },
+            org.slug,
+        );
+        const second = await patchProfile(
+            request,
+            user.access_token,
+            { roles: ['engineering'] },
+            org.slug,
+        );
+
+        expect(second.organizationProfile).toEqual({
+            roles: ['engineering'],
+            teamSize: 'mid-11-50',
+        });
+    });
+
+    test('unknown role ids are still rejected with a 400 (org write must not widen the contract)', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request, {});
+        const org = await createOrganizationViaAPI(
+            request,
+            user.access_token,
+            `Comms Org ${Date.now().toString(36)}c`,
+        );
+
+        const res = await request.patch(`${API_BASE}/api/onboarding/state`, {
+            headers: { ...authedHeaders(user.access_token), 'X-Scope-Slug': org.slug },
+            data: { state: { profile: { roles: ['astronaut'] } } },
+        });
+        expect(res.status()).toBe(400);
+    });
+
+    test('a user with no organization gets a null organizationProfile', async ({ request }) => {
+        const user = await registerUserViaAPI(request, {});
+
+        const patched = await patchProfile(request, user.access_token, {
+            roles: ['founder-ceo'],
+            teamSize: 'solo',
+        });
+
+        expect(patched.state.profile).toEqual({ roles: ['founder-ceo'], teamSize: 'solo' });
+        expect(patched.organizationProfile ?? null).toBeNull();
+    });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -272,7 +272,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -14,7 +14,7 @@ import { ChoiceStep } from './steps/ChoiceStep';
 import { ConfigStep } from './steps/ConfigStep';
 import { PluginsCatalogStep } from './steps/PluginsCatalogStep';
 import { ProfileStep } from './steps/ProfileStep';
-import { CommunicationStep } from './steps/CommunicationStep';
+import { CommunicationStep, SLACK_CONNECTOR_PLUGIN_ID } from './steps/CommunicationStep';
 import { CreateWorkStep } from './steps/CreateWorkStep';
 import { useTurnstile } from './use-turnstile';
 import { AI_ICONS, DB_ICONS, DEPLOY_ICONS, STORAGE_ICONS } from './brand-icons';
@@ -240,6 +240,7 @@ export function EverWorksOnboardingWizard({
                                 isStatusLoading={isStatusLoading}
                                 turnstile={turnstile}
                                 correlationId={correlationId}
+                                onPluginConnected={(pluginId) => void refreshConnections(pluginId)}
                             />
                         </div>
                         <WizardFooter
@@ -372,6 +373,7 @@ function StepBody({
     isStatusLoading,
     turnstile,
     correlationId,
+    onPluginConnected,
 }: {
     step: WizardStep;
     flow: ReturnType<typeof useOnboardingFlow>;
@@ -382,6 +384,7 @@ function StepBody({
     isStatusLoading: boolean;
     turnstile: ReturnType<typeof useTurnstile>;
     correlationId: string;
+    onPluginConnected: (pluginId: string) => void;
 }) {
     switch (step.kind) {
         case 'welcome':
@@ -508,7 +511,18 @@ function StepBody({
                 />
             );
         case 'communication':
-            return <CommunicationStep />;
+            // Audit item (b) — connect in place. The connector plugin is
+            // passed in so the card can render its settings panel + enable
+            // action inline; when the image ships without it the step
+            // degrades to the Settings → Plugins link it used to be.
+            return (
+                <CommunicationStep
+                    slackPlugin={pluginsById[SLACK_CONNECTOR_PLUGIN_ID] ?? null}
+                    slackConnection={connections[SLACK_CONNECTOR_PLUGIN_ID] ?? null}
+                    isStatusLoading={isStatusLoading}
+                    onConnected={onPluginConnected}
+                />
+            );
         case 'plugins-catalog':
             return (
                 <PluginsCatalogStep

--- a/apps/web/src/components/onboarding/steps/CommunicationStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CommunicationStep.tsx
@@ -1,12 +1,24 @@
 'use client';
 
+import { useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, Check, ChevronDown, ExternalLink } from 'lucide-react';
+import { toast } from 'sonner';
 import { Link } from '@/i18n/navigation';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import { enablePlugin } from '@/app/actions/plugins';
+import { OnboardingPluginStep } from '../OnboardingPluginStep';
+import type { UserPlugin } from '@/lib/api/plugins';
+import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
+import type { GitProviderConnectionInfo } from '@/lib/api/plugins-capabilities/git-providers';
 
 const ICON_CLASS = 'h-5 w-5';
+
+/** Plugin id backing the Slack card. Mirrors the ids the wizard already
+ *  hard-codes for the GitHub / Postgres steps. */
+export const SLACK_CONNECTOR_PLUGIN_ID = 'slack-connector';
 
 /** Monochrome Slack mark (four lozenges), rendered at currentColor. */
 function SlackMark() {
@@ -38,16 +50,48 @@ function DiscordMark() {
     );
 }
 
+export interface CommunicationStepProps {
+    /**
+     * The `slack-connector` plugin as returned by `GET /api/plugins`, when
+     * it is installed in this environment. Present ⇒ the card connects in
+     * place; absent ⇒ the card falls back to the Settings → Plugins link
+     * (self-hosted images that ship without the connector).
+     */
+    readonly slackPlugin?: UserPlugin | null;
+    readonly slackConnection?: OAuthConnectionInfo | GitProviderConnectionInfo | null;
+    readonly isStatusLoading?: boolean;
+    /** Fired after a successful enable so the wizard can refresh statuses. */
+    readonly onConnected?: (pluginId: string) => void;
+}
+
 /**
  * "Communication" step (Wave 6, feature b) — connect the chat
- * workspaces the org lives in. The Slack card links to the
- * slack-connector plugin settings page (bot token + signing secret +
- * default channel), where the platform-side Slack app wiring lives;
- * Discord shows a coming-soon chip. The step is additive and always
- * skippable via the wizard footer.
+ * workspaces the org lives in.
+ *
+ * Audit item (b): the Slack card used to be a link OUT to
+ * `/plugins/slack-connector`, which dropped the user out of the wizard
+ * mid-flow. It now connects IN PLACE: expanding the card renders the
+ * connector's own settings panel (`OnboardingPluginStep` — the exact
+ * component every other config step uses, so the bot token / signing
+ * secret / default channel fields and their save+validate round-trip are
+ * unchanged) plus an Enable action wired to the existing
+ * `enablePlugin` server action.
+ *
+ * The link to the full plugin settings page is kept as a secondary
+ * affordance — additive, not a replacement.
+ *
+ * Discord shows a coming-soon chip. The step is always skippable via the
+ * wizard footer.
  */
-export function CommunicationStep() {
+export function CommunicationStep({
+    slackPlugin,
+    slackConnection,
+    isStatusLoading,
+    onConnected,
+}: CommunicationStepProps = {}) {
     const t = useTranslations('onboarding.communicationStep');
+    const [expanded, setExpanded] = useState(false);
+    const canConnectInPlace = Boolean(slackPlugin);
 
     return (
         <div className="space-y-5 max-w-3xl">
@@ -61,7 +105,14 @@ export function CommunicationStep() {
             </header>
 
             <div className="space-y-2">
-                <div className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark hover:border-border-secondary dark:hover:border-white/15 transition-all">
+                <div
+                    className={cn(
+                        'rounded-lg border bg-surface dark:bg-surface-dark transition-all',
+                        expanded
+                            ? 'border-primary/40 shadow-sm'
+                            : 'border-border dark:border-border-dark hover:border-border-secondary dark:hover:border-white/15',
+                    )}
+                >
                     <div className="flex items-start gap-3 p-3">
                         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-secondary dark:bg-white/5 text-text dark:text-text-dark">
                             <SlackMark />
@@ -71,21 +122,53 @@ export function CommunicationStep() {
                                 <p className="text-sm font-semibold text-text dark:text-text-dark truncate">
                                     {t('slack.name')}
                                 </p>
-                                <Button size="sm" variant="secondary" asChild>
-                                    <Link
-                                        href={`${ROUTES.DASHBOARD_PLUGINS}/slack-connector`}
+                                {canConnectInPlace ? (
+                                    <Button
+                                        size="sm"
+                                        variant={expanded ? 'ghost' : 'secondary'}
+                                        aria-expanded={expanded}
                                         data-testid="onboarding-communication-connect-slack"
+                                        onClick={() => setExpanded((open) => !open)}
                                     >
-                                        {t('slack.action')}
-                                        <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
-                                    </Link>
-                                </Button>
+                                        {expanded ? t('slack.close') : t('slack.action')}
+                                        <ChevronDown
+                                            className={cn(
+                                                'ml-1.5 h-3.5 w-3.5 transition-transform',
+                                                expanded && 'rotate-180',
+                                            )}
+                                        />
+                                    </Button>
+                                ) : (
+                                    <Button size="sm" variant="secondary" asChild>
+                                        <Link
+                                            href={`${ROUTES.DASHBOARD_PLUGINS}/${SLACK_CONNECTOR_PLUGIN_ID}`}
+                                            data-testid="onboarding-communication-connect-slack"
+                                        >
+                                            {t('slack.action')}
+                                            <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+                                        </Link>
+                                    </Button>
+                                )}
                             </div>
                             <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark leading-relaxed">
                                 {t('slack.description')}
                             </p>
                         </div>
                     </div>
+
+                    {expanded && slackPlugin ? (
+                        <div
+                            className="border-t border-border dark:border-border-dark px-4 py-3 space-y-4"
+                            data-testid="onboarding-communication-slack-panel"
+                        >
+                            <OnboardingPluginStep
+                                plugin={slackPlugin}
+                                connection={slackConnection}
+                                isStatusLoading={isStatusLoading}
+                            />
+                            <SlackEnableRow plugin={slackPlugin} onConnected={onConnected} />
+                        </div>
+                    ) : null}
                 </div>
 
                 <div className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark opacity-80">
@@ -114,6 +197,79 @@ export function CommunicationStep() {
             </div>
 
             <p className="text-xs text-text-muted dark:text-text-muted-dark">{t('skipHint')}</p>
+        </div>
+    );
+}
+
+// ─── In-place enable ────────────────────────────────────────────────────────
+
+/**
+ * Enable row for the expanded Slack card. Saving credentials
+ * (`OnboardingPluginStep`) and enabling the plugin are two distinct
+ * server operations in this codebase, so both are offered here rather
+ * than being conflated: the user pastes the bot token, saves, then flips
+ * the connector on without leaving the wizard.
+ *
+ * The Settings → Plugins link is kept as a secondary escape hatch for
+ * everything the compact panel doesn't cover (per-Work overrides,
+ * disable, advanced fields).
+ */
+function SlackEnableRow({
+    plugin,
+    onConnected,
+}: {
+    readonly plugin: UserPlugin;
+    readonly onConnected?: (pluginId: string) => void;
+}) {
+    const t = useTranslations('onboarding.communicationStep');
+    const [enabled, setEnabled] = useState(Boolean(plugin.enabled));
+    const [isEnabling, setIsEnabling] = useState(false);
+
+    const handleEnable = useCallback(async () => {
+        setIsEnabling(true);
+        try {
+            const result = await enablePlugin(plugin.pluginId);
+            if (result.success) {
+                setEnabled(true);
+                toast.success(t('slack.enabledToast'));
+                onConnected?.(plugin.pluginId);
+            } else {
+                toast.error(result.error ?? t('slack.enableFailed'));
+            }
+        } finally {
+            setIsEnabling(false);
+        }
+    }, [onConnected, plugin.pluginId, t]);
+
+    return (
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border dark:border-border-dark pt-3">
+            {enabled ? (
+                <span
+                    className="inline-flex items-center gap-1.5 text-sm text-success"
+                    data-testid="onboarding-communication-slack-enabled"
+                >
+                    <Check className="h-4 w-4" />
+                    {t('slack.enabled')}
+                </span>
+            ) : (
+                <Button
+                    size="sm"
+                    loading={isEnabling}
+                    data-testid="onboarding-communication-slack-enable"
+                    onClick={() => void handleEnable()}
+                >
+                    {t('slack.enable')}
+                </Button>
+            )}
+
+            <Link
+                href={`${ROUTES.DASHBOARD_PLUGINS}/${plugin.pluginId}`}
+                data-testid="onboarding-communication-slack-settings-link"
+                className="inline-flex items-center gap-1 text-xs text-text-muted dark:text-text-muted-dark underline hover:text-primary"
+            >
+                {t('slack.advancedSettings')}
+                <ExternalLink className="h-3 w-3" />
+            </Link>
         </div>
     );
 }

--- a/apps/web/src/components/onboarding/steps/CommunicationStep.unit.spec.tsx
+++ b/apps/web/src/components/onboarding/steps/CommunicationStep.unit.spec.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & Record<string, unknown>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const enablePlugin = vi.fn();
+vi.mock('@/app/actions/plugins', () => ({
+    enablePlugin: (...args: unknown[]) => enablePlugin(...args),
+}));
+
+// `OnboardingPluginStep` pulls in the whole plugin-settings stack
+// (server actions, hooks). The step under test only has to RENDER it in
+// place — the settings round-trip has its own coverage — so stub it with
+// a marker element.
+vi.mock('../OnboardingPluginStep', () => ({
+    OnboardingPluginStep: ({ plugin }: { plugin: { pluginId: string } }) => (
+        <div data-testid="stub-plugin-settings">settings:{plugin.pluginId}</div>
+    ),
+}));
+
+import { CommunicationStep, SLACK_CONNECTOR_PLUGIN_ID } from './CommunicationStep';
+import type { UserPlugin } from '@/lib/api/plugins';
+
+function slackPlugin(overrides: Partial<UserPlugin> = {}): UserPlugin {
+    return {
+        pluginId: SLACK_CONNECTOR_PLUGIN_ID,
+        name: 'Slack Connector',
+        category: 'connector',
+        capabilities: ['connector', 'connector-slack'],
+        installed: true,
+        enabled: false,
+        ...overrides,
+    } as unknown as UserPlugin;
+}
+
+describe('CommunicationStep', () => {
+    beforeEach(() => {
+        enablePlugin.mockReset();
+        enablePlugin.mockResolvedValue({ success: true });
+    });
+
+    it('falls back to the Settings link when the connector is not installed', () => {
+        render(<CommunicationStep />);
+        const action = screen.getByTestId('onboarding-communication-connect-slack');
+        // A link OUT — the pre-existing degraded path, kept for images
+        // that ship without the connector.
+        expect(action.tagName).toBe('A');
+        expect(action).toHaveAttribute('href', `/plugins/${SLACK_CONNECTOR_PLUGIN_ID}`);
+        expect(screen.queryByTestId('onboarding-communication-slack-panel')).toBeNull();
+    });
+
+    it('connects IN PLACE (no navigation) when the connector is installed', async () => {
+        render(<CommunicationStep slackPlugin={slackPlugin()} />);
+
+        const action = screen.getByTestId('onboarding-communication-connect-slack');
+        // A button, not an anchor — the user never leaves the wizard.
+        expect(action.tagName).toBe('BUTTON');
+        expect(action).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByTestId('onboarding-communication-slack-panel')).toBeNull();
+
+        await userEvent.click(action);
+
+        const panel = screen.getByTestId('onboarding-communication-slack-panel');
+        expect(panel).toBeInTheDocument();
+        // The connector's own settings panel renders inline.
+        expect(screen.getByTestId('stub-plugin-settings')).toHaveTextContent(
+            `settings:${SLACK_CONNECTOR_PLUGIN_ID}`,
+        );
+        expect(screen.getByTestId('onboarding-communication-connect-slack')).toHaveAttribute(
+            'aria-expanded',
+            'true',
+        );
+    });
+
+    it('collapses the panel again on a second click', async () => {
+        render(<CommunicationStep slackPlugin={slackPlugin()} />);
+        const action = screen.getByTestId('onboarding-communication-connect-slack');
+        await userEvent.click(action);
+        expect(screen.getByTestId('onboarding-communication-slack-panel')).toBeInTheDocument();
+        await userEvent.click(screen.getByTestId('onboarding-communication-connect-slack'));
+        expect(screen.queryByTestId('onboarding-communication-slack-panel')).toBeNull();
+    });
+
+    it('enables the connector through the existing enablePlugin flow', async () => {
+        const onConnected = vi.fn();
+        render(<CommunicationStep slackPlugin={slackPlugin()} onConnected={onConnected} />);
+
+        await userEvent.click(screen.getByTestId('onboarding-communication-connect-slack'));
+        await userEvent.click(screen.getByTestId('onboarding-communication-slack-enable'));
+
+        expect(enablePlugin).toHaveBeenCalledWith(SLACK_CONNECTOR_PLUGIN_ID);
+        await waitFor(() => {
+            expect(
+                screen.getByTestId('onboarding-communication-slack-enabled'),
+            ).toBeInTheDocument();
+        });
+        expect(onConnected).toHaveBeenCalledWith(SLACK_CONNECTOR_PLUGIN_ID);
+        expect(screen.queryByTestId('onboarding-communication-slack-enable')).toBeNull();
+    });
+
+    it('keeps the Enable action available when the server rejects the enable', async () => {
+        enablePlugin.mockResolvedValue({ success: false, error: 'nope' });
+        const onConnected = vi.fn();
+        render(<CommunicationStep slackPlugin={slackPlugin()} onConnected={onConnected} />);
+
+        await userEvent.click(screen.getByTestId('onboarding-communication-connect-slack'));
+        await userEvent.click(screen.getByTestId('onboarding-communication-slack-enable'));
+
+        await waitFor(() => expect(enablePlugin).toHaveBeenCalledTimes(1));
+        expect(onConnected).not.toHaveBeenCalled();
+        expect(screen.getByTestId('onboarding-communication-slack-enable')).toBeInTheDocument();
+        expect(screen.queryByTestId('onboarding-communication-slack-enabled')).toBeNull();
+    });
+
+    it('shows the connected state up-front for an already-enabled connector', async () => {
+        render(<CommunicationStep slackPlugin={slackPlugin({ enabled: true })} />);
+        await userEvent.click(screen.getByTestId('onboarding-communication-connect-slack'));
+        expect(screen.getByTestId('onboarding-communication-slack-enabled')).toBeInTheDocument();
+        expect(screen.queryByTestId('onboarding-communication-slack-enable')).toBeNull();
+    });
+
+    it('keeps the advanced-settings escape hatch and the Discord coming-soon chip', async () => {
+        render(<CommunicationStep slackPlugin={slackPlugin()} />);
+        expect(screen.getByTestId('onboarding-communication-discord-soon')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByTestId('onboarding-communication-connect-slack'));
+        expect(screen.getByTestId('onboarding-communication-slack-settings-link')).toHaveAttribute(
+            'href',
+            `/plugins/${SLACK_CONNECTOR_PLUGIN_ID}`,
+        );
+    });
+});

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -110,6 +110,7 @@ import { UserNotificationSubscription } from '../entities/user-notification-subs
 import { UserNotificationPreference } from '../entities/user-notification-preference.entity';
 import { UserNotificationCategoryMute } from '../entities/user-notification-category-mute.entity';
 import { OrganizationNotificationDefault } from '../entities/organization-notification-default.entity';
+import { OrganizationOnboardingProfile } from '../entities/organization-onboarding-profile.entity';
 import { ComposioTriggerSubscription } from '../entities/composio-trigger-subscription.entity';
 import { TenantJobRuntimeConfig } from '../entities/tenant-job-runtime-config.entity';
 import { TenantJobRuntimeAudit } from '../entities/tenant-job-runtime-audit.entity';
@@ -260,6 +261,8 @@ export const ENTITIES = [
     UserNotificationPreference,
     UserNotificationCategoryMute,
     OrganizationNotificationDefault,
+    // Onboarding "What do you do" answers, mirrored at org level (A53)
+    OrganizationOnboardingProfile,
     // Tenant-scoped job-runtime overlay (EW-742 P1)
     TenantJobRuntimeConfig,
     TenantJobRuntimeAudit,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -107,6 +107,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'OnboardingRequest',
     'Organization',
     'OrganizationNotificationDefault',
+    'OrganizationOnboardingProfile',
     // Plan entitlements (pricing Wave 9 M1)
     'PlanEntitlement',
     'PluginUsageEvent',

--- a/packages/agent/src/database/_repository-inventory.ts
+++ b/packages/agent/src/database/_repository-inventory.ts
@@ -49,6 +49,7 @@ import { NotificationEventTypeRepository } from './repositories/notification-eve
 import { NotificationRepository } from './repositories/notification.repository';
 import { OnboardingRequestRepository } from './repositories/onboarding-request.repository';
 import { OrganizationNotificationDefaultRepository } from './repositories/organization-notification-default.repository';
+import { OrganizationOnboardingProfileRepository } from './repositories/organization-onboarding-profile.repository';
 import { OrganizationRepository } from './repositories/organization.repository';
 import { PlanEntitlementRepository } from './repositories/plan-entitlement.repository';
 import { PluginUsageRepository } from './repositories/plugin-usage.repository';
@@ -99,6 +100,7 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     NotificationRepository,
     OnboardingRequestRepository,
     OrganizationNotificationDefaultRepository,
+    OrganizationOnboardingProfileRepository,
     OrganizationRepository,
     PlanEntitlementRepository,
     PluginUsageRepository,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -74,4 +74,5 @@ export * from './repositories/user-notification-subscription.repository';
 export * from './repositories/user-notification-preference.repository';
 export * from './repositories/user-notification-category-mute.repository';
 export * from './repositories/organization-notification-default.repository';
+export * from './repositories/organization-onboarding-profile.repository';
 export * from './database-init.service';

--- a/packages/agent/src/database/repositories/organization-onboarding-profile.repository.spec.ts
+++ b/packages/agent/src/database/repositories/organization-onboarding-profile.repository.spec.ts
@@ -1,0 +1,126 @@
+import { OrganizationOnboardingProfileRepository } from './organization-onboarding-profile.repository';
+
+/**
+ * Audit item A53 — the org-level mirror of the onboarding wizard's
+ * "What do you do" answers.
+ *
+ * The behaviour worth pinning is `upsert`'s FIELD-LEVEL merge: the
+ * wizard sends roles-only or team-size-only patches all the time, so an
+ * omitted field must leave the persisted value alone while an explicit
+ * `null` clears it. Getting that wrong silently wipes a previously
+ * answered team size the first time somebody re-picks their roles.
+ */
+
+interface Harness {
+    repository: OrganizationOnboardingProfileRepository;
+    repo: {
+        findOne: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+        update: jest.Mock;
+    };
+}
+
+function makeHarness(existing?: Record<string, unknown> | null): Harness {
+    let row: Record<string, unknown> | null = existing ?? null;
+    const repo = {
+        findOne: jest.fn(async () => row),
+        create: jest.fn((value: Record<string, unknown>) => value),
+        save: jest.fn(async (value: Record<string, unknown>) => {
+            row = { ...value };
+            return row;
+        }),
+        update: jest.fn(async (_where: unknown, patch: Record<string, unknown>) => {
+            row = { ...(row ?? {}), ...patch };
+            return { affected: 1 };
+        }),
+    };
+    return {
+        repository: new OrganizationOnboardingProfileRepository(repo as never),
+        repo,
+    };
+}
+
+describe('OrganizationOnboardingProfileRepository', () => {
+    it('creates the row on the first answer', async () => {
+        const { repository, repo } = makeHarness(null);
+
+        const saved = await repository.upsert('org-1', {
+            roles: ['marketing'],
+            teamSize: 'solo',
+            updatedByUserId: 'u1',
+        });
+
+        expect(repo.create).toHaveBeenCalledWith({
+            organizationId: 'org-1',
+            roles: ['marketing'],
+            teamSize: 'solo',
+            updatedByUserId: 'u1',
+        });
+        expect(repo.save).toHaveBeenCalled();
+        expect(saved).toMatchObject({ organizationId: 'org-1', roles: ['marketing'] });
+    });
+
+    it('updates in place when the organization already has a row', async () => {
+        const { repository, repo } = makeHarness({
+            organizationId: 'org-1',
+            roles: ['sales'],
+            teamSize: 'solo',
+        });
+
+        const saved = await repository.upsert('org-1', { roles: ['engineering'] });
+
+        expect(repo.create).not.toHaveBeenCalled();
+        expect(repo.update).toHaveBeenCalledWith(
+            { organizationId: 'org-1' },
+            { roles: ['engineering'] },
+        );
+        // The omitted `teamSize` survives — field-level merge.
+        expect(saved).toMatchObject({ roles: ['engineering'], teamSize: 'solo' });
+    });
+
+    it('leaves omitted fields untouched (never writes undefined columns)', async () => {
+        const { repository, repo } = makeHarness({ organizationId: 'org-1', teamSize: 'solo' });
+
+        await repository.upsert('org-1', { updatedByUserId: 'u2' });
+
+        expect(repo.update).toHaveBeenCalledWith(
+            { organizationId: 'org-1' },
+            { updatedByUserId: 'u2' },
+        );
+    });
+
+    it('clears a field when an explicit null is passed', async () => {
+        const { repository, repo } = makeHarness({
+            organizationId: 'org-1',
+            roles: ['sales'],
+            teamSize: 'solo',
+        });
+
+        await repository.upsert('org-1', { roles: null, teamSize: null });
+
+        expect(repo.update).toHaveBeenCalledWith(
+            { organizationId: 'org-1' },
+            { roles: null, teamSize: null },
+        );
+    });
+
+    it('copies the incoming roles array instead of storing the caller reference', async () => {
+        const { repository, repo } = makeHarness(null);
+        const roles = ['product'];
+
+        await repository.upsert('org-1', { roles });
+        roles.push('mutated-after-the-call');
+
+        const created = repo.create.mock.calls[0][0] as { roles: string[] };
+        expect(created.roles).toEqual(['product']);
+    });
+
+    it('findByOrg queries by the organization primary key', async () => {
+        const { repository, repo } = makeHarness({ organizationId: 'org-1' });
+
+        await repository.findByOrg('org-1');
+
+        expect(repo.findOne).toHaveBeenCalledWith({ where: { organizationId: 'org-1' } });
+    });
+});

--- a/packages/agent/src/database/repositories/organization-onboarding-profile.repository.ts
+++ b/packages/agent/src/database/repositories/organization-onboarding-profile.repository.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OrganizationOnboardingProfile } from '../../entities/organization-onboarding-profile.entity';
+
+/** Fields a wizard write may set on the org-level onboarding profile. */
+export interface OrganizationOnboardingProfileInput {
+    readonly roles?: readonly string[] | null;
+    readonly teamSize?: string | null;
+    readonly updatedByUserId?: string | null;
+}
+
+/**
+ * Audit item A53 — repository for `organization_onboarding_profiles`.
+ *
+ * Single row per organization, keyed by `organizationId`. Mirrors the
+ * shape of `OrganizationNotificationDefaultRepository` (find + upsert,
+ * no list/delete) because the table has exactly the same access
+ * pattern: read the one row for the active scope, overwrite it on the
+ * next answer.
+ *
+ * `upsert` is field-level: omitting `roles` (or `teamSize`) leaves the
+ * persisted value alone, so a roles-only wizard patch cannot silently
+ * wipe a previously answered team size. Passing an explicit `null`
+ * clears the field.
+ */
+@Injectable()
+export class OrganizationOnboardingProfileRepository {
+    constructor(
+        @InjectRepository(OrganizationOnboardingProfile)
+        private readonly repository: Repository<OrganizationOnboardingProfile>,
+    ) {}
+
+    async findByOrg(organizationId: string): Promise<OrganizationOnboardingProfile | null> {
+        return this.repository.findOne({ where: { organizationId } });
+    }
+
+    async upsert(
+        organizationId: string,
+        input: OrganizationOnboardingProfileInput,
+    ): Promise<OrganizationOnboardingProfile> {
+        const existing = await this.findByOrg(organizationId);
+
+        const patch: Partial<OrganizationOnboardingProfile> = {};
+        if (input.roles !== undefined) {
+            patch.roles = input.roles ? [...input.roles] : null;
+        }
+        if (input.teamSize !== undefined) {
+            patch.teamSize = input.teamSize ?? null;
+        }
+        if (input.updatedByUserId !== undefined) {
+            patch.updatedByUserId = input.updatedByUserId ?? null;
+        }
+
+        if (existing) {
+            await this.repository.update({ organizationId }, patch);
+            return (await this.findByOrg(organizationId)) as OrganizationOnboardingProfile;
+        }
+
+        const created = this.repository.create({ organizationId, ...patch });
+        return this.repository.save(created);
+    }
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -94,6 +94,10 @@ export * from './user-notification-preference.entity';
 export * from './user-notification-category-mute.entity';
 export * from './organization-notification-default.entity';
 
+// Onboarding — organization-scoped mirror of the wizard's "What do you
+// do" answers (audit item A53).
+export * from './organization-onboarding-profile.entity';
+
 // Goals & Metrics (PR-8) — measurable targets + samples + Mission link
 export * from './goal.entity';
 export * from './goal-metric-sample.entity';

--- a/packages/agent/src/entities/organization-onboarding-profile.entity.ts
+++ b/packages/agent/src/entities/organization-onboarding-profile.entity.ts
@@ -1,0 +1,56 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import { Organization } from './organization.entity';
+
+/**
+ * Audit item A53 — organization-scoped mirror of the onboarding wizard's
+ * "What do you do" answers (roles multi-select + team size).
+ *
+ * The wizard already persists these on `users.onboarding_state`, which is
+ * per-user and therefore invisible to anyone else in the same
+ * organization. Suggestion surfaces that reason about the WHOLE team
+ * (agent recommendations, digest tone, seat sizing) need an org-level
+ * answer, so the same payload is mirrored here whenever the PATCH runs
+ * inside a resolved organization scope.
+ *
+ * Shape mirrors `OrganizationNotificationDefault`: PK = `organizationId`,
+ * one row per organization, `ON DELETE CASCADE` from `organizations`.
+ * The user-level blob stays the source of truth for the wizard UI; this
+ * row is the org-wide read model (last writer inside the org wins, and
+ * `updatedByUserId` records who that was).
+ *
+ * Values are validated against `ROLE_OPTIONS` / `TEAM_SIZE_OPTIONS` ids
+ * before they reach this table (drop-if-unrecognised, never defaulted).
+ */
+@Entity({ name: 'organization_onboarding_profiles' })
+export class OrganizationOnboardingProfile {
+    @PrimaryColumn({ type: 'uuid' })
+    organizationId: string;
+
+    /**
+     * No `@ManyToOne`/eager relation is declared beyond this `@OneToOne`
+     * back-pointer — same call as `OrganizationNotificationDefault`, which
+     * keeps the organization/tenant/user import cycle from widening.
+     */
+    @OneToOne(() => Organization, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'organizationId' })
+    organization?: Organization;
+
+    /**
+     * Selected role ids (kebab-case `ROLE_OPTIONS` ids). `simple-json`
+     * maps to `text` on Postgres and better-sqlite3 alike. NULL when the
+     * step was skipped without picking a role.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    roles?: string[] | null;
+
+    /** Selected `TEAM_SIZE_OPTIONS` id, or NULL when never answered. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    teamSize?: string | null;
+
+    /** Last user in this organization whose wizard write produced this row. */
+    @Column({ type: 'uuid', nullable: true })
+    updatedByUserId?: string | null;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/contracts/src/api/onboarding/wizard-state.ts
+++ b/packages/contracts/src/api/onboarding/wizard-state.ts
@@ -105,6 +105,21 @@ export interface OnboardingStateResponse {
 	readonly completedAt: string | null;
 	readonly dismissedAt: string | null;
 	readonly state: OnboardingWizardStateV2;
+	/**
+	 * Audit item A53 — the ORGANIZATION-level mirror of the "What do you
+	 * do" answers, persisted on `organization_onboarding_profiles`.
+	 *
+	 * `state.profile` above stays the per-user answer that drives the
+	 * wizard UI; this field is the org-wide read model (last writer
+	 * inside the organization wins) so team-shaped suggestion surfaces
+	 * can reason about the whole organization rather than one member.
+	 *
+	 * `null` when the request resolved no organization scope (e.g. a
+	 * user who has not created an Organization yet) or when nobody in
+	 * the organization has answered the step. Optional so older clients
+	 * and the web fallback payloads keep type-checking unchanged.
+	 */
+	readonly organizationProfile?: OnboardingProfile | null;
 }
 
 /**

--- a/packages/plugins/slack-connector/package.json
+++ b/packages/plugins/slack-connector/package.json
@@ -90,6 +90,14 @@
 					}
 				}
 			},
+			"uiHints": {
+				"includeInOnboarding": true,
+				"onboardingPriority": 1,
+				"completionFields": [
+					"botToken"
+				],
+				"onboardingDescription": "Connect your Slack workspace so the Ever Works bot can chat, build, and report in-channel."
+			},
 			"distribution": "registry"
 		}
 	},


### PR DESCRIPTION
## Two onboarding gaps (audit item (b) + A53)

### 1. The Communication step linked *out* instead of connecting

A new user was ejected from the wizard to settings to do the one thing the step
asked for — and usually did not come back. It now connects **in place**,
through the existing connector/plugin enable flow. Same path the settings page
drives, not a parallel implementation.

### 2. The org profile was collected and thrown away

The "what do you do" roles + team-size answers had nowhere to go, so nothing
downstream could use them. They now persist on the organization via a new
`OrganizationOnboardingProfile` entity.

Registered in **all three** inventories, which is the failure mode this repo has
hit before (a `forFeature`'d entity missing from the explicit array throws
`EntityMetadataNotFoundError` on every query, in production too):

| Inventory | Purpose |
|---|---|
| `_entities-inventory.ts` | the explicit `ENTITIES` array TypeORM boots from |
| `_entity-names.ts` | the name map |
| `_repository-inventory.ts` | the repository registration |

Shipped with its migration in the same change, per the repo rule. The entity's
`@UpdateDateColumn()` is the established portable pattern — not the explicit
`timestamp` spelling the `portable-date-columns` guard forbids.

## Migration

Renumbered `1784700000000` → **`1784750000000`**, since `1784700000000` is now
taken by the merged `AddUserSubscriptionProviderRef` (#1900).

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 445 suites, 8106 tests |
| `apps/api` jest | green — 230 suites, 3769 tests |
| `apps/web` tsc --noEmit | green |
| `pnpm build --filter=ever-works-web` | green |
| prettier | clean |

### Two environment faults fixed to get a trustworthy signal

Neither was a defect in this change, but both are recorded because each
initially *looked* like a real bug class:

1. **11 suites failed at DataSource init** — the signature of an unregistered
   entity or a non-portable date column, exactly what this branch risks. Actual
   cause: `better-sqlite3`'s native binding was never compiled in this worktree
   (pnpm blocks postinstall scripts). The stack terminates in `bindings.js`,
   *before* TypeORM reads metadata; a genuine entity fault names the entity, a
   column fault names the column. Neither did. Confirmed by diffing against the
   sibling worktree that had just passed — it had the `.node` binary, this one
   did not.
2. **`Cannot find module 'next/cache'`** on eight files this branch never
   touches. Same `next` version as the healthy sibling (16.2.11) but **46 of 57
   files** present — a truncated extraction. `pnpm install --force` restored it.

Worth flagging for whoever runs the pre-release suite: those sqlite integration
specs are the net that catches a bad entity registration, so a worktree missing
that binding is one where the net is silently absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-level onboarding profile persistence for roles and team size.
  * Onboarding state now displays organization profile information when available.
  * Slack setup can be completed directly within the onboarding wizard, with connection status and feedback.
  * Added Slack onboarding guidance and configuration labels.
  * Communication connectors are now separated from the general plugins catalog.

* **Bug Fixes**
  * Preserved existing organization profile fields when only part of the profile is updated.
  * Improved onboarding behavior for users without an organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->