### PR TITLE
feat(ingest): promote backfill to a capability, map external issues, filter salience

### DIFF
--- a/apps/api/src/migrations/1784730000000-CreateExternalIssueLinks.ts
+++ b/apps/api/src/migrations/1784730000000-CreateExternalIssueLinks.ts
@@ -1,0 +1,117 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Event-ingest spine — creates the `external_issue_links` table, the
+ * external tracker issue ↔ platform Task mapping.
+ *
+ * Entity: `packages/agent/src/entities/external-issue-link.entity.ts`
+ *
+ * **Schema notes:**
+ *   - UNIQUE `(userId, source, externalIssueId)` — an external issue maps
+ *     to at most ONE Task per owner. This is the load-bearing constraint:
+ *     it makes "is this issue already linked?" a single indexed lookup on
+ *     the ingest drain, and it makes re-linking an idempotent upsert
+ *     instead of a duplicate row. Scoping the uniqueness by `userId` (not
+ *     globally) is what lets two customers connect the same public
+ *     repository without colliding — or seeing each other's Tasks.
+ *   - The REVERSE direction is intentionally non-unique: one Task may
+ *     mirror several issues (an epic plus its tracking issue), so
+ *     `idx_external_issue_links_task` is a plain index.
+ *   - `lastIngestedEventId` / `lastSeenAt` are freshness breadcrumbs
+ *     stamped by the drain; the link is valid with both NULL.
+ *   - Scope columns (`tenantId`, `organizationId`) are raw uuid
+ *     references — no entity-level @ManyToOne (cycle avoidance per
+ *     EW-654).
+ *   - FK `userId` → `users.id` ON DELETE CASCADE and FK `taskId` →
+ *     `tasks.id` ON DELETE CASCADE: a link is meaningless without either
+ *     side, and a dangling link would silently re-point a future issue at
+ *     a deleted Task.
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1784200000000-CreateIngestInstallBindings`.
+ */
+export class CreateExternalIssueLinks1784730000000 implements MigrationInterface {
+    name = 'CreateExternalIssueLinks1784730000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('external_issue_links')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'external_issue_links',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'taskId', type: 'uuid' },
+                    { name: 'source', type: 'varchar', length: '100' },
+                    { name: 'externalIssueId', type: 'varchar', length: '200' },
+                    { name: 'externalKey', type: 'varchar', length: '100', isNullable: true },
+                    { name: 'title', type: 'varchar', length: '500', isNullable: true },
+                    { name: 'url', type: 'varchar', length: '2048', isNullable: true },
+                    { name: 'lastIngestedEventId', type: 'uuid', isNullable: true },
+                    { name: 'lastSeenAt', type: 'timestamp', isNullable: true },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // One Task per external issue per owner — see the schema note.
+        await queryRunner.createIndex(
+            'external_issue_links',
+            new TableIndex({
+                name: 'uq_external_issue_links_identity',
+                columnNames: ['userId', 'source', 'externalIssueId'],
+                isUnique: true,
+            }),
+        );
+
+        // "Which issues does this Task mirror?" — deliberately non-unique.
+        await queryRunner.createIndex(
+            'external_issue_links',
+            new TableIndex({
+                name: 'idx_external_issue_links_task',
+                columnNames: ['taskId'],
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'external_issue_links',
+            new TableForeignKey({
+                name: 'fk_external_issue_links_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'external_issue_links',
+            new TableForeignKey({
+                name: 'fk_external_issue_links_task',
+                columnNames: ['taskId'],
+                referencedTableName: 'tasks',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('external_issue_links')) {
+            await queryRunner.dropTable('external_issue_links', true);
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateExternalIssueLinks.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateExternalIssueLinks.spec.ts
@@ -1,0 +1,151 @@
+import { DataSource } from 'typeorm';
+import { CreateExternalIssueLinks1784730000000 } from '../1784730000000-CreateExternalIssueLinks';
+
+/**
+ * External-issue ↔ Task mapping — migration test for
+ * `external_issue_links`, run against an in-memory better-sqlite3
+ * DataSource (same harness as `CreateIngestInstallBindings.spec.ts`).
+ *
+ * The load-bearing assertions are the two index shapes:
+ *   - UNIQUE `(userId, source, externalIssueId)` — one Task per external
+ *     issue per owner, which is what makes the ingest-side "is this
+ *     already linked?" lookup exact and re-linking idempotent;
+ *   - the reverse direction is deliberately NON-unique — one Task may
+ *     mirror several issues.
+ *
+ * The inserts pass `createdAt`/`updatedAt` explicitly: the table's
+ * `now()` / `uuid_generate_v4()` defaults are Postgres functions (the
+ * shape every migration in this folder ships), and sqlite is used here
+ * only as a cheap DDL harness.
+ */
+describe('CreateExternalIssueLinks1784730000000', () => {
+    let dataSource: DataSource;
+    const migration = new CreateExternalIssueLinks1784730000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(`CREATE TABLE "users" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "users" ("id") VALUES ('u-a'), ('u-b')`);
+        await dataSource.query(`CREATE TABLE "tasks" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "tasks" ("id") VALUES ('t-1'), ('t-2')`);
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function up(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function columnNames(): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("external_issue_links")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    const COLUMNS =
+        '"id", "userId", "taskId", "source", "externalIssueId", "createdAt", "updatedAt"';
+    const STAMPS = `'2026-07-26 00:00:00', '2026-07-26 00:00:00'`;
+
+    it('creates the table with the mapping + provenance columns', async () => {
+        await up();
+        expect(await columnNames()).toEqual(
+            expect.arrayContaining([
+                'id',
+                'userId',
+                'taskId',
+                'source',
+                'externalIssueId',
+                'externalKey',
+                'title',
+                'url',
+                'lastIngestedEventId',
+                'lastSeenAt',
+                'tenantId',
+                'organizationId',
+                'createdAt',
+                'updatedAt',
+            ]),
+        );
+    });
+
+    it('⭐ enforces one Task per external issue per owner', async () => {
+        await up();
+        await dataSource.query(
+            `INSERT INTO "external_issue_links" (${COLUMNS})
+             VALUES ('l-1', 'u-a', 't-1', 'linear-connector', 'issue-42', ${STAMPS})`,
+        );
+
+        await expect(
+            dataSource.query(
+                `INSERT INTO "external_issue_links" (${COLUMNS})
+                 VALUES ('l-2', 'u-a', 't-2', 'linear-connector', 'issue-42', ${STAMPS})`,
+            ),
+        ).rejects.toThrow();
+    });
+
+    it('⭐ scopes that uniqueness per OWNER — two tenants may link the same external issue', async () => {
+        await up();
+        await dataSource.query(
+            `INSERT INTO "external_issue_links" (${COLUMNS})
+             VALUES ('l-1', 'u-a', 't-1', 'github', 'issue-42', ${STAMPS}),
+                    ('l-2', 'u-b', 't-2', 'github', 'issue-42', ${STAMPS})`,
+        );
+        const rows = await dataSource.query(`SELECT COUNT(*) AS n FROM "external_issue_links"`);
+        expect(Number(rows[0].n)).toBe(2);
+    });
+
+    it('keeps source namespaces independent for the same issue id', async () => {
+        await up();
+        await dataSource.query(
+            `INSERT INTO "external_issue_links" (${COLUMNS})
+             VALUES ('l-1', 'u-a', 't-1', 'linear-connector', 'shared-id', ${STAMPS}),
+                    ('l-2', 'u-a', 't-2', 'jira-connector', 'shared-id', ${STAMPS})`,
+        );
+        const rows = await dataSource.query(`SELECT COUNT(*) AS n FROM "external_issue_links"`);
+        expect(Number(rows[0].n)).toBe(2);
+    });
+
+    it('⭐ allows ONE Task to mirror several issues (reverse direction is not unique)', async () => {
+        await up();
+        await dataSource.query(
+            `INSERT INTO "external_issue_links" (${COLUMNS})
+             VALUES ('l-1', 'u-a', 't-1', 'jira-connector', 'EPIC-1', ${STAMPS}),
+                    ('l-2', 'u-a', 't-1', 'github', 'tracking-9', ${STAMPS})`,
+        );
+        const rows = await dataSource.query(
+            `SELECT COUNT(*) AS n FROM "external_issue_links" WHERE "taskId" = 't-1'`,
+        );
+        expect(Number(rows[0].n)).toBe(2);
+    });
+
+    it('is idempotent — running up() twice does not throw', async () => {
+        await up();
+        const runner = dataSource.createQueryRunner();
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await runner.release();
+        expect(await columnNames()).toContain('externalIssueId');
+    });
+
+    it('down() drops the table', async () => {
+        await up();
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+
+        const tables: Array<{ name: string }> = await dataSource.query(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name='external_issue_links'`,
+        );
+        expect(tables).toHaveLength(0);
+    });
+});

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -855,6 +855,13 @@ describe('agent/config', () => {
                 // (EVER_WORKS_IDEA_BUILD_EXECUTOR_ENABLED, default off, +
                 // DRY_RUN default on). Pinned alphabetically.
                 'ideaBuildExecutor',
+                // Audit item (k) — `ingest.*` group adds the event-ingest
+                // salience filter knobs (INGEST_SALIENCE_MIN_SCORE,
+                // INGEST_SALIENCE_MUTED_KINDS,
+                // INGEST_SALIENCE_MUTED_ACTORS). All default to OFF so
+                // ingest behaviour is unchanged when unset. Pinned
+                // alphabetically.
+                'ingest',
                 'isCli',
                 // EW-683 / EW-685 P0 T3 — `jobRuntime.*` group adds the
                 // `EVER_WORKS_JOB_RUNTIME` selector for the pluggable

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -1055,4 +1055,67 @@ export const config = {
             return process.env.KB_EMBEDDING_MODE || 'auto';
         },
     },
+
+    /**
+     * Event-ingest spine — salience filter knobs.
+     *
+     * The ingest pipeline used to write EVERY envelope a connector
+     * produced straight into the feed, so a chatty source (bot pings,
+     * presence changes, reaction spam) could drown the signal a user
+     * actually connected the source for.
+     *
+     * All three knobs default to OFF, which reproduces the previous
+     * behaviour byte for byte: min score `0` admits everything, and both
+     * mute lists are empty. An operator opts in per deployment.
+     */
+    ingest: {
+        /**
+         * Minimum salience score (0–100) an envelope must reach to be
+         * stored. `0` (default) = filter disabled, everything is kept.
+         * Values outside 0–100 and unparseable input fall back to `0` —
+         * a typo must never start silently dropping a customer's events.
+         */
+        getSalienceMinScore(): number {
+            const raw = Number.parseInt(process.env.INGEST_SALIENCE_MIN_SCORE || '', 10);
+            if (!Number.isFinite(raw) || raw <= 0) return 0;
+            return Math.min(raw, 100);
+        },
+        /**
+         * Comma-separated event kinds to drop outright, e.g.
+         * `slack.presence,github.watch`. Matched case-insensitively
+         * against the envelope `kind`; a trailing `.*` makes it a
+         * prefix match (`slack.*`). Empty (default) = nothing muted.
+         */
+        getSalienceMutedKinds(): string[] {
+            return parseCsvList(process.env.INGEST_SALIENCE_MUTED_KINDS);
+        },
+        /**
+         * Comma-separated actor names to drop outright (noisy bots and
+         * automations). Matched case-insensitively as a SUBSTRING of the
+         * envelope actor name, so `dependabot` mutes
+         * `dependabot[bot]`. Empty (default) = nothing muted.
+         */
+        getSalienceMutedActors(): string[] {
+            return parseCsvList(process.env.INGEST_SALIENCE_MUTED_ACTORS);
+        },
+        /** True when any knob is set — i.e. the filter can drop something. */
+        isSalienceFilterEnabled(): boolean {
+            return (
+                this.getSalienceMinScore() > 0 ||
+                this.getSalienceMutedKinds().length > 0 ||
+                this.getSalienceMutedActors().length > 0
+            );
+        },
+    },
 };
+
+/** Comma-separated env list → trimmed, lowercased, blank-dropped, deduped. */
+function parseCsvList(raw: string | undefined): string[] {
+    if (typeof raw !== 'string' || raw.trim().length === 0) return [];
+    const seen = new Set<string>();
+    for (const part of raw.split(',')) {
+        const value = part.trim().toLowerCase();
+        if (value.length > 0) seen.add(value);
+    }
+    return [...seen];
+}

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -120,6 +120,7 @@ import { InboundTrigger } from '../entities/inbound-trigger.entity';
 import { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestCursor } from '../entities/ingest-cursor.entity';
 import { IngestInstallBinding } from '../entities/ingest-install-binding.entity';
+import { ExternalIssueLink } from '../entities/external-issue-link.entity';
 import { Meeting } from '../entities/meeting.entity';
 import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
 import { PlanEntitlement } from '../entities/plan-entitlement.entity';
@@ -286,6 +287,10 @@ export const ENTITIES = [
     // binding, so Slack/GitHub deliveries are attributed to the account
     // that actually owns the workspace instead of the oldest install.
     IngestInstallBinding,
+    // Event-ingest spine — external tracker issue → platform Task
+    // mapping, so an ingested Linear/Jira/GitHub issue can be bound to
+    // the Task that mirrors it.
+    ExternalIssueLink,
     // Meetings v1 (Wave 8, feature a) — captured meetings with
     // transcripts, summaries and provider dedupe.
     Meeting,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -70,6 +70,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'CreditLedgerEntry',
     'EmailConversation',
     'EmailMessage',
+    // Event-ingest spine — external tracker issue → platform Task mapping
+    'ExternalIssueLink',
     // Fleet job runtime (Desktop PRD M4) — lease-able work for nodes
     'FleetJob',
     // Fleet (Wave 12, slice 1) — enrolled execution nodes w/ heartbeat

--- a/packages/agent/src/entities/external-issue-link.entity.ts
+++ b/packages/agent/src/entities/external-issue-link.entity.ts
@@ -1,0 +1,116 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { PortableDateColumn } from './_types';
+
+/**
+ * Event-ingest spine — the external-issue ↔ Task mapping.
+ *
+ * ## Problem it fixes
+ *
+ * The tracker connectors (Linear, Jira, and GitHub Issues through the
+ * webhook receiver) already ingest `*.issue` events into
+ * `ingested_events`, and the platform already has first-class `tasks`.
+ * There was NOTHING joining the two: an ingested issue could land on the
+ * feed and in Memory, but nobody could say "this external issue IS that
+ * platform Task". Every downstream want — mirroring status, avoiding a
+ * duplicate Task when the same issue is re-ingested, showing "linked
+ * issues" on a Task, routing a comment back — needs that join to exist
+ * first.
+ *
+ * ## Shape
+ *
+ * One row = one external issue bound to one platform Task, owned by one
+ * user. `(userId, source, externalIssueId)` is UNIQUE: an external issue
+ * maps to at most ONE Task per owner, which is what makes
+ * "already linked?" a single indexed lookup on the ingest hot path. The
+ * reverse direction is deliberately NOT unique — a Task may legitimately
+ * mirror several issues (a Jira epic plus its GitHub tracking issue).
+ *
+ * Scoping is per-user, not global: two customers who both connect the
+ * same public repository must not see each other's Task links.
+ *
+ * `lastSeenAt` / `lastIngestedEventId` are freshness breadcrumbs stamped
+ * by the ingest drain when a matching issue event comes through. They
+ * are observability, not state — the link is valid with both NULL.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; FKs live in the migration
+ * (`1784730000000-CreateExternalIssueLinks`).
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this repo
+ * has no `autoLoadEntities`, so a forFeature'd-but-unregistered entity
+ * throws EntityMetadataNotFoundError on first query.
+ */
+@Entity({ name: 'external_issue_links' })
+@Index('uq_external_issue_links_identity', ['userId', 'source', 'externalIssueId'], {
+    unique: true,
+})
+@Index('idx_external_issue_links_task', ['taskId'])
+export class ExternalIssueLink {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner of both sides of the link (scopes every read). */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    /** The platform Task this external issue is bound to. */
+    @Column({ type: 'uuid' })
+    taskId: string;
+
+    /**
+     * Producing plugin id / receiver namespace, e.g. `linear-connector`,
+     * `jira-connector`, `github`. Same vocabulary as
+     * `ingested_events.source` so the two join without a translation
+     * table.
+     */
+    @Column({ type: 'varchar', length: 100 })
+    source: string;
+
+    /** The issue's stable id in the source system. */
+    @Column({ type: 'varchar', length: 200 })
+    externalIssueId: string;
+
+    /** Human-facing key, e.g. `ENG-123` / `PROJ-45` / `#1234`. */
+    @Column({ type: 'varchar', length: 100, nullable: true })
+    externalKey?: string | null;
+
+    /** Issue title as the source last reported it. */
+    @Column({ type: 'varchar', length: 500, nullable: true })
+    title?: string | null;
+
+    /** Deep link back to the issue in the source system. */
+    @Column({ type: 'varchar', length: 2048, nullable: true })
+    url?: string | null;
+
+    /** `ingested_events.id` of the most recent event seen for this issue. */
+    @Column({ type: 'uuid', nullable: true })
+    lastIngestedEventId?: string | null;
+
+    /** When that most recent event occurred at the source. */
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn({ nullable: true })
+    lastSeenAt?: Date | null;
+
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -127,6 +127,8 @@ export * from './ingested-event.entity';
 export * from './ingest-cursor.entity';
 // Inbound receivers — external workspace/installation → platform user binding
 export * from './ingest-install-binding.entity';
+// Event-ingest spine — external tracker issue → platform Task mapping
+export * from './external-issue-link.entity';
 // Meetings v1 (Wave 8, feature a) — captured meetings with transcripts
 export * from './meeting.entity';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)

--- a/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
@@ -70,7 +70,7 @@ describe('EventIngestService', () => {
         it('maps the envelope onto the row shape (actor/subject flattened, occurredAt parsed)', async () => {
             const result = await build().ingest('user-1', [envelope()]);
 
-            expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 0 });
+            expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 0, filtered: 0 });
             expect(repository.createIfNew).toHaveBeenCalledWith({
                 userId: 'user-1',
                 organizationId: null,
@@ -95,7 +95,7 @@ describe('EventIngestService', () => {
 
             const result = await build().ingest('user-1', [envelope(), envelope()]);
 
-            expect(result).toEqual({ inserted: 1, duplicates: 1, rejected: 0 });
+            expect(result).toEqual({ inserted: 1, duplicates: 1, rejected: 0, filtered: 0 });
             expect(repository.createIfNew).toHaveBeenCalledTimes(2);
         });
 
@@ -104,14 +104,14 @@ describe('EventIngestService', () => {
 
             const result = await build().ingest('user-1', [oversized, envelope()]);
 
-            expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 1 });
+            expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 1, filtered: 0 });
             expect(repository.createIfNew).toHaveBeenCalledTimes(1);
         });
 
         it('rejects envelopes with an unparseable occurredAt', async () => {
             const result = await build().ingest('user-1', [envelope({ occurredAt: 'not-a-date' })]);
 
-            expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 1 });
+            expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 1, filtered: 0 });
             expect(repository.createIfNew).not.toHaveBeenCalled();
         });
 
@@ -122,7 +122,7 @@ describe('EventIngestService', () => {
                 envelope({ kind: '' }),
             ]);
 
-            expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 3 });
+            expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 3, filtered: 0 });
             expect(repository.createIfNew).not.toHaveBeenCalled();
         });
     });
@@ -134,7 +134,13 @@ describe('EventIngestService', () => {
 
             const result = await build().processBatch(10);
 
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 0 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 1,
+                issueLinks: 0,
+                failed: 0,
+            });
             expect(activityLog.log).toHaveBeenCalledWith(
                 expect.objectContaining({
                     userId: 'user-1',
@@ -181,7 +187,13 @@ describe('EventIngestService', () => {
 
             const result = await build().processBatch(10);
 
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 0, failed: 0 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 0,
+                issueLinks: 0,
+                failed: 0,
+            });
             expect(repository.markProcessed).toHaveBeenCalledWith('row-1');
         });
 
@@ -190,7 +202,13 @@ describe('EventIngestService', () => {
 
             const result = await build({ withMemory: false }).processBatch(10);
 
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 0, failed: 0 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 0,
+                issueLinks: 0,
+                failed: 0,
+            });
             expect(repository.markProcessed).toHaveBeenCalledWith('row-1');
         });
 
@@ -204,7 +222,13 @@ describe('EventIngestService', () => {
 
             const result = await build().processBatch(10);
 
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 1 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 1,
+                issueLinks: 0,
+                failed: 1,
+            });
             expect(repository.markProcessed).not.toHaveBeenCalledWith('row-bad');
             expect(repository.markProcessed).toHaveBeenCalledWith('row-good');
         });
@@ -307,7 +331,13 @@ describe('EventIngestService', () => {
 
             expect(process).toHaveBeenCalledWith(event);
             expect(order).toEqual(['processor', 'activity']);
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 0 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 1,
+                issueLinks: 0,
+                failed: 0,
+            });
         });
 
         it('never invokes a processor for kinds it did not register', async () => {
@@ -320,7 +350,13 @@ describe('EventIngestService', () => {
             const result = await service.processBatch(10);
 
             expect(process).not.toHaveBeenCalled();
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 0 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 1,
+                issueLinks: 0,
+                failed: 0,
+            });
         });
 
         it('processor failure is REQUIRED-grade: row left unprocessed, no Activity duplicate risk', async () => {
@@ -338,7 +374,13 @@ describe('EventIngestService', () => {
 
             const result = await service.processBatch(10);
 
-            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 1 });
+            expect(result).toEqual({
+                processed: 1,
+                activities: 1,
+                memories: 1,
+                issueLinks: 0,
+                failed: 1,
+            });
             expect(repository.markProcessed).not.toHaveBeenCalledWith('row-bad');
             expect(repository.markProcessed).toHaveBeenCalledWith('row-good');
             // The failed row's Activity was NOT written — the retry next
@@ -433,5 +475,126 @@ describe('EventIngestService — workId routing', () => {
         expect(repository.createIfNew).toHaveBeenCalledWith(
             expect.objectContaining({ workId: 'work-explicit' }),
         );
+    });
+});
+
+/**
+ * Salience filter seam (audit item (k)) — the spine's pre-filter
+ * behaviour (store everything) is the contract when no filter is bound.
+ */
+describe('EventIngestService — salience filter seam', () => {
+    let repository: { createIfNew: jest.Mock };
+    let activityLog: { log: jest.Mock };
+    let salience: { isSalient: jest.Mock };
+
+    const build = (withFilter = true) =>
+        new EventIngestService(
+            repository as never,
+            activityLog as never,
+            undefined,
+            undefined,
+            withFilter ? (salience as never) : undefined,
+        );
+
+    beforeEach(() => {
+        repository = {
+            createIfNew: jest.fn(async () => ({ event: storedEvent(), created: true })),
+        };
+        activityLog = { log: jest.fn(async () => ({ id: 'activity-1' })) };
+        salience = { isSalient: jest.fn(() => true) };
+    });
+
+    it('⭐ stores everything when no filter is bound (pre-filter behaviour preserved)', async () => {
+        const result = await build(false).ingest('user-1', [envelope(), envelope()]);
+        expect(result).toEqual({ inserted: 2, duplicates: 0, rejected: 0, filtered: 0 });
+        expect(repository.createIfNew).toHaveBeenCalledTimes(2);
+    });
+
+    it('drops non-salient envelopes before insert and counts them separately', async () => {
+        salience.isSalient.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+        const result = await build().ingest('user-1', [
+            envelope({ sourceEventId: 'noise' }),
+            envelope({ sourceEventId: 'signal' }),
+        ]);
+
+        expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 0, filtered: 1 });
+        expect(repository.createIfNew).toHaveBeenCalledTimes(1);
+        expect(repository.createIfNew).toHaveBeenCalledWith(
+            expect.objectContaining({ sourceEventId: 'signal' }),
+        );
+    });
+
+    it('the structural floor still wins — a malformed envelope is `rejected`, not `filtered`', async () => {
+        const result = await build().ingest('user-1', [envelope({ kind: '' })]);
+        expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 1, filtered: 0 });
+        // Never even asked the filter about a malformed envelope.
+        expect(salience.isSalient).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * External-issue ↔ Task link refresh (audit item (i)) — a best-effort
+ * drain step that must never fail the batch and must never run when the
+ * mapping service is not bound.
+ */
+describe('EventIngestService — external-issue link refresh', () => {
+    let repository: {
+        createIfNew: jest.Mock;
+        findUnprocessed: jest.Mock;
+        markProcessed: jest.Mock;
+    };
+    let activityLog: { log: jest.Mock };
+    let externalIssueLinks: { tryRecordEvent: jest.Mock };
+
+    const build = (withLinks = true) =>
+        new EventIngestService(
+            repository as never,
+            activityLog as never,
+            undefined,
+            undefined,
+            undefined,
+            withLinks ? (externalIssueLinks as never) : undefined,
+        );
+
+    beforeEach(() => {
+        repository = {
+            createIfNew: jest.fn(async () => ({ event: storedEvent(), created: true })),
+            findUnprocessed: jest.fn(async () => [storedEvent({ kind: 'linear.issue' })]),
+            markProcessed: jest.fn(async () => undefined),
+        };
+        activityLog = { log: jest.fn(async () => ({ id: 'activity-1' })) };
+        externalIssueLinks = { tryRecordEvent: jest.fn(async () => true) };
+    });
+
+    it('refreshes the link for a processed event and counts it', async () => {
+        const result = await build().processBatch(10);
+        expect(externalIssueLinks.tryRecordEvent).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            processed: 1,
+            activities: 1,
+            memories: 0,
+            issueLinks: 1,
+            failed: 0,
+        });
+    });
+
+    it('counts nothing when the event is not a linked issue', async () => {
+        externalIssueLinks.tryRecordEvent.mockResolvedValue(false);
+        const result = await build().processBatch(10);
+        expect(result.issueLinks).toBe(0);
+        expect(result.processed).toBe(1);
+    });
+
+    it('runs the drain unchanged when the mapping service is not bound', async () => {
+        const result = await build(false).processBatch(10);
+        expect(result).toEqual({
+            processed: 1,
+            activities: 1,
+            memories: 0,
+            issueLinks: 0,
+            failed: 0,
+        });
+        expect(repository.markProcessed).toHaveBeenCalledWith('row-1');
     });
 });

--- a/packages/agent/src/ingest/__tests__/event-source-pull.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-source-pull.service.spec.ts
@@ -59,7 +59,9 @@ describe('EventSourcePullService', () => {
     }
 
     beforeEach(() => {
-        ingestMock = jest.fn().mockResolvedValue({ inserted: 1, duplicates: 0, rejected: 0 });
+        ingestMock = jest
+            .fn()
+            .mockResolvedValue({ inserted: 1, duplicates: 0, rejected: 0, filtered: 0 });
         eventIngestService = { ingest: ingestMock } as unknown as EventIngestService;
 
         cursorRows = new Map();
@@ -115,6 +117,7 @@ describe('EventSourcePullService', () => {
             inserted: 0,
             duplicates: 0,
             rejected: 0,
+            filtered: 0,
             errors: 0,
         });
     });
@@ -293,5 +296,124 @@ describe('EventSourcePullService', () => {
         expect(real.pullEvents).toHaveBeenCalledTimes(1);
         expect(result.pulled).toBe(1);
         expect(result.errors).toBe(0);
+    });
+
+    /**
+     * `backfill()` capability method (audit item (l)) — the out-of-band
+     * historical sibling of `pullSources()`.
+     */
+    describe('backfillSource', () => {
+        const WINDOW = { since: '2026-06-01T00:00:00.000Z', until: '2026-07-01T00:00:00.000Z' };
+
+        function addBackfillSource(id: string): FakePlugin & { backfill: jest.Mock } {
+            const plugin = addSource(id) as FakePlugin & { backfill: jest.Mock };
+            plugin.backfill = jest.fn().mockResolvedValue({ events: [], complete: true });
+            return plugin;
+        }
+
+        it('reports `supported: false` for a connector that does not implement the optional method', async () => {
+            addSource('linear-connector'); // pullEvents only
+
+            const result = await makeService().backfillSource('user-1', 'linear-connector', WINDOW);
+
+            expect(result.supported).toBe(false);
+            expect(result.pages).toBe(0);
+            expect(ingestMock).not.toHaveBeenCalled();
+        });
+
+        it('passes the window + resolved settings through and ingests the returned envelopes', async () => {
+            const plugin = addBackfillSource('zoom-connector');
+            plugin.backfill.mockResolvedValue({
+                events: [makeEnvelope('zoom-connector', 'old-1')],
+                complete: true,
+            });
+
+            const result = await makeService().backfillSource('user-1', 'zoom-connector', WINDOW);
+
+            expect(plugin.backfill).toHaveBeenCalledWith({
+                since: WINDOW.since,
+                until: WINDOW.until,
+                settings: { apiKey: 'secret-key' },
+            });
+            expect(ingestMock).toHaveBeenCalledWith('user-1', [
+                makeEnvelope('zoom-connector', 'old-1'),
+            ]);
+            expect(result).toMatchObject({
+                supported: true,
+                pages: 1,
+                inserted: 1,
+                complete: true,
+            });
+            expect(result.nextCursor).toBeUndefined();
+        });
+
+        it('pages through the window and stops at the budget, returning a resume cursor', async () => {
+            const plugin = addBackfillSource('zoom-connector');
+            plugin.backfill.mockResolvedValue({ events: [], nextCursor: 'more' });
+
+            const result = await makeService().backfillSource('user-1', 'zoom-connector', {
+                ...WINDOW,
+                pageBudget: 3,
+            });
+
+            expect(plugin.backfill).toHaveBeenCalledTimes(3);
+            expect(result.pages).toBe(3);
+            expect(result.complete).toBe(false);
+            expect(result.nextCursor).toBe('more');
+            // The resume cursor is fed back on every subsequent page.
+            expect(plugin.backfill.mock.calls[1][0]).toMatchObject({ cursor: 'more' });
+        });
+
+        it('⭐ never touches the incremental watermark — the cron sweep is left alone', async () => {
+            const plugin = addBackfillSource('zoom-connector');
+            plugin.backfill.mockResolvedValue({
+                events: [makeEnvelope('zoom-connector', 'old-1')],
+                complete: true,
+            });
+
+            await makeService().backfillSource('user-1', 'zoom-connector', WINDOW);
+
+            // Advancing the watermark from a HISTORICAL sweep would skip
+            // everything between the backfill window and now.
+            expect(cursorSaveMock).not.toHaveBeenCalled();
+            expect(cursorRepository.findByUserAndPlugin).not.toHaveBeenCalled();
+        });
+
+        it('refuses to backfill a plugin the user has not enabled', async () => {
+            addBackfillSource('zoom-connector');
+            (registry.isPluginEnabledForScope as unknown as jest.Mock).mockResolvedValue(false);
+
+            const result = await makeService().backfillSource('user-1', 'zoom-connector', WINDOW);
+
+            expect(result.supported).toBe(false);
+            expect(ingestMock).not.toHaveBeenCalled();
+        });
+
+        it('materializes a lazy proxy BEFORE feature-detecting backfill', async () => {
+            const real = {
+                id: 'lazy-connector',
+                capabilities: ['event-source'],
+                pullEvents: jest.fn(),
+                backfill: jest.fn().mockResolvedValue({ events: [], complete: true }),
+            };
+            const lazy = {
+                id: 'lazy-connector',
+                capabilities: ['event-source'],
+                __materialize: jest.fn().mockResolvedValue(real),
+            };
+            registered.push({ plugin: lazy as unknown as FakePlugin, state: 'loaded' });
+
+            const result = await makeService().backfillSource('user-1', 'lazy-connector', WINDOW);
+
+            expect(lazy.__materialize).toHaveBeenCalledTimes(1);
+            expect(real.backfill).toHaveBeenCalledTimes(1);
+            expect(result.supported).toBe(true);
+        });
+
+        it('degrades to an unsupported no-op when the plugin system is not wired', async () => {
+            const service = new EventSourcePullService(eventIngestService, cursorRepository);
+            const result = await service.backfillSource('user-1', 'zoom-connector', WINDOW);
+            expect(result).toMatchObject({ supported: false, pages: 0, complete: false });
+        });
     });
 });

--- a/packages/agent/src/ingest/__tests__/external-issue-link.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/external-issue-link.service.spec.ts
@@ -1,0 +1,263 @@
+import {
+    ExternalIssueLinkService,
+    ExternalIssueLinkOwnershipError,
+    externalIssueIdOf,
+} from '../external-issue-link.service';
+import type { ExternalIssueLinkRepository } from '../external-issue-link.repository';
+import type { TaskRepository } from '../../database/repositories/task.repository';
+import type { IngestedEvent } from '../../entities/ingested-event.entity';
+
+/**
+ * External-issue ↔ Task mapping (audit item (i)).
+ *
+ * The load-bearing assertions:
+ *   - a link is NEVER written for a Task the caller does not own (the
+ *     schema carries no cross-entity FK, so this check is the only guard);
+ *   - the ingest drain never CREATES a link — binding an issue to a Task
+ *     stays a deliberate act, so ingest can only refresh what exists.
+ */
+
+const storedEvent = (overrides: Partial<IngestedEvent> = {}): IngestedEvent =>
+    ({
+        id: 'row-1',
+        userId: 'user-1',
+        organizationId: null,
+        workId: null,
+        source: 'linear-connector',
+        sourceEventId: 'issue-42:2026-07-24T10:00:00.000Z',
+        kind: 'linear.issue',
+        occurredAt: new Date('2026-07-24T10:00:00.000Z'),
+        actorName: 'Ada',
+        subjectType: 'issue',
+        subjectExternalId: 'issue-42',
+        title: 'Fix the flaky sweep',
+        sourceUrl: 'https://linear.app/acme/issue/ENG-42',
+        payload: {},
+        processedAt: null,
+        dedupeKey: 'abc',
+        createdAt: new Date('2026-07-24T10:00:05.000Z'),
+        ...overrides,
+    }) as IngestedEvent;
+
+describe('ExternalIssueLinkService', () => {
+    let links: {
+        findByExternal: jest.Mock;
+        findByTask: jest.Mock;
+        findByUser: jest.Mock;
+        upsert: jest.Mock;
+        touch: jest.Mock;
+        unlink: jest.Mock;
+    };
+    let tasks: { findByIdAndUser: jest.Mock };
+
+    const build = (withTasks = true) =>
+        new ExternalIssueLinkService(
+            links as unknown as ExternalIssueLinkRepository,
+            withTasks ? (tasks as unknown as TaskRepository) : undefined,
+        );
+
+    beforeEach(() => {
+        links = {
+            findByExternal: jest.fn(async () => null),
+            findByTask: jest.fn(async () => []),
+            findByUser: jest.fn(async () => []),
+            upsert: jest.fn(async (data) => ({ id: 'link-1', ...data })),
+            touch: jest.fn(async () => ({ id: 'link-1' })),
+            unlink: jest.fn(async () => true),
+        };
+        tasks = { findByIdAndUser: jest.fn(async () => ({ id: 'task-1', userId: 'user-1' })) };
+    });
+
+    describe('link', () => {
+        it('binds the issue to the Task after the ownership check passes', async () => {
+            const link = await build().link({
+                userId: 'user-1',
+                taskId: 'task-1',
+                source: 'linear-connector',
+                externalIssueId: 'issue-42',
+                externalKey: 'ENG-42',
+                title: 'Fix the flaky sweep',
+                url: 'https://linear.app/acme/issue/ENG-42',
+            });
+
+            expect(tasks.findByIdAndUser).toHaveBeenCalledWith('task-1', 'user-1');
+            expect(links.upsert).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    taskId: 'task-1',
+                    source: 'linear-connector',
+                    externalIssueId: 'issue-42',
+                    externalKey: 'ENG-42',
+                }),
+            );
+            expect(link).toMatchObject({ id: 'link-1', taskId: 'task-1' });
+        });
+
+        it('⭐ refuses to link a Task the caller does not own — and never writes', async () => {
+            tasks.findByIdAndUser.mockResolvedValue(null);
+
+            await expect(
+                build().link({
+                    userId: 'attacker',
+                    taskId: 'someone-elses-task',
+                    source: 'linear-connector',
+                    externalIssueId: 'issue-42',
+                }),
+            ).rejects.toMatchObject({ name: 'ExternalIssueLinkOwnershipError' });
+
+            expect(links.upsert).not.toHaveBeenCalled();
+        });
+
+        it('refuses when the Tasks feature is not wired — cannot prove ownership, so does not guess', async () => {
+            await expect(
+                build(false).link({
+                    userId: 'user-1',
+                    taskId: 'task-1',
+                    source: 'linear-connector',
+                    externalIssueId: 'issue-42',
+                }),
+            ).rejects.toBeInstanceOf(ExternalIssueLinkOwnershipError);
+            expect(links.upsert).not.toHaveBeenCalled();
+        });
+
+        it('normalizes absent optional labels to null so an upsert clears stale values', async () => {
+            await build().link({
+                userId: 'user-1',
+                taskId: 'task-1',
+                source: 'jira-connector',
+                externalIssueId: 'ISSUE-9',
+            });
+            expect(links.upsert).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    externalKey: null,
+                    title: null,
+                    url: null,
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            );
+        });
+    });
+
+    describe('resolveTaskId / listForTask / unlink', () => {
+        it('resolves the linked Task for an owner-scoped external issue', async () => {
+            links.findByExternal.mockResolvedValue({ taskId: 'task-7' });
+            await expect(
+                build().resolveTaskId('user-1', 'linear-connector', 'issue-42'),
+            ).resolves.toBe('task-7');
+            expect(links.findByExternal).toHaveBeenCalledWith(
+                'user-1',
+                'linear-connector',
+                'issue-42',
+            );
+        });
+
+        it('resolves to null when the issue is not linked', async () => {
+            await expect(
+                build().resolveTaskId('user-1', 'linear-connector', 'issue-42'),
+            ).resolves.toBeNull();
+        });
+
+        it('lists every issue mirrored by a Task', async () => {
+            links.findByTask.mockResolvedValue([{ id: 'link-1' }, { id: 'link-2' }]);
+            await expect(build().listForTask('task-1')).resolves.toHaveLength(2);
+        });
+
+        it('unlink delegates owner-scoped', async () => {
+            await expect(build().unlink('user-1', 'linear-connector', 'issue-42')).resolves.toBe(
+                true,
+            );
+            expect(links.unlink).toHaveBeenCalledWith('user-1', 'linear-connector', 'issue-42');
+        });
+    });
+
+    describe('recordEvent (ingest drain hook)', () => {
+        it('refreshes an existing link with the event id, timestamp, title and url', async () => {
+            await build().recordEvent(storedEvent());
+
+            expect(links.touch).toHaveBeenCalledWith('user-1', 'linear-connector', 'issue-42', {
+                lastIngestedEventId: 'row-1',
+                lastSeenAt: new Date('2026-07-24T10:00:00.000Z'),
+                title: 'Fix the flaky sweep',
+                url: 'https://linear.app/acme/issue/ENG-42',
+            });
+        });
+
+        it('⭐ a COMMENT on a linked issue stamps freshness but never rewrites the issue url', async () => {
+            // Tracker connectors give comment events the parent ISSUE as
+            // their subject, which is how they reach this method — but
+            // their sourceUrl is the comment permalink. Writing it onto
+            // the link would replace the canonical issue link with a deep
+            // link to one reply.
+            await build().recordEvent(
+                storedEvent({
+                    kind: 'linear.comment',
+                    sourceUrl: 'https://linear.app/acme/issue/ENG-42#comment-9',
+                }),
+            );
+
+            expect(links.touch).toHaveBeenCalledWith('user-1', 'linear-connector', 'issue-42', {
+                lastIngestedEventId: 'row-1',
+                lastSeenAt: new Date('2026-07-24T10:00:00.000Z'),
+            });
+        });
+
+        it('⭐ never CREATES a link — an unlinked issue is a no-op', async () => {
+            links.touch.mockResolvedValue(null);
+            await expect(build().recordEvent(storedEvent())).resolves.toBeNull();
+            expect(links.upsert).not.toHaveBeenCalled();
+        });
+
+        it('ignores non-issue events entirely (no repository round-trip)', async () => {
+            const chat = storedEvent({
+                kind: 'slack.message',
+                subjectType: 'channel',
+                subjectExternalId: 'C123',
+            });
+            await expect(build().recordEvent(chat)).resolves.toBeNull();
+            expect(links.touch).not.toHaveBeenCalled();
+        });
+
+        it('tryRecordEvent swallows repository failures — the drain must never fail on it', async () => {
+            links.touch.mockRejectedValue(new Error('db down'));
+            await expect(build().tryRecordEvent(storedEvent())).resolves.toBe(false);
+        });
+
+        it('tryRecordEvent reports true only when a link was actually touched', async () => {
+            await expect(build().tryRecordEvent(storedEvent())).resolves.toBe(true);
+            links.touch.mockResolvedValue(null);
+            await expect(build().tryRecordEvent(storedEvent())).resolves.toBe(false);
+        });
+    });
+});
+
+describe('externalIssueIdOf', () => {
+    it('uses subject.externalId — NOT sourceEventId, which carries a revision suffix', () => {
+        // `linear-connector` builds `${issue.id}:${updatedAt}`; joining on
+        // that would produce a new "issue" on every single update.
+        const event = storedEvent();
+        expect(event.sourceEventId).toContain(':');
+        expect(externalIssueIdOf(event)).toBe('issue-42');
+    });
+
+    it('recognises issue-shaped subject types', () => {
+        for (const subjectType of ['issue', 'ticket', 'story', 'bug', 'ISSUE']) {
+            expect(externalIssueIdOf(storedEvent({ subjectType, kind: 'x.thing' }))).toBe(
+                'issue-42',
+            );
+        }
+    });
+
+    it('falls back to the kind when the connector does not type the subject', () => {
+        expect(
+            externalIssueIdOf(storedEvent({ subjectType: null, kind: 'github.issues.opened' })),
+        ).toBe('issue-42');
+    });
+
+    it('returns undefined for non-issue events and for events without a subject id', () => {
+        expect(
+            externalIssueIdOf(storedEvent({ subjectType: 'channel', kind: 'slack.message' })),
+        ).toBeUndefined();
+        expect(externalIssueIdOf(storedEvent({ subjectExternalId: null }))).toBeUndefined();
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingest-salience.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest-salience.service.spec.ts
@@ -1,0 +1,184 @@
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { IngestSalienceService, SALIENCE_BASE_SCORE } from '../ingest-salience.service';
+
+/**
+ * Ingest salience filter (audit item (k)).
+ *
+ * The load-bearing assertion is the FIRST one: with no env configured
+ * the filter admits everything. Every deployment that never opts in must
+ * keep ingesting byte-for-byte what it ingested before, because silently
+ * dropping a customer's events is a much worse failure than a noisy feed.
+ */
+
+const envelope = (overrides: Partial<IngestedEventEnvelope> = {}): IngestedEventEnvelope => ({
+    id: 'env-1',
+    source: 'slack-connector',
+    sourceEventId: 'evt-1',
+    kind: 'slack.message',
+    occurredAt: '2026-07-01T10:00:00.000Z',
+    actor: { name: 'Ada' },
+    subject: { type: 'channel', externalId: 'C123', title: 'general' },
+    sourceUrl: 'https://example.com/archives/C123/p1',
+    payload: { text: 'hello' },
+    ...overrides,
+});
+
+/** Minimum-information envelope: no title, no url, empty payload, no actor. */
+const bareEnvelope = (overrides: Partial<IngestedEventEnvelope> = {}): IngestedEventEnvelope => {
+    const stripped = envelope();
+    delete (stripped as Partial<IngestedEventEnvelope>).actor;
+    delete (stripped as Partial<IngestedEventEnvelope>).subject;
+    delete (stripped as Partial<IngestedEventEnvelope>).sourceUrl;
+    return { ...stripped, payload: {}, ...overrides };
+};
+
+describe('IngestSalienceService', () => {
+    const ENV_KEYS = [
+        'INGEST_SALIENCE_MIN_SCORE',
+        'INGEST_SALIENCE_MUTED_KINDS',
+        'INGEST_SALIENCE_MUTED_ACTORS',
+    ] as const;
+
+    let service: IngestSalienceService;
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) delete process.env[key];
+        service = new IngestSalienceService();
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) delete process.env[key];
+    });
+
+    describe('safe default (unconfigured)', () => {
+        it('⭐ admits EVERY envelope when nothing is configured — current behaviour preserved', () => {
+            expect(service.isEnabled()).toBe(false);
+            const candidates = [
+                envelope(),
+                bareEnvelope(),
+                envelope({ kind: 'slack.typing' }),
+                envelope({ actor: { name: 'ci-bot' }, kind: 'github.heartbeat' }),
+                bareEnvelope({ kind: 'x.ping', actor: { name: 'noreply-bot' } }),
+            ];
+            for (const candidate of candidates) {
+                expect(service.isSalient(candidate)).toBe(true);
+            }
+        });
+
+        it('a garbage min-score is treated as OFF, never as "drop everything"', () => {
+            process.env.INGEST_SALIENCE_MIN_SCORE = 'not-a-number';
+            expect(service.isEnabled()).toBe(false);
+            expect(service.isSalient(bareEnvelope({ kind: 'x.ping' }))).toBe(true);
+        });
+
+        it('a negative min-score is treated as OFF', () => {
+            process.env.INGEST_SALIENCE_MIN_SCORE = '-10';
+            expect(service.isEnabled()).toBe(false);
+            expect(service.isSalient(bareEnvelope({ kind: 'x.ping' }))).toBe(true);
+        });
+    });
+
+    describe('scoring rubric', () => {
+        it('is deterministic and stays inside 0–100', () => {
+            const rich = envelope({ kind: 'github.issue.opened' });
+            expect(service.score(rich)).toBe(service.score(rich));
+            for (const candidate of [rich, bareEnvelope({ kind: 'x.ping' })]) {
+                const score = service.score(candidate);
+                expect(score).toBeGreaterThanOrEqual(0);
+                expect(score).toBeLessThanOrEqual(100);
+            }
+        });
+
+        it('scores a titled, linked, human-authored issue above the neutral base', () => {
+            expect(service.score(envelope({ kind: 'github.issue.opened' }))).toBeGreaterThan(
+                SALIENCE_BASE_SCORE,
+            );
+        });
+
+        it('scores heartbeat/presence chatter below the neutral base', () => {
+            expect(service.score(bareEnvelope({ kind: 'slack.presence_change' }))).toBeLessThan(
+                SALIENCE_BASE_SCORE,
+            );
+        });
+
+        it('penalizes bot actors relative to the same event from a human', () => {
+            const human = envelope({ kind: 'github.push', actor: { name: 'Ada' } });
+            const bot = envelope({ kind: 'github.push', actor: { name: 'dependabot[bot]' } });
+            expect(service.score(bot)).toBeLessThan(service.score(human));
+        });
+
+        it('penalizes an envelope with nothing to read and nowhere to go', () => {
+            const bare = bareEnvelope({ kind: 'demo.thing' });
+            const withTitle = envelope({ kind: 'demo.thing' });
+            expect(service.score(bare)).toBeLessThan(service.score(withTitle));
+        });
+    });
+
+    describe('min-score gate', () => {
+        it('drops below-threshold envelopes and keeps the rest', () => {
+            process.env.INGEST_SALIENCE_MIN_SCORE = '60';
+            expect(service.isEnabled()).toBe(true);
+
+            const noisy = bareEnvelope({ kind: 'slack.typing' });
+            const signal = envelope({ kind: 'github.issue.opened' });
+
+            expect(service.evaluate(noisy)).toMatchObject({
+                salient: false,
+                reason: 'below-min-score',
+            });
+            expect(service.evaluate(signal).salient).toBe(true);
+        });
+
+        it('clamps an absurd threshold to 100 rather than rejecting the config', () => {
+            process.env.INGEST_SALIENCE_MIN_SCORE = '9999';
+            // Everything scores <= 100, so a 100 threshold only admits the
+            // theoretical maximum — but the service still answers, it does
+            // not throw.
+            expect(service.evaluate(envelope()).salient).toBe(false);
+        });
+    });
+
+    describe('mute lists', () => {
+        it('mutes an exact kind regardless of how well it scores', () => {
+            process.env.INGEST_SALIENCE_MUTED_KINDS = 'github.issue.opened';
+            const signal = envelope({ kind: 'github.issue.opened' });
+            expect(service.score(signal)).toBeGreaterThan(SALIENCE_BASE_SCORE);
+            expect(service.evaluate(signal)).toMatchObject({
+                salient: false,
+                reason: 'muted-kind',
+            });
+        });
+
+        it('supports a trailing wildcard to mute a whole source', () => {
+            process.env.INGEST_SALIENCE_MUTED_KINDS = 'slack.*';
+            expect(service.isSalient(envelope({ kind: 'slack.message' }))).toBe(false);
+            expect(service.isSalient(envelope({ kind: 'github.issue' }))).toBe(true);
+        });
+
+        it('matches muted kinds case-insensitively and ignores blank list entries', () => {
+            process.env.INGEST_SALIENCE_MUTED_KINDS = ' , SLACK.MESSAGE , ';
+            expect(service.isSalient(envelope({ kind: 'slack.message' }))).toBe(false);
+        });
+
+        it('mutes an actor by substring so `dependabot` covers `dependabot[bot]`', () => {
+            process.env.INGEST_SALIENCE_MUTED_ACTORS = 'dependabot';
+            expect(
+                service.evaluate(envelope({ actor: { name: 'dependabot[bot]' } })),
+            ).toMatchObject({ salient: false, reason: 'muted-actor' });
+            expect(service.isSalient(envelope({ actor: { name: 'Ada' } }))).toBe(true);
+        });
+
+        it('an actorless envelope is never dropped by the actor mute list', () => {
+            process.env.INGEST_SALIENCE_MUTED_ACTORS = 'bot';
+            const anonymous = envelope();
+            delete (anonymous as Partial<IngestedEventEnvelope>).actor;
+            expect(service.isSalient(anonymous)).toBe(true);
+        });
+
+        it('mutes win over the score gate — the verdict names the mute, not the score', () => {
+            process.env.INGEST_SALIENCE_MIN_SCORE = '1';
+            process.env.INGEST_SALIENCE_MUTED_KINDS = 'slack.message';
+            expect(service.evaluate(envelope()).reason).toBe('muted-kind');
+        });
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
@@ -43,9 +43,22 @@ jest.mock('../event-source-pull.service', () => ({
 jest.mock('../ingest-install-binding.repository', () => ({
     IngestInstallBindingRepository: class IngestInstallBindingRepository {},
 }));
+jest.mock('../../entities/external-issue-link.entity', () => ({
+    ExternalIssueLink: class ExternalIssueLink {},
+}));
+jest.mock('../ingest-salience.service', () => ({
+    IngestSalienceService: class IngestSalienceService {},
+}));
+jest.mock('../external-issue-link.repository', () => ({
+    ExternalIssueLinkRepository: class ExternalIssueLinkRepository {},
+}));
+jest.mock('../external-issue-link.service', () => ({
+    ExternalIssueLinkService: class ExternalIssueLinkService {},
+}));
 
 import 'reflect-metadata';
 import { WorkRepository } from '../../database/repositories/work.repository';
+import { TaskRepository } from '../../database/repositories/task.repository';
 import { WorkHintResolverService } from '../work-hint-resolver.service';
 import { EventIngestModule } from '../ingest.module';
 import { IngestedEventRepository } from '../ingested-event.repository';
@@ -53,43 +66,48 @@ import { EventIngestService } from '../event-ingest.service';
 import { IngestCursorRepository } from '../ingest-cursor.repository';
 import { EventSourcePullService } from '../event-source-pull.service';
 import { IngestInstallBindingRepository } from '../ingest-install-binding.repository';
+import { IngestSalienceService } from '../ingest-salience.service';
+import { ExternalIssueLinkRepository } from '../external-issue-link.repository';
+import { ExternalIssueLinkService } from '../external-issue-link.service';
 import { ActivityLogModule } from '../../activity-log/activity-log.module';
 import { FacadesModule } from '../../facades/facades.module';
+
+const EXPECTED_PROVIDERS = [
+    IngestedEventRepository,
+    EventIngestService,
+    IngestCursorRepository,
+    EventSourcePullService,
+    WorkRepository,
+    WorkHintResolverService,
+    IngestInstallBindingRepository,
+    // Salience filter (audit item (k)) + external-issue ↔ Task mapping
+    // (audit item (i)). `TaskRepository` backs the ownership check the
+    // link service runs before every write.
+    IngestSalienceService,
+    ExternalIssueLinkRepository,
+    ExternalIssueLinkService,
+    TaskRepository,
+];
 
 describe('EventIngestModule', () => {
     const meta = (key: string): unknown[] => Reflect.getMetadata(key, EventIngestModule) ?? [];
 
     it('provides the repositories, the ingest service and the pull service', () => {
-        expect(meta('providers')).toEqual([
-            IngestedEventRepository,
-            EventIngestService,
-            IngestCursorRepository,
-            EventSourcePullService,
-            WorkRepository,
-            WorkHintResolverService,
-            IngestInstallBindingRepository,
-        ]);
+        expect(meta('providers')).toEqual(EXPECTED_PROVIDERS);
     });
 
-    it('exports all five for the API surface + trigger-internal RPC wiring', () => {
-        expect(meta('exports')).toEqual([
-            IngestedEventRepository,
-            EventIngestService,
-            IngestCursorRepository,
-            EventSourcePullService,
-            WorkRepository,
-            WorkHintResolverService,
-            IngestInstallBindingRepository,
-        ]);
+    it('exports every provider for the API surface + trigger-internal RPC wiring', () => {
+        expect(meta('exports')).toEqual(EXPECTED_PROVIDERS);
     });
 
-    it('imports the two processor modules (Activity log + Facades) beside the entity feature', () => {
+    it('imports the two processor modules (Activity log + Facades) beside the entity features', () => {
         const imports = meta('imports');
         expect(imports).toContain(ActivityLogModule);
         expect(imports).toContain(FacadesModule);
-        // Two forFeature() calls now: the ingest entities plus Work, which the
-        // workId-routing resolver reads. Both render as TypeOrmFeatureStub.
-        expect(imports).toHaveLength(4);
+        // Three forFeature() calls now: the ingest entities, Work (read by
+        // the workId-routing resolver), and the external-issue-link pair
+        // (ExternalIssueLink + Task). All render as TypeOrmFeatureStub.
+        expect(imports).toHaveLength(5);
     });
 });
 
@@ -104,6 +122,9 @@ describe('ingest barrel', () => {
         expect(barrel.EventSourcePullService).toBe(EventSourcePullService);
         expect(barrel.IngestCursorRepository).toBe(IngestCursorRepository);
         expect(barrel.IngestInstallBindingRepository).toBe(IngestInstallBindingRepository);
+        expect(barrel.IngestSalienceService).toBe(IngestSalienceService);
+        expect(barrel.ExternalIssueLinkRepository).toBe(ExternalIssueLinkRepository);
+        expect(barrel.ExternalIssueLinkService).toBe(ExternalIssueLinkService);
         expect(typeof barrel.buildIngestEventTools).toBe('function');
     });
 });

--- a/packages/agent/src/ingest/event-ingest.service.ts
+++ b/packages/agent/src/ingest/event-ingest.service.ts
@@ -7,6 +7,8 @@ import { ActivityActionType, ActivityStatus } from '../entities/activity-log.typ
 import type { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestedEventRepository } from './ingested-event.repository';
 import { WorkHintResolverService } from './work-hint-resolver.service';
+import { IngestSalienceService } from './ingest-salience.service';
+import { ExternalIssueLinkService } from './external-issue-link.service';
 
 /**
  * Kinds that resolve to a DEDICATED Activity action type instead of the
@@ -43,6 +45,12 @@ export interface IngestResult {
     duplicates: number;
     /** Envelopes rejected before insert (oversized payload, bad shape). */
     rejected: number;
+    /**
+     * Envelopes dropped by the salience filter — well-formed, just not
+     * worth a feed row under the operator's configuration. Always `0`
+     * when the filter is unconfigured (its default).
+     */
+    filtered: number;
 }
 
 export interface ProcessBatchResult {
@@ -52,6 +60,11 @@ export interface ProcessBatchResult {
     activities: number;
     /** Memory observations saved (0 when no provider is enabled). */
     memories: number;
+    /**
+     * External-issue ↔ Task links refreshed (0 when the mapping service
+     * is not bound, or when no processed event was a linked issue).
+     */
+    issueLinks: number;
     /**
      * Rows whose REQUIRED processor (kind processor or Activity write)
      * failed — left unprocessed for retry.
@@ -100,6 +113,19 @@ export interface IngestedEventKindProcessor {
  * Activity write — e.g. `zoom.recording` envelopes becoming Meeting
  * rows. A kind-processor failure is REQUIRED-grade: the row stays
  * unprocessed and retries next tick.
+ *
+ * Two later, deliberately OPTIONAL stages hang off the same pipeline:
+ *
+ *   - **Salience filter** (audit item (k)) — `IngestSalienceService`
+ *     drops low-value envelopes at `ingest()` time so a chatty source
+ *     cannot flood the feed. Unbound or unconfigured (its default) means
+ *     nothing is filtered, i.e. byte-for-byte the previous behaviour.
+ *   - **External-issue ↔ Task links** (audit item (i)) —
+ *     `ExternalIssueLinkService` refreshes an existing issue↔Task link
+ *     during the drain (best-effort, never creates one).
+ *
+ * Both are `@Optional()` constructor params appended LAST, so every
+ * positional `new EventIngestService(...)` fixture keeps compiling.
  */
 @Injectable()
 export class EventIngestService {
@@ -118,6 +144,15 @@ export class EventIngestService {
         // so every positional `new EventIngestService(...)` fixture keeps
         // compiling and ingests exactly as it did before.
         @Optional() private readonly workHints?: WorkHintResolverService,
+        // Salience filter (audit item (k)) — drops low-value envelopes
+        // before they reach the feed. Appended LAST + @Optional() for the
+        // same reason as `workHints`; absent (or unconfigured) means
+        // NOTHING is filtered, i.e. exactly the pre-filter behaviour.
+        @Optional() private readonly salience?: IngestSalienceService,
+        // External-issue ↔ Task links (audit item (i)). Best-effort
+        // freshness stamping during the drain; absent = no-op. Appended
+        // LAST + @Optional() per the same fixture-compatibility rule.
+        @Optional() private readonly externalIssueLinks?: ExternalIssueLinkService,
     ) {}
 
     /**
@@ -133,7 +168,7 @@ export class EventIngestService {
 
     /** Dedupe-insert a batch of envelopes for one owner. */
     async ingest(userId: string, envelopes: IngestedEventEnvelope[]): Promise<IngestResult> {
-        const result: IngestResult = { inserted: 0, duplicates: 0, rejected: 0 };
+        const result: IngestResult = { inserted: 0, duplicates: 0, rejected: 0, filtered: 0 };
 
         for (const envelope of envelopes) {
             if (!this.isIngestible(envelope)) {
@@ -144,6 +179,15 @@ export class EventIngestService {
             const occurredAt = new Date(envelope.occurredAt);
             if (Number.isNaN(occurredAt.getTime())) {
                 result.rejected += 1;
+                continue;
+            }
+
+            // Salience gate runs AFTER the structural floor so a
+            // malformed envelope is still counted as `rejected`, not
+            // silently reclassified as "not interesting". No filter
+            // bound (or none configured) = nothing dropped.
+            if (this.salience && !this.salience.isSalient(envelope)) {
+                result.filtered += 1;
                 continue;
             }
 
@@ -205,7 +249,13 @@ export class EventIngestService {
      * retried next tick (Activity write failed) or completed.
      */
     async processBatch(limit = 50): Promise<ProcessBatchResult> {
-        const result: ProcessBatchResult = { processed: 0, activities: 0, memories: 0, failed: 0 };
+        const result: ProcessBatchResult = {
+            processed: 0,
+            activities: 0,
+            memories: 0,
+            issueLinks: 0,
+            failed: 0,
+        };
         const events = await this.repository.findUnprocessed(limit);
 
         for (const event of events) {
@@ -244,6 +294,14 @@ export class EventIngestService {
 
             if (await this.trySaveMemory(event)) {
                 result.memories += 1;
+            }
+
+            // External-issue ↔ Task freshness — best-effort, never fails
+            // the batch, never creates a link (see the service doc).
+            if (this.externalIssueLinks) {
+                if (await this.externalIssueLinks.tryRecordEvent(event)) {
+                    result.issueLinks += 1;
+                }
             }
 
             await this.repository.markProcessed(event.id);

--- a/packages/agent/src/ingest/event-source-pull.service.ts
+++ b/packages/agent/src/ingest/event-source-pull.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import type { IEventSourcePlugin, IPlugin } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, supportsEventSourceBackfill } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 import { UserPluginRepository } from '../plugins/repositories/user-plugin.repository';
@@ -20,8 +20,41 @@ export interface PullSourcesResult {
     duplicates: number;
     /** Envelopes rejected by the ingest floor (shape/size). */
     rejected: number;
+    /** Envelopes dropped by the salience filter (0 when it is off). */
+    filtered: number;
     /** (plugin, user) pairs that failed — never fail the batch. */
     errors: number;
+}
+
+/** Options for one out-of-band historical backfill run. */
+export interface BackfillSourceOptions {
+    /** ISO 8601 lower bound of the window to import. */
+    since: string;
+    /** ISO 8601 upper bound; the connector defaults it to "now". */
+    until?: string;
+    /** Continuation cursor from a previous `backfillSource` result. */
+    cursor?: string;
+    /** Pages this run may fetch before handing the cursor back. */
+    pageBudget?: number;
+}
+
+export interface BackfillSourceResult {
+    /** True when the plugin implements the optional `backfill()` method. */
+    supported: boolean;
+    /** `backfill()` pages fetched this run. */
+    pages: number;
+    /** New `ingested_events` rows written. */
+    inserted: number;
+    /** Envelopes dropped as duplicates by the dedupe insert. */
+    duplicates: number;
+    /** Envelopes rejected by the ingest floor (shape/size). */
+    rejected: number;
+    /** Envelopes dropped by the salience filter (0 when it is off). */
+    filtered: number;
+    /** True when the connector reported the window fully drained. */
+    complete: boolean;
+    /** Present when the budget ran out mid-window — pass back to resume. */
+    nextCursor?: string;
 }
 
 /**
@@ -30,6 +63,14 @@ export interface PullSourcesResult {
  * a single noisy source can never monopolize the cron slot.
  */
 export const EVENT_SOURCE_PULL_PAGE_BUDGET = 5;
+
+/**
+ * Per-run page budget for an out-of-band historical backfill. Higher
+ * than the cron budget (a backfill is a deliberate, user-initiated
+ * import, not a shared cron slot) but still bounded — the caller
+ * resumes with the returned cursor.
+ */
+export const EVENT_SOURCE_BACKFILL_PAGE_BUDGET = 20;
 
 /** `since` handed to a source that has never completed a sweep. */
 const EPOCH_ISO = new Date(0).toISOString();
@@ -57,6 +98,10 @@ const EPOCH_ISO = new Date(0).toISOString();
  *     (never "now"), so events landing mid-sweep are re-covered next
  *     tick — overlap is free, the pipeline dedupes on
  *     `(source, sourceEventId)`.
+ *
+ * `backfillSource()` is the out-of-band sibling: an explicit historical
+ * window through the capability's optional `backfill()` method, with no
+ * watermark side effects. See its doc for why the two are separate.
  *
  * Isolation: every (plugin, user) pair is pulled inside its own
  * try/catch — one broken connector (or one user's revoked credentials)
@@ -90,6 +135,7 @@ export class EventSourcePullService {
             inserted: 0,
             duplicates: 0,
             rejected: 0,
+            filtered: 0,
             errors: 0,
         };
 
@@ -193,6 +239,7 @@ export class EventSourcePullService {
                 result.inserted += ingest.inserted;
                 result.duplicates += ingest.duplicates;
                 result.rejected += ingest.rejected;
+                result.filtered += ingest.filtered;
             }
 
             cursor = pull.nextCursor;
@@ -220,6 +267,104 @@ export class EventSourcePullService {
             });
         }
         return true;
+    }
+
+    /**
+     * Run one out-of-band HISTORICAL backfill for a (plugin, user) pair
+     * through the capability's optional `backfill()` method.
+     *
+     * Deliberately separate from `pullSources()`:
+     *   - it is user/caller initiated, not cron-driven;
+     *   - it targets an EXPLICIT window instead of the watermark;
+     *   - it NEVER touches `ingest_cursors`. Moving the watermark from a
+     *     historical sweep would skip everything between the backfill
+     *     window and now, so the incremental sweep is left exactly as it
+     *     was. Re-delivery across the two is free — the pipeline dedupes
+     *     on `(source, sourceEventId)`.
+     *
+     * Bounded: at most `pageBudget` pages per run; a window that needs
+     * more comes back with `nextCursor` for the caller to resume.
+     * `supported: false` (not an error) is the answer for a connector
+     * that does not implement the optional method.
+     */
+    async backfillSource(
+        userId: string,
+        pluginId: string,
+        options: BackfillSourceOptions,
+    ): Promise<BackfillSourceResult> {
+        const result: BackfillSourceResult = {
+            supported: false,
+            pages: 0,
+            inserted: 0,
+            duplicates: 0,
+            rejected: 0,
+            filtered: 0,
+            complete: false,
+        };
+
+        if (!this.registry || !this.settingsService) {
+            this.logger.debug('Plugin system not wired in this runtime — skipping backfill');
+            return result;
+        }
+
+        const enabled = await this.registry.isPluginEnabledForScope(pluginId, undefined, userId);
+        if (!enabled) {
+            this.logger.debug(
+                `Backfill skipped: event-source plugin ${pluginId} is not enabled for user ${userId}`,
+            );
+            return result;
+        }
+
+        const registered = this.registry
+            .getByCapability(PLUGIN_CAPABILITIES.EVENT_SOURCE)
+            .find((reg) => reg.plugin.id === pluginId && reg.state === 'loaded');
+        if (!registered) return result;
+
+        // Materialize FIRST: a cold lazy proxy's synchronous surface is
+        // empty, so feature-detecting `backfill` on it would fail-closed
+        // for a connector that does implement it.
+        const plugin = await this.materializeForUse(registered.plugin);
+        if (!supportsEventSourceBackfill(plugin)) return result;
+        result.supported = true;
+
+        const settings = await this.settingsService.getSettings(pluginId, {
+            userId,
+            includeSecrets: true,
+        });
+
+        const pageBudget = options.pageBudget ?? EVENT_SOURCE_BACKFILL_PAGE_BUDGET;
+        let cursor = options.cursor;
+
+        for (let page = 0; page < pageBudget; page += 1) {
+            const sweep = await plugin.backfill({
+                since: options.since,
+                ...(options.until ? { until: options.until } : {}),
+                ...(cursor ? { cursor } : {}),
+                settings,
+            });
+            result.pages += 1;
+
+            if (sweep.events.length > 0) {
+                const ingest = await this.eventIngestService.ingest(userId, sweep.events);
+                result.inserted += ingest.inserted;
+                result.duplicates += ingest.duplicates;
+                result.rejected += ingest.rejected;
+                result.filtered += ingest.filtered;
+            }
+
+            cursor = sweep.nextCursor;
+            if (!cursor) {
+                // No continuation cursor = the window is drained. A
+                // connector that also sets `complete` agrees; one that
+                // omits it still means the same thing, since there is
+                // nothing left to resume from.
+                result.complete = true;
+                break;
+            }
+        }
+
+        if (cursor) result.nextCursor = cursor;
+        return result;
     }
 
     /**

--- a/packages/agent/src/ingest/external-issue-link.repository.ts
+++ b/packages/agent/src/ingest/external-issue-link.repository.ts
@@ -1,0 +1,146 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ExternalIssueLink } from '../entities/external-issue-link.entity';
+
+/** Everything needed to bind one external issue to one Task. */
+export interface UpsertExternalIssueLinkData {
+    userId: string;
+    taskId: string;
+    source: string;
+    externalIssueId: string;
+    externalKey?: string | null;
+    title?: string | null;
+    url?: string | null;
+    lastIngestedEventId?: string | null;
+    lastSeenAt?: Date | null;
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
+/** Freshness breadcrumbs stamped by the ingest drain. */
+export interface TouchExternalIssueLinkData {
+    lastIngestedEventId?: string | null;
+    lastSeenAt?: Date | null;
+    title?: string | null;
+    url?: string | null;
+}
+
+/**
+ * Feature-owned repository for the external-issue ↔ Task mapping
+ * (`ExternalIssueLink`). Provided by `EventIngestModule` — same split as
+ * `IngestedEventRepository` / `IngestCursorRepository` /
+ * `IngestInstallBindingRepository`.
+ *
+ * Every read is owner-scoped by construction: `userId` is part of the
+ * unique identity and of every lookup signature, so one customer can
+ * never resolve another customer's Task from a shared external issue id.
+ */
+@Injectable()
+export class ExternalIssueLinkRepository {
+    private readonly logger = new Logger(ExternalIssueLinkRepository.name);
+
+    constructor(
+        @InjectRepository(ExternalIssueLink)
+        private readonly repository: Repository<ExternalIssueLink>,
+    ) {}
+
+    /** The link for one external issue under one owner, or null. */
+    async findByExternal(
+        userId: string,
+        source: string,
+        externalIssueId: string,
+    ): Promise<ExternalIssueLink | null> {
+        if (!userId || !source || !externalIssueId) return null;
+        return this.repository.findOne({ where: { userId, source, externalIssueId } });
+    }
+
+    /** Every external issue linked to one Task (a Task may mirror several). */
+    async findByTask(taskId: string): Promise<ExternalIssueLink[]> {
+        if (!taskId) return [];
+        return this.repository.find({ where: { taskId }, order: { createdAt: 'ASC' } });
+    }
+
+    /** Every link owned by one user (settings UI / diagnostics). */
+    async findByUser(userId: string): Promise<ExternalIssueLink[]> {
+        if (!userId) return [];
+        return this.repository.find({ where: { userId }, order: { createdAt: 'ASC' } });
+    }
+
+    /**
+     * Bind (or re-point) an external issue to a Task — idempotent on
+     * `(userId, source, externalIssueId)`.
+     *
+     * SECURITY: callers MUST have verified that `taskId` belongs to
+     * `userId` before calling. Like `TaskRelation`, the schema carries no
+     * FK that enforces ownership across the join (EW-654 cycle
+     * avoidance), so the check lives in the service layer
+     * (`ExternalIssueLinkService.link`) and any new insert path has to
+     * re-implement it.
+     */
+    async upsert(data: UpsertExternalIssueLinkData): Promise<ExternalIssueLink> {
+        const existing = await this.findByExternal(data.userId, data.source, data.externalIssueId);
+        if (existing) {
+            existing.taskId = data.taskId;
+            if (data.externalKey !== undefined) existing.externalKey = data.externalKey;
+            if (data.title !== undefined) existing.title = data.title;
+            if (data.url !== undefined) existing.url = data.url;
+            if (data.lastIngestedEventId !== undefined) {
+                existing.lastIngestedEventId = data.lastIngestedEventId;
+            }
+            if (data.lastSeenAt !== undefined) existing.lastSeenAt = data.lastSeenAt;
+            if (data.tenantId !== undefined) existing.tenantId = data.tenantId;
+            if (data.organizationId !== undefined) existing.organizationId = data.organizationId;
+            return this.repository.save(existing);
+        }
+
+        try {
+            return await this.repository.save(this.repository.create({ ...data }));
+        } catch (error) {
+            // Concurrent first link for the same issue — the UNIQUE index
+            // picked a winner; adopt it rather than throw.
+            const winner = await this.findByExternal(
+                data.userId,
+                data.source,
+                data.externalIssueId,
+            );
+            if (winner) return winner;
+            this.logger.warn(
+                `Failed to link ${data.source} issue "${data.externalIssueId}" to task ${data.taskId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            throw error;
+        }
+    }
+
+    /**
+     * Refresh the freshness breadcrumbs on an EXISTING link. Never
+     * creates one — a Task association is a deliberate decision, not
+     * something ingest infers.
+     */
+    async touch(
+        userId: string,
+        source: string,
+        externalIssueId: string,
+        data: TouchExternalIssueLinkData,
+    ): Promise<ExternalIssueLink | null> {
+        const existing = await this.findByExternal(userId, source, externalIssueId);
+        if (!existing) return null;
+        if (data.lastIngestedEventId !== undefined) {
+            existing.lastIngestedEventId = data.lastIngestedEventId;
+        }
+        if (data.lastSeenAt !== undefined) existing.lastSeenAt = data.lastSeenAt;
+        if (data.title) existing.title = data.title;
+        if (data.url) existing.url = data.url;
+        return this.repository.save(existing);
+    }
+
+    /** Remove one link (unbind), owner-scoped. Returns true when a row went. */
+    async unlink(userId: string, source: string, externalIssueId: string): Promise<boolean> {
+        const existing = await this.findByExternal(userId, source, externalIssueId);
+        if (!existing) return false;
+        await this.repository.remove(existing);
+        return true;
+    }
+}

--- a/packages/agent/src/ingest/external-issue-link.service.ts
+++ b/packages/agent/src/ingest/external-issue-link.service.ts
@@ -1,0 +1,185 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { IngestedEvent } from '../entities/ingested-event.entity';
+import type { ExternalIssueLink } from '../entities/external-issue-link.entity';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { ExternalIssueLinkRepository } from './external-issue-link.repository';
+
+/** Thrown when the caller does not own the Task they are linking to. */
+export class ExternalIssueLinkOwnershipError extends Error {
+    constructor(taskId: string) {
+        super(`Task ${taskId} is not owned by the linking user`);
+        // Matched BY NAME across packages (same convention as
+        // `EventSourceNotConfiguredError`) so the API layer can map it to
+        // a 404/403 without importing the class.
+        this.name = 'ExternalIssueLinkOwnershipError';
+    }
+}
+
+/** Input for an explicit "this issue IS that Task" binding. */
+export interface LinkExternalIssueInput {
+    userId: string;
+    taskId: string;
+    /** Producing plugin id / receiver namespace (`linear-connector`, `github`). */
+    source: string;
+    /** The issue's stable id in the source system. */
+    externalIssueId: string;
+    externalKey?: string | null;
+    title?: string | null;
+    url?: string | null;
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
+/**
+ * The `subject.type` values a connector uses for issue-shaped subjects,
+ * plus the `kind` suffix fallback. An event qualifies as an external
+ * issue when EITHER matches — connectors are free-form on `kind`, so
+ * relying on only one signal would miss half of them.
+ */
+export const EXTERNAL_ISSUE_SUBJECT_TYPES: readonly string[] = ['issue', 'ticket', 'story', 'bug'];
+export const EXTERNAL_ISSUE_KIND_FRAGMENTS: readonly string[] = ['issue', 'ticket'];
+
+/**
+ * External-issue ↔ Task mapping (audit item (i)).
+ *
+ * Two jobs:
+ *
+ *  1. **Binding** — `link()` records "external issue X in source S IS
+ *     platform Task T", after verifying the caller owns T. This is the
+ *     join that did not exist: tracker connectors ingested `*.issue`
+ *     events and the platform had Tasks, with nothing connecting them.
+ *
+ *  2. **Freshness** — `recordEvent()` is called from the ingest drain
+ *     for every processed row. When the row is an issue event that is
+ *     ALREADY linked, it stamps the link with the event id / timestamp /
+ *     latest title + url. It NEVER creates a link: inferring a Task
+ *     association from an ingested event would manufacture Tasks nobody
+ *     asked for, so the binding stays a deliberate act.
+ *
+ * Ownership is enforced here, not in the schema: like `TaskRelation`,
+ * the entity carries no cross-entity FK (EW-654 cycle avoidance), so any
+ * future insert path must re-run the `findByIdAndUser` check.
+ */
+@Injectable()
+export class ExternalIssueLinkService {
+    private readonly logger = new Logger(ExternalIssueLinkService.name);
+
+    constructor(
+        private readonly links: ExternalIssueLinkRepository,
+        // @Optional() so lean bootstraps (and the trigger worker's remote
+        // proxy graph) can construct the service without the Tasks
+        // feature wired. Without it, ownership cannot be proven, so
+        // `link()` refuses rather than trusting the caller.
+        @Optional() private readonly tasks?: TaskRepository,
+    ) {}
+
+    /**
+     * Bind an external issue to a Task. Idempotent: re-linking the same
+     * issue re-points it (and refreshes the labels) instead of
+     * duplicating.
+     */
+    async link(input: LinkExternalIssueInput): Promise<ExternalIssueLink> {
+        if (!this.tasks) {
+            throw new ExternalIssueLinkOwnershipError(input.taskId);
+        }
+        const task = await this.tasks.findByIdAndUser(input.taskId, input.userId);
+        if (!task) {
+            // Same 404-shaped answer whether the Task is missing or owned
+            // by somebody else — never leak existence.
+            throw new ExternalIssueLinkOwnershipError(input.taskId);
+        }
+
+        return this.links.upsert({
+            userId: input.userId,
+            taskId: input.taskId,
+            source: input.source,
+            externalIssueId: input.externalIssueId,
+            externalKey: input.externalKey ?? null,
+            title: input.title ?? null,
+            url: input.url ?? null,
+            tenantId: input.tenantId ?? null,
+            organizationId: input.organizationId ?? null,
+        });
+    }
+
+    /** Remove a binding, owner-scoped. True when a row went. */
+    async unlink(userId: string, source: string, externalIssueId: string): Promise<boolean> {
+        return this.links.unlink(userId, source, externalIssueId);
+    }
+
+    /** The Task an external issue maps to for this owner, or null. */
+    async resolveTaskId(
+        userId: string,
+        source: string,
+        externalIssueId: string,
+    ): Promise<string | null> {
+        const link = await this.links.findByExternal(userId, source, externalIssueId);
+        return link?.taskId ?? null;
+    }
+
+    /** Every external issue linked to one Task. */
+    async listForTask(taskId: string): Promise<ExternalIssueLink[]> {
+        return this.links.findByTask(taskId);
+    }
+
+    /**
+     * Ingest-drain hook: refresh an EXISTING link from a just-processed
+     * event. Returns the touched link, or null when the event is not an
+     * issue event or the issue is not linked to anything.
+     *
+     * Only ISSUE-level events refresh the stored `title`/`url`. Comment
+     * events carry the parent issue as their subject (that is how they
+     * reach this method at all), but their `sourceUrl` is the comment
+     * permalink — writing it onto the link would quietly replace the
+     * canonical issue link with a deep link to one reply.
+     */
+    async recordEvent(event: IngestedEvent): Promise<ExternalIssueLink | null> {
+        const externalIssueId = externalIssueIdOf(event);
+        if (!externalIssueId) return null;
+
+        return this.links.touch(event.userId, event.source, externalIssueId, {
+            lastIngestedEventId: event.id,
+            lastSeenAt: event.occurredAt,
+            ...(isIssueKind(event.kind)
+                ? { title: event.title ?? null, url: event.sourceUrl ?? null }
+                : {}),
+        });
+    }
+
+    /** Best-effort wrapper for the drain — never throws. */
+    async tryRecordEvent(event: IngestedEvent): Promise<boolean> {
+        try {
+            return (await this.recordEvent(event)) !== null;
+        } catch (error) {
+            this.logger.warn(
+                `External-issue link refresh skipped for ingested event ${event.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+}
+
+/**
+ * The external issue id an event refers to, or undefined when the event
+ * is not issue-shaped. Reads `subject.externalId` — the only field a
+ * connector guarantees is the SOURCE's own stable id (`sourceEventId`
+ * carries a revision suffix such as `${issueId}:${updatedAt}` and is
+ * therefore useless as a join key).
+ */
+export function externalIssueIdOf(event: IngestedEvent): string | undefined {
+    const externalId = event.subjectExternalId;
+    if (!externalId) return undefined;
+
+    const subjectType = (event.subjectType ?? '').toLowerCase();
+    if (EXTERNAL_ISSUE_SUBJECT_TYPES.includes(subjectType)) return externalId;
+    if (isIssueKind(event.kind)) return externalId;
+    return undefined;
+}
+
+/** True when the event's own kind names an issue (not a comment on one). */
+export function isIssueKind(kind: string | null | undefined): boolean {
+    const lowered = (kind ?? '').toLowerCase();
+    return EXTERNAL_ISSUE_KIND_FRAGMENTS.some((fragment) => lowered.includes(fragment));
+}

--- a/packages/agent/src/ingest/index.ts
+++ b/packages/agent/src/ingest/index.ts
@@ -8,6 +8,9 @@ export * from './event-source-pull.service';
 export * from './ingest-cursor.repository';
 export * from './work-hint-resolver.service';
 export * from './ingest-install-binding.repository';
+export * from './ingest-salience.service';
+export * from './external-issue-link.repository';
+export * from './external-issue-link.service';
 export * from './agent-ingest-tools';
 export { IngestedEvent } from '../entities/ingested-event.entity';
 export { IngestCursor } from '../entities/ingest-cursor.entity';
@@ -15,3 +18,4 @@ export {
     IngestInstallBinding,
     type IngestInstallProvider,
 } from '../entities/ingest-install-binding.entity';
+export { ExternalIssueLink } from '../entities/external-issue-link.entity';

--- a/packages/agent/src/ingest/ingest-salience.service.ts
+++ b/packages/agent/src/ingest/ingest-salience.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { config } from '../config';
+
+/** Verdict for one envelope. */
+export interface SalienceVerdict {
+    /** 0–100. Higher = more worth a human's attention. */
+    score: number;
+    /** False when the envelope should be dropped before insert. */
+    salient: boolean;
+    /** Short machine-readable reason when `salient` is false. */
+    reason?: 'muted-kind' | 'muted-actor' | 'below-min-score';
+}
+
+/**
+ * Neutral score every envelope starts from. Signals push it up or down;
+ * the operator's `INGEST_SALIENCE_MIN_SCORE` decides where the cut is.
+ */
+export const SALIENCE_BASE_SCORE = 50;
+
+/**
+ * Kind fragments that mark an event as high-signal — the things a user
+ * connected the source FOR. Matched as a substring of the lowercased
+ * `kind`, so `github.pull_request.merged` matches `pull_request`.
+ */
+export const SALIENT_KIND_FRAGMENTS: readonly string[] = [
+    'issue',
+    'pull_request',
+    'pull-request',
+    'merge',
+    'review',
+    'incident',
+    'alert',
+    'deploy',
+    'release',
+    'recording',
+    'meeting',
+    'decision',
+    'mention',
+];
+
+/**
+ * Kind fragments that mark an event as low-signal chatter — the traffic
+ * that drowns a feed without telling anyone anything.
+ */
+export const NOISY_KIND_FRAGMENTS: readonly string[] = [
+    'heartbeat',
+    'ping',
+    'presence',
+    'typing',
+    'reaction',
+    'view',
+    'visit',
+    'watch',
+    'star',
+    'poll',
+    'sync',
+];
+
+/** Actor-name fragments that read as "an automation did this". */
+export const BOT_ACTOR_FRAGMENTS: readonly string[] = [
+    'bot',
+    'webhook',
+    'automation',
+    'no-reply',
+    'noreply',
+];
+
+/**
+ * Event-ingest salience filter (audit item (k)).
+ *
+ * ## Why
+ *
+ * The spine wrote EVERY envelope a connector produced. A chatty source —
+ * reaction events, presence changes, bot heartbeats, a CI account
+ * commenting on every push — could bury the handful of events the user
+ * actually connected the source for, in the feed, in Activity, and in
+ * agent Memory (each ingested row fans out to all three).
+ *
+ * ## Contract
+ *
+ * **Off by default.** `INGEST_SALIENCE_MIN_SCORE` defaults to `0` and
+ * both mute lists default to empty, so an unconfigured deployment keeps
+ * exactly the pre-filter behaviour — nothing is dropped. That is the
+ * deliberate safe default: silently discarding a customer's events is a
+ * far worse failure than a noisy feed, so the filter only ever bites
+ * when an operator asked for it.
+ *
+ * Scoring is a transparent, deterministic rubric (no model call, no
+ * network, no per-event state) so a dropped event is always explainable
+ * and a spec can pin the exact numbers.
+ *
+ * Ordering: mutes are absolute and evaluated first (an operator naming a
+ * kind or an actor means it, regardless of score), then the score gate.
+ *
+ * Blast radius, stated plainly: the gate sits in `EventIngestService`
+ * `ingest()`, which is the ONE door every path uses (pull cron, the
+ * `POST /api/ingest/events` push surface, the Slack and GitHub inbound
+ * bridges). A filtered envelope therefore never becomes a row, so
+ * anything keyed off `inserted > 0` — the Slack chat reply, the GitHub PR
+ * review trigger — does not fire for it either. That is the intended
+ * reading of "mute this kind", and it is why the filter is opt-in.
+ */
+@Injectable()
+export class IngestSalienceService {
+    private readonly logger = new Logger(IngestSalienceService.name);
+
+    /** True when at least one knob is configured. */
+    isEnabled(): boolean {
+        return config.ingest.isSalienceFilterEnabled();
+    }
+
+    /**
+     * Score one envelope on the 0–100 rubric. Pure: same envelope in,
+     * same score out, independent of configuration.
+     */
+    score(envelope: IngestedEventEnvelope): number {
+        let score = SALIENCE_BASE_SCORE;
+
+        const kind = (envelope.kind ?? '').toLowerCase();
+        if (SALIENT_KIND_FRAGMENTS.some((fragment) => kind.includes(fragment))) score += 20;
+        if (NOISY_KIND_FRAGMENTS.some((fragment) => kind.includes(fragment))) score -= 30;
+
+        // A titled subject is the difference between "someone changed
+        // something" and a row a human can act on.
+        const title = envelope.subject?.title;
+        if (typeof title === 'string' && title.trim().length > 0) score += 15;
+
+        // Without a deep link the feed row is a dead end.
+        if (typeof envelope.sourceUrl === 'string' && envelope.sourceUrl.length > 0) score += 10;
+
+        const actorName = envelope.actor?.name;
+        if (typeof actorName === 'string' && actorName.trim().length > 0) {
+            score += 5;
+            const lowered = actorName.toLowerCase();
+            if (BOT_ACTOR_FRAGMENTS.some((fragment) => lowered.includes(fragment))) score -= 20;
+        }
+
+        // Nothing to read AND nowhere to go AND no details: the row can
+        // only ever say "an event happened".
+        const payloadKeys = envelope.payload ? Object.keys(envelope.payload).length : 0;
+        if (!title && !envelope.sourceUrl && payloadKeys === 0) score -= 20;
+
+        return Math.max(0, Math.min(100, score));
+    }
+
+    /** Score + verdict for one envelope under the current configuration. */
+    evaluate(envelope: IngestedEventEnvelope): SalienceVerdict {
+        const score = this.score(envelope);
+
+        const kind = (envelope.kind ?? '').toLowerCase();
+        if (config.ingest.getSalienceMutedKinds().some((muted) => matchesKind(kind, muted))) {
+            return { score, salient: false, reason: 'muted-kind' };
+        }
+
+        const actorName = (envelope.actor?.name ?? '').toLowerCase();
+        if (
+            actorName.length > 0 &&
+            config.ingest.getSalienceMutedActors().some((muted) => actorName.includes(muted))
+        ) {
+            return { score, salient: false, reason: 'muted-actor' };
+        }
+
+        const min = config.ingest.getSalienceMinScore();
+        if (min > 0 && score < min) {
+            return { score, salient: false, reason: 'below-min-score' };
+        }
+
+        return { score, salient: true };
+    }
+
+    /**
+     * Convenience wrapper used by the ingest hot path. Returns `true`
+     * when the envelope should be stored. Logs at debug on a drop so an
+     * operator tuning the knobs can see what the filter is eating.
+     */
+    isSalient(envelope: IngestedEventEnvelope): boolean {
+        const verdict = this.evaluate(envelope);
+        if (!verdict.salient) {
+            this.logger.debug(
+                `Salience filter dropped ${envelope.source}/${envelope.sourceEventId} ` +
+                    `(${envelope.kind}) — ${verdict.reason}, score ${verdict.score}`,
+            );
+        }
+        return verdict.salient;
+    }
+}
+
+/**
+ * Mute-list match. Exact by default; a trailing `.*` (or a bare `*`)
+ * makes it a prefix match so `slack.*` mutes a whole source.
+ */
+function matchesKind(kind: string, muted: string): boolean {
+    if (muted === '*') return true;
+    if (muted.endsWith('*')) {
+        return kind.startsWith(muted.slice(0, -1));
+    }
+    return kind === muted;
+}

--- a/packages/agent/src/ingest/ingest.module.ts
+++ b/packages/agent/src/ingest/ingest.module.ts
@@ -3,16 +3,22 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestCursor } from '../entities/ingest-cursor.entity';
 import { Work } from '../entities/work.entity';
+import { Task } from '../entities/task.entity';
 import { IngestInstallBinding } from '../entities/ingest-install-binding.entity';
+import { ExternalIssueLink } from '../entities/external-issue-link.entity';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { FacadesModule } from '../facades/facades.module';
 import { WorkRepository } from '../database/repositories/work.repository';
+import { TaskRepository } from '../database/repositories/task.repository';
 import { IngestedEventRepository } from './ingested-event.repository';
 import { EventIngestService } from './event-ingest.service';
 import { IngestCursorRepository } from './ingest-cursor.repository';
 import { EventSourcePullService } from './event-source-pull.service';
 import { WorkHintResolverService } from './work-hint-resolver.service';
 import { IngestInstallBindingRepository } from './ingest-install-binding.repository';
+import { IngestSalienceService } from './ingest-salience.service';
+import { ExternalIssueLinkRepository } from './external-issue-link.repository';
+import { ExternalIssueLinkService } from './external-issue-link.service';
 
 /**
  * Event-ingest spine (Wave 6, pull path Wave 8) — agent-side module
@@ -32,9 +38,16 @@ import { IngestInstallBindingRepository } from './ingest-install-binding.reposit
  * event is attributed to the account that actually owns the workspace
  * instead of "the oldest enabled install platform-wide".
  *
- * `IngestedEvent` + `IngestCursor` + `IngestInstallBinding` MUST also
- * stay registered in the DataSource ENTITIES array
- * (`database/_entities-inventory.ts`) — this repo has no
+ * Also owns the two later ingest-side stages:
+ *   - `IngestSalienceService` — the configurable low-value-event filter
+ *     applied at `ingest()` time (audit item (k)); off by default.
+ *   - `ExternalIssueLinkRepository` / `ExternalIssueLinkService` — the
+ *     external tracker issue → platform Task mapping (audit item (i)),
+ *     with `TaskRepository` backing the ownership check on every write.
+ *
+ * `IngestedEvent` + `IngestCursor` + `IngestInstallBinding` +
+ * `ExternalIssueLink` MUST also stay registered in the DataSource
+ * ENTITIES array (`database/_entities-inventory.ts`) — this repo has no
  * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
  * EntityMetadataNotFoundError on first query.
  */
@@ -46,6 +59,12 @@ import { IngestInstallBindingRepository } from './ingest-install-binding.reposit
         // EntityMetadataNotFoundError on first query.
         TypeOrmModule.forFeature([IngestedEvent, IngestCursor, Work]),
         TypeOrmModule.forFeature([IngestedEvent, IngestCursor, IngestInstallBinding]),
+        // External-issue ↔ Task mapping. `Task` backs the ownership check
+        // that guards every link write; `ExternalIssueLink` is the join
+        // itself. Both MUST also be in the DataSource ENTITIES array —
+        // a forFeature'd-but-unregistered entity throws
+        // EntityMetadataNotFoundError on first query.
+        TypeOrmModule.forFeature([ExternalIssueLink, Task]),
         // Processor 1 — Activity-log rows with sourceUrl provenance.
         ActivityLogModule,
         // Processor 2 — best-effort Memory observations via
@@ -60,6 +79,10 @@ import { IngestInstallBindingRepository } from './ingest-install-binding.reposit
         WorkRepository,
         WorkHintResolverService,
         IngestInstallBindingRepository,
+        IngestSalienceService,
+        ExternalIssueLinkRepository,
+        ExternalIssueLinkService,
+        TaskRepository,
     ],
     exports: [
         IngestedEventRepository,
@@ -69,6 +92,10 @@ import { IngestInstallBindingRepository } from './ingest-install-binding.reposit
         WorkRepository,
         WorkHintResolverService,
         IngestInstallBindingRepository,
+        IngestSalienceService,
+        ExternalIssueLinkRepository,
+        ExternalIssueLinkService,
+        TaskRepository,
     ],
 })
 export class EventIngestModule {}

--- a/packages/plugin/src/contracts/__tests__/event-source.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/event-source.spec.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
 	EventSourceNotConfiguredError,
 	isEventSourcePlugin,
+	supportsEventSourceBackfill,
+	clampEventSourceBackfillDays,
+	EVENT_SOURCE_BACKFILL_MAX_DAYS,
 	type IEventSourcePlugin
 } from '../capabilities/event-source.interface.js';
 import { ALL_PLUGIN_CAPABILITIES, PLUGIN_CAPABILITIES } from '../facade-capabilities.js';
@@ -50,5 +53,87 @@ describe('event-source capability (Wave 6)', () => {
 		expect(result.events).toHaveLength(1);
 		expect(result.events[0].sourceEventId).toBe('after:2026-07-01T00:00:00.000Z');
 		expect(result.nextCursor).toBe('page-2');
+	});
+});
+
+describe('event-source backfill (audit item (l))', () => {
+	const pullOnly: IEventSourcePlugin = {
+		id: 'pull-only',
+		capabilities: ['event-source'],
+		providerName: 'pull-only',
+		pullEvents: async () => ({ events: [] })
+	} as unknown as IEventSourcePlugin;
+
+	const withBackfill: IEventSourcePlugin = {
+		id: 'with-backfill',
+		capabilities: ['event-source'],
+		providerName: 'with-backfill',
+		pullEvents: async () => ({ events: [] }),
+		backfill: async ({ since, until, cursor }) => ({
+			events: [
+				{
+					id: 'env-b1',
+					source: 'with-backfill',
+					sourceEventId: `${since}->${until ?? 'now'}`,
+					kind: 'demo.historical',
+					occurredAt: since,
+					payload: { resumedFrom: cursor ?? null }
+				}
+			],
+			nextCursor: cursor ? undefined : 'page-2',
+			complete: cursor ? true : undefined
+		})
+	} as unknown as IEventSourcePlugin;
+
+	it('`backfill` is OPTIONAL — a source without it is still a valid event source', () => {
+		// The load path only ever checks the capability string, so a
+		// connector with no history to offer keeps working untouched.
+		expect(isEventSourcePlugin(pullOnly)).toBe(true);
+		expect(supportsEventSourceBackfill(pullOnly)).toBe(false);
+	});
+
+	it('supportsEventSourceBackfill feature-detects the METHOD, not a capability string', () => {
+		expect(supportsEventSourceBackfill(withBackfill)).toBe(true);
+		// Declaring `event-source` alone is not enough...
+		expect(supportsEventSourceBackfill({ capabilities: ['event-source'] } as never)).toBe(false);
+		// ...and implementing `backfill` without the capability is not either.
+		expect(
+			supportsEventSourceBackfill({ capabilities: ['search'], backfill: async () => ({ events: [] }) } as never)
+		).toBe(false);
+	});
+
+	it('backfill round-trips the window and pages through its own cursor', async () => {
+		const first = await withBackfill.backfill!({
+			since: '2026-06-01T00:00:00.000Z',
+			until: '2026-07-01T00:00:00.000Z'
+		});
+		expect(first.events[0].sourceEventId).toBe('2026-06-01T00:00:00.000Z->2026-07-01T00:00:00.000Z');
+		expect(first.nextCursor).toBe('page-2');
+		expect(first.complete).toBeUndefined();
+
+		const second = await withBackfill.backfill!({
+			since: '2026-06-01T00:00:00.000Z',
+			cursor: first.nextCursor
+		});
+		expect(second.events[0].payload).toEqual({ resumedFrom: 'page-2' });
+		expect(second.nextCursor).toBeUndefined();
+		expect(second.complete).toBe(true);
+	});
+
+	it('clampEventSourceBackfillDays: garbage and negatives mean OFF, never a wider window', () => {
+		expect(clampEventSourceBackfillDays(undefined)).toBe(0);
+		expect(clampEventSourceBackfillDays('nope')).toBe(0);
+		expect(clampEventSourceBackfillDays(Number.NaN)).toBe(0);
+		expect(clampEventSourceBackfillDays(-30)).toBe(0);
+		expect(clampEventSourceBackfillDays(0)).toBe(0);
+	});
+
+	it('clampEventSourceBackfillDays: floors fractions and caps at the shared maximum', () => {
+		expect(clampEventSourceBackfillDays(14.9)).toBe(14);
+		expect(clampEventSourceBackfillDays('7')).toBe(7);
+		expect(clampEventSourceBackfillDays(10_000)).toBe(EVENT_SOURCE_BACKFILL_MAX_DAYS);
+		expect(EVENT_SOURCE_BACKFILL_MAX_DAYS).toBe(90);
+		// A caller may tighten the bound but the clamp still applies.
+		expect(clampEventSourceBackfillDays(60, 30)).toBe(30);
 	});
 });

--- a/packages/plugin/src/contracts/capabilities/event-source.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/event-source.interface.ts
@@ -17,6 +17,15 @@ import type { PluginSettings } from '../../settings/settings.types.js';
  * Dedupe contract: `(source, sourceEventId)` is the event identity.
  * Implementations may re-deliver events freely (overlapping windows,
  * retries, backfill) — the ingest pipeline drops duplicates.
+ *
+ * Historical catch-up is the OPTIONAL `backfill()` method on this same
+ * capability (see {@link EventSourceBackfillInput}). It used to be a
+ * private, settings-shaped convention re-invented inside each connector
+ * (`backfillDays` widening the first pull); promoting it onto the
+ * contract means every connector exposes history the same way, callers
+ * feature-detect once with {@link supportsEventSourceBackfill}, and a
+ * connector with no history to offer simply omits the method and keeps
+ * loading exactly as before.
  */
 export interface EventSourcePullInput {
 	/** ISO 8601 watermark — return events that occurred at/after this. */
@@ -38,6 +47,68 @@ export interface EventSourcePullResult {
 }
 
 /**
+ * Upper bound on the opt-in historical backfill window, in days.
+ *
+ * Shared by every connector so "how far back can I go?" has ONE answer
+ * across the fabric instead of a per-plugin constant that drifts.
+ */
+export const EVENT_SOURCE_BACKFILL_MAX_DAYS = 90;
+
+/**
+ * Normalize a user-supplied backfill window (settings value, API body,
+ * env var) to a whole number of days inside `0 … max`.
+ *
+ * `0` means "backfill off" and is the safe default for every garbage
+ * input (`undefined`, `'nope'`, `NaN`, negatives) — an unparseable
+ * window must never widen the sweep.
+ */
+export function clampEventSourceBackfillDays(value: unknown, max: number = EVENT_SOURCE_BACKFILL_MAX_DAYS): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), max);
+}
+
+/**
+ * Input for an explicit, bounded HISTORICAL sweep — the opt-in
+ * `backfill()` capability method.
+ *
+ * `pullEvents` is the incremental, watermark-driven half of an event
+ * source: it answers "what happened since the last sweep?". `backfill`
+ * is the out-of-band half: "go fetch this window of history, once".
+ * Activation-time catch-up, a user clicking "import the last 30 days",
+ * and a repair sweep after an outage all speak this shape.
+ */
+export interface EventSourceBackfillInput {
+	/** ISO 8601 lower bound (inclusive) of the historical window. */
+	since: string;
+	/**
+	 * ISO 8601 upper bound. Defaults to "now" when absent. Sources whose
+	 * API cannot bound the far end (Drive/Calendar `updatedMin`-style
+	 * filters) MAY ignore it — over-wide windows are free because the
+	 * ingest pipeline dedupes on `(source, sourceEventId)`.
+	 */
+	until?: string;
+	/**
+	 * Opaque continuation cursor from a previous `backfill` page. Callers
+	 * only round-trip it; the format is the implementation's business
+	 * (sharing it with `pullEvents` is fine and encouraged).
+	 */
+	cursor?: string;
+	/** Resolved plugin settings (4-level hierarchy, resolved upstream). */
+	settings?: PluginSettings;
+}
+
+/**
+ * Result of one `backfill` page. Same shape as a pull page plus an
+ * explicit `complete` flag, so a caller does not have to infer "done"
+ * from a missing cursor when a source wants to say it out loud.
+ */
+export interface EventSourceBackfillResult extends EventSourcePullResult {
+	/** True when the requested window is fully drained. */
+	complete?: boolean;
+}
+
+/**
  * Thrown when the event source cannot pull in this runtime/config
  * (missing credentials, no workspace connected, …). Matched BY NAME
  * across packages — maps to a loud, actionable failure upstream, never
@@ -56,9 +127,42 @@ export interface IEventSourcePlugin extends IPlugin {
 
 	/** Pull normalized events since the watermark (cursor-paged). */
 	pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult>;
+
+	/**
+	 * OPTIONAL — bounded historical sweep over an explicit window.
+	 *
+	 * Optional on purpose: a source with no history to offer (a webhook
+	 * relay, a live-only feed) simply omits it and still loads and pulls
+	 * exactly as before. Callers MUST feature-detect with
+	 * {@link supportsEventSourceBackfill} rather than assume.
+	 *
+	 * Implementations MUST stay bounded: cap the pages fetched per call
+	 * and hand back a `nextCursor` so a long window resumes instead of
+	 * turning one activation into an unbounded crawl. Re-delivering
+	 * events already ingested is fine — `(source, sourceEventId)` dedupe
+	 * makes overlap free.
+	 */
+	backfill?(input: EventSourceBackfillInput): Promise<EventSourceBackfillResult>;
 }
 
 /** Type guard — true when a plugin declares the `event-source` capability. */
 export function isEventSourcePlugin(plugin: IPlugin): plugin is IEventSourcePlugin {
 	return plugin.capabilities.includes('event-source');
+}
+
+/**
+ * Feature-detect the optional `backfill()` method.
+ *
+ * Checks the METHOD, not a capability string: `backfill` is opt-in
+ * within the `event-source` capability, so a connector advertises it by
+ * implementing it. Callers must materialize a lazily-loaded plugin
+ * BEFORE calling this — a cold lazy proxy's synchronous surface is
+ * empty, so an un-materialized plugin reports `false` (fail-closed,
+ * which is the safe direction: worst case the caller skips a backfill
+ * it could have run).
+ */
+export function supportsEventSourceBackfill(
+	plugin: IPlugin
+): plugin is IEventSourcePlugin & Required<Pick<IEventSourcePlugin, 'backfill'>> {
+	return isEventSourcePlugin(plugin) && typeof (plugin as IEventSourcePlugin).backfill === 'function';
 }

--- a/packages/plugins/google-workspace-connector/README.md
+++ b/packages/plugins/google-workspace-connector/README.md
@@ -42,6 +42,14 @@ accounts and requires super-admin configuration — while a refresh token is the
 same "paste one secret" operation and works for both. Service accounts with
 domain-wide delegation remain a documented follow-up for org-wide sweeps.
 
+- **Historical backfill (`backfill()` capability method)** — the optional
+  `backfill()` method on the `event-source` capability runs the same sweep
+  out-of-band over an EXPLICIT window, so history can be imported at any time
+  instead of only as a side effect of the first pull's `backfillDays`. One call
+  fetches one page and hands back a cursor, so the per-phase page bound still
+  applies. Re-delivery is free — the ingest pipeline dedupes on
+  `(source, sourceEventId)`.
+
 ## Settings
 
 | Key               | Notes                                                               |

--- a/packages/plugins/google-workspace-connector/src/google-workspace-connector-plugin.spec.ts
+++ b/packages/plugins/google-workspace-connector/src/google-workspace-connector-plugin.spec.ts
@@ -12,6 +12,7 @@ import {
 	GOOGLE_EVENT_TEXT_MAX_CHARS,
 	GOOGLE_TRANSCRIPT_MAX_CHARS
 } from './google-workspace-connector-plugin.js';
+import { supportsEventSourceBackfill } from '@ever-works/plugin';
 
 const listDriveFilesMock = vi.fn();
 const exportDocMock = vi.fn();
@@ -422,6 +423,60 @@ describe('GoogleWorkspaceConnectorPlugin', () => {
 			});
 			expect(listDriveFilesMock).toHaveBeenCalledTimes(1);
 			expect(res.events).toEqual([]);
+		});
+	});
+
+	// `backfill()` capability method (audit item (l)).
+	describe('backfill', () => {
+		it('is exposed as the capability method, feature-detectable by callers', () => {
+			expect(typeof plugin.backfill).toBe('function');
+			expect(supportsEventSourceBackfill(plugin as never)).toBe(true);
+		});
+
+		it('⭐ sweeps an EXPLICIT window regardless of the settings backfillDays', async () => {
+			listDriveFilesMock.mockResolvedValue({ files: [] });
+
+			// `backfillDays` deliberately absent: history used to be
+			// reachable ONLY through that first-pull setting.
+			const result = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: DRIVE_ONLY });
+
+			expect(listDriveFilesMock.mock.calls[0][0].q).toContain('2026-05-01T00:00:00.000Z');
+			expect(result.complete).toBe(true);
+			expect(result.nextCursor).toBeUndefined();
+		});
+
+		it('opens on the first CONFIGURED surface, not always drive', async () => {
+			listCalendarEventsMock.mockResolvedValue({ items: [] });
+			await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: CALENDAR_ONLY });
+			expect(listCalendarEventsMock).toHaveBeenCalledTimes(1);
+			expect(listDriveFilesMock).not.toHaveBeenCalled();
+		});
+
+		it('marks the sweep as a backfill so the per-phase page bound engages, and resumes', async () => {
+			listDriveFilesMock.mockResolvedValue({ files: [], nextPageToken: 'more' });
+
+			const first = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: DRIVE_ONLY });
+			expect(JSON.parse(first.nextCursor as string).f).toBe(1);
+			expect(first.complete).toBeUndefined();
+
+			await plugin.backfill({
+				since: '2026-05-01T00:00:00.000Z',
+				cursor: first.nextCursor,
+				settings: DRIVE_ONLY
+			});
+			expect(listDriveFilesMock.mock.calls[1][0].pageToken).toBe('more');
+		});
+
+		it('rejects a malformed window loudly instead of sweeping something arbitrary', async () => {
+			await expect(plugin.backfill({ since: 'last week', settings: DRIVE_ONLY })).rejects.toThrow(
+				/valid ISO 8601/
+			);
+		});
+
+		it('still requires credentials — an unconfigured source fails with the stable error name', async () => {
+			await expect(plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
 		});
 	});
 });

--- a/packages/plugins/google-workspace-connector/src/google-workspace-connector-plugin.ts
+++ b/packages/plugins/google-workspace-connector/src/google-workspace-connector-plugin.ts
@@ -12,11 +12,13 @@ import type {
 	ChannelVerification,
 	EventSourcePullInput,
 	EventSourcePullResult,
+	EventSourceBackfillInput,
+	EventSourceBackfillResult,
 	PluginCategory,
 	PluginSettings,
 	JsonSchema
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError, clampEventSourceBackfillDays } from '@ever-works/plugin';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
 
 /**
@@ -50,11 +52,15 @@ export const GOOGLE_DOC_MIME_TYPE = 'application/vnd.google-apps.document';
 export const GOOGLE_SURFACES = ['drive', 'calendar'] as const;
 export type GoogleSurface = (typeof GOOGLE_SURFACES)[number];
 
-/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+/**
+ * Clamp the opt-in backfill window to the supported 0–90 day range.
+ *
+ * Delegates to the shared capability helper so the bound is stated once
+ * for the whole connector fabric; the local export stays because it is
+ * part of this plugin's published surface.
+ */
 export function clampBackfillDays(value: unknown): number {
-	const num = typeof value === 'number' ? value : Number(value);
-	if (!Number.isFinite(num) || num <= 0) return 0;
-	return Math.min(Math.floor(num), 90);
+	return clampEventSourceBackfillDays(value);
 }
 
 function truncateText(text: string): string {
@@ -559,6 +565,65 @@ export class GoogleWorkspaceConnectorPlugin implements IConnectorPlugin, IEventS
 		}
 
 		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	/**
+	 * Bounded HISTORICAL sweep from an explicit `since` — the
+	 * capability's opt-in `backfill()` method.
+	 *
+	 * Before this method existed, history was reachable only as a side
+	 * effect of the FIRST pull (`settings.backfillDays` widening the
+	 * initial window), so a user who activated the connector without the
+	 * setting could never go back and fetch it. `backfill()` runs the
+	 * same phase sweep (drive → each calendar) out-of-band on a
+	 * caller-chosen window, as many times as wanted — re-delivery is free
+	 * because the ingest pipeline dedupes on `(source, sourceEventId)`.
+	 *
+	 * `until` is accepted for contract symmetry but NOT applied: the
+	 * Drive `q` filter and the Calendar `updatedMin` parameter both bound
+	 * only the near end of the window, so the sweep runs `since → now`.
+	 * An over-wide window costs duplicate deliveries, which the pipeline
+	 * drops — never wrong data.
+	 *
+	 * The per-phase page bound (`GOOGLE_BACKFILL_MAX_PAGES`) applies
+	 * here too: one call fetches ONE page and hands back a cursor, so a
+	 * large Drive can never turn a backfill into an unbounded crawl.
+	 */
+	async backfill(input: EventSourceBackfillInput): Promise<EventSourceBackfillResult> {
+		const sinceMs = Date.parse(input.since);
+		if (!Number.isFinite(sinceMs)) {
+			throw new EventSourceNotConfiguredError(
+				`google-workspace-connector: backfill requires a valid ISO 8601 "since" (received ${JSON.stringify(input.since)})`
+			);
+		}
+
+		const surfaces = resolveSurfaces(input.settings);
+		if (surfaces.length === 0) {
+			return { events: [], complete: true };
+		}
+
+		// Resume the caller's cursor, or open the sweep on the first
+		// configured surface. `f: 1` marks it as a backfill sweep so the
+		// per-phase page bound engages.
+		const cursor =
+			input.cursor ??
+			JSON.stringify({
+				p: surfaces[0],
+				...(surfaces[0] === 'calendar' ? { i: 0 } : {}),
+				s: new Date(sinceMs).toISOString(),
+				f: 1 as const,
+				b: 0
+			} satisfies GooglePullCursor);
+
+		const page = await this.pullEvents({
+			since: input.since,
+			cursor,
+			...(input.settings ? { settings: input.settings } : {})
+		});
+
+		return page.nextCursor
+			? { events: page.events, nextCursor: page.nextCursor }
+			: { events: page.events, complete: true };
 	}
 
 	/**

--- a/packages/plugins/jira-connector/README.md
+++ b/packages/plugins/jira-connector/README.md
@@ -47,6 +47,14 @@ That is safe in both directions: dedupe is `(source, sourceEventId)`, so an
 over-wide window costs one extra page and drops nothing, and each comment
 re-checks `since` before its envelope is emitted.
 
+- **Historical backfill (`backfill()` capability method)** — the optional
+  `backfill()` method on the `event-source` capability runs the same sweep
+  out-of-band over an EXPLICIT window, so history can be imported at any time
+  instead of only as a side effect of the first pull's `backfillDays`. One call
+  fetches one page and hands back a cursor, so the per-phase page bound still
+  applies. Re-delivery is free — the ingest pipeline dedupes on
+  `(source, sourceEventId)`.
+
 ## Settings
 
 | Key               | Notes                                                              |

--- a/packages/plugins/jira-connector/src/jira-connector-plugin.spec.ts
+++ b/packages/plugins/jira-connector/src/jira-connector-plugin.spec.ts
@@ -10,6 +10,7 @@ import {
 	JIRA_BACKFILL_MAX_PAGES,
 	JIRA_EVENT_TEXT_MAX_CHARS
 } from './jira-connector-plugin.js';
+import { supportsEventSourceBackfill } from '@ever-works/plugin';
 
 const getCurrentUserMock = vi.fn();
 const searchIssuesMock = vi.fn();
@@ -404,6 +405,51 @@ describe('JiraConnectorPlugin', () => {
 				settings: { ...SETTINGS, projectKeys: 'ENG, OPS' }
 			});
 			expect(searchIssuesMock.mock.calls[0][0].jql).toContain('project in (ENG, OPS)');
+		});
+	});
+
+	// `backfill()` capability method (audit item (l)).
+	describe('backfill', () => {
+		it('is exposed as the capability method, feature-detectable by callers', () => {
+			expect(typeof plugin.backfill).toBe('function');
+			expect(supportsEventSourceBackfill(plugin as never)).toBe(true);
+		});
+
+		it('⭐ sweeps an EXPLICIT window regardless of the settings backfillDays', async () => {
+			searchIssuesMock.mockResolvedValue(emptyPage());
+
+			// `backfillDays` deliberately absent: history used to be
+			// reachable ONLY through that first-pull setting.
+			const result = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+
+			expect(searchIssuesMock.mock.calls[0][0].jql).toContain(toJqlDateTime('2026-05-01T00:00:00.000Z'));
+			expect(result.complete).toBe(true);
+			expect(result.nextCursor).toBeUndefined();
+		});
+
+		it('marks the sweep as a backfill so the page bound engages, and resumes from its cursor', async () => {
+			searchIssuesMock.mockResolvedValue({ issues: [], nextPageToken: 'more' });
+
+			const first = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+			expect(JSON.parse(first.nextCursor as string).f).toBe(1);
+			expect(first.complete).toBeUndefined();
+
+			await plugin.backfill({
+				since: '2026-05-01T00:00:00.000Z',
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			expect(searchIssuesMock.mock.calls[1][0].nextPageToken).toBe('more');
+		});
+
+		it('rejects a malformed window loudly instead of sweeping something arbitrary', async () => {
+			await expect(plugin.backfill({ since: 'last week', settings: SETTINGS })).rejects.toThrow(/valid ISO 8601/);
+		});
+
+		it('still requires credentials — an unconfigured source fails with the stable error name', async () => {
+			await expect(plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
 		});
 	});
 });

--- a/packages/plugins/jira-connector/src/jira-connector-plugin.ts
+++ b/packages/plugins/jira-connector/src/jira-connector-plugin.ts
@@ -11,11 +11,13 @@ import type {
 	ChannelVerification,
 	EventSourcePullInput,
 	EventSourcePullResult,
+	EventSourceBackfillInput,
+	EventSourceBackfillResult,
 	PluginCategory,
 	PluginSettings,
 	JsonSchema
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError, clampEventSourceBackfillDays } from '@ever-works/plugin';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
 
 /**
@@ -48,11 +50,15 @@ export const JIRA_ISSUE_FIELDS = [
 	'comment'
 ] as const;
 
-/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+/**
+ * Clamp the opt-in backfill window to the supported 0–90 day range.
+ *
+ * Delegates to the shared capability helper so the bound is stated once
+ * for the whole connector fabric; the local export stays because it is
+ * part of this plugin's published surface.
+ */
 export function clampBackfillDays(value: unknown): number {
-	const num = typeof value === 'number' ? value : Number(value);
-	if (!Number.isFinite(num) || num <= 0) return 0;
-	return Math.min(Math.floor(num), 90);
+	return clampEventSourceBackfillDays(value);
 }
 
 function truncateText(text: string): string {
@@ -568,6 +574,57 @@ export class JiraConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin
 				: undefined;
 
 		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	/**
+	 * Bounded HISTORICAL sweep from an explicit `since` — the
+	 * capability's opt-in `backfill()` method.
+	 *
+	 * Before this method existed, history was reachable only as a side
+	 * effect of the FIRST pull (`settings.backfillDays` widening the
+	 * initial window), so a user who activated the connector without the
+	 * setting could never go back and fetch it. `backfill()` runs the
+	 * same JQL sweep out-of-band on a caller-chosen window, as many times
+	 * as wanted — re-delivery is free because the ingest pipeline dedupes
+	 * on `(source, sourceEventId)`.
+	 *
+	 * `until` is accepted for contract symmetry but NOT applied: the
+	 * sweep's JQL bounds only the near end (`updated >= since`). An
+	 * over-wide window costs duplicate deliveries, which the pipeline
+	 * drops — never wrong data.
+	 *
+	 * The page bound (`JIRA_BACKFILL_MAX_PAGES`) applies here too: one
+	 * call fetches ONE page and hands back a cursor, so a large project
+	 * can never turn a backfill into an unbounded crawl.
+	 */
+	async backfill(input: EventSourceBackfillInput): Promise<EventSourceBackfillResult> {
+		const sinceMs = Date.parse(input.since);
+		if (!Number.isFinite(sinceMs)) {
+			throw new EventSourceNotConfiguredError(
+				`jira-connector: backfill requires a valid ISO 8601 "since" (received ${JSON.stringify(input.since)})`
+			);
+		}
+
+		// Resume the caller's cursor, or open the sweep at the requested
+		// window start. `f: 1` marks it a backfill sweep so the page bound
+		// engages.
+		const cursor =
+			input.cursor ??
+			JSON.stringify({
+				s: new Date(sinceMs).toISOString(),
+				f: 1 as const,
+				b: 0
+			} satisfies JiraPullCursor);
+
+		const page = await this.pullEvents({
+			since: input.since,
+			cursor,
+			...(input.settings ? { settings: input.settings } : {})
+		});
+
+		return page.nextCursor
+			? { events: page.events, nextCursor: page.nextCursor }
+			: { events: page.events, complete: true };
 	}
 
 	private normalizeIssue(issue: JiraIssueNode, since: string, baseUrl: string): IngestedEventEnvelope | null {

--- a/packages/plugins/linear-connector/README.md
+++ b/packages/plugins/linear-connector/README.md
@@ -18,6 +18,14 @@ Capabilities: `connector`, `connector-linear`, `event-source`.
   widens the FIRST pull's window only, bounded to
   `LINEAR_BACKFILL_MAX_PAGES` pages per phase.
 
+- **Historical backfill (`backfill()` capability method)** — the optional
+  `backfill()` method on the `event-source` capability runs the same sweep
+  out-of-band over an EXPLICIT window, so history can be imported at any time
+  instead of only as a side effect of the first pull's `backfillDays`. One call
+  fetches one page and hands back a cursor, so the per-phase page bound still
+  applies. Re-delivery is free — the ingest pipeline dedupes on
+  `(source, sourceEventId)`.
+
 ## Settings
 
 | Key              | Notes                                                        |

--- a/packages/plugins/linear-connector/src/linear-connector-plugin.spec.ts
+++ b/packages/plugins/linear-connector/src/linear-connector-plugin.spec.ts
@@ -5,6 +5,7 @@ import {
 	LINEAR_EVENT_TEXT_MAX_CHARS,
 	LINEAR_BACKFILL_MAX_PAGES
 } from './linear-connector-plugin.js';
+import { supportsEventSourceBackfill } from '@ever-works/plugin';
 
 const viewerMock = vi.fn();
 const issuesMock = vi.fn();
@@ -322,6 +323,59 @@ describe('LinearConnectorPlugin', () => {
 			});
 			expect(issuesMock).toHaveBeenCalledTimes(1);
 			expect(res.events).toEqual([]);
+		});
+	});
+
+	// `backfill()` capability method (audit item (l)).
+	describe('backfill', () => {
+		it('is exposed as the capability method, feature-detectable by callers', () => {
+			expect(typeof plugin.backfill).toBe('function');
+			expect(supportsEventSourceBackfill(plugin as never)).toBe(true);
+		});
+
+		it('⭐ sweeps an EXPLICIT window regardless of the settings backfillDays', async () => {
+			issuesMock.mockResolvedValue(emptyPage());
+
+			// `backfillDays` deliberately absent: history used to be
+			// reachable ONLY through that first-pull setting.
+			const result = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+
+			expect(issuesMock.mock.calls[0][0].filter.updatedAt.gte).toEqual(new Date('2026-05-01T00:00:00.000Z'));
+			// Sweep opens on the issues phase and advances to comments.
+			expect(JSON.parse(result.nextCursor as string).p).toBe('comments');
+			expect(result.complete).toBeUndefined();
+		});
+
+		it('marks the sweep as a backfill so the per-phase page bound engages', async () => {
+			issuesMock.mockResolvedValue(emptyPage());
+			const result = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+			expect(JSON.parse(result.nextCursor as string).f).toBe(1);
+		});
+
+		it('resumes from the returned cursor and reports completion at the end', async () => {
+			issuesMock.mockResolvedValue(emptyPage());
+			commentsMock.mockResolvedValue(emptyPage());
+
+			const first = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+			const second = await plugin.backfill({
+				since: '2026-05-01T00:00:00.000Z',
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+
+			expect(commentsMock).toHaveBeenCalledTimes(1);
+			expect(second.nextCursor).toBeUndefined();
+			expect(second.complete).toBe(true);
+		});
+
+		it('rejects a malformed window loudly instead of sweeping something arbitrary', async () => {
+			await expect(plugin.backfill({ since: 'last week', settings: SETTINGS })).rejects.toThrow(/valid ISO 8601/);
+		});
+
+		it('still requires credentials — an unconfigured source fails with the stable error name', async () => {
+			await expect(plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
 		});
 	});
 });

--- a/packages/plugins/linear-connector/src/linear-connector-plugin.ts
+++ b/packages/plugins/linear-connector/src/linear-connector-plugin.ts
@@ -11,11 +11,13 @@ import type {
 	ChannelVerification,
 	EventSourcePullInput,
 	EventSourcePullResult,
+	EventSourceBackfillInput,
+	EventSourceBackfillResult,
 	PluginCategory,
 	PluginSettings,
 	JsonSchema
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError, clampEventSourceBackfillDays } from '@ever-works/plugin';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
 
 /**
@@ -36,11 +38,15 @@ export const LINEAR_PULL_PAGE_SIZE = 50;
  */
 export const LINEAR_BACKFILL_MAX_PAGES = 10;
 
-/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+/**
+ * Clamp the opt-in backfill window to the supported 0–90 day range.
+ *
+ * Delegates to the shared capability helper so the bound is stated once
+ * for the whole connector fabric; the local export stays because it is
+ * part of this plugin's published surface.
+ */
 export function clampBackfillDays(value: unknown): number {
-	const num = typeof value === 'number' ? value : Number(value);
-	if (!Number.isFinite(num) || num <= 0) return 0;
-	return Math.min(Math.floor(num), 90);
+	return clampEventSourceBackfillDays(value);
 }
 
 function truncateText(text: string): string {
@@ -418,6 +424,58 @@ export class LinearConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 		}
 
 		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	/**
+	 * Bounded HISTORICAL sweep from an explicit `since` — the
+	 * capability's opt-in `backfill()` method.
+	 *
+	 * Before this method existed, history was reachable only as a side
+	 * effect of the FIRST pull (`settings.backfillDays` widening the
+	 * initial window), so a user who activated the connector without the
+	 * setting could never go back and fetch it. `backfill()` runs the
+	 * same two-phase sweep (issues → comments) out-of-band on a
+	 * caller-chosen window, as many times as wanted — re-delivery is free
+	 * because the ingest pipeline dedupes on `(source, sourceEventId)`.
+	 *
+	 * `until` is accepted for contract symmetry but NOT applied: the SDK
+	 * filter bounds only the near end (`updatedAt >= since`). An
+	 * over-wide window costs duplicate deliveries, which the pipeline
+	 * drops — never wrong data.
+	 *
+	 * The per-phase page bound (`LINEAR_BACKFILL_MAX_PAGES`) applies here
+	 * too: one call fetches ONE page and hands back a cursor, so a large
+	 * workspace can never turn a backfill into an unbounded crawl.
+	 */
+	async backfill(input: EventSourceBackfillInput): Promise<EventSourceBackfillResult> {
+		const sinceMs = Date.parse(input.since);
+		if (!Number.isFinite(sinceMs)) {
+			throw new EventSourceNotConfiguredError(
+				`linear-connector: backfill requires a valid ISO 8601 "since" (received ${JSON.stringify(input.since)})`
+			);
+		}
+
+		// Resume the caller's cursor, or open the sweep on the issues
+		// phase. `f: 1` marks it a backfill sweep so the page bound
+		// engages.
+		const cursor =
+			input.cursor ??
+			JSON.stringify({
+				p: 'issues',
+				s: new Date(sinceMs).toISOString(),
+				f: 1 as const,
+				b: 0
+			} satisfies LinearPullCursor);
+
+		const page = await this.pullEvents({
+			since: input.since,
+			cursor,
+			...(input.settings ? { settings: input.settings } : {})
+		});
+
+		return page.nextCursor
+			? { events: page.events, nextCursor: page.nextCursor }
+			: { events: page.events, complete: true };
 	}
 
 	private normalizeIssue(issue: LinearIssueNode, since: string): IngestedEventEnvelope | null {

--- a/packages/plugins/notion-connector/README.md
+++ b/packages/plugins/notion-connector/README.md
@@ -22,6 +22,14 @@ Capabilities: `connector`, `connector-notion`, `event-source`.
   widens the FIRST pull's window only, bounded to
   `NOTION_BACKFILL_MAX_PAGES` result pages per phase.
 
+- **Historical backfill (`backfill()` capability method)** — the optional
+  `backfill()` method on the `event-source` capability runs the same sweep
+  out-of-band over an EXPLICIT window, so history can be imported at any time
+  instead of only as a side effect of the first pull's `backfillDays`. One call
+  fetches one page and hands back a cursor, so the per-phase page bound still
+  applies. Re-delivery is free — the ingest pipeline dedupes on
+  `(source, sourceEventId)`.
+
 ## Settings
 
 | Key             | Notes                                                         |

--- a/packages/plugins/notion-connector/src/notion-connector-plugin.spec.ts
+++ b/packages/plugins/notion-connector/src/notion-connector-plugin.spec.ts
@@ -5,6 +5,7 @@ import {
 	extractPageTitle,
 	NOTION_BACKFILL_MAX_PAGES
 } from './notion-connector-plugin.js';
+import { supportsEventSourceBackfill } from '@ever-works/plugin';
 
 const usersMeMock = vi.fn();
 const searchMock = vi.fn();
@@ -316,6 +317,62 @@ describe('NotionConnectorPlugin', () => {
 			});
 			expect(searchMock).toHaveBeenCalledTimes(1);
 			expect(res.events).toEqual([]);
+		});
+	});
+
+	// `backfill()` capability method (audit item (l)).
+	describe('backfill', () => {
+		it('is exposed as the capability method, feature-detectable by callers', () => {
+			expect(typeof plugin.backfill).toBe('function');
+			expect(supportsEventSourceBackfill(plugin as never)).toBe(true);
+		});
+
+		it('⭐ sweeps an EXPLICIT window regardless of the settings backfillDays', async () => {
+			searchMock.mockResolvedValue({ results: [], has_more: false, next_cursor: null });
+
+			// `backfillDays` deliberately absent: history used to be
+			// reachable ONLY through that first-pull setting.
+			const result = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+
+			expect(searchMock).toHaveBeenCalledTimes(1);
+			expect(result.complete).toBe(true);
+			expect(result.nextCursor).toBeUndefined();
+		});
+
+		it('opens on the configured databases when there are any, else workspace search', async () => {
+			databasesQueryMock.mockResolvedValue({ results: [], has_more: false, next_cursor: null });
+			await plugin.backfill({
+				since: '2026-05-01T00:00:00.000Z',
+				settings: { ...SETTINGS, databaseIds: 'db-1' }
+			});
+			expect(databasesQueryMock.mock.calls[0][0].database_id).toBe('db-1');
+			expect(searchMock).not.toHaveBeenCalled();
+		});
+
+		it('marks the sweep as a backfill so the page bound engages, and resumes from its cursor', async () => {
+			searchMock.mockResolvedValue({ results: [], has_more: true, next_cursor: 'more' });
+
+			const first = await plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: SETTINGS });
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed.f).toBe(1);
+			expect(first.complete).toBeUndefined();
+
+			await plugin.backfill({
+				since: '2026-05-01T00:00:00.000Z',
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			expect(searchMock.mock.calls[1][0].start_cursor).toBe('more');
+		});
+
+		it('rejects a malformed window loudly instead of sweeping something arbitrary', async () => {
+			await expect(plugin.backfill({ since: 'last week', settings: SETTINGS })).rejects.toThrow(/valid ISO 8601/);
+		});
+
+		it('still requires credentials — an unconfigured source fails with the stable error name', async () => {
+			await expect(plugin.backfill({ since: '2026-05-01T00:00:00.000Z', settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
 		});
 	});
 });

--- a/packages/plugins/notion-connector/src/notion-connector-plugin.ts
+++ b/packages/plugins/notion-connector/src/notion-connector-plugin.ts
@@ -11,11 +11,13 @@ import type {
 	ChannelVerification,
 	EventSourcePullInput,
 	EventSourcePullResult,
+	EventSourceBackfillInput,
+	EventSourceBackfillResult,
 	PluginCategory,
 	PluginSettings,
 	JsonSchema
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError, clampEventSourceBackfillDays } from '@ever-works/plugin';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
 
 /**
@@ -35,11 +37,15 @@ export const NOTION_PULL_PAGE_SIZE = 50;
  */
 export const NOTION_BACKFILL_MAX_PAGES = 10;
 
-/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+/**
+ * Clamp the opt-in backfill window to the supported 0–90 day range.
+ *
+ * Delegates to the shared capability helper so the bound is stated once
+ * for the whole connector fabric; the local export stays because it is
+ * part of this plugin's published surface.
+ */
 export function clampBackfillDays(value: unknown): number {
-	const num = typeof value === 'number' ? value : Number(value);
-	if (!Number.isFinite(num) || num <= 0) return 0;
-	return Math.min(Math.floor(num), 90);
+	return clampEventSourceBackfillDays(value);
 }
 
 function truncateText(text: string): string {
@@ -462,6 +468,62 @@ export class NotionConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 			};
 		}
 		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	/**
+	 * Bounded HISTORICAL sweep from an explicit `since` — the
+	 * capability's opt-in `backfill()` method.
+	 *
+	 * Before this method existed, history was reachable only as a side
+	 * effect of the FIRST pull (`settings.backfillDays` widening the
+	 * initial window), so a user who activated the connector without the
+	 * setting could never go back and fetch it. `backfill()` runs the
+	 * same sweep (configured databases, else workspace search)
+	 * out-of-band on a caller-chosen window, as many times as wanted —
+	 * re-delivery is free because the ingest pipeline dedupes on
+	 * `(source, sourceEventId)`.
+	 *
+	 * `until` is accepted for contract symmetry but NOT applied: the
+	 * Notion filter bounds only the near end
+	 * (`last_edited_time on_or_after`). An over-wide window costs
+	 * duplicate deliveries, which the pipeline drops — never wrong data.
+	 *
+	 * The per-phase page bound (`NOTION_BACKFILL_MAX_PAGES`) applies here
+	 * too: one call fetches ONE page and hands back a cursor, so a large
+	 * workspace can never turn a backfill into an unbounded crawl.
+	 */
+	async backfill(input: EventSourceBackfillInput): Promise<EventSourceBackfillResult> {
+		const sinceMs = Date.parse(input.since);
+		if (!Number.isFinite(sinceMs)) {
+			throw new EventSourceNotConfiguredError(
+				`notion-connector: backfill requires a valid ISO 8601 "since" (received ${JSON.stringify(input.since)})`
+			);
+		}
+
+		// Resume the caller's cursor, or open the sweep the same way a
+		// first pull does: configured databases when present, otherwise
+		// the workspace search. `f: 1` marks it a backfill sweep so the
+		// page bound engages.
+		const databaseIds = resolveDatabaseIds(input.settings);
+		const cursor =
+			input.cursor ??
+			JSON.stringify({
+				m: databaseIds.length > 0 ? 'db' : 'search',
+				...(databaseIds[0] ? { d: databaseIds[0] } : {}),
+				s: new Date(sinceMs).toISOString(),
+				f: 1 as const,
+				b: 0
+			} satisfies NotionPullCursor);
+
+		const page = await this.pullEvents({
+			since: input.since,
+			cursor,
+			...(input.settings ? { settings: input.settings } : {})
+		});
+
+		return page.nextCursor
+			? { events: page.events, nextCursor: page.nextCursor }
+			: { events: page.events, complete: true };
 	}
 
 	private normalizePage(page: NotionPageObject, since: string, databaseId?: string): IngestedEventEnvelope | null {

--- a/packages/plugins/zoom-connector/README.md
+++ b/packages/plugins/zoom-connector/README.md
@@ -18,6 +18,14 @@ Zoom connector for the Ever Works platform (Wave 8, Meetings v1 — transcript-f
   Server-to-Server OAuth credentials. Outbound messaging is **not** part of v1;
   `send` rejects loudly.
 
+- **Historical backfill (`backfill()` capability method)** — the optional
+  `backfill()` method on the `event-source` capability runs the same sweep
+  out-of-band over an EXPLICIT window, so history can be imported at any time
+  instead of only as a side effect of the first pull's `backfillDays`. One call
+  fetches one page and hands back a cursor, so the per-phase page bound still
+  applies. Re-delivery is free — the ingest pipeline dedupes on
+  `(source, sourceEventId)`.
+
 ## Settings
 
 | Key            | Notes                                                             |

--- a/packages/plugins/zoom-connector/src/zoom-connector-plugin.spec.ts
+++ b/packages/plugins/zoom-connector/src/zoom-connector-plugin.spec.ts
@@ -8,6 +8,7 @@ import {
 	ZOOM_WINDOW_MAX_DAYS
 } from './zoom-connector-plugin.js';
 import type { ZoomRecordingsPage } from './zoom-connector-plugin.js';
+import { supportsEventSourceBackfill } from '@ever-works/plugin';
 
 const listAllRecordingsMock = vi.fn();
 const downloadTranscriptMock = vi.fn();
@@ -289,5 +290,94 @@ describe('ZoomConnectorPlugin', () => {
 		await expect(
 			plugin.send({ messageRef: 'ref-1', text: 'hello' } as never, { settings: SETTINGS })
 		).rejects.toThrow(/not supported in v1/);
+	});
+
+	// `backfill()` capability method (audit item (l)).
+	describe('backfill', () => {
+		it('is exposed as the capability method, feature-detectable by callers', () => {
+			expect(typeof plugin.backfill).toBe('function');
+			expect(supportsEventSourceBackfill(plugin as never)).toBe(true);
+		});
+
+		it('⭐ sweeps an EXPLICIT window regardless of the settings backfillDays', async () => {
+			listAllRecordingsMock.mockResolvedValue(emptyPage());
+			const since = '2026-05-01T00:00:00.000Z';
+			const until = '2026-05-10T00:00:00.000Z';
+
+			// `backfillDays` is deliberately absent: history used to be
+			// reachable ONLY through that first-pull setting.
+			const result = await plugin.backfill({ since, until, settings: SETTINGS });
+
+			const query = listAllRecordingsMock.mock.calls[0][0];
+			expect(query.from).toBe('2026-05-01');
+			expect(query.to).toBe('2026-05-10');
+			expect(result.complete).toBe(true);
+			expect(result.nextCursor).toBeUndefined();
+		});
+
+		it('chunks a long window and resumes from the returned cursor', async () => {
+			listAllRecordingsMock.mockResolvedValue(emptyPage());
+			const since = '2026-01-01T00:00:00.000Z';
+			const until = new Date(Date.parse(since) + 3 * ZOOM_WINDOW_MAX_DAYS * DAY_MS).toISOString();
+
+			const first = await plugin.backfill({ since, until, settings: SETTINGS });
+			expect(first.nextCursor).toBeDefined();
+			expect(first.complete).toBeUndefined();
+
+			const second = await plugin.backfill({
+				since,
+				until,
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			// The second call advanced past the first ≤30-day chunk.
+			expect(listAllRecordingsMock.mock.calls[1][0].from).not.toBe(listAllRecordingsMock.mock.calls[0][0].from);
+			expect(second.nextCursor).toBeDefined();
+		});
+
+		it('defaults `until` to now and normalizes an inverted window to a no-op', async () => {
+			listAllRecordingsMock.mockResolvedValue(emptyPage());
+
+			const empty = await plugin.backfill({
+				since: '2026-07-01T00:00:00.000Z',
+				until: '2026-06-01T00:00:00.000Z',
+				settings: SETTINGS
+			});
+			expect(empty).toEqual({ events: [], complete: true });
+			expect(listAllRecordingsMock).not.toHaveBeenCalled();
+
+			await plugin.backfill({ since: new Date(Date.now() - DAY_MS).toISOString(), settings: SETTINGS });
+			expect(listAllRecordingsMock.mock.calls[0][0].to).toBe(new Date().toISOString().slice(0, 10));
+		});
+
+		it('normalizes ingested recordings the same way the incremental sweep does', async () => {
+			listAllRecordingsMock.mockResolvedValue({ meetings: [recordingMeeting()] });
+
+			const result = await plugin.backfill({
+				since: '2026-07-01T00:00:00.000Z',
+				until: '2026-07-20T00:00:00.000Z',
+				settings: SETTINGS
+			});
+
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0]).toMatchObject({
+				source: 'zoom-connector',
+				kind: 'zoom.recording',
+				sourceEventId: 'uuid-1:recording'
+			});
+		});
+
+		it('rejects a malformed window loudly instead of sweeping something arbitrary', async () => {
+			await expect(plugin.backfill({ since: 'yesterday', settings: SETTINGS })).rejects.toThrow(/valid ISO 8601/);
+			await expect(
+				plugin.backfill({ since: '2026-07-01T00:00:00.000Z', until: 'soon', settings: SETTINGS })
+			).rejects.toThrow(/valid ISO 8601/);
+		});
+
+		it('still requires credentials — an unconfigured source fails with the stable error name', async () => {
+			await expect(plugin.backfill({ since: '2026-07-01T00:00:00.000Z', settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
+		});
 	});
 });

--- a/packages/plugins/zoom-connector/src/zoom-connector-plugin.ts
+++ b/packages/plugins/zoom-connector/src/zoom-connector-plugin.ts
@@ -11,11 +11,13 @@ import type {
 	ChannelVerification,
 	EventSourcePullInput,
 	EventSourcePullResult,
+	EventSourceBackfillInput,
+	EventSourceBackfillResult,
 	PluginCategory,
 	PluginSettings,
 	JsonSchema
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError, clampEventSourceBackfillDays } from '@ever-works/plugin';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
 
 /**
@@ -45,11 +47,15 @@ export const ZOOM_BACKFILL_MAX_PAGES = 10;
 
 const DAY_MS = 86_400_000;
 
-/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+/**
+ * Clamp the opt-in backfill window to the supported 0–90 day range.
+ *
+ * Delegates to the shared capability helper so the bound is stated once
+ * for the whole connector fabric; the local export stays because it is
+ * part of this plugin's published surface.
+ */
 export function clampBackfillDays(value: unknown): number {
-	const num = typeof value === 'number' ? value : Number(value);
-	if (!Number.isFinite(num) || num <= 0) return 0;
-	return Math.min(Math.floor(num), 90);
+	return clampEventSourceBackfillDays(value);
 }
 
 /**
@@ -464,6 +470,66 @@ export class ZoomConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin
 		}
 
 		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	/**
+	 * Bounded HISTORICAL sweep over an explicit `[since, until]` window —
+	 * the capability's opt-in `backfill()` method.
+	 *
+	 * Before this method existed, history was reachable only as a side
+	 * effect of the FIRST pull (`settings.backfillDays` widening the
+	 * initial window), so a user who activated the connector without the
+	 * setting could never go back and fetch it. `backfill()` runs the same
+	 * chunked sweep out-of-band, on a caller-chosen window, as many times
+	 * as wanted — re-delivery is free because the ingest pipeline dedupes
+	 * on `(source, sourceEventId)`.
+	 *
+	 * The per-chunk page bound (`ZOOM_BACKFILL_MAX_PAGES`) applies here
+	 * too: one call fetches ONE page and hands back a cursor, so a
+	 * recording-heavy account can never turn a backfill into an
+	 * unbounded crawl.
+	 */
+	async backfill(input: EventSourceBackfillInput): Promise<EventSourceBackfillResult> {
+		const sinceMs = Date.parse(input.since);
+		if (!Number.isFinite(sinceMs)) {
+			throw new EventSourceNotConfiguredError(
+				`zoom-connector: backfill requires a valid ISO 8601 "since" (received ${JSON.stringify(input.since)})`
+			);
+		}
+		const untilMs = input.until ? Date.parse(input.until) : Date.now();
+		if (!Number.isFinite(untilMs)) {
+			throw new EventSourceNotConfiguredError(
+				`zoom-connector: backfill "until" must be a valid ISO 8601 timestamp (received ${JSON.stringify(input.until)})`
+			);
+		}
+		// An inverted or empty window is a no-op, not an error — callers
+		// derive windows from user input and clock skew is real.
+		if (untilMs <= sinceMs) {
+			return { events: [], complete: true };
+		}
+
+		// Resume the caller's cursor, or open the sweep on the first
+		// ≤30-day chunk of the requested window. `f: 1` marks it as a
+		// backfill sweep so the per-chunk page bound engages.
+		const cursor =
+			input.cursor ??
+			JSON.stringify({
+				from: new Date(sinceMs).toISOString(),
+				to: new Date(Math.min(sinceMs + ZOOM_WINDOW_MAX_DAYS * DAY_MS, untilMs)).toISOString(),
+				w: new Date(untilMs).toISOString(),
+				f: 1 as const,
+				b: 0
+			} satisfies ZoomPullCursor);
+
+		const page = await this.pullEvents({
+			since: input.since,
+			cursor,
+			...(input.settings ? { settings: input.settings } : {})
+		});
+
+		return page.nextCursor
+			? { events: page.events, nextCursor: page.nextCursor }
+			: { events: page.events, complete: true };
 	}
 
 	/**


### PR DESCRIPTION
Three ingest-side gaps (audit items (l), (i), (k)), fixed together because they
all sit on the same spine.

## 1. `backfill()` is now a capability method — (l)

Historical catch-up existed only as per-connector ad-hoc code, so there was no
uniform way to ask "can this connector backfill, and over what window?".

`backfill()` is promoted onto the event-source capability contract as an
**optional** method — optional so connectors without it still load — and
implemented for the five that already had backfill logic:

| Connector |
|---|
| google-workspace |
| jira |
| linear |
| notion |
| zoom |

The window is normalized and clamped in **one** place instead of five.

## 2. External issue ↔ Task mapping — (i)

An ingested external issue had nowhere to record which Task it corresponds to,
so the link had to be re-derived or guessed at every read. Adds an
`ExternalIssueLink` entity + repository + service, registered in the entity
inventories and shipped with its migration.

## 3. Salience filter — (k)

Ingest had no way to drop low-value events, so a chatty connector could flood
the feed. `IngestSalienceService` scores envelopes and the drain skips
non-salient ones. Configurable through a new `ingest` config group with a
**safe default that preserves today's behaviour when unset** — an install that
configures nothing sees no change. The `config.spec` group pin is updated in the
same commit.

## Who calls this in production?

All three are `@Optional()` at the injection point **and actually invoked** —
worth stating separately, because an optional constructor param with no call
site is exactly the dead-code shape this whole audit exists to catch:

| Feature | Production call site |
|---|---|
| salience filter | `packages/agent/src/ingest/event-ingest.service.ts:189` — `if (this.salience && !this.salience.isSalient(envelope))` |
| external issue link | refreshed on the same drain, `event-ingest.service.ts` |
| backfill sweep | `packages/agent/src/ingest/event-source-pull.service.ts:339` — `await plugin.backfill({…})` |

## Migration

Renumbered `1784700000000` → **`1784730000000`** to avoid colliding with the
already-merged `AddUserSubscriptionProviderRef` (#1900). The class name, the
`name` property, the spec's import path and `describe` block, and a doc
reference in the entity were all updated to match — a rename that leaves those
stale compiles fine and fails at runtime.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `pnpm build --filter=@ever-works/plugin` | green |
| `packages/agent` jest | green — 447 suites, 8153 tests |
| `apps/api` jest | green — 231 suites, 3776 tests |
| `packages/plugin` vitest | green — 24 files |
| prettier | clean |

The `better-sqlite3` native binding was verified present before running, so the
sqlite-backed entity-registration integration specs — the net that catches a
missing `ENTITIES` entry — genuinely executed rather than silently erroring out.