### PR TITLE
fix(fleet): share node contracts and enforce configurable limits

### DIFF
--- a/apps/api/src/fleet/dto/fleet-capability.validators.ts
+++ b/apps/api/src/fleet/dto/fleet-capability.validators.ts
@@ -1,0 +1,79 @@
+import {
+    registerDecorator,
+    ValidationArguments,
+    ValidationOptions,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
+} from 'class-validator';
+import { config } from '@ever-works/agent/config';
+
+/**
+ * Capability-tag bounds for the Fleet DTOs, read from `config.fleet.*`
+ * AT VALIDATION TIME.
+ *
+ * Why not plain `@ArrayMaxSize(config.fleet.getMaxCapabilityTags())`?
+ * Decorator arguments are evaluated when the module is imported, and
+ * `apps/api` imports `ApiModule` (and therefore every DTO) BEFORE
+ * `bootstrap()` calls `configDotenv()`. A decorator-time read would
+ * silently ignore anything set in a `.env`, so the knob would appear to
+ * work in production and appear broken in local dev — the worst of both.
+ * A constraint class reads the value on each `validate()` call instead,
+ * which is also what makes the override testable.
+ *
+ * These bound the EDGE. `FleetService.sanitizeCapabilities` re-applies
+ * the same configured caps as the single source of truth, so a request
+ * that slips past (internal callers, a future transport) is still
+ * truncated rather than stored oversized.
+ */
+
+@ValidatorConstraint({ name: 'fleetMaxCapabilityTags', async: false })
+export class FleetMaxCapabilityTagsConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        // Non-arrays are `@IsArray`'s problem, not ours — reporting the
+        // same value twice just produces two confusing messages.
+        if (!Array.isArray(value)) return true;
+        return value.length <= config.fleet.getMaxCapabilityTags();
+    }
+
+    defaultMessage(args: ValidationArguments): string {
+        return `${args.property} must contain no more than ${config.fleet.getMaxCapabilityTags()} tags`;
+    }
+}
+
+@ValidatorConstraint({ name: 'fleetMaxCapabilityTagLength', async: false })
+export class FleetMaxCapabilityTagLengthConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        if (typeof value !== 'string') return true;
+        return value.length <= config.fleet.getMaxCapabilityTagLength();
+    }
+
+    defaultMessage(args: ValidationArguments): string {
+        return `each value in ${args.property} must be shorter than or equal to ${config.fleet.getMaxCapabilityTagLength()} characters`;
+    }
+}
+
+/** Array length <= the configured capability-tag cap (default 16). */
+export function MaxConfiguredCapabilityTags(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string): void {
+        registerDecorator({
+            target: object.constructor,
+            propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: FleetMaxCapabilityTagsConstraint,
+        });
+    };
+}
+
+/** Each tag <= the configured tag-length cap (default 32). Use with `{ each: true }`. */
+export function MaxConfiguredCapabilityTagLength(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string): void {
+        registerDecorator({
+            target: object.constructor,
+            propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: FleetMaxCapabilityTagLengthConstraint,
+        });
+    };
+}

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-    ArrayMaxSize,
     IsArray,
     IsBoolean,
     IsIn,
@@ -10,9 +9,32 @@ import {
     MaxLength,
     MinLength,
 } from 'class-validator';
-import type { FleetNodeKind } from '@ever-works/agent/fleet';
+import {
+    FLEET_CREDENTIAL_MAX_LENGTH,
+    FLEET_CREDENTIAL_MIN_LENGTH,
+    FLEET_ENROLLABLE_NODE_KINDS,
+    FLEET_MAX_NODE_NAME_LENGTH,
+    FLEET_MAX_PLATFORM_LENGTH,
+    FLEET_MAX_VERSION_LENGTH,
+    FLEET_MIN_NODE_NAME_LENGTH,
+} from '@ever-works/contracts';
+import type { FleetEnrollableNodeKind } from '@ever-works/contracts';
+import {
+    MaxConfiguredCapabilityTagLength,
+    MaxConfiguredCapabilityTags,
+} from './fleet-capability.validators';
 
-const ENROLLABLE_KINDS: FleetNodeKind[] = ['desktop-node', 'node'];
+/**
+ * Every bound below comes from the SHARED fleet contract
+ * (`@ever-works/contracts`) rather than a literal typed twice: the node
+ * apps validate against the same constants, so a change is a compile
+ * error on both sides instead of a runtime rejection nobody sees.
+ *
+ * The capability caps are the exception — they are operator knobs
+ * (`config.fleet.*`), so they go through the validation-time
+ * constraints in `./fleet-capability.validators`.
+ */
+const ENROLLABLE_KINDS: readonly FleetEnrollableNodeKind[] = FLEET_ENROLLABLE_NODE_KINDS;
 
 /**
  * Request body for `POST /api/fleet/nodes/enrollment-token` — issue a
@@ -21,24 +43,28 @@ const ENROLLABLE_KINDS: FleetNodeKind[] = ['desktop-node', 'node'];
  * of truth.
  */
 export class CreateFleetEnrollmentTokenDto {
-    @ApiProperty({ minLength: 1, maxLength: 200 })
+    @ApiProperty({ minLength: FLEET_MIN_NODE_NAME_LENGTH, maxLength: FLEET_MAX_NODE_NAME_LENGTH })
     @IsString()
-    @MinLength(1)
-    @MaxLength(200)
+    @MinLength(FLEET_MIN_NODE_NAME_LENGTH)
+    @MaxLength(FLEET_MAX_NODE_NAME_LENGTH)
     name: string;
 
     @ApiProperty({ enum: ENROLLABLE_KINDS, description: 'App shape of the node.' })
     @IsIn(ENROLLABLE_KINDS)
-    kind: FleetNodeKind;
+    kind: FleetEnrollableNodeKind;
 }
 
 /** Request body for `PATCH /api/fleet/nodes/:id` (partial update). */
 export class UpdateFleetNodeDto {
-    @ApiProperty({ required: false, minLength: 1, maxLength: 200 })
+    @ApiProperty({
+        required: false,
+        minLength: FLEET_MIN_NODE_NAME_LENGTH,
+        maxLength: FLEET_MAX_NODE_NAME_LENGTH,
+    })
     @IsOptional()
     @IsString()
-    @MinLength(1)
-    @MaxLength(200)
+    @MinLength(FLEET_MIN_NODE_NAME_LENGTH)
+    @MaxLength(FLEET_MAX_NODE_NAME_LENGTH)
     name?: string;
 
     @ApiProperty({
@@ -53,28 +79,33 @@ export class UpdateFleetNodeDto {
 
 /** Node self-description shared by enroll + heartbeat refresh. */
 export class FleetNodeSelfDescriptionDto {
-    @ApiProperty({ required: false, maxLength: 64, description: 'os/arch, e.g. linux/x64.' })
+    @ApiProperty({
+        required: false,
+        maxLength: FLEET_MAX_PLATFORM_LENGTH,
+        description: 'os/arch, e.g. linux/x64.',
+    })
     @IsOptional()
     @IsString()
-    @MaxLength(64)
+    @MaxLength(FLEET_MAX_PLATFORM_LENGTH)
     platform?: string;
 
-    @ApiProperty({ required: false, maxLength: 32 })
+    @ApiProperty({ required: false, maxLength: FLEET_MAX_VERSION_LENGTH })
     @IsOptional()
     @IsString()
-    @MaxLength(32)
+    @MaxLength(FLEET_MAX_VERSION_LENGTH)
     version?: string;
 
     @ApiProperty({
         required: false,
         type: [String],
-        description: "Capability tags, e.g. ['terminal', 'workspace', 'docker'].",
+        description:
+            "Capability tags, e.g. ['terminal', 'workspace', 'docker']. Count and per-tag length are operator-configurable (FLEET_MAX_CAPABILITY_TAGS / FLEET_MAX_CAPABILITY_TAG_LENGTH; defaults 16 / 32).",
     })
     @IsOptional()
     @IsArray()
-    @ArrayMaxSize(16)
+    @MaxConfiguredCapabilityTags()
     @IsString({ each: true })
-    @MaxLength(32, { each: true })
+    @MaxConfiguredCapabilityTagLength({ each: true })
     capabilities?: string[];
 }
 
@@ -84,10 +115,14 @@ export class FleetNodeSelfDescriptionDto {
  * `FleetService.enroll` (fail-closed 401 on any invalid path).
  */
 export class EnrollFleetNodeDto extends FleetNodeSelfDescriptionDto {
-    @ApiProperty({ minLength: 16, maxLength: 256, description: 'One-time enrollment token.' })
+    @ApiProperty({
+        minLength: FLEET_CREDENTIAL_MIN_LENGTH,
+        maxLength: FLEET_CREDENTIAL_MAX_LENGTH,
+        description: 'One-time enrollment token.',
+    })
     @IsString()
-    @MinLength(16)
-    @MaxLength(256)
+    @MinLength(FLEET_CREDENTIAL_MIN_LENGTH)
+    @MaxLength(FLEET_CREDENTIAL_MAX_LENGTH)
     token: string;
 }
 
@@ -100,9 +135,13 @@ export class FleetHeartbeatDto extends FleetNodeSelfDescriptionDto {
     @IsUUID()
     nodeId: string;
 
-    @ApiProperty({ minLength: 16, maxLength: 256, description: 'Node secret minted at enroll.' })
+    @ApiProperty({
+        minLength: FLEET_CREDENTIAL_MIN_LENGTH,
+        maxLength: FLEET_CREDENTIAL_MAX_LENGTH,
+        description: 'Node secret minted at enroll.',
+    })
     @IsString()
-    @MinLength(16)
-    @MaxLength(256)
+    @MinLength(FLEET_CREDENTIAL_MIN_LENGTH)
+    @MaxLength(FLEET_CREDENTIAL_MAX_LENGTH)
     secret: string;
 }

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -14,8 +14,13 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import type { CreateEnrollmentTokenResult, FleetNodeView } from '@ever-works/agent/fleet';
+import type { CreateEnrollmentTokenResult } from '@ever-works/agent/fleet';
 import { FleetJobService, FleetService } from '@ever-works/agent/fleet';
+import type {
+    FleetEnrollResponse,
+    FleetHeartbeatResponse,
+    FleetNodeView,
+} from '@ever-works/contracts';
 import { Public } from '../auth/decorators/public.decorator';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
@@ -132,9 +137,7 @@ export class FleetController {
     })
     @HttpCode(HttpStatus.CREATED)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
-    async enroll(
-        @Body() body: EnrollFleetNodeDto,
-    ): Promise<{ nodeId: string; secret: string; node: FleetNodeView }> {
+    async enroll(@Body() body: EnrollFleetNodeDto): Promise<FleetEnrollResponse> {
         const result = await this.service.enroll(body.token, {
             platform: body.platform,
             version: body.version,
@@ -155,7 +158,7 @@ export class FleetController {
     })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 240, ttl: 60_000 } })
-    async heartbeat(@Body() body: FleetHeartbeatDto): Promise<{ ok: true; node: FleetNodeView }> {
+    async heartbeat(@Body() body: FleetHeartbeatDto): Promise<FleetHeartbeatResponse> {
         const result = await this.service.heartbeat(body.nodeId, body.secret, {
             platform: body.platform,
             version: body.version,

--- a/apps/api/src/onboarding/dto/onboarding-seed.dto.ts
+++ b/apps/api/src/onboarding/dto/onboarding-seed.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, IsArray, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ROLE_OPTIONS } from '@ever-works/contracts/api';
+
+/**
+ * Bounds for the role list accepted by the seeding endpoints.
+ *
+ * There are only `ROLE_OPTIONS.length` distinct answers, so the array
+ * cap is exactly that: a caller sending more is either confused or
+ * probing, and neither deserves the work. Unknown ids are then DROPPED
+ * by the resolver rather than rejected — the same posture the wizard
+ * state uses — so an older client sending a retired id still gets a
+ * useful answer instead of a 400.
+ */
+export const ONBOARDING_MAX_SEED_ROLES = ROLE_OPTIONS.length;
+
+/** Longest role id the resolver will look at; ids are short kebab-case. */
+export const ONBOARDING_MAX_ROLE_ID_LENGTH = 64;
+
+/** Request body for `POST /api/onboarding/suggestions/seed`. */
+export class OnboardingSeedRequestDto {
+    @ApiProperty({
+        required: false,
+        type: [String],
+        description:
+            'Role ids to seed for. Omit to use the roles already saved on the caller’s onboarding state.',
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(ONBOARDING_MAX_SEED_ROLES)
+    @IsString({ each: true })
+    @MaxLength(ONBOARDING_MAX_ROLE_ID_LENGTH, { each: true })
+    roles?: string[];
+}

--- a/apps/api/src/onboarding/onboarding-suggestions.controller.ts
+++ b/apps/api/src/onboarding/onboarding-suggestions.controller.ts
@@ -1,0 +1,110 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { OnboardingRoleSeedingService } from '@ever-works/agent/agents';
+import type {
+    OnboardingSeedResponse,
+    OnboardingSeedSuggestionsResponse,
+} from '@ever-works/contracts/api';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { OnboardingStateService } from './onboarding-state.service';
+import { ONBOARDING_MAX_SEED_ROLES, OnboardingSeedRequestDto } from './dto/onboarding-seed.dto';
+
+/**
+ * A55 — role-driven starter seeding, server-side.
+ *
+ * `GET  /api/onboarding/suggestions`      resolve the kit for some roles
+ * `POST /api/onboarding/suggestions/seed` activate that kit for the caller
+ *
+ * Both are auth-required (the global session guard). The resolution
+ * itself is catalog data, but the seed endpoint creates rows owned by
+ * the caller, and keeping the pair on the same guard means the UI never
+ * has to reason about "this half needs a session and that half does
+ * not".
+ *
+ * Splitting resolve from seed is deliberate: the wizard shows the kit
+ * first and only creates when the user asks. `GET` therefore has no
+ * side effects at all, and `POST` is idempotent per template.
+ */
+@ApiTags('onboarding')
+@Controller('api/onboarding/suggestions')
+export class OnboardingSuggestionsController {
+    constructor(
+        private readonly seeding: OnboardingRoleSeedingService,
+        private readonly stateService: OnboardingStateService,
+    ) {}
+
+    @Get()
+    @ApiOperation({
+        summary:
+            'Resolve the starter kit (prebuilt agents + skills) for a set of onboarding roles. Every role in ROLE_OPTIONS is covered.',
+    })
+    @ApiQuery({
+        name: 'roles',
+        required: false,
+        description:
+            'Comma-separated role ids (repeatable). Omit to use the roles saved on the caller’s onboarding state.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async suggest(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query('roles') roles?: string | string[],
+    ): Promise<OnboardingSeedSuggestionsResponse> {
+        const requested = parseRolesQuery(roles);
+        const effective = requested.length > 0 ? requested : await this.savedRoles(auth.userId);
+        return this.seeding.suggest(effective);
+    }
+
+    @Post('seed')
+    @ApiOperation({
+        summary:
+            'Create the starter agents for the caller’s onboarding roles. Idempotent per template; partial failures are reported, never thrown.',
+    })
+    @HttpCode(HttpStatus.OK)
+    // Seeding writes rows. The cap is generous enough for a user who
+    // re-runs the step a few times and tight enough that it cannot be
+    // used to bulk-create agents.
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async seed(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: OnboardingSeedRequestDto,
+    ): Promise<OnboardingSeedResponse> {
+        const requested = Array.isArray(body.roles)
+            ? body.roles.slice(0, ONBOARDING_MAX_SEED_ROLES)
+            : [];
+        const effective = requested.length > 0 ? requested : await this.savedRoles(auth.userId);
+        return this.seeding.seed(auth.userId, effective);
+    }
+
+    /**
+     * Roles the user already answered with. Best-effort: a state read
+     * failure degrades to "no roles" (an empty kit) rather than failing
+     * a suggestion call — the wizard can always pass roles explicitly.
+     */
+    private async savedRoles(userId: string): Promise<string[]> {
+        try {
+            const state = await this.stateService.getState(userId);
+            return [...(state.state.profile?.roles ?? [])];
+        } catch {
+            return [];
+        }
+    }
+}
+
+/**
+ * Accept both `?roles=a,b` and `?roles=a&roles=b` — Nest hands the
+ * second form over as an array, and a caller should not have to know
+ * which one this endpoint prefers.
+ */
+export function parseRolesQuery(raw: string | string[] | undefined): string[] {
+    const parts = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+    const out: string[] = [];
+    for (const part of parts) {
+        for (const piece of part.split(',')) {
+            const trimmed = piece.trim();
+            if (trimmed && !out.includes(trimmed)) out.push(trimmed);
+        }
+    }
+    return out.slice(0, ONBOARDING_MAX_SEED_ROLES);
+}

--- a/apps/api/src/onboarding/onboarding.module.ts
+++ b/apps/api/src/onboarding/onboarding.module.ts
@@ -13,6 +13,11 @@ import {
 import { FacadesModule, GitFacadeService } from '@ever-works/agent/facades';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { WorkModule } from '@ever-works/agent/services';
+// A55 — the role-seeding service lives with the agent templates it
+// activates; importing the agent-side module (Nest resolves it once for
+// the whole app) is what gives this module the provider without
+// duplicating the template catalog wiring here.
+import { AgentsModule as AgentDomainAgentsModule } from '@ever-works/agent/agents';
 import { OnboardingController } from './onboarding.controller';
 import { OnboardingService } from './onboarding.service';
 import { OnboardingTerminalService } from './onboarding-terminal.service';
@@ -25,12 +30,20 @@ import { OnboardingStateService } from './onboarding-state.service';
 import { OnboardingCatalogController } from './onboarding-catalog.controller';
 import { OnboardingCatalogService } from './onboarding-catalog.service';
 import { OnboardingTelemetryController } from './onboarding-telemetry.controller';
+import { OnboardingSuggestionsController } from './onboarding-suggestions.controller';
 import { ClaimController } from './claim.controller';
 import { AuthModule } from '../auth';
 import { UsersModule } from '../users/users.module';
 
 @Module({
-    imports: [FacadesModule, DatabaseModule, WorkModule, AuthModule, UsersModule],
+    imports: [
+        FacadesModule,
+        DatabaseModule,
+        WorkModule,
+        AuthModule,
+        UsersModule,
+        AgentDomainAgentsModule,
+    ],
     controllers: [
         OnboardingController,
         WellKnownController,
@@ -39,6 +52,7 @@ import { UsersModule } from '../users/users.module';
         OnboardingStateController,
         OnboardingCatalogController,
         OnboardingTelemetryController,
+        OnboardingSuggestionsController,
     ],
     providers: [
         OnboardingService,

--- a/apps/node/src/core/config-store.ts
+++ b/apps/node/src/core/config-store.ts
@@ -1,8 +1,9 @@
 import {
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
+	isFleetEnrollableNodeKind,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
-	type FleetNodeKind,
+	type FleetEnrollableNodeKind,
 	type NodeConfig
 } from './types';
 
@@ -71,8 +72,6 @@ export function resolveConfigPath(input: ResolveConfigPathInput): string {
 	return join(base, CONFIG_DIR_NAME, CONFIG_FILE_NAME);
 }
 
-const ENROLLABLE_KINDS: readonly FleetNodeKind[] = ['desktop-node', 'node'];
-
 function clampInterval(value: unknown): number {
 	if (typeof value !== 'number' || !Number.isFinite(value)) {
 		return DEFAULT_HEARTBEAT_INTERVAL_MS;
@@ -111,8 +110,10 @@ export function parseConfig(raw: string | null): NodeConfig | null {
 		return null;
 	}
 
-	const kind: FleetNodeKind =
-		typeof candidate.kind === 'string' && ENROLLABLE_KINDS.includes(candidate.kind) ? candidate.kind : 'node';
+	// Unrecognised kinds are DROPPED to the safe default, never trusted:
+	// the enrollable set is the shared contract's, so a server-side
+	// addition needs no edit here.
+	const kind: FleetEnrollableNodeKind = isFleetEnrollableNodeKind(candidate.kind) ? candidate.kind : 'node';
 
 	const config: NodeConfig = {
 		apiUrl: candidate.apiUrl,

--- a/apps/node/src/core/fleet-client.ts
+++ b/apps/node/src/core/fleet-client.ts
@@ -1,5 +1,14 @@
 import type { Logger } from './logger';
-import { MAX_CREDENTIAL_LENGTH, MIN_CREDENTIAL_LENGTH, type FleetNodeView, type NodeSelfDescription } from './types';
+import {
+	MAX_CREDENTIAL_LENGTH,
+	MIN_CREDENTIAL_LENGTH,
+	type FleetEnrollRequest,
+	type FleetEnrollResponse,
+	type FleetHeartbeatRequest,
+	type FleetHeartbeatResponse,
+	type FleetNodeView,
+	type NodeSelfDescription
+} from './types';
 
 /**
  * HTTP client for the two public Fleet endpoints the node apps use:
@@ -55,25 +64,18 @@ export interface FetchRequestInit {
 
 export type FetchLike = (url: string, init: FetchRequestInit) => Promise<FetchResponseLike>;
 
-export interface EnrollRequest extends NodeSelfDescription {
-	token: string;
-}
-
-export interface EnrollResponse {
-	nodeId: string;
-	secret: string;
-	node: FleetNodeView;
-}
-
-export interface HeartbeatRequest extends NodeSelfDescription {
-	nodeId: string;
-	secret: string;
-}
-
-export interface HeartbeatResponse {
-	ok: true;
-	node: FleetNodeView;
-}
+/**
+ * The four enroll/heartbeat wire shapes, aliased to the SHARED contract
+ * in `@ever-works/contracts` under the names this app has always used.
+ *
+ * These are deliberately aliases and not re-declarations: adding or
+ * renaming a field server-side now fails this app's `tsc` instead of
+ * silently producing a request the API rejects at runtime.
+ */
+export type EnrollRequest = FleetEnrollRequest;
+export type EnrollResponse = FleetEnrollResponse;
+export type HeartbeatRequest = FleetHeartbeatRequest;
+export type HeartbeatResponse = FleetHeartbeatResponse;
 
 export interface FleetClientOptions {
 	apiUrl: string;

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -10,7 +10,7 @@ import {
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
-	type FleetNodeKind,
+	type FleetEnrollableNodeKind,
 	type NodeConfig
 } from './types';
 
@@ -37,7 +37,7 @@ export interface NodeIo {
 export interface EnrollNodeOptions extends NodeIo {
 	apiUrl: string;
 	token: string;
-	kind: FleetNodeKind;
+	kind: FleetEnrollableNodeKind;
 	/** Local display label. Optional — defaults to the platform-assigned name. */
 	name?: string;
 	heartbeatIntervalMs?: number;

--- a/apps/node/src/core/types.ts
+++ b/apps/node/src/core/types.ts
@@ -1,62 +1,79 @@
 /**
- * Wire types and limits shared with the platform Fleet API.
+ * Node-local types, plus the node's view of the shared Fleet contract.
  *
- * These MIRROR the server contract (`apps/api/src/fleet/dto/fleet.dto.ts` +
- * `packages/agent/src/fleet/fleet.service.ts`) — they are a client-side copy so
- * the node apps stay dependency-free, and they must not drift from it. The
- * server re-validates and sanitizes everything anyway; the limits below exist
- * so the node never sends a value the server would silently truncate or drop.
+ * The enroll/heartbeat wire shapes and their protocol bounds are NOT
+ * defined here any more — they live in `@ever-works/contracts`
+ * (`fleet/fleet-node.types.ts`), the zero-dependency package the API,
+ * the web tier and this app all already depend on. This file re-exports
+ * them under the names the node code has always used, so a change to
+ * the contract now breaks the node at COMPILE time instead of at 3am on
+ * a machine nobody is watching (which is the entire reason the mirror
+ * that used to live here was a bug).
+ *
+ * What is still genuinely local: {@link NodeConfig} — how THIS app
+ * persists its enrollment on disk. That is not a wire shape and the
+ * server has no opinion about it.
  */
 
-/** App shapes a machine can enroll as (server: `FLEET_ENROLLABLE_KINDS`). */
-export type FleetNodeKind = 'desktop-node' | 'node';
+import {
+	FLEET_CREDENTIAL_MAX_LENGTH,
+	FLEET_CREDENTIAL_MIN_LENGTH,
+	FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
+	FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
+	FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
+	FLEET_MAX_PLATFORM_LENGTH,
+	FLEET_MAX_VERSION_LENGTH,
+	type FleetEnrollableNodeKind,
+	type FleetNodeSelfDescription
+} from '@ever-works/contracts';
 
-/** Node lifecycle as reported by the platform. */
-export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
+export type {
+	FleetEnrollableNodeKind,
+	FleetEnrollRequest,
+	FleetEnrollResponse,
+	FleetHeartbeatRequest,
+	FleetHeartbeatResponse,
+	FleetNodeKind,
+	FleetNodeSelfDescription,
+	FleetNodeStatus,
+	FleetNodeView
+} from '@ever-works/contracts';
 
-/** Wire view of one fleet node — never carries credentials. */
-export interface FleetNodeView {
-	id: string;
-	name: string;
-	kind: FleetNodeKind;
-	status: FleetNodeStatus;
-	platform: string | null;
-	version: string | null;
-	capabilities: string[];
-	lastHeartbeatAt: string | null;
-	createdAt: string | null;
-	persisted: boolean;
-}
+export { FLEET_ENROLLABLE_NODE_KINDS, isFleetEnrollableNodeKind } from '@ever-works/contracts';
 
-/** Self-description sent on enroll and refreshed on every heartbeat. */
-export interface NodeSelfDescription {
-	platform?: string;
-	version?: string;
-	capabilities?: string[];
-}
+/**
+ * The node's historical name for the shared
+ * {@link FleetNodeSelfDescription}. Kept as an alias so the whole app
+ * did not have to be renamed to adopt the shared contract.
+ */
+export type NodeSelfDescription = FleetNodeSelfDescription;
 
-/** Server: `FLEET_MAX_CAPABILITY_TAGS`. */
-export const MAX_CAPABILITY_TAGS = 16;
-/** Server: `FLEET_MAX_CAPABILITY_TAG_LENGTH`. */
-export const MAX_CAPABILITY_TAG_LENGTH = 32;
-/** Server: `sanitizeText(input.platform, 64)`. */
-export const MAX_PLATFORM_LENGTH = 64;
-/** Server: `sanitizeText(input.version, 32)`. */
-export const MAX_VERSION_LENGTH = 32;
-/** Server: `CREDENTIAL_MIN_LENGTH` / `CREDENTIAL_MAX_LENGTH`. */
-export const MIN_CREDENTIAL_LENGTH = 16;
-export const MAX_CREDENTIAL_LENGTH = 256;
+/**
+ * Server-side caps, re-exported under the node's short names.
+ *
+ * The tag caps are operator-tunable on the server (`config.fleet.*`);
+ * these are the DEFAULTS, which is the best a node can assume — it
+ * normalizes to them so what it reports is what the platform stores. A
+ * server configured with a LOWER cap still truncates authoritatively;
+ * one configured higher simply accepts everything the node sends.
+ */
+export const MAX_CAPABILITY_TAGS = FLEET_DEFAULT_MAX_CAPABILITY_TAGS;
+export const MAX_CAPABILITY_TAG_LENGTH = FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH;
+export const MAX_PLATFORM_LENGTH = FLEET_MAX_PLATFORM_LENGTH;
+export const MAX_VERSION_LENGTH = FLEET_MAX_VERSION_LENGTH;
+export const MIN_CREDENTIAL_LENGTH = FLEET_CREDENTIAL_MIN_LENGTH;
+export const MAX_CREDENTIAL_LENGTH = FLEET_CREDENTIAL_MAX_LENGTH;
 
-/** Default heartbeat cadence — comfortably inside the server's 5-minute stale window. */
+/** Default heartbeat cadence — comfortably inside the server's stale window. */
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
 
 /**
- * Backoff ceiling. Capped at the server's `FLEET_NODE_OFFLINE_AFTER_MS`
- * (5 minutes): once the platform has already flipped us to `offline` there is
- * nothing to gain from backing off further, and a longer ceiling would leave a
- * recovered node dark for many extra minutes.
+ * Backoff ceiling. Capped at the server's DEFAULT offline window
+ * (5 minutes): once the platform has already flipped us to `offline`
+ * there is nothing to gain from backing off further, and a longer
+ * ceiling would leave a recovered node dark for many extra minutes.
  */
-export const MAX_HEARTBEAT_BACKOFF_MS = 5 * 60_000;
+export const MAX_HEARTBEAT_BACKOFF_MS = FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS;
 
 /** Floor/ceiling for the operator-configurable heartbeat interval. */
 export const MIN_HEARTBEAT_INTERVAL_MS = 5_000;
@@ -74,7 +91,7 @@ export interface NodeConfig {
 	nodeId: string;
 	/** Heartbeat credential, minted once at enroll. NEVER log this. */
 	secret: string;
-	kind: FleetNodeKind;
+	kind: FleetEnrollableNodeKind;
 	capabilities: string[];
 	/** Local display label; the authoritative name lives on the platform. */
 	name?: string;
@@ -86,7 +103,7 @@ export interface NodeConfig {
 export interface RedactedNodeConfig {
 	apiUrl: string;
 	nodeId: string;
-	kind: FleetNodeKind;
+	kind: FleetEnrollableNodeKind;
 	capabilities: string[];
 	name?: string;
 	heartbeatIntervalMs: number;

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -364,7 +364,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         },

--- a/apps/web/src/app/actions/onboarding/agent-suggestions.ts
+++ b/apps/web/src/app/actions/onboarding/agent-suggestions.ts
@@ -1,6 +1,11 @@
 'use server';
 
 import { agentsAPI, type Agent, type AgentTemplateSummary } from '@/lib/api/agents';
+import { onboardingSuggestionsAPI } from '@/lib/api/onboarding-suggestions';
+import type {
+    OnboardingSeedResponse,
+    OnboardingSeedSuggestionsResponse,
+} from '@ever-works/contracts/api';
 import type { ActionResult } from '@/app/actions/plugins';
 
 /**
@@ -40,5 +45,45 @@ export async function createAgentFromTemplateForOnboarding(
     } catch (error) {
         console.error('Failed to create agent from template:', error);
         return { success: false, error: 'Failed to create the agent' };
+    }
+}
+
+/**
+ * A55 — resolve the SERVER-side starter kit for `roles`.
+ *
+ * Supersedes the browser-side catalog filter the ProfileStep used: the
+ * mapping covers every role in `ROLE_OPTIONS` (not the three that
+ * happened to be tagged on a template) and returns skills as well as
+ * agents. Best-effort, like the list call above — the block hides
+ * itself rather than blocking the wizard on a suggestion.
+ */
+export async function getRoleSeedSuggestions(
+    roles: readonly string[],
+): Promise<ActionResult<OnboardingSeedSuggestionsResponse>> {
+    try {
+        const data = await onboardingSuggestionsAPI.suggest(roles);
+        return { success: true, data };
+    } catch (error) {
+        console.error('Failed to resolve onboarding role suggestions:', error);
+        return { success: false, error: 'Failed to load suggestions' };
+    }
+}
+
+/**
+ * A55 — create the whole starter kit server-side in one call.
+ *
+ * Idempotent per template: re-running the step reports the already
+ * activated ones instead of creating duplicates, which the old
+ * one-create-per-card client flow could not do.
+ */
+export async function seedRoleStarterAgents(
+    roles: readonly string[],
+): Promise<ActionResult<OnboardingSeedResponse>> {
+    try {
+        const data = await onboardingSuggestionsAPI.seed(roles);
+        return { success: true, data };
+    } catch (error) {
+        console.error('Failed to seed onboarding starter agents:', error);
+        return { success: false, error: 'Failed to set up your starter agents' };
     }
 }

--- a/apps/web/src/components/onboarding/steps/ProfileStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ProfileStep.tsx
@@ -7,14 +7,11 @@ import { toast } from 'sonner';
 import { cn } from '@/lib/utils/cn';
 import { Button } from '@/components/ui/button';
 import { ROLE_OPTIONS, TEAM_SIZE_OPTIONS } from '@ever-works/contracts/api';
-import {
-    filterSuggestedTemplates,
-    shouldShowSuggestions,
-    type SuggestableAgentTemplate,
-} from '../profile-suggestions';
+import type { OnboardingSeedSuggestionsResponse } from '@ever-works/contracts/api';
 import {
     createAgentFromTemplateForOnboarding,
-    listAgentTemplatesForOnboarding,
+    getRoleSeedSuggestions,
+    seedRoleStarterAgents,
 } from '@/app/actions/onboarding/agent-suggestions';
 
 export interface ProfileStepProps {
@@ -133,27 +130,44 @@ export function ProfileStep({ roles, teamSize, onToggleRole, onSelectTeamSize }:
     );
 }
 
-// ─── Suggested agents (best-effort) ─────────────────────────────────────────
+// ─── Suggested starter kit (server-resolved, best-effort) ───────────────────
 
+/**
+ * A55 — the suggestion block.
+ *
+ * Resolution moved to the API: this component no longer downloads the
+ * agent catalog and filters it locally (which covered 3 of the 14 roles
+ * and knew nothing about skills). It asks
+ * `GET /api/onboarding/suggestions` for the kit that matches the
+ * selected roles and renders what comes back, so every role produces a
+ * starting point and the mapping is the same everywhere.
+ *
+ * Still best-effort: a failed resolve hides the block for the rest of
+ * the wizard session rather than retrying, and nothing here gates the
+ * step.
+ */
 function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
     const t = useTranslations('onboarding.profileStep.suggestions');
-    const show = shouldShowSuggestions(roles);
+    const roleKey = [...roles].sort().join(',');
 
-    const [templates, setTemplates] = useState<SuggestableAgentTemplate[] | null>(null);
+    const [kit, setKit] = useState<OnboardingSeedSuggestionsResponse | null>(null);
     const [failed, setFailed] = useState(false);
     const [creating, setCreating] = useState<string | null>(null);
     const [created, setCreated] = useState<readonly string[]>([]);
+    const [seeding, setSeeding] = useState(false);
 
-    // Fetch the catalog once, lazily, the first time a trigger role is
-    // selected. Best-effort: a failed fetch marks the block hidden for
-    // the rest of the wizard session (no retry storm mid-onboarding).
+    // Re-resolve whenever the selected roles change: the kit is a
+    // function of the answers, and the previous kit would be stale.
     useEffect(() => {
-        if (!show || failed || templates !== null) return;
+        if (failed || roleKey === '') {
+            setKit(null);
+            return;
+        }
         let cancelled = false;
-        void listAgentTemplatesForOnboarding().then((result) => {
+        void getRoleSeedSuggestions(roleKey.split(',')).then((result) => {
             if (cancelled) return;
             if (result.success && result.data) {
-                setTemplates(result.data);
+                setKit(result.data);
             } else {
                 setFailed(true);
             }
@@ -161,12 +175,9 @@ function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
         return () => {
             cancelled = true;
         };
-    }, [show, failed, templates]);
+    }, [roleKey, failed]);
 
-    if (!show || failed || templates === null) return null;
-
-    const suggested = filterSuggestedTemplates(templates, roles);
-    if (suggested.length === 0) return null;
+    if (failed || kit === null || kit.agents.length === 0) return null;
 
     const handleCreate = async (slug: string) => {
         setCreating(slug);
@@ -183,6 +194,38 @@ function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
         }
     };
 
+    // One call creates the whole kit server-side. Idempotent, so a
+    // second click reports "already set up" instead of duplicating.
+    const handleSeedAll = async () => {
+        setSeeding(true);
+        try {
+            const result = await seedRoleStarterAgents(kit.roles);
+            if (!result.success || !result.data) {
+                toast.error(result.error ?? t('seedFailed'));
+                return;
+            }
+            const { createdCount, skippedCount, failedCount, agents } = result.data;
+            setCreated((prev) => {
+                const next = new Set(prev);
+                for (const entry of agents) {
+                    if (entry.outcome === 'created' || entry.outcome === 'already-exists') {
+                        next.add(entry.slug);
+                    }
+                }
+                return [...next];
+            });
+            if (failedCount > 0) {
+                toast.warning(t('seedPartial', { created: createdCount, failed: failedCount }));
+            } else if (createdCount === 0 && skippedCount > 0) {
+                toast.success(t('seedAlreadyDone'));
+            } else {
+                toast.success(t('seedDone', { count: createdCount }));
+            }
+        } finally {
+            setSeeding(false);
+        }
+    };
+
     return (
         <section data-testid="onboarding-profile-suggestions">
             <h4 className="flex items-center gap-1.5 text-sm font-semibold text-text dark:text-text-dark mb-1">
@@ -193,7 +236,7 @@ function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
                 {t('description')}
             </p>
             <div className="space-y-2">
-                {suggested.map((template) => {
+                {kit.agents.map((template) => {
                     const isCreated = created.includes(template.slug);
                     const isCreating = creating === template.slug;
                     return (
@@ -216,7 +259,7 @@ function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
                                 <Button
                                     size="sm"
                                     variant="secondary"
-                                    disabled={isCreated || isCreating}
+                                    disabled={isCreated || isCreating || seeding}
                                     data-testid={`onboarding-profile-suggestion-create-${template.slug}`}
                                     onClick={() => void handleCreate(template.slug)}
                                 >
@@ -241,6 +284,49 @@ function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
                         </div>
                     );
                 })}
+            </div>
+
+            {kit.skills.length > 0 ? (
+                <div className="mt-3">
+                    <p className="text-xs font-semibold text-text dark:text-text-dark mb-1.5">
+                        {t('skillsTitle')}
+                    </p>
+                    <div
+                        className="flex flex-wrap gap-1.5"
+                        data-testid="onboarding-profile-suggested-skills"
+                    >
+                        {kit.skills.map((skill) => (
+                            <span
+                                key={skill.slug}
+                                title={skill.description}
+                                className="inline-flex items-center rounded-full border border-border dark:border-border-dark px-2.5 py-1 text-xs text-text-secondary dark:text-text-secondary-dark"
+                            >
+                                {skill.title}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            ) : null}
+
+            <div className="mt-3">
+                <Button
+                    size="sm"
+                    disabled={seeding}
+                    data-testid="onboarding-profile-suggestion-seed-all"
+                    onClick={() => void handleSeedAll()}
+                >
+                    {seeding ? (
+                        <>
+                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                            {t('seeding')}
+                        </>
+                    ) : (
+                        <>
+                            <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+                            {t('seedAll')}
+                        </>
+                    )}
+                </Button>
             </div>
         </section>
     );

--- a/apps/web/src/lib/api/fleet.ts
+++ b/apps/web/src/lib/api/fleet.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import type { FleetEnrollableNodeKind, FleetNodeView } from '@ever-works/contracts';
 import { serverFetch, serverMutation } from './server-api';
 
 /**
@@ -13,43 +14,23 @@ import { serverFetch, serverMutation } from './server-api';
  * is never readable again.
  */
 
-export type FleetNodeKind = 'desktop-node' | 'node' | 'k8s';
-
-export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
-
-export interface FleetNodeView {
-    id: string;
-    name: string;
-    kind: FleetNodeKind;
-    status: FleetNodeStatus;
-    platform: string | null;
-    version: string | null;
-    capabilities: string[];
-    lastHeartbeatAt: string | null;
-    createdAt: string | null;
-    /** False for live nodes of the user's own configured clusters. */
-    persisted: boolean;
-    /**
-     * Live execution load (Desktop PRD §4.1 "current load (running
-     * Tasks)"). `null`/absent means idle. Cluster-sourced rows never
-     * carry it — the platform does not lease work onto them.
-     */
-    load?: FleetNodeLoadView | null;
-}
-
-/** Per-node execution summary merged into the node list by the API edge. */
-export interface FleetNodeLoadView {
-    /** Jobs this node currently holds a live claim on. */
-    activeJobCount: number;
-    /** Kind of the oldest live claim, or null when idle. */
-    currentJobKind: string | null;
-    /** Id of the oldest live claim, or null when idle. */
-    currentJobId: string | null;
-}
+/**
+ * Node kind/status and the node view are the SHARED contract
+ * (`@ever-works/contracts`), re-exported here so this tier, the API and
+ * the node apps compile against ONE declaration. This file used to
+ * hand-copy them, which is exactly how the three copies drifted.
+ */
+export type {
+    FleetNodeKind,
+    FleetNodeStatus,
+    FleetNodeView,
+    FleetNodeLoadView,
+    FleetEnrollableNodeKind,
+} from '@ever-works/contracts';
 
 export interface CreateFleetEnrollmentTokenPayload {
     name: string;
-    kind: Exclude<FleetNodeKind, 'k8s'>;
+    kind: FleetEnrollableNodeKind;
 }
 
 export interface CreateFleetEnrollmentTokenResponse {

--- a/apps/web/src/lib/api/onboarding-suggestions.ts
+++ b/apps/web/src/lib/api/onboarding-suggestions.ts
@@ -1,0 +1,42 @@
+import 'server-only';
+import type {
+    OnboardingSeedResponse,
+    OnboardingSeedSuggestionsResponse,
+} from '@ever-works/contracts/api';
+import { serverFetch, serverMutation } from './server-api';
+
+/**
+ * A55 — web client for the SERVER-side onboarding starter seeding
+ * (`apps/api/src/onboarding/onboarding-suggestions.controller.ts`).
+ *
+ * The wizard used to pull the whole agent catalog and do the role
+ * matching in the browser, which covered 3 of the 14 roles the step
+ * offers and knew nothing about skills. The matching now happens once,
+ * server-side, for every role — this file just carries the answer.
+ */
+
+// No leading `/api` — `serverFetch`/`serverMutation` prepend `API_URL`,
+// which `lib/constants.ts` already normalises to end in `/api`.
+const BASE = '/onboarding/suggestions';
+
+export const onboardingSuggestionsAPI = {
+    /**
+     * Resolve the starter kit for `roles`. Passing none lets the server
+     * fall back to the roles already saved on the user's onboarding
+     * state, so the client is never the authority on that answer.
+     */
+    suggest: async (roles: readonly string[] = []): Promise<OnboardingSeedSuggestionsResponse> => {
+        const query = roles.length > 0 ? `?roles=${encodeURIComponent(roles.join(','))}` : '';
+        return serverFetch<OnboardingSeedSuggestionsResponse>(`${BASE}${query}`);
+    },
+
+    /** Activate the starter agents for `roles`. Idempotent per template. */
+    seed: async (roles: readonly string[] = []): Promise<OnboardingSeedResponse> => {
+        return serverMutation<OnboardingSeedResponse>({
+            endpoint: `${BASE}/seed`,
+            data: { roles: [...roles] },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+};

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -24,6 +24,7 @@ import { AgentEscalationRepository } from '../database/repositories/agent-escala
 import { TaskReviewRejectionRepository } from '../database/repositories/task-review-rejection.repository';
 import { AgentsService } from './agents.service';
 import { AgentTemplatesService } from './agent-templates.service';
+import { OnboardingRoleSeedingService } from './role-seeding.service';
 import { AgentFileService } from './agent-file.service';
 import { AgentScheduleDispatcherService } from './agent-schedule-dispatcher.service';
 import { AgentRunSweeperService } from './agent-run-sweeper.service';
@@ -110,6 +111,9 @@ import { FacadesModule } from '../facades/facades.module';
         // Wave 10 — prebuilt agent-template activation (catalog data +
         // ordinary Agent rows; no new persistence concepts).
         AgentTemplatesService,
+        // A55 — server-side, role-driven starter seeding for onboarding
+        // (all 14 roles, agents AND skills; was a 3-role client filter).
+        OnboardingRoleSeedingService,
         AgentFileService,
         AgentScheduleDispatcherService,
         AgentRunSweeperService,
@@ -146,6 +150,7 @@ import { FacadesModule } from '../facades/facades.module';
         TaskReviewRejectionRepository,
         AgentsService,
         AgentTemplatesService,
+        OnboardingRoleSeedingService,
         AgentFileService,
         AgentScheduleDispatcherService,
         AgentRunSweeperService,

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -4,6 +4,8 @@ export * from './agents.module';
 export * from './agents.service';
 export * from './agent-templates';
 export * from './agent-templates.service';
+export * from './role-seeding';
+export * from './role-seeding.service';
 export * from './agent-file.service';
 export * from './agent-schedule-dispatcher.service';
 export * from './agent-export.service';

--- a/packages/agent/src/agents/role-seeding.service.ts
+++ b/packages/agent/src/agents/role-seeding.service.ts
@@ -1,0 +1,103 @@
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import type {
+    OnboardingSeedResponse,
+    OnboardingSeedResultEntry,
+    OnboardingSeedSuggestionsResponse,
+} from '@ever-works/contracts/api';
+import { AgentTemplatesService } from './agent-templates.service';
+import { resolveRoleSeedSuggestions, type ResolveRoleSeedOptions } from './role-seeding';
+
+/**
+ * Server-side starter seeding for the onboarding role step.
+ *
+ * The browser used to own this: it fetched the whole agent catalog,
+ * intersected `suggestedRoles` locally, and fired one create per card.
+ * Moving it here buys three things the client version could not have:
+ *
+ *  - **One authority.** The role → kit mapping is the same for the web
+ *    wizard, the desktop shell and any API caller, because there is one
+ *    copy of it and it is not in a bundle.
+ *  - **Idempotence.** Seeding twice (a refresh, a back-navigation, a
+ *    double click) reports `already-exists` instead of creating a second
+ *    "Content Marketer". The client had no way to know.
+ *  - **Partial success.** One template failing does not abort the kit;
+ *    each entry carries its own outcome, so the user gets the four
+ *    agents that worked plus an honest note about the one that did not.
+ *
+ * Nothing here is gated on the user's answers — seeding is opt-in, and
+ * a user who seeds nothing has a fully functional account.
+ */
+@Injectable()
+export class OnboardingRoleSeedingService {
+    private readonly logger = new Logger(OnboardingRoleSeedingService.name);
+
+    constructor(private readonly templates: AgentTemplatesService) {}
+
+    /** Resolve (but do not create) the starter kit for a set of roles. */
+    suggest(
+        roles: readonly string[] | undefined | null,
+        options: ResolveRoleSeedOptions = {},
+    ): OnboardingSeedSuggestionsResponse {
+        return resolveRoleSeedSuggestions(roles, options);
+    }
+
+    /**
+     * Activate the starter agents for `roles` on behalf of `userId`.
+     *
+     * Sequential on purpose: `AgentsService.create` enforces a per-user
+     * name uniqueness check, and firing the kit in parallel would race
+     * that check into a spurious conflict for templates that share no
+     * name at all. A kit is three or four rows — the latency is not the
+     * interesting number here, the correctness is.
+     */
+    async seed(
+        userId: string,
+        roles: readonly string[] | undefined | null,
+        options: ResolveRoleSeedOptions = {},
+    ): Promise<OnboardingSeedResponse> {
+        const suggestions = this.suggest(roles, options);
+        const entries: OnboardingSeedResultEntry[] = [];
+
+        for (const suggestion of suggestions.agents) {
+            try {
+                const created = await this.templates.createFromTemplate(userId, suggestion.slug);
+                entries.push({ slug: suggestion.slug, outcome: 'created', agentId: created.id });
+            } catch (error) {
+                // A name conflict means this template is ALREADY activated
+                // for this user — the expected outcome of re-running the
+                // step, not an error worth surfacing as one.
+                if (error instanceof ConflictException) {
+                    entries.push({
+                        slug: suggestion.slug,
+                        outcome: 'already-exists',
+                        agentId: null,
+                    });
+                    continue;
+                }
+                // Best-effort per template: log the detail, return a short
+                // reason. The message is catalog/validation text, never
+                // credential or user data.
+                this.logger.warn(
+                    `Role seeding could not activate template "${suggestion.slug}": ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                entries.push({
+                    slug: suggestion.slug,
+                    outcome: 'failed',
+                    agentId: null,
+                    reason: 'Could not create this agent — try it from the Agents page.',
+                });
+            }
+        }
+
+        return {
+            roles: suggestions.roles,
+            agents: entries,
+            skills: suggestions.skills,
+            createdCount: entries.filter((entry) => entry.outcome === 'created').length,
+            skippedCount: entries.filter((entry) => entry.outcome === 'already-exists').length,
+            failedCount: entries.filter((entry) => entry.outcome === 'failed').length,
+        };
+    }
+}

--- a/packages/agent/src/agents/role-seeding.ts
+++ b/packages/agent/src/agents/role-seeding.ts
@@ -1,0 +1,269 @@
+import { GTM_SKILLS } from '@ever-works/contracts';
+import { ROLE_OPTIONS } from '@ever-works/contracts/api';
+import type {
+    OnboardingRoleId,
+    OnboardingSeedAgentSuggestion,
+    OnboardingSeedSkillSuggestion,
+    OnboardingSeedSuggestionsResponse,
+} from '@ever-works/contracts/api';
+import { AGENT_TEMPLATES, getAgentTemplate } from './agent-templates';
+
+/**
+ * Role → starter-kit mapping for the onboarding "What do you do" step.
+ *
+ * ## Why this is server-side and exhaustive
+ *
+ * The first cut derived suggestions in the browser by intersecting the
+ * agent catalog's `suggestedRoles` with the selected roles. That made
+ * coverage a SIDE EFFECT of how six template authors happened to tag
+ * their templates: three of the fourteen roles the step offers produced
+ * anything at all, and the other eleven silently got nothing. "Nothing
+ * suggested" and "nobody wrote a mapping" look identical to a user, and
+ * only one of them is honest.
+ *
+ * So the mapping is explicit and total. `ROLE_SEED_KITS` has an entry
+ * for EVERY id in `ROLE_OPTIONS`, and the spec fails the build when a
+ * role is added without one — the coverage guarantee is enforced, not
+ * asserted in a comment.
+ *
+ * ## Why it is not Agents-only
+ *
+ * A role implies a starting kit, not a starting agent. An agent with no
+ * skills is a prompt; the skills are what make it do the job. Each kit
+ * therefore names both, and the API returns both.
+ *
+ * ## Honesty about fit
+ *
+ * The first-party catalog is go-to-market shaped. For roles it covers
+ * well (marketing, sales, founder) the kits are genuinely tailored; for
+ * roles it covers loosely (legal, HR, finance) the kit is the closest
+ * useful starting point — a monitoring/digest agent and the reporting
+ * skills — rather than a pretend-tailored recommendation. Every kit is
+ * a suggestion the user can ignore; nothing is gated on the answer.
+ */
+
+/** The agents + skills offered for one onboarding role. */
+export interface RoleSeedKit {
+    /** Prebuilt agent-template slugs, in the order they should be shown. */
+    readonly agents: readonly string[];
+    /** First-party Skill catalog slugs. */
+    readonly skills: readonly string[];
+}
+
+/**
+ * The mapping. Keyed by `OnboardingRoleId`, so a role added to
+ * `ROLE_OPTIONS` without a kit is a TYPE error here and a failing spec
+ * — which is the whole point of pinning it.
+ */
+export const ROLE_SEED_KITS: Readonly<Record<OnboardingRoleId, RoleSeedKit>> = {
+    'founder-ceo': {
+        agents: ['content-marketer', 'lead-researcher', 'competitive-analyst'],
+        skills: ['digest-compilation', 'competitor-watch', 'campaign-reporting'],
+    },
+    engineering: {
+        agents: ['seo-auditor', 'competitive-analyst'],
+        skills: ['seo-audit', 'news-signal-detection', 'digest-compilation'],
+    },
+    product: {
+        agents: ['competitive-analyst', 'seo-auditor'],
+        skills: ['competitor-watch', 'news-signal-detection', 'engagement-analysis'],
+    },
+    marketing: {
+        agents: ['content-marketer', 'social-scheduler', 'seo-auditor'],
+        skills: ['newsletter-drafting', 'social-scheduling', 'seo-audit', 'campaign-reporting'],
+    },
+    sales: {
+        agents: ['lead-researcher', 'outreach-drafter'],
+        skills: ['lead-research', 'lead-scoring', 'outreach-personalization', 'follow-up-cadence'],
+    },
+    consultant: {
+        agents: ['competitive-analyst', 'content-marketer'],
+        skills: ['competitor-watch', 'digest-compilation', 'newsletter-drafting'],
+    },
+    research: {
+        agents: ['competitive-analyst', 'lead-researcher'],
+        skills: ['competitor-watch', 'news-signal-detection', 'digest-compilation'],
+    },
+    operations: {
+        agents: ['competitive-analyst', 'content-marketer'],
+        skills: ['crm-sync-hygiene', 'digest-compilation', 'campaign-reporting'],
+    },
+    support: {
+        agents: ['content-marketer'],
+        skills: ['reply-detection', 'follow-up-cadence', 'engagement-analysis'],
+    },
+    finance: {
+        agents: ['competitive-analyst'],
+        skills: ['campaign-reporting', 'digest-compilation', 'engagement-analysis'],
+    },
+    hr: {
+        agents: ['content-marketer', 'social-scheduler'],
+        skills: ['newsletter-drafting', 'digest-compilation', 'social-scheduling'],
+    },
+    legal: {
+        agents: ['competitive-analyst'],
+        skills: ['risk-filter', 'competitor-watch', 'digest-compilation'],
+    },
+    education: {
+        agents: ['content-marketer', 'social-scheduler'],
+        skills: ['newsletter-drafting', 'social-scheduling', 'digest-compilation'],
+    },
+    other: {
+        agents: ['content-marketer'],
+        skills: ['digest-compilation', 'newsletter-drafting'],
+    },
+};
+
+/** Every role id the onboarding step offers, as a lookup set. */
+const KNOWN_ROLE_IDS: ReadonlySet<string> = new Set(ROLE_OPTIONS.map((option) => option.id));
+
+/**
+ * Fold a role tag to the kebab-case id space.
+ *
+ * Callers legitimately hold role tags in two shapes: the wizard stores
+ * `ROLE_OPTIONS` ids (`founder-ceo`), while the agent templates carry
+ * display-cased hints (`Founder/CEO`). Normalising both into one space
+ * is what lets a template's own `suggestedRoles` stay human-readable
+ * without a translation table at every call site.
+ */
+export function normalizeRoleId(tag: string): string {
+    return tag
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Split incoming role tags into recognised ids and unknown ones.
+ *
+ * Unknown values are DROPPED, never defaulted — the same posture the
+ * wizard state uses for `profile.roles`. Order is preserved and
+ * duplicates collapse, so `['Marketing', 'marketing']` is one role.
+ */
+export function partitionRoles(roles: readonly string[] | undefined | null): {
+    known: OnboardingRoleId[];
+    unknown: string[];
+} {
+    const known: OnboardingRoleId[] = [];
+    const unknown: string[] = [];
+    for (const raw of roles ?? []) {
+        if (typeof raw !== 'string' || !raw.trim()) continue;
+        const id = normalizeRoleId(raw);
+        if (KNOWN_ROLE_IDS.has(id)) {
+            if (!known.includes(id as OnboardingRoleId)) known.push(id as OnboardingRoleId);
+        } else if (!unknown.includes(raw)) {
+            unknown.push(raw);
+        }
+    }
+    return { known, unknown };
+}
+
+/** Default cap on how many agents / skills one resolution returns. */
+export const ROLE_SEED_MAX_AGENTS = 3;
+export const ROLE_SEED_MAX_SKILLS = 6;
+
+export interface ResolveRoleSeedOptions {
+    maxAgents?: number;
+    maxSkills?: number;
+}
+
+/**
+ * Resolve the starter kit for a set of selected roles.
+ *
+ * Multi-select is normal (the step says so), so kits are UNIONED in
+ * role order with duplicates collapsed, and each suggestion records
+ * which roles produced it — the UI can say "because you picked Sales"
+ * instead of presenting an unexplained list.
+ *
+ * A slug that no longer exists in either catalog is skipped rather than
+ * emitted as a broken card; the integrity spec is what stops that from
+ * happening quietly in the first place.
+ */
+export function resolveRoleSeedSuggestions(
+    roles: readonly string[] | undefined | null,
+    options: ResolveRoleSeedOptions = {},
+): OnboardingSeedSuggestionsResponse {
+    const { known, unknown } = partitionRoles(roles);
+    const maxAgents = Math.max(0, options.maxAgents ?? ROLE_SEED_MAX_AGENTS);
+    const maxSkills = Math.max(0, options.maxSkills ?? ROLE_SEED_MAX_SKILLS);
+
+    const agentMatches = new Map<string, string[]>();
+    const skillMatches = new Map<string, string[]>();
+    for (const role of known) {
+        const kit = ROLE_SEED_KITS[role];
+        for (const slug of kit.agents) {
+            const existing = agentMatches.get(slug);
+            if (existing) existing.push(role);
+            else agentMatches.set(slug, [role]);
+        }
+        for (const slug of kit.skills) {
+            const existing = skillMatches.get(slug);
+            if (existing) existing.push(role);
+            else skillMatches.set(slug, [role]);
+        }
+    }
+
+    const agents: OnboardingSeedAgentSuggestion[] = [];
+    for (const [slug, matchedRoles] of agentMatches) {
+        if (agents.length >= maxAgents) break;
+        const template = getAgentTemplate(slug);
+        if (!template) continue;
+        agents.push({
+            slug: template.slug,
+            name: template.name,
+            title: template.title,
+            description: template.description,
+            category: template.category,
+            matchedRoles,
+        });
+    }
+
+    const skills: OnboardingSeedSkillSuggestion[] = [];
+    for (const [slug, matchedRoles] of skillMatches) {
+        if (skills.length >= maxSkills) break;
+        const skill = GTM_SKILLS.find((entry) => entry.slug === slug);
+        if (!skill) continue;
+        skills.push({
+            slug: skill.slug,
+            title: skill.title,
+            description: skill.description,
+            stage: skill.stage,
+            matchedRoles,
+        });
+    }
+
+    return { roles: known, unknownRoles: unknown, agents, skills };
+}
+
+/**
+ * Agent-template slugs to seed for the given roles, in kit order and
+ * capped the same way the suggestion surface is — so "seed my starter
+ * agents" creates exactly the kit the user was shown, not a superset.
+ */
+export function resolveSeedableAgentSlugs(
+    roles: readonly string[] | undefined | null,
+    options: ResolveRoleSeedOptions = {},
+): string[] {
+    return resolveRoleSeedSuggestions(roles, options).agents.map((agent) => agent.slug);
+}
+
+/** Every template slug referenced by any kit — used by the integrity spec. */
+export function listSeedReferencedAgentSlugs(): string[] {
+    const slugs = new Set<string>();
+    for (const kit of Object.values(ROLE_SEED_KITS)) {
+        for (const slug of kit.agents) slugs.add(slug);
+    }
+    return [...slugs];
+}
+
+/** Every skill slug referenced by any kit — used by the integrity spec. */
+export function listSeedReferencedSkillSlugs(): string[] {
+    const slugs = new Set<string>();
+    for (const kit of Object.values(ROLE_SEED_KITS)) {
+        for (const slug of kit.skills) slugs.add(slug);
+    }
+    return [...slugs];
+}
+
+/** Exposed for the integrity spec: the catalog the kits resolve against. */
+export const SEED_AGENT_TEMPLATE_SLUGS: readonly string[] = AGENT_TEMPLATES.map((t) => t.slug);

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -839,6 +839,11 @@ describe('agent/config', () => {
                 'branding',
                 'database',
                 'everWorks',
+                // Fleet limits — `fleet.*` holds the clamped
+                // enrollment-token TTL, offline-after window and
+                // capability-tag ceilings shared with the node.
+                // Pinned alphabetically, before `fleetNode`.
+                'fleet',
                 // Desktop PRD M4 — `fleetNode.*` group reads the
                 // `FLEET_NODE_*` operator knobs for the `node` job
                 // runtime (lease TTL, capability tags, kill switch and

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -1,6 +1,35 @@
+import {
+    FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS,
+    FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
+    FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
+    FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
+    FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING,
+    FLEET_MAX_CAPABILITY_TAGS_CEILING,
+    FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS,
+    FLEET_MIN_NODE_OFFLINE_AFTER_MS,
+} from '@ever-works/contracts';
 import { DatabaseType } from '@src/database';
 
 type AppType = 'cli' | 'api';
+
+/**
+ * Parse an integer env var into a clamped range, falling back to
+ * `fallback` when unset/unparseable. Used by the Fleet knobs, where a
+ * deploy-manifest typo must degrade to the documented default rather
+ * than to `NaN` (which silently expires every enrollment token).
+ */
+function clampedIntEnv(
+    raw: string | undefined,
+    fallback: number,
+    min: number,
+    max: number,
+): number {
+    const parsed = parseInt(raw ?? '', 10);
+    if (!Number.isFinite(parsed)) {
+        return fallback;
+    }
+    return Math.min(Math.max(parsed, min), max);
+}
 
 export const config = {
     getEnvironment() {
@@ -873,6 +902,72 @@ export const config = {
          */
         isMergePolicyEnforcementEnabled() {
             return (process.env.AGENT_MERGE_POLICY_ENFORCEMENT || 'on').toLowerCase() !== 'off';
+        },
+    },
+
+    /**
+     * Fleet (Wave 12) — operator knobs for the node registry.
+     *
+     * These four values shipped as hard-coded constants in
+     * `FleetService`, which made them un-tunable for anyone running the
+     * platform: a fleet of slow-to-provision machines could not lengthen
+     * the enrollment window, and an operator whose nodes advertise a
+     * richer capability vocabulary could not raise the tag caps without
+     * a code change. Defaults are EXACTLY the previous constants, so an
+     * environment that sets nothing behaves byte-for-byte as before.
+     *
+     * Every getter clamps into a documented range rather than trusting
+     * the env: `capabilities` is a stored JSON column and a lease-time
+     * filter input, so an unbounded knob would be a denial-of-service
+     * surface, and a zero/NaN TTL would expire every token instantly.
+     */
+    fleet: {
+        /**
+         * How long a one-time enrollment token stays redeemable.
+         * Default 15 minutes (`FLEET_ENROLLMENT_TOKEN_TTL_MS`), floored
+         * at 30s so a token can always actually be typed in.
+         */
+        getEnrollmentTokenTtlMs(): number {
+            return clampedIntEnv(
+                process.env.FLEET_ENROLLMENT_TOKEN_TTL_MS,
+                FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS,
+                FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS,
+                Number.MAX_SAFE_INTEGER,
+            );
+        },
+        /**
+         * Silence after which an `online` node is swept to `offline` by
+         * the next owner-scoped list read. Default 5 minutes.
+         *
+         * Shortening this below a node's heartbeat cadence makes healthy
+         * nodes flap; the 30s floor stops the value becoming nonsense,
+         * it does not stop it becoming unwise.
+         */
+        getNodeOfflineAfterMs(): number {
+            return clampedIntEnv(
+                process.env.FLEET_NODE_OFFLINE_AFTER_MS,
+                FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
+                FLEET_MIN_NODE_OFFLINE_AFTER_MS,
+                Number.MAX_SAFE_INTEGER,
+            );
+        },
+        /** Max capability tags one node may advertise. Default 16, hard ceiling 64. */
+        getMaxCapabilityTags(): number {
+            return clampedIntEnv(
+                process.env.FLEET_MAX_CAPABILITY_TAGS,
+                FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
+                1,
+                FLEET_MAX_CAPABILITY_TAGS_CEILING,
+            );
+        },
+        /** Max length of one capability tag. Default 32, hard ceiling 128. */
+        getMaxCapabilityTagLength(): number {
+            return clampedIntEnv(
+                process.env.FLEET_MAX_CAPABILITY_TAG_LENGTH,
+                FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
+                1,
+                FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING,
+            );
         },
     },
 

--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import type { FleetNodeKind, FleetNodeStatus } from '@ever-works/contracts';
 import { PortableDateColumn } from './_types';
 
 /**
@@ -38,11 +39,15 @@ import { PortableDateColumn } from './_types';
  * entity throws EntityMetadataNotFoundError on first query.
  */
 
-/** App shape of the node ('k8s' is list-time only — never persisted). */
-export type FleetNodeKind = 'desktop-node' | 'node' | 'k8s';
-
-/** Heartbeat-derived lifecycle state. */
-export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
+/**
+ * The kind/status unions are the SHARED contract's
+ * (`@ever-works/contracts`), re-exported here so the entity, the API
+ * edge, the web tier and the node apps cannot drift: adding a status
+ * server-side is a compile error everywhere that switches on it.
+ *
+ * `k8s` is list-time only — never persisted as a row.
+ */
+export type { FleetNodeKind, FleetNodeStatus } from '@ever-works/contracts';
 
 @Entity({ name: 'fleet_nodes' })
 @Index('idx_fleet_nodes_user', ['userId'])

--- a/packages/agent/src/fleet/fleet.service.ts
+++ b/packages/agent/src/fleet/fleet.service.ts
@@ -7,7 +7,19 @@ import {
     Optional,
 } from '@nestjs/common';
 import type { IPlugin } from '@ever-works/plugin';
-import type { FleetNodeLoadView } from '@ever-works/contracts';
+import {
+    FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS,
+    FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
+    FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
+    FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
+    FLEET_ENROLLABLE_NODE_KINDS,
+    FLEET_MAX_NODE_NAME_LENGTH,
+    FLEET_MAX_PLATFORM_LENGTH,
+    FLEET_MAX_VERSION_LENGTH,
+    FLEET_MIN_NODE_NAME_LENGTH,
+} from '@ever-works/contracts';
+import type { FleetNodeView } from '@ever-works/contracts';
+import { config } from '../config';
 import { FleetNode, FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
@@ -20,18 +32,35 @@ import {
     UUID_RE,
 } from './fleet-node-credential';
 
-/** One-time enrollment tokens expire 15 minutes after issue. */
-export const FLEET_ENROLLMENT_TOKEN_TTL_MS = 15 * 60_000;
+/**
+ * Fleet limits are OPERATOR KNOBS, read through `config.fleet.*` on
+ * every use so an env change lands without a restart-shaped code change
+ * (and so tests can drive both branches). The constants below are the
+ * DEFAULTS those getters fall back to — the same values these used to
+ * be hard-coded at — and they stay exported because the node apps and
+ * the specs legitimately need the default, not the live setting.
+ */
 
-/** An `online` node with no heartbeat for this long sweeps to `offline`. */
-export const FLEET_NODE_OFFLINE_AFTER_MS = 5 * 60_000;
+/** Default one-time enrollment-token lifetime (15 minutes). */
+export const FLEET_ENROLLMENT_TOKEN_TTL_MS = FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS;
+
+/** Default silence after which an `online` node sweeps to `offline` (5 minutes). */
+export const FLEET_NODE_OFFLINE_AFTER_MS = FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS;
 
 /** Kinds a machine can enroll as ('k8s' is list-time only, never a row). */
-export const FLEET_ENROLLABLE_KINDS: readonly FleetNodeKind[] = ['desktop-node', 'node'];
+export const FLEET_ENROLLABLE_KINDS: readonly FleetNodeKind[] = FLEET_ENROLLABLE_NODE_KINDS;
 
-/** Caps on the node self-description (defensive, DTOs cap the edge too). */
-export const FLEET_MAX_CAPABILITY_TAGS = 16;
-export const FLEET_MAX_CAPABILITY_TAG_LENGTH = 32;
+/** Default caps on the node self-description (defensive, DTOs cap the edge too). */
+export const FLEET_MAX_CAPABILITY_TAGS = FLEET_DEFAULT_MAX_CAPABILITY_TAGS;
+export const FLEET_MAX_CAPABILITY_TAG_LENGTH = FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH;
+
+/**
+ * The wire view of one fleet node now lives in `@ever-works/contracts`
+ * so the API, the web tier and the node apps compile against ONE
+ * declaration. Re-exported here because `@ever-works/agent/fleet` is
+ * where every server-side consumer already imports it from.
+ */
+export type { FleetNodeView };
 
 /**
  * Sentinel `DeployFacadeService.getTokenFromSettings` returns for
@@ -42,31 +71,6 @@ export const FLEET_MAX_CAPABILITY_TAG_LENGTH = 32;
  * excludes every platform-managed cluster.
  */
 const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';
-
-/** Wire/view shape of one fleet node (never carries credential hashes). */
-export interface FleetNodeView {
-    id: string;
-    name: string;
-    kind: FleetNodeKind;
-    status: FleetNodeStatus;
-    platform: string | null;
-    version: string | null;
-    capabilities: string[];
-    lastHeartbeatAt: string | null;
-    createdAt: string | null;
-    /**
-     * True for enrolled rows; false for nodes of the user's own
-     * configured clusters, which are surfaced live and never stored.
-     */
-    persisted: boolean;
-    /**
-     * Live execution load (Desktop PRD §4.1 "current load (running
-     * Tasks)"). Populated by the API edge from `FleetJobService`;
-     * `null`/absent means idle. Cluster-sourced rows never carry it —
-     * the platform does not lease work onto them.
-     */
-    load?: FleetNodeLoadView | null;
-}
 
 export interface CreateEnrollmentTokenInput {
     name: string;
@@ -140,8 +144,10 @@ export class FleetService {
         input: CreateEnrollmentTokenInput,
     ): Promise<CreateEnrollmentTokenResult> {
         const name = typeof input.name === 'string' ? input.name.trim() : '';
-        if (name.length < 1 || name.length > 200) {
-            throw new BadRequestException('Node name must be 1-200 characters');
+        if (name.length < FLEET_MIN_NODE_NAME_LENGTH || name.length > FLEET_MAX_NODE_NAME_LENGTH) {
+            throw new BadRequestException(
+                `Node name must be ${FLEET_MIN_NODE_NAME_LENGTH}-${FLEET_MAX_NODE_NAME_LENGTH} characters`,
+            );
         }
         if (!FLEET_ENROLLABLE_KINDS.includes(input.kind)) {
             throw new BadRequestException(
@@ -163,7 +169,7 @@ export class FleetService {
         return {
             node: this.toView(node),
             token,
-            expiresInSec: Math.floor(FLEET_ENROLLMENT_TOKEN_TTL_MS / 1000),
+            expiresInSec: Math.floor(config.fleet.getEnrollmentTokenTtlMs() / 1000),
         };
     }
 
@@ -194,7 +200,10 @@ export class FleetService {
             return null;
         }
         const issuedAt = node.createdAt instanceof Date ? node.createdAt.getTime() : NaN;
-        if (!Number.isFinite(issuedAt) || Date.now() - issuedAt > FLEET_ENROLLMENT_TOKEN_TTL_MS) {
+        if (
+            !Number.isFinite(issuedAt) ||
+            Date.now() - issuedAt > config.fleet.getEnrollmentTokenTtlMs()
+        ) {
             return null;
         }
 
@@ -204,8 +213,8 @@ export class FleetService {
             enrollmentTokenHash: sha256Hex(secret),
             status: 'online' as FleetNodeStatus,
             lastHeartbeatAt: now,
-            platform: sanitizeText(input.platform, 64),
-            version: sanitizeText(input.version, 32),
+            platform: sanitizeText(input.platform, FLEET_MAX_PLATFORM_LENGTH),
+            version: sanitizeText(input.version, FLEET_MAX_VERSION_LENGTH),
             capabilities: sanitizeCapabilities(input.capabilities),
         };
         // CAS: single-use by construction — a raced duplicate enroll
@@ -260,9 +269,9 @@ export class FleetService {
         if (refresh.capabilities !== undefined) {
             patch.capabilities = sanitizeCapabilities(refresh.capabilities);
         }
-        const platform = sanitizeText(refresh.platform, 64);
+        const platform = sanitizeText(refresh.platform, FLEET_MAX_PLATFORM_LENGTH);
         if (platform) patch.platform = platform;
-        const version = sanitizeText(refresh.version, 32);
+        const version = sanitizeText(refresh.version, FLEET_MAX_VERSION_LENGTH);
         if (version) patch.version = version;
 
         await this.repository.update(node.id, patch);
@@ -278,7 +287,7 @@ export class FleetService {
     async listForUser(userId: string): Promise<FleetNodeView[]> {
         await this.repository.sweepOffline(
             userId,
-            new Date(Date.now() - FLEET_NODE_OFFLINE_AFTER_MS),
+            new Date(Date.now() - config.fleet.getNodeOfflineAfterMs()),
         );
         const rows = await this.repository.findByUser(userId);
         const clusterNodes = await this.listOwnClusterNodes(userId);
@@ -288,8 +297,13 @@ export class FleetService {
     /** Rename an enrolled node (owner-scoped, no existence leak). */
     async renameForUser(userId: string, nodeId: string, name: string): Promise<FleetNodeView> {
         const trimmed = typeof name === 'string' ? name.trim() : '';
-        if (trimmed.length < 1 || trimmed.length > 200) {
-            throw new BadRequestException('Node name must be 1-200 characters');
+        if (
+            trimmed.length < FLEET_MIN_NODE_NAME_LENGTH ||
+            trimmed.length > FLEET_MAX_NODE_NAME_LENGTH
+        ) {
+            throw new BadRequestException(
+                `Node name must be ${FLEET_MIN_NODE_NAME_LENGTH}-${FLEET_MAX_NODE_NAME_LENGTH} characters`,
+            );
         }
         const node = await this.getOwnedNode(userId, nodeId);
         await this.repository.update(node.id, { name: trimmed });
@@ -392,8 +406,8 @@ export class FleetService {
             name,
             kind: 'k8s',
             status: node.ready ? 'online' : 'offline',
-            platform: sanitizeText(node.platform, 64),
-            version: sanitizeText(node.version, 32),
+            platform: sanitizeText(node.platform, FLEET_MAX_PLATFORM_LENGTH),
+            version: sanitizeText(node.version, FLEET_MAX_VERSION_LENGTH),
             capabilities: sanitizeCapabilities(node.roles),
             lastHeartbeatAt: null,
             createdAt: null,
@@ -425,15 +439,22 @@ function sanitizeText(value: unknown, maxLength: number): string | null {
     return trimmed.slice(0, maxLength);
 }
 
+/**
+ * Truncate + dedupe capability tags to the CONFIGURED caps. Read per
+ * call rather than captured at module load so an operator override is
+ * honoured by the running process and both branches are testable.
+ */
 function sanitizeCapabilities(value: unknown): string[] {
     if (!Array.isArray(value)) return [];
+    const maxTags = config.fleet.getMaxCapabilityTags();
+    const maxTagLength = config.fleet.getMaxCapabilityTagLength();
     const out: string[] = [];
     for (const entry of value) {
         if (typeof entry !== 'string') continue;
-        const tag = entry.trim().slice(0, FLEET_MAX_CAPABILITY_TAG_LENGTH);
+        const tag = entry.trim().slice(0, maxTagLength);
         if (!tag || out.includes(tag)) continue;
         out.push(tag);
-        if (out.length >= FLEET_MAX_CAPABILITY_TAGS) break;
+        if (out.length >= maxTags) break;
     }
     return out;
 }

--- a/packages/contracts/src/api/onboarding/index.ts
+++ b/packages/contracts/src/api/onboarding/index.ts
@@ -45,3 +45,12 @@ export type {
 	OnboardingTeamSizeId
 } from './wizard-state.js';
 export { ONBOARDING_DEFAULT_STATE, ROLE_OPTIONS, TEAM_SIZE_OPTIONS } from './wizard-state.js';
+export type {
+	OnboardingSeedAgentSuggestion,
+	OnboardingSeedSkillSuggestion,
+	OnboardingSeedSuggestionsResponse,
+	OnboardingSeedRequest,
+	OnboardingSeedOutcome,
+	OnboardingSeedResultEntry,
+	OnboardingSeedResponse
+} from './role-seeding.js';

--- a/packages/contracts/src/api/onboarding/role-seeding.ts
+++ b/packages/contracts/src/api/onboarding/role-seeding.ts
@@ -1,0 +1,106 @@
+/**
+ * Role-driven starter seeding for the onboarding "What do you do" step.
+ *
+ * The first cut of this feature resolved suggestions IN THE BROWSER: the
+ * step fetched the whole prebuilt-agent catalog and intersected
+ * `suggestedRoles` client-side. Three things were wrong with that.
+ *
+ *  1. Coverage was accidental. Only the roles that happened to appear in
+ *     a go-to-market template's `suggestedRoles` produced anything —
+ *     3 of the 14 roles the step actually offers. The other 11 selected
+ *     a role and were shown nothing, which reads as "we have nothing
+ *     for you" rather than "nobody wrote the mapping".
+ *  2. It was Agents-only. A role implies a starting KIT — the agents to
+ *     activate AND the skills that make them useful — and the skills
+ *     half simply did not exist.
+ *  3. The mapping lived in the client bundle, so every non-web surface
+ *     (desktop shell, chat, API consumers) had no way to ask "what
+ *     should a Marketing person start with?".
+ *
+ * The mapping is therefore server-side (`@ever-works/agent/agents`,
+ * `role-seeding.ts`), exposed over `/api/onboarding/suggestions`, and
+ * pinned by a spec that fails if ANY role in `ROLE_OPTIONS` is missing.
+ * These are the wire shapes for that surface.
+ */
+
+/** One prebuilt Agent template offered for the selected roles. */
+export interface OnboardingSeedAgentSuggestion {
+	/** Template slug — the id `POST /api/agents/from-template/:slug` takes. */
+	readonly slug: string;
+	readonly name: string;
+	readonly title: string;
+	readonly description: string;
+	/** Template category, e.g. `marketing` / `sales` / `ops`. */
+	readonly category: string;
+	/** Role ids (from `ROLE_OPTIONS`) that caused this template to surface. */
+	readonly matchedRoles: readonly string[];
+}
+
+/** One first-party Skill offered for the selected roles. */
+export interface OnboardingSeedSkillSuggestion {
+	/** Skill catalog slug. */
+	readonly slug: string;
+	readonly title: string;
+	readonly description: string;
+	/** Go-to-market stage the Skill powers. */
+	readonly stage: string;
+	/** Role ids (from `ROLE_OPTIONS`) that caused this Skill to surface. */
+	readonly matchedRoles: readonly string[];
+}
+
+/**
+ * Wire shape of `GET /api/onboarding/suggestions`.
+ *
+ * `roles` echoes the RECOGNISED subset of the request (unknown ids are
+ * dropped, never defaulted, matching how the wizard state validates its
+ * own `profile.roles`). An empty `roles` yields empty suggestion lists
+ * rather than a "here is everything" dump.
+ */
+export interface OnboardingSeedSuggestionsResponse {
+	readonly roles: readonly string[];
+	/** Ids that were sent but are not in `ROLE_OPTIONS` — echoed so the caller can notice a typo. */
+	readonly unknownRoles: readonly string[];
+	readonly agents: readonly OnboardingSeedAgentSuggestion[];
+	readonly skills: readonly OnboardingSeedSkillSuggestion[];
+}
+
+/**
+ * Request body of `POST /api/onboarding/suggestions/seed`.
+ *
+ * `roles` is optional: omitted, the server uses the roles already saved
+ * on the caller's onboarding state, so the client never has to be the
+ * authority on what the user picked.
+ */
+export interface OnboardingSeedRequest {
+	readonly roles?: readonly string[];
+}
+
+/** Per-template outcome of a seeding run. */
+export type OnboardingSeedOutcome = 'created' | 'already-exists' | 'failed';
+
+export interface OnboardingSeedResultEntry {
+	readonly slug: string;
+	readonly outcome: OnboardingSeedOutcome;
+	/** Id of the Agent created by THIS run; null for every other outcome. */
+	readonly agentId: string | null;
+	/** Short, non-sensitive reason — present only for `failed`. */
+	readonly reason?: string;
+}
+
+/**
+ * Wire shape of `POST /api/onboarding/suggestions/seed`.
+ *
+ * Seeding is idempotent and best-effort per template: a template that
+ * is already activated reports `already-exists` instead of failing the
+ * whole call, so re-running the step never produces duplicates and a
+ * single bad template never blocks the rest of the kit.
+ */
+export interface OnboardingSeedResponse {
+	readonly roles: readonly string[];
+	readonly agents: readonly OnboardingSeedResultEntry[];
+	/** Skills recommended alongside the seeded agents (informational). */
+	readonly skills: readonly OnboardingSeedSkillSuggestion[];
+	readonly createdCount: number;
+	readonly skippedCount: number;
+	readonly failedCount: number;
+}

--- a/packages/contracts/src/fleet/fleet-node.types.ts
+++ b/packages/contracts/src/fleet/fleet-node.types.ts
@@ -1,0 +1,188 @@
+/**
+ * Fleet node registry — the enroll / heartbeat wire contract shared by
+ * the platform API and every node app.
+ *
+ * Before this file the node apps carried a hand-written MIRROR of these
+ * shapes (`apps/node/src/core/types.ts`) with a comment asking future
+ * readers not to let it drift. That is not a contract, it is a promise:
+ * a field renamed server-side stayed green on both sides and only broke
+ * at runtime, against a machine nobody was watching. Putting the shapes
+ * here — in the zero-dependency package both tiers already depend on —
+ * makes a contract change a COMPILE error on both sides, which is the
+ * whole point.
+ *
+ * What lives here: wire shapes and protocol-level bounds. What does NOT:
+ * the server's operator-tunable limits (enrollment-token TTL, offline
+ * sweep window, capability-tag caps). Those are read from the platform
+ * config module (`config.fleet.*` in `@ever-works/agent/config`); the
+ * `FLEET_DEFAULT_*` constants below are the DEFAULTS those getters fall
+ * back to, and the values a node assumes when it cannot ask the server.
+ *
+ * ## Protocol
+ *
+ * ```
+ *   POST /api/fleet/enroll      one-time token  → { nodeId, secret, node }
+ *   POST /api/fleet/heartbeat   nodeId + secret → { ok, node }
+ * ```
+ *
+ * Both endpoints are public and self-authenticating: the credential IS
+ * the body. Every invalid path answers with one undifferentiated 401.
+ */
+
+import type { FleetNodeLoadView } from './fleet-jobs.types.js';
+
+/**
+ * App shape of a fleet node.
+ *
+ * `k8s` is list-time only — nodes of a user's OWN configured cluster are
+ * merged into list responses live and never persisted as rows, so a
+ * machine can never enroll as one (see {@link FleetEnrollableNodeKind}).
+ */
+export type FleetNodeKind = 'desktop-node' | 'node' | 'k8s';
+
+/** Canonical kind list — one source of truth for validators and UI. */
+export const FLEET_NODE_KINDS: readonly FleetNodeKind[] = ['desktop-node', 'node', 'k8s'];
+
+/** The kinds a machine can actually enroll as. */
+export type FleetEnrollableNodeKind = Exclude<FleetNodeKind, 'k8s'>;
+
+/** Canonical enrollable-kind list (server: `FLEET_ENROLLABLE_KINDS`). */
+export const FLEET_ENROLLABLE_NODE_KINDS: readonly FleetEnrollableNodeKind[] = ['desktop-node', 'node'];
+
+/** Type guard for an enrollable kind arriving off the wire or a config file. */
+export function isFleetEnrollableNodeKind(value: unknown): value is FleetEnrollableNodeKind {
+	return typeof value === 'string' && (FLEET_ENROLLABLE_NODE_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Heartbeat-derived lifecycle state.
+ *
+ * - `enrolling` — row exists, its one-time token has not been consumed.
+ * - `online`    — a heartbeat was accepted inside the offline window.
+ * - `offline`   — no heartbeat for the configured window, or drained.
+ * - `disabled`  — operator-drained; heartbeats are refused.
+ */
+export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
+
+/** Canonical status list. */
+export const FLEET_NODE_STATUSES: readonly FleetNodeStatus[] = ['enrolling', 'online', 'offline', 'disabled'];
+
+/**
+ * Self-description a node sends on enroll and refreshes on every
+ * heartbeat. Every field is optional: a node that reports nothing is
+ * still a valid node, just an undescribed one.
+ */
+export interface FleetNodeSelfDescription {
+	/** `os/arch`, e.g. `linux/x64`. Capped at {@link FLEET_MAX_PLATFORM_LENGTH}. */
+	platform?: string;
+	/** Node app version. Capped at {@link FLEET_MAX_VERSION_LENGTH}. */
+	version?: string;
+	/** Scheduling capability tags, e.g. `['terminal', 'workspace', 'docker']`. */
+	capabilities?: string[];
+}
+
+/** Wire view of one fleet node — never carries credentials or hashes. */
+export interface FleetNodeView {
+	id: string;
+	name: string;
+	kind: FleetNodeKind;
+	status: FleetNodeStatus;
+	platform: string | null;
+	version: string | null;
+	capabilities: string[];
+	lastHeartbeatAt: string | null;
+	createdAt: string | null;
+	/**
+	 * True for enrolled rows; false for nodes of the user's own
+	 * configured clusters, which are surfaced live and never stored.
+	 */
+	persisted: boolean;
+	/**
+	 * Live execution load. Populated by the API edge from the job
+	 * service; `null`/absent means idle. Cluster-sourced rows never
+	 * carry it — the platform does not lease work onto them.
+	 */
+	load?: FleetNodeLoadView | null;
+}
+
+/** Request body for `POST /api/fleet/enroll`. */
+export interface FleetEnrollRequest extends FleetNodeSelfDescription {
+	/** One-time enrollment token, single-use and short-lived. */
+	token: string;
+}
+
+/** Response body for `POST /api/fleet/enroll`. */
+export interface FleetEnrollResponse {
+	nodeId: string;
+	/** Heartbeat secret, returned exactly once — only its sha256 is stored. */
+	secret: string;
+	node: FleetNodeView;
+}
+
+/** Request body for `POST /api/fleet/heartbeat`. */
+export interface FleetHeartbeatRequest extends FleetNodeSelfDescription {
+	nodeId: string;
+	secret: string;
+}
+
+/** Response body for `POST /api/fleet/heartbeat`. */
+export interface FleetHeartbeatResponse {
+	ok: true;
+	node: FleetNodeView;
+}
+
+// ─── Protocol bounds (fixed) ────────────────────────────────────────────────
+
+/** `sanitizeText(platform, 64)` server-side; the node truncates to match. */
+export const FLEET_MAX_PLATFORM_LENGTH = 64;
+
+/** `sanitizeText(version, 32)` server-side; the node truncates to match. */
+export const FLEET_MAX_VERSION_LENGTH = 32;
+
+/** Node display-name bounds, enforced by the DTO and re-checked in the service. */
+export const FLEET_MIN_NODE_NAME_LENGTH = 1;
+export const FLEET_MAX_NODE_NAME_LENGTH = 200;
+
+/**
+ * Credential length window shared by enrollment tokens and node
+ * secrets. Both are 32 random bytes base64url-encoded (43 chars); the
+ * window exists so an obviously malformed credential is refused before
+ * any database round-trip, and with the same answer as a wrong one.
+ */
+export const FLEET_CREDENTIAL_MIN_LENGTH = 16;
+export const FLEET_CREDENTIAL_MAX_LENGTH = 256;
+
+// ─── Operator-tunable limits: DEFAULTS ──────────────────────────────────────
+
+/** Default one-time enrollment-token lifetime (15 minutes). */
+export const FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS = 15 * 60_000;
+
+/** Default silence after which an `online` node sweeps to `offline` (5 minutes). */
+export const FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS = 5 * 60_000;
+
+/** Default cap on how many capability tags one node may advertise. */
+export const FLEET_DEFAULT_MAX_CAPABILITY_TAGS = 16;
+
+/** Default cap on the length of a single capability tag. */
+export const FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH = 32;
+
+/**
+ * Hard ceilings an operator override may not exceed.
+ *
+ * The limits above are knobs, not opinions — but an unbounded knob is a
+ * denial-of-service surface (`capabilities` is a stored JSON column and
+ * a lease-time filter input). These ceilings bound what any env value
+ * can widen the edge to; the service clamps into them.
+ */
+export const FLEET_MAX_CAPABILITY_TAGS_CEILING = 64;
+export const FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING = 128;
+
+/** Floor for the enrollment-token TTL — a zero-TTL token cannot be redeemed. */
+export const FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS = 30_000;
+
+/**
+ * Floor for the offline sweep window. Below the node's own minimum
+ * heartbeat cadence every healthy node would flap to `offline` between
+ * beats, so the window can be shortened but not to nonsense.
+ */
+export const FLEET_MIN_NODE_OFFLINE_AFTER_MS = 30_000;

--- a/packages/contracts/src/fleet/index.ts
+++ b/packages/contracts/src/fleet/index.ts
@@ -1,1 +1,2 @@
 export * from './fleet-jobs.types.js';
+export * from './fleet-node.types.js';


### PR DESCRIPTION
## The problem

Fleet limits were magic numbers **duplicated** between the API and `apps/node`,
and the capability-tag caps were not enforced at the DTO boundary at all — an
enrollment could advertise unbounded tags.

## What changed

- Shared constants moved into `@ever-works/contracts`: enrollment-token TTL,
  offline-after window, capability-tag count and length ceilings. The API and
  the node now read **one** definition.
- A `config.fleet` group that **clamps** each env override between a documented
  floor and ceiling rather than trusting the value.
- The caps enforced where the request enters, on the enrollment DTO.

### Why custom validators rather than `@ArrayMaxSize(n)`

The limit is read from config **at validation time**. A decorator argument
would freeze whatever the value was at class-definition time, so an operator's
env override would silently not apply. `@MaxConfiguredCapabilityTags()` and
`@MaxConfiguredCapabilityTagLength({ each: true })` are `ValidatorConstraint`s
that read `config.fleet.*` on each call.

Applied at `apps/api/src/fleet/dto/fleet.dto.ts:97-99`.

## Onboarding role seeding

The profile step's roles now drive real agent suggestions through
`OnboardingRoleSeedingService` (provided and exported by `agents.module.ts`,
consumed by a dedicated suggestions controller registered in
`onboarding.module.ts`) instead of being collected and discarded.

## Pin spec

The branch added a `fleet` config group **without** updating `config.spec`'s
group pin — the gate caught it, and it is fixed in this change. Pinned
alphabetically, before `fleetNode`.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 448 suites, 8233 tests |
| `apps/api` jest | green — 233 suites, 3816 tests |
| `apps/node` vitest | green — 10 files |
| `apps/web` tsc --noEmit | green |
| prettier | clean |