### PR TITLE
feat(fleet): add the admin surface — detail, rotate, drain, tokens, handoff

### DIFF
--- a/apps/api/src/fleet/decorators/fleet-node.decorator.ts
+++ b/apps/api/src/fleet/decorators/fleet-node.decorator.ts
@@ -1,0 +1,17 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { AuthenticatedFleetNode, FleetNodeRequest } from '../guards/fleet-node-auth.guard';
+
+/**
+ * The node authenticated by `FleetNodeAuthGuard`, mirroring
+ * `@CurrentUser()` on the session side.
+ *
+ * Handlers must scope node-channel reads by THIS value, never by an id
+ * taken from the request body: the body is attacker-controlled, this is
+ * the credential's own resolved identity. That distinction is the whole
+ * reason a node token cannot authorise a cross-owner read.
+ */
+export const CurrentFleetNode = createParamDecorator(
+    (data: unknown, ctx: ExecutionContext): AuthenticatedFleetNode | undefined => {
+        return ctx.switchToHttp().getRequest<FleetNodeRequest>().fleetNode;
+    },
+);

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -75,6 +75,47 @@ export class UpdateFleetNodeDto {
     @IsOptional()
     @IsBoolean()
     disabled?: boolean;
+
+    @ApiProperty({
+        required: false,
+        type: [String],
+        description:
+            "Admin-edited capability tags, e.g. ['terminal', 'workspace']. Writing them PINS the set so the node's heartbeats stop overwriting it; send capabilitiesPinned:false in the same call to hand ownership back to the node.",
+    })
+    @IsOptional()
+    @IsArray()
+    // The SAME configurable caps the enroll DTO uses. Hardcoding 16/32
+    // here would let an operator who raised FLEET_MAX_CAPABILITY_TAGS
+    // enroll a node with more tags than they could subsequently edit.
+    @MaxConfiguredCapabilityTags()
+    @IsString({ each: true })
+    @MaxConfiguredCapabilityTagLength({ each: true })
+    capabilities?: string[];
+
+    @ApiProperty({
+        required: false,
+        description:
+            'Whether the admin-edited tag set is authoritative. Only meaningful alongside `capabilities`; defaults to true.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    capabilitiesPinned?: boolean;
+}
+
+/**
+ * Request body for `POST /api/fleet/nodes/:id/drain`.
+ *
+ * Explicit boolean rather than two verbs: draining and undraining are
+ * one idempotent control, and an operator retrying a drain must not
+ * accidentally toggle a node back into service.
+ */
+export class DrainFleetNodeDto {
+    @ApiProperty({
+        description:
+            'true drains the node (disables it AND requeues its in-flight claims); false returns it to service as offline until its next heartbeat.',
+    })
+    @IsBoolean()
+    drain: boolean;
 }
 
 /** Node self-description shared by enroll + heartbeat refresh. */

--- a/apps/api/src/fleet/fleet-admin.types.ts
+++ b/apps/api/src/fleet/fleet-admin.types.ts
@@ -1,0 +1,16 @@
+/**
+ * Wire shapes for the Fleet ADMIN endpoints — the reads and controls
+ * that were missing from the original thin surface (node detail with
+ * failure history, credential rotation, drain).
+ *
+ * They are DECLARED in `@ever-works/contracts` and re-exported here.
+ * The web tier renders these same shapes, and this file previously
+ * declared its own copy — which is the drift that turned `FleetNodeView`
+ * into three hand-written mirrors before it was consolidated. One
+ * declaration, two importers.
+ */
+export type {
+    FleetNodeDetailView,
+    FleetNodeDrainResult,
+    FleetEnrollmentTokenView,
+} from '@ever-works/contracts';

--- a/apps/api/src/fleet/fleet-jobs.controller.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.ts
@@ -7,6 +7,7 @@ import {
     ParseUUIDPipe,
     Post,
     UnauthorizedException,
+    UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
@@ -18,6 +19,8 @@ import type {
 import { FleetJobService } from '@ever-works/agent/fleet';
 import { Public } from '../auth/decorators/public.decorator';
 import { CompleteFleetJobDto, FleetJobHeartbeatDto, LeaseFleetJobsDto } from './dto/fleet-job.dto';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
 
 /**
  * Fleet job lease protocol (Desktop PRD §6.2 / M4) — the endpoints an
@@ -44,9 +47,18 @@ import { CompleteFleetJobDto, FleetJobHeartbeatDto, LeaseFleetJobsDto } from './
  * management (owner-scoped, session-authenticated) and the work channel
  * (node-authenticated, public) are two different trust boundaries and
  * should not share a class.
+ *
+ * **Guards.** `FleetEnabledGuard` gates the whole surface on
+ * `FLEET_ENABLED` (404 when off — a disabled deployment does not admit
+ * the channel exists). `FleetNodeAuthGuard` then authenticates the node
+ * credential BEFORE any handler runs, so the trust boundary is
+ * declarative at the edge instead of implicit inside each service call.
+ * The service still re-verifies: the guard is the edge contract, the
+ * service is the invariant, and neither is allowed to be the only check.
  */
 @ApiTags('fleet')
 @Controller('api/fleet/jobs')
+@UseGuards(FleetEnabledGuard, FleetNodeAuthGuard)
 export class FleetJobsController {
     constructor(private readonly service: FleetJobService) {}
 

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -11,10 +11,14 @@ import {
     Patch,
     Post,
     UnauthorizedException,
+    UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import type { CreateEnrollmentTokenResult } from '@ever-works/agent/fleet';
+import type {
+    CreateEnrollmentTokenResult,
+    FleetEnrollmentTokenView,
+} from '@ever-works/agent/fleet';
 import { FleetJobService, FleetService } from '@ever-works/agent/fleet';
 import type {
     FleetEnrollResponse,
@@ -24,12 +28,18 @@ import type {
 import { Public } from '../auth/decorators/public.decorator';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import type { FleetNodeDetailView, FleetNodeDrainResult } from './fleet-admin.types';
 import {
     CreateFleetEnrollmentTokenDto,
+    DrainFleetNodeDto,
     EnrollFleetNodeDto,
     FleetHeartbeatDto,
     UpdateFleetNodeDto,
 } from './dto/fleet.dto';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+
+/** How much of a node's job history the detail drawer reads. */
+const NODE_HISTORY_LIMIT = 25;
 
 /**
  * Fleet (Wave 12, slice 1) — thin HTTP surface over the agent-side
@@ -38,18 +48,39 @@ import {
  * Owner-scoped (session/API-key auth via the global guard):
  *   GET    /api/fleet/nodes                   list mine (incl. live
  *                                             own-cluster nodes)
+ *   GET    /api/fleet/nodes/:id               node detail + job/failure
+ *                                             history
  *   POST   /api/fleet/nodes/enrollment-token  issue one-time token
- *   PATCH  /api/fleet/nodes/:id               rename / disable / enable
+ *   PATCH  /api/fleet/nodes/:id               rename / disable / enable /
+ *                                             edit capability tags
+ *   POST   /api/fleet/nodes/:id/rotate        re-key: new one-time token,
+ *                                             old secret dies immediately
+ *   POST   /api/fleet/nodes/:id/drain         drain: disable AND requeue
+ *                                             the node's in-flight claims
  *   DELETE /api/fleet/nodes/:id               remove registration
+ *   GET    /api/fleet/enrollment-tokens       outstanding (unused) tokens
+ *   DELETE /api/fleet/enrollment-tokens/:id   revoke one BEFORE it is used
  *
  * Public, self-authenticating (called by the node apps — throttled,
  * fail-closed: any invalid credential path is one undifferentiated
  * 401, mirroring the terminal internal endpoints' posture):
  *   POST   /api/fleet/enroll                  consume token → secret
  *   POST   /api/fleet/heartbeat               node secret → last-seen
+ *
+ * **Scoping.** EVERY owner-scoped route resolves its target through
+ * `FleetService`'s owner-scoped lookups, which answer 404 for another
+ * account's node id — indistinguishable from one that does not exist.
+ * No route accepts an owner/organization id from the caller; the scope
+ * comes from the session. That is what stops a node id (a value that
+ * travels: it is printed in UIs, logs and job payloads) from being a
+ * cross-account read primitive.
+ *
+ * `FleetEnabledGuard` gates the class on `FLEET_ENABLED`, so the
+ * registry and the node work channel go dark together.
  */
 @ApiTags('fleet')
 @Controller('api/fleet')
+@UseGuards(FleetEnabledGuard)
 export class FleetController {
     constructor(
         private readonly service: FleetService,
@@ -82,6 +113,99 @@ export class FleetController {
         })) as FleetNodeView[];
     }
 
+    @Get('nodes/:id')
+    @ApiOperation({
+        summary:
+            'One fleet node with its recent job history and the failed subset of it (owner-scoped; another account’s node id answers 404, exactly like an unknown one)',
+    })
+    @HttpCode(HttpStatus.OK)
+    async detail(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<FleetNodeDetailView> {
+        // Ownership is settled FIRST and by the registry: if this throws
+        // 404 nothing else runs, so the job history can never be read
+        // for a node the caller does not own.
+        const node = await this.service.getForUser(auth.userId, id);
+
+        let recentJobs: Awaited<ReturnType<FleetJobService['historyForNode']>> = [];
+        let historyUnavailable = false;
+        try {
+            recentJobs = await this.jobs.historyForNode(auth.userId, id, NODE_HISTORY_LIMIT);
+        } catch {
+            // Same degradation contract as `list`: a job-runtime hiccup
+            // must not make an existing node look missing.
+            historyUnavailable = true;
+        }
+
+        return {
+            node,
+            recentJobs,
+            failures: recentJobs.filter((job) => job.status === 'failed'),
+            historyUnavailable,
+        };
+    }
+
+    @Get('enrollment-tokens')
+    @ApiOperation({
+        summary:
+            'Outstanding (minted but never used) enrollment tokens for my fleet. Lists the token metadata only — the plaintext token was returned exactly once at mint time and is not recoverable.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async listOutstandingTokens(
+        @CurrentUser() auth: AuthenticatedUser,
+    ): Promise<FleetEnrollmentTokenView[]> {
+        return this.service.listOutstandingTokensForUser(auth.userId);
+    }
+
+    @Delete('enrollment-tokens/:id')
+    @ApiOperation({
+        summary:
+            'Revoke an outstanding enrollment token BEFORE it is used. Only unused tokens qualify — for an already-enrolled node use rotate (re-key) or delete (remove the machine).',
+    })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async revokeEnrollmentToken(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<void> {
+        await this.service.revokeEnrollmentTokenForUser(auth.userId, id);
+    }
+
+    @Post('nodes/:id/rotate')
+    @ApiOperation({
+        summary:
+            'Rotate a node credential: mints a fresh one-time enrollment token (returned exactly once) and invalidates the old node secret immediately, so the machine must re-enroll.',
+    })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    async rotate(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<CreateEnrollmentTokenResult> {
+        return this.service.rotateCredentialForUser(auth.userId, id);
+    }
+
+    @Post('nodes/:id/drain')
+    @ApiOperation({
+        summary:
+            'Drain a node: disable it AND return its in-flight claims to the queue so the work is picked up elsewhere immediately instead of waiting out each lease. `drain: false` returns it to service.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async drain(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: DrainFleetNodeDto,
+    ): Promise<FleetNodeDrainResult> {
+        // Order matters: disable FIRST. The node stops being able to
+        // lease the instant its status flips, so a claim requeued after
+        // that cannot be re-claimed by the machine being drained.
+        const node = await this.service.setDisabledForUser(auth.userId, id, body.drain);
+        const releasedJobs = body.drain ? await this.jobs.releaseClaimsForNode(auth.userId, id) : 0;
+        return { node, releasedJobs };
+    }
+
     @Post('nodes/enrollment-token')
     @ApiOperation({
         summary:
@@ -97,7 +221,9 @@ export class FleetController {
     }
 
     @Patch('nodes/:id')
-    @ApiOperation({ summary: 'Rename and/or disable/enable a fleet node' })
+    @ApiOperation({
+        summary: 'Rename, disable/enable, and/or hand-edit the capability tags of a fleet node',
+    })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     async update(
@@ -105,12 +231,27 @@ export class FleetController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: UpdateFleetNodeDto,
     ): Promise<FleetNodeView> {
-        if (typeof body.name !== 'string' && typeof body.disabled !== 'boolean') {
-            throw new BadRequestException('Provide name and/or disabled');
+        if (
+            typeof body.name !== 'string' &&
+            typeof body.disabled !== 'boolean' &&
+            !Array.isArray(body.capabilities)
+        ) {
+            throw new BadRequestException('Provide name, disabled and/or capabilities');
         }
         let view: FleetNodeView | null = null;
         if (typeof body.name === 'string') {
             view = await this.service.renameForUser(auth.userId, id, body.name);
+        }
+        if (Array.isArray(body.capabilities)) {
+            // Writing tags pins them by default: an admin edit the
+            // machine silently reverts on its next heartbeat would not
+            // be an edit. `capabilitiesPinned: false` opts back out.
+            view = await this.service.setCapabilitiesForUser(
+                auth.userId,
+                id,
+                body.capabilities,
+                body.capabilitiesPinned ?? true,
+            );
         }
         if (typeof body.disabled === 'boolean') {
             view = await this.service.setDisabledForUser(auth.userId, id, body.disabled);

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -12,6 +12,8 @@ import {
     NODE_JOB_RUNTIME_PLUGIN,
     NODE_JOB_RUNTIME_STORE,
 } from './node-job-runtime.providers';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
 
 /**
  * Fleet (Wave 12, slice 1 + Desktop PRD M4) — thin API module exposing
@@ -34,11 +36,24 @@ import {
  * into an actual `FleetJobService.enqueue`. The `TenantJobRuntimeConfig`
  * feature registration is what lets the router honour a per-tenant
  * overlay row rather than only the instance-global selector.
+ *
+ * Both guards are ordinary providers so Nest can inject them (the node
+ * guard needs `FleetNodeRepository`, which `AgentFleetModule` exports):
+ *   - `FleetEnabledGuard` — the `FLEET_ENABLED` gate on BOTH controllers,
+ *     so the surface cannot end up half-on.
+ *   - `FleetNodeAuthGuard` — node-credential authentication for the work
+ *     channel, at the edge instead of only inside the services.
  */
 @Module({
     imports: [AgentFleetModule, DatabaseModule, TypeOrmModule.forFeature([TenantJobRuntimeConfig])],
     controllers: [FleetController, FleetJobsController],
-    providers: [...buildNodeJobRuntimeProviders(), FleetRunRouterService],
+    providers: [
+        ...buildNodeJobRuntimeProviders(),
+        FleetRunRouterService,
+        // Guards are ordinary providers so Nest can inject them.
+        FleetEnabledGuard,
+        FleetNodeAuthGuard,
+    ],
     exports: [
         AgentFleetModule,
         NODE_JOB_RUNTIME_STORE,

--- a/apps/api/src/fleet/guards/fleet-enabled.guard.ts
+++ b/apps/api/src/fleet/guards/fleet-enabled.guard.ts
@@ -1,0 +1,31 @@
+import { CanActivate, Injectable, NotFoundException } from '@nestjs/common';
+import { config } from '@ever-works/agent/config';
+
+/**
+ * The single gate for the WHOLE Fleet surface (`FLEET_ENABLED`).
+ *
+ * Applied at class level to both fleet controllers, so registry
+ * management, the admin endpoints and the node work channel go dark
+ * together. A half-disabled Fleet — a settings page with no API, or a
+ * lease channel with no registry — would be worse than either state.
+ *
+ * **404, not 403.** A disabled deployment should not confirm that the
+ * surface exists at all: `/api/fleet/**` must look exactly like a route
+ * that was never mounted. 403 would answer "yes, Fleet is here, you just
+ * can't have it", which is a free reconnaissance answer on a public,
+ * node-authenticated channel.
+ *
+ * The flag defaults to ON (`config.fleet.isEnabled()` returns true
+ * unless `FLEET_ENABLED=false`) because Fleet already ships — a
+ * default-off flag would silently remove a working feature from every
+ * existing deployment on upgrade.
+ */
+@Injectable()
+export class FleetEnabledGuard implements CanActivate {
+    canActivate(): boolean {
+        if (!config.fleet.isEnabled()) {
+            throw new NotFoundException('Cannot find route');
+        }
+        return true;
+    }
+}

--- a/apps/api/src/fleet/guards/fleet-node-auth.guard.ts
+++ b/apps/api/src/fleet/guards/fleet-node-auth.guard.ts
@@ -1,0 +1,98 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { FleetNodeRepository, verifyNodeSecret } from '@ever-works/agent/fleet';
+
+/** The ONE message every refused node credential gets, on every route. */
+export const FLEET_NODE_UNAUTHORIZED_MESSAGE = 'Invalid node credential';
+
+/**
+ * The authenticated node, attached to the request by
+ * {@link FleetNodeAuthGuard} and read with `@CurrentFleetNode()`.
+ *
+ * This is the node-channel equivalent of `request.user`: it is what
+ * SCOPES every read the node is allowed to make. Nothing downstream may
+ * take a node/owner id from the request BODY — a node token that could
+ * name its own owner is a cross-org read waiting to happen.
+ */
+export interface AuthenticatedFleetNode {
+    id: string;
+    /** Owner the node executes for — the only scope its token buys. */
+    userId: string;
+    organizationId: string | null;
+    capabilities: string[];
+}
+
+/** Request shape after the guard has run. */
+export interface FleetNodeRequest {
+    body?: { nodeId?: unknown; secret?: unknown };
+    fleetNode?: AuthenticatedFleetNode;
+}
+
+/**
+ * Nest guard for the node work channel (`/api/fleet/jobs/*`).
+ *
+ * Node authentication used to exist only as a bare helper called from
+ * inside each service method. That worked, but it left the trust
+ * boundary invisible at the edge: nothing in the controller said "this
+ * route is node-authenticated", a new endpoint could be added without
+ * it, and the check ran only after routing, validation and the handler
+ * body had already been entered. Expressing it as a guard makes the
+ * boundary declarative and refuses a bad credential before any handler
+ * code runs — the house rule for access control (see the NestJS
+ * "security-use-guards" skill).
+ *
+ * It does NOT replace the service-side verification: `FleetJobService`
+ * still re-verifies every call. Two independent checks on the same fact
+ * is the point — the guard is the edge contract, the service is the
+ * invariant, and a future caller that reaches the service by another
+ * path (chat tool, cron, another controller) is still fail-closed.
+ *
+ * Posture, identical to the rest of Fleet:
+ *   - the credential is `(nodeId, secret)` in the BODY, shape-validated
+ *     and constant-time compared against the stored sha256 via the
+ *     shared `verifyNodeSecret` helper — ONE definition of "verified"
+ *     across enroll / heartbeat / lease;
+ *   - disabled and still-enrolling nodes are refused (a drained node
+ *     stops working the instant it is drained);
+ *   - EVERY invalid path — malformed id, unknown node, drained node,
+ *     wrong secret — throws the SAME 401 with the SAME message, so an
+ *     attacker holding a random uuid cannot enumerate which nodes exist.
+ *
+ * The routes it guards stay `@Public()`: the node secret IS the
+ * credential, and there is no platform session on a node.
+ */
+@Injectable()
+export class FleetNodeAuthGuard implements CanActivate {
+    constructor(private readonly nodes: FleetNodeRepository) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest<FleetNodeRequest>();
+        const body = request.body ?? {};
+
+        const verified = verifyNodeSecret(body.nodeId, body.secret);
+        if (!verified) {
+            throw new UnauthorizedException(FLEET_NODE_UNAUTHORIZED_MESSAGE);
+        }
+
+        const node = await this.nodes.findById(verified.nodeId);
+        if (!node) {
+            throw new UnauthorizedException(FLEET_NODE_UNAUTHORIZED_MESSAGE);
+        }
+        // Drained (`disabled`) and not-yet-enrolled (`enrolling`, whose
+        // hash column still holds a TOKEN, not a secret) nodes are not
+        // authenticated — they must not be able to touch work at all.
+        if (node.status === 'disabled' || node.status === 'enrolling') {
+            throw new UnauthorizedException(FLEET_NODE_UNAUTHORIZED_MESSAGE);
+        }
+        if (!verified.matches(node.enrollmentTokenHash)) {
+            throw new UnauthorizedException(FLEET_NODE_UNAUTHORIZED_MESSAGE);
+        }
+
+        request.fleetNode = {
+            id: node.id,
+            userId: node.userId,
+            organizationId: node.organizationId ?? null,
+            capabilities: node.capabilities ?? [],
+        };
+        return true;
+    }
+}

--- a/apps/api/src/migrations/1784760000000-AddFleetNodeAdminColumns.ts
+++ b/apps/api/src/migrations/1784760000000-AddFleetNodeAdminColumns.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fleet admin surface — the two `fleet_nodes` columns the credential
+ * rotation and admin-editable capability tags need.
+ *
+ *  - `credentialIssuedAt` — when the CURRENT credential was minted.
+ *                           Enrollment-token expiry is measured from
+ *                           here instead of `createdAt`, because
+ *                           rotation mints a fresh token on an EXISTING
+ *                           row: judging it by the row's creation date
+ *                           would make every rotated token expired on
+ *                           arrival. NULL on pre-existing rows, and the
+ *                           service falls back to `createdAt` for those,
+ *                           so nothing about the shipped enroll flow
+ *                           changes.
+ *  - `capabilitiesPinned` — true once an operator hand-edited the tag
+ *                           set. While pinned, a heartbeat no longer
+ *                           overwrites `capabilities`, so an admin edit
+ *                           is not silently reverted by the machine on
+ *                           its next beat. Defaults to false = today's
+ *                           behaviour (the node owns its tags).
+ *
+ * Forward-only with per-step guards (house pattern, mirrors
+ * `1784400000000-AddRunAttentionColumns`). No new index: every read of
+ * these columns is already narrowed by `idx_fleet_nodes_user` or by an
+ * exact primary-key lookup.
+ */
+export class AddFleetNodeAdminColumns1784760000000 implements MigrationInterface {
+    name = 'AddFleetNodeAdminColumns1784760000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('fleet_nodes');
+        if (!table) return;
+
+        if (!table.findColumnByName('credentialIssuedAt')) {
+            await queryRunner.query(
+                `ALTER TABLE "fleet_nodes" ADD COLUMN "credentialIssuedAt" TIMESTAMP`,
+            );
+        }
+        if (!table.findColumnByName('capabilitiesPinned')) {
+            await queryRunner.query(
+                `ALTER TABLE "fleet_nodes" ADD COLUMN "capabilitiesPinned" boolean NOT NULL DEFAULT false`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('fleet_nodes');
+        if (!table) return;
+        for (const col of ['capabilitiesPinned', 'credentialIssuedAt']) {
+            if (table.findColumnByName(col)) {
+                await queryRunner.query(`ALTER TABLE "fleet_nodes" DROP COLUMN "${col}"`);
+            }
+        }
+    }
+}

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1892,7 +1905,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "تثبيتات تطبيق GitHub",
@@ -2268,7 +2282,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2307,7 +2338,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2360,6 +2411,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2387,6 +2444,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2450,7 +2516,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2473,6 +2540,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2566,6 +2693,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1892,7 +1905,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Инсталации на GitHub App",
@@ -2268,7 +2282,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2307,7 +2338,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2360,6 +2411,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2387,6 +2444,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2450,7 +2516,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2473,6 +2540,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2566,6 +2693,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1892,7 +1905,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub-App-Installationen",
@@ -2268,7 +2282,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2307,7 +2338,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2360,6 +2411,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2387,6 +2444,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2450,7 +2516,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2473,6 +2540,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2566,6 +2693,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2388,7 +2388,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2411,6 +2412,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Rotated",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1892,7 +1905,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Instalaciones de GitHub App",
@@ -2268,7 +2282,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2307,7 +2338,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2360,6 +2411,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2387,6 +2444,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2450,7 +2516,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2473,6 +2540,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2566,6 +2693,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1892,7 +1905,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Installations GitHub App",
@@ -2268,7 +2282,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2307,7 +2338,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2360,6 +2411,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2387,6 +2444,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2450,7 +2516,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2473,6 +2540,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2566,6 +2693,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1892,7 +1905,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "התקנות GitHub App",
@@ -2268,7 +2282,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2307,7 +2338,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2360,6 +2411,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2387,6 +2444,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2450,7 +2516,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2473,6 +2540,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2566,6 +2693,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub ऐप इंस्टॉलेशन",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Instalasi GitHub App",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Installazioni GitHub App",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub App インストール",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub 앱 설치",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub App-installaties",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Instalacje aplikacji GitHub",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Instalações do GitHub App",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Установки GitHub App",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "การติดตั้ง GitHub App",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub App Kurulumları",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Інсталяції GitHub App",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "Cài đặt Ứng dụng GitHub",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -460,7 +460,13 @@
             "slack": {
                 "name": "Slack",
                 "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
-                "action": "Connect Slack"
+                "action": "Connect Slack",
+                "close": "Close",
+                "enable": "Enable Slack",
+                "enabled": "Slack is connected",
+                "enabledToast": "Slack connected",
+                "enableFailed": "Could not enable Slack. Please try again.",
+                "advancedSettings": "Advanced settings"
             },
             "discord": {
                 "name": "Discord",
@@ -546,7 +552,14 @@
                 "creating": "Creating…",
                 "created": "Created",
                 "createdToast": "Agent created — find it under Agents.",
-                "createFailed": "Failed to create the agent. Try again."
+                "createFailed": "Failed to create the agent. Try again.",
+                "skillsTitle": "Skills that pair with these",
+                "seedAll": "Set up my starter agents",
+                "seeding": "Setting up…",
+                "seedDone": "Set up {count} starter agents — find them under Agents.",
+                "seedAlreadyDone": "Your starter agents are already set up.",
+                "seedPartial": "Set up {created} agents; {failed} could not be created.",
+                "seedFailed": "Could not set up your starter agents. Try again."
             },
             "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
         }
@@ -1824,7 +1837,8 @@
                 "billing": "Billing",
                 "usageCredits": "Usage & Credits",
                 "fleet": "Fleet",
-                "jobRuntime": "Job Runtime"
+                "jobRuntime": "Job Runtime",
+                "digest": "Digest"
             },
             "githubApp": {
                 "title": "GitHub App 安装",
@@ -2200,7 +2214,24 @@
                 "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
                 "currentPlan": {
                     "title": "Current plan",
-                    "statusActive": "Active"
+                    "statusActive": "Active",
+                    "statuses": {
+                        "trialing": "Trial",
+                        "past_due": "Past due",
+                        "unpaid": "Unpaid",
+                        "paused": "Paused",
+                        "canceled": "Canceled",
+                        "incomplete": "Incomplete",
+                        "incomplete_expired": "Expired"
+                    },
+                    "cancel": "Cancel subscription",
+                    "cancelSuccess": "Your subscription will end at the end of the current period.",
+                    "cancelError": "Failed to cancel the subscription.",
+                    "cancelScheduled": "Your subscription ends at the end of the current period.",
+                    "cancelScheduledOn": "Your subscription ends on {date}.",
+                    "resume": "Resume subscription",
+                    "resumeSuccess": "Your subscription will continue as normal.",
+                    "resumeError": "Failed to resume the subscription."
                 },
                 "plans": {
                     "title": "Plans",
@@ -2239,7 +2270,27 @@
                     "empty": "No payment method on file.",
                     "expires": "Expires {expiry}",
                     "managedAtCheckout": "Card details are held by the payment provider — we only store the brand, last four digits and expiry.",
-                    "addAtCheckout": "A card is saved automatically the first time you buy credits."
+                    "addAtCheckout": "A card is saved automatically the first time you buy credits.",
+                    "manage": "Manage payment methods",
+                    "addCta": "Add a payment method",
+                    "manageTitle": "Payment methods",
+                    "manageSubtitle": "Add, replace or remove the cards on your account.",
+                    "backToBilling": "Back to billing",
+                    "storedTitle": "Stored cards",
+                    "add": "Add card",
+                    "redirecting": "Redirecting…",
+                    "card": "Card",
+                    "default": "Default",
+                    "makeDefault": "Make default",
+                    "remove": "Remove",
+                    "removed": "Payment method removed.",
+                    "removeError": "Could not remove the payment method.",
+                    "defaultUpdated": "Default payment method updated.",
+                    "defaultError": "Could not update the default payment method.",
+                    "addError": "Could not start card setup.",
+                    "loadError": "Your payment methods could not be loaded. Refresh the page to try again.",
+                    "lastOnPaidPlan": "Add another card before removing the last one while a paid plan is active.",
+                    "hostedNotice": "Card details are entered on the payment provider's secure page and never reach our servers. We only ever store the brand, last four digits and expiry."
                 },
                 "autoRecharge": {
                     "title": "Auto-recharge",
@@ -2292,6 +2343,12 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "pastDue": {
+                    "title": "We could not collect your latest payment",
+                    "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
+                    "action": "Update payment method",
+                    "error": "Could not open the billing portal."
                 }
             },
             "usage": {
@@ -2319,6 +2376,15 @@
                     "loading": "Loading…",
                     "error": "Failed to load chart data.",
                     "unattributed": "Unattributed"
+                },
+                "period": {
+                    "label": "Reporting period",
+                    "monthLabel": "Calendar month",
+                    "monthPlaceholder": "Pick a month"
+                },
+                "export": {
+                    "csv": "Export CSV",
+                    "csvHint": "Download every usage event in {period} as a CSV file"
                 }
             },
             "fleet": {
@@ -2382,7 +2448,8 @@
                     "rename": "Rename",
                     "disable": "Disable",
                     "enable": "Enable",
-                    "remove": "Remove"
+                    "remove": "Remove",
+                    "details": "Details"
                 },
                 "rename": {
                     "title": "Rename node",
@@ -2405,6 +2472,66 @@
                     "idle": "Idle",
                     "busy": "{count} running",
                     "currentJob": "Current job: {kind}"
+                },
+                "tokens": {
+                    "title": "Outstanding enrollment tokens",
+                    "description": "Tokens that have been minted but not yet used. The token itself was shown once at mint time and cannot be read again — revoke and re-issue if it was lost.",
+                    "empty": "No outstanding tokens.",
+                    "loading": "Loading tokens…",
+                    "refresh": "Refresh",
+                    "issuedAt": "Issued",
+                    "expiresAt": "Expires",
+                    "expired": "Expired",
+                    "revoke": "Revoke",
+                    "rotated": "Credential rotated. The replacement token is shown once — copy it now.",
+                    "revoked": "Enrollment token revoked.",
+                    "revokeTitle": "Revoke this enrollment token?",
+                    "revokeDescription": "The token stops working immediately. The machine it was minted for will not be able to enroll until you issue a new one.",
+                    "revokeCancel": "Keep token"
+                },
+                "controls": {
+                    "rotatedTitle": "Credential rotated",
+                    "rotated": "Copy the replacement token now — it is shown once and cannot be read again.",
+                    "undrained": "Node returned to service.",
+                    "title": "Controls",
+                    "rotate": "Rotate credential",
+                    "rotateHint": "Issues a replacement enrollment token and invalidates the current credential. The machine must re-enroll.",
+                    "drain": "Drain",
+                    "drainHint": "Disables the node and returns its in-flight work to the queue so it is picked up elsewhere immediately.",
+                    "drained": "Node drained.",
+                    "undrain": "Return to service",
+                    "undrainHint": "Re-enables the node so it can lease work again."
+                },
+                "capabilities": {
+                    "title": "Capability tags",
+                    "placeholder": "Add a tag, e.g. workspace",
+                    "add": "Add",
+                    "remove": "Remove",
+                    "save": "Save tags",
+                    "saved": "Capability tags saved.",
+                    "none": "No tags. This node is eligible for any work that names no requirements.",
+                    "pinned": "Pinned",
+                    "pinnedHint": "You own these tags — the node's heartbeats will not overwrite them.",
+                    "unpinned": "Reported by the node",
+                    "unpinnedHint": "The node reports these on every heartbeat. Editing them hands ownership to you."
+                },
+                "handoff": {
+                    "qrLabel": "Scan to enrol",
+                    "qrHint": "Scan this from the machine you are adding. The code carries the one-time token — treat it like a password.",
+                    "commandTitle": "Or run this on the machine",
+                    "copyCommand": "Copy command",
+                    "downloadsTitle": "Downloads",
+                    "downloadFile": "Download config file",
+                    "downloadDesktop": "Desktop app",
+                    "downloadNode": "Headless node"
+                },
+                "history": {
+                    "failuresTitle": "Recent failures",
+                    "noFailures": "No failures in the recent history.",
+                    "recentCount": "{count} recent jobs",
+                    "attempts": "{count} attempts",
+                    "loading": "Loading history…",
+                    "unavailable": "Job history is unavailable right now. The node itself is fine."
                 }
             },
             "jobRuntime": {
@@ -2498,6 +2625,42 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "digest": {
+                "title": "Digest",
+                "subtitle": "Scheduled activity briefings: agent runs, task movement, pull requests, connected-source events and goal progress, delivered on the cadence you choose. Your personal digest and your organization’s digest are separate settings — turning one on never changes the other.",
+                "scopes": {
+                    "personal": "Personal",
+                    "organization": "Organization"
+                },
+                "cadences": {
+                    "daily": "Daily",
+                    "weekly": "Weekly"
+                },
+                "fields": {
+                    "scopeLabel": "Scope",
+                    "scopeHelper": "Personal covers only your own activity. Organization covers everything happening across your organization. Both can be on at the same time.",
+                    "orgContext": "Editing the digest for {name}.",
+                    "enabledLabel": "Send me a personal digest",
+                    "enabledHelper": "Delivered in-app and to any notification channel you have connected. Quiet windows are skipped instead of sending an empty briefing.",
+                    "orgEnabledLabel": "Send an organization digest",
+                    "orgEnabledHelper": "One shared briefing covering the whole organization, delivered to the organization owner. Members keep receiving their own personal digests.",
+                    "cadenceLabel": "Cadence",
+                    "cadenceHelper": "Daily covers the last 24 hours; weekly covers the last 7 days.",
+                    "narrativeLabel": "Include an AI summary",
+                    "narrativeHelper": "Adds a short written summary on top of the counts. The counts are always computed exactly; if no AI provider is available the summary is skipped and the digest says so.",
+                    "lastRunAt": "Last sent {when}"
+                },
+                "actions": {
+                    "save": "Save",
+                    "saving": "Saving..."
+                },
+                "messages": {
+                    "saveSuccess": "Digest settings saved",
+                    "saveError": "Failed to save the digest settings",
+                    "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
+                    "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/settings/fleet/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/fleet/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
-import { fleetAPI, type FleetNodeView } from '@/lib/api/fleet';
+import { fleetAPI, type FleetEnrollmentTokenView, type FleetNodeView } from '@/lib/api/fleet';
 import { FleetSettings } from '@/components/settings/FleetSettings';
+import {
+    isFleetEnabled,
+    resolveFleetDownloadUrls,
+    resolvePublicApiBaseUrl,
+} from '@/lib/fleet-flags';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.settings.fleet');
@@ -9,25 +15,65 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 /**
- * Fleet (Wave 12, slice 1) — settings page for the node registry:
- * where the user's work CAN run (Job Runtime, directly below in the
- * menu, stays HOW work is dispatched).
+ * Fleet — settings page for the node registry: where the user's work
+ * CAN run (Job Runtime, directly below in the menu, stays HOW work is
+ * dispatched).
  *
  * Server component: fetches the merged node list (enrolled machines +
  * live nodes of the user's own configured clusters, tagged `k8s`) and
- * hands it to the client component. Graceful degradation: a hard fetch
- * failure still renders the page with an empty list + error banner so
- * the enroll flow's actions can surface the real error on submit.
+ * the outstanding enrollment tokens, then hands them to the client
+ * component. Graceful degradation: each fetch fails independently and
+ * still renders the page with an error banner, so the enroll flow's
+ * actions can surface the real error on submit.
+ *
+ * Gated by `FLEET_ENABLED` — the SAME switch the API enforces, so a
+ * disabled deployment has no page and no route rather than a page whose
+ * every call 404s.
  */
 export default async function FleetSettingsPage() {
-    let initialNodes: FleetNodeView[] = [];
-    let loadError: string | null = null;
-
-    try {
-        initialNodes = await fleetAPI.listNodes();
-    } catch (error) {
-        loadError = error instanceof Error ? error.message : 'Failed to load fleet nodes';
+    if (!isFleetEnabled()) {
+        notFound();
     }
 
-    return <FleetSettings initialNodes={initialNodes} loadError={loadError} />;
+    let initialNodes: FleetNodeView[] = [];
+    let loadError: string | null = null;
+    let initialTokens: FleetEnrollmentTokenView[] = [];
+    let tokensError: string | null = null;
+
+    const [nodesResult, tokensResult] = await Promise.allSettled([
+        fleetAPI.listNodes(),
+        fleetAPI.listOutstandingTokens(),
+    ]);
+
+    if (nodesResult.status === 'fulfilled') {
+        initialNodes = nodesResult.value;
+    } else {
+        loadError =
+            nodesResult.reason instanceof Error
+                ? nodesResult.reason.message
+                : 'Failed to load fleet nodes';
+    }
+
+    if (tokensResult.status === 'fulfilled') {
+        initialTokens = tokensResult.value;
+    } else {
+        tokensError =
+            tokensResult.reason instanceof Error
+                ? tokensResult.reason.message
+                : 'Failed to load outstanding enrollment tokens';
+    }
+
+    const downloads = resolveFleetDownloadUrls();
+
+    return (
+        <FleetSettings
+            initialNodes={initialNodes}
+            loadError={loadError}
+            initialTokens={initialTokens}
+            tokensError={tokensError}
+            apiBaseUrl={resolvePublicApiBaseUrl()}
+            desktopDownloadUrl={downloads.desktop}
+            nodeDownloadUrl={downloads.node}
+        />
+    );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/layout.tsx
@@ -1,4 +1,5 @@
 import { pluginsAPI, type SettingsMenuResponse } from '@/lib/api/plugins';
+import { isFleetEnabled } from '@/lib/fleet-flags';
 import { SettingsLayoutClient } from './settings-layout-client';
 
 export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
@@ -11,5 +12,14 @@ export default async function SettingsLayout({ children }: { children: React.Rea
         console.error('Failed to fetch settings menu:', error);
     }
 
-    return <SettingsLayoutClient settingsMenu={settingsMenu}>{children}</SettingsLayoutClient>;
+    // `FLEET_ENABLED` is read here, on the server, and passed down: the
+    // nav is a client component and must not read a non-public env var
+    // itself (it would be `undefined` in the browser and the tab would
+    // reappear). Same switch the API and the Fleet page enforce, so a
+    // disabled deployment has no entry point AND no route.
+    return (
+        <SettingsLayoutClient settingsMenu={settingsMenu} fleetEnabled={isFleetEnabled()}>
+            {children}
+        </SettingsLayoutClient>
+    );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -26,6 +26,13 @@ import { getCategoryIcon } from '@/lib/utils/plugin-category-icons';
 interface SettingsLayoutClientProps {
     children: React.ReactNode;
     settingsMenu: SettingsMenuResponse | null;
+    /**
+     * `FLEET_ENABLED`, resolved on the server. Defaults to true so a
+     * caller that has not been updated still shows the tab — the flag
+     * exists to let an operator turn Fleet OFF, never to make the
+     * shipped default depend on someone remembering to pass a prop.
+     */
+    fleetEnabled?: boolean;
 }
 
 interface StaticTab {

--- a/apps/web/src/app/actions/settings/fleet.ts
+++ b/apps/web/src/app/actions/settings/fleet.ts
@@ -9,6 +9,9 @@ import {
     fleetAPI,
     type CreateFleetEnrollmentTokenPayload,
     type CreateFleetEnrollmentTokenResponse,
+    type FleetEnrollmentTokenView,
+    type FleetNodeDetailView,
+    type FleetNodeDrainResult,
     type FleetNodeView,
     type UpdateFleetNodePayload,
 } from '@/lib/api/fleet';
@@ -93,6 +96,98 @@ export async function deleteFleetNodeAction(
             success: false,
             data: null,
             error: errorMessage(error, 'Failed to remove the node'),
+        };
+    }
+}
+
+/** Node-detail drawer: the node plus its recent job / failure history. */
+export async function getFleetNodeDetailAction(
+    nodeId: string,
+): Promise<FleetActionResult<FleetNodeDetailView>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.nodeDetail(nodeId);
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to load the node'),
+        };
+    }
+}
+
+/** Outstanding (minted but never used) enrollment tokens. */
+export async function listFleetEnrollmentTokensAction(): Promise<
+    FleetActionResult<FleetEnrollmentTokenView[]>
+> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.listOutstandingTokens();
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to load outstanding enrollment tokens'),
+        };
+    }
+}
+
+/** Revoke an outstanding token BEFORE anyone uses it. */
+export async function revokeFleetEnrollmentTokenAction(
+    nodeId: string,
+): Promise<FleetActionResult<{ revoked: true }>> {
+    await ensureAuth();
+    try {
+        await fleetAPI.revokeEnrollmentToken(nodeId);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data: { revoked: true }, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to revoke the enrollment token'),
+        };
+    }
+}
+
+/**
+ * Re-key a node. The replacement token comes back exactly once, so the
+ * caller MUST surface it immediately — there is no second read.
+ */
+export async function rotateFleetNodeCredentialAction(
+    nodeId: string,
+): Promise<FleetActionResult<CreateFleetEnrollmentTokenResponse>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.rotateNodeCredential(nodeId);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to rotate the node credential'),
+        };
+    }
+}
+
+/** Drain (or return to service) a node, requeuing its in-flight claims. */
+export async function drainFleetNodeAction(
+    nodeId: string,
+    drain: boolean,
+): Promise<FleetActionResult<FleetNodeDrainResult>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.drainNode(nodeId, drain);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to drain the node'),
         };
     }
 }

--- a/apps/web/src/components/settings/FleetEnrollHandoff.tsx
+++ b/apps/web/src/components/settings/FleetEnrollHandoff.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Copy, Download, ExternalLink, Terminal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { CreateFleetEnrollmentTokenResponse } from '@/lib/api/fleet';
+import { FleetQrCode } from './FleetQrCode';
+
+interface FleetEnrollHandoffProps {
+    issued: CreateFleetEnrollmentTokenResponse;
+    /** Public API base the node will call (no trailing `/api`). */
+    apiBaseUrl: string;
+    /** Where the desktop node app is downloaded from. */
+    desktopDownloadUrl: string;
+    /** Where the headless node app is downloaded from. */
+    nodeDownloadUrl: string;
+}
+
+/**
+ * Everything needed to get a one-time token ONTO the target machine
+ * without anyone retyping 43 characters of base64url:
+ *
+ *   - the token itself, with a copy button (as before);
+ *   - the ready-to-run CLI command, with its own copy button;
+ *   - a QR of that command, for the very common case where the machine
+ *     you are standing at is not the machine you are logged in on;
+ *   - a downloadable handoff file, for moving it to a box with no
+ *     clipboard between you and it;
+ *   - links to actually download the node apps.
+ *
+ * The token is never persisted anywhere by this component: the download
+ * is built in memory, handed to the browser, and the object URL is
+ * revoked immediately. Closing the dialog drops the token for good —
+ * the server only ever stored its hash.
+ */
+export function FleetEnrollHandoff({
+    issued,
+    apiBaseUrl,
+    desktopDownloadUrl,
+    nodeDownloadUrl,
+}: FleetEnrollHandoffProps) {
+    const t = useTranslations('dashboard.settings.fleet');
+    const [copied, setCopied] = useState<'token' | 'command' | null>(null);
+
+    // The node CLI wants the API ORIGIN, not the `/api` prefix the web
+    // tier talks to, so a deployment whose public URL already carries it
+    // does not produce `…/api/api/fleet/enroll`.
+    const normalizedApiUrl = apiBaseUrl.replace(/\/+$/, '').replace(/\/api$/, '');
+    const command = `ever-works-node enroll --api-url ${normalizedApiUrl} --token ${issued.token}`;
+
+    const copy = async (value: string, which: 'token' | 'command') => {
+        try {
+            await navigator.clipboard.writeText(value);
+            setCopied(which);
+            setTimeout(() => setCopied(null), 2000);
+        } catch {
+            toast.error(t('add.copyError'));
+        }
+    };
+
+    const downloadHandoffFile = () => {
+        const payload = {
+            apiUrl: normalizedApiUrl,
+            token: issued.token,
+            nodeId: issued.node.id,
+            name: issued.node.name,
+            kind: issued.node.kind,
+            expiresInSec: issued.expiresInSec,
+            command,
+        };
+        const blob = new Blob([JSON.stringify(payload, null, 2)], {
+            type: 'application/json',
+        });
+        const url = URL.createObjectURL(blob);
+        try {
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = `ever-works-node-enrollment-${issued.node.id}.json`;
+            anchor.click();
+        } finally {
+            // Do not leave a blob holding a live credential in memory.
+            URL.revokeObjectURL(url);
+        }
+    };
+
+    return (
+        <div className="space-y-4" data-testid="fleet-enroll-handoff">
+            <p className="text-sm text-text dark:text-text-dark">
+                {t('add.tokenIntro', { minutes: Math.round(issued.expiresInSec / 60) })}
+            </p>
+
+            <div className="flex items-center gap-2">
+                <code
+                    className="flex-1 px-3 py-2 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-sm break-all select-all"
+                    data-testid="fleet-enroll-token"
+                >
+                    {issued.token}
+                </code>
+                <Button
+                    variant="secondary"
+                    onClick={() => copy(issued.token, 'token')}
+                    data-testid="fleet-copy-token"
+                >
+                    <Copy className="w-4 h-4" />
+                    {copied === 'token' ? t('add.copied') : t('add.copy')}
+                </Button>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-[auto_1fr] sm:items-start">
+                <div className="space-y-1.5">
+                    <FleetQrCode
+                        value={command}
+                        label={t('handoff.qrLabel')}
+                        data-testid="fleet-enroll-qr"
+                    />
+                    <p className="text-xs text-center text-text-muted dark:text-text-muted-dark max-w-[168px]">
+                        {t('handoff.qrHint')}
+                    </p>
+                </div>
+
+                <div className="space-y-2">
+                    <div className="flex items-center gap-1.5 text-sm font-medium text-text dark:text-text-dark">
+                        <Terminal className="w-4 h-4" />
+                        {t('handoff.commandTitle')}
+                    </div>
+                    <code
+                        className="block px-3 py-2 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-xs break-all select-all"
+                        data-testid="fleet-enroll-command"
+                    >
+                        {command}
+                    </code>
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            variant="secondary"
+                            onClick={() => copy(command, 'command')}
+                            data-testid="fleet-copy-command"
+                        >
+                            <Copy className="w-4 h-4" />
+                            {copied === 'command' ? t('add.copied') : t('handoff.copyCommand')}
+                        </Button>
+                        <Button
+                            variant="secondary"
+                            onClick={downloadHandoffFile}
+                            data-testid="fleet-download-handoff"
+                        >
+                            <Download className="w-4 h-4" />
+                            {t('handoff.downloadFile')}
+                        </Button>
+                    </div>
+                </div>
+            </div>
+
+            <div className="p-3 rounded-lg bg-info/10 border border-info/20 space-y-2">
+                <p className="text-sm font-medium text-text dark:text-text-dark">
+                    {t('handoff.downloadsTitle')}
+                </p>
+                <div className="flex flex-wrap gap-3 text-sm">
+                    <a
+                        href={desktopDownloadUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-info hover:underline"
+                        data-testid="fleet-download-desktop"
+                    >
+                        {t('handoff.downloadDesktop')}
+                        <ExternalLink className="w-3 h-3" />
+                    </a>
+                    <a
+                        href={nodeDownloadUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-info hover:underline"
+                        data-testid="fleet-download-node"
+                    >
+                        {t('handoff.downloadNode')}
+                        <ExternalLink className="w-3 h-3" />
+                    </a>
+                </div>
+            </div>
+
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                {t('add.tokenOnce')}
+            </p>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/FleetNodeDrawer.tsx
+++ b/apps/web/src/components/settings/FleetNodeDrawer.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, KeyRound, Pin, PinOff, Plus, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import type { FleetNodeDetailView, FleetNodeView } from '@/lib/api/fleet';
+
+interface FleetNodeDrawerProps {
+    node: FleetNodeView | null;
+    detail: FleetNodeDetailView | null;
+    loading: boolean;
+    error: string | null;
+    isPending: boolean;
+    onClose: () => void;
+    onSaveCapabilities: (capabilities: string[], pinned: boolean) => void;
+    onRotate: () => void;
+    onDrain: (drain: boolean) => void;
+}
+
+/** Max tags the API accepts; mirrored here so the UI refuses first. */
+const MAX_TAGS = 16;
+const MAX_TAG_LENGTH = 32;
+
+function formatMoment(value: string | null): string {
+    if (!value) return '-';
+    try {
+        return new Date(value).toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return value;
+    }
+}
+
+/**
+ * Node detail — everything about ONE machine that the table row cannot
+ * carry: its recent job history, the failures pulled out of that history,
+ * an editor for its capability tags, and the two credential-lifecycle
+ * controls (rotate, drain).
+ *
+ * The failure list is the reason this exists. "Node X is online" is not
+ * an answer to "why did my checks stop passing on X": before this, the
+ * only way to see that a machine had failed its last nine jobs was to
+ * read the database.
+ */
+export function FleetNodeDrawer({
+    node,
+    detail,
+    loading,
+    error,
+    isPending,
+    onClose,
+    onSaveCapabilities,
+    onRotate,
+    onDrain,
+}: FleetNodeDrawerProps) {
+    const t = useTranslations('dashboard.settings.fleet');
+    const [tags, setTags] = useState<string[]>([]);
+    const [pinned, setPinned] = useState(false);
+    const [draft, setDraft] = useState('');
+
+    // Re-seed the editor whenever a different node (or fresher data for
+    // the same node) arrives, so the form never shows another machine's
+    // tags. Keyed on the node id + the server's own values.
+    const serverTags = detail?.node.capabilities ?? node?.capabilities ?? [];
+    const serverPinned = detail?.node.capabilitiesPinned ?? node?.capabilitiesPinned ?? false;
+    const seedKey = `${node?.id ?? ''}|${serverTags.join(',')}|${serverPinned}`;
+    useEffect(() => {
+        setTags(serverTags);
+        setPinned(serverPinned);
+        setDraft('');
+        // `seedKey` collapses the identity of the seed into one primitive
+        // so this does not re-run on every parent render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [seedKey]);
+
+    if (!node) return null;
+
+    const addTag = () => {
+        const tag = draft.trim().slice(0, MAX_TAG_LENGTH);
+        if (!tag || tags.includes(tag) || tags.length >= MAX_TAGS) {
+            setDraft('');
+            return;
+        }
+        setTags([...tags, tag]);
+        setDraft('');
+    };
+
+    const drained = node.status === 'disabled';
+
+    return (
+        <Dialog open onOpenChange={(open) => !open && onClose()}>
+            <DialogContent className="max-w-3xl">
+                <DialogClose onClose={onClose} />
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                        {node.name}
+                    </DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-6" data-testid="fleet-node-drawer">
+                    {error ? (
+                        <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                            <AlertTriangle className="w-4 h-4 text-warning flex-shrink-0 mt-0.5" />
+                            <p className="text-sm text-text dark:text-text-dark">{error}</p>
+                        </div>
+                    ) : null}
+
+                    {/* Summary */}
+                    <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+                        <div>
+                            <dt className="text-text-muted dark:text-text-muted-dark text-xs">
+                                {t('table.status')}
+                            </dt>
+                            <dd className="text-text dark:text-text-dark">
+                                {t(`statuses.${node.status}` as never)}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-text-muted dark:text-text-muted-dark text-xs">
+                                {t('table.kind')}
+                            </dt>
+                            <dd className="text-text dark:text-text-dark">
+                                {t(`kinds.${node.kind}` as never)}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-text-muted dark:text-text-muted-dark text-xs">
+                                {t('table.platform')}
+                            </dt>
+                            <dd className="text-text dark:text-text-dark">
+                                {node.platform ?? '-'}
+                                {node.version ? ` · ${node.version}` : ''}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-text-muted dark:text-text-muted-dark text-xs">
+                                {t('table.lastSeen')}
+                            </dt>
+                            <dd className="text-text dark:text-text-dark">
+                                {formatMoment(node.lastHeartbeatAt)}
+                            </dd>
+                        </div>
+                    </dl>
+
+                    {/* Capability tags — admin-editable */}
+                    <section className="space-y-2" data-testid="fleet-capability-editor">
+                        <div className="flex items-center justify-between gap-3">
+                            <h4 className="text-sm font-semibold text-text dark:text-text-dark">
+                                {t('capabilities.title')}
+                            </h4>
+                            <button
+                                type="button"
+                                onClick={() => setPinned(!pinned)}
+                                className="inline-flex items-center gap-1.5 text-xs text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark"
+                                data-testid="fleet-capability-pin-toggle"
+                            >
+                                {pinned ? (
+                                    <Pin className="w-3.5 h-3.5" />
+                                ) : (
+                                    <PinOff className="w-3.5 h-3.5" />
+                                )}
+                                {pinned ? t('capabilities.pinned') : t('capabilities.unpinned')}
+                            </button>
+                        </div>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {pinned ? t('capabilities.pinnedHint') : t('capabilities.unpinnedHint')}
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                            {tags.length === 0 ? (
+                                <span className="text-sm text-text-muted dark:text-text-muted-dark">
+                                    {t('capabilities.none')}
+                                </span>
+                            ) : (
+                                tags.map((tag) => (
+                                    <span
+                                        key={tag}
+                                        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-info/10 text-info"
+                                        data-testid={`fleet-capability-tag-${tag}`}
+                                    >
+                                        {tag}
+                                        <button
+                                            type="button"
+                                            onClick={() =>
+                                                setTags(tags.filter((entry) => entry !== tag))
+                                            }
+                                            aria-label={t('capabilities.remove', { tag })}
+                                        >
+                                            <X className="w-3 h-3" />
+                                        </button>
+                                    </span>
+                                ))
+                            )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Input
+                                value={draft}
+                                onChange={(event) => setDraft(event.target.value)}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                        event.preventDefault();
+                                        addTag();
+                                    }
+                                }}
+                                maxLength={MAX_TAG_LENGTH}
+                                placeholder={t('capabilities.placeholder')}
+                                data-testid="fleet-capability-input"
+                            />
+                            <Button
+                                variant="secondary"
+                                onClick={addTag}
+                                disabled={isPending}
+                                data-testid="fleet-capability-add"
+                            >
+                                <Plus className="w-4 h-4" />
+                                {t('capabilities.add')}
+                            </Button>
+                            <Button
+                                onClick={() => onSaveCapabilities(tags, pinned)}
+                                loading={isPending}
+                                data-testid="fleet-capability-save"
+                            >
+                                {t('capabilities.save')}
+                            </Button>
+                        </div>
+                    </section>
+
+                    {/* Credential + drain controls */}
+                    <section className="space-y-2" data-testid="fleet-node-controls">
+                        <h4 className="text-sm font-semibold text-text dark:text-text-dark">
+                            {t('controls.title')}
+                        </h4>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                variant="secondary"
+                                onClick={onRotate}
+                                disabled={isPending}
+                                data-testid="fleet-node-rotate"
+                            >
+                                <KeyRound className="w-4 h-4" />
+                                {t('controls.rotate')}
+                            </Button>
+                            <Button
+                                variant={drained ? 'secondary' : 'danger'}
+                                onClick={() => onDrain(!drained)}
+                                disabled={isPending}
+                                data-testid="fleet-node-drain"
+                            >
+                                {drained ? t('controls.undrain') : t('controls.drain')}
+                            </Button>
+                        </div>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {drained ? t('controls.undrainHint') : t('controls.drainHint')}
+                        </p>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('controls.rotateHint')}
+                        </p>
+                    </section>
+
+                    {/* Failure history */}
+                    <section className="space-y-2" data-testid="fleet-node-failures">
+                        <h4 className="text-sm font-semibold text-text dark:text-text-dark">
+                            {t('history.failuresTitle')}
+                        </h4>
+                        {loading ? (
+                            <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                                {t('history.loading')}
+                            </p>
+                        ) : detail?.historyUnavailable ? (
+                            <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                                {t('history.unavailable')}
+                            </p>
+                        ) : (detail?.failures.length ?? 0) === 0 ? (
+                            <p
+                                className="text-sm text-text-muted dark:text-text-muted-dark"
+                                data-testid="fleet-node-failures-empty"
+                            >
+                                {t('history.noFailures')}
+                            </p>
+                        ) : (
+                            <ul className="space-y-1.5">
+                                {detail?.failures.map((job) => (
+                                    <li
+                                        key={job.id}
+                                        className="p-2 rounded-lg border border-danger/20 bg-danger/5 text-sm"
+                                        data-testid={`fleet-node-failure-${job.id}`}
+                                    >
+                                        <div className="flex items-center justify-between gap-3">
+                                            <span className="font-medium text-text dark:text-text-dark">
+                                                {job.kind}
+                                            </span>
+                                            <span className="text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+                                                {formatMoment(job.completedAt ?? job.createdAt)}
+                                            </span>
+                                        </div>
+                                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                            {t('history.attempts', {
+                                                attempts: job.attempts,
+                                                maxAttempts: job.maxAttempts,
+                                            })}
+                                        </p>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+
+                        {(detail?.recentJobs.length ?? 0) > 0 ? (
+                            <p
+                                className="text-xs text-text-muted dark:text-text-muted-dark"
+                                data-testid="fleet-node-history-count"
+                            >
+                                {t('history.recentCount', {
+                                    count: detail?.recentJobs.length ?? 0,
+                                })}
+                            </p>
+                        ) : null}
+                    </section>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/web/src/components/settings/FleetQrCode.tsx
+++ b/apps/web/src/components/settings/FleetQrCode.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useMemo } from 'react';
+import { encodeQrCode, qrCodeToSvgPath, qrCodeViewBoxSize } from '@/lib/utils/qr-code';
+
+interface FleetQrCodeProps {
+    /** Text to encode. */
+    value: string;
+    /** Accessible name — the QR itself is not readable by assistive tech. */
+    label: string;
+    className?: string;
+    'data-testid'?: string;
+}
+
+/**
+ * A QR rendering of a short handoff string, drawn as one inline SVG path.
+ *
+ * Renders NOTHING when the payload cannot be encoded (too long for the
+ * supported versions). That is the important behaviour: the enroll
+ * dialog always shows the copyable token and command as well, so a
+ * missing QR costs a convenience, while a wrongly drawn one would cost
+ * an operator a confusing failed scan on a machine they walked to.
+ *
+ * `currentColor` on the fill and a white plate behind it keep the code
+ * high-contrast in both themes — QR scanners want dark-on-light, so the
+ * plate is intentionally light in dark mode too.
+ */
+export function FleetQrCode({ value, label, className, ...rest }: FleetQrCodeProps) {
+    const path = useMemo(() => {
+        const matrix = encodeQrCode(value);
+        if (!matrix) return null;
+        return { d: qrCodeToSvgPath(matrix), viewBox: qrCodeViewBoxSize(matrix) };
+    }, [value]);
+
+    if (!path) return null;
+
+    return (
+        <div
+            className={`inline-flex items-center justify-center rounded-lg bg-white p-3 ${className ?? ''}`}
+            data-testid={rest['data-testid']}
+        >
+            <svg
+                viewBox={`0 0 ${path.viewBox} ${path.viewBox}`}
+                width={168}
+                height={168}
+                role="img"
+                aria-label={label}
+                shapeRendering="crispEdges"
+            >
+                <path d={path.d} fill="#000000" />
+            </svg>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/FleetSettings.tsx
+++ b/apps/web/src/components/settings/FleetSettings.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useMemo, useState, useTransition } from 'react';
+import { useCallback, useMemo, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import {
     Activity,
     AlertTriangle,
-    Copy,
+    Info,
     Laptop,
     Pause,
     Pencil,
@@ -29,18 +29,35 @@ import {
 } from '@/components/ui/dialog';
 import type {
     CreateFleetEnrollmentTokenResponse,
+    FleetEnrollmentTokenView,
+    FleetNodeDetailView,
     FleetNodeKind,
     FleetNodeView,
 } from '@/lib/api/fleet';
 import {
     createFleetEnrollmentTokenAction,
     deleteFleetNodeAction,
+    drainFleetNodeAction,
+    getFleetNodeDetailAction,
+    listFleetEnrollmentTokensAction,
+    revokeFleetEnrollmentTokenAction,
+    rotateFleetNodeCredentialAction,
     updateFleetNodeAction,
 } from '@/app/actions/settings/fleet';
+import { FleetEnrollHandoff } from './FleetEnrollHandoff';
+import { FleetNodeDrawer } from './FleetNodeDrawer';
+import { FleetTokensSection } from './FleetTokensSection';
 
 interface FleetSettingsProps {
     initialNodes: FleetNodeView[];
     loadError: string | null;
+    /** Outstanding (minted, unused) enrollment tokens. */
+    initialTokens: FleetEnrollmentTokenView[];
+    tokensError: string | null;
+    /** Public API base a node should call — used in the CLI one-liner + QR. */
+    apiBaseUrl: string;
+    desktopDownloadUrl: string;
+    nodeDownloadUrl: string;
 }
 
 const ENROLLABLE_KINDS: Exclude<FleetNodeKind, 'k8s'>[] = ['desktop-node', 'node'];
@@ -61,17 +78,30 @@ function formatLastSeen(value: string | null): string {
 }
 
 /**
- * Fleet (Wave 12, slice 1) — settings UI for the node registry:
+ * Fleet — settings UI for the node registry:
  *   - Enrolled-nodes table (name, kind badge, status dot, platform,
- *     capability chips, last-seen) with rename / disable / remove
- *     (confirm) actions.
- *   - "Add node" flow issuing a ONE-TIME enrollment token (copy
- *     button + short install-instructions placeholder — the node apps
- *     themselves are the next slice).
+ *     capability chips, last-seen) with details / rename / disable /
+ *     remove (confirm) actions.
+ *   - "Add node" flow issuing a ONE-TIME enrollment token, handed over
+ *     without retyping: copy button, ready-to-run CLI command, a QR of
+ *     that command, a downloadable handoff file, and links to the node
+ *     app downloads.
+ *   - Outstanding-token list with pre-use revoke, so a minted-but-never
+ *     used credential is visible and killable.
+ *   - Per-node detail drawer: job/failure history, admin-editable
+ *     capability tags, credential rotation and drain.
  *   - Read-only section for live nodes of the user's OWN configured
  *     clusters (never the shared platform clusters, never persisted).
  */
-export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
+export function FleetSettings({
+    initialNodes,
+    loadError,
+    initialTokens,
+    tokensError,
+    apiBaseUrl,
+    desktopDownloadUrl,
+    nodeDownloadUrl,
+}: FleetSettingsProps) {
     const t = useTranslations('dashboard.settings.fleet');
     const [nodes, setNodes] = useState<FleetNodeView[]>(initialNodes);
     const [isPending, startTransition] = useTransition();
@@ -82,12 +112,26 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
         [nodes],
     );
 
-    // "Add node" dialog: form phase, then the one-time-token phase.
+    // "Add node" dialog: form phase, then the one-time-token phase. The
+    // token phase is shared with credential rotation — both hand over a
+    // one-time token that is shown exactly once.
     const [addOpen, setAddOpen] = useState(false);
     const [addName, setAddName] = useState('');
     const [addKind, setAddKind] = useState<Exclude<FleetNodeKind, 'k8s'>>('desktop-node');
     const [issued, setIssued] = useState<CreateFleetEnrollmentTokenResponse | null>(null);
-    const [copied, setCopied] = useState(false);
+    const [issuedFromRotation, setIssuedFromRotation] = useState(false);
+
+    // Outstanding enrollment tokens.
+    const [tokens, setTokens] = useState<FleetEnrollmentTokenView[]>(initialTokens);
+    const [tokensLoading, setTokensLoading] = useState(false);
+    const [tokensLoadError, setTokensLoadError] = useState<string | null>(tokensError);
+    const [revokeTarget, setRevokeTarget] = useState<FleetEnrollmentTokenView | null>(null);
+
+    // Node-detail drawer.
+    const [drawerNode, setDrawerNode] = useState<FleetNodeView | null>(null);
+    const [drawerDetail, setDrawerDetail] = useState<FleetNodeDetailView | null>(null);
+    const [drawerLoading, setDrawerLoading] = useState(false);
+    const [drawerError, setDrawerError] = useState<string | null>(null);
 
     // Rename dialog.
     const [renameTarget, setRenameTarget] = useState<FleetNodeView | null>(null);
@@ -111,13 +155,27 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
         }
     };
 
+    const refreshTokens = useCallback(() => {
+        setTokensLoading(true);
+        startTransition(async () => {
+            const result = await listFleetEnrollmentTokensAction();
+            setTokensLoading(false);
+            if (result.success) {
+                setTokens(result.data);
+                setTokensLoadError(null);
+            } else {
+                setTokensLoadError(result.error);
+            }
+        });
+    }, []);
+
     const closeAddDialog = () => {
         setAddOpen(false);
         // The token is shown exactly once — drop it with the dialog.
         setIssued(null);
+        setIssuedFromRotation(false);
         setAddName('');
         setAddKind('desktop-node');
-        setCopied(false);
     };
 
     const handleIssueToken = () => {
@@ -132,23 +190,14 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
             });
             if (result.success) {
                 setIssued(result.data);
+                setIssuedFromRotation(false);
                 setNodes((prev) => [...prev, result.data.node]);
                 toast.success(t('add.issued'));
+                refreshTokens();
             } else {
                 toast.error(result.error);
             }
         });
-    };
-
-    const handleCopyToken = async () => {
-        if (!issued) return;
-        try {
-            await navigator.clipboard.writeText(issued.token);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
-        } catch {
-            toast.error(t('add.copyError'));
-        }
     };
 
     const handleRename = () => {
@@ -192,6 +241,111 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                 setNodes((prev) => prev.filter((node) => node.id !== target.id));
                 setRemoveTarget(null);
                 toast.success(t('messages.removed'));
+                refreshTokens();
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const openDrawer = (node: FleetNodeView) => {
+        setDrawerNode(node);
+        setDrawerDetail(null);
+        setDrawerError(null);
+        setDrawerLoading(true);
+        startTransition(async () => {
+            const result = await getFleetNodeDetailAction(node.id);
+            setDrawerLoading(false);
+            if (result.success) {
+                setDrawerDetail(result.data);
+                setNodes((prev) =>
+                    prev.map((entry) => (entry.id === node.id ? result.data.node : entry)),
+                );
+                setDrawerNode(result.data.node);
+            } else {
+                setDrawerError(result.error);
+            }
+        });
+    };
+
+    const handleSaveCapabilities = (capabilities: string[], pinned: boolean) => {
+        const target = drawerNode;
+        if (!target) return;
+        startTransition(async () => {
+            const result = await updateFleetNodeAction(target.id, {
+                capabilities,
+                capabilitiesPinned: pinned,
+            });
+            if (result.success) {
+                setNodes((prev) =>
+                    prev.map((entry) => (entry.id === target.id ? result.data : entry)),
+                );
+                setDrawerNode(result.data);
+                setDrawerDetail((prev) => (prev ? { ...prev, node: result.data } : prev));
+                toast.success(t('capabilities.saved'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const handleRotate = () => {
+        const target = drawerNode;
+        if (!target) return;
+        startTransition(async () => {
+            const result = await rotateFleetNodeCredentialAction(target.id);
+            if (result.success) {
+                setNodes((prev) =>
+                    prev.map((entry) => (entry.id === target.id ? result.data.node : entry)),
+                );
+                // Close the drawer and surface the replacement token —
+                // it is returned exactly once, so it must not be behind
+                // anything the operator has to go looking for.
+                setDrawerNode(null);
+                setDrawerDetail(null);
+                setIssued(result.data);
+                setIssuedFromRotation(true);
+                setAddOpen(true);
+                toast.success(t('controls.rotated'));
+                refreshTokens();
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const handleDrain = (drain: boolean) => {
+        const target = drawerNode;
+        if (!target) return;
+        startTransition(async () => {
+            const result = await drainFleetNodeAction(target.id, drain);
+            if (result.success) {
+                setNodes((prev) =>
+                    prev.map((entry) => (entry.id === target.id ? result.data.node : entry)),
+                );
+                setDrawerNode(result.data.node);
+                setDrawerDetail((prev) => (prev ? { ...prev, node: result.data.node } : prev));
+                toast.success(
+                    drain
+                        ? t('controls.drained', { count: result.data.releasedJobs })
+                        : t('controls.undrained'),
+                );
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const handleRevokeToken = () => {
+        if (!revokeTarget) return;
+        const target = revokeTarget;
+        startTransition(async () => {
+            const result = await revokeFleetEnrollmentTokenAction(target.nodeId);
+            if (result.success) {
+                setTokens((prev) => prev.filter((token) => token.nodeId !== target.nodeId));
+                setNodes((prev) => prev.filter((node) => node.id !== target.nodeId));
+                setRevokeTarget(null);
+                toast.success(t('tokens.revoked'));
             } else {
                 toast.error(result.error);
             }
@@ -354,6 +508,15 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                                         <div className="flex items-center justify-end gap-1">
                                             <Button
                                                 variant="ghost"
+                                                onClick={() => openDrawer(node)}
+                                                disabled={isPending}
+                                                data-testid={`fleet-node-details-${node.id}`}
+                                                title={t('actions.details')}
+                                            >
+                                                <Info className="w-4 h-4" />
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
                                                 onClick={() => {
                                                     setRenameTarget(node);
                                                     setRenameValue(node.name);
@@ -398,6 +561,15 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                     </table>
                 </div>
             )}
+
+            <FleetTokensSection
+                tokens={tokens}
+                loading={tokensLoading}
+                error={tokensLoadError}
+                isPending={isPending}
+                onRefresh={refreshTokens}
+                onRevoke={setRevokeTarget}
+            />
 
             <div className="space-y-3" data-testid="fleet-cluster-section">
                 <div className="flex items-center gap-2">
@@ -481,16 +653,16 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                 )}
             </div>
 
-            {/* Add node — form phase, then one-time-token phase. */}
+            {/* Add node — form phase, then the one-time-token handoff. */}
             <Dialog
                 open={addOpen}
                 onOpenChange={(open) => (open ? setAddOpen(true) : closeAddDialog())}
             >
-                <DialogContent>
+                <DialogContent className="max-w-2xl">
                     <DialogClose onClose={closeAddDialog} />
                     <DialogHeader>
                         <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
-                            {t('add.title')}
+                            {issuedFromRotation ? t('controls.rotatedTitle') : t('add.title')}
                         </DialogTitle>
                     </DialogHeader>
                     {!issued ? (
@@ -546,38 +718,12 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                         </div>
                     ) : (
                         <div className="space-y-4">
-                            <p className="text-sm text-text dark:text-text-dark">
-                                {t('add.tokenIntro', {
-                                    minutes: Math.round(issued.expiresInSec / 60),
-                                })}
-                            </p>
-                            <div className="flex items-center gap-2">
-                                <code
-                                    className="flex-1 px-3 py-2 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-sm break-all select-all"
-                                    data-testid="fleet-enroll-token"
-                                >
-                                    {issued.token}
-                                </code>
-                                <Button
-                                    variant="secondary"
-                                    onClick={handleCopyToken}
-                                    data-testid="fleet-copy-token"
-                                >
-                                    <Copy className="w-4 h-4" />
-                                    {copied ? t('add.copied') : t('add.copy')}
-                                </Button>
-                            </div>
-                            <div className="p-3 rounded-lg bg-info/10 border border-info/20 space-y-1">
-                                <p className="text-sm font-medium text-text dark:text-text-dark">
-                                    {t('add.instructionsTitle')}
-                                </p>
-                                <p className="text-xs text-text-muted dark:text-text-muted-dark">
-                                    {t('add.instructionsBody')}
-                                </p>
-                            </div>
-                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
-                                {t('add.tokenOnce')}
-                            </p>
+                            <FleetEnrollHandoff
+                                issued={issued}
+                                apiBaseUrl={apiBaseUrl}
+                                desktopDownloadUrl={desktopDownloadUrl}
+                                nodeDownloadUrl={nodeDownloadUrl}
+                            />
                             <DialogFooter>
                                 <Button onClick={closeAddDialog} data-testid="fleet-add-done">
                                     {t('add.done')}
@@ -587,6 +733,23 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                     )}
                 </DialogContent>
             </Dialog>
+
+            {/* Node detail */}
+            <FleetNodeDrawer
+                node={drawerNode}
+                detail={drawerDetail}
+                loading={drawerLoading}
+                error={drawerError}
+                isPending={isPending}
+                onClose={() => {
+                    setDrawerNode(null);
+                    setDrawerDetail(null);
+                    setDrawerError(null);
+                }}
+                onSaveCapabilities={handleSaveCapabilities}
+                onRotate={handleRotate}
+                onDrain={handleDrain}
+            />
 
             {/* Rename */}
             <Dialog
@@ -616,6 +779,37 @@ export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
                             data-testid="fleet-rename-confirm"
                         >
                             {t('rename.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Revoke an outstanding token (confirm) */}
+            <Dialog
+                open={revokeTarget !== null}
+                onOpenChange={(open) => !open && setRevokeTarget(null)}
+            >
+                <DialogContent>
+                    <DialogClose onClose={() => setRevokeTarget(null)} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('tokens.revokeTitle')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('tokens.revokeDescription', { name: revokeTarget?.name ?? '' })}
+                    </p>
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setRevokeTarget(null)}>
+                            {t('tokens.revokeCancel')}
+                        </Button>
+                        <Button
+                            variant="danger"
+                            onClick={handleRevokeToken}
+                            loading={isPending}
+                            data-testid="fleet-token-revoke-confirm"
+                        >
+                            {t('tokens.revoke')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/apps/web/src/components/settings/FleetTokensSection.tsx
+++ b/apps/web/src/components/settings/FleetTokensSection.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, KeyRound, RefreshCw, Ban } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { FleetEnrollmentTokenView } from '@/lib/api/fleet';
+
+interface FleetTokensSectionProps {
+    tokens: FleetEnrollmentTokenView[];
+    loading: boolean;
+    error: string | null;
+    isPending: boolean;
+    onRefresh: () => void;
+    onRevoke: (token: FleetEnrollmentTokenView) => void;
+}
+
+function formatMoment(value: string | null): string {
+    if (!value) return '-';
+    try {
+        return new Date(value).toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return value;
+    }
+}
+
+/**
+ * Outstanding enrollment tokens — every credential that has been minted
+ * and not yet used, with a revoke button next to each.
+ *
+ * Without this the only trace of an issued token was a toast that had
+ * long since disappeared: an operator who minted a token, got
+ * distracted, and never enrolled the machine had no way to see that a
+ * usable credential was out there, and no way to kill it short of
+ * deleting the node row by guesswork. Both halves matter — SEEING the
+ * outstanding set is what makes revoking it possible.
+ *
+ * Expired rows stay listed (marked as such) on purpose: a stale
+ * credential row is exactly the thing worth cleaning up, and hiding it
+ * would make this list disagree with the node table above.
+ */
+export function FleetTokensSection({
+    tokens,
+    loading,
+    error,
+    isPending,
+    onRefresh,
+    onRevoke,
+}: FleetTokensSectionProps) {
+    const t = useTranslations('dashboard.settings.fleet');
+
+    return (
+        <div className="space-y-3" data-testid="fleet-tokens-section">
+            <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-2">
+                    <KeyRound className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                    <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('tokens.title')}
+                    </h3>
+                </div>
+                <Button
+                    variant="ghost"
+                    onClick={onRefresh}
+                    disabled={loading}
+                    title={t('tokens.refresh')}
+                    data-testid="fleet-tokens-refresh"
+                >
+                    <RefreshCw className="w-4 h-4" />
+                </Button>
+            </div>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                {t('tokens.description')}
+            </p>
+
+            {error ? (
+                <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                    <AlertTriangle className="w-4 h-4 text-warning flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-text dark:text-text-dark">{error}</p>
+                </div>
+            ) : tokens.length === 0 ? (
+                <p
+                    className="text-sm text-text-muted dark:text-text-muted-dark"
+                    data-testid="fleet-tokens-empty"
+                >
+                    {loading ? t('tokens.loading') : t('tokens.empty')}
+                </p>
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-border dark:border-border-dark">
+                    <table className="w-full text-sm" data-testid="fleet-tokens-table">
+                        <thead>
+                            <tr className="border-b border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-left">
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.name')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.kind')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('tokens.issuedAt')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('tokens.expiresAt')}
+                                </th>
+                                <th className="px-4 py-2.5" />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {tokens.map((token) => (
+                                <tr
+                                    key={token.nodeId}
+                                    className="border-b last:border-b-0 border-border dark:border-border-dark"
+                                    data-testid={`fleet-token-row-${token.nodeId}`}
+                                >
+                                    <td className="px-4 py-3 font-medium text-text dark:text-text-dark">
+                                        {token.name}
+                                        {token.rotated ? (
+                                            <span className="ml-2 px-1.5 py-0.5 rounded text-xs bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark">
+                                                {t('tokens.rotated')}
+                                            </span>
+                                        ) : null}
+                                    </td>
+                                    <td className="px-4 py-3 text-text-muted dark:text-text-muted-dark">
+                                        {t(`kinds.${token.kind}` as never)}
+                                    </td>
+                                    <td className="px-4 py-3 text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+                                        {formatMoment(token.issuedAt)}
+                                    </td>
+                                    <td className="px-4 py-3 whitespace-nowrap">
+                                        <span
+                                            className={
+                                                token.expired
+                                                    ? 'text-danger'
+                                                    : 'text-text-muted dark:text-text-muted-dark'
+                                            }
+                                            data-testid={`fleet-token-expiry-${token.nodeId}`}
+                                        >
+                                            {token.expired
+                                                ? t('tokens.expired')
+                                                : formatMoment(token.expiresAt)}
+                                        </span>
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <div className="flex justify-end">
+                                            <Button
+                                                variant="ghost"
+                                                onClick={() => onRevoke(token)}
+                                                disabled={isPending}
+                                                title={t('tokens.revoke')}
+                                                data-testid={`fleet-token-revoke-${token.nodeId}`}
+                                            >
+                                                <Ban className="w-4 h-4 text-danger" />
+                                            </Button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/fleet.ts
+++ b/apps/web/src/lib/api/fleet.ts
@@ -20,12 +20,21 @@ import { serverFetch, serverMutation } from './server-api';
  * the node apps compile against ONE declaration. This file used to
  * hand-copy them, which is exactly how the three copies drifted.
  */
+import type {
+    FleetNodeDetailView,
+    FleetNodeDrainResult,
+    FleetEnrollmentTokenView,
+} from '@ever-works/contracts';
+
 export type {
     FleetNodeKind,
     FleetNodeStatus,
     FleetNodeView,
     FleetNodeLoadView,
     FleetEnrollableNodeKind,
+    FleetNodeDetailView,
+    FleetNodeDrainResult,
+    FleetEnrollmentTokenView,
 } from '@ever-works/contracts';
 
 export interface CreateFleetEnrollmentTokenPayload {
@@ -43,6 +52,10 @@ export interface CreateFleetEnrollmentTokenResponse {
 export interface UpdateFleetNodePayload {
     name?: string;
     disabled?: boolean;
+    /** Admin-edited tags. Writing them pins the set by default. */
+    capabilities?: string[];
+    /** `false` hands tag ownership back to the node's heartbeats. */
+    capabilitiesPinned?: boolean;
 }
 
 // NOTE: no leading `/api` here — `serverFetch`/`serverMutation` prepend
@@ -78,6 +91,42 @@ export const fleetAPI = {
             endpoint: `${BASE}/nodes/${nodeId}`,
             data: {},
             method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+
+    nodeDetail: async (nodeId: string) => {
+        return serverFetch<FleetNodeDetailView>(`${BASE}/nodes/${nodeId}`);
+    },
+
+    listOutstandingTokens: async () => {
+        return serverFetch<FleetEnrollmentTokenView[]>(`${BASE}/enrollment-tokens`);
+    },
+
+    revokeEnrollmentToken: async (nodeId: string) => {
+        return serverMutation<void>({
+            endpoint: `${BASE}/enrollment-tokens/${nodeId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+
+    /** Re-key a node. The replacement token is returned exactly once. */
+    rotateNodeCredential: async (nodeId: string) => {
+        return serverMutation<CreateFleetEnrollmentTokenResponse>({
+            endpoint: `${BASE}/nodes/${nodeId}/rotate`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    drainNode: async (nodeId: string, drain: boolean) => {
+        return serverMutation<FleetNodeDrainResult>({
+            endpoint: `${BASE}/nodes/${nodeId}/drain`,
+            data: { drain },
+            method: 'POST',
             wrapInData: false,
         });
     },

--- a/apps/web/src/lib/fleet-flags.ts
+++ b/apps/web/src/lib/fleet-flags.ts
@@ -1,0 +1,51 @@
+/**
+ * Fleet gating + link resolution.
+ *
+ * Deliberately dependency-free (no `server-only`, no API client) so the
+ * settings LAYOUT — which must hide the nav entry — and the fleet PAGE
+ * can both read it without either one dragging a server-only module
+ * into a client bundle.
+ *
+ * Everything here is a pure read of `process.env`, evaluated on the
+ * server. None of these names is `NEXT_PUBLIC_`-prefixed by accident:
+ * the values are passed DOWN as props, never inlined into the browser
+ * bundle from here.
+ */
+
+/** Fallback download location for the node apps. */
+const DEFAULT_DOWNLOAD_URL = 'https://github.com/ever-works/ever-works/releases';
+
+/**
+ * The `FLEET_ENABLED` switch, matching `config.fleet.isEnabled()` on the
+ * API exactly — including the default.
+ *
+ * **Default ON.** Fleet already ships; a default-off flag would silently
+ * remove a working feature from every existing deployment on upgrade.
+ * Operators opt out explicitly with `FLEET_ENABLED=false`.
+ */
+export function isFleetEnabled(): boolean {
+    return process.env.FLEET_ENABLED !== 'false';
+}
+
+/**
+ * The API base a NODE should call — which is not necessarily the one the
+ * web tier calls.
+ *
+ * `API_URL` is frequently an in-cluster address (`http://api:3100`) that
+ * a laptop in an office cannot reach, so the browser-facing
+ * `NEXT_PUBLIC_API_URL` wins when it is set. The trailing `/api` is
+ * stripped because the node CLI takes an origin and appends its own
+ * paths.
+ */
+export function resolvePublicApiBaseUrl(): string {
+    const raw = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL || 'http://localhost:3100';
+    return raw.replace(/\/+$/, '').replace(/\/api$/, '');
+}
+
+/** Where the desktop and headless node apps are downloaded from. */
+export function resolveFleetDownloadUrls(): { desktop: string; node: string } {
+    return {
+        desktop: process.env.FLEET_DESKTOP_DOWNLOAD_URL || DEFAULT_DOWNLOAD_URL,
+        node: process.env.FLEET_NODE_DOWNLOAD_URL || DEFAULT_DOWNLOAD_URL,
+    };
+}

--- a/apps/web/src/lib/utils/qr-code.ts
+++ b/apps/web/src/lib/utils/qr-code.ts
@@ -1,0 +1,591 @@
+/**
+ * A small, dependency-free QR encoder — just enough of ISO/IEC 18004 to
+ * turn a short enrollment payload into a scannable code.
+ *
+ * **Why hand-rolled.** The only thing the Fleet enroll flow needs is
+ * "put this one short string on the screen so a phone or a node app can
+ * read it without anyone retyping a 43-character secret". That is byte
+ * mode, error-correction level L, versions 1–9 — a closed, testable
+ * subset. Pulling a general-purpose QR library into the web bundle to
+ * draw one square would be a worse trade, and everything here is pure:
+ * no canvas, no DOM, no network, safe on the server and the client.
+ *
+ * **Scope (deliberate limits).**
+ *   - Byte mode only (UTF-8). No numeric/alphanumeric/kanji compaction —
+ *     they would shrink the code, not change what it can carry.
+ *   - EC level L. The code is displayed on a screen, inches from the
+ *     scanner; the higher levels buy damage tolerance nobody needs here
+ *     and cost capacity.
+ *   - Versions 1–9 (up to 230 bytes). Beyond v9 the block layout stops
+ *     being uniform, and a payload that big does not belong in a QR on a
+ *     settings page anyway. Oversize input returns `null` so the caller
+ *     can fall back to the copy button rather than render a wrong code.
+ *
+ * The algorithm follows the reference structure (finder/alignment/timing
+ * patterns, BCH-coded format + version info, zigzag data placement,
+ * eight mask candidates scored by the four standard penalty rules).
+ * `decodeQrCodeForTest` in the spec re-extracts the payload straight
+ * from the finished matrix, so placement, masking and the Reed–Solomon
+ * codewords are all verified end to end rather than eyeballed.
+ */
+
+/** Highest version this encoder emits (uniform block layout up to here). */
+const MAX_VERSION = 9;
+
+/** Total codewords per version, v1..v9. */
+const TOTAL_CODEWORDS = [26, 44, 70, 100, 134, 172, 196, 242, 292];
+
+/** EC codewords per block at level L, v1..v9. */
+const ECC_PER_BLOCK_L = [7, 10, 15, 20, 26, 18, 20, 24, 30];
+
+/** Number of EC blocks at level L, v1..v9. */
+const NUM_BLOCKS_L = [1, 1, 1, 1, 1, 2, 2, 2, 2];
+
+/** Format-info bits for error-correction level L. */
+const EC_FORMAT_BITS_L = 1;
+
+/** Penalty weights from the specification. */
+const PENALTY_N1 = 3;
+const PENALTY_N2 = 3;
+const PENALTY_N3 = 40;
+const PENALTY_N4 = 10;
+
+/** A finished QR symbol: `modules[row][col]`, true = dark. */
+export interface QrCodeMatrix {
+    /** Modules per side (4 × version + 17). */
+    size: number;
+    modules: boolean[][];
+}
+
+/**
+ * Encode `text` as a QR symbol, or return `null` when it does not fit
+ * the supported range (empty, or larger than version 9 at level L).
+ *
+ * Returning null rather than throwing is deliberate: a QR is a
+ * convenience next to a copy button, and a failure to draw one must
+ * never take down the dialog that also shows the token.
+ */
+export function encodeQrCode(text: string): QrCodeMatrix | null {
+    if (typeof text !== 'string' || text.length === 0) return null;
+
+    const data = utf8Bytes(text);
+    const version = pickVersion(data.length);
+    if (version === null) return null;
+
+    const codewords = buildCodewords(data, version);
+    const size = version * 4 + 17;
+
+    const modules: boolean[][] = createGrid(size, false);
+    const isFunction: boolean[][] = createGrid(size, false);
+
+    drawFunctionPatterns(modules, isFunction, version, size);
+    drawCodewords(modules, isFunction, codewords, size);
+
+    // Try every mask, keep the least-penalised one. The mask is not a
+    // free choice: an unmasked symbol can contain large uniform areas or
+    // accidental finder-like runs that scanners misread.
+    let bestMask = 0;
+    let bestPenalty = Number.POSITIVE_INFINITY;
+    for (let mask = 0; mask < 8; mask++) {
+        applyMask(modules, isFunction, mask, size);
+        drawFormatBits(modules, isFunction, mask, size);
+        const penalty = penaltyScore(modules, size);
+        if (penalty < bestPenalty) {
+            bestPenalty = penalty;
+            bestMask = mask;
+        }
+        // Masking is an XOR — applying it again restores the original.
+        applyMask(modules, isFunction, mask, size);
+    }
+    applyMask(modules, isFunction, bestMask, size);
+    drawFormatBits(modules, isFunction, bestMask, size);
+
+    return { size, modules };
+}
+
+/**
+ * Render a matrix as a single SVG `path` `d` attribute (one `M…h1v1h-1z`
+ * per dark module), in a coordinate space of `size + 2 * quietZone`.
+ *
+ * One path for the whole symbol keeps the DOM to a single node — a v9
+ * code is 2809 modules, and that many `<rect>`s is a real cost on a
+ * settings page.
+ */
+export function qrCodeToSvgPath(matrix: QrCodeMatrix, quietZone = 2): string {
+    const parts: string[] = [];
+    for (let row = 0; row < matrix.size; row++) {
+        for (let col = 0; col < matrix.size; col++) {
+            if (matrix.modules[row][col]) {
+                parts.push(`M${col + quietZone} ${row + quietZone}h1v1h-1z`);
+            }
+        }
+    }
+    return parts.join('');
+}
+
+/** Side length of the SVG viewBox for a matrix drawn with a quiet zone. */
+export function qrCodeViewBoxSize(matrix: QrCodeMatrix, quietZone = 2): number {
+    return matrix.size + quietZone * 2;
+}
+
+/**
+ * The reserved (function-pattern) module map for a version — true where
+ * a module belongs to a finder, separator, alignment, timing, format or
+ * version area and therefore carries no data.
+ *
+ * Exported so the unit spec can decode a finished symbol back to its
+ * payload. Everything else about the round trip (unmasking, the zigzag
+ * read, de-interleaving, the Reed–Solomon syndrome check) is written
+ * independently there, so the two halves genuinely cross-check.
+ */
+export function qrFunctionModuleMap(version: number): boolean[][] {
+    const size = version * 4 + 17;
+    const modules = createGrid(size, false);
+    const isFunction = createGrid(size, false);
+    drawFunctionPatterns(modules, isFunction, version, size);
+    return isFunction;
+}
+
+/** Byte-mode payload capacity of a version at EC level L. */
+export function qrByteCapacity(version: number): number {
+    return byteCapacity(version);
+}
+
+/** Largest version this encoder emits. */
+export const QR_MAX_VERSION = MAX_VERSION;
+
+// ── encoding ────────────────────────────────────────────────────────
+
+function utf8Bytes(text: string): number[] {
+    // `TextEncoder` is available in every runtime this app targets
+    // (browser, Node ≥22, edge) — no polyfill branch needed.
+    return Array.from(new TextEncoder().encode(text));
+}
+
+/** Usable byte-mode payload for a version: data codewords minus the 12-bit header. */
+function byteCapacity(version: number): number {
+    return dataCodewordCount(version) - 2;
+}
+
+function dataCodewordCount(version: number): number {
+    const index = version - 1;
+    return TOTAL_CODEWORDS[index] - ECC_PER_BLOCK_L[index] * NUM_BLOCKS_L[index];
+}
+
+function pickVersion(byteLength: number): number | null {
+    for (let version = 1; version <= MAX_VERSION; version++) {
+        if (byteLength <= byteCapacity(version)) return version;
+    }
+    return null;
+}
+
+/**
+ * Bit stream → padded data codewords → per-block Reed–Solomon → the
+ * interleaved codeword sequence the matrix is filled with.
+ */
+function buildCodewords(data: number[], version: number): number[] {
+    const bits: number[] = [];
+    appendBits(bits, 0b0100, 4); // byte mode
+    appendBits(bits, data.length, 8); // v1–v9 byte-mode length field
+    for (const byte of data) appendBits(bits, byte, 8);
+
+    const capacityBits = dataCodewordCount(version) * 8;
+    // Terminator, then pad to a whole codeword.
+    appendBits(bits, 0, Math.min(4, capacityBits - bits.length));
+    appendBits(bits, 0, (8 - (bits.length % 8)) % 8);
+
+    const codewords: number[] = [];
+    for (let i = 0; i < bits.length; i += 8) {
+        let byte = 0;
+        for (let j = 0; j < 8; j++) byte = (byte << 1) | bits[i + j];
+        codewords.push(byte);
+    }
+    // The two specified pad codewords, alternating.
+    for (let pad = 0xec; codewords.length < dataCodewordCount(version); pad ^= 0xec ^ 0x11) {
+        codewords.push(pad);
+    }
+
+    return addEccAndInterleave(codewords, version);
+}
+
+function appendBits(bits: number[], value: number, length: number): void {
+    for (let i = length - 1; i >= 0; i--) bits.push((value >>> i) & 1);
+}
+
+function addEccAndInterleave(data: number[], version: number): number[] {
+    const index = version - 1;
+    const numBlocks = NUM_BLOCKS_L[index];
+    const blockEccLen = ECC_PER_BLOCK_L[index];
+    const rawCodewords = TOTAL_CODEWORDS[index];
+    const numShortBlocks = numBlocks - (rawCodewords % numBlocks);
+    const shortBlockLen = Math.floor(rawCodewords / numBlocks);
+
+    const divisor = rsComputeDivisor(blockEccLen);
+    const blocks: number[][] = [];
+    for (let i = 0, k = 0; i < numBlocks; i++) {
+        const dataLen = shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1);
+        const block = data.slice(k, k + dataLen);
+        k += dataLen;
+        const ecc = rsComputeRemainder(block, divisor);
+        // Pad short blocks to a uniform length so the interleave below
+        // is a plain column read; the padding slot is skipped, never
+        // emitted.
+        if (i < numShortBlocks) block.push(0);
+        blocks.push(block.concat(ecc));
+    }
+
+    const result: number[] = [];
+    for (let i = 0; i < blocks[0].length; i++) {
+        for (let j = 0; j < blocks.length; j++) {
+            if (i !== shortBlockLen - blockEccLen || j >= numShortBlocks) {
+                result.push(blocks[j][i]);
+            }
+        }
+    }
+    return result;
+}
+
+// ── Reed–Solomon over GF(256), primitive polynomial 0x11D ───────────
+
+function rsComputeDivisor(degree: number): number[] {
+    const result = new Array<number>(degree).fill(0);
+    result[degree - 1] = 1;
+    let root = 1;
+    for (let i = 0; i < degree; i++) {
+        for (let j = 0; j < result.length; j++) {
+            result[j] = rsMultiply(result[j], root);
+            if (j + 1 < result.length) result[j] ^= result[j + 1];
+        }
+        root = rsMultiply(root, 0x02);
+    }
+    return result;
+}
+
+function rsComputeRemainder(data: readonly number[], divisor: readonly number[]): number[] {
+    const result = new Array<number>(divisor.length).fill(0);
+    for (const byte of data) {
+        const factor = byte ^ (result.shift() as number);
+        result.push(0);
+        for (let i = 0; i < divisor.length; i++) {
+            result[i] ^= rsMultiply(divisor[i], factor);
+        }
+    }
+    return result;
+}
+
+function rsMultiply(x: number, y: number): number {
+    let z = 0;
+    for (let i = 7; i >= 0; i--) {
+        z = (z << 1) ^ ((z >>> 7) * 0x11d);
+        z ^= ((y >>> i) & 1) * x;
+    }
+    return z & 0xff;
+}
+
+// ── matrix construction ─────────────────────────────────────────────
+
+function createGrid(size: number, value: boolean): boolean[][] {
+    return Array.from({ length: size }, () => new Array<boolean>(size).fill(value));
+}
+
+function drawFunctionPatterns(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    version: number,
+    size: number,
+): void {
+    // Timing patterns.
+    for (let i = 0; i < size; i++) {
+        setFunction(modules, isFunction, 6, i, i % 2 === 0);
+        setFunction(modules, isFunction, i, 6, i % 2 === 0);
+    }
+
+    // Finder patterns + their separators.
+    drawFinder(modules, isFunction, 3, 3, size);
+    drawFinder(modules, isFunction, 3, size - 4, size);
+    drawFinder(modules, isFunction, size - 4, 3, size);
+
+    // Alignment patterns, skipping the three that collide with finders.
+    const positions = alignmentPositions(version, size);
+    for (let i = 0; i < positions.length; i++) {
+        for (let j = 0; j < positions.length; j++) {
+            const isFinderCorner =
+                (i === 0 && j === 0) ||
+                (i === 0 && j === positions.length - 1) ||
+                (i === positions.length - 1 && j === 0);
+            if (!isFinderCorner) {
+                drawAlignment(modules, isFunction, positions[i], positions[j]);
+            }
+        }
+    }
+
+    // Reserve the format areas (a dummy mask; the real bits are written
+    // once the mask is chosen) and, from v7, the version areas.
+    drawFormatBits(modules, isFunction, 0, size);
+    if (version >= 7) drawVersionBits(modules, isFunction, version, size);
+}
+
+function drawFinder(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    centreRow: number,
+    centreCol: number,
+    size: number,
+): void {
+    for (let dr = -4; dr <= 4; dr++) {
+        for (let dc = -4; dc <= 4; dc++) {
+            const distance = Math.max(Math.abs(dr), Math.abs(dc));
+            const row = centreRow + dr;
+            const col = centreCol + dc;
+            if (row >= 0 && row < size && col >= 0 && col < size) {
+                setFunction(modules, isFunction, row, col, distance !== 2 && distance !== 4);
+            }
+        }
+    }
+}
+
+function drawAlignment(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    centreRow: number,
+    centreCol: number,
+): void {
+    for (let dr = -2; dr <= 2; dr++) {
+        for (let dc = -2; dc <= 2; dc++) {
+            setFunction(
+                modules,
+                isFunction,
+                centreRow + dr,
+                centreCol + dc,
+                Math.max(Math.abs(dr), Math.abs(dc)) !== 1,
+            );
+        }
+    }
+}
+
+function alignmentPositions(version: number, size: number): number[] {
+    if (version === 1) return [];
+    const count = Math.floor(version / 7) + 2;
+    const step = Math.ceil((version * 4 + 4) / (count * 2 - 2)) * 2;
+    const result = [6];
+    for (let pos = size - 7; result.length < count; pos -= step) result.splice(1, 0, pos);
+    return result;
+}
+
+/**
+ * Write (or, on the reservation pass, merely claim) the 15 format bits:
+ * EC level + mask, BCH(15,5)-coded and XORed with the specified mask
+ * pattern so an all-zero format is never valid.
+ */
+function drawFormatBits(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    mask: number,
+    size: number,
+): void {
+    const data = (EC_FORMAT_BITS_L << 3) | mask;
+    let rem = data;
+    for (let i = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >>> 9) * 0x537);
+    const bits = (((data << 10) | rem) ^ 0x5412) & 0x7fff;
+
+    // Copy 1 — around the top-left finder.
+    for (let i = 0; i <= 5; i++) setFunction(modules, isFunction, i, 8, getBit(bits, i));
+    setFunction(modules, isFunction, 7, 8, getBit(bits, 6));
+    setFunction(modules, isFunction, 8, 8, getBit(bits, 7));
+    setFunction(modules, isFunction, 8, 7, getBit(bits, 8));
+    for (let i = 9; i < 15; i++) setFunction(modules, isFunction, 8, 14 - i, getBit(bits, i));
+
+    // Copy 2 — split between the other two finders.
+    for (let i = 0; i < 8; i++) setFunction(modules, isFunction, 8, size - 1 - i, getBit(bits, i));
+    for (let i = 8; i < 15; i++)
+        setFunction(modules, isFunction, size - 15 + i, 8, getBit(bits, i));
+    // The always-dark module.
+    setFunction(modules, isFunction, size - 8, 8, true);
+}
+
+/** BCH(18,6)-coded version number, mirrored near the two far finders. */
+function drawVersionBits(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    version: number,
+    size: number,
+): void {
+    let rem = version;
+    for (let i = 0; i < 12; i++) rem = (rem << 1) ^ ((rem >>> 11) * 0x1f25);
+    const bits = (version << 12) | rem;
+
+    for (let i = 0; i < 18; i++) {
+        const bit = getBit(bits, i);
+        const a = size - 11 + (i % 3);
+        const b = Math.floor(i / 3);
+        setFunction(modules, isFunction, b, a, bit);
+        setFunction(modules, isFunction, a, b, bit);
+    }
+}
+
+function setFunction(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    row: number,
+    col: number,
+    dark: boolean,
+): void {
+    modules[row][col] = dark;
+    isFunction[row][col] = true;
+}
+
+function getBit(value: number, index: number): boolean {
+    return ((value >>> index) & 1) !== 0;
+}
+
+/**
+ * Fill the non-function modules with the codeword bits, in the standard
+ * two-module-wide zigzag that runs right-to-left, skipping the vertical
+ * timing column.
+ */
+function drawCodewords(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    codewords: readonly number[],
+    size: number,
+): void {
+    let bitIndex = 0;
+    const totalBits = codewords.length * 8;
+
+    for (let right = size - 1; right >= 1; right -= 2) {
+        if (right === 6) right = 5; // skip the timing column
+        for (let vert = 0; vert < size; vert++) {
+            for (let j = 0; j < 2; j++) {
+                const col = right - j;
+                const upward = ((right + 1) & 2) === 0;
+                const row = upward ? size - 1 - vert : vert;
+                if (!isFunction[row][col] && bitIndex < totalBits) {
+                    modules[row][col] = getBit(codewords[bitIndex >>> 3], 7 - (bitIndex & 7));
+                    bitIndex++;
+                }
+                // Remainder bits past the codewords stay light, which is
+                // what the specification requires.
+            }
+        }
+    }
+}
+
+/** XOR one of the eight mask patterns over the data modules only. */
+function applyMask(
+    modules: boolean[][],
+    isFunction: boolean[][],
+    mask: number,
+    size: number,
+): void {
+    for (let row = 0; row < size; row++) {
+        for (let col = 0; col < size; col++) {
+            if (isFunction[row][col]) continue;
+            if (maskBit(mask, row, col)) modules[row][col] = !modules[row][col];
+        }
+    }
+}
+
+function maskBit(mask: number, row: number, col: number): boolean {
+    switch (mask) {
+        case 0:
+            return (row + col) % 2 === 0;
+        case 1:
+            return row % 2 === 0;
+        case 2:
+            return col % 3 === 0;
+        case 3:
+            return (row + col) % 3 === 0;
+        case 4:
+            return (Math.floor(row / 2) + Math.floor(col / 3)) % 2 === 0;
+        case 5:
+            return ((row * col) % 2) + ((row * col) % 3) === 0;
+        case 6:
+            return (((row * col) % 2) + ((row * col) % 3)) % 2 === 0;
+        default:
+            return (((row + col) % 2) + ((row * col) % 3)) % 2 === 0;
+    }
+}
+
+/** The four penalty rules that pick the least scanner-hostile mask. */
+function penaltyScore(modules: boolean[][], size: number): number {
+    let result = 0;
+
+    // Rules 1 + 3, scanned in both directions.
+    for (let row = 0; row < size; row++) {
+        result += lineScore(modules[row], size);
+        result += lineScore(
+            Array.from({ length: size }, (_, r) => modules[r][row]),
+            size,
+        );
+    }
+
+    // Rule 2 — 2×2 blocks of one colour.
+    for (let row = 0; row < size - 1; row++) {
+        for (let col = 0; col < size - 1; col++) {
+            const value = modules[row][col];
+            if (
+                value === modules[row][col + 1] &&
+                value === modules[row + 1][col] &&
+                value === modules[row + 1][col + 1]
+            ) {
+                result += PENALTY_N2;
+            }
+        }
+    }
+
+    // Rule 4 — deviation of the dark ratio from 50%.
+    let dark = 0;
+    for (const row of modules) for (const cell of row) if (cell) dark++;
+    const total = size * size;
+    const k = Math.ceil(Math.abs(dark * 20 - total * 10) / total) - 1;
+    result += Math.max(k, 0) * PENALTY_N4;
+
+    return result;
+}
+
+/** Rule 1 (runs of five or more) plus rule 3 (finder-like patterns). */
+function lineScore(line: readonly boolean[], size: number): number {
+    // Collapse the line into colour runs once; both rules read them.
+    const runs: { length: number; dark: boolean }[] = [];
+    let runColour = line[0];
+    let runLength = 1;
+    for (let i = 1; i < size; i++) {
+        if (line[i] === runColour) {
+            runLength++;
+            continue;
+        }
+        runs.push({ length: runLength, dark: runColour });
+        runColour = line[i];
+        runLength = 1;
+    }
+    runs.push({ length: runLength, dark: runColour });
+
+    let score = 0;
+
+    // Rule 1 — every run of five or more same-coloured modules.
+    for (const run of runs) {
+        if (run.length >= 5) score += PENALTY_N1 + (run.length - 5);
+    }
+
+    // Rule 3 — a dark:light:dark:light:dark 1:1:3:1:1 core (the finder
+    // signature) with at least 4n light modules on one side, which is
+    // what makes a scanner mistake it for a finder pattern.
+    for (let i = 0; i + 4 < runs.length; i++) {
+        const [a, b, c, d, e] = runs.slice(i, i + 5);
+        const unit = a.length;
+        const isCore =
+            a.dark &&
+            unit > 0 &&
+            b.length === unit &&
+            c.length === unit * 3 &&
+            d.length === unit &&
+            e.length === unit;
+        if (!isCore) continue;
+        // The symbol edge counts as unlimited light (the quiet zone).
+        const before = i === 0 ? Number.POSITIVE_INFINITY : runs[i - 1].length;
+        const after = i + 5 >= runs.length ? Number.POSITIVE_INFINITY : runs[i + 5].length;
+        if (before >= unit * 4 || after >= unit * 4) score += PENALTY_N3;
+    }
+
+    return score;
+}

--- a/apps/web/src/lib/utils/qr-code.unit.spec.ts
+++ b/apps/web/src/lib/utils/qr-code.unit.spec.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import {
+    QR_MAX_VERSION,
+    encodeQrCode,
+    qrByteCapacity,
+    qrCodeToSvgPath,
+    qrCodeViewBoxSize,
+    qrFunctionModuleMap,
+    type QrCodeMatrix,
+} from './qr-code';
+
+/**
+ * The encoder is hand-rolled, so "it renders a square of dots" is not
+ * evidence of anything. These tests DECODE the finished matrix back to
+ * the payload with an independently written reader — unmask, zigzag
+ * read, de-interleave — and separately verify the Reed–Solomon parity
+ * by evaluating the codeword polynomial at the generator's roots.
+ *
+ * The syndrome check is deliberately a different formulation from the
+ * encoder's polynomial long division: if both were the same algorithm,
+ * agreeing would prove nothing.
+ */
+
+// ── GF(256) helpers for the syndrome check (primitive poly 0x11D) ────
+
+const GF_EXP = new Uint8Array(512);
+const GF_LOG = new Uint8Array(256);
+(() => {
+    let x = 1;
+    for (let i = 0; i < 255; i++) {
+        GF_EXP[i] = x;
+        GF_LOG[x] = i;
+        x <<= 1;
+        if (x & 0x100) x ^= 0x11d;
+    }
+    for (let i = 255; i < 512; i++) GF_EXP[i] = GF_EXP[i - 255];
+})();
+
+function gfMul(a: number, b: number): number {
+    if (a === 0 || b === 0) return 0;
+    return GF_EXP[GF_LOG[a] + GF_LOG[b]];
+}
+
+/** True when every syndrome of the codeword block is zero. */
+function hasValidParity(block: readonly number[], eccLength: number): boolean {
+    for (let i = 0; i < eccLength; i++) {
+        const root = GF_EXP[i];
+        let value = 0;
+        for (const coefficient of block) {
+            value = gfMul(value, root) ^ coefficient;
+        }
+        if (value !== 0) return false;
+    }
+    return true;
+}
+
+// ── an independent reader ───────────────────────────────────────────
+
+const TOTAL_CODEWORDS = [26, 44, 70, 100, 134, 172, 196, 242, 292];
+const ECC_PER_BLOCK_L = [7, 10, 15, 20, 26, 18, 20, 24, 30];
+const NUM_BLOCKS_L = [1, 1, 1, 1, 1, 2, 2, 2, 2];
+
+function maskBit(mask: number, row: number, col: number): boolean {
+    switch (mask) {
+        case 0:
+            return (row + col) % 2 === 0;
+        case 1:
+            return row % 2 === 0;
+        case 2:
+            return col % 3 === 0;
+        case 3:
+            return (row + col) % 3 === 0;
+        case 4:
+            return (Math.floor(row / 2) + Math.floor(col / 3)) % 2 === 0;
+        case 5:
+            return ((row * col) % 2) + ((row * col) % 3) === 0;
+        case 6:
+            return (((row * col) % 2) + ((row * col) % 3)) % 2 === 0;
+        default:
+            return (((row + col) % 2) + ((row * col) % 3)) % 2 === 0;
+    }
+}
+
+/** Read the interleaved codeword stream out of a (still masked) matrix. */
+function readCodewords(matrix: QrCodeMatrix, mask: number, total: number): number[] {
+    const { size, modules } = matrix;
+    const version = (size - 17) / 4;
+    const isFunction = qrFunctionModuleMap(version);
+
+    const bits: number[] = [];
+    for (let right = size - 1; right >= 1; right -= 2) {
+        if (right === 6) right = 5;
+        for (let vert = 0; vert < size; vert++) {
+            for (let j = 0; j < 2; j++) {
+                const col = right - j;
+                const upward = ((right + 1) & 2) === 0;
+                const row = upward ? size - 1 - vert : vert;
+                if (isFunction[row][col]) continue;
+                const masked = maskBit(mask, row, col);
+                bits.push(modules[row][col] !== masked ? 1 : 0);
+            }
+        }
+    }
+
+    const codewords: number[] = [];
+    for (let i = 0; i + 7 < bits.length && codewords.length < total; i += 8) {
+        let byte = 0;
+        for (let j = 0; j < 8; j++) byte = (byte << 1) | bits[i + j];
+        codewords.push(byte);
+    }
+    return codewords;
+}
+
+/**
+ * Decode a symbol back to its payload, or null when no mask produces a
+ * parity-clean, well-formed byte-mode message.
+ *
+ * Brute-forcing the mask (instead of parsing the format bits) means a
+ * wrong mask cannot accidentally pass: it has to survive the RS parity
+ * check on every block AND yield a byte-mode header.
+ */
+function decode(matrix: QrCodeMatrix): string | null {
+    const version = (matrix.size - 17) / 4;
+    const index = version - 1;
+    const eccLength = ECC_PER_BLOCK_L[index];
+    const numBlocks = NUM_BLOCKS_L[index];
+    const total = TOTAL_CODEWORDS[index];
+    const blockLength = total / numBlocks;
+    const dataPerBlock = blockLength - eccLength;
+
+    for (let mask = 0; mask < 8; mask++) {
+        const stream = readCodewords(matrix, mask, total);
+        if (stream.length < total) continue;
+
+        // De-interleave: data codewords first (round-robin across
+        // blocks), then the ecc codewords the same way.
+        const blocks: number[][] = Array.from({ length: numBlocks }, () => []);
+        let cursor = 0;
+        for (let i = 0; i < dataPerBlock; i++) {
+            for (let b = 0; b < numBlocks; b++) blocks[b].push(stream[cursor++]);
+        }
+        const eccBlocks: number[][] = Array.from({ length: numBlocks }, () => []);
+        for (let i = 0; i < eccLength; i++) {
+            for (let b = 0; b < numBlocks; b++) eccBlocks[b].push(stream[cursor++]);
+        }
+
+        const parityOk = blocks.every((block, b) =>
+            hasValidParity(block.concat(eccBlocks[b]), eccLength),
+        );
+        if (!parityOk) continue;
+
+        const data = blocks.flat();
+        const mode = data[0] >> 4;
+        if (mode !== 0b0100) continue;
+        const length = ((data[0] & 0x0f) << 4) | (data[1] >> 4);
+        const bytes: number[] = [];
+        for (let i = 0; i < length; i++) {
+            bytes.push(((data[1 + i] & 0x0f) << 4) | (data[2 + i] >> 4));
+        }
+        return new TextDecoder().decode(new Uint8Array(bytes));
+    }
+    return null;
+}
+
+describe('encodeQrCode', () => {
+    it('round-trips a short ASCII payload', () => {
+        const matrix = encodeQrCode('ever-works');
+        expect(matrix).not.toBeNull();
+        expect(decode(matrix as QrCodeMatrix)).toBe('ever-works');
+    });
+
+    it('round-trips a realistic enrollment payload across a multi-block version', () => {
+        // Shaped like what the enroll dialog encodes: an API base plus a
+        // 43-character base64url token. Long enough to push past the
+        // single-block versions and to require version-info bits.
+        const payload =
+            'everworks://enroll?api=https://api.example.com&token=' +
+            'aZ9-_bcdefghijklmnopqrstuvwxyzABCDEFGHIJK12' +
+            '&name=Office%20workstation&kind=node';
+        const matrix = encodeQrCode(payload);
+        expect(matrix).not.toBeNull();
+        // ≥ v6 (size 41) — the first version with two EC blocks, so the
+        // interleave is genuinely exercised rather than a no-op.
+        expect((matrix as QrCodeMatrix).size).toBeGreaterThanOrEqual(41);
+        expect(decode(matrix as QrCodeMatrix)).toBe(payload);
+    });
+
+    it('round-trips a payload large enough to carry version-info bits', () => {
+        // ≥ v7 symbols embed two BCH-coded copies of the version number
+        // near the far finders; those areas must be reserved, not data.
+        const payload = 'v'.repeat(200);
+        const matrix = encodeQrCode(payload) as QrCodeMatrix;
+        expect(matrix.size).toBe(53); // version 9
+        expect(decode(matrix)).toBe(payload);
+    });
+
+    it('round-trips multi-byte UTF-8', () => {
+        const payload = 'nœud — 節点 — узел';
+        const matrix = encodeQrCode(payload);
+        expect(decode(matrix as QrCodeMatrix)).toBe(payload);
+    });
+
+    it('sizes the symbol to 4 × version + 17 and grows with the payload', () => {
+        const small = encodeQrCode('x') as QrCodeMatrix;
+        expect((small.size - 17) % 4).toBe(0);
+        expect(small.size).toBe(21); // version 1
+
+        const larger = encodeQrCode('x'.repeat(120)) as QrCodeMatrix;
+        expect(larger.size).toBeGreaterThan(small.size);
+    });
+
+    it('returns null rather than a wrong code for unsupported input', () => {
+        expect(encodeQrCode('')).toBeNull();
+        // One byte past the largest supported version.
+        expect(encodeQrCode('x'.repeat(qrByteCapacity(QR_MAX_VERSION) + 1))).toBeNull();
+        // …and exactly at the limit it still encodes.
+        expect(encodeQrCode('x'.repeat(qrByteCapacity(QR_MAX_VERSION)))).not.toBeNull();
+    });
+
+    it('places the three finder patterns and the timing rows', () => {
+        const matrix = encodeQrCode('finder-check') as QrCodeMatrix;
+        const { size, modules } = matrix;
+
+        for (const [top, left] of [
+            [0, 0],
+            [0, size - 7],
+            [size - 7, 0],
+        ]) {
+            // Dark 7×7 border, light ring, dark 3×3 core.
+            expect(modules[top][left]).toBe(true);
+            expect(modules[top + 1][left + 1]).toBe(false);
+            expect(modules[top + 3][left + 3]).toBe(true);
+        }
+
+        // Timing patterns alternate, starting dark at index 8.
+        for (let i = 8; i < size - 8; i++) {
+            expect(modules[6][i]).toBe(i % 2 === 0);
+            expect(modules[i][6]).toBe(i % 2 === 0);
+        }
+
+        // The always-dark module below the top-left format area.
+        expect(modules[size - 8][8]).toBe(true);
+    });
+});
+
+describe('qrCodeToSvgPath', () => {
+    it('emits one sub-path per dark module, offset by the quiet zone', () => {
+        const matrix = encodeQrCode('svg') as QrCodeMatrix;
+        const path = qrCodeToSvgPath(matrix, 2);
+
+        const darkCount = matrix.modules.flat().filter(Boolean).length;
+        expect(path.split('M').length - 1).toBe(darkCount);
+        // The top-left finder's first module lands at the quiet-zone offset.
+        expect(path).toContain('M2 2h1v1h-1z');
+    });
+
+    it('sizes the viewBox to include the quiet zone on both sides', () => {
+        const matrix = encodeQrCode('svg') as QrCodeMatrix;
+        expect(qrCodeViewBoxSize(matrix, 2)).toBe(matrix.size + 4);
+        expect(qrCodeViewBoxSize(matrix, 0)).toBe(matrix.size);
+    });
+});

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -839,9 +839,12 @@ describe('agent/config', () => {
                 'branding',
                 'database',
                 'everWorks',
-                // Fleet limits — `fleet.*` holds the clamped
-                // enrollment-token TTL, offline-after window and
-                // capability-tag ceilings shared with the node.
+                // Fleet — ONE group covering both halves of the surface:
+                // the `FLEET_ENABLED` switch that gates the whole thing
+                // (registry + admin + node work channel + settings page,
+                // default ON because the surface already shipped), and
+                // the clamped limits shared with the node (token TTL,
+                // offline-after window, capability-tag ceilings).
                 // Pinned alphabetically, before `fleetNode`.
                 'fleet',
                 // Desktop PRD M4 — `fleetNode.*` group reads the

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -213,6 +213,80 @@ export const config = {
         },
     },
 
+    /**
+     * Fleet — the owner's own machines (desktop nodes, headless nodes,
+     * their configured clusters) and the job-lease channel that runs
+     * work on them.
+     *
+     * ONE switch for the whole surface: the `/api/fleet/**` controllers
+     * (registry, admin and the node work channel), the Fleet settings
+     * page and its nav entry. Turning it off is a deployment saying "my
+     * users have no machines of their own" — the platform's own runtimes
+     * are untouched.
+     *
+     * **Default ON**, deliberately, and that is not a style choice: the
+     * Fleet surface already ships, so a default-off flag would silently
+     * REMOVE a working feature from every existing deployment on
+     * upgrade. Operators who want it gone set `FLEET_ENABLED=false`
+     * explicitly, exactly like `SCHEDULED_UPDATES_ENABLED`.
+     *
+     * Off is a hard gate, not a hint: the API answers 404 (not 403) on
+     * every fleet route, so a disabled deployment does not even confirm
+     * the surface exists, and an enrolled node's credential buys nothing.
+     */
+    fleet: {
+        isEnabled(): boolean {
+            return process.env.FLEET_ENABLED !== 'false';
+        },
+        /**
+         * How long a one-time enrollment token stays redeemable.
+         * Default 15 minutes (`FLEET_ENROLLMENT_TOKEN_TTL_MS`), floored
+         * at 30s so a token can always actually be typed in.
+         */
+        getEnrollmentTokenTtlMs(): number {
+            return clampedIntEnv(
+                process.env.FLEET_ENROLLMENT_TOKEN_TTL_MS,
+                FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS,
+                FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS,
+                Number.MAX_SAFE_INTEGER,
+            );
+        },
+        /**
+         * Silence after which an `online` node is swept to `offline` by
+         * the next owner-scoped list read. Default 5 minutes.
+         *
+         * Shortening this below a node's heartbeat cadence makes healthy
+         * nodes flap; the 30s floor stops the value becoming nonsense,
+         * it does not stop it becoming unwise.
+         */
+        getNodeOfflineAfterMs(): number {
+            return clampedIntEnv(
+                process.env.FLEET_NODE_OFFLINE_AFTER_MS,
+                FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
+                FLEET_MIN_NODE_OFFLINE_AFTER_MS,
+                Number.MAX_SAFE_INTEGER,
+            );
+        },
+        /** Max capability tags one node may advertise. Default 16, hard ceiling 64. */
+        getMaxCapabilityTags(): number {
+            return clampedIntEnv(
+                process.env.FLEET_MAX_CAPABILITY_TAGS,
+                FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
+                1,
+                FLEET_MAX_CAPABILITY_TAGS_CEILING,
+            );
+        },
+        /** Max length of one capability tag. Default 32, hard ceiling 128. */
+        getMaxCapabilityTagLength(): number {
+            return clampedIntEnv(
+                process.env.FLEET_MAX_CAPABILITY_TAG_LENGTH,
+                FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
+                1,
+                FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING,
+            );
+        },
+    },
+
     // Database configuration
     database: {
         getType() {
@@ -921,55 +995,6 @@ export const config = {
      * filter input, so an unbounded knob would be a denial-of-service
      * surface, and a zero/NaN TTL would expire every token instantly.
      */
-    fleet: {
-        /**
-         * How long a one-time enrollment token stays redeemable.
-         * Default 15 minutes (`FLEET_ENROLLMENT_TOKEN_TTL_MS`), floored
-         * at 30s so a token can always actually be typed in.
-         */
-        getEnrollmentTokenTtlMs(): number {
-            return clampedIntEnv(
-                process.env.FLEET_ENROLLMENT_TOKEN_TTL_MS,
-                FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS,
-                FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS,
-                Number.MAX_SAFE_INTEGER,
-            );
-        },
-        /**
-         * Silence after which an `online` node is swept to `offline` by
-         * the next owner-scoped list read. Default 5 minutes.
-         *
-         * Shortening this below a node's heartbeat cadence makes healthy
-         * nodes flap; the 30s floor stops the value becoming nonsense,
-         * it does not stop it becoming unwise.
-         */
-        getNodeOfflineAfterMs(): number {
-            return clampedIntEnv(
-                process.env.FLEET_NODE_OFFLINE_AFTER_MS,
-                FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
-                FLEET_MIN_NODE_OFFLINE_AFTER_MS,
-                Number.MAX_SAFE_INTEGER,
-            );
-        },
-        /** Max capability tags one node may advertise. Default 16, hard ceiling 64. */
-        getMaxCapabilityTags(): number {
-            return clampedIntEnv(
-                process.env.FLEET_MAX_CAPABILITY_TAGS,
-                FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
-                1,
-                FLEET_MAX_CAPABILITY_TAGS_CEILING,
-            );
-        },
-        /** Max length of one capability tag. Default 32, hard ceiling 128. */
-        getMaxCapabilityTagLength(): number {
-            return clampedIntEnv(
-                process.env.FLEET_MAX_CAPABILITY_TAG_LENGTH,
-                FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
-                1,
-                FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING,
-            );
-        },
-    },
 
     /**
      * Streaming-terminal M9 / founder decision D1 — persisted terminal

--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -22,6 +22,10 @@ import { PortableDateColumn } from './_types';
  *      that hash (fail-closed) and server-stamps `lastHeartbeatAt`.
  *   4. List reads sweep `online` nodes with no heartbeat for 5 minutes
  *      to `offline` (no dedicated cron).
+ *   5. `rotateCredentialForUser` puts an enrolled node BACK to
+ *      `enrolling` with a freshly minted one-time token: the old
+ *      heartbeat secret stops working the instant the hash is replaced,
+ *      and the operator re-enrolls the machine with the new token.
  *
  * Cluster boundary: rows only ever describe user-enrolled machines.
  * Nodes of user-configured clusters (`clusterSource:
@@ -90,9 +94,35 @@ export class FleetNode {
     @PortableDateColumn({ nullable: true })
     lastHeartbeatAt?: Date | null;
 
+    /**
+     * When the CURRENT credential was issued.
+     *
+     * Enrollment-token expiry is measured from here rather than from
+     * `createdAt`, because a credential ROTATION mints a fresh token on
+     * an existing row: judging that token by the row's creation date
+     * would make every rotated token instantly expired. NULL on rows
+     * written before rotation existed — the service falls back to
+     * `createdAt` for those, so the pre-rotation behaviour is unchanged.
+     */
+    @PortableDateColumn({ nullable: true })
+    credentialIssuedAt?: Date | null;
+
     /** Capability tags ('terminal', 'workspace', 'docker', ...). */
     @Column({ type: 'simple-json' })
     capabilities: string[];
+
+    /**
+     * True once an admin has hand-edited {@link capabilities}.
+     *
+     * Tags are normally the NODE's self-description, refreshed on every
+     * heartbeat. Pinning is what makes them admin-editable in a way that
+     * survives: while pinned, an incoming heartbeat no longer overwrites
+     * the tag set, so an operator can add (or withhold) a capability
+     * without the machine silently reverting it seconds later. Unpinning
+     * hands ownership back to the node.
+     */
+    @Column({ type: 'boolean', default: false })
+    capabilitiesPinned: boolean;
 
     /** os/arch self-description, e.g. 'linux/x64' (sanitized at enroll). */
     @Column({ type: 'varchar', length: 64, nullable: true })

--- a/packages/agent/src/fleet/fleet-job.repository.ts
+++ b/packages/agent/src/fleet/fleet-job.repository.ts
@@ -191,4 +191,40 @@ export class FleetJobRepository {
             take: limit,
         });
     }
+
+    /**
+     * One node's job history, newest first — what the node-detail drawer
+     * renders (including the failures an operator is usually there for).
+     *
+     * `userId` is in the WHERE clause and not merely assumed from the
+     * caller: this is the only read keyed by a node id, and a node id is
+     * exactly the kind of value that travels. Owner-scoping it here
+     * means a mistake at the edge cannot turn into a cross-owner read.
+     */
+    async findByNodeForUser(userId: string, nodeId: string, limit: number): Promise<FleetJob[]> {
+        return this.repository.find({
+            where: { userId, nodeId },
+            order: { createdAt: 'DESC' },
+            take: limit,
+        });
+    }
+
+    /**
+     * Return every live claim held by one node to the pool — the write
+     * half of DRAINING a node.
+     *
+     * Draining without this leaves the node's in-flight work stranded
+     * until each lease lapses: the machine is already refusing to
+     * heartbeat, so nothing will ever complete those jobs, and the fleet
+     * sits idle for up to a full lease TTL per job. Requeuing them makes
+     * the drain immediate. `attempts` is deliberately NOT incremented —
+     * the operator withdrew the node, the job did not fail.
+     */
+    async releaseClaimsForNode(userId: string, nodeId: string): Promise<number> {
+        const result = await this.repository.update(
+            { userId, nodeId, status: In([...FLEET_JOB_ACTIVE_STATUSES]) },
+            { status: 'queued', nodeId: null, leaseExpiresAt: null },
+        );
+        return result.affected ?? 0;
+    }
 }

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -344,6 +344,42 @@ export class FleetJobService {
     }
 
     /**
+     * One node's recent job history, newest first (node-detail drawer).
+     * Owner-scoped in the query itself, not just by convention at the
+     * edge — a node id is a travelling value.
+     */
+    async historyForNode(userId: string, nodeId: string, limit = 20): Promise<FleetJobView[]> {
+        const rows = await this.jobs.findByNodeForUser(
+            userId,
+            nodeId,
+            Math.min(Math.max(limit, 1), 100),
+        );
+        return rows.map(toJobView);
+    }
+
+    /**
+     * Requeue everything a node currently holds — the work half of a
+     * DRAIN. Returns how many claims went back to the pool.
+     *
+     * Best-effort by contract: the caller has already disabled the node
+     * (which is what actually stops it receiving work), so a failure
+     * here must degrade to "the leases lapse on their own" rather than
+     * un-draining the node.
+     */
+    async releaseClaimsForNode(userId: string, nodeId: string): Promise<number> {
+        try {
+            return await this.jobs.releaseClaimsForNode(userId, nodeId);
+        } catch (error) {
+            this.logger.warn(
+                `fleet drain could not requeue claims for node ${nodeId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return 0;
+        }
+    }
+
+    /**
      * Resolve + verify a node credential. Fail-closed on every path:
      * malformed ids, unknown nodes, disabled nodes (drained — they must
      * stop receiving work immediately), still-enrolling nodes (whose

--- a/packages/agent/src/fleet/fleet-node.repository.ts
+++ b/packages/agent/src/fleet/fleet-node.repository.ts
@@ -10,6 +10,8 @@ export interface CreateFleetNodeData {
     kind: FleetNodeKind;
     status: FleetNodeStatus;
     enrollmentTokenHash: string;
+    /** When the credential above was minted — drives token expiry. */
+    credentialIssuedAt?: Date | null;
     capabilities?: string[];
 }
 

--- a/packages/agent/src/fleet/fleet.service.ts
+++ b/packages/agent/src/fleet/fleet.service.ts
@@ -72,6 +72,35 @@ export type { FleetNodeView };
  */
 const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';
 
+/**
+ * One OUTSTANDING enrollment token — a node row that has been minted but
+ * never enrolled.
+ *
+ * There is no separate token table by design: while a node is
+ * `enrolling`, the row IS the token (its `enrollmentTokenHash` holds the
+ * token's sha256). Listing the outstanding set is therefore a read of
+ * the `enrolling` rows, and revoking one pre-use is a delete of that
+ * row. The plaintext token is NOT here and can never be re-read — it was
+ * returned exactly once at mint time.
+ */
+export interface FleetEnrollmentTokenView {
+    /** Id of the node the token was minted for (the revoke handle). */
+    nodeId: string;
+    name: string;
+    kind: FleetNodeKind;
+    /** When the token was issued (ISO). */
+    issuedAt: string | null;
+    /** When it stops being consumable (ISO). */
+    expiresAt: string | null;
+    /** True once `expiresAt` has passed — still revocable, never usable. */
+    expired: boolean;
+    /**
+     * True when the token was minted by a credential ROTATION on an
+     * already-enrolled node rather than by a fresh "add node".
+     */
+    rotated: boolean;
+}
+
 export interface CreateEnrollmentTokenInput {
     name: string;
     kind: FleetNodeKind;
@@ -163,6 +192,7 @@ export class FleetService {
             kind: input.kind,
             status: 'enrolling',
             enrollmentTokenHash: sha256Hex(token),
+            credentialIssuedAt: new Date(),
             capabilities: [],
         });
 
@@ -199,7 +229,12 @@ export class FleetService {
         if (!constantTimeEquals(node.enrollmentTokenHash, tokenHash)) {
             return null;
         }
-        const issuedAt = node.createdAt instanceof Date ? node.createdAt.getTime() : NaN;
+        // `credentialIssuedAtMs` (not `node.createdAt`): once a
+        // credential can be ROTATED, its age must be measured from the
+        // rotation, not from when the row was first created — and it
+        // also copes with the string dates sqlite hands back. The TTL
+        // itself stays the configurable, clamped one.
+        const issuedAt = credentialIssuedAtMs(node);
         if (
             !Number.isFinite(issuedAt) ||
             Date.now() - issuedAt > config.fleet.getEnrollmentTokenTtlMs()
@@ -266,7 +301,10 @@ export class FleetService {
             // Server-stamped — the node never supplies its own clock.
             lastHeartbeatAt: new Date(),
         };
-        if (refresh.capabilities !== undefined) {
+        // A PINNED tag set is the operator's, not the machine's: an
+        // admin edit that a heartbeat silently reverted seconds later
+        // would not be an edit at all. Unpinning hands the tags back.
+        if (refresh.capabilities !== undefined && !node.capabilitiesPinned) {
             patch.capabilities = sanitizeCapabilities(refresh.capabilities);
         }
         const platform = sanitizeText(refresh.platform, FLEET_MAX_PLATFORM_LENGTH);
@@ -292,6 +330,131 @@ export class FleetService {
         const rows = await this.repository.findByUser(userId);
         const clusterNodes = await this.listOwnClusterNodes(userId);
         return [...rows.map((row) => this.toView(row)), ...clusterNodes];
+    }
+
+    /**
+     * One enrolled node (owner-scoped, no existence leak). Backs the
+     * node-detail drawer; the failure history shown alongside it is
+     * composed at the API edge from `FleetJobService`, so the registry
+     * stays independent of the job runtime.
+     */
+    async getForUser(userId: string, nodeId: string): Promise<FleetNodeView> {
+        return this.toView(await this.getOwnedNode(userId, nodeId));
+    }
+
+    /**
+     * Every OUTSTANDING enrollment token of this owner — i.e. every node
+     * still sitting in `enrolling`, whether the token is fresh, about to
+     * expire, or already expired.
+     *
+     * Expired entries are deliberately still listed: "there is a stale
+     * credential row for a machine I never finished setting up" is
+     * exactly the thing an operator wants to see and clean up, and
+     * hiding it would make the registry quietly disagree with the node
+     * list. Nothing here can reconstruct the plaintext token.
+     */
+    async listOutstandingTokensForUser(userId: string): Promise<FleetEnrollmentTokenView[]> {
+        const rows = await this.repository.findByUser(userId);
+        const now = Date.now();
+        return rows
+            .filter((row) => row.status === 'enrolling')
+            .map((row) => {
+                const issuedAtMs = credentialIssuedAtMs(row);
+                const hasIssuedAt = Number.isFinite(issuedAtMs);
+                const expiresAtMs = issuedAtMs + FLEET_ENROLLMENT_TOKEN_TTL_MS;
+                return {
+                    nodeId: row.id,
+                    name: row.name,
+                    kind: row.kind,
+                    issuedAt: hasIssuedAt ? new Date(issuedAtMs).toISOString() : null,
+                    expiresAt: hasIssuedAt ? new Date(expiresAtMs).toISOString() : null,
+                    // A row we cannot date is treated as expired — the
+                    // enroll path refuses it for the same reason.
+                    expired: !hasIssuedAt || expiresAtMs <= now,
+                    // A rotation mints a token on a row that already
+                    // beat once; a fresh "add node" never has.
+                    rotated: Boolean(row.lastHeartbeatAt),
+                };
+            });
+    }
+
+    /**
+     * Revoke an outstanding enrollment token BEFORE it is used.
+     *
+     * Only `enrolling` rows qualify: once a token has been consumed the
+     * row's hash is a heartbeat secret, and destroying that silently
+     * would be a node deletion wearing a token-revocation label. For an
+     * enrolled node the operator wants {@link rotateCredentialForUser}
+     * (mint a replacement) or `deleteForUser` (remove the machine) —
+     * both explicit, both already surfaced.
+     *
+     * Revoking a never-enrolled row deletes it, because the row exists
+     * only to carry the token: there is no machine behind it yet.
+     */
+    async revokeEnrollmentTokenForUser(userId: string, nodeId: string): Promise<void> {
+        const node = await this.getOwnedNode(userId, nodeId);
+        if (node.status !== 'enrolling') {
+            throw new BadRequestException(
+                'Only an unused enrollment token can be revoked; rotate the node credential instead',
+            );
+        }
+        await this.repository.delete(node.id);
+    }
+
+    /**
+     * Rotate a node's credential: mint a fresh one-time enrollment token
+     * and put the node back to `enrolling`.
+     *
+     * The old heartbeat secret dies the instant the hash is replaced —
+     * that is the entire point, and it is why rotation is a drain as
+     * well as a re-key: the machine stops being able to report or lease
+     * until it re-enrolls with the new token. Returned exactly once,
+     * like every other Fleet credential.
+     */
+    async rotateCredentialForUser(
+        userId: string,
+        nodeId: string,
+    ): Promise<CreateEnrollmentTokenResult> {
+        const node = await this.getOwnedNode(userId, nodeId);
+        const token = randomBytes(32).toString('base64url');
+        const patch: Partial<FleetNode> = {
+            enrollmentTokenHash: sha256Hex(token),
+            credentialIssuedAt: new Date(),
+            status: 'enrolling',
+        };
+        await this.repository.update(node.id, patch);
+        return {
+            node: this.toView({ ...node, ...patch } as FleetNode),
+            token,
+            expiresInSec: Math.floor(FLEET_ENROLLMENT_TOKEN_TTL_MS / 1000),
+        };
+    }
+
+    /**
+     * Hand-edit a node's capability tags (owner-scoped).
+     *
+     * Writing tags PINS them, so the node's next heartbeat no longer
+     * overwrites the operator's set. Passing `pinned: false` clears the
+     * pin and hands ownership of the tags back to the machine — the tags
+     * written in the same call still land, they simply stop being
+     * authoritative from the next beat onwards.
+     */
+    async setCapabilitiesForUser(
+        userId: string,
+        nodeId: string,
+        capabilities: unknown,
+        pinned = true,
+    ): Promise<FleetNodeView> {
+        if (!Array.isArray(capabilities)) {
+            throw new BadRequestException('Capabilities must be an array of tags');
+        }
+        const node = await this.getOwnedNode(userId, nodeId);
+        const patch: Partial<FleetNode> = {
+            capabilities: sanitizeCapabilities(capabilities),
+            capabilitiesPinned: pinned,
+        };
+        await this.repository.update(node.id, patch);
+        return this.toView({ ...node, ...patch } as FleetNode);
     }
 
     /** Rename an enrolled node (owner-scoped, no existence leak). */
@@ -412,6 +575,9 @@ export class FleetService {
             lastHeartbeatAt: null,
             createdAt: null,
             persisted: false,
+            // Cluster roles are read live from the cluster on every list;
+            // there is no row to pin them onto.
+            capabilitiesPinned: false,
         };
     }
 
@@ -428,8 +594,23 @@ export class FleetService {
             lastHeartbeatAt: node.lastHeartbeatAt ? toIso(node.lastHeartbeatAt) : null,
             createdAt: node.createdAt ? toIso(node.createdAt) : null,
             persisted: true,
+            capabilitiesPinned: Boolean(node.capabilitiesPinned),
         };
     }
+}
+
+/**
+ * When the row's CURRENT credential was issued, in epoch ms.
+ *
+ * Falls back to `createdAt` for rows written before rotation existed —
+ * for those the two are the same instant by construction. `NaN` when
+ * neither is a usable date, which every caller treats as "expired".
+ */
+function credentialIssuedAtMs(node: FleetNode): number {
+    const issued = node.credentialIssuedAt ?? node.createdAt;
+    if (issued instanceof Date) return issued.getTime();
+    if (typeof issued === 'string') return new Date(issued).getTime();
+    return NaN;
 }
 
 function sanitizeText(value: unknown, maxLength: number): string | null {

--- a/packages/contracts/src/fleet/fleet-node.types.ts
+++ b/packages/contracts/src/fleet/fleet-node.types.ts
@@ -29,6 +29,8 @@
  * the body. Every invalid path answers with one undifferentiated 401.
  */
 
+import type { FleetJobView } from './fleet-jobs.types';
+
 import type { FleetNodeLoadView } from './fleet-jobs.types.js';
 
 /**
@@ -97,6 +99,12 @@ export interface FleetNodeView {
 	 * configured clusters, which are surfaced live and never stored.
 	 */
 	persisted: boolean;
+	/**
+	 * True once an operator hand-edited the capability tags, which stops
+	 * heartbeats from overwriting them. Always false for cluster rows,
+	 * which are surfaced live and never stored.
+	 */
+	capabilitiesPinned?: boolean;
 	/**
 	 * Live execution load. Populated by the API edge from the job
 	 * service; `null`/absent means idle. Cluster-sourced rows never
@@ -186,3 +194,67 @@ export const FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS = 30_000;
  * beats, so the window can be shortened but not to nonsense.
  */
 export const FLEET_MIN_NODE_OFFLINE_AFTER_MS = 30_000;
+
+/**
+ * `GET /api/fleet/nodes/:id` — one node plus what it has been doing.
+ *
+ * Lives in contracts (not at the API edge) because the web tier renders
+ * it: two hand-copied declarations is exactly how `FleetNodeView` drifted
+ * into three copies before it was consolidated here.
+ */
+export interface FleetNodeDetailView {
+	node: FleetNodeView;
+	/** Newest-first job history for this node (all outcomes). */
+	recentJobs: FleetJobView[];
+	/**
+	 * The failed subset of {@link recentJobs}, newest first — pulled out
+	 * so the drawer can lead with "why is this machine unhappy" instead
+	 * of making the operator filter a mixed list by eye.
+	 */
+	failures: FleetJobView[];
+	/**
+	 * True when the job history could not be read at all (job tables
+	 * unavailable). The node itself still renders — a job-runtime hiccup
+	 * must never make a node look like it does not exist.
+	 */
+	historyUnavailable: boolean;
+}
+
+/** `POST /api/fleet/nodes/:id/drain` — drain / undrain result. */
+export interface FleetNodeDrainResult {
+	node: FleetNodeView;
+	/**
+	 * How many in-flight claims went back to the queue. Draining without
+	 * requeuing would strand the node's work until each lease lapsed — up
+	 * to a full lease TTL per job, on a machine that is by then refusing
+	 * to report.
+	 */
+	releasedJobs: number;
+}
+
+/**
+ * One OUTSTANDING enrollment token — minted but never used.
+ *
+ * The plaintext token is NOT here and can never be re-read; it was
+ * returned exactly once at mint time. This is the metadata the admin
+ * list and the revoke control need.
+ */
+export interface FleetEnrollmentTokenView {
+	/** Id of the node the token was minted for (the revoke handle). */
+	nodeId: string;
+	name: string;
+	kind: FleetNodeKind;
+	/** When the token was issued (ISO). */
+	issuedAt: string | null;
+	/** When it stops being consumable (ISO). */
+	expiresAt: string | null;
+	/** True once `expiresAt` has passed — still revocable, never usable. */
+	expired: boolean;
+	/**
+	 * True when this token REPLACED an existing credential (a rotate)
+	 * rather than being a first enrollment. Drives a badge so an
+	 * operator can tell a re-key apart from a machine that has never
+	 * connected.
+	 */
+	rotated?: boolean;
+}


### PR DESCRIPTION
## The problem

The Fleet page could list nodes and little else. No way to see *why* a machine
was unhappy, no way to re-key one, no way to take one out of service without
stranding its work, no view of outstanding enrollment tokens, and no help
getting a new machine connected.

## What changed

- **Node detail** with job history and a failures-first view
- **Credential rotation** — the replacement token is shown exactly once
- **Drain / return-to-service**, which **requeues** in-flight claims rather than
  letting each lease lapse on a machine that has already stopped reporting
- **Outstanding-token list** with revoke
- **Enrollment handoff** — QR, command, downloads
- **`FLEET_ENABLED`** — a hard gate answering **404 (not 403)** on every fleet
  route, so a disabled deployment does not even confirm the surface exists

## Integration with the merged contracts consolidation

This branch predates #1911. Merging surfaced three problems that would each have
shipped broken:

**1. A duplicate config key that auto-merged silently.** Both branches added a
`fleet` group, and git merged the file *without conflicting* — two identical keys
in one object literal. The later wins, so `config.fleet.isEnabled()` would have
been `undefined` and `FleetEnabledGuard` would have failed at runtime. Now one
group holding both the switch and the clamped limits.

**2. `FleetNodeView` declared twice** — a contracts re-export *and* a local
interface. The local copy is gone; this branch's extra field
(`capabilitiesPinned`) moved into the contracts declaration.

**3. Three view types declared at the API edge** while the web tier rendered the
same shapes: `FleetNodeDetailView`, `FleetNodeDrainResult`,
`FleetEnrollmentTokenView`. They now live in contracts with the API and web both
re-exporting — the same direction that stopped `FleetNodeView` drifting into
three hand-written mirrors.

## A capability-cap inconsistency

The admin-edit DTO used hardcoded `16`/`32` caps while the enroll DTO used the
configurable validators. Raising `FLEET_MAX_CAPABILITY_TAGS` would have let an
operator enroll a node with more tags than they could subsequently **edit**. Both
now read config.

## Credential age

Kept `credentialIssuedAtMs()` over `node.createdAt` — once a credential can
**rotate**, its age must be measured from the rotation, not from row creation,
and the helper also copes with the string dates sqlite returns. The TTL itself
stays the configurable clamped one from #1911.

## i18n

**34 keys** across `capabilities` / `controls` / `handoff` / `history` were
missing entirely — the UI called `t()` with nothing behind it. All added, and the
20 non-English locales re-synced (they were already behind from earlier merges).
All 21 files parse; zero duplicate keys.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 448 suites, 8233 tests |
| `apps/api` jest | green — 233 suites, 3816 tests |
| `apps/web` tsc --noEmit | green |
| `apps/web` vitest | green — 9 tests |
| `pnpm build --filter=ever-works-web` | green |
| prettier | clean |

Migration renumbered `1784700000000` → `1784760000000` to avoid the merged
collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Fleet management with node details, job history, capability tags, credential rotation, draining, and return-to-service controls.
  * Added enrollment-token listing, revocation, expiration visibility, and rotation workflows.
  * Added QR codes, CLI commands, downloadable handoff files, and application download links for node enrollment.
  * Fleet access can now be disabled and is consistently gated across the application.
* **Bug Fixes**
  * Improved handling when node history or enrollment-token data is temporarily unavailable.
* **Documentation**
  * Added and updated translations across supported languages for Fleet, Digest, billing, usage, and onboarding experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->