### PR TITLE
feat(billing): add subscription lifecycle — dunning, cancel, resume, portal (B07/B08)

### DIFF
--- a/apps/api/src/billing/billing-webhook.controller.spec.ts
+++ b/apps/api/src/billing/billing-webhook.controller.spec.ts
@@ -129,6 +129,25 @@ describe('BillingWebhookController', () => {
         });
     });
 
+    it('acknowledges a subscription lifecycle delivery (audit B07/B08)', async () => {
+        // A dunning / cancellation delivery reconciles state rather than
+        // moving credits, and must still answer 200 with its action.
+        const controller = new BillingWebhookController(
+            makeService({
+                handleWebhook: jest.fn().mockResolvedValue({
+                    eventId: 'evt_sub',
+                    kind: 'subscription.updated',
+                    action: 'subscription-reconciled',
+                }),
+            }),
+        );
+
+        await expect(controller.receive({ rawBody: '{}' }, 'sig')).resolves.toEqual({
+            ok: true,
+            action: 'subscription-reconciled',
+        });
+    });
+
     it('lets an unexpected internal error surface (not masked as a 401)', async () => {
         const controller = new BillingWebhookController(
             makeService({ handleWebhook: jest.fn().mockRejectedValue(new Error('db down')) }),

--- a/apps/api/src/billing/billing.controller.spec.ts
+++ b/apps/api/src/billing/billing.controller.spec.ts
@@ -23,11 +23,18 @@ class FakeUnknownCreditPackError extends Error {
         this.name = 'UnknownCreditPackError';
     }
 }
+class FakeNoActiveSubscriptionError extends Error {
+    constructor(message = 'No manageable subscription for this account') {
+        super(message);
+        this.name = 'NoActiveSubscriptionError';
+    }
+}
 
 jest.mock('@ever-works/agent/subscriptions', () => ({
     BillingProviderNotConfiguredError: FakeBillingProviderNotConfiguredError,
     BillingProviderError: FakeBillingProviderError,
     UnknownCreditPackError: FakeUnknownCreditPackError,
+    NoActiveSubscriptionError: FakeNoActiveSubscriptionError,
     BillingService: class BillingService {},
     CREDIT_PACK_IDS: ['credits-1000', 'credits-5500', 'credits-25000'],
 }));
@@ -90,6 +97,14 @@ function makeService(overrides: Record<string, unknown> = {}) {
                 packId: null,
                 failureCount: 0,
             },
+            subscription: {
+                status: 'active',
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+                canceledAt: null,
+                pastDue: false,
+                manageable: true,
+            },
         }),
         listInvoices: jest
             .fn()
@@ -100,6 +115,26 @@ function makeService(overrides: Record<string, unknown> = {}) {
             autoRechargePackId: 'credits-1000',
             autoRechargeFailureCount: 0,
         }),
+        // Subscription lifecycle (audit B07/B08).
+        cancelSubscription: jest.fn().mockResolvedValue({
+            status: 'active',
+            cancelAtPeriodEnd: true,
+            currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+            canceledAt: null,
+            pastDue: false,
+            manageable: true,
+        }),
+        resumeSubscription: jest.fn().mockResolvedValue({
+            status: 'active',
+            cancelAtPeriodEnd: false,
+            currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+            canceledAt: null,
+            pastDue: false,
+            manageable: true,
+        }),
+        createBillingPortalSession: jest
+            .fn()
+            .mockResolvedValue({ url: 'https://pay.example/portal/bps_1' }),
         ...overrides,
     } as any;
 }
@@ -293,6 +328,107 @@ describe('BillingController — overview, invoices, auto-recharge', () => {
             packId: 'credits-1000',
         });
         expect(result).toEqual(expect.objectContaining({ enabled: true, thresholdCredits: 500 }));
+    });
+});
+
+/**
+ * Subscription lifecycle at the HTTP boundary (audit B07/B08).
+ *
+ * The routes take NO body and NO id: everything is resolved from the
+ * session user, which is what makes a cross-account (or cross-org)
+ * request structurally impossible rather than merely checked.
+ */
+describe('BillingController — subscription cancel / resume / portal', () => {
+    beforeAll(() => {
+        process.env.WEB_URL = 'https://app.test';
+    });
+
+    it('cancels for the AUTHENTICATED user and echoes the new state', async () => {
+        const service = makeService();
+        const controller = new BillingController(service);
+
+        const result = await controller.cancelSubscription(auth);
+
+        expect(service.cancelSubscription).toHaveBeenCalledWith('user-1');
+        expect(result.subscription).toEqual(
+            expect.objectContaining({ cancelAtPeriodEnd: true, status: 'active' }),
+        );
+    });
+
+    it('cannot be pointed at another account: the session user is the only input', async () => {
+        const service = makeService();
+        const controller = new BillingController(service);
+
+        await controller.cancelSubscription(auth);
+        await controller.cancelSubscription(otherAuth);
+
+        expect(service.cancelSubscription).toHaveBeenNthCalledWith(1, 'user-1');
+        expect(service.cancelSubscription).toHaveBeenNthCalledWith(2, 'user-2');
+        // There is no id/body parameter on the route at all.
+        expect(controller.cancelSubscription).toHaveLength(1);
+        expect(controller.resumeSubscription).toHaveLength(1);
+    });
+
+    it('resumes for the authenticated user', async () => {
+        const service = makeService();
+        const controller = new BillingController(service);
+
+        const result = await controller.resumeSubscription(auth);
+
+        expect(service.resumeSubscription).toHaveBeenCalledWith('user-1');
+        expect(result.subscription.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it('maps "no subscription" to 409 — the same answer a foreign account gets', async () => {
+        const service = makeService({
+            cancelSubscription: jest.fn().mockRejectedValue(new FakeNoActiveSubscriptionError()),
+            resumeSubscription: jest.fn().mockRejectedValue(new FakeNoActiveSubscriptionError()),
+        });
+        const controller = new BillingController(service);
+
+        await expect(controller.cancelSubscription(auth)).rejects.toBeInstanceOf(ConflictException);
+        await expect(controller.resumeSubscription(otherAuth)).rejects.toBeInstanceOf(
+            ConflictException,
+        );
+    });
+
+    it('maps provider-not-configured to 503 so the UI can degrade', async () => {
+        const service = makeService({
+            cancelSubscription: jest
+                .fn()
+                .mockRejectedValue(new FakeBillingProviderNotConfiguredError()),
+        });
+        const controller = new BillingController(service);
+
+        await expect(controller.cancelSubscription(auth)).rejects.toBeInstanceOf(
+            ServiceUnavailableException,
+        );
+    });
+
+    it('builds the portal return URL server-side (no client-supplied redirect)', async () => {
+        const service = makeService();
+        const controller = new BillingController(service);
+
+        const result = await controller.createPortalSession(auth);
+
+        expect(service.createBillingPortalSession).toHaveBeenCalledWith(
+            'user-1',
+            'https://app.test/settings/billing',
+        );
+        expect(result.url).toBe('https://pay.example/portal/bps_1');
+    });
+
+    it('surfaces the subscription state on the overview (the status chip’s source)', async () => {
+        const service = makeService();
+        const controller = new BillingController(service);
+
+        const result = await controller.getOverview(auth);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                subscription: expect.objectContaining({ status: 'active', manageable: true }),
+            }),
+        );
     });
 });
 

--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -21,6 +21,7 @@ import {
     BillingProviderError,
     BillingProviderNotConfiguredError,
     BillingService,
+    NoActiveSubscriptionError,
     UnknownCreditPackError,
 } from '@ever-works/agent/subscriptions';
 import { Invoice } from '@ever-works/agent/entities';
@@ -129,6 +130,78 @@ export class BillingController {
         }
     }
 
+    // ── Subscription lifecycle (audit B07/B08) ───────────────────────
+
+    @Post('subscription/cancel')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Cancel the subscription at the end of the paid period',
+        description:
+            'Schedules an at-period-end cancellation through the billing-provider seam and persists ' +
+            'the returned lifecycle state on the billing profile. The plan keeps working until the ' +
+            'period ends and `POST subscription/resume` reverses it. Owner-scoped: the subscription ' +
+            'is resolved from the session user, so no caller can cancel another account’s plan.',
+    })
+    @ApiResponse({ status: 200, description: 'Cancellation scheduled' })
+    @ApiResponse({ status: 409, description: 'No manageable subscription for this account' })
+    @ApiResponse({ status: 503, description: 'Payment provider not configured' })
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async cancelSubscription(@CurrentUser() auth: AuthenticatedUser) {
+        try {
+            const subscription = await this.billingService.cancelSubscription(auth.userId);
+            return { status: 'success', subscription };
+        } catch (error) {
+            throw mapBillingError(error);
+        }
+    }
+
+    @Post('subscription/resume')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Resume a subscription that was set to cancel at period end',
+        description:
+            'Clears a pending at-period-end cancellation through the billing-provider seam. Refused ' +
+            'with 409 once the subscription has actually ended — there is nothing left to resume.',
+    })
+    @ApiResponse({ status: 200, description: 'Subscription resumed' })
+    @ApiResponse({ status: 409, description: 'No manageable subscription for this account' })
+    @ApiResponse({ status: 503, description: 'Payment provider not configured' })
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async resumeSubscription(@CurrentUser() auth: AuthenticatedUser) {
+        try {
+            const subscription = await this.billingService.resumeSubscription(auth.userId);
+            return { status: 'success', subscription };
+        } catch (error) {
+            throw mapBillingError(error);
+        }
+    }
+
+    @Post('portal')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Open the provider’s hosted billing portal',
+        description:
+            'The PAST_DUE recovery action: returns a redirect URL where the owner can update the card ' +
+            'that failed. Capture stays on the provider’s tokenized surface. The return URL is built ' +
+            'server-side from WEB_URL — a client-supplied one would be an open redirect.',
+    })
+    @ApiResponse({ status: 200, description: 'Portal session created' })
+    @ApiResponse({ status: 409, description: 'No billing account for this user' })
+    @ApiResponse({ status: 503, description: 'Payment provider not configured' })
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async createPortalSession(@CurrentUser() auth: AuthenticatedUser) {
+        const base = config.webAppUrl().replace(/\/+$/, '');
+        try {
+            const session = await this.billingService.createBillingPortalSession(
+                auth.userId,
+                `${base}/settings/billing`,
+            );
+            return { status: 'success', url: session.url };
+        } catch (error) {
+            throw mapBillingError(error);
+        }
+    }
+
     /**
      * Explicit projection. `defaultPaymentMethodRef` and every provider
      * secret stay server-side; only display metadata crosses the wire.
@@ -228,6 +301,13 @@ function mapBillingError(error: unknown): unknown {
     }
     if (error instanceof UnknownCreditPackError) {
         return new BadRequestException(error.message);
+    }
+    // Subscription lifecycle (audit B07/B08): "you have nothing to
+    // cancel/resume" is a state conflict, not a server fault — and it is
+    // the same answer a cross-owner attempt gets, so the response cannot
+    // be used to probe whether another account has a subscription.
+    if (error instanceof NoActiveSubscriptionError) {
+        return new ConflictException(error.message);
     }
     if (error instanceof BillingProviderError) {
         return new ConflictException(error.message);

--- a/apps/api/src/migrations/1784720000000-AddBillingSubscriptionLifecycleColumns.ts
+++ b/apps/api/src/migrations/1784720000000-AddBillingSubscriptionLifecycleColumns.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Subscription lifecycle on the billing profile (audit B07/B08).
+ *
+ * The Billing page could START a subscription but never manage one:
+ * there was no cancel path, no `cancelAtPeriodEnd` state, and the status
+ * chip was hardcoded. These five columns give the money path somewhere to
+ * persist what the provider reports, so cancel/resume and the PAST_DUE
+ * banner read real state instead of an assumption.
+ *
+ *  - `providerSubscriptionId`   — opaque provider subscription id. NULL ⇒
+ *                                 no recurring plan (free tier / payments
+ *                                 not wired) and cancel/resume are refused
+ *                                 with a 409 rather than silently no-op'ing.
+ *  - `subscriptionStatus`       — vendor-neutral lifecycle token
+ *                                 (`active` / `past_due` / `canceled` …),
+ *                                 written by cancel/resume AND by the
+ *                                 signature-verified webhook.
+ *  - `cancelAtPeriodEnd`        — cancel requested, paid period still
+ *                                 running. Defaults FALSE, which is
+ *                                 exactly right for every existing row.
+ *  - `currentPeriodEnd`         — when a pending cancellation takes effect.
+ *  - `subscriptionCanceledAt`   — when it actually ended.
+ *
+ * Entity: `packages/agent/src/entities/billing-profile.entity.ts`. The
+ * two date columns are `PortableDateColumn` (`timestamp` NULL), matching
+ * `autoRechargeInFlightAt` / `autoRechargeLastFailureAt` on the same table.
+ *
+ * Nothing is backfilled: every pre-existing profile keeps NULL status +
+ * FALSE `cancelAtPeriodEnd`, which the service reads as "this account has
+ * no provider subscription" — the behaviour it had before this change.
+ *
+ * Forward-only with per-step guards (house pattern, mirrors
+ * `1784400000000-AddRunAttentionColumns`).
+ */
+export class AddBillingSubscriptionLifecycleColumns1784720000000 implements MigrationInterface {
+    name = 'AddBillingSubscriptionLifecycleColumns1784720000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('billing_profiles');
+        if (!table) return;
+
+        const addColumn = async (name: string, ddl: string) => {
+            if (!table.findColumnByName(name)) {
+                await queryRunner.query(`ALTER TABLE "billing_profiles" ADD COLUMN ${ddl}`);
+            }
+        };
+
+        await addColumn('providerSubscriptionId', `"providerSubscriptionId" varchar(128)`);
+        await addColumn('subscriptionStatus', `"subscriptionStatus" varchar(32)`);
+        await addColumn('cancelAtPeriodEnd', `"cancelAtPeriodEnd" boolean NOT NULL DEFAULT false`);
+        await addColumn('currentPeriodEnd', `"currentPeriodEnd" TIMESTAMP`);
+        await addColumn('subscriptionCanceledAt', `"subscriptionCanceledAt" TIMESTAMP`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('billing_profiles');
+        if (!table) return;
+        for (const col of [
+            'subscriptionCanceledAt',
+            'currentPeriodEnd',
+            'cancelAtPeriodEnd',
+            'subscriptionStatus',
+            'providerSubscriptionId',
+        ]) {
+            if (table.findColumnByName(col)) {
+                await queryRunner.query(`ALTER TABLE "billing_profiles" DROP COLUMN "${col}"`);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddBillingSubscriptionLifecycleColumns.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddBillingSubscriptionLifecycleColumns.spec.ts
@@ -1,0 +1,113 @@
+import { DataSource } from 'typeorm';
+import { AddBillingSubscriptionLifecycleColumns1784720000000 } from '../1784720000000-AddBillingSubscriptionLifecycleColumns';
+
+/**
+ * Subscription lifecycle columns (audit B07/B08) — migration test on an
+ * in-memory better-sqlite3 DataSource (same harness as
+ * `AddRunSteeringColumns.spec.ts`).
+ *
+ * The load-bearing assertion is the `cancelAtPeriodEnd` DEFAULT: every
+ * pre-existing billing profile must read as "no cancellation pending".
+ * A NULL there would make the Billing page offer `Resume` on an account
+ * that never asked to cancel.
+ */
+describe('AddBillingSubscriptionLifecycleColumns1784720000000 (audit B07/B08)', () => {
+    let dataSource: DataSource;
+    const migration = new AddBillingSubscriptionLifecycleColumns1784720000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(
+            `CREATE TABLE "billing_profiles" ("id" varchar PRIMARY KEY NOT NULL, "userId" varchar NOT NULL, "provider" varchar NOT NULL, "providerCustomerId" varchar NOT NULL)`,
+        );
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function columnNames(): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("billing_profiles")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    it('adds the five lifecycle columns', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        expect(await columnNames()).toEqual(
+            expect.arrayContaining([
+                'providerSubscriptionId',
+                'subscriptionStatus',
+                'cancelAtPeriodEnd',
+                'currentPeriodEnd',
+                'subscriptionCanceledAt',
+            ]),
+        );
+    });
+
+    it('⭐ every pre-existing profile reads as "no subscription, nothing pending"', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        await dataSource.query(
+            `INSERT INTO "billing_profiles" ("id", "userId", "provider", "providerCustomerId") VALUES ('bp-1', 'u1', 'stripe', 'cus_1')`,
+        );
+        const [row] = await dataSource.query(
+            `SELECT "providerSubscriptionId", "subscriptionStatus", "cancelAtPeriodEnd", "currentPeriodEnd" FROM "billing_profiles" WHERE "id" = 'bp-1'`,
+        );
+
+        expect(row.providerSubscriptionId).toBeNull();
+        // NULL status is read by the service as `none` — a free account,
+        // not a broken one.
+        expect(row.subscriptionStatus).toBeNull();
+        expect(row.currentPeriodEnd).toBeNull();
+        // sqlite renders booleans as 0/1; both drivers must read "not pending".
+        expect(Boolean(row.cancelAtPeriodEnd)).toBe(false);
+    });
+
+    it('is idempotent — running up() twice does not throw or duplicate columns', async () => {
+        const r1 = dataSource.createQueryRunner();
+        await migration.up(r1);
+        await r1.release();
+
+        const r2 = dataSource.createQueryRunner();
+        await expect(migration.up(r2)).resolves.toBeUndefined();
+        await r2.release();
+
+        const cols = await columnNames();
+        expect(cols.filter((c) => c === 'cancelAtPeriodEnd')).toHaveLength(1);
+        expect(cols.filter((c) => c === 'subscriptionStatus')).toHaveLength(1);
+    });
+
+    it('down() drops all five columns', async () => {
+        const up = dataSource.createQueryRunner();
+        await migration.up(up);
+        await up.release();
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+
+        const cols = await columnNames();
+        for (const col of [
+            'providerSubscriptionId',
+            'subscriptionStatus',
+            'cancelAtPeriodEnd',
+            'currentPeriodEnd',
+            'subscriptionCanceledAt',
+        ]) {
+            expect(cols).not.toContain(col);
+        }
+    });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2506,7 +2506,30 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 },
                 "plans": {
                     "title": "Plans",

--- a/apps/web/src/app/actions/dashboard/billing.ts
+++ b/apps/web/src/app/actions/dashboard/billing.ts
@@ -146,3 +146,88 @@ export async function updateAutoRechargeAction(settings: {
         return { success: false as const, enabled: null, error: message };
     }
 }
+
+/**
+ * Cancel the subscription at the end of the paid period (audit B07).
+ *
+ * Returns a discriminated union rather than throwing — production
+ * redacts thrown server-action messages, so the client must branch on
+ * the return value. 409 means "nothing to cancel", which is also the
+ * answer a cross-account attempt would get.
+ */
+export async function cancelSubscriptionAction() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const result = await billingAPI.cancelSubscription();
+        revalidatePath(ROUTES.DASHBOARD_SETTINGS_BILLING);
+        return { success: true as const, subscription: result.subscription, error: null };
+    } catch (error) {
+        console.error('[cancelSubscriptionAction]', error);
+        let message = 'Failed to cancel the subscription';
+        if (error instanceof ApiResponseError) {
+            if (error.statusCode === 409) {
+                message = 'There is no active subscription to cancel.';
+            } else if (error.statusCode === 503) {
+                message = 'Card payments are not enabled on this deployment yet.';
+            }
+        }
+        return { success: false as const, subscription: null, error: message };
+    }
+}
+
+/** Undo a pending at-period-end cancellation (audit B07). */
+export async function resumeSubscriptionAction() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const result = await billingAPI.resumeSubscription();
+        revalidatePath(ROUTES.DASHBOARD_SETTINGS_BILLING);
+        return { success: true as const, subscription: result.subscription, error: null };
+    } catch (error) {
+        console.error('[resumeSubscriptionAction]', error);
+        let message = 'Failed to resume the subscription';
+        if (error instanceof ApiResponseError) {
+            if (error.statusCode === 409) {
+                message = 'This subscription has already ended.';
+            } else if (error.statusCode === 503) {
+                message = 'Card payments are not enabled on this deployment yet.';
+            }
+        }
+        return { success: false as const, subscription: null, error: message };
+    }
+}
+
+/**
+ * Open the provider's hosted billing portal — the PAST_DUE recovery
+ * action (audit B08). The URL comes from the API, which builds the
+ * return URL from its own WEB_URL; nothing from the browser is trusted.
+ */
+export async function openBillingPortalAction() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const result = await billingAPI.billingPortal();
+        return { success: true as const, url: result.url, error: null };
+    } catch (error) {
+        console.error('[openBillingPortalAction]', error);
+        let message = 'Could not open the billing portal';
+        if (error instanceof ApiResponseError) {
+            if (error.statusCode === 409) {
+                message = 'There is no billing account to manage yet.';
+            } else if (error.statusCode === 503) {
+                message = 'Card payments are not enabled on this deployment yet.';
+            }
+        }
+        return { success: false as const, url: null, error: message };
+    }
+}

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -3,12 +3,24 @@
 import { useCallback, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { AlertCircle, CreditCard, FileText, RefreshCw, Wallet, Zap, Check } from 'lucide-react';
+import {
+    AlertCircle,
+    AlertTriangle,
+    CreditCard,
+    FileText,
+    RefreshCw,
+    Wallet,
+    Zap,
+    Check,
+} from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import {
+    cancelSubscriptionAction,
     changePlanAction,
+    openBillingPortalAction,
+    resumeSubscriptionAction,
     startCreditCheckoutAction,
     startPlanCheckoutAction,
     updateAutoRechargeAction,
@@ -29,14 +41,21 @@ import {
 } from '@/lib/api/credits.shared';
 import {
     canBuyCredits,
+    canCancelSubscription,
     canConfigureAutoRecharge,
     canUpgradePlan,
+    canResumeSubscription,
     formatCardExpiry,
     formatPaymentMethod,
     invoiceStatusTone,
+    isSubscriptionPastDue,
     packBonusPercent,
+    subscriptionState,
+    subscriptionStatusLabelKey,
+    subscriptionStatusTone,
     type BillingOverview,
     type InvoiceListPage,
+    type SubscriptionState,
 } from '@/lib/api/billing.shared';
 
 interface BillingSettingsProps {
@@ -59,6 +78,23 @@ const KIND_TONE_CLASSES: Record<ReturnType<typeof ledgerKindTone>, string> = {
     neutral:
         'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark border border-border dark:border-border-dark',
 };
+
+/** Subscription status chip tones (audit B08) — one extra `warning` bucket. */
+const STATUS_TONE_CLASSES: Record<ReturnType<typeof subscriptionStatusTone>, string> = {
+    ...KIND_TONE_CLASSES,
+    warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20',
+};
+
+/** `Aug 12, 2026`, or null when the provider gave us no period end. */
+function formatPeriodDate(value: string | null): string | null {
+    if (!value) {
+        return null;
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime())
+        ? null
+        : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
 
 function SectionCard({
     icon: Icon,
@@ -148,6 +184,67 @@ export function BillingSettings({
     const invoices = initialInvoices?.invoices ?? [];
     const paymentMethodLabel = formatPaymentMethod(overview?.paymentMethod ?? null);
     const paymentMethodExpiry = formatCardExpiry(overview?.paymentMethod ?? null);
+
+    // ── Subscription lifecycle (audit B07/B08) ────────────────────────
+    // The server snapshot is the source of truth; a successful mutation
+    // swaps in what the provider just confirmed so the chip and the
+    // buttons flip immediately, before the revalidated page arrives.
+    const [subscription, setSubscription] = useState<SubscriptionState>(() =>
+        subscriptionState(initialOverview),
+    );
+    const [lifecyclePending, setLifecyclePending] = useState(false);
+    // Re-derive the gates from the live state rather than the initial
+    // fetch, so cancel → resume swaps without a page refresh.
+    const overviewWithLiveSubscription = overview ? { ...overview, subscription } : null;
+    const showPastDue = isSubscriptionPastDue(overviewWithLiveSubscription);
+    const showCancel = canCancelSubscription(overviewWithLiveSubscription, paymentsEnabled);
+    const showResume = canResumeSubscription(overviewWithLiveSubscription, paymentsEnabled);
+    const statusToneClass = STATUS_TONE_CLASSES[subscriptionStatusTone(subscription.status)];
+    const periodEndLabel = formatPeriodDate(subscription.currentPeriodEnd);
+
+    const handleCancelSubscription = useCallback(async () => {
+        setLifecyclePending(true);
+        try {
+            const result = await cancelSubscriptionAction();
+            if (result.success && result.subscription) {
+                setSubscription(result.subscription);
+                toast.success(t('currentPlan.cancelSuccess'));
+                return;
+            }
+            toast.error(result.error ?? t('currentPlan.cancelError'));
+        } finally {
+            setLifecyclePending(false);
+        }
+    }, [t]);
+
+    const handleResumeSubscription = useCallback(async () => {
+        setLifecyclePending(true);
+        try {
+            const result = await resumeSubscriptionAction();
+            if (result.success && result.subscription) {
+                setSubscription(result.subscription);
+                toast.success(t('currentPlan.resumeSuccess'));
+                return;
+            }
+            toast.error(result.error ?? t('currentPlan.resumeError'));
+        } finally {
+            setLifecyclePending(false);
+        }
+    }, [t]);
+
+    const handleOpenPortal = useCallback(async () => {
+        setLifecyclePending(true);
+        try {
+            const result = await openBillingPortalAction();
+            if (result.success && result.url) {
+                window.location.assign(result.url);
+                return;
+            }
+            toast.error(result.error ?? t('pastDue.error'));
+        } finally {
+            setLifecyclePending(false);
+        }
+    }, [t]);
 
     const handleBuyCredits = useCallback(async () => {
         if (!selectedPackId) {
@@ -295,13 +392,40 @@ export function BillingSettings({
                 </div>
             ) : null}
 
+            {/* ── PAST_DUE recovery banner (audit B08) ─────────────── */}
+            {showPastDue ? (
+                <div
+                    data-testid="billing-past-due-banner"
+                    role="alert"
+                    className="flex flex-wrap items-center gap-3 rounded-lg border border-rose-500/40 bg-rose-500/5 p-4"
+                >
+                    <AlertTriangle className="w-4 h-4 shrink-0 text-rose-600 dark:text-rose-400" />
+                    <div className="flex-1 min-w-48">
+                        <p className="text-sm font-medium text-text dark:text-text-dark">
+                            {t('pastDue.title')}
+                        </p>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('pastDue.body')}
+                        </p>
+                    </div>
+                    <Button
+                        className="text-xs"
+                        disabled={lifecyclePending}
+                        data-testid="billing-past-due-action"
+                        onClick={() => void handleOpenPortal()}
+                    >
+                        {t('pastDue.action')}
+                    </Button>
+                </div>
+            ) : null}
+
             {/* ── Current plan ─────────────────────────────────────── */}
             <SectionCard
                 icon={CreditCard}
                 title={t('currentPlan.title')}
                 testId="billing-current-plan"
             >
-                <div className="flex items-center justify-between">
+                <div className="flex items-center justify-between gap-3">
                     <div>
                         <p className="text-lg font-semibold text-text dark:text-text-dark">
                             {currentPlan?.name ?? initialPlan?.plan?.name ?? 'Free'}
@@ -315,15 +439,65 @@ export function BillingSettings({
                         </p>
                     </div>
                     {subscriptionsEnabled ? (
+                        // The REAL lifecycle status (audit B08) — this chip
+                        // used to be hardcoded to "active" no matter what
+                        // the provider said.
                         <span
                             data-testid="billing-plan-status"
-                            className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+                            data-status={subscription.status}
+                            className={cn(
+                                'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium',
+                                statusToneClass,
+                            )}
                         >
-                            <Check className="w-3 h-3" />
-                            {t('currentPlan.statusActive')}
+                            {subscriptionStatusTone(subscription.status) === 'positive' ? (
+                                <Check className="w-3 h-3" />
+                            ) : (
+                                <AlertCircle className="w-3 h-3" />
+                            )}
+                            {t(subscriptionStatusLabelKey(subscription.status))}
                         </span>
                     ) : null}
                 </div>
+
+                {/* Cancel / resume (audit B07) — only ever rendered for a
+                    subscription the provider can actually act on. */}
+                {subscription.cancelAtPeriodEnd ? (
+                    <p
+                        className="text-xs text-text-muted dark:text-text-muted-dark"
+                        data-testid="billing-cancel-scheduled"
+                    >
+                        {periodEndLabel
+                            ? t('currentPlan.cancelScheduledOn', { date: periodEndLabel })
+                            : t('currentPlan.cancelScheduled')}
+                    </p>
+                ) : null}
+
+                {showCancel || showResume ? (
+                    <div className="flex flex-wrap gap-2">
+                        {showResume ? (
+                            <Button
+                                className="text-xs"
+                                disabled={lifecyclePending}
+                                data-testid="billing-subscription-resume"
+                                onClick={() => void handleResumeSubscription()}
+                            >
+                                {t('currentPlan.resume')}
+                            </Button>
+                        ) : null}
+                        {showCancel ? (
+                            <Button
+                                variant="secondary"
+                                className="text-xs"
+                                disabled={lifecyclePending}
+                                data-testid="billing-subscription-cancel"
+                                onClick={() => void handleCancelSubscription()}
+                            >
+                                {t('currentPlan.cancel')}
+                            </Button>
+                        ) : null}
+                    </div>
+                ) : null}
             </SectionCard>
 
             {/* ── Plan switcher (credits-forward, PRD §3.1) ─────────── */}

--- a/apps/web/src/lib/api/billing.shared.ts
+++ b/apps/web/src/lib/api/billing.shared.ts
@@ -33,6 +33,44 @@ export interface AutoRechargeSettings {
     failureCount: number;
 }
 
+/**
+ * Vendor-neutral subscription lifecycle (audit B07/B08). Mirrors the
+ * API's `BillingSubscriptionStatus`; `none` means the account has no
+ * provider subscription at all (free tier / payments not wired), which
+ * is distinct from `canceled` (it had one and it ended).
+ */
+export type SubscriptionLifecycleStatus =
+    | 'none'
+    | 'trialing'
+    | 'active'
+    | 'past_due'
+    | 'unpaid'
+    | 'paused'
+    | 'canceled'
+    | 'incomplete'
+    | 'incomplete_expired';
+
+export interface SubscriptionState {
+    status: SubscriptionLifecycleStatus;
+    /** Cancel requested; the plan runs until `currentPeriodEnd`. */
+    cancelAtPeriodEnd: boolean;
+    currentPeriodEnd: string | null;
+    canceledAt: string | null;
+    pastDue: boolean;
+    /** There is a real provider subscription cancel/resume can act on. */
+    manageable: boolean;
+}
+
+/** What an overview with no subscription block looks like. */
+export const EMPTY_SUBSCRIPTION_STATE: SubscriptionState = {
+    status: 'none',
+    cancelAtPeriodEnd: false,
+    currentPeriodEnd: null,
+    canceledAt: null,
+    pastDue: false,
+    manageable: false,
+};
+
 export interface BillingOverview {
     status: string;
     /** False ⇒ render the coming-soon state instead of live controls. */
@@ -43,6 +81,22 @@ export interface BillingOverview {
     balanceCredits: number;
     paymentMethod: PaymentMethodSummary | null;
     autoRecharge: AutoRechargeSettings;
+    /**
+     * Optional on the wire: an older API (or a degraded response) simply
+     * omits it, and {@link subscriptionState} falls back to `none` rather
+     * than the page crashing on an undefined read.
+     */
+    subscription?: SubscriptionState;
+}
+
+export interface SubscriptionMutationResponse {
+    status: string;
+    subscription: SubscriptionState;
+}
+
+export interface BillingPortalResponse {
+    status: string;
+    url: string;
 }
 
 export type InvoiceStatus = 'draft' | 'open' | 'paid' | 'void' | 'uncollectible' | 'refunded';
@@ -175,4 +229,104 @@ export function canUpgradePlan(
     subscriptionsEnabled: boolean,
 ): boolean {
     return canBuyCredits(overview, paymentsEnabled) && subscriptionsEnabled;
+}
+
+// ── Subscription lifecycle (audit B07/B08) ─────────────────────────
+
+/** Never-undefined lifecycle state for the page to render from. */
+export function subscriptionState(overview: BillingOverview | null): SubscriptionState {
+    return overview?.subscription ?? EMPTY_SUBSCRIPTION_STATE;
+}
+
+/**
+ * Badge tone for the plan status chip. `none` reads as positive because
+ * an account with no provider subscription is a perfectly healthy free
+ * account — the chip should not imply something is wrong.
+ */
+export function subscriptionStatusTone(
+    status: SubscriptionLifecycleStatus,
+): 'positive' | 'negative' | 'warning' | 'neutral' {
+    switch (status) {
+        case 'none':
+        case 'active':
+        case 'trialing':
+            return 'positive';
+        case 'past_due':
+        case 'unpaid':
+            return 'negative';
+        case 'canceled':
+        case 'incomplete_expired':
+            return 'neutral';
+        case 'paused':
+        case 'incomplete':
+            return 'warning';
+        default:
+            return 'neutral';
+    }
+}
+
+/**
+ * Message keys the status chip can render, as a literal union — next-intl
+ * types `t()` against the message tree, so a plain `string` would not
+ * typecheck at the call site.
+ */
+export type SubscriptionStatusLabelKey =
+    | 'currentPlan.statusActive'
+    | `currentPlan.statuses.${Exclude<SubscriptionLifecycleStatus, 'none' | 'active'>}`;
+
+/**
+ * Translation key (relative to `dashboard.settings.billing`) for a
+ * status. `active` and `none` deliberately keep the pre-existing
+ * `currentPlan.statusActive` key so the copy — and anything asserting on
+ * it — is unchanged for the common case.
+ */
+export function subscriptionStatusLabelKey(
+    status: SubscriptionLifecycleStatus,
+): SubscriptionStatusLabelKey {
+    return status === 'none' || status === 'active'
+        ? 'currentPlan.statusActive'
+        : `currentPlan.statuses.${status}`;
+}
+
+/** The recovery banner shows only for a genuinely uncollected subscription. */
+export function isSubscriptionPastDue(overview: BillingOverview | null): boolean {
+    const state = subscriptionState(overview);
+    return state.pastDue || state.status === 'past_due' || state.status === 'unpaid';
+}
+
+/**
+ * Cancel is offerable while the plan is live and not already scheduled to
+ * end. Both gates from `canBuyCredits` still apply — a deployment with
+ * payments off never shows a money control.
+ */
+export function canCancelSubscription(
+    overview: BillingOverview | null,
+    paymentsEnabled: boolean,
+): boolean {
+    const state = subscriptionState(overview);
+    return (
+        canBuyCredits(overview, paymentsEnabled) &&
+        state.manageable &&
+        !state.cancelAtPeriodEnd &&
+        (state.status === 'active' ||
+            state.status === 'trialing' ||
+            state.status === 'past_due' ||
+            state.status === 'unpaid' ||
+            state.status === 'paused')
+    );
+}
+
+/** Resume is offerable only while a scheduled cancellation is still pending. */
+export function canResumeSubscription(
+    overview: BillingOverview | null,
+    paymentsEnabled: boolean,
+): boolean {
+    const state = subscriptionState(overview);
+    return (
+        canBuyCredits(overview, paymentsEnabled) &&
+        state.manageable &&
+        state.cancelAtPeriodEnd &&
+        state.status !== 'canceled' &&
+        state.status !== 'incomplete_expired'
+    );
 }

--- a/apps/web/src/lib/api/billing.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/billing.shared.unit.spec.ts
@@ -6,13 +6,20 @@
 import { describe, expect, it } from 'vitest';
 import {
     canBuyCredits,
+    canCancelSubscription,
     canConfigureAutoRecharge,
+    canResumeSubscription,
     canUpgradePlan,
     formatCardExpiry,
     formatPaymentMethod,
     invoiceStatusTone,
+    isSubscriptionPastDue,
     packBonusPercent,
+    subscriptionState,
+    subscriptionStatusLabelKey,
+    subscriptionStatusTone,
     type BillingOverview,
+    type SubscriptionState,
 } from './billing.shared';
 
 function overview(partial: Partial<BillingOverview> = {}): BillingOverview {
@@ -25,6 +32,19 @@ function overview(partial: Partial<BillingOverview> = {}): BillingOverview {
         balanceCredits: 0,
         paymentMethod: null,
         autoRecharge: { enabled: false, thresholdCredits: null, packId: null, failureCount: 0 },
+        ...partial,
+    };
+}
+
+/** A live, manageable subscription unless a test says otherwise. */
+function subscription(partial: Partial<SubscriptionState> = {}): SubscriptionState {
+    return {
+        status: 'active',
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: '2026-08-01T00:00:00.000Z',
+        canceledAt: null,
+        pastDue: false,
+        manageable: true,
         ...partial,
     };
 }
@@ -142,5 +162,125 @@ describe('canUpgradePlan — a tier is only sellable when it can also be applied
 
     it('is true only when all three gates pass', () => {
         expect(canUpgradePlan(configured, true, true)).toBe(true);
+    });
+});
+
+/**
+ * Subscription lifecycle (audit B07/B08). These helpers ARE the UI rule:
+ * which chip renders, whether the past-due banner shows, and whether the
+ * page offers cancel or resume. Pinning them here keeps the JSX free of
+ * untested conditionals.
+ */
+describe('subscriptionState — a missing block never crashes the page', () => {
+    it('falls back to `none` when the API omitted the subscription', () => {
+        expect(subscriptionState(overview())).toEqual({
+            status: 'none',
+            cancelAtPeriodEnd: false,
+            currentPeriodEnd: null,
+            canceledAt: null,
+            pastDue: false,
+            manageable: false,
+        });
+    });
+
+    it('falls back to `none` when the overview failed to load', () => {
+        expect(subscriptionState(null).status).toBe('none');
+    });
+});
+
+describe('subscriptionStatusTone / subscriptionStatusLabelKey (B08)', () => {
+    it('reads a free account (`none`) as healthy, not broken', () => {
+        expect(subscriptionStatusTone('none')).toBe('positive');
+        expect(subscriptionStatusTone('active')).toBe('positive');
+        expect(subscriptionStatusTone('trialing')).toBe('positive');
+    });
+
+    it('flags the uncollected states as negative', () => {
+        expect(subscriptionStatusTone('past_due')).toBe('negative');
+        expect(subscriptionStatusTone('unpaid')).toBe('negative');
+    });
+
+    it('keeps the pre-existing key for the common case, adds keys for the rest', () => {
+        expect(subscriptionStatusLabelKey('none')).toBe('currentPlan.statusActive');
+        expect(subscriptionStatusLabelKey('active')).toBe('currentPlan.statusActive');
+        expect(subscriptionStatusLabelKey('past_due')).toBe('currentPlan.statuses.past_due');
+        expect(subscriptionStatusLabelKey('canceled')).toBe('currentPlan.statuses.canceled');
+    });
+});
+
+describe('isSubscriptionPastDue — when the recovery banner shows', () => {
+    it('shows for past_due and unpaid', () => {
+        expect(
+            isSubscriptionPastDue(overview({ subscription: subscription({ status: 'past_due' }) })),
+        ).toBe(true);
+        expect(
+            isSubscriptionPastDue(overview({ subscription: subscription({ status: 'unpaid' }) })),
+        ).toBe(true);
+    });
+
+    it('does not show for a healthy or absent subscription', () => {
+        expect(isSubscriptionPastDue(overview({ subscription: subscription() }))).toBe(false);
+        expect(isSubscriptionPastDue(overview())).toBe(false);
+        expect(isSubscriptionPastDue(null)).toBe(false);
+    });
+
+    it('trusts the server-computed flag even if the token set later grows', () => {
+        expect(
+            isSubscriptionPastDue(
+                overview({ subscription: subscription({ status: 'active', pastDue: true }) }),
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('canCancelSubscription / canResumeSubscription (B07)', () => {
+    it('offers cancel on a live, manageable subscription', () => {
+        expect(canCancelSubscription(overview({ subscription: subscription() }), true)).toBe(true);
+        expect(canResumeSubscription(overview({ subscription: subscription() }), true)).toBe(false);
+    });
+
+    it('swaps to resume once a cancellation is pending', () => {
+        const pending = overview({ subscription: subscription({ cancelAtPeriodEnd: true }) });
+        expect(canCancelSubscription(pending, true)).toBe(false);
+        expect(canResumeSubscription(pending, true)).toBe(true);
+    });
+
+    it('offers neither once the subscription has actually ended', () => {
+        const ended = overview({
+            subscription: subscription({ status: 'canceled', cancelAtPeriodEnd: true }),
+        });
+        expect(canCancelSubscription(ended, true)).toBe(false);
+        expect(canResumeSubscription(ended, true)).toBe(false);
+    });
+
+    it('still offers cancel while the subscription is past due', () => {
+        expect(
+            canCancelSubscription(
+                overview({ subscription: subscription({ status: 'past_due' }) }),
+                true,
+            ),
+        ).toBe(true);
+    });
+
+    it('offers nothing on a free account with no provider subscription', () => {
+        expect(canCancelSubscription(overview(), true)).toBe(false);
+        expect(canResumeSubscription(overview(), true)).toBe(false);
+    });
+
+    it('offers nothing when the subscription is not manageable', () => {
+        const unmanageable = overview({ subscription: subscription({ manageable: false }) });
+        expect(canCancelSubscription(unmanageable, true)).toBe(false);
+        expect(canResumeSubscription(unmanageable, true)).toBe(false);
+    });
+
+    it('respects the deployment master switch and the provider gate', () => {
+        const live = overview({ subscription: subscription() });
+        expect(canCancelSubscription(live, false)).toBe(false);
+        expect(
+            canCancelSubscription(
+                overview({ providerConfigured: false, subscription: subscription() }),
+                true,
+            ),
+        ).toBe(false);
     });
 });

--- a/apps/web/src/lib/api/billing.ts
+++ b/apps/web/src/lib/api/billing.ts
@@ -2,18 +2,22 @@ import 'server-only';
 import { serverFetch } from './server-api';
 import type {
     BillingOverview,
+    BillingPortalResponse,
     CreditCheckoutResponse,
     InvoiceListPage,
     PlanCheckoutResponse,
     PlanCheckoutReturnResponse,
+    SubscriptionMutationResponse,
 } from './billing.shared';
 
 export type {
     BillingOverview,
+    BillingPortalResponse,
     CreditCheckoutResponse,
     InvoiceListPage,
     PlanCheckoutResponse,
     PlanCheckoutReturnResponse,
+    SubscriptionMutationResponse,
 };
 
 /**
@@ -77,6 +81,23 @@ export const billingAPI = {
     },
 
     /**
+     * Schedule an at-period-end cancellation (audit B07). No body: the
+     * subscription is resolved server-side from the session user.
+     */
+    async cancelSubscription(): Promise<SubscriptionMutationResponse> {
+        return serverFetch<SubscriptionMutationResponse>('/billing/subscription/cancel', {
+            method: 'POST',
+        });
+    },
+
+    /** Clear a pending at-period-end cancellation (audit B07). */
+    async resumeSubscription(): Promise<SubscriptionMutationResponse> {
+        return serverFetch<SubscriptionMutationResponse>('/billing/subscription/resume', {
+            method: 'POST',
+        });
+    },
+
+    /**
      * Finalize the browser's return from a plan checkout so the new tier
      * shows immediately. The webhook is still the authority; this call is
      * idempotent and scoped to the session user by the API.
@@ -87,6 +108,14 @@ export const billingAPI = {
             `/billing/checkout/plan/return?${search.toString()}`,
             { method: 'GET' },
         );
+    },
+
+    /**
+     * Hosted portal redirect — the PAST_DUE recovery action (audit B08).
+     * The return URL is built by the API from its own WEB_URL.
+     */
+    async billingPortal(): Promise<BillingPortalResponse> {
+        return serverFetch<BillingPortalResponse>('/billing/portal', { method: 'POST' });
     },
 
     /** Enable/disable threshold-triggered top-ups. */

--- a/packages/agent/src/database/repositories/billing-profile.repository.spec.ts
+++ b/packages/agent/src/database/repositories/billing-profile.repository.spec.ts
@@ -154,4 +154,61 @@ describe('BillingProfileRepository', () => {
             where: { provider: 'stripe', providerCustomerId: 'cus_1' },
         });
     });
+
+    /**
+     * Subscription lifecycle (audit B07/B08). The write is PARTIAL by
+     * construction so a webhook carrying one field cannot blank the rest.
+     */
+    describe('updateSubscriptionState', () => {
+        it('writes only the fields the caller supplied', async () => {
+            const { repository, repo } = makeHarness({ existing: { id: 'bp-1' } });
+
+            await repository.updateSubscriptionState('u1', { cancelAtPeriodEnd: true });
+
+            const [where, values] = repo.update.mock.calls[0];
+            expect(where).toEqual({ userId: 'u1' });
+            expect(Object.keys(values)).toEqual(['cancelAtPeriodEnd']);
+            expect(values.cancelAtPeriodEnd).toBe(true);
+        });
+
+        it('treats an explicit null as a real write (a finished period clears)', async () => {
+            const { repository, repo } = makeHarness({ existing: { id: 'bp-1' } });
+
+            await repository.updateSubscriptionState('u1', { currentPeriodEnd: null });
+
+            const [, values] = repo.update.mock.calls[0];
+            expect(Object.keys(values)).toEqual(['currentPeriodEnd']);
+            expect(values.currentPeriodEnd).toBeNull();
+        });
+
+        it('persists the full snapshot the provider returned', async () => {
+            const { repository, repo } = makeHarness({ existing: { id: 'bp-1' } });
+            const periodEnd = new Date('2026-08-01T00:00:00Z');
+
+            await repository.updateSubscriptionState('u1', {
+                providerSubscriptionId: 'sub_1',
+                subscriptionStatus: 'past_due',
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: periodEnd,
+                subscriptionCanceledAt: null,
+            });
+
+            const [, values] = repo.update.mock.calls[0];
+            expect(values).toEqual({
+                providerSubscriptionId: 'sub_1',
+                subscriptionStatus: 'past_due',
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: periodEnd,
+                subscriptionCanceledAt: null,
+            });
+        });
+
+        it('does not issue an UPDATE when the caller supplied nothing', async () => {
+            const { repository, repo } = makeHarness({ existing: { id: 'bp-1' } });
+
+            await repository.updateSubscriptionState('u1', {});
+
+            expect(repo.update).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/agent/src/database/repositories/billing-profile.repository.ts
+++ b/packages/agent/src/database/repositories/billing-profile.repository.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { BillingProfile } from '@src/entities/billing-profile.entity';
+import {
+    BillingProfile,
+    type BillingSubscriptionStatus,
+} from '@src/entities/billing-profile.entity';
 
 /** Columns a caller may set when creating a profile lazily. */
 export interface BillingProfileUpsert {
@@ -25,6 +28,19 @@ export interface AutoRechargeWrite {
     autoRechargeEnabled: boolean;
     autoRechargeThresholdCredits?: number | null;
     autoRechargePackId?: string | null;
+}
+
+/**
+ * Subscription lifecycle write (audit B07/B08). Every field is optional:
+ * a webhook that only reports a status change must not blank the period
+ * end, and a cancel that only flips the flag must not blank the id.
+ */
+export interface SubscriptionStateWrite {
+    providerSubscriptionId?: string | null;
+    subscriptionStatus?: BillingSubscriptionStatus | null;
+    cancelAtPeriodEnd?: boolean;
+    currentPeriodEnd?: Date | null;
+    subscriptionCanceledAt?: Date | null;
 }
 
 /**
@@ -109,6 +125,41 @@ export class BillingProfileRepository {
                 autoRechargePackId: settings.autoRechargePackId ?? null,
             },
         );
+        return this.findByUserId(userId);
+    }
+
+    /**
+     * Persist the subscription lifecycle (audit B07/B08).
+     *
+     * PARTIAL by construction: only the keys the caller actually supplied
+     * are written, so a `subscription.updated` webhook that carries just a
+     * status cannot wipe `currentPeriodEnd`, and a cancel that only flips
+     * the flag cannot wipe `providerSubscriptionId`. An explicit `null`
+     * IS a write (that is how a finished subscription clears its period).
+     */
+    async updateSubscriptionState(
+        userId: string,
+        state: SubscriptionStateWrite,
+    ): Promise<BillingProfile | null> {
+        const patch: SubscriptionStateWrite = {};
+        if ('providerSubscriptionId' in state) {
+            patch.providerSubscriptionId = state.providerSubscriptionId ?? null;
+        }
+        if ('subscriptionStatus' in state) {
+            patch.subscriptionStatus = state.subscriptionStatus ?? null;
+        }
+        if ('cancelAtPeriodEnd' in state) {
+            patch.cancelAtPeriodEnd = state.cancelAtPeriodEnd ?? false;
+        }
+        if ('currentPeriodEnd' in state) {
+            patch.currentPeriodEnd = state.currentPeriodEnd ?? null;
+        }
+        if ('subscriptionCanceledAt' in state) {
+            patch.subscriptionCanceledAt = state.subscriptionCanceledAt ?? null;
+        }
+        if (Object.keys(patch).length > 0) {
+            await this.repository.update({ userId }, patch);
+        }
         return this.findByUserId(userId);
     }
 

--- a/packages/agent/src/entities/billing-profile.entity.ts
+++ b/packages/agent/src/entities/billing-profile.entity.ts
@@ -9,6 +9,41 @@ import {
 } from 'typeorm';
 
 /**
+ * Vendor-neutral subscription lifecycle states (audit B07/B08).
+ *
+ * The list is the intersection every mainstream payment provider models,
+ * so nothing here leaks a vendor vocabulary into the schema or the UI.
+ * `none` is the platform's own value: the account has no provider-side
+ * subscription at all (free tier, or payments not wired), which is
+ * distinct from `canceled` (it HAD one and it ended).
+ */
+export const BILLING_SUBSCRIPTION_STATUSES = [
+    'none',
+    'trialing',
+    'active',
+    'past_due',
+    'unpaid',
+    'paused',
+    'canceled',
+    'incomplete',
+    'incomplete_expired',
+] as const;
+
+export type BillingSubscriptionStatus = (typeof BILLING_SUBSCRIPTION_STATUSES)[number];
+
+/** Statuses that mean "the provider could not collect" — drives the banner. */
+export const BILLING_PAST_DUE_STATUSES: readonly BillingSubscriptionStatus[] = [
+    'past_due',
+    'unpaid',
+];
+
+export function isPastDueSubscriptionStatus(
+    status: BillingSubscriptionStatus | null | undefined,
+): boolean {
+    return status != null && BILLING_PAST_DUE_STATUSES.includes(status);
+}
+
+/**
  * Billing profile (billing PRD §4.2 / §5.3(3)) — the per-owner bridge
  * between a platform user and the external payment provider.
  *
@@ -129,6 +164,42 @@ export class BillingProfile {
 
     @PortableDateColumn({ nullable: true })
     autoRechargeLastFailureAt?: Date | null;
+
+    // ── Subscription lifecycle (audit B07/B08) ──────────────────────
+    /**
+     * The provider's subscription identifier, when this owner has a
+     * recurring plan. Opaque, never a secret. NULL means "no provider
+     * subscription" — the account is on the free tier (or payments are
+     * not wired), and cancel/resume are inoperable rather than silently
+     * no-op'ing.
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    providerSubscriptionId?: string | null;
+
+    /**
+     * Last reconciled lifecycle status. Written by the cancel/resume
+     * calls AND by the signature-verified webhook, so a provider-side
+     * change (dunning → `past_due`, final failure → `canceled`) lands
+     * here without anyone visiting the Billing page.
+     */
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    subscriptionStatus?: BillingSubscriptionStatus | null;
+
+    /**
+     * True once the owner has asked to cancel but the paid period is
+     * still running. The plan stays usable until `currentPeriodEnd`;
+     * resuming before then clears the flag with no gap in service.
+     */
+    @Column({ type: 'boolean', default: false })
+    cancelAtPeriodEnd: boolean;
+
+    /** End of the paid period — when a pending cancellation takes effect. */
+    @PortableDateColumn({ nullable: true })
+    currentPeriodEnd?: Date | null;
+
+    /** When the subscription actually ended (not when cancel was requested). */
+    @PortableDateColumn({ nullable: true })
+    subscriptionCanceledAt?: Date | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/subscriptions/billing/billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.spec.ts
@@ -1,4 +1,8 @@
-import { BillingProvider, ManualBillingProvider } from './billing.provider';
+import {
+    BillingProvider,
+    BillingProviderNotConfiguredError,
+    ManualBillingProvider,
+} from './billing.provider';
 
 /**
  * BillingProvider is the abstract surface UsageLedgerService talks to. The
@@ -78,5 +82,28 @@ describe('ManualBillingProvider', () => {
     it('inherits the no-op recordUsageCharge() (no external gateway in manual mode)', async () => {
         const provider = new ManualBillingProvider();
         await expect(provider.recordUsageCharge({ id: 'led-1' } as any)).resolves.toBeUndefined();
+    });
+
+    /**
+     * Subscription lifecycle (audit B07/B08). The manual binding moves no
+     * money and manages no subscription, so cancel/resume/portal inherit
+     * the not-configured throw — a keyless deployment surfaces a 503 and
+     * the UI degrades, rather than pretending a cancellation happened.
+     */
+    it('fails closed on every subscription lifecycle call', async () => {
+        const provider = new ManualBillingProvider();
+
+        await expect(
+            provider.cancelSubscriptionAtPeriodEnd({ subscriptionId: 'sub_1' }),
+        ).rejects.toBeInstanceOf(BillingProviderNotConfiguredError);
+        await expect(
+            provider.resumeSubscription({ subscriptionId: 'sub_1' }),
+        ).rejects.toBeInstanceOf(BillingProviderNotConfiguredError);
+        await expect(
+            provider.createBillingPortalSession({
+                customerId: 'cus_1',
+                returnUrl: 'https://app.test/settings/billing',
+            }),
+        ).rejects.toBeInstanceOf(BillingProviderNotConfiguredError);
     });
 });

--- a/packages/agent/src/subscriptions/billing/billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { config } from '@src/config';
+import type { BillingSubscriptionStatus } from '@src/entities/billing-profile.entity';
 import { UsageLedgerEntry } from '@src/entities/usage-ledger-entry.entity';
 import type { CreditPack } from './credit-packs';
 
@@ -209,6 +210,43 @@ export interface BillingInvoiceSnapshot {
 }
 
 /**
+ * A subscription's lifecycle as the provider currently reports it
+ * (audit B07/B08). Vendor-neutral: `status` is the shared token set from
+ * {@link BillingSubscriptionStatus}, dates are real `Date`s, and the id
+ * is opaque. Returned by cancel/resume AND carried on the reconciling
+ * webhook, so both paths persist the same shape.
+ */
+export interface BillingSubscriptionSnapshot {
+    readonly subscriptionId: string;
+    readonly status: BillingSubscriptionStatus;
+    /** Cancel requested, paid period still running. */
+    readonly cancelAtPeriodEnd: boolean;
+    /** When a pending cancellation takes effect. */
+    readonly currentPeriodEnd: Date | null;
+    /** When the subscription actually ended. */
+    readonly canceledAt: Date | null;
+}
+
+/** Cancel/resume input. The id is server-resolved, never client-supplied. */
+export interface SubscriptionMutationRequest {
+    readonly subscriptionId: string;
+}
+
+/**
+ * Hosted self-service portal (the PAST_DUE recovery action, B08). The
+ * return URL is always built server-side from the platform's own web
+ * origin — accepting one from the client would be an open redirect.
+ */
+export interface BillingPortalRequest {
+    readonly customerId: string;
+    readonly returnUrl: string;
+}
+
+export interface BillingPortalSession {
+    readonly url: string;
+}
+
+/**
  * The closed set of provider events the money path reacts to. Anything
  * else the provider sends is acknowledged and ignored — an unknown event
  * type must never 500 a webhook (the provider would retry forever).
@@ -230,6 +268,20 @@ export type BillingWebhookEventKind =
     | 'subscription.activated'
     /** A paid plan lapsed (cancelled, unpaid, or deleted). */
     | 'subscription.canceled'
+    /**
+     * A subscription's LIFECYCLE moved (audit B07/B08) — dunning, pause,
+     * resume, or a period roll — carrying the full provider snapshot.
+     *
+     * Deliberately NOT a grant or a revoke. Those remain
+     * `subscription.activated` / `subscription.canceled` above, which are
+     * the only two kinds allowed to move a user's tier. This one exists
+     * so the states those two treat as "not actionable" (`past_due`,
+     * `paused`, `incomplete`) still reach the product instead of being
+     * dropped — that is what makes a dunning banner or a resume button
+     * possible without giving the lifecycle path the power to downgrade
+     * anyone.
+     */
+    | 'subscription.updated'
     /** Recognized envelope, no action for us. */
     | 'ignored';
 
@@ -250,6 +302,8 @@ export interface BillingWebhookEvent {
     readonly invoice?: BillingInvoiceSnapshot;
     /** Populated for `payment_method.updated`. */
     readonly paymentMethod?: PaymentMethodSummary;
+    /** Populated for `subscription.updated` (audit B07/B08). */
+    readonly subscription?: BillingSubscriptionSnapshot;
     /** Provider payment id, for correlation on refunds. */
     readonly paymentId: string | null;
     /** Raw provider event type, for logging/diagnostics. Never a secret. */
@@ -334,6 +388,37 @@ export abstract class BillingProvider {
 
     /** Off-session charge against a stored payment method (auto-recharge). */
     async chargeOffSession(_request: OffSessionChargeRequest): Promise<OffSessionChargeResult> {
+        throw new BillingProviderNotConfiguredError();
+    }
+
+    /**
+     * Schedule a cancellation for the end of the paid period (audit B07).
+     *
+     * At-period-end ONLY by design: the owner keeps what they paid for,
+     * and {@link resumeSubscription} can undo it with no gap in service.
+     * There is deliberately no immediate-termination method on this seam.
+     */
+    async cancelSubscriptionAtPeriodEnd(
+        _request: SubscriptionMutationRequest,
+    ): Promise<BillingSubscriptionSnapshot> {
+        throw new BillingProviderNotConfiguredError();
+    }
+
+    /** Undo a pending at-period-end cancellation (audit B07). */
+    async resumeSubscription(
+        _request: SubscriptionMutationRequest,
+    ): Promise<BillingSubscriptionSnapshot> {
+        throw new BillingProviderNotConfiguredError();
+    }
+
+    /**
+     * Hosted self-service portal — the PAST_DUE recovery action (B08).
+     * Card capture stays entirely on the provider's tokenized surface, so
+     * no cardholder datum ever reaches the platform.
+     */
+    async createBillingPortalSession(
+        _request: BillingPortalRequest,
+    ): Promise<BillingPortalSession> {
         throw new BillingProviderNotConfiguredError();
     }
 

--- a/packages/agent/src/subscriptions/billing/billing.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.spec.ts
@@ -1,9 +1,14 @@
 import {
     BillingService,
+    NoActiveSubscriptionError,
     UnknownCreditPackError,
     BILLING_PAYMENT_REF_TYPE,
 } from './billing.service';
-import { BillingProviderNotConfiguredError, type BillingWebhookEvent } from './billing.provider';
+import {
+    BillingProviderNotConfiguredError,
+    type BillingSubscriptionSnapshot,
+    type BillingWebhookEvent,
+} from './billing.provider';
 import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
 
 /**
@@ -32,6 +37,24 @@ function makeProvider(overrides: Record<string, unknown> = {}) {
         }),
         chargeOffSession: jest.fn(),
         verifyAndParseWebhook: jest.fn(),
+        // Subscription lifecycle (audit B07/B08).
+        cancelSubscriptionAtPeriodEnd: jest.fn().mockResolvedValue({
+            subscriptionId: 'sub_1',
+            status: 'active',
+            cancelAtPeriodEnd: true,
+            currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+            canceledAt: null,
+        }),
+        resumeSubscription: jest.fn().mockResolvedValue({
+            subscriptionId: 'sub_1',
+            status: 'active',
+            cancelAtPeriodEnd: false,
+            currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+            canceledAt: null,
+        }),
+        createBillingPortalSession: jest
+            .fn()
+            .mockResolvedValue({ url: 'https://pay.example/portal/bps_1' }),
         ...overrides,
     } as any;
 }
@@ -45,6 +68,14 @@ function makeProfileRepository(profile: any = null, overrides: Record<string, un
             .mockResolvedValue(profile ?? { userId: 'u1', providerCustomerId: 'cus_1' }),
         updatePaymentMethod: jest.fn().mockResolvedValue(profile),
         updateAutoRecharge: jest.fn().mockResolvedValue(profile),
+        // Last-write-wins projection of the provider's lifecycle state.
+        updateSubscriptionState: jest
+            .fn()
+            .mockImplementation(async (_userId: string, state: any) => ({
+                ...(profile ?? {}),
+                ...state,
+                subscriptionCanceledAt: state.subscriptionCanceledAt ?? null,
+            })),
         claimAutoRechargeSlot: jest.fn().mockResolvedValue(true),
         releaseAutoRechargeSlot: jest.fn().mockResolvedValue(undefined),
         recordAutoRechargeFailure: jest.fn().mockResolvedValue(undefined),
@@ -737,5 +768,312 @@ describe('handleWebhook — paid-plan lifecycle is delegated, not duplicated (au
         // A 5xx here would make the provider retry a delivery we can
         // never resolve.
         expect((await service.handleWebhook('{}', 'sig')).action).toBe('ignored');
+    });
+});
+
+/**
+ * Subscription lifecycle (audit B07/B08).
+ *
+ * B07 — the page could start a subscription but not manage one: no
+ * cancel path and no `cancelAtPeriodEnd` state. B08 — the status chip
+ * was hardcoded to "active" and nothing surfaced a failed collection.
+ *
+ * What these pin: cancel goes through the SEAM and persists the flag;
+ * resume clears it; a past-due webhook flips the persisted status; and
+ * every lifecycle call is owner-scoped so a caller can never reach
+ * another account's (or another org's) subscription.
+ */
+
+/** An owner on a paid plan, org-scoped, with a live provider subscription. */
+const SUBSCRIBED_PROFILE = {
+    ...PROFILE,
+    organizationId: 'org-a',
+    providerSubscriptionId: 'sub_1',
+    subscriptionStatus: 'active',
+    cancelAtPeriodEnd: false,
+    currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+    subscriptionCanceledAt: null,
+};
+
+describe('BillingService — subscription cancel / resume (B07)', () => {
+    it('cancels AT PERIOD END through the provider seam and persists the flag', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const { service, provider } = build({ profiles });
+
+        const state = await service.cancelSubscription('u1');
+
+        expect(provider.cancelSubscriptionAtPeriodEnd).toHaveBeenCalledWith({
+            subscriptionId: 'sub_1',
+        });
+        // The persisted row is what the UI reads back.
+        expect(profiles.updateSubscriptionState).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({
+                providerSubscriptionId: 'sub_1',
+                subscriptionStatus: 'active',
+                cancelAtPeriodEnd: true,
+                currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+            }),
+        );
+        expect(state.cancelAtPeriodEnd).toBe(true);
+        expect(state.status).toBe('active');
+        expect(state.manageable).toBe(true);
+    });
+
+    it('keeps the paid period the owner already bought', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const { service } = build({ profiles });
+
+        const state = await service.cancelSubscription('u1');
+
+        // At-period-end, not immediate: the plan is still `active` and
+        // the period end is preserved so the UI can say when it stops.
+        expect(state.status).toBe('active');
+        expect(state.currentPeriodEnd).toEqual(new Date('2026-08-01T00:00:00Z'));
+        expect(state.canceledAt).toBeNull();
+    });
+
+    it('resume clears the pending cancellation', async () => {
+        const profiles = makeProfileRepository({
+            ...SUBSCRIBED_PROFILE,
+            cancelAtPeriodEnd: true,
+        });
+        const { service, provider } = build({ profiles });
+
+        const state = await service.resumeSubscription('u1');
+
+        expect(provider.resumeSubscription).toHaveBeenCalledWith({ subscriptionId: 'sub_1' });
+        expect(state.cancelAtPeriodEnd).toBe(false);
+        expect(profiles.updateSubscriptionState).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ cancelAtPeriodEnd: false }),
+        );
+    });
+
+    it('refuses to resume a subscription that has already ended', async () => {
+        const profiles = makeProfileRepository({
+            ...SUBSCRIBED_PROFILE,
+            subscriptionStatus: 'canceled',
+            cancelAtPeriodEnd: false,
+        });
+        const { service, provider } = build({ profiles });
+
+        await expect(service.resumeSubscription('u1')).rejects.toBeInstanceOf(
+            NoActiveSubscriptionError,
+        );
+        expect(provider.resumeSubscription).not.toHaveBeenCalled();
+    });
+
+    it('refuses cancel when the owner has no provider subscription', async () => {
+        // A free-tier profile: customer mapping only, no subscription id.
+        const profiles = makeProfileRepository(PROFILE);
+        const { service, provider } = build({ profiles });
+
+        await expect(service.cancelSubscription('u1')).rejects.toBeInstanceOf(
+            NoActiveSubscriptionError,
+        );
+        expect(provider.cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+        expect(profiles.updateSubscriptionState).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the payment provider is not configured', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const provider = makeProvider({ isConfigured: jest.fn().mockReturnValue(false) });
+        const { service } = build({ provider, profiles });
+
+        await expect(service.cancelSubscription('u1')).rejects.toBeInstanceOf(
+            BillingProviderNotConfiguredError,
+        );
+        expect(provider.cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+    });
+});
+
+describe('BillingService — subscription lifecycle is owner/org scoped', () => {
+    it('resolves the subscription from the CALLER, never a supplied id', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const { service } = build({ profiles });
+
+        await service.cancelSubscription('u1');
+
+        // The only input that reaches the lookup is the caller's user id.
+        expect(profiles.findByUserId).toHaveBeenCalledWith('u1');
+    });
+
+    it('refuses a caller from another org: they simply have no subscription', async () => {
+        // User `u2` (org-b) has no billing profile at all; `u1` (org-a)
+        // owns the only subscription in the system.
+        const profiles = makeProfileRepository(null, {
+            findByUserId: jest.fn().mockResolvedValue(null),
+        });
+        const { service, provider } = build({ profiles });
+
+        await expect(service.cancelSubscription('u2')).rejects.toBeInstanceOf(
+            NoActiveSubscriptionError,
+        );
+        // Nothing was cancelled anywhere — u1's subscription is untouched.
+        expect(provider.cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+        expect(profiles.updateSubscriptionState).not.toHaveBeenCalled();
+    });
+
+    it('refuses to mutate a row belonging to a different owner/org', async () => {
+        // Defence in depth: even if the lookup ever handed back another
+        // org's row, the ownership re-check stops the mutation.
+        const profiles = makeProfileRepository(null, {
+            findByUserId: jest.fn().mockResolvedValue(SUBSCRIBED_PROFILE),
+        });
+        const { service, provider } = build({ profiles });
+
+        await expect(service.cancelSubscription('u2')).rejects.toBeInstanceOf(
+            NoActiveSubscriptionError,
+        );
+        expect(provider.cancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+    });
+
+    it('refuses a portal session for a foreign billing account', async () => {
+        const profiles = makeProfileRepository(null, {
+            findByUserId: jest.fn().mockResolvedValue(SUBSCRIBED_PROFILE),
+        });
+        const { service, provider } = build({ profiles });
+
+        await expect(
+            service.createBillingPortalSession('u2', 'https://app.test/settings/billing'),
+        ).rejects.toBeInstanceOf(NoActiveSubscriptionError);
+        expect(provider.createBillingPortalSession).not.toHaveBeenCalled();
+    });
+
+    it('opens the portal for the caller’s own customer (the past-due recovery action)', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const { service, provider } = build({ profiles });
+
+        const session = await service.createBillingPortalSession(
+            'u1',
+            'https://app.test/settings/billing',
+        );
+
+        expect(provider.createBillingPortalSession).toHaveBeenCalledWith({
+            customerId: 'cus_1',
+            returnUrl: 'https://app.test/settings/billing',
+        });
+        expect(session.url).toBe('https://pay.example/portal/bps_1');
+    });
+});
+
+describe('BillingService — subscription webhook reconciliation (B08)', () => {
+    function subscriptionEvent(snapshot: Partial<BillingSubscriptionSnapshot> = {}) {
+        return event({
+            id: 'evt_sub',
+            kind: 'subscription.updated',
+            customerId: 'cus_1',
+            providerType: 'customer.subscription.updated',
+            subscription: {
+                subscriptionId: 'sub_1',
+                status: 'active',
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: new Date('2026-08-01T00:00:00Z'),
+                canceledAt: null,
+                ...snapshot,
+            },
+        });
+    }
+
+    it('a past-due delivery flips the persisted status', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest
+                .fn()
+                .mockResolvedValue(subscriptionEvent({ status: 'past_due' })),
+        });
+        const { service } = build({ provider, profiles });
+
+        const outcome = await service.handleWebhook('{}', 'sig');
+
+        expect(outcome.action).toBe('subscription-reconciled');
+        expect(profiles.updateSubscriptionState).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ subscriptionStatus: 'past_due' }),
+        );
+    });
+
+    it('the overview then reports pastDue so the banner renders', async () => {
+        const profiles = makeProfileRepository({
+            ...SUBSCRIBED_PROFILE,
+            subscriptionStatus: 'past_due',
+        });
+        const { service } = build({ profiles });
+
+        const overview = await service.getOverview('u1');
+
+        expect(overview.subscription.status).toBe('past_due');
+        expect(overview.subscription.pastDue).toBe(true);
+        expect(overview.subscription.manageable).toBe(true);
+    });
+
+    it('reconciles an out-of-band cancellation made in the provider’s portal', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(
+                subscriptionEvent({
+                    status: 'canceled',
+                    cancelAtPeriodEnd: false,
+                    canceledAt: new Date('2026-07-20T00:00:00Z'),
+                }),
+            ),
+        });
+        const { service } = build({ provider, profiles });
+
+        await service.handleWebhook('{}', 'sig');
+
+        expect(profiles.updateSubscriptionState).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({
+                subscriptionStatus: 'canceled',
+                subscriptionCanceledAt: new Date('2026-07-20T00:00:00Z'),
+            }),
+        );
+    });
+
+    it('is replay-safe: a re-delivered event writes the same state', async () => {
+        const profiles = makeProfileRepository(SUBSCRIBED_PROFILE);
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest
+                .fn()
+                .mockResolvedValue(subscriptionEvent({ cancelAtPeriodEnd: true })),
+        });
+        const { service } = build({ provider, profiles });
+
+        await service.handleWebhook('{}', 'sig');
+        await service.handleWebhook('{}', 'sig');
+
+        const writes = profiles.updateSubscriptionState.mock.calls.map(
+            (call: unknown[]) => call[1],
+        );
+        expect(writes[0]).toEqual(writes[1]);
+    });
+
+    it('acknowledges a subscription event it cannot attribute', async () => {
+        const profiles = makeProfileRepository(null, {
+            findByCustomerId: jest.fn().mockResolvedValue(null),
+            findByUserId: jest.fn().mockResolvedValue(null),
+        });
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(subscriptionEvent({})),
+        });
+        const { service } = build({ provider, profiles });
+
+        const outcome = await service.handleWebhook('{}', 'sig');
+
+        expect(outcome.action).toBe('unattributed');
+        expect(profiles.updateSubscriptionState).not.toHaveBeenCalled();
+    });
+
+    it('an account with no provider subscription reads as `none`, not `active`', async () => {
+        const profiles = makeProfileRepository(PROFILE);
+        const { service } = build({ profiles });
+
+        const overview = await service.getOverview('u1');
+
+        expect(overview.subscription.status).toBe('none');
+        expect(overview.subscription.manageable).toBe(false);
+        expect(overview.subscription.pastDue).toBe(false);
     });
 });

--- a/packages/agent/src/subscriptions/billing/billing.service.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.ts
@@ -3,7 +3,11 @@ import { BillingProfileRepository } from '@src/database/repositories/billing-pro
 import { CreditLedgerRepository } from '@src/database/repositories/credit-ledger.repository';
 import { InvoiceRepository } from '@src/database/repositories/invoice.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
-import { BillingProfile } from '@src/entities/billing-profile.entity';
+import {
+    BillingProfile,
+    isPastDueSubscriptionStatus,
+    type BillingSubscriptionStatus,
+} from '@src/entities/billing-profile.entity';
 import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
 import { Invoice, InvoiceStatus } from '@src/entities/invoice.entity';
 import { CreditLedgerService } from '../credits/credit-ledger.service';
@@ -11,6 +15,7 @@ import {
     BillingProvider,
     BillingProviderError,
     BillingProviderNotConfiguredError,
+    type BillingSubscriptionSnapshot,
     type BillingWebhookEvent,
 } from './billing.provider';
 import { CREDIT_PACKS, findCreditPack, type CreditPack } from './credit-packs';
@@ -24,6 +29,22 @@ export class UnknownCreditPackError extends Error {
     constructor(packId: string) {
         super(`Unknown credit pack: ${packId}`);
         this.name = 'UnknownCreditPackError';
+    }
+}
+
+/**
+ * A lifecycle mutation (cancel / resume / portal) was asked for on an
+ * owner who has no manageable provider subscription. Stable `name` so the
+ * API boundary maps it to a 409 instead of an unmapped 500.
+ *
+ * This is also what a CROSS-OWNER attempt surfaces as: every lifecycle
+ * call resolves the profile from the authenticated user id, so asking
+ * about somebody else's subscription resolves to "you have none".
+ */
+export class NoActiveSubscriptionError extends Error {
+    constructor(message = 'No manageable subscription for this account') {
+        super(message);
+        this.name = 'NoActiveSubscriptionError';
     }
 }
 
@@ -45,6 +66,24 @@ export interface CreditCheckoutStarted {
     credits: number;
 }
 
+/**
+ * The subscription lifecycle as the Billing page renders it (audit
+ * B07/B08). Deliberately does NOT carry the provider subscription id:
+ * the client never needs it, and every mutation is resolved server-side
+ * from the session user.
+ */
+export interface SubscriptionStateView {
+    status: BillingSubscriptionStatus;
+    /** Cancel requested; the plan runs until `currentPeriodEnd`. */
+    cancelAtPeriodEnd: boolean;
+    currentPeriodEnd: Date | null;
+    canceledAt: Date | null;
+    /** `past_due` / `unpaid` — drives the recovery banner. */
+    pastDue: boolean;
+    /** There is a real provider subscription that cancel/resume can act on. */
+    manageable: boolean;
+}
+
 export interface BillingOverview {
     providerConfigured: boolean;
     providerId: string;
@@ -63,6 +102,8 @@ export interface BillingOverview {
         packId: string | null;
         failureCount: number;
     };
+    /** Real lifecycle state — the status chip is no longer assumed active. */
+    subscription: SubscriptionStateView;
 }
 
 export interface WebhookOutcome {
@@ -81,6 +122,7 @@ export interface WebhookOutcome {
         // `PlanSubscriptionService`, which owns the tier grant/revoke.
         | 'subscription-activated'
         | 'subscription-canceled'
+        | 'subscription-reconciled'
         | 'ignored'
         | 'unattributed';
     creditsDelta?: number;
@@ -218,7 +260,137 @@ export class BillingService {
                 packId: profile?.autoRechargePackId ?? null,
                 failureCount: profile?.autoRechargeFailureCount ?? 0,
             },
+            subscription: this.toSubscriptionState(profile),
         };
+    }
+
+    // ── Subscription lifecycle (audit B07/B08) ───────────────────────
+
+    /**
+     * Project the persisted lifecycle columns into what the UI renders.
+     *
+     * No profile, or no provider subscription id, ⇒ `none` + not
+     * manageable: the account is on the free tier (or payments are not
+     * wired), so the page shows a plain plan card and no cancel control
+     * rather than a button that would 409.
+     */
+    private toSubscriptionState(profile: BillingProfile | null): SubscriptionStateView {
+        const status: BillingSubscriptionStatus = profile?.subscriptionStatus ?? 'none';
+        const hasSubscription = Boolean(profile?.providerSubscriptionId);
+        return {
+            status,
+            cancelAtPeriodEnd: profile?.cancelAtPeriodEnd ?? false,
+            currentPeriodEnd: profile?.currentPeriodEnd ?? null,
+            canceledAt: profile?.subscriptionCanceledAt ?? null,
+            pastDue: isPastDueSubscriptionStatus(profile?.subscriptionStatus),
+            // Manageable only when the provider is wired AND we hold an
+            // id to act on — otherwise cancel/resume have nothing to call.
+            manageable: hasSubscription && this.billingProvider.isConfigured(),
+        };
+    }
+
+    /**
+     * Schedule a cancellation for the end of the paid period (B07).
+     *
+     * Owner-scoped by construction: the profile is resolved from the
+     * AUTHENTICATED user id — there is no subscription id parameter to
+     * smuggle, so no caller can reach another account's (or another
+     * org's) subscription. {@link requireOwnedSubscription} additionally
+     * re-checks ownership on the row that came back, so a future lookup
+     * bug cannot turn into a cross-owner mutation.
+     */
+    async cancelSubscription(userId: string): Promise<SubscriptionStateView> {
+        const profile = await this.requireOwnedSubscription(userId);
+        const snapshot = await this.billingProvider.cancelSubscriptionAtPeriodEnd({
+            subscriptionId: profile.providerSubscriptionId as string,
+        });
+        return this.persistSubscriptionSnapshot(userId, snapshot);
+    }
+
+    /** Undo a pending at-period-end cancellation (B07). */
+    async resumeSubscription(userId: string): Promise<SubscriptionStateView> {
+        const profile = await this.requireOwnedSubscription(userId);
+        if (profile.subscriptionStatus === 'canceled') {
+            // Already ended — there is nothing to resume, and pretending
+            // otherwise would leave the UI showing a plan that is gone.
+            throw new NoActiveSubscriptionError('This subscription has already ended');
+        }
+        const snapshot = await this.billingProvider.resumeSubscription({
+            subscriptionId: profile.providerSubscriptionId as string,
+        });
+        return this.persistSubscriptionSnapshot(userId, snapshot);
+    }
+
+    /**
+     * Hosted portal session — the PAST_DUE recovery action (B08).
+     *
+     * Needs only a provider CUSTOMER (not a subscription), so an owner
+     * whose card failed can fix it even after the subscription lapsed.
+     * The return URL is built by the caller from the platform's own web
+     * origin; nothing from the browser reaches the provider.
+     */
+    async createBillingPortalSession(userId: string, returnUrl: string): Promise<{ url: string }> {
+        if (!this.billingProvider.isConfigured()) {
+            throw new BillingProviderNotConfiguredError();
+        }
+        const profile = await this.billingProfileRepository.findByUserId(userId);
+        if (!profile || profile.userId !== userId || !profile.providerCustomerId) {
+            throw new NoActiveSubscriptionError('No billing account for this user');
+        }
+        return this.billingProvider.createBillingPortalSession({
+            customerId: profile.providerCustomerId,
+            returnUrl,
+        });
+    }
+
+    /**
+     * Resolve the caller's OWN profile and assert it carries a
+     * subscription the provider can act on.
+     *
+     * The `profile.userId !== userId` re-check is deliberate defence in
+     * depth: the lookup is already keyed by user id, so a mismatch can
+     * only mean a future bug in the query — and a mismatch here would be
+     * a cross-account mutation, the one failure this path must never have.
+     */
+    private async requireOwnedSubscription(userId: string): Promise<BillingProfile> {
+        if (!this.billingProvider.isConfigured()) {
+            throw new BillingProviderNotConfiguredError();
+        }
+        const profile = await this.billingProfileRepository.findByUserId(userId);
+        if (!profile || profile.userId !== userId) {
+            throw new NoActiveSubscriptionError();
+        }
+        if (!profile.providerSubscriptionId) {
+            throw new NoActiveSubscriptionError();
+        }
+        return profile;
+    }
+
+    /** Persist a provider snapshot and return the projected view. */
+    private async persistSubscriptionSnapshot(
+        userId: string,
+        snapshot: BillingSubscriptionSnapshot,
+    ): Promise<SubscriptionStateView> {
+        const updated = await this.billingProfileRepository.updateSubscriptionState(userId, {
+            providerSubscriptionId: snapshot.subscriptionId,
+            subscriptionStatus: snapshot.status,
+            cancelAtPeriodEnd: snapshot.cancelAtPeriodEnd,
+            currentPeriodEnd: snapshot.currentPeriodEnd,
+            subscriptionCanceledAt: snapshot.canceledAt,
+        });
+        // The row read-back is authoritative when we have it; the
+        // snapshot is the fallback so a repository that returns nothing
+        // still yields the state the provider just confirmed.
+        return updated
+            ? this.toSubscriptionState(updated)
+            : {
+                  status: snapshot.status,
+                  cancelAtPeriodEnd: snapshot.cancelAtPeriodEnd,
+                  currentPeriodEnd: snapshot.currentPeriodEnd,
+                  canceledAt: snapshot.canceledAt,
+                  pastDue: isPastDueSubscriptionStatus(snapshot.status),
+                  manageable: this.billingProvider.isConfigured(),
+              };
     }
 
     /** Owner-scoped invoice history (PRD §3.5). */
@@ -291,6 +463,7 @@ export class BillingService {
                 return this.applyPaymentMethod(event);
             case 'subscription.activated':
             case 'subscription.canceled':
+            case 'subscription.updated':
                 return this.applySubscription(event);
             case 'ignored':
             default:
@@ -299,20 +472,44 @@ export class BillingService {
     }
 
     /**
-     * Paid-plan lifecycle (audit B24). Delegated whole — the tier grant
-     * lives with the plan repositories, not with the credits ledger. A
-     * deployment that somehow lacks the collaborator acknowledges the
+     * Subscription deliveries — the ONE entry point for all three kinds.
+     *
+     * Two things can happen, and they are deliberately separate:
+     *
+     *  1. **The snapshot projection** (audit B07/B08) runs for every kind
+     *     that carries one. It is what the Billing page reads: the status
+     *     chip, the past-due banner, a pending at-period-end cancel. A
+     *     `past_due` or `paused` delivery moves ONLY this.
+     *  2. **The tier move** (audit B24) is delegated to
+     *     `PlanSubscriptionService` and happens for exactly two kinds —
+     *     `subscription.activated` and `subscription.canceled`. Nothing
+     *     else may grant or revoke a paid plan.
+     *
+     * Keeping (2) narrow is the point. Before these were separated, the
+     * plan handler's `else` branch revoked on every non-activation kind,
+     * so a dunning delivery would have downgraded a paying customer.
+     *
+     * A deployment that lacks the plan collaborator acknowledges the
      * delivery rather than 500-ing it into an infinite provider retry.
      */
     private async applySubscription(event: BillingWebhookEvent): Promise<WebhookOutcome> {
-        if (!this.planSubscriptionService) {
-            this.logger.warn(
-                `Billing webhook ${event.id}: subscription event received but plan handling is not wired — acknowledged`,
-            );
-            return { eventId: event.id, kind: event.kind, action: 'ignored' };
+        const reconciled = await this.reconcileSubscriptionSnapshot(event);
+
+        if (event.kind === 'subscription.activated' || event.kind === 'subscription.canceled') {
+            if (!this.planSubscriptionService) {
+                this.logger.warn(
+                    `Billing webhook ${event.id}: subscription event received but plan handling is not wired — acknowledged`,
+                );
+                return { eventId: event.id, kind: event.kind, action: 'ignored' };
+            }
+            const action = await this.planSubscriptionService.applyWebhook(event);
+            return { eventId: event.id, kind: event.kind, action };
         }
-        const action = await this.planSubscriptionService.applyWebhook(event);
-        return { eventId: event.id, kind: event.kind, action };
+
+        if (!reconciled) {
+            return this.unattributed(event);
+        }
+        return { eventId: event.id, kind: event.kind, action: 'subscription-reconciled' };
     }
 
     private async applyPurchase(event: BillingWebhookEvent): Promise<WebhookOutcome> {
@@ -465,6 +662,34 @@ export class BillingService {
             paymentMethodExpYear: event.paymentMethod.expYear,
         });
         return { eventId: event.id, kind: event.kind, action: 'payment-method-updated' };
+    }
+
+    /**
+     * Reconcile the provider's view of the subscription onto the owner's
+     * profile (audit B07/B08).
+     *
+     * This is what makes the status chip and the PAST_DUE banner true
+     * without anyone visiting the page: dunning, recovery, an
+     * out-of-band cancellation in the provider's own portal, and the
+     * terminal delete all arrive here and overwrite the same columns.
+     *
+     * Naturally idempotent — it is a last-write-wins projection of state,
+     * not a ledger movement, so a replayed delivery writes the same row.
+     */
+    private async reconcileSubscriptionSnapshot(event: BillingWebhookEvent): Promise<boolean> {
+        const profile = await this.resolveProfile(event);
+        if (!profile || !event.subscription) {
+            return false;
+        }
+        const snapshot = event.subscription;
+        await this.billingProfileRepository.updateSubscriptionState(profile.userId, {
+            providerSubscriptionId: snapshot.subscriptionId,
+            subscriptionStatus: snapshot.status,
+            cancelAtPeriodEnd: snapshot.cancelAtPeriodEnd,
+            currentPeriodEnd: snapshot.currentPeriodEnd,
+            subscriptionCanceledAt: snapshot.canceledAt,
+        });
+        return true;
     }
 
     private async resolveProfile(event: BillingWebhookEvent): Promise<BillingProfile | null> {

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -379,6 +379,38 @@ describe('applyWebhook — activation and revocation', () => {
         };
     }
 
+    /**
+     * REGRESSION (audit B07/B08). `applyWebhook` used to be
+     * `if (activated) {…} else { cancel() }` — a bare fallthrough that was
+     * only safe while the kind union had exactly two members. Adding
+     * `subscription.updated` for the lifecycle made every dunning, pause
+     * and resume delivery land in the else-branch, which would have
+     * silently downgraded a PAYING customer. Revoking is now something
+     * only an explicit `subscription.canceled` can do.
+     */
+    it.each([
+        // The real third member: a lifecycle snapshot.
+        ['subscription.updated', 'subscription-reconciled'],
+        // A kind this service has never heard of. Cast deliberately —
+        // the whole point is to simulate a FUTURE union member reaching a
+        // build of this service that predates it, which is exactly how the
+        // old fallthrough would have started revoking plans.
+        ['subscription.trial_ending', 'ignored'],
+    ])('a %s delivery never revokes the plan', async (kind, expected) => {
+        const { service, subscriptionService } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(
+            service.applyWebhook(event({ kind: kind as BillingWebhookEvent['kind'] })),
+        ).resolves.toBe(expected);
+        // Granting is `assignPlanToUser`; revoking is `cancel()`, which
+        // reaches the subscription repository. Neither may happen here.
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
     it('activates the plan, attributing by provider customer id', async () => {
         const { service, subscriptionService, profileRepository } = build({
             profileRepository: makeProfileRepository({

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -78,6 +78,13 @@ export interface PlanCheckoutReturn {
 export type PlanWebhookAction =
     | 'subscription-activated'
     | 'subscription-canceled'
+    /**
+     * A lifecycle snapshot was accepted (audit B07/B08) — dunning, pause,
+     * resume or a period roll. Distinct from activated/canceled because
+     * it changes NEITHER: the tier is untouched and only the billing
+     * profile's view of the subscription moves.
+     */
+    | 'subscription-reconciled'
     | 'ignored'
     | 'unattributed';
 
@@ -252,8 +259,34 @@ export class PlanSubscriptionService {
             return activated ? 'subscription-activated' : 'ignored';
         }
 
-        const canceled = await this.cancel(userId, event.subscriptionId ?? null);
-        return canceled ? 'subscription-canceled' : 'ignored';
+        if (event.kind === 'subscription.canceled') {
+            const canceled = await this.cancel(userId, event.subscriptionId ?? null);
+            return canceled ? 'subscription-canceled' : 'ignored';
+        }
+
+        // `subscription.updated` (audit B07/B08) is a LIFECYCLE SNAPSHOT —
+        // dunning, pause, resume, a period roll. It deliberately does NOT
+        // grant and does NOT revoke: the grant is `subscription.activated`
+        // and the revoke is `subscription.canceled`, both of which the
+        // provider emits alongside this. Reconciling the snapshot is the
+        // billing profile's job, not the tier's.
+        if (event.kind === 'subscription.updated') {
+            return 'subscription-reconciled';
+        }
+
+        // Any OTHER kind is acknowledged, never acted on.
+        //
+        // This branch used to be a bare fallthrough to `cancel()`, which
+        // meant every kind that was not `subscription.activated` revoked
+        // the plan. That was safe only while the union had exactly two
+        // members; the moment a third arrived (this change), a `past_due`
+        // or `paused` delivery would have silently downgraded a paying
+        // customer. Revoking is now something only an explicit
+        // `subscription.canceled` can do.
+        this.logger.warn(
+            `Billing webhook ${event.id}: unhandled subscription kind '${event.kind}' — acknowledged without changing the plan`,
+        );
+        return 'ignored';
     }
 
     // ── Persistence ──────────────────────────────────────────────────

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -522,6 +522,205 @@ describe('StripeBillingProvider — event normalization', () => {
         expect(normalized.customerId).toBe('cus_expanded');
         expect(normalized.paymentId).toBe('pi_expanded');
     });
+
+    // ── Subscription lifecycle (audit B07/B08) ───────────────────────
+
+    function subscriptionObject(overrides: Record<string, unknown> = {}) {
+        return {
+            id: 'sub_1',
+            customer: 'cus_1',
+            currency: 'usd',
+            status: 'active',
+            cancel_at_period_end: false,
+            canceled_at: null,
+            // Only subscriptions WE sold carry this marker, and the
+            // normalizer refuses to speak about any others — a Stripe
+            // account may hold subscriptions this platform never sold, and
+            // projecting their state onto one of our billing profiles
+            // would be wrong. The fixture represents one of ours.
+            metadata: {
+                [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
+                [STRIPE_METADATA_KEYS.userId]: 'u1',
+                [STRIPE_METADATA_KEYS.planCode]: 'standard',
+                [STRIPE_METADATA_KEYS.referenceId]: 'u1:standard',
+            },
+            // Period end lives on the ITEMS in the current API version.
+            items: { data: [{ id: 'si_1', current_period_end: 1_790_000_000 }] },
+            ...overrides,
+        };
+    }
+
+    it('normalizes a subscription update, reading the period end off the item', async () => {
+        const normalized = await parse({
+            id: 'evt_12',
+            type: 'customer.subscription.updated',
+            data: { object: subscriptionObject({ cancel_at_period_end: true }) },
+        });
+
+        // An ACTIVE subscription re-asserts the tier, so the kind is
+        // `subscription.activated` (idempotent). What this test is really
+        // about is the SNAPSHOT — which now rides on every kind, so a
+        // `cancel_at_period_end` toggle reaches the billing profile.
+        expect(normalized.kind).toBe('subscription.activated');
+        expect(normalized.customerId).toBe('cus_1');
+        expect(normalized.subscription).toEqual({
+            subscriptionId: 'sub_1',
+            status: 'active',
+            cancelAtPeriodEnd: true,
+            currentPeriodEnd: new Date(1_790_000_000 * 1000),
+            canceledAt: null,
+        });
+    });
+
+    it('carries a past_due status straight through (drives the recovery banner)', async () => {
+        const normalized = await parse({
+            id: 'evt_13',
+            type: 'customer.subscription.updated',
+            data: { object: subscriptionObject({ status: 'past_due' }) },
+        });
+
+        expect(normalized.subscription?.status).toBe('past_due');
+    });
+
+    it('treats a delete as terminal regardless of what the object still says', async () => {
+        const normalized = await parse({
+            id: 'evt_14',
+            type: 'customer.subscription.deleted',
+            data: {
+                object: subscriptionObject({
+                    status: 'active',
+                    cancel_at_period_end: true,
+                    canceled_at: 1_789_000_000,
+                }),
+            },
+        });
+
+        expect(normalized.subscription).toEqual(
+            expect.objectContaining({
+                status: 'canceled',
+                cancelAtPeriodEnd: false,
+                canceledAt: new Date(1_789_000_000 * 1000),
+            }),
+        );
+    });
+
+    it('falls back to the legacy top-level period end on an older payload', async () => {
+        const normalized = await parse({
+            id: 'evt_15',
+            type: 'customer.subscription.updated',
+            data: {
+                object: subscriptionObject({
+                    items: { data: [] },
+                    current_period_end: 1_791_000_000,
+                }),
+            },
+        });
+
+        expect(normalized.subscription?.currentPeriodEnd).toEqual(new Date(1_791_000_000 * 1000));
+    });
+
+    it('maps an unrecognized provider status to `none` rather than trusting it', async () => {
+        const normalized = await parse({
+            id: 'evt_16',
+            type: 'customer.subscription.updated',
+            data: { object: subscriptionObject({ status: 'some_future_state' }) },
+        });
+
+        expect(normalized.subscription?.status).toBe('none');
+    });
+});
+
+describe('StripeBillingProvider — subscription mutations + portal (B07/B08)', () => {
+    beforeEach(() => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+    });
+
+    function withSubscriptions() {
+        const updated = {
+            id: 'sub_1',
+            status: 'active',
+            cancel_at_period_end: true,
+            canceled_at: null,
+            items: { data: [{ current_period_end: 1_790_000_000 }] },
+        };
+        const client = fakeClient({
+            subscriptions: { update: jest.fn().mockResolvedValue(updated) },
+            billingPortal: {
+                sessions: {
+                    create: jest
+                        .fn()
+                        .mockResolvedValue({ url: 'https://pay.example/portal/bps_1' }),
+                },
+            },
+        });
+        return build(client);
+    }
+
+    it('cancel schedules at period end — it never deletes the subscription', async () => {
+        const { provider, client } = withSubscriptions();
+
+        const snapshot = await provider.cancelSubscriptionAtPeriodEnd({
+            subscriptionId: 'sub_1',
+        });
+
+        expect(client.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+            cancel_at_period_end: true,
+        });
+        // There is no `cancel`/delete call on the fake — if the provider
+        // ever reached for one this spec would throw.
+        expect(client.subscriptions.cancel).toBeUndefined();
+        expect(snapshot).toEqual({
+            subscriptionId: 'sub_1',
+            status: 'active',
+            cancelAtPeriodEnd: true,
+            currentPeriodEnd: new Date(1_790_000_000 * 1000),
+            canceledAt: null,
+        });
+    });
+
+    it('resume clears the pending cancellation flag', async () => {
+        const { provider, client } = withSubscriptions();
+
+        await provider.resumeSubscription({ subscriptionId: 'sub_1' });
+
+        expect(client.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+            cancel_at_period_end: false,
+        });
+    });
+
+    it('creates a portal session with the SERVER-built return URL', async () => {
+        const { provider, client } = withSubscriptions();
+
+        const session = await provider.createBillingPortalSession({
+            customerId: 'cus_1',
+            returnUrl: 'https://app.test/settings/billing',
+        });
+
+        expect(client.billingPortal.sessions.create).toHaveBeenCalledWith({
+            customer: 'cus_1',
+            return_url: 'https://app.test/settings/billing',
+        });
+        expect(session).toEqual({ url: 'https://pay.example/portal/bps_1' });
+    });
+
+    it('fails closed on every lifecycle call without a secret key', async () => {
+        delete process.env.STRIPE_SECRET_KEY;
+        const { provider, factory } = build();
+
+        await expect(
+            provider.cancelSubscriptionAtPeriodEnd({ subscriptionId: 'sub_1' }),
+        ).rejects.toBeInstanceOf(BillingProviderNotConfiguredError);
+        await expect(
+            provider.resumeSubscription({ subscriptionId: 'sub_1' }),
+        ).rejects.toBeInstanceOf(BillingProviderNotConfiguredError);
+        await expect(
+            provider.createBillingPortalSession({
+                customerId: 'cus_1',
+                returnUrl: 'https://app.test/settings/billing',
+            }),
+        ).rejects.toBeInstanceOf(BillingProviderNotConfiguredError);
+        expect(factory).not.toHaveBeenCalled();
+    });
 });
 
 describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
@@ -816,7 +1015,17 @@ describe('StripeBillingProvider — subscription event normalization (audit B24)
                 type: 'customer.subscription.updated',
                 data: { object: { id: 'sub_1', status, metadata: planMeta } },
             });
-            expect(normalized.kind).toBe('ignored');
+            // The invariant this test is named for: a transient state must
+            // never produce a REVOKING kind. `subscription.canceled` is
+            // the only kind that revokes.
+            expect(normalized.kind).not.toBe('subscription.canceled');
+            // It used to assert `ignored`, which was the proxy for "nothing
+            // happens" back when there was nowhere else for these to go.
+            // Audit B07/B08 gives them a home: they now surface as a
+            // lifecycle snapshot, which is what drives the dunning banner.
+            // The no-revoke guarantee moved to where revoking actually
+            // happens — see plan-subscription.service.spec.
+            expect(normalized.kind).toBe('subscription.updated');
         }
     });
 

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -6,12 +6,16 @@ import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 // headers and (critically here) the webhook signature verification.
 import Stripe from 'stripe';
 import { config } from '@src/config';
+import type { BillingSubscriptionStatus } from '@src/entities/billing-profile.entity';
 import {
     BillingProvider,
     BillingProviderError,
     BillingProviderNotConfiguredError,
     type BillingInvoiceLine,
     type BillingInvoiceSnapshot,
+    type BillingPortalRequest,
+    type BillingPortalSession,
+    type BillingSubscriptionSnapshot,
     type BillingWebhookEvent,
     type BillingWebhookEventKind,
     type CheckoutSessionSnapshot,
@@ -22,6 +26,7 @@ import {
     type PaymentMethodSummary,
     type PlanCheckoutRequest,
     type PlanCheckoutSession,
+    type SubscriptionMutationRequest,
 } from './billing.provider';
 
 /**
@@ -340,6 +345,54 @@ export class StripeBillingProvider extends BillingProvider {
         }
     }
 
+    /**
+     * Schedule the cancellation for the end of the paid period (B07).
+     *
+     * `cancel_at_period_end: true` is an UPDATE, not a delete: the
+     * subscription keeps serving until the period ends and
+     * {@link resumeSubscription} can reverse it. We deliberately never
+     * call `subscriptions.cancel()` (immediate termination) from the
+     * self-service path — the owner already paid for the period.
+     */
+    async cancelSubscriptionAtPeriodEnd(
+        request: SubscriptionMutationRequest,
+    ): Promise<BillingSubscriptionSnapshot> {
+        const stripe = this.requireClient();
+        const subscription = await stripe.subscriptions.update(request.subscriptionId, {
+            cancel_at_period_end: true,
+        });
+        return toSubscriptionSnapshot(subscription);
+    }
+
+    /** Clear a pending at-period-end cancellation (B07). */
+    async resumeSubscription(
+        request: SubscriptionMutationRequest,
+    ): Promise<BillingSubscriptionSnapshot> {
+        const stripe = this.requireClient();
+        const subscription = await stripe.subscriptions.update(request.subscriptionId, {
+            cancel_at_period_end: false,
+        });
+        return toSubscriptionSnapshot(subscription);
+    }
+
+    /**
+     * Hosted portal session — the PAST_DUE recovery action (B08). Card
+     * re-entry happens entirely on the provider's tokenized surface, so
+     * no cardholder datum reaches the platform, and the return URL is the
+     * server-built one the caller passed.
+     */
+    async createBillingPortalSession(request: BillingPortalRequest): Promise<BillingPortalSession> {
+        const stripe = this.requireClient();
+        const session = await stripe.billingPortal.sessions.create({
+            customer: request.customerId,
+            return_url: request.returnUrl,
+        });
+        if (!session.url) {
+            throw new BillingProviderError('Billing portal session did not return a redirect URL');
+        }
+        return { url: session.url };
+    }
+
     async verifyAndParseWebhook(
         rawBody: string,
         signature: string | undefined,
@@ -490,6 +543,8 @@ export class StripeBillingProvider extends BillingProvider {
 
             case 'customer.subscription.created':
             case 'customer.subscription.updated':
+            case 'customer.subscription.paused':
+            case 'customer.subscription.resumed':
             case 'customer.subscription.deleted': {
                 const subscription = event.data.object as Stripe.Subscription;
                 const meta = subscription.metadata ?? {};
@@ -509,6 +564,16 @@ export class StripeBillingProvider extends BillingProvider {
                     subscriptionId: subscription.id,
                     currentPeriodEnd: readCurrentPeriodEnd(subscription),
                     cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
+                    currency: subscription.currency ?? null,
+                    // The snapshot rides on EVERY kind, not just the
+                    // lifecycle one. An `active` update is how
+                    // `cancel_at_period_end` first becomes true — if the
+                    // snapshot only travelled with `subscription.updated`,
+                    // a scheduled cancellation would never reach the
+                    // billing profile and the resume button could never
+                    // appear. The kind decides whether the TIER moves; the
+                    // snapshot is projected regardless.
+                    subscription: toSubscriptionSnapshot(subscription),
                 };
                 if (live) {
                     return { ...shared, kind: 'subscription.activated' };
@@ -521,9 +586,29 @@ export class StripeBillingProvider extends BillingProvider {
                     subscription.status === 'unpaid' ||
                     subscription.status === 'incomplete_expired'
                 ) {
-                    return { ...shared, kind: 'subscription.canceled' };
+                    return {
+                        ...shared,
+                        kind: 'subscription.canceled',
+                        subscription:
+                            event.type === 'customer.subscription.deleted'
+                                ? // A delete is terminal regardless of what
+                                  // the object still says about the period.
+                                  {
+                                      ...shared.subscription,
+                                      status: 'canceled' as const,
+                                      cancelAtPeriodEnd: false,
+                                  }
+                                : shared.subscription,
+                    };
                 }
-                return { ...shared, kind: 'ignored' };
+                // Everything left is a LIFECYCLE move that must not touch
+                // the tier: dunning (`past_due`), `paused`, `incomplete`.
+                // Audit B24 returned `ignored` here, which is why the
+                // product could never show a dunning banner or a resume
+                // button — the events existed and were thrown away.
+                // B07/B08 surfaces them as a snapshot instead. The tier is
+                // still moved only by the two branches above.
+                return { ...shared, kind: 'subscription.updated' };
             }
 
             case 'payment_method.attached': {
@@ -654,6 +739,51 @@ function toInvoiceSnapshot(invoice: Stripe.Invoice): BillingInvoiceSnapshot {
         pdfUrl: invoice.invoice_pdf ?? null,
         lines,
         issuedAt: toUnixDate((raw['created'] as number | undefined) ?? null),
+    };
+}
+
+/**
+ * Every provider lifecycle token maps 1:1 onto the platform's own set,
+ * so this is a lookup, not a heuristic. An unrecognized token (a future
+ * provider state) resolves to `none` rather than being trusted as active
+ * — the fail-closed direction for anything that gates paid capability.
+ */
+const SUBSCRIPTION_STATUS_MAP: Record<string, BillingSubscriptionStatus> = {
+    active: 'active',
+    trialing: 'trialing',
+    past_due: 'past_due',
+    unpaid: 'unpaid',
+    paused: 'paused',
+    canceled: 'canceled',
+    incomplete: 'incomplete',
+    incomplete_expired: 'incomplete_expired',
+};
+
+/**
+ * Period end moved from the subscription onto its ITEMS in the current
+ * API version, so read the item value first and keep the legacy
+ * top-level field as a fallback — a webhook replay of an older delivery
+ * must still yield a period end.
+ */
+function subscriptionPeriodEnd(subscription: Stripe.Subscription): Date | null {
+    const items = subscription.items?.data ?? [];
+    for (const item of items) {
+        const end = (item as unknown as Record<string, unknown>)['current_period_end'];
+        if (typeof end === 'number') {
+            return toUnixDate(end);
+        }
+    }
+    const legacy = (subscription as unknown as Record<string, unknown>)['current_period_end'];
+    return typeof legacy === 'number' ? toUnixDate(legacy) : null;
+}
+
+function toSubscriptionSnapshot(subscription: Stripe.Subscription): BillingSubscriptionSnapshot {
+    return {
+        subscriptionId: subscription.id,
+        status: SUBSCRIPTION_STATUS_MAP[subscription.status] ?? 'none',
+        cancelAtPeriodEnd: subscription.cancel_at_period_end === true,
+        currentPeriodEnd: subscriptionPeriodEnd(subscription),
+        canceledAt: toUnixDate(subscription.canceled_at),
     };
 }
 

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -9,7 +9,11 @@ import {
     ManualBillingProvider,
 } from './billing/billing.provider';
 import { StripeBillingProvider, STRIPE_METADATA_KEYS } from './billing/stripe-billing.provider';
-import { BillingService, UnknownCreditPackError } from './billing/billing.service';
+import {
+    BillingService,
+    NoActiveSubscriptionError,
+    UnknownCreditPackError,
+} from './billing/billing.service';
 import { AutoRechargeService } from './billing/auto-recharge.service';
 import {
     CheckoutSessionNotFoundError,
@@ -84,6 +88,9 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.StripeBillingProvider).toBe(StripeBillingProvider);
             expect(subscriptionsBarrel.CREDIT_PACKS).toBe(CREDIT_PACKS);
             expect(subscriptionsBarrel.UnknownCreditPackError).toBe(UnknownCreditPackError);
+            // Subscription lifecycle (audit B07/B08) — cancel/resume and
+            // the portal recovery action map this to a 409 at the API.
+            expect(subscriptionsBarrel.NoActiveSubscriptionError).toBe(NoActiveSubscriptionError);
             expect(subscriptionsBarrel.BillingProviderNotConfiguredError).toBe(
                 BillingProviderNotConfiguredError,
             );
@@ -124,6 +131,8 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'BillingService',
                     'BILLING_PAYMENT_REF_TYPE',
                     'UnknownCreditPackError',
+                    // Subscription lifecycle (audit B07/B08)
+                    'NoActiveSubscriptionError',
                     'AutoRechargeService',
                     // Paid-plan purchase (audit B24)
                     'PlanSubscriptionService',


### PR DESCRIPTION
## The problem

A subscription had exactly two observable states: **on** or **gone**. Dunning
was invisible, a scheduled cancellation could not be seen or undone, and a
failed payment had no recovery action.

## What changed

- A provider **snapshot** projected onto the billing profile — status,
  `cancelAtPeriodEnd`, `currentPeriodEnd`, `canceledAt`
- **Cancel at period end** and **resume** mutations
- The hosted **billing portal** redirect (PAST_DUE recovery)
- The UI that renders all of it: status chip, dunning banner, cancel/resume

## ⚠️ Integration with the merged checkout path (B24)

This branch was written before #1900 landed and assumed it owned the
subscription webhook path. It does not — and merging the two designs naively
**would have caused a production regression**.

`PlanSubscriptionService.applyWebhook` was:

```ts
if (event.kind === 'subscription.activated') { …activate… }
const canceled = await this.cancel(userId, …);   // ← bare fallthrough
```

That is safe only while the kind union has exactly **two** members. Adding a
third for the lifecycle would have sent every dunning, pause and resume
delivery into the else-branch, **silently downgrading a paying customer**.

### The integrated design

| Kind | Moves the tier? | Snapshot projected? |
|---|---|---|
| `subscription.activated` | grants | yes |
| `subscription.canceled` | revokes | yes (forced terminal on delete) |
| `subscription.updated` | **no** | yes |
| anything unrecognised | **no** — logged + acknowledged | n/a |

Revoking is now something only an explicit `subscription.canceled` can do.

**The snapshot rides on every kind**, not just the lifecycle one.
`cancel_at_period_end` first becomes true on an *active* update, so a snapshot
that only travelled with `subscription.updated` would never have reached the
billing profile and the resume button could never have appeared. The kind
decides whether the **tier** moves; the snapshot is projected regardless.

`BillingService.applySubscription` is now one dispatcher: snapshot projection
for every kind that carries one, tier delegate for exactly two.

The states B24 discarded as `ignored` (`past_due`, `paused`, `incomplete`) are
exactly what this change surfaces — which is *why* the product could never show
a dunning banner or a resume button. Those events existed and were thrown away.

## Test changes — none of them a weakening

1. **The lifecycle fixture carried no Stripe metadata**, so the normalizer
   correctly refused it. A Stripe account may hold subscriptions this platform
   never sold; projecting their state onto one of our billing profiles would be
   wrong. The fixture now represents one of ours — a correction, not a loosened
   gate.
2. **B24's "does NOT revoke on a transient dunning state"** asserted `ignored`,
   which was a proxy for "nothing happens" back when these events had nowhere to
   go. It now asserts the kind is **not** `subscription.canceled` **and** is
   `subscription.updated`. The invariant it is named for is preserved, made
   explicit, and additionally enforced at the layer where revoking happens.
3. **New regression test** — a `subscription.updated` and a deliberately-cast
   unknown kind both leave the tier untouched. The cast simulates a future union
   member reaching an older build, which is exactly how the old fallthrough
   would have started revoking.

## Migration

Renumbered `1784700000000` → **`1784720000000`** (collides with the merged
`AddUserSubscriptionProviderRef`). Class name, `name` property, and the spec's
import / `describe` / constructor all updated — a rename that leaves those stale
compiles fine and fails at runtime.

## Merge conflicts

9 files, 16 hunks, all resolved by hand. Three were initially broken by a naive
"keep both sides" pass (orphaned JSDoc openers — the union-merge damage the repo
docs warn about); those were restored via `git checkout -m` and rebuilt properly,
the worst of them from develop's version plus the new actions written out
longhand.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 447 suites, 8186 tests |
| `apps/api` jest | green — 232 suites, 3788 tests |
| `apps/web` tsc --noEmit | green |
| prettier | clean |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription lifecycle visibility, including status, renewal dates, cancellation scheduling, and past-due alerts.
  * Added options to cancel or resume subscriptions and open the hosted billing portal.
  * Added support for reconciling subscription updates from billing provider events.
* **Bug Fixes**
  * Improved handling of subscription states, payment issues, cancellations, and provider configuration errors.
  * Prevented unrelated subscription events from changing account plans.
* **Tests**
  * Expanded coverage for subscription actions, webhook processing, billing status display, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->