### PR TITLE
feat(billing): add account-wide usage CSV export and a period filter (B29)

### DIFF
--- a/apps/api/src/subscriptions/credits.controller.spec.ts
+++ b/apps/api/src/subscriptions/credits.controller.spec.ts
@@ -13,6 +13,20 @@ jest.mock('@ever-works/agent/subscriptions', () => ({
         }
     },
     USAGE_SUMMARY_GROUP_BYS: ['day', 'model', 'agent', 'work'],
+    USAGE_EXPORT_COLUMNS: [
+        'occurredAt',
+        'pluginId',
+        'capability',
+        'units',
+        'costCents',
+        'currency',
+        'modelId',
+        'workId',
+        'agentId',
+        'taskId',
+        'runId',
+        'requestId',
+    ],
 }));
 jest.mock('@ever-works/agent/entities', () => ({
     CreditLedgerKind: {
@@ -34,12 +48,59 @@ import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { InvalidUsagePeriodError } from '@ever-works/agent/subscriptions';
 import type { CreditLedgerService, UsageSummaryService } from '@ever-works/agent/subscriptions';
-import { CreditsController, CreditsUsageSummaryQueryDto } from './credits.controller';
+import type { ScopeContextService } from '../scope';
+import {
+    CreditsController,
+    CreditsUsageExportQueryDto,
+    CreditsUsageSummaryQueryDto,
+} from './credits.controller';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+/** Collects everything the controller streams onto the response. */
+function makeCsvResponse() {
+    const headers: Record<string, string> = {};
+    const written: string[] = [];
+    let ended = false;
+    return {
+        headers,
+        written,
+        get body() {
+            return written.join('');
+        },
+        get ended() {
+            return ended;
+        },
+        setHeader(name: string, value: string) {
+            headers[name] = value;
+        },
+        write(chunk: string) {
+            written.push(chunk);
+            return true;
+        },
+        end() {
+            ended = true;
+            return true;
+        },
+    };
+}
+
+/** Wraps pre-built pages in the lazy async-iterable shape the service returns. */
+function chunksOf(pages: Record<string, unknown>[][]) {
+    return {
+        async *[Symbol.asyncIterator]() {
+            for (const page of pages) {
+                yield page as never;
+            }
+        },
+    };
+}
 
 describe('CreditsController', () => {
     let creditLedgerService: jest.Mocked<Pick<CreditLedgerService, 'getBalance' | 'getLedger'>>;
-    let usageSummaryService: jest.Mocked<Pick<UsageSummaryService, 'getTotals' | 'getGrouped'>>;
+    let usageSummaryService: jest.Mocked<
+        Pick<UsageSummaryService, 'getTotals' | 'getGrouped' | 'createExport'>
+    >;
+    let scopeContext: jest.Mocked<Pick<ScopeContextService, 'getOrganizationId'>>;
     let controller: CreditsController;
 
     const auth: AuthenticatedUser = {
@@ -87,10 +148,21 @@ describe('CreditsController', () => {
                 groupBy: 'day',
                 rows: [],
             }),
+            createExport: jest.fn().mockReturnValue({
+                window: {
+                    period: '2026-07',
+                    from: new Date('2026-07-01T00:00:00.000Z'),
+                    to: new Date('2026-08-01T00:00:00.000Z'),
+                },
+                organizationId: null,
+                chunks: chunksOf([]),
+            }),
         } as any;
+        scopeContext = { getOrganizationId: jest.fn().mockReturnValue(null) } as any;
         controller = new CreditsController(
             creditLedgerService as unknown as CreditLedgerService,
             usageSummaryService as unknown as UsageSummaryService,
+            scopeContext as unknown as ScopeContextService,
         );
     });
 
@@ -161,6 +233,215 @@ describe('CreditsController', () => {
             for (const period of ['2026-13', '90d', 'last-week', '2026-7']) {
                 expect((await validateQuery({ period })).length).toBeGreaterThan(0);
             }
+        });
+    });
+
+    describe('exportUsageCsv (B29 — account-wide CSV export)', () => {
+        const row = {
+            occurredAt: '2026-07-04T10:00:00.000Z',
+            pluginId: 'openrouter',
+            capability: 'ai',
+            units: 2,
+            costCents: 31,
+            currency: 'usd',
+            modelId: 'model-a',
+            workId: 'work-1',
+            agentId: null,
+            taskId: null,
+            runId: null,
+            requestId: null,
+        };
+
+        function primeExport(
+            pages: Record<string, unknown>[][],
+            window = {
+                period: '2026-07',
+                from: new Date('2026-07-01T00:00:00.000Z'),
+                to: new Date('2026-08-01T00:00:00.000Z'),
+            },
+        ) {
+            usageSummaryService.createExport.mockReturnValue({
+                window,
+                organizationId: null,
+                chunks: chunksOf(pages),
+            } as any);
+        }
+
+        it('scopes the export to the ACTIVE ORGANIZATION from the request scope context', async () => {
+            scopeContext.getOrganizationId.mockReturnValue('org-a');
+            primeExport([[row]]);
+            const res = makeCsvResponse();
+
+            await controller.exportUsageCsv(auth, res, {});
+
+            expect(usageSummaryService.createExport).toHaveBeenCalledWith('user-1', {
+                period: undefined,
+                organizationId: 'org-a',
+            });
+        });
+
+        it('never lets a caller-supplied query override the org scope', async () => {
+            scopeContext.getOrganizationId.mockReturnValue('org-a');
+            primeExport([[row]]);
+            const res = makeCsvResponse();
+
+            // A hostile client adds organizationId/orgId/userId. The
+            // global ValidationPipe (whitelist + forbidNonWhitelisted)
+            // 400s them before the handler; even if one slipped through,
+            // the handler reads scope + auth and ignores the payload.
+            await controller.exportUsageCsv(auth, res, {
+                organizationId: 'org-b',
+                orgId: 'org-b',
+                userId: 'someone-else',
+            } as never);
+
+            expect(usageSummaryService.createExport).toHaveBeenCalledWith('user-1', {
+                period: undefined,
+                organizationId: 'org-a',
+            });
+        });
+
+        it('omits the org filter (null) when the request has no active Organization', async () => {
+            scopeContext.getOrganizationId.mockReturnValue(null);
+            primeExport([[row]]);
+
+            await controller.exportUsageCsv(auth, makeCsvResponse(), { period: '30d' });
+
+            expect(usageSummaryService.createExport).toHaveBeenCalledWith('user-1', {
+                period: '30d',
+                organizationId: null,
+            });
+        });
+
+        it('forwards a YYYY-MM period and names the file after the resolved month', async () => {
+            primeExport([[row]], {
+                period: '2026-06',
+                from: new Date('2026-06-01T00:00:00.000Z'),
+                to: new Date('2026-07-01T00:00:00.000Z'),
+            });
+            const res = makeCsvResponse();
+
+            await controller.exportUsageCsv(auth, res, { period: '2026-06' });
+
+            expect(usageSummaryService.createExport).toHaveBeenCalledWith('user-1', {
+                period: '2026-06',
+                organizationId: null,
+            });
+            expect(res.headers['Content-Type']).toBe('text/csv; charset=utf-8');
+            expect(res.headers['Content-Disposition']).toBe(
+                'attachment; filename="usage-2026-06.csv"',
+            );
+        });
+
+        it('writes the pinned header then one line per row, and ends the response', async () => {
+            primeExport([[row]]);
+            const res = makeCsvResponse();
+
+            await controller.exportUsageCsv(auth, res, {});
+
+            const lines = res.body.trimEnd().split('\n');
+            expect(lines[0]).toBe(
+                'occurredAt,pluginId,capability,units,costCents,currency,modelId,workId,agentId,taskId,runId,requestId',
+            );
+            expect(lines[1]).toBe(
+                '2026-07-04T10:00:00.000Z,openrouter,ai,2,31,usd,model-a,work-1,,,,',
+            );
+            expect(res.ended).toBe(true);
+        });
+
+        it('streams chunk-by-chunk instead of buffering the whole period', async () => {
+            primeExport([[row], [{ ...row, pluginId: 'tavily' }]]);
+            const res = makeCsvResponse();
+
+            await controller.exportUsageCsv(auth, res, {});
+
+            // header write + one write per repository page
+            expect(res.written).toHaveLength(3);
+            expect(res.body).toContain('tavily');
+        });
+
+        it('RFC 4180-escapes values containing commas or quotes', async () => {
+            primeExport([[{ ...row, modelId: 'a,b', requestId: 'say "hi"' }]]);
+            const res = makeCsvResponse();
+
+            await controller.exportUsageCsv(auth, res, {});
+
+            expect(res.body).toContain('"a,b"');
+            expect(res.body).toContain('"say ""hi"""');
+        });
+
+        it('maps InvalidUsagePeriodError to a 400 (never an unmapped 500)', async () => {
+            usageSummaryService.createExport.mockImplementation(() => {
+                throw new InvalidUsagePeriodError('bogus');
+            });
+
+            await expect(
+                controller.exportUsageCsv(auth, makeCsvResponse(), {}),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('propagates unexpected errors untouched', async () => {
+            usageSummaryService.createExport.mockImplementation(() => {
+                throw new Error('db down');
+            });
+
+            await expect(controller.exportUsageCsv(auth, makeCsvResponse(), {})).rejects.toThrow(
+                'db down',
+            );
+        });
+
+        it('throws (rather than half-writing a 200) when the FIRST page fails', async () => {
+            usageSummaryService.createExport.mockReturnValue({
+                window: {
+                    period: '2026-07',
+                    from: new Date('2026-07-01T00:00:00.000Z'),
+                    to: new Date('2026-08-01T00:00:00.000Z'),
+                },
+                organizationId: null,
+                chunks: {
+                    // eslint-disable-next-line require-yield
+                    async *[Symbol.asyncIterator]() {
+                        throw new Error('query failed');
+                    },
+                },
+            } as any);
+            const res = makeCsvResponse();
+
+            await expect(controller.exportUsageCsv(auth, res, {})).rejects.toThrow('query failed');
+            expect(res.written).toHaveLength(0);
+            expect(res.headers['Content-Disposition']).toBeUndefined();
+        });
+
+        it('an empty period still returns a header-only CSV', async () => {
+            primeExport([]);
+            const res = makeCsvResponse();
+
+            await controller.exportUsageCsv(auth, res, {});
+
+            expect(res.body).toBe(
+                'occurredAt,pluginId,capability,units,costCents,currency,modelId,workId,agentId,taskId,runId,requestId\n',
+            );
+            expect(res.ended).toBe(true);
+        });
+    });
+
+    describe('CreditsUsageExportQueryDto validation', () => {
+        async function validateQuery(query: Record<string, unknown>) {
+            return validate(plainToInstance(CreditsUsageExportQueryDto, query));
+        }
+
+        it('accepts YYYY-MM / 7d / 30d periods (B20 — the month option is reachable)', async () => {
+            for (const period of ['2026-07', '2025-12', '7d', '30d']) {
+                expect(await validateQuery({ period })).toHaveLength(0);
+            }
+        });
+
+        it('rejects malformed periods and non-csv formats', async () => {
+            for (const period of ['2026-13', '90d', 'last-month', '2026-7']) {
+                expect((await validateQuery({ period })).length).toBeGreaterThan(0);
+            }
+            expect(await validateQuery({ format: 'csv' })).toHaveLength(0);
+            expect((await validateQuery({ format: 'xlsx' })).length).toBeGreaterThan(0);
         });
     });
 

--- a/apps/api/src/subscriptions/credits.controller.ts
+++ b/apps/api/src/subscriptions/credits.controller.ts
@@ -2,9 +2,12 @@ import {
     BadRequestException,
     Controller,
     Get,
+    Header,
     HttpCode,
     HttpStatus,
+    Logger,
     Query,
+    Res,
     UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -12,14 +15,30 @@ import { Type } from 'class-transformer';
 import { IsIn, IsInt, IsOptional, IsString, Matches, Max, Min } from 'class-validator';
 import { AuthSessionGuard, CurrentUser } from '@src/auth';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { ScopeContextService } from '@src/scope';
 import {
     CreditLedgerService,
     InvalidUsagePeriodError,
+    USAGE_EXPORT_COLUMNS,
     USAGE_SUMMARY_GROUP_BYS,
     UsageSummaryService,
+    type UsageExportRow,
+    type UsageExportStream,
     type UsageSummaryGroupBy,
 } from '@ever-works/agent/subscriptions';
 import { CreditLedgerEntry, CreditLedgerKind } from '@ever-works/agent/entities';
+
+/**
+ * Minimal Response surface for the streamed CSV. Mirrors the convention
+ * in budgets/usage.controller.ts and activity-log.controller.ts (avoids
+ * pulling the full `import('express').Response` type), extended with
+ * `write`/`end` because this export streams instead of buffering.
+ */
+type StreamingCsvResponse = {
+    setHeader(name: string, value: string): void;
+    write(chunk: string): unknown;
+    end(): unknown;
+};
 
 export class CreditsUsageSummaryQueryDto {
     /**
@@ -37,6 +56,21 @@ export class CreditsUsageSummaryQueryDto {
         message: 'period must be YYYY-MM, 7d, or 30d',
     })
     period?: string;
+}
+
+/** B29 — query contract for the account-wide usage CSV export. */
+export class CreditsUsageExportQueryDto {
+    /** `YYYY-MM` calendar month (default: current), or rolling `7d`/`30d`. */
+    @IsOptional()
+    @Matches(/^(\d{4}-(0[1-9]|1[0-2])|7d|30d)$/, {
+        message: 'period must be YYYY-MM, 7d, or 30d',
+    })
+    period?: string;
+
+    /** Only `csv` is supported — mirrors the per-Work export's contract. */
+    @IsOptional()
+    @IsIn(['csv'], { message: "Unsupported format. Only 'csv' is supported." })
+    format?: string;
 }
 
 class CreditsLedgerQueryDto {
@@ -77,11 +111,16 @@ const VALID_KINDS = new Set<string>(Object.values(CreditLedgerKind));
 @Controller('api/credits')
 @UseGuards(AuthSessionGuard)
 export class CreditsController {
+    private readonly logger = new Logger(CreditsController.name);
+
     constructor(
         private readonly creditLedgerService: CreditLedgerService,
         // Wave 13 — account-wide usage aggregations for the Usage &
         // Credits page (`usage-summary` below).
         private readonly usageSummaryService: UsageSummaryService,
+        // B29 — the active Organization for the CSV export's scope
+        // filter. Read from the request scope context, never a param.
+        private readonly scopeContext: ScopeContextService,
     ) {}
 
     @Get('balance')
@@ -163,6 +202,104 @@ export class CreditsController {
             }
             throw error;
         }
+    }
+
+    @Get('usage/export')
+    @HttpCode(HttpStatus.OK)
+    @Header('Cache-Control', 'no-store')
+    @ApiOperation({
+        summary: 'Download account-wide usage events as CSV',
+        description:
+            'Streams every metered usage event attributed to the authenticated user inside the ' +
+            "period as CSV. Scoped to the request's active Organization when there is one, so a " +
+            "user acting inside one Org never exports another Org's spend. period accepts " +
+            'YYYY-MM (default: current month), 7d, or 30d.',
+    })
+    @ApiResponse({ status: 200, description: 'CSV stream of usage events' })
+    @ApiResponse({ status: 400, description: 'Invalid period or format' })
+    async exportUsageCsv(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Res() res: StreamingCsvResponse,
+        @Query() query: CreditsUsageExportQueryDto,
+    ): Promise<void> {
+        // Scope filter comes from the request context ONLY — accepting an
+        // orgId param here would be a cross-org billing read.
+        const organizationId = this.scopeContext.getOrganizationId();
+
+        let stream: UsageExportStream;
+        try {
+            stream = this.usageSummaryService.createExport(auth.userId, {
+                period: query.period,
+                organizationId,
+            });
+        } catch (error) {
+            // Defence-in-depth: the DTO regex already rejects bad periods.
+            if (error instanceof InvalidUsagePeriodError) {
+                throw new BadRequestException(error.message);
+            }
+            throw error;
+        }
+
+        // Headers + the CSV header row are written LAZILY, on the first
+        // chunk (or once the stream completes empty). A repository error
+        // on the very first page therefore still maps to a normal HTTP
+        // error response instead of a half-written 200.
+        let started = false;
+        const start = () => {
+            if (started) {
+                return;
+            }
+            started = true;
+            // Security: strip `"`/CR/LF before interpolating into the
+            // quoted Content-Disposition header so a quote/newline can't
+            // terminate the quoted-string and inject additional header
+            // parameters or split the response. Mirrors
+            // budgets/usage.controller.ts. The period is already
+            // regex-validated, so valid inputs are unchanged.
+            const filename = `usage-${stream.window.period}.csv`.replace(/["\r\n]/g, '_');
+            res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+            res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+            res.write(`${USAGE_EXPORT_COLUMNS.join(',')}\n`);
+        };
+
+        try {
+            // Streamed, not buffered: each repository page is written out
+            // and dropped, so a long period costs one page of rows in
+            // memory rather than the whole period.
+            for await (const chunk of stream.chunks) {
+                start();
+                res.write(chunk.map((row) => this.toCsvLine(row)).join(''));
+            }
+            start();
+        } catch (error) {
+            if (!started) {
+                // Nothing on the wire yet — let the exception filters map it.
+                throw error;
+            }
+            // Mid-stream failure: the response is already committed, so all
+            // we can do is log and close rather than hang the download.
+            this.logger.error(
+                `Account-wide usage export failed mid-stream for period ${stream.window.period}`,
+                error instanceof Error ? error.stack : String(error),
+            );
+        }
+        res.end();
+    }
+
+    /** One CSV record (RFC 4180 escaping), newline included. */
+    private toCsvLine(row: UsageExportRow): string {
+        return `${USAGE_EXPORT_COLUMNS.map((column) => this.escapeCsv(row[column])).join(',')}\n`;
+    }
+
+    private escapeCsv(value: unknown): string {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        const str = typeof value === 'string' ? value : String(value);
+        if (/[",\n\r]/.test(str)) {
+            return `"${str.replace(/"/g, '""')}"`;
+        }
+        return str;
     }
 
     private parseKinds(raw?: string): CreditLedgerKind[] | undefined {

--- a/apps/web/e2e/flow-billing-usage-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-billing-usage-ui-journey.spec.ts
@@ -147,4 +147,55 @@ test.describe('/settings/usage', () => {
         await expect(page.getByTestId('usage-by-day-loading')).toHaveCount(0, { timeout: 20_000 });
         await expect(page.getByTestId('usage-by-day-error')).toHaveCount(0);
     });
+
+    test('B20 — the month picker offers calendar months and selecting one refetches', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'usage', 'usage-credits-settings');
+
+        const monthPicker = page.getByTestId('usage-period-month');
+        await expect(monthPicker).toBeVisible();
+
+        // The picker must actually be populated with `YYYY-MM` values —
+        // the whole point of B20 is that the month option is reachable.
+        const values = await monthPicker
+            .locator('option')
+            .evaluateAll((options) =>
+                options.map((option) => (option as HTMLOptionElement).value).filter(Boolean),
+            );
+        expect(values.length).toBeGreaterThan(1);
+        for (const value of values) {
+            expect(value).toMatch(/^\d{4}-(0[1-9]|1[0-2])$/);
+        }
+
+        // Picking a past month refetches every panel through the proxy;
+        // the loading state is transient, the ERROR state is not.
+        await monthPicker.selectOption(values[1]);
+        await expect(page.getByTestId('usage-by-day-loading')).toHaveCount(0, { timeout: 20_000 });
+        await expect(page.getByTestId('usage-by-day-error')).toHaveCount(0);
+        await expect(page.getByTestId('usage-load-error')).toHaveCount(0);
+    });
+
+    test('B21/B29 — the CSV export control points at the account-wide export endpoint', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'usage', 'usage-credits-settings');
+
+        const exportLink = page.getByTestId('usage-export-csv');
+        await expect(exportLink).toBeVisible();
+        await expect(exportLink).toHaveAttribute(
+            'href',
+            /^\/api\/credits\/usage\/export\?period=(\d{4}-(0[1-9]|1[0-2])|7d|30d)$/,
+        );
+
+        // The proxy must answer with a CSV attachment, not an HTML error
+        // page — a broken export is otherwise invisible from the UI.
+        const href = await exportLink.getAttribute('href');
+        const response = await page.request.get(href as string);
+        expect(response.status()).toBe(200);
+        expect(response.headers()['content-type']).toContain('text/csv');
+        expect(response.headers()['content-disposition']).toContain('attachment');
+        // Header row is the pinned column contract.
+        expect(await response.text()).toContain('occurredAt,pluginId,capability');
+    });
 });

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2668,6 +2668,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "digest": {

--- a/apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx
@@ -2,12 +2,21 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { creditsAPI } from '@/lib/api/credits';
 import { usageAPI, type AccountWideUsage } from '@/lib/api/usage';
-import type { UsageSummaryGrouped, UsageSummaryTotals } from '@/lib/api/credits.shared';
+import {
+    currentUsageMonth,
+    parseUsagePeriod,
+    type UsageSummaryGrouped,
+    type UsageSummaryTotals,
+} from '@/lib/api/credits.shared';
 import { UsageCreditsSettings } from '@/components/settings/UsageCreditsSettings';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('metadata.pages');
     return { title: t('usage') };
+}
+
+interface UsageSettingsPageProps {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
 /**
@@ -16,25 +25,37 @@ export async function generateMetadata(): Promise<Metadata> {
  * per-agent / per-Work spend charts from the owner-scoped
  * `GET /api/credits/usage-summary` aggregations.
  *
- * Server component fetches the initial snapshot (current month for the
- * grouped charts, 30d for the by-day chart); the client's 7d/30d
- * toggle refetches through the `/api/credits/usage-summary` proxy.
- * Static page by design — no polling; refresh on navigation.
+ * B20 — ONE period drives every panel, and it accepts a `YYYY-MM`
+ * calendar month as well as the rolling `7d` / `30d` windows. A
+ * `?period=` deep link is honoured server-side (validated through
+ * `parseUsagePeriod`, falling back to the current month), so a shared
+ * link renders exactly the month it names; the client selector then
+ * refetches through the `/api/credits/usage-summary` proxy.
  */
-export default async function UsageSettingsPage() {
+export default async function UsageSettingsPage({ searchParams }: UsageSettingsPageProps) {
+    const params = await searchParams;
+    const period = parseUsagePeriod(params.period) ?? currentUsageMonth();
+
     const [totals, byDay, byModel, byAgent, byWork, accountWide] = await Promise.all([
-        creditsAPI.usageSummary().catch((): UsageSummaryTotals | null => null),
+        creditsAPI.usageSummary({ period }).catch((): UsageSummaryTotals | null => null),
         creditsAPI
-            .usageGrouped({ groupBy: 'day', period: '30d' })
+            .usageGrouped({ groupBy: 'day', period })
             .catch((): UsageSummaryGrouped | null => null),
-        creditsAPI.usageGrouped({ groupBy: 'model' }).catch((): UsageSummaryGrouped | null => null),
-        creditsAPI.usageGrouped({ groupBy: 'agent' }).catch((): UsageSummaryGrouped | null => null),
-        creditsAPI.usageGrouped({ groupBy: 'work' }).catch((): UsageSummaryGrouped | null => null),
+        creditsAPI
+            .usageGrouped({ groupBy: 'model', period })
+            .catch((): UsageSummaryGrouped | null => null),
+        creditsAPI
+            .usageGrouped({ groupBy: 'agent', period })
+            .catch((): UsageSummaryGrouped | null => null),
+        creditsAPI
+            .usageGrouped({ groupBy: 'work', period })
+            .catch((): UsageSummaryGrouped | null => null),
         usageAPI.accountWide().catch((): AccountWideUsage | null => null),
     ]);
 
     return (
         <UsageCreditsSettings
+            initialPeriod={period}
             initialTotals={totals}
             initialByDay={byDay}
             initialByModel={byModel}

--- a/apps/web/src/app/api/credits/usage/export/route.ts
+++ b/apps/web/src/app/api/credits/usage/export/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * B29 (account-wide usage CSV export) — Next.js proxy for
+ * `GET /api/credits/usage/export`, so the Usage & Credits page can offer
+ * a plain download link. Forwards the auth cookie as a Bearer token and
+ * PIPES the upstream body through (never `await response.text()`), which
+ * keeps the whole period out of this process's memory — the API streams
+ * page by page and so does this route.
+ *
+ * Org scoping is enforced upstream from the request scope context; there
+ * is deliberately no org/user parameter to forward.
+ *
+ * Mirrors apps/web/src/app/api/works/[id]/usage/export/route.ts.
+ */
+
+// Security: allowlist of query parameters forwarded to the upstream API.
+// Forwarding the raw query string would let a caller inject unknown
+// parameters (e.g. a scope override) into the internal API.
+const ALLOWED_PARAMS = new Set(['period', 'format']);
+
+// Security: the upstream sets the filename from the resolved period, but
+// fall back to a constant if the header is missing — never echo a
+// caller-controlled value into a response header.
+const FALLBACK_DISPOSITION = 'attachment; filename="usage.csv"';
+
+export async function GET(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstreamParams = new URLSearchParams();
+    request.nextUrl.searchParams.forEach((value, key) => {
+        if (ALLOWED_PARAMS.has(key)) {
+            upstreamParams.set(key, value);
+        }
+    });
+    const upstreamSearch = upstreamParams.size > 0 ? `?${upstreamParams.toString()}` : '';
+
+    const response = await fetch(`${API_URL}/credits/usage/export${upstreamSearch}`, {
+        method: 'GET',
+        headers,
+        cache: 'no-store',
+    });
+
+    if (!response.ok || !response.body) {
+        return NextResponse.json(
+            { error: 'Failed to export usage data' },
+            { status: response.status || 500 },
+        );
+    }
+
+    const upstreamDisposition = response.headers.get('content-disposition');
+    const disposition =
+        upstreamDisposition && !/[\r\n]/.test(upstreamDisposition)
+            ? upstreamDisposition
+            : FALLBACK_DISPOSITION;
+
+    return new Response(response.body, {
+        status: 200,
+        headers: {
+            'Content-Type': 'text/csv; charset=utf-8',
+            'Content-Disposition': disposition,
+            'Cache-Control': 'no-store',
+        },
+    });
+}

--- a/apps/web/src/components/settings/UsageCreditsSettings.tsx
+++ b/apps/web/src/components/settings/UsageCreditsSettings.tsx
@@ -1,21 +1,41 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, Download } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 import { Button } from '@/components/ui/button';
 import { UsageByDayChart } from '@/components/settings/usage/UsageByDayChart';
 import { UsageBreakdownChart } from '@/components/settings/usage/UsageBreakdownChart';
 import {
+    buildUsageExportQuery,
+    buildUsageSummaryQuery,
+    currentUsageMonth,
     formatCents,
     formatCreditsAsDollars,
+    formatUsageMonthLabel,
+    isUsageMonthPeriod,
+    parseUsagePeriod,
+    recentUsageMonths,
+    USAGE_ROLLING_PERIODS,
+    type UsagePeriod,
     type UsageSummaryGrouped,
     type UsageSummaryTotals,
 } from '@/lib/api/credits.shared';
 import type { AccountWideUsage } from '@/lib/api/usage';
 
+/** Everything the page renders for ONE period. */
+interface UsageSnapshot {
+    totals: UsageSummaryTotals | null;
+    byDay: UsageSummaryGrouped | null;
+    byModel: UsageSummaryGrouped | null;
+    byAgent: UsageSummaryGrouped | null;
+    byWork: UsageSummaryGrouped | null;
+}
+
 interface UsageCreditsSettingsProps {
+    /** Period the server rendered the initial snapshot with (B20). */
+    initialPeriod: UsagePeriod;
     initialTotals: UsageSummaryTotals | null;
     initialByDay: UsageSummaryGrouped | null;
     initialByModel: UsageSummaryGrouped | null;
@@ -24,7 +44,19 @@ interface UsageCreditsSettingsProps {
     accountWide: AccountWideUsage | null;
 }
 
-type DayRange = '7d' | '30d';
+/** How many calendar months the month picker offers (B20). */
+const MONTH_OPTION_COUNT = 12;
+
+async function fetchUsage<T>(query: string): Promise<T> {
+    const response = await fetch(`/api/credits/usage-summary${query}`, {
+        method: 'GET',
+        cache: 'no-store',
+    });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+    }
+    return (await response.json()) as T;
+}
 
 function StatTile({ label, value, testId }: { label: string; value: string; testId: string }) {
     // Monochrome KPI tiles per the house UI pattern — status colour
@@ -61,6 +93,7 @@ function ChartCard({
 }
 
 export function UsageCreditsSettings({
+    initialPeriod,
     initialTotals,
     initialByDay,
     initialByModel,
@@ -70,54 +103,153 @@ export function UsageCreditsSettings({
 }: UsageCreditsSettingsProps) {
     const t = useTranslations('dashboard.settings.usage');
 
-    // 7d/30d toggle for the by-day chart: refetch through the web
-    // proxy, cache each range so flipping back is instant.
-    const [dayRange, setDayRange] = useState<DayRange>('30d');
-    const [byDayCache, setByDayCache] = useState<Record<DayRange, UsageSummaryGrouped | null>>({
-        '30d': initialByDay,
-        '7d': null,
-    });
-    const [dayLoading, setDayLoading] = useState(false);
-    const [dayError, setDayError] = useState(false);
+    const initialSnapshot = useMemo<UsageSnapshot>(
+        () => ({
+            totals: initialTotals,
+            byDay: initialByDay,
+            byModel: initialByModel,
+            byAgent: initialByAgent,
+            byWork: initialByWork,
+        }),
+        [initialTotals, initialByDay, initialByModel, initialByAgent, initialByWork],
+    );
 
-    const handleRangeChange = async (range: DayRange) => {
-        setDayRange(range);
-        if (byDayCache[range]) {
+    // B20 — one period drives the WHOLE page (tiles + all four charts),
+    // and it accepts a `YYYY-MM` month as well as the rolling ranges.
+    // Each period's snapshot is cached so flipping back is instant.
+    const [period, setPeriod] = useState<UsagePeriod>(initialPeriod);
+    const [snapshot, setSnapshot] = useState<UsageSnapshot>(initialSnapshot);
+    const [cache, setCache] = useState<Record<string, UsageSnapshot>>({
+        [initialPeriod]: initialSnapshot,
+    });
+    const [loading, setLoading] = useState(false);
+    const [loadFailed, setLoadFailed] = useState(false);
+
+    // Newest-first month options; the server-rendered period is included
+    // even when it predates the window (a `?period=` deep link).
+    const monthOptions = useMemo(() => {
+        const months = recentUsageMonths(MONTH_OPTION_COUNT);
+        if (isUsageMonthPeriod(initialPeriod) && !months.includes(initialPeriod)) {
+            months.push(initialPeriod);
+        }
+        return months;
+    }, [initialPeriod]);
+
+    const handlePeriodChange = async (next: UsagePeriod) => {
+        if (next === period) {
             return;
         }
-        setDayLoading(true);
-        setDayError(false);
+        setPeriod(next);
+        setLoadFailed(false);
+
+        const cached = cache[next];
+        if (cached) {
+            setSnapshot(cached);
+            return;
+        }
+
+        setLoading(true);
         try {
-            const response = await fetch(`/api/credits/usage-summary?groupBy=day&period=${range}`, {
-                method: 'GET',
-                cache: 'no-store',
-            });
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-            const data = (await response.json()) as UsageSummaryGrouped;
-            setByDayCache((cache) => ({ ...cache, [range]: data }));
+            const [totals, byDay, byModel, byAgent, byWork] = await Promise.all([
+                fetchUsage<UsageSummaryTotals>(buildUsageSummaryQuery({ period: next })),
+                fetchUsage<UsageSummaryGrouped>(
+                    buildUsageSummaryQuery({ groupBy: 'day', period: next }),
+                ),
+                fetchUsage<UsageSummaryGrouped>(
+                    buildUsageSummaryQuery({ groupBy: 'model', period: next }),
+                ),
+                fetchUsage<UsageSummaryGrouped>(
+                    buildUsageSummaryQuery({ groupBy: 'agent', period: next }),
+                ),
+                fetchUsage<UsageSummaryGrouped>(
+                    buildUsageSummaryQuery({ groupBy: 'work', period: next }),
+                ),
+            ]);
+            const fresh: UsageSnapshot = { totals, byDay, byModel, byAgent, byWork };
+            setCache((current) => ({ ...current, [next]: fresh }));
+            setSnapshot(fresh);
         } catch {
-            setDayError(true);
+            setLoadFailed(true);
         } finally {
-            setDayLoading(false);
+            setLoading(false);
         }
     };
 
-    const byDay = byDayCache[dayRange];
-    const dataUnavailable =
-        !initialTotals && !initialByDay && !initialByModel && !initialByAgent && !initialByWork;
+    const selectedMonth = isUsageMonthPeriod(period) ? period : '';
+    const exportHref = `/api/credits/usage/export${buildUsageExportQuery({ period })}`;
+    const periodLabel = isUsageMonthPeriod(period) ? formatUsageMonthLabel(period) : period;
+
+    // `accountWide` is the CURRENT month's account-wide spend; it must not
+    // stand in for the tile once the user selects another period.
+    const currentMonth = useMemo(() => currentUsageMonth(), []);
+    const showsCurrentMonth = period === currentMonth;
+
+    const { totals, byDay, byModel, byAgent, byWork } = snapshot;
+    const dataUnavailable = !totals && !byDay && !byModel && !byAgent && !byWork;
 
     return (
         <div className="space-y-8" data-testid="usage-credits-settings">
-            <div>
-                <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
-                    {t('title')}
-                </h2>
-                <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+                        {t('title')}
+                    </h2>
+                    <p className="text-text-muted dark:text-text-muted-dark text-sm">
+                        {t('subtitle')}
+                    </p>
+                </div>
+
+                {/* ── B20 period selector + B21 CSV export ─────────── */}
+                <div
+                    role="group"
+                    aria-label={t('period.label')}
+                    className="flex flex-wrap items-center gap-2"
+                    data-testid="usage-period-bar"
+                >
+                    {USAGE_ROLLING_PERIODS.map((range) => (
+                        <Button
+                            key={range}
+                            variant={period === range ? 'primary' : 'secondary'}
+                            className={cn('text-xs px-3 py-1')}
+                            data-testid={`usage-range-${range}`}
+                            onClick={() => handlePeriodChange(range)}
+                        >
+                            {t(`charts.range${range}`)}
+                        </Button>
+                    ))}
+                    <select
+                        aria-label={t('period.monthLabel')}
+                        data-testid="usage-period-month"
+                        value={selectedMonth}
+                        onChange={(event) => {
+                            const next = parseUsagePeriod(event.target.value);
+                            if (next) {
+                                void handlePeriodChange(next);
+                            }
+                        }}
+                        className="rounded-md border border-border dark:border-border-dark bg-transparent px-2 py-1 text-xs text-text dark:text-text-dark"
+                    >
+                        <option value="">{t('period.monthPlaceholder')}</option>
+                        {monthOptions.map((month) => (
+                            <option key={month} value={month}>
+                                {formatUsageMonthLabel(month)}
+                            </option>
+                        ))}
+                    </select>
+                    <a
+                        href={exportHref}
+                        download
+                        data-testid="usage-export-csv"
+                        title={t('export.csvHint', { period: periodLabel })}
+                        className="inline-flex items-center gap-1.5 rounded-md border border-border dark:border-border-dark px-3 py-1.5 text-xs font-medium text-text dark:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark"
+                    >
+                        <Download className="w-3.5 h-3.5" aria-hidden="true" />
+                        {t('export.csv')}
+                    </a>
+                </div>
             </div>
 
-            {dataUnavailable ? (
+            {dataUnavailable || loadFailed ? (
                 <div
                     data-testid="usage-load-error"
                     className="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 p-4 text-sm text-text dark:text-text-dark"
@@ -128,83 +260,68 @@ export function UsageCreditsSettings({
             ) : null}
 
             {/* ── §4.1/§4.2 — period summary tiles ─────────────────── */}
-            {initialTotals ? (
+            {totals ? (
                 <div
                     className="grid grid-cols-2 gap-4 sm:grid-cols-3 @5xl/main:grid-cols-7"
                     data-testid="usage-summary-tiles"
                 >
                     <StatTile
                         label={t('tiles.balance')}
-                        value={formatCreditsAsDollars(initialTotals.balanceCredits)}
+                        value={formatCreditsAsDollars(totals.balanceCredits)}
                         testId="usage-tile-balance"
                     />
                     <StatTile
                         label={t('tiles.consumed')}
-                        value={formatCreditsAsDollars(initialTotals.creditsConsumed)}
+                        value={formatCreditsAsDollars(totals.creditsConsumed)}
                         testId="usage-tile-consumed"
                     />
                     <StatTile
                         label={t('tiles.added')}
-                        value={formatCreditsAsDollars(initialTotals.creditsAdded)}
+                        value={formatCreditsAsDollars(totals.creditsAdded)}
                         testId="usage-tile-added"
                     />
                     <StatTile
                         label={t('tiles.spend')}
                         value={formatCents(
-                            accountWide?.currentSpendCents ?? initialTotals.spendCents,
+                            showsCurrentMonth
+                                ? (accountWide?.currentSpendCents ?? totals.spendCents)
+                                : totals.spendCents,
                         )}
                         testId="usage-tile-spend"
                     />
                     <StatTile
                         label={t('tiles.tasksCompleted')}
-                        value={String(initialTotals.tasksCompleted)}
+                        value={String(totals.tasksCompleted)}
                         testId="usage-tile-tasks"
                     />
                     <StatTile
                         label={t('tiles.worksActive')}
-                        value={String(initialTotals.worksActive)}
+                        value={String(totals.worksActive)}
                         testId="usage-tile-works"
                     />
                     <StatTile
                         label={t('tiles.agentRuns')}
-                        value={String(initialTotals.agentRuns)}
+                        value={String(totals.agentRuns)}
                         testId="usage-tile-runs"
                     />
                 </div>
             ) : null}
-            {initialTotals ? (
+            {totals ? (
                 <p className="text-xs text-text-muted dark:text-text-muted-dark -mt-4">
-                    {t('tiles.periodNote', { period: initialTotals.period })}
+                    {t('tiles.periodNote', { period: totals.period })}
                 </p>
             ) : null}
 
-            {/* ── §4.3 — usage per day (7d/30d toggle) ─────────────── */}
-            <ChartCard
-                title={t('charts.byDay')}
-                action={
-                    <div className="flex gap-1">
-                        {(['7d', '30d'] as const).map((range) => (
-                            <Button
-                                key={range}
-                                variant={dayRange === range ? 'primary' : 'secondary'}
-                                className={cn('text-xs px-3 py-1')}
-                                data-testid={`usage-range-${range}`}
-                                onClick={() => handleRangeChange(range)}
-                            >
-                                {t(`charts.range${range}`)}
-                            </Button>
-                        ))}
-                    </div>
-                }
-            >
-                {dayLoading ? (
+            {/* ── §4.3 — usage per day ─────────────────────────────── */}
+            <ChartCard title={t('charts.byDay')}>
+                {loading ? (
                     <p
                         className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
                         data-testid="usage-by-day-loading"
                     >
                         {t('charts.loading')}
                     </p>
-                ) : dayError ? (
+                ) : loadFailed ? (
                     <p
                         className="py-10 text-center text-xs text-danger"
                         data-testid="usage-by-day-error"
@@ -220,7 +337,7 @@ export function UsageCreditsSettings({
             <div className="grid gap-4 @3xl/main:grid-cols-2">
                 <ChartCard title={t('charts.byModel')}>
                     <UsageBreakdownChart
-                        rows={initialByModel?.rows ?? []}
+                        rows={byModel?.rows ?? []}
                         emptyLabel={t('charts.empty')}
                         unattributedLabel={t('charts.unattributed')}
                         testId="usage-by-model-chart"
@@ -228,7 +345,7 @@ export function UsageCreditsSettings({
                 </ChartCard>
                 <ChartCard title={t('charts.byAgent')}>
                     <UsageBreakdownChart
-                        rows={initialByAgent?.rows ?? []}
+                        rows={byAgent?.rows ?? []}
                         emptyLabel={t('charts.empty')}
                         unattributedLabel={t('charts.unattributed')}
                         testId="usage-by-agent-chart"
@@ -237,7 +354,7 @@ export function UsageCreditsSettings({
             </div>
             <ChartCard title={t('charts.byWork')}>
                 <UsageBreakdownChart
-                    rows={initialByWork?.rows ?? []}
+                    rows={byWork?.rows ?? []}
                     emptyLabel={t('charts.empty')}
                     unattributedLabel={t('charts.unattributed')}
                     testId="usage-by-work-chart"

--- a/apps/web/src/lib/api/credits.shared.ts
+++ b/apps/web/src/lib/api/credits.shared.ts
@@ -58,6 +58,28 @@ export interface CreditsLedgerPage {
 
 export type UsageSummaryGroupBy = 'day' | 'model' | 'agent' | 'work';
 
+/** Rolling windows offered by the Usage & Credits period selector. */
+export const USAGE_ROLLING_PERIODS = ['7d', '30d'] as const;
+export type UsageRollingPeriod = (typeof USAGE_ROLLING_PERIODS)[number];
+
+/**
+ * B20 — a `YYYY-MM` calendar month.
+ *
+ * The period selector used to be hard-typed `'7d' | '30d'`, which made
+ * the month option the API has always accepted unreachable from the UI.
+ * Modelled as a template-literal type (rather than a bare `string`) so a
+ * random string still can't be passed where a period is expected; the
+ * two-arm split (`-0x` / `-1x`) keeps `2026-07` assignable without
+ * relying on `${number}` matching a zero-padded segment. The type can't
+ * express "01…12", so `isUsageMonthPeriod` validates at runtime.
+ */
+export type UsageMonthPeriod = `${number}-0${number}` | `${number}-1${number}`;
+
+/** Everything `GET /credits/usage-summary?period=` accepts. */
+export type UsagePeriod = UsageRollingPeriod | UsageMonthPeriod;
+
+const USAGE_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+
 export interface UsageSummaryTotals {
     status: string;
     period: string;
@@ -204,12 +226,85 @@ export function buildLedgerQuery(params: {
 /** Build the `/credits/usage-summary` query string. */
 export function buildUsageSummaryQuery(params: {
     groupBy?: UsageSummaryGroupBy;
-    period?: string;
+    period?: UsagePeriod;
 }): string {
     const search = new URLSearchParams();
     if (params.groupBy) {
         search.set('groupBy', params.groupBy);
     }
+    if (params.period) {
+        search.set('period', params.period);
+    }
+    const qs = search.toString();
+    return qs ? `?${qs}` : '';
+}
+
+// ── B20 period helpers (unit-tested in credits.shared.unit.spec.ts) ──
+
+/** `2026-07` → true; `2026-13` / `7d` / `2026-7` → false. */
+export function isUsageMonthPeriod(value: string): value is UsageMonthPeriod {
+    return USAGE_MONTH_RE.test(value);
+}
+
+/** Runtime guard for anything the selector / a `?period=` deep link yields. */
+export function isUsagePeriod(value: string): value is UsagePeriod {
+    return (
+        (USAGE_ROLLING_PERIODS as readonly string[]).includes(value) || isUsageMonthPeriod(value)
+    );
+}
+
+/**
+ * Normalize an untrusted value (URL param, storage) to a period.
+ * Returns `undefined` rather than throwing so callers can fall back to
+ * their own default — a bad `?period=` must never blank the page.
+ */
+export function parseUsagePeriod(value: unknown): UsagePeriod | undefined {
+    if (Array.isArray(value)) {
+        return parseUsagePeriod(value[0]);
+    }
+    return typeof value === 'string' && isUsagePeriod(value) ? value : undefined;
+}
+
+/** Current UTC calendar month as `YYYY-MM` (matches the API's default). */
+export function currentUsageMonth(now: Date = new Date()): UsageMonthPeriod {
+    const month = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    return month as UsageMonthPeriod;
+}
+
+/**
+ * The `count` most recent calendar months, newest first — the option
+ * list for the month picker. UTC throughout so it agrees with the API's
+ * window resolution regardless of the viewer's timezone.
+ */
+export function recentUsageMonths(count = 12, now: Date = new Date()): UsageMonthPeriod[] {
+    const months: UsageMonthPeriod[] = [];
+    for (let offset = 0; offset < Math.max(0, count); offset += 1) {
+        const cursor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
+        months.push(currentUsageMonth(cursor));
+    }
+    return months;
+}
+
+/** `2026-07` → `July 2026`. Falls back to the raw value if unformattable. */
+export function formatUsageMonthLabel(month: string, locale = 'en-US'): string {
+    if (!isUsageMonthPeriod(month)) {
+        return month;
+    }
+    const [year, monthNumber] = month.split('-').map(Number);
+    try {
+        return new Intl.DateTimeFormat(locale, {
+            month: 'long',
+            year: 'numeric',
+            timeZone: 'UTC',
+        }).format(new Date(Date.UTC(year, monthNumber - 1, 1)));
+    } catch {
+        return month;
+    }
+}
+
+/** Build the `/credits/usage/export` query string (B29 CSV download). */
+export function buildUsageExportQuery(params: { period?: UsagePeriod } = {}): string {
+    const search = new URLSearchParams();
     if (params.period) {
         search.set('period', params.period);
     }

--- a/apps/web/src/lib/api/credits.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/credits.shared.unit.spec.ts
@@ -3,16 +3,24 @@
 import { describe, expect, it } from 'vitest';
 import {
     buildLedgerQuery,
+    buildUsageExportQuery,
     buildUsageSummaryQuery,
     CREDIT_LEDGER_KINDS,
     CREDIT_TOPUP_PRESETS_CENTS,
     creditsForTopupCents,
+    currentUsageMonth,
     formatCents,
     formatCreditsAsDollars,
     formatMonthlyPrice,
     formatSignedCredits,
+    formatUsageMonthLabel,
     isFreePlan,
+    isUsageMonthPeriod,
+    isUsagePeriod,
     ledgerKindTone,
+    parseUsagePeriod,
+    recentUsageMonths,
+    USAGE_ROLLING_PERIODS,
 } from './credits.shared';
 
 describe('formatCreditsAsDollars / formatCents', () => {
@@ -94,6 +102,75 @@ describe('buildUsageSummaryQuery', () => {
         expect(buildUsageSummaryQuery({ groupBy: 'model', period: '2026-07' })).toBe(
             '?groupBy=model&period=2026-07',
         );
+    });
+});
+
+describe('B20 — usage period grammar (7d / 30d / YYYY-MM)', () => {
+    it('recognises both rolling ranges AND calendar months', () => {
+        for (const rolling of USAGE_ROLLING_PERIODS) {
+            expect(isUsagePeriod(rolling)).toBe(true);
+            expect(isUsageMonthPeriod(rolling)).toBe(false);
+        }
+        for (const month of ['2026-01', '2026-07', '2026-12', '1999-09']) {
+            expect(isUsageMonthPeriod(month)).toBe(true);
+            expect(isUsagePeriod(month)).toBe(true);
+        }
+    });
+
+    it('rejects everything the API would 400 on', () => {
+        for (const bad of ['2026-13', '2026-00', '2026-7', '90d', '7D', 'last-month', '']) {
+            expect(isUsagePeriod(bad)).toBe(false);
+        }
+    });
+
+    it('parseUsagePeriod normalizes untrusted input instead of throwing', () => {
+        expect(parseUsagePeriod('2026-06')).toBe('2026-06');
+        expect(parseUsagePeriod('7d')).toBe('7d');
+        // Next.js hands repeated query params through as an array.
+        expect(parseUsagePeriod(['30d', '7d'])).toBe('30d');
+        expect(parseUsagePeriod('nonsense')).toBeUndefined();
+        expect(parseUsagePeriod(undefined)).toBeUndefined();
+        expect(parseUsagePeriod(42)).toBeUndefined();
+    });
+});
+
+describe('currentUsageMonth / recentUsageMonths', () => {
+    it('formats the current UTC month zero-padded', () => {
+        expect(currentUsageMonth(new Date('2026-07-25T12:00:00.000Z'))).toBe('2026-07');
+        expect(currentUsageMonth(new Date('2026-01-01T00:00:00.000Z'))).toBe('2026-01');
+        // Late-UTC-day instants must not roll into the next month.
+        expect(currentUsageMonth(new Date('2026-11-30T23:59:59.000Z'))).toBe('2026-11');
+    });
+
+    it('lists the N most recent months newest-first, crossing the year boundary', () => {
+        const months = recentUsageMonths(4, new Date('2026-02-10T00:00:00.000Z'));
+        expect(months).toEqual(['2026-02', '2026-01', '2025-12', '2025-11']);
+        // Every generated option is a period the API accepts.
+        for (const month of months) {
+            expect(isUsagePeriod(month)).toBe(true);
+        }
+        expect(recentUsageMonths(0, new Date('2026-02-10T00:00:00.000Z'))).toEqual([]);
+    });
+});
+
+describe('formatUsageMonthLabel', () => {
+    it('renders a human month label in UTC', () => {
+        expect(formatUsageMonthLabel('2026-07')).toBe('July 2026');
+        expect(formatUsageMonthLabel('2025-12')).toBe('December 2025');
+    });
+
+    it('passes non-month values (7d / 30d) through untouched', () => {
+        expect(formatUsageMonthLabel('7d')).toBe('7d');
+        expect(formatUsageMonthLabel('30d')).toBe('30d');
+    });
+});
+
+describe('buildUsageExportQuery', () => {
+    it('serializes the period only, and omits it when absent', () => {
+        expect(buildUsageExportQuery()).toBe('');
+        expect(buildUsageExportQuery({})).toBe('');
+        expect(buildUsageExportQuery({ period: '2026-06' })).toBe('?period=2026-06');
+        expect(buildUsageExportQuery({ period: '7d' })).toBe('?period=7d');
     });
 });
 

--- a/apps/web/src/lib/api/credits.ts
+++ b/apps/web/src/lib/api/credits.ts
@@ -8,6 +8,7 @@ import {
     type CreditsLedgerPage,
     type SubscriptionPlanList,
     type SubscriptionPlanSummary,
+    type UsagePeriod,
     type UsageSummaryGroupBy,
     type UsageSummaryGrouped,
     type UsageSummaryTotals,
@@ -19,6 +20,7 @@ export type {
     CreditsLedgerPage,
     SubscriptionPlanList,
     SubscriptionPlanSummary,
+    UsagePeriod,
     UsageSummaryGroupBy,
     UsageSummaryGrouped,
     UsageSummaryTotals,
@@ -51,8 +53,11 @@ export const creditsAPI = {
         });
     },
 
-    /** §4.1/§4.2 stat-tile totals for a period (default: current month). */
-    async usageSummary(params: { period?: string } = {}): Promise<UsageSummaryTotals> {
+    /**
+     * §4.1/§4.2 stat-tile totals for a period (default: current month).
+     * B20 — `period` accepts `7d` / `30d` AND any `YYYY-MM` month.
+     */
+    async usageSummary(params: { period?: UsagePeriod } = {}): Promise<UsageSummaryTotals> {
         return serverFetch<UsageSummaryTotals>(
             `/credits/usage-summary${buildUsageSummaryQuery(params)}`,
             { method: 'GET' },
@@ -62,7 +67,7 @@ export const creditsAPI = {
     /** §4.3 grouped chart rows (day / model / agent / work). */
     async usageGrouped(params: {
         groupBy: UsageSummaryGroupBy;
-        period?: string;
+        period?: UsagePeriod;
     }): Promise<UsageSummaryGrouped> {
         return serverFetch<UsageSummaryGrouped>(
             `/credits/usage-summary${buildUsageSummaryQuery(params)}`,

--- a/packages/agent/src/database/repositories/plugin-usage.repository.ts
+++ b/packages/agent/src/database/repositories/plugin-usage.repository.ts
@@ -479,6 +479,55 @@ export class PluginUsageRepository {
         }));
     }
 
+    /**
+     * B29 (account-wide usage CSV export) — ONE page of the user's
+     * metered events inside the window, ordered deterministically so the
+     * caller can keyset/offset its way through an arbitrarily long
+     * period without ever materializing it all in memory.
+     *
+     * Scope contract:
+     *   - `userId` is always applied (owner scope — a caller only ever
+     *     reads their OWN events, never another account's).
+     *   - `organizationId`, when a non-empty string, restricts the rows
+     *     to that Organization. It comes from the request SCOPE CONTEXT
+     *     at the API boundary, never from a caller-supplied param, so a
+     *     user acting inside Org A cannot export Org B's spend. When the
+     *     request has no active Organization the filter is omitted and
+     *     the export is the user's full account-wide history — their own
+     *     rows either way.
+     *
+     * Half-open `[start, end)` window, matching every other aggregation
+     * on this repository (see `findForExport`'s note about the inclusive
+     * `Between()` regression).
+     */
+    async findPageForUserExport(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+        options: { organizationId?: string | null; limit: number; offset: number },
+    ): Promise<PluginUsageEvent[]> {
+        const qb = this.repository
+            .createQueryBuilder('e')
+            .where('e.userId = :userId', { userId })
+            .andWhere('e.occurredAt >= :start', { start: periodStart })
+            .andWhere('e.occurredAt < :end', { end: periodEnd });
+
+        if (options.organizationId) {
+            qb.andWhere('e.organizationId = :organizationId', {
+                organizationId: options.organizationId,
+            });
+        }
+
+        // `id` is the tie-breaker: `occurredAt` alone is not unique, and
+        // an unstable sort would duplicate/skip rows across pages.
+        return qb
+            .orderBy('e.occurredAt', 'ASC')
+            .addOrderBy('e.id', 'ASC')
+            .skip(options.offset)
+            .take(options.limit)
+            .getMany();
+    }
+
     async findForExport(
         workId: string,
         periodStart: Date,

--- a/packages/agent/src/subscriptions/credits/usage-summary.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/usage-summary.service.spec.ts
@@ -1,10 +1,13 @@
 import {
     InvalidUsagePeriodError,
     resolveUsageSummaryWindow,
+    USAGE_EXPORT_COLUMNS,
     UsageSummaryService,
 } from './usage-summary.service';
 import type { CreditLedgerRepository } from '@src/database/repositories/credit-ledger.repository';
 import type { PluginUsageRepository } from '@src/database/repositories/plugin-usage.repository';
+import { BudgetOwnerType } from '@src/entities/_types';
+import type { PluginUsageEvent } from '@src/entities/plugin-usage-event.entity';
 
 describe('resolveUsageSummaryWindow', () => {
     const now = new Date('2026-07-25T12:00:00.000Z');
@@ -52,6 +55,7 @@ describe('UsageSummaryService', () => {
             | 'getSpendByWorkForUser'
             | 'getAgentNames'
             | 'getWorkNames'
+            | 'findPageForUserExport'
         >
     >;
     let creditLedgerRepository: jest.Mocked<
@@ -84,6 +88,7 @@ describe('UsageSummaryService', () => {
                 .mockResolvedValue([{ key: 'work-1', units: 6, costCents: 240 }]),
             getAgentNames: jest.fn().mockResolvedValue(new Map([['agent-1', 'Research Agent']])),
             getWorkNames: jest.fn().mockResolvedValue(new Map([['work-1', 'My Directory']])),
+            findPageForUserExport: jest.fn().mockResolvedValue([]),
         } as any;
         creditLedgerRepository = {
             getBalance: jest.fn().mockResolvedValue(500),
@@ -179,5 +184,167 @@ describe('UsageSummaryService', () => {
         );
         expect(creditLedgerRepository.getBalance).not.toHaveBeenCalled();
         expect(pluginUsageRepository.getDailySpendForUser).not.toHaveBeenCalled();
+    });
+
+    describe('createExport (B29 — account-wide CSV export)', () => {
+        // Typed as the real entity so the fixture cannot drift away
+        // from it silently — the previous untyped literal is exactly
+        // how it ended up missing four required columns.
+        function event(overrides: Partial<PluginUsageEvent> = {}): PluginUsageEvent {
+            return {
+                id: 'evt-1',
+                occurredAt: new Date('2026-06-04T10:00:00.000Z'),
+                pluginId: 'openrouter',
+                capability: 'ai',
+                units: 2,
+                costCents: 31,
+                currency: 'usd',
+                modelId: 'model-a',
+                workId: 'work-1',
+                // Owner columns + the two relations the entity declares.
+                // The export reads none of them, but `PluginUsageEvent`
+                // requires them, so a fixture without them does not
+                // typecheck — and an untyped fixture would stop pinning
+                // that the export omits exactly these.
+                userId: 'user-1',
+                ownerType: BudgetOwnerType.WORK,
+                work: null as never,
+                user: null as never,
+                agentId: null,
+                taskId: null,
+                runId: null,
+                requestId: 'req-1',
+                // Scope + free-form columns that must NOT reach the wire.
+                tenantId: 'tenant-1',
+                organizationId: 'org-a',
+                metadata: { secret: 'nope' },
+                ...overrides,
+            } as PluginUsageEvent;
+        }
+
+        async function drain(chunks: AsyncIterable<unknown[]>) {
+            const rows: unknown[] = [];
+            for await (const chunk of chunks) {
+                rows.push(...chunk);
+            }
+            return rows;
+        }
+
+        it('passes the active organizationId into every repository page (org scope)', async () => {
+            pluginUsageRepository.findPageForUserExport.mockResolvedValue([event()]);
+
+            const stream = service.createExport('user-1', {
+                period: '2026-06',
+                organizationId: 'org-a',
+            });
+            await drain(stream.chunks);
+
+            expect(stream.organizationId).toBe('org-a');
+            expect(pluginUsageRepository.findPageForUserExport).toHaveBeenCalledWith(
+                'user-1',
+                new Date('2026-06-01T00:00:00.000Z'),
+                new Date('2026-07-01T00:00:00.000Z'),
+                expect.objectContaining({ organizationId: 'org-a' }),
+            );
+        });
+
+        it('passes organizationId: null when the request has no active Organization', async () => {
+            pluginUsageRepository.findPageForUserExport.mockResolvedValue([]);
+
+            const stream = service.createExport('user-1', { period: '2026-06' });
+            await drain(stream.chunks);
+
+            expect(stream.organizationId).toBeNull();
+            expect(pluginUsageRepository.findPageForUserExport).toHaveBeenCalledWith(
+                'user-1',
+                expect.any(Date),
+                expect.any(Date),
+                expect.objectContaining({ organizationId: null }),
+            );
+        });
+
+        it('a YYYY-MM period returns THAT month rows (half-open UTC window)', async () => {
+            pluginUsageRepository.findPageForUserExport.mockResolvedValue([
+                event({ occurredAt: new Date('2026-06-01T00:00:00.000Z') }),
+                event({ id: 'evt-2', occurredAt: new Date('2026-06-30T23:59:59.000Z') }),
+            ]);
+
+            const stream = service.createExport('user-1', { period: '2026-06' });
+            const rows = (await drain(stream.chunks)) as { occurredAt: string }[];
+
+            expect(stream.window).toMatchObject({ period: '2026-06' });
+            expect(stream.window.from.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+            expect(stream.window.to.toISOString()).toBe('2026-07-01T00:00:00.000Z');
+            expect(rows.map((r) => r.occurredAt)).toEqual([
+                '2026-06-01T00:00:00.000Z',
+                '2026-06-30T23:59:59.000Z',
+            ]);
+        });
+
+        it('projects only the wire columns — scope + metadata never leave the service', async () => {
+            pluginUsageRepository.findPageForUserExport.mockResolvedValue([event()]);
+
+            const [row] = (await drain(
+                service.createExport('user-1', { period: '2026-06' }).chunks,
+            )) as Record<string, unknown>[];
+
+            expect(Object.keys(row).sort()).toEqual([...USAGE_EXPORT_COLUMNS].sort());
+            expect(row).not.toHaveProperty('tenantId');
+            expect(row).not.toHaveProperty('organizationId');
+            expect(row).not.toHaveProperty('metadata');
+        });
+
+        it('pages until a short page arrives — never buffers the whole period', async () => {
+            pluginUsageRepository.findPageForUserExport
+                .mockResolvedValueOnce([event(), event({ id: 'evt-2' })])
+                .mockResolvedValueOnce([event({ id: 'evt-3' })]);
+
+            const rows = await drain(
+                service.createExport('user-1', { period: '2026-06', pageSize: 2 }).chunks,
+            );
+
+            expect(rows).toHaveLength(3);
+            expect(pluginUsageRepository.findPageForUserExport).toHaveBeenNthCalledWith(
+                1,
+                'user-1',
+                expect.any(Date),
+                expect.any(Date),
+                { organizationId: null, limit: 2, offset: 0 },
+            );
+            expect(pluginUsageRepository.findPageForUserExport).toHaveBeenNthCalledWith(
+                2,
+                'user-1',
+                expect.any(Date),
+                expect.any(Date),
+                { organizationId: null, limit: 2, offset: 2 },
+            );
+        });
+
+        it('stops immediately on an empty first page (no runaway paging)', async () => {
+            pluginUsageRepository.findPageForUserExport.mockResolvedValue([]);
+
+            const rows = await drain(service.createExport('user-1').chunks);
+
+            expect(rows).toHaveLength(0);
+            expect(pluginUsageRepository.findPageForUserExport).toHaveBeenCalledTimes(1);
+        });
+
+        it('clamps an absurd page size and rejects a malformed period up front', async () => {
+            pluginUsageRepository.findPageForUserExport.mockResolvedValue([]);
+
+            await drain(service.createExport('user-1', { pageSize: 10_000_000 }).chunks);
+            expect(pluginUsageRepository.findPageForUserExport).toHaveBeenCalledWith(
+                'user-1',
+                expect.any(Date),
+                expect.any(Date),
+                expect.objectContaining({ limit: 5000 }),
+            );
+
+            pluginUsageRepository.findPageForUserExport.mockClear();
+            expect(() => service.createExport('user-1', { period: 'nope' })).toThrow(
+                InvalidUsagePeriodError,
+            );
+            expect(pluginUsageRepository.findPageForUserExport).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/agent/src/subscriptions/credits/usage-summary.service.ts
+++ b/packages/agent/src/subscriptions/credits/usage-summary.service.ts
@@ -4,6 +4,7 @@ import {
     PluginUsageRepository,
     UserSpendGroupRow,
 } from '@src/database/repositories/plugin-usage.repository';
+import type { PluginUsageEvent } from '@src/entities/plugin-usage-event.entity';
 
 /** Wave 13 — grouping dimensions for `GET /api/credits/usage-summary`. */
 export const USAGE_SUMMARY_GROUP_BYS = ['day', 'model', 'agent', 'work'] as const;
@@ -109,6 +110,95 @@ export interface UsageSummaryGrouped {
 }
 
 /**
+ * B29 — one CSV line of the account-wide usage export. Deliberately an
+ * explicit projection of `plugin_usage_events` (never the entity): the
+ * scope columns (`tenantId` / `organizationId`) and the free-form
+ * `metadata` blob stay server-side.
+ */
+export interface UsageExportRow {
+    occurredAt: string;
+    pluginId: string;
+    capability: string;
+    units: number;
+    costCents: number;
+    currency: string;
+    modelId: string | null;
+    workId: string | null;
+    agentId: string | null;
+    taskId: string | null;
+    runId: string | null;
+    requestId: string | null;
+}
+
+/**
+ * CSV column order for the account-wide export. Exported so the API
+ * controller writes the header from the same source of truth the rows
+ * are projected from (a column added here can never silently drift out
+ * of the header).
+ */
+export const USAGE_EXPORT_COLUMNS = [
+    'occurredAt',
+    'pluginId',
+    'capability',
+    'units',
+    'costCents',
+    'currency',
+    'modelId',
+    'workId',
+    'agentId',
+    'taskId',
+    'runId',
+    'requestId',
+] as const satisfies readonly (keyof UsageExportRow)[];
+
+export interface UsageExportOptions {
+    /** `YYYY-MM` calendar month (default: current), or rolling `7d`/`30d`. */
+    period?: string;
+    /**
+     * Active Organization from the request scope context. When set, only
+     * that org's rows are exported. NEVER caller-supplied.
+     */
+    organizationId?: string | null;
+    /** Rows fetched per DB round-trip while streaming (test seam). */
+    pageSize?: number;
+}
+
+/** A resolved export: the echoed window plus a lazy chunked row stream. */
+export interface UsageExportStream {
+    window: UsageSummaryWindow;
+    organizationId: string | null;
+    /** Yields pages of rows — never the whole period at once. */
+    chunks: AsyncIterable<UsageExportRow[]>;
+}
+
+/** Rows pulled per DB round-trip while streaming the CSV export. */
+const USAGE_EXPORT_PAGE_SIZE = 500;
+
+/** Hard ceiling so a caller-supplied page size can't force a huge read. */
+const USAGE_EXPORT_MAX_PAGE_SIZE = 5000;
+
+/** Entity → wire projection. Scope columns + metadata never leave here. */
+function toUsageExportRow(event: PluginUsageEvent): UsageExportRow {
+    return {
+        occurredAt:
+            event.occurredAt instanceof Date
+                ? event.occurredAt.toISOString()
+                : String(event.occurredAt ?? ''),
+        pluginId: event.pluginId,
+        capability: event.capability,
+        units: Number(event.units ?? 0),
+        costCents: Number(event.costCents ?? 0),
+        currency: event.currency,
+        modelId: event.modelId ?? null,
+        workId: event.workId ?? null,
+        agentId: event.agentId ?? null,
+        taskId: event.taskId ?? null,
+        runId: event.runId ?? null,
+        requestId: event.requestId ?? null,
+    };
+}
+
+/**
  * Wave 13 (Billing / Usage & Credits pages) — owner-scoped account-wide
  * usage aggregations behind `GET /api/credits/usage-summary`.
  *
@@ -164,6 +254,57 @@ export class UsageSummaryService {
             groupBy,
             rows,
         };
+    }
+
+    /**
+     * B29 — account-wide usage CSV export (`GET /api/credits/usage/export`).
+     *
+     * Returns the resolved window synchronously (so the API boundary can
+     * map a bad period to a 400 and build the filename BEFORE a single
+     * byte is written) plus a lazy async iterable that pages the
+     * repository. The whole period is never buffered: the controller
+     * writes each chunk out as it arrives, so a year-long export costs
+     * one page of rows in memory, not the year.
+     *
+     * Scope: `userId` is the authenticated caller; `organizationId` is
+     * the request's active Organization (from the scope context) and is
+     * never caller-supplied — see
+     * `PluginUsageRepository.findPageForUserExport`.
+     */
+    createExport(userId: string, options: UsageExportOptions = {}): UsageExportStream {
+        const window = resolveUsageSummaryWindow(options.period);
+        const organizationId = options.organizationId ?? null;
+        const pageSize = this.resolvePageSize(options.pageSize);
+        const repository = this.pluginUsageRepository;
+
+        async function* chunks(): AsyncGenerator<UsageExportRow[]> {
+            let offset = 0;
+            for (;;) {
+                const events = await repository.findPageForUserExport(
+                    userId,
+                    window.from,
+                    window.to,
+                    { organizationId, limit: pageSize, offset },
+                );
+                if (events.length === 0) {
+                    return;
+                }
+                yield events.map(toUsageExportRow);
+                if (events.length < pageSize) {
+                    return;
+                }
+                offset += events.length;
+            }
+        }
+
+        return { window, organizationId, chunks: { [Symbol.asyncIterator]: chunks } };
+    }
+
+    private resolvePageSize(requested?: number): number {
+        if (!requested || !Number.isFinite(requested) || requested < 1) {
+            return USAGE_EXPORT_PAGE_SIZE;
+        }
+        return Math.min(Math.floor(requested), USAGE_EXPORT_MAX_PAGE_SIZE);
     }
 
     private async resolveRows(

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -33,6 +33,7 @@ import { RunCostSettlementService } from './credits/run-cost-settlement.service'
 import {
     InvalidUsagePeriodError,
     resolveUsageSummaryWindow,
+    USAGE_EXPORT_COLUMNS,
     USAGE_SUMMARY_GROUP_BYS,
     UsageSummaryService,
 } from './credits/usage-summary.service';
@@ -85,6 +86,27 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.resolveUsageSummaryWindow).toBe(resolveUsageSummaryWindow);
             expect(subscriptionsBarrel.InvalidUsagePeriodError).toBe(InvalidUsagePeriodError);
             expect(subscriptionsBarrel.USAGE_SUMMARY_GROUP_BYS).toBe(USAGE_SUMMARY_GROUP_BYS);
+        });
+
+        it('re-exports the account-wide CSV export column contract (B29)', () => {
+            expect(subscriptionsBarrel.USAGE_EXPORT_COLUMNS).toBe(USAGE_EXPORT_COLUMNS);
+            // Pinned column order — the CSV header is a wire format the
+            // downloaded file's consumers (spreadsheets, finance tooling)
+            // depend on; reordering silently breaks them.
+            expect(USAGE_EXPORT_COLUMNS).toEqual([
+                'occurredAt',
+                'pluginId',
+                'capability',
+                'units',
+                'costCents',
+                'currency',
+                'modelId',
+                'workId',
+                'agentId',
+                'taskId',
+                'runId',
+                'requestId',
+            ]);
         });
 
         it('re-exports the money path (billing PRD B5)', () => {
@@ -170,6 +192,8 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'resolveUsageSummaryWindow',
                     'InvalidUsagePeriodError',
                     'USAGE_SUMMARY_GROUP_BYS',
+                    // Account-wide usage CSV export (B29)
+                    'USAGE_EXPORT_COLUMNS',
                 ].sort(),
             );
         });


### PR DESCRIPTION
## The problem

Usage could only be read as an all-time roll-up on one page. There was no way
to scope it to a billing period, and no way to get the underlying rows out at
all — so reconciling a charge meant reading a summary and trusting it.

## What changed

- A **period filter** (current / previous / custom), resolved server-side
- A **streaming CSV export** of the account's usage rows

## Streaming end to end

The export never buffers a period into memory. The API pages the repository and
writes each chunk; the Next.js proxy **pipes** the upstream body rather than
`await response.text()`. A long period stays out of both processes' heaps.

## Proxy security posture

| Concern | Handling |
|---|---|
| Parameter injection | Forwards an **allowlist** (`period`, `format`), not the raw query string — forwarding it wholesale would let a caller inject parameters the internal API understands, including a scope override |
| Owner scoping | Enforced upstream from the request scope context; there is deliberately **no** owner/org parameter to forward |
| Response headers | `Content-Disposition` falls back to a constant rather than echoing a caller-controlled value |

## Who calls this in production?

`UsageCreditsSettings.tsx:179` builds `exportHref` → the Next route at
`app/api/credits/usage/export/route.ts` → `GET /api/credits/usage/export`
(`credits.controller.ts:220`). A real link, a real proxy, a real endpoint.

## Fixture typed against the entity

The usage-export fixture was an untyped object literal and had drifted from
`PluginUsageEvent`: it declared none of `userId`, `ownerType`, `work`, `user`,
and typed `capability` as a bare string rather than the enum.

The export reads none of those columns — which is exactly what the spec exists
to pin — so an untyped fixture would have kept compiling while silently no
longer describing the row it claims to. It is now annotated as the real entity,
so the next drift is a compile error rather than a quietly meaningless test.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 448 suites, 8233 tests |
| `apps/api` jest | green — 233 suites, 3816 tests |
| `apps/web` tsc --noEmit | green |
| `apps/web` vitest | green — 20 tests |
| prettier | clean |

Merged cleanly against `develop` with **no conflicts** — the two preceding
billing branches absorbed the collisions.