### PR TITLE
feat(node): package the headless node, add pause/drain and a browser check

### DIFF
--- a/.deploy/docker/node/Dockerfile
+++ b/.deploy/docker/node/Dockerfile
@@ -1,0 +1,88 @@
+FROM node:22-bookworm-slim AS base
+
+# bookworm (not alpine) on purpose: the node's `browser-check` executor
+# drives a real Chromium, and the prebuilt Chromium/keyring binaries the
+# optional dependencies ship are glibc-linked. A musl base would silently
+# lose both capabilities.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable \
+    && corepack prepare pnpm@10 --activate \
+    && npm install -g turbo@latest
+
+#-- Pruner
+FROM base AS pruner
+WORKDIR /app
+COPY . .
+RUN turbo prune --scope=ever-works-node --docker
+
+#-- Installer
+FROM base AS installer
+WORKDIR /app
+
+COPY --from=pruner /app/out/json/ .
+COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN echo "shamefully-hoist=true" > .npmrc
+
+# Package registry selection (backward-compatible, fork-safe) — see the
+# API/MCP Dockerfiles for the full rationale. Empty is a no-op.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+    fi
+
+RUN pnpm install --frozen-lockfile
+
+COPY --from=pruner /app/out/full/ .
+# `turbo` directly, not the root `pnpm build`: that script filters out
+# apps/docs, which does not exist in the pruned workspace.
+RUN pnpm exec turbo build --filter=ever-works-node...
+RUN pnpm deploy --filter=ever-works-node --prod --legacy /app/deploy
+
+#-- Production
+FROM node:22-bookworm-slim
+
+# WITH_BROWSER=true installs Chromium so the image advertises — and can
+# honour — the `browser` capability. It roughly triples the image size,
+# so it is opt-in: a node that only runs acceptance checks has no reason
+# to carry a browser.
+ARG WITH_BROWSER="false"
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git tini \
+    && if [ "$WITH_BROWSER" = "true" ]; then \
+         apt-get install -y --no-install-recommends chromium fonts-liberation; \
+       fi \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production
+# Config lives on a volume, not in the image layer: the node's heartbeat
+# credential is written here, and it must survive `docker run --rm` only
+# when the operator explicitly mounts it.
+ENV EVER_WORKS_NODE_CONFIG=/var/lib/ever-works-node/node-config.json
+# There is no OS keychain in a container, so the credential falls back to
+# the config file. Declaring it keeps the fallback deliberate and keeps
+# the node's warning honest instead of surprising.
+ENV EVER_WORKS_NODE_DISABLE_KEYCHAIN=1
+# Chromium cannot use its own sandbox inside an unprivileged container;
+# the container IS the isolation boundary here.
+ENV EVER_WORKS_NODE_BROWSER_NO_SANDBOX=1
+ENV EVER_WORKS_NODE_BROWSER=/usr/bin/chromium
+
+WORKDIR /app
+
+COPY --from=installer --chown=node:node /app/deploy/dist ./dist
+COPY --from=installer --chown=node:node /app/deploy/node_modules ./node_modules
+COPY --from=installer --chown=node:node /app/deploy/package.json ./
+
+RUN mkdir -p /var/lib/ever-works-node /workspaces \
+    && chown -R node:node /var/lib/ever-works-node /workspaces
+
+USER node
+VOLUME ["/var/lib/ever-works-node"]
+
+# tini as PID 1: the node's graceful shutdown is a SIGTERM handler that
+# drains in-flight jobs, and PID 1 without an init does not get default
+# signal handling — the drain would never run.
+ENTRYPOINT ["/usr/bin/tini", "--", "node", "dist/cli.js"]
+CMD ["start", "--work"]

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -70,11 +70,20 @@ export class UpdateFleetNodeDto {
     @ApiProperty({
         required: false,
         description:
-            'true drains the node (stops heartbeats being accepted); false re-enables it as offline until its next heartbeat.',
+            'true drains the node (no new work is leased onto it; in-flight jobs still report and heartbeats are still accepted so it stays observable); false re-enables it as offline until its next heartbeat.',
     })
     @IsOptional()
     @IsBoolean()
     disabled?: boolean;
+
+    @ApiProperty({
+        required: false,
+        description:
+            'true pauses (drains) the node without disabling it; false resumes it as offline until its next heartbeat. A paused node keeps heartbeating and keeps reporting the jobs it already holds.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    paused?: boolean;
 
     @ApiProperty({
         required: false,
@@ -168,6 +177,23 @@ export class EnrollFleetNodeDto extends FleetNodeSelfDescriptionDto {
 }
 
 /**
+ * Credential pair every node-initiated fleet call carries. The
+ * `(nodeId, secret)` pair IS the credential — checked constant-time
+ * against the stored sha256, fail-closed to one undifferentiated 401.
+ */
+export class FleetNodeCredentialDto {
+    @ApiProperty({ format: 'uuid' })
+    @IsUUID()
+    nodeId: string;
+
+    @ApiProperty({ minLength: 16, maxLength: 256, description: 'Node secret minted at enroll.' })
+    @IsString()
+    @MinLength(16)
+    @MaxLength(256)
+    secret: string;
+}
+
+/**
  * Request body for the PUBLIC `POST /api/fleet/heartbeat` — node
  * credential auth (constant-time hash check, fail-closed 401).
  */
@@ -186,3 +212,24 @@ export class FleetHeartbeatDto extends FleetNodeSelfDescriptionDto {
     @MaxLength(FLEET_CREDENTIAL_MAX_LENGTH)
     secret: string;
 }
+
+/**
+ * Request body for the PUBLIC `POST /api/fleet/pause` — a node draining
+ * (or resuming) ITSELF with its own heartbeat credential, so an
+ * operator at the machine's keyboard does not need a platform session.
+ */
+export class FleetNodePauseDto extends FleetNodeCredentialDto {
+    @ApiProperty({
+        description:
+            'true drains this node (no new work is leased onto it; in-flight jobs still report); false resumes it.',
+    })
+    @IsBoolean()
+    paused: boolean;
+}
+
+/**
+ * Request body for the PUBLIC `POST /api/fleet/unenroll` — a node
+ * retiring its own registration. Deleting the row is what makes the
+ * credential worthless from that moment on.
+ */
+export class FleetUnenrollDto extends FleetNodeCredentialDto {}

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -34,6 +34,8 @@ import {
     DrainFleetNodeDto,
     EnrollFleetNodeDto,
     FleetHeartbeatDto,
+    FleetNodePauseDto,
+    FleetUnenrollDto,
     UpdateFleetNodeDto,
 } from './dto/fleet.dto';
 import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
@@ -57,6 +59,7 @@ const NODE_HISTORY_LIMIT = 25;
  *                                             old secret dies immediately
  *   POST   /api/fleet/nodes/:id/drain         drain: disable AND requeue
  *                                             the node's in-flight claims
+ *   PATCH  /api/fleet/nodes/:id               rename / pause / disable
  *   DELETE /api/fleet/nodes/:id               remove registration
  *   GET    /api/fleet/enrollment-tokens       outstanding (unused) tokens
  *   DELETE /api/fleet/enrollment-tokens/:id   revoke one BEFORE it is used
@@ -77,6 +80,8 @@ const NODE_HISTORY_LIMIT = 25;
  *
  * `FleetEnabledGuard` gates the class on `FLEET_ENABLED`, so the
  * registry and the node work channel go dark together.
+ *   POST   /api/fleet/pause                   node drains/resumes itself
+ *   POST   /api/fleet/unenroll                node retires itself
  */
 @ApiTags('fleet')
 @Controller('api/fleet')
@@ -224,6 +229,7 @@ export class FleetController {
     @ApiOperation({
         summary: 'Rename, disable/enable, and/or hand-edit the capability tags of a fleet node',
     })
+    @ApiOperation({ summary: 'Rename and/or pause/disable a fleet node' })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     async update(
@@ -231,12 +237,16 @@ export class FleetController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: UpdateFleetNodeDto,
     ): Promise<FleetNodeView> {
+        // Reject only when NOTHING actionable arrived. Each field is an
+        // independent edit, so the guard has to name all four — dropping
+        // one here would 400 a perfectly valid single-field PATCH.
         if (
             typeof body.name !== 'string' &&
             typeof body.disabled !== 'boolean' &&
+            typeof body.paused !== 'boolean' &&
             !Array.isArray(body.capabilities)
         ) {
-            throw new BadRequestException('Provide name, disabled and/or capabilities');
+            throw new BadRequestException('Provide name, disabled, paused and/or capabilities');
         }
         let view: FleetNodeView | null = null;
         if (typeof body.name === 'string') {
@@ -252,6 +262,11 @@ export class FleetController {
                 body.capabilities,
                 body.capabilitiesPinned ?? true,
             );
+        }
+        // Pause first, disable second: when both arrive, the harder stop
+        // is the one that must be visible in the returned view.
+        if (typeof body.paused === 'boolean') {
+            view = await this.service.setPausedForUser(auth.userId, id, body.paused);
         }
         if (typeof body.disabled === 'boolean') {
             view = await this.service.setDisabledForUser(auth.userId, id, body.disabled);
@@ -309,5 +324,41 @@ export class FleetController {
             throw new UnauthorizedException('Invalid node credential');
         }
         return { ok: true, node: result.node };
+    }
+
+    @Public()
+    @Post('pause')
+    @ApiOperation({
+        summary:
+            'Node self-pause/resume (public, node-secret-authenticated). Pausing DRAINS: no new work is leased onto the node, the jobs it already holds keep reporting, and heartbeats stay accepted so it remains observable.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async pause(@Body() body: FleetNodePauseDto): Promise<{ ok: true; node: FleetNodeView }> {
+        const result = await this.service.setPausedByCredential(
+            body.nodeId,
+            body.secret,
+            body.paused,
+        );
+        if (!result) {
+            throw new UnauthorizedException('Invalid node credential');
+        }
+        return { ok: true, node: result.node };
+    }
+
+    @Public()
+    @Post('unenroll')
+    @ApiOperation({
+        summary:
+            'Node self-unenrollment (public, node-secret-authenticated). Deletes the registration the presented credential belongs to, which is what renders that credential worthless.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async unenroll(@Body() body: FleetUnenrollDto): Promise<{ ok: true }> {
+        const removed = await this.service.unenrollByCredential(body.nodeId, body.secret);
+        if (!removed) {
+            throw new UnauthorizedException('Invalid node credential');
+        }
+        return { ok: true };
     }
 }

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -13,19 +13,34 @@ headless and desktop shells can never drift apart (PRD §3.3).
 ```bash
 ever-works-node enroll --api-url <url> --token <one-time-token> [--name <label>] [-i <seconds>]
 ever-works-node start [-i <seconds>] [--work] [--concurrency <count>]
+ever-works-node pause [--local-only]
+ever-works-node resume [--local-only]
+ever-works-node unenroll [--local-only]
 ever-works-node status
 ever-works-node capabilities
 ```
 
 - **`enroll`** consumes a one-time token from the platform's Fleet page (`POST /api/fleet/enroll`)
-  and writes `{apiUrl, nodeId, secret, capabilities, …}` to the OS config directory.
+  and writes `{apiUrl, nodeId, capabilities, …}` to the OS config directory, with the credential
+  itself going to the OS keychain where one exists.
 - **`start`** runs the heartbeat loop (`POST /api/fleet/heartbeat`, default every 60s) with
   exponential backoff on failure, refreshing capability tags on every beat, until SIGINT/SIGTERM.
   With **`--work`** it also runs the worker host: lease → execute → report against
   `POST /api/fleet/jobs/*`. This is opt-in on purpose — enrolling a machine and letting it run the
   owner's commands are two different consents.
-- **`status`** prints the local enrollment with the credential reported but never shown.
+- **`pause` / `resume`** drain and undrain this machine. Pausing stops leasing **immediately** and
+  lets in-flight jobs finish and report — it is not a kill. It tells the platform
+  (`POST /api/fleet/pause`, so the scheduler stops offering work) _and_ records the intent locally,
+  so a service restart comes back paused. A paused node keeps heartbeating: a drained machine that
+  vanishes from Fleet is indistinguishable from a dead one.
+- **`unenroll`** retires the machine — `POST /api/fleet/unenroll` deletes the registration, then the
+  local credential is erased. The local erase happens **even if the API call fails**: a
+  decommissioned laptop holding a live fleet secret is the worse outcome.
+- **`status`** prints the local enrollment with the credential reported but never shown, including
+  where it is stored and whether the node is paused.
 - **`capabilities`** prints the tags this machine would report, without enrolling.
+
+`--local-only` skips the API call, for a machine being drained or decommissioned offline.
 
 Exit codes: `0` ok, `1` failure, `3` not enrolled (so provisioning scripts can branch on it).
 
@@ -37,18 +52,43 @@ Exit codes: `0` ok, `1` failure, `3` not enrolled (so provisioning scripts can b
 | macOS    | `~/Library/Application Support/ever-works-node/node-config.json`     |
 | Linux    | `$XDG_CONFIG_HOME/ever-works-node/node-config.json` (or `~/.config`) |
 
-`EVER_WORKS_NODE_CONFIG` overrides the path entirely. The file is created with mode **0600** and
-re-chmod'ed after write on POSIX; on Windows the chmod is skipped rather than faked (no POSIX mode
-bits — the file inherits the user profile's ACL).
+`EVER_WORKS_NODE_CONFIG` overrides the path entirely.
+
+**The credential does not live in this file when it does not have to.** With an OS keychain
+available (macOS Keychain, Windows Credential Manager, Linux Secret Service — all reached through
+the `@napi-rs/keyring` SDK) the secret is stored there and the file records only
+`"secretStorage": "keychain"`. Where no keychain exists — headless servers, containers — it falls
+back into the file and **says so loudly**, on every load and every save.
+
+Either way the file is locked to its owner: mode **0600** at creation and re-chmod'ed after write on
+POSIX, and on Windows an inheritance-stripped owner-only ACL applied with `icacls`. Windows is no
+longer skipped.
+
+`EVER_WORKS_NODE_DISABLE_KEYCHAIN=1` forces the file fallback (the container image sets it, because
+a container never has a keychain and a surprise warning is worse than a declared choice).
 
 ## Capability tags
 
 Detected at enroll and re-detected on **every heartbeat**, so installing Docker or Git on a running
 node shows up in Fleet without a restart:
 
-`os:<platform>` · `arch:<arch>` · `node:<major>` · `terminal` · `workspace` · plus `docker`, `git`
-and `display` when present. Tags are normalized with the same rules the server applies
-(trim → 32 chars → dedupe → max 16), so what the node reports is exactly what Fleet stores.
+`os:<platform>` · `arch:<arch>` · `node:<major>` · `terminal` · `workspace` · plus `docker`, `git`,
+`display`, `browser`, `gpu` and `gpu:<vendor>` when present. Tags are normalized with the same rules
+the server applies (trim → 32 chars → dedupe → max 16), so what the node reports is exactly what
+Fleet stores.
+
+Two rules govern what may appear:
+
+1. **A tag is a promise the node can keep.** `browser` is emitted only when a browser executable was
+   actually resolved — the same path `browser-check` will spawn — and the `browser-check` executor is
+   registered by that same fact. A tag with nothing behind it routes real work to a machine that
+   cannot do it.
+2. **Detection never fails the beat.** Every probe swallows its own errors: a missing tool is a
+   missing tag, not a missing heartbeat.
+
+`EVER_WORKS_NODE_BROWSER` pins the browser executable explicitly. A pinned path that does not exist
+disables the tag rather than falling through to some other browser — silently launching a different
+engine than the one an operator chose is how a check passes for the wrong reason.
 
 ## Layout
 
@@ -59,8 +99,12 @@ and `display` when present. Tags are normalized with the same rules the server a
     - `config-store.ts` persistence over an injected filesystem
     - `logger.ts` redacting logger — credentials are `protect()`ed once and scrubbed everywhere
     - `job-client.ts` lease/heartbeat/complete HTTP over the same injected `fetch`
-    - `worker-loop.ts` the lease → execute → report loop (backoff, keep-alive, draining shutdown)
+    - `worker-loop.ts` the lease → execute → report loop (backoff, keep-alive, draining shutdown
+      **and draining pause**)
+    - `browser-probe.ts` / `gpu-probe.ts` the `browser` and `gpu` capability probes
+    - `secret-store.ts` OS keychain over an injected SDK loader, with a loud file fallback
     - `executors/acceptance-checks.ts` the v1 job kind, with its own scrubbed subprocess env
+    - `executors/browser-check.ts` the v2 job kind — a real browser in a throwaway profile
     - `runtime.ts` composition root (`enrollNode`, `createNodeRuntime`, shutdown handlers)
     - `types.ts` wire types + the server's limits, mirrored (the job protocol instead comes from
       `@ever-works/contracts`, which is where drift would actually hurt: it carries executable work)
@@ -97,16 +141,22 @@ pnpm --filter ever-works-node test    # vitest unit tests (no network, no disk, 
 - **Excluded from the default root build**: like `apps/docs` and `apps/desktop`, this app is
   filtered out of root `pnpm build` / `pnpm build:apps`; build it explicitly with
   `pnpm build:node` (root `pnpm build:all` includes it).
-- **Publishing is a follow-up.** The package is `private` today; the npm/container/systemd
-  packaging of PRD §3.3 lands with the packaging milestone.
+- **Running it unattended** — systemd unit, Windows service / scheduled task, container image — is
+  documented in [`packaging/README.md`](packaging/README.md).
 
 ## What a node can and cannot run
 
 The worker host resolves an executor by `job.kind`. Today exactly one kind is registered:
 
-| Kind                | Status                                                                                                                                                                                                               |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `acceptance-checks` | **Working end to end.** Runs a Task's dispatch-frozen acceptance checks in a workspace directory on this machine and reports each exit code, with verdict rules identical to the platform's `TaskGateRunnerService`. |
+| Kind                | Status                                                                                                                                                                                                                                                                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `acceptance-checks` | **Working end to end.** Runs a Task's dispatch-frozen acceptance checks in a workspace directory on this machine and reports each exit code, with verdict rules identical to the platform's `TaskGateRunnerService`.                                                   |
+| `browser-check`     | **Working end to end, on a node that resolved a browser.** Drives the machine's real browser against a URL in a throwaway profile and reports what it rendered (DOM bytes, `<title>`, an optional `expectText`). Registered only when the `browser` tag is advertised. |
+
+`browser-check` runs headless by default (`--headless=new --dump-dom`), which is what makes its
+verdict a real observation rather than "the process did not crash". `headed: true` opens a visible
+window on a node that also advertises `display`; because Chrome exposes no DOM outside headless, a
+headed job that asks for `expectText` is **refused** rather than quietly downgraded.
 
 A leased job of any other kind is completed as a **failure naming the kind** — never silently
 dropped, which would leave it to expire and retry forever on the same incapable node.
@@ -119,4 +169,5 @@ dropped, which would leave it to expire and retry forever on the same incapable 
 - Workspace **provisioning** on the node: today `acceptance-checks` requires the workspace to
   already exist on this machine (it refuses a path it cannot resolve), so the end-to-end cloud
   path still wants a checkout step.
-- `pause` / `unenroll` CLI verbs (PRD §3.3) follow the corresponding Fleet API surface.
+- **Publishing to npm.** The package is still `private`, and the packaging scripts therefore refuse
+  to install a service unless `ever-works-node` is already on `PATH`.

--- a/apps/node/packaging/README.md
+++ b/apps/node/packaging/README.md
@@ -1,0 +1,126 @@
+# Running the Ever Works node unattended
+
+`ever-works-node start` is a foreground process. Everything in this
+directory exists so it does not have to be — so an enrolled machine
+survives a reboot, restarts after a crash, and can be drained without
+throwing away work it is half-way through.
+
+Three shapes, one binary:
+
+| Host            | Mechanism                                        | Where                                     |
+| --------------- | ------------------------------------------------ | ----------------------------------------- |
+| Linux (systemd) | template unit `ever-works-node@<user>.service`   | `systemd/`                                |
+| Windows         | Windows service (NSSM) or Scheduled Task at boot | `windows/`                                |
+| Container / k8s | image built from the node's Dockerfile           | `../../../.deploy/docker/node/Dockerfile` |
+
+Enrollment is **never** part of installation. It consumes a one-time
+token from the platform's Fleet settings page and is an explicit,
+interactive act:
+
+```bash
+ever-works-node enroll --api-url https://api.ever.works --token <token>
+```
+
+Install the service afterwards.
+
+---
+
+## Linux — systemd
+
+```bash
+sudo apps/node/packaging/systemd/install.sh alice
+sudo -u alice ever-works-node enroll --api-url https://api.ever.works --token <token>
+sudo systemctl enable --now ever-works-node@alice
+journalctl -fu ever-works-node@alice
+```
+
+The unit is a **template** whose instance name is the user the node runs
+as. A fleet node executes that user's commands, so it runs as that user
+rather than as root or a shared service account.
+
+`TimeoutStopSec=900` is load-bearing: stopping the node stops the
+heartbeat and then **waits** for in-flight jobs to report their verdicts.
+If systemd `SIGKILL`s the drain half-way, those claims lapse and the
+platform re-runs the same work on another machine. Raise it above your
+longest expected job.
+
+`systemctl reload` is wired to `ever-works-node pause` — a drain, not a
+restart.
+
+## Windows
+
+From an **elevated** PowerShell session:
+
+```powershell
+.\apps\node\packaging\windows\install-service.ps1 -Work
+```
+
+The script prefers a real Windows service via [NSSM](https://nssm.cc).
+This matters: Node.js cannot answer Service Control Manager messages, so
+`sc.exe create` pointed straight at `node.exe` yields a service Windows
+reports as "did not respond in a timely fashion" (error 1053). A wrapper
+is what makes it a genuine service _and_ what gives the node a graceful
+stop long enough to drain.
+
+Without NSSM the script registers a **Scheduled Task** at boot and says
+so. That runs unattended and survives reboots, but it will not appear in
+`services.msc`.
+
+Remove with `uninstall-service.ps1`. That leaves the node enrolled — use
+`ever-works-node unenroll` to retire it on the platform too.
+
+## Container
+
+```bash
+docker build -f .deploy/docker/node/Dockerfile -t ever-works-node .
+docker run -d --name ever-works-node \
+  -v ever-works-node-config:/var/lib/ever-works-node \
+  ever-works-node start --work
+```
+
+Enroll into the same volume first:
+
+```bash
+docker run --rm -it \
+  -v ever-works-node-config:/var/lib/ever-works-node \
+  ever-works-node enroll --api-url https://api.ever.works --token <token>
+```
+
+Build with `--build-arg WITH_BROWSER=true` to install Chromium, so the
+image can honour the `browser` capability it would otherwise not
+advertise. It roughly triples the image size, which is why it is opt-in.
+
+`tini` is PID 1 on purpose: PID 1 does not get default signal handling,
+and without it the node's SIGTERM drain would never run.
+
+---
+
+## Credential storage
+
+The heartbeat secret goes into the OS keychain (macOS Keychain, Windows
+Credential Manager, Linux Secret Service) when one is available, and the
+config file holds only a pointer. Where no keychain exists — headless
+servers, containers — it falls back into the config file and **says so**,
+loudly, on every load. The file is then restricted to its owner: `0600`
+on POSIX, and an inheritance-stripped owner-only ACL on Windows.
+
+Two environment variables change this:
+
+| Variable                             | Effect                                                       |
+| ------------------------------------ | ------------------------------------------------------------ |
+| `EVER_WORKS_NODE_DISABLE_KEYCHAIN=1` | Force the file fallback (set in the container image).        |
+| `EVER_WORKS_NODE_CONFIG`             | Absolute path of the config file, overriding the OS default. |
+
+## Draining
+
+`pause` is a drain, not a kill:
+
+```bash
+ever-works-node pause     # stop leasing; in-flight jobs finish and report
+ever-works-node resume    # take work again
+```
+
+It tells the platform (so the scheduler stops offering work) _and_
+records the intent locally (so a restart comes back paused). A paused
+node keeps heartbeating: a drained machine that vanishes from Fleet is
+indistinguishable from a dead one.

--- a/apps/node/packaging/systemd/ever-works-node@.service
+++ b/apps/node/packaging/systemd/ever-works-node@.service
@@ -1,0 +1,64 @@
+# Template unit: the instance name IS the user the node runs as.
+#   systemctl enable --now ever-works-node@alice
+# A fleet node executes the OWNER'S commands, so it runs as that owner
+# rather than as root or as a shared service account.
+[Unit]
+Description=Ever Works execution node (running as %i)
+Documentation=https://docs.ever.works
+# Enrollment and heartbeat are outbound HTTPS; starting before the
+# network is up just burns the first few backoff intervals.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=%i
+Group=%i
+
+# `--work` is what makes this machine capacity rather than inventory.
+# Drop it to enroll a node for visibility only.
+ExecStart=/usr/bin/env ever-works-node start --work
+# `pause` drains: leasing stops immediately, in-flight jobs finish and
+# report. Wired to ExecReload so `systemctl reload` is a drain, not a cut.
+ExecReload=/usr/bin/env ever-works-node pause
+
+# The node's own SIGTERM handler stops the heartbeat and then WAITS for
+# in-flight jobs to report their verdicts. TimeoutStopSec must therefore
+# be longer than the longest job you expect, or systemd SIGKILLs the
+# drain half-way through and the platform re-runs the work elsewhere.
+KillSignal=SIGTERM
+TimeoutStopSec=900
+
+Restart=on-failure
+RestartSec=10s
+# A node that crash-loops on a bad config should stop and be visible,
+# not hammer the API forever.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# Hardening. The node executes the OWNER'S commands by design, so this is
+# a blast-radius limit, not a sandbox: it keeps a check from touching the
+# rest of the system, it does not make an untrusted check safe.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+# Config (credential) and workspaces are the only writable paths.
+StateDirectory=ever-works-node
+ReadWritePaths=/var/lib/ever-works-node
+
+Environment=NODE_ENV=production
+Environment=EVER_WORKS_NODE_CONFIG=/var/lib/ever-works-node/node-config.json
+# Drop-in overrides go in
+# /etc/systemd/system/ever-works-node@.service.d/override.conf
+EnvironmentFile=-/etc/default/ever-works-node
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ever-works-node
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/node/packaging/systemd/install.sh
+++ b/apps/node/packaging/systemd/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Install the Ever Works node as a systemd service.
+#
+#   sudo ./install.sh <user>
+#
+# Idempotent: re-running refreshes the unit and reloads systemd. It does
+# NOT enroll the node — enrollment consumes a one-time token and is an
+# explicit, interactive act:
+#
+#   ever-works-node enroll --api-url https://api.ever.works --token <token>
+#
+# Run that as <user> first, then start the service.
+
+set -euo pipefail
+
+UNIT_NAME="ever-works-node@.service"
+UNIT_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/${UNIT_NAME}"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+STATE_DIR="/var/lib/ever-works-node"
+
+RUN_AS="${1:-}"
+if [ -z "${RUN_AS}" ]; then
+    echo "usage: $0 <user>" >&2
+    echo "  the node runs as that user and executes ITS commands" >&2
+    exit 2
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "error: must run as root (installing a system unit)" >&2
+    exit 1
+fi
+
+if ! id "${RUN_AS}" >/dev/null 2>&1; then
+    echo "error: user '${RUN_AS}' does not exist" >&2
+    exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "error: systemd is not available on this host" >&2
+    echo "  use the container image (.deploy/docker/node/Dockerfile) instead" >&2
+    exit 1
+fi
+
+if ! command -v ever-works-node >/dev/null 2>&1; then
+    # Refuse rather than install a unit that will crash-loop on start.
+    echo "error: 'ever-works-node' is not on PATH" >&2
+    echo "  install it first, e.g.: npm install -g ever-works-node" >&2
+    exit 1
+fi
+
+install -d -m 0700 -o "${RUN_AS}" -g "${RUN_AS}" "${STATE_DIR}"
+install -m 0644 "${UNIT_SRC}" "${UNIT_DEST}"
+
+systemctl daemon-reload
+
+echo "Installed ${UNIT_DEST}"
+echo
+echo "Next:"
+echo "  1. enroll (as ${RUN_AS}):"
+echo "     sudo -u ${RUN_AS} ever-works-node enroll --api-url <url> --token <token>"
+echo "  2. start:"
+echo "     systemctl enable --now ever-works-node@${RUN_AS}"
+echo
+echo "Operating:"
+echo "  drain (finish in-flight work, take no more):  ever-works-node pause"
+echo "  take work again:                              ever-works-node resume"
+echo "  follow logs:                                  journalctl -fu ever-works-node@${RUN_AS}"

--- a/apps/node/packaging/windows/install-service.ps1
+++ b/apps/node/packaging/windows/install-service.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+    Register the Ever Works node to run unattended on Windows.
+
+.DESCRIPTION
+    Windows has two honest ways to run a Node.js program unattended, and
+    this script picks whichever the machine actually supports:
+
+      1. A real Windows SERVICE, when a service wrapper (NSSM) is
+         present. Node cannot answer Service Control Manager messages on
+         its own, so `sc.exe create` pointed straight at node.exe
+         produces a service that starts and is then reported as "did not
+         respond in a timely fashion" (error 1053). A wrapper is what
+         makes it a genuine service — including a graceful SIGTERM-style
+         stop, which is what lets the node DRAIN its in-flight jobs.
+
+      2. A SCHEDULED TASK at boot, otherwise. It runs unattended with no
+         extra software, survives reboots, and restarts on failure. It
+         is not a service — it will not appear in services.msc — and the
+         script says so rather than pretending.
+
+    Enrollment is deliberately NOT done here: it consumes a one-time
+    token and is an explicit, interactive act. Run
+    `ever-works-node enroll --api-url <url> --token <token>` first.
+
+.PARAMETER Name
+    Service / task name. Default: EverWorksNode
+
+.PARAMETER Work
+    Lease and execute platform work (adds --work). Without it the node
+    reports liveness and capabilities only.
+
+.PARAMETER UseScheduledTask
+    Skip the NSSM lookup and register a scheduled task.
+
+.EXAMPLE
+    .\install-service.ps1 -Work
+#>
+[CmdletBinding()]
+param(
+    [string] $Name = 'EverWorksNode',
+    [switch] $Work,
+    [switch] $UseScheduledTask
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-Administrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-Administrator)) {
+    throw 'This script must run from an elevated PowerShell session.'
+}
+
+$cli = Get-Command 'ever-works-node' -ErrorAction SilentlyContinue
+if ($null -eq $cli) {
+    # Refuse rather than register something that will fail on every start.
+    throw "'ever-works-node' is not on PATH. Install it first (npm install -g ever-works-node)."
+}
+
+$arguments = @('start')
+if ($Work) { $arguments += '--work' }
+$argumentLine = $arguments -join ' '
+
+$stateDir = Join-Path $env:ProgramData 'ever-works-node'
+if (-not (Test-Path $stateDir)) {
+    New-Item -ItemType Directory -Path $stateDir | Out-Null
+}
+
+$nssm = $null
+if (-not $UseScheduledTask) {
+    $nssm = Get-Command 'nssm' -ErrorAction SilentlyContinue
+}
+
+if ($null -ne $nssm) {
+    if (Get-Service -Name $Name -ErrorAction SilentlyContinue) {
+        Write-Host "Service '$Name' already exists; updating its configuration."
+        & $nssm.Source stop $Name | Out-Null
+    }
+    else {
+        & $nssm.Source install $Name $cli.Source $argumentLine
+    }
+
+    & $nssm.Source set $Name AppDirectory $stateDir
+    & $nssm.Source set $Name Start SERVICE_AUTO_START
+    & $nssm.Source set $Name AppStdout (Join-Path $stateDir 'node.log')
+    & $nssm.Source set $Name AppStderr (Join-Path $stateDir 'node.err.log')
+    # Give the drain room: stopping the node stops the heartbeat and then
+    # WAITS for in-flight jobs to report. Killing it early means the
+    # platform re-runs that work somewhere else.
+    & $nssm.Source set $Name AppStopMethodConsole 900000
+    & $nssm.Source set $Name AppExit Default Restart
+    & $nssm.Source set $Name AppRestartDelay 10000
+    & $nssm.Source start $Name | Out-Null
+
+    Write-Host "Registered Windows service '$Name' (via NSSM) and started it."
+    Write-Host "  stop/start:  Stop-Service $Name / Start-Service $Name"
+}
+else {
+    Write-Warning 'NSSM was not found — registering a Scheduled Task instead of a Windows service.'
+    Write-Warning 'The node will run unattended at boot, but will NOT appear in services.msc.'
+    Write-Warning 'Install NSSM (https://nssm.cc) and re-run this script for a real service.'
+
+    if (Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue) {
+        Unregister-ScheduledTask -TaskName $Name -Confirm:$false
+    }
+
+    $action = New-ScheduledTaskAction -Execute $cli.Source -Argument $argumentLine -WorkingDirectory $stateDir
+    $trigger = New-ScheduledTaskTrigger -AtStartup
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -RestartCount 5 `
+        -RestartInterval (New-TimeSpan -Minutes 1) `
+        -ExecutionTimeLimit (New-TimeSpan -Seconds 0)
+    $principal = New-ScheduledTaskPrincipal `
+        -UserId "$env:USERDOMAIN\$env:USERNAME" `
+        -LogonType S4U `
+        -RunLevel Highest
+
+    Register-ScheduledTask `
+        -TaskName $Name `
+        -Action $action `
+        -Trigger $trigger `
+        -Settings $settings `
+        -Principal $principal | Out-Null
+
+    Start-ScheduledTask -TaskName $Name
+
+    Write-Host "Registered scheduled task '$Name' and started it."
+    Write-Host "  stop/start:  Stop-ScheduledTask -TaskName $Name / Start-ScheduledTask -TaskName $Name"
+}
+
+Write-Host ''
+Write-Host 'Operating:'
+Write-Host '  drain (finish in-flight work, take no more):  ever-works-node pause'
+Write-Host '  take work again:                              ever-works-node resume'
+Write-Host '  retire this machine:                          ever-works-node unenroll'

--- a/apps/node/packaging/windows/uninstall-service.ps1
+++ b/apps/node/packaging/windows/uninstall-service.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    Remove the Ever Works node service / scheduled task from this machine.
+
+.DESCRIPTION
+    Stops and removes whichever registration `install-service.ps1`
+    created. It does NOT unenroll the node — the credential and the
+    platform-side registration are separate concerns, and deleting a
+    service should never silently revoke a machine's identity.
+
+    To retire the machine completely:
+
+        ever-works-node unenroll
+
+.PARAMETER Name
+    Service / task name. Default: EverWorksNode
+#>
+[CmdletBinding()]
+param(
+    [string] $Name = 'EverWorksNode'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-Administrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-Administrator)) {
+    throw 'This script must run from an elevated PowerShell session.'
+}
+
+$removed = $false
+
+$service = Get-Service -Name $Name -ErrorAction SilentlyContinue
+if ($null -ne $service) {
+    $nssm = Get-Command 'nssm' -ErrorAction SilentlyContinue
+    if ($null -ne $nssm) {
+        # `nssm stop` waits for the node's own drain before killing it.
+        & $nssm.Source stop $Name | Out-Null
+        & $nssm.Source remove $Name confirm | Out-Null
+    }
+    else {
+        Stop-Service -Name $Name -Force
+        & sc.exe delete $Name | Out-Null
+    }
+    Write-Host "Removed Windows service '$Name'."
+    $removed = $true
+}
+
+$task = Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue
+if ($null -ne $task) {
+    try { Stop-ScheduledTask -TaskName $Name } catch {}
+    Unregister-ScheduledTask -TaskName $Name -Confirm:$false
+    Write-Host "Removed scheduled task '$Name'."
+    $removed = $true
+}
+
+if (-not $removed) {
+    Write-Host "Nothing named '$Name' is registered on this machine."
+}
+
+Write-Host ''
+Write-Host 'The node is still enrolled. To retire it on the platform too:'
+Write-Host '  ever-works-node unenroll'

--- a/apps/node/src/cli.ts
+++ b/apps/node/src/cli.ts
@@ -4,6 +4,7 @@ import { createLogger } from './core/logger';
 import {
 	createCommandRunner,
 	createConfigFileSystem,
+	createSecretStore,
 	currentEnvironment,
 	defaultConfigPath,
 	systemFetch
@@ -31,6 +32,9 @@ function buildDeps(): CliDeps {
 		fs: createConfigFileSystem(),
 		configPath: defaultConfigPath(),
 		platform: process.platform,
+		// Null when this host has no keychain — `resolveSecretStore`
+		// warns on that path rather than downgrading in silence.
+		secrets: createSecretStore(logger),
 		out: (line) => process.stdout.write(`${line}\n`),
 		signals: {
 			on: (signal, handler) => {

--- a/apps/node/src/cli/program.spec.ts
+++ b/apps/node/src/cli/program.spec.ts
@@ -3,6 +3,7 @@ import type { CapabilityEnvironment, CommandRunner } from '../core/capabilities'
 import { parseConfig, type ConfigFileSystem } from '../core/config-store';
 import type { FetchLike } from '../core/fleet-client';
 import { createLogger, type LogEntry } from '../core/logger';
+import type { SecretStore } from '../core/secret-store';
 import { DEFAULT_HEARTBEAT_INTERVAL_MS } from '../core/types';
 import {
 	CliError,
@@ -46,15 +47,30 @@ const apiNode = {
 	persisted: true
 };
 
+/** In-memory {@link SecretStore} so keychain paths are testable. */
+function fakeKeychain(seed: Record<string, string> = {}) {
+	const entries = new Map<string, string>(Object.entries(seed));
+	const store: SecretStore = {
+		label: 'test keychain',
+		get: async (account) => entries.get(account) ?? null,
+		set: async (account, secret) => void entries.set(account, secret),
+		delete: async (account) => void entries.delete(account)
+	};
+	return { store, entries };
+}
+
 function harness(
 	options: {
 		fetchFn?: FetchLike;
 		files?: Record<string, string>;
 		platform?: string;
+		secrets?: SecretStore | null;
 	} = {}
 ) {
 	const files = new Map<string, string>(Object.entries(options.files ?? {}));
 	const chmods: Array<{ path: string; mode: number }> = [];
+	const restricted: string[] = [];
+	const removed: string[] = [];
 	const stdout: string[] = [];
 	const entries: LogEntry[] = [];
 	const logger = createLogger({ sink: (entry) => entries.push(entry) });
@@ -64,6 +80,11 @@ function harness(
 		writeFile: async (filePath, content) => void files.set(filePath, content),
 		mkdir: async () => undefined,
 		chmod: async (filePath, mode) => void chmods.push({ path: filePath, mode }),
+		remove: async (filePath) => {
+			removed.push(filePath);
+			files.delete(filePath);
+		},
+		restrict: async (filePath) => void restricted.push(filePath),
 		dirname: (filePath) => filePath.replace(/\/[^/]*$/, '')
 	};
 
@@ -78,13 +99,16 @@ function harness(
 		fs,
 		configPath: CONFIG_PATH,
 		platform: options.platform ?? 'linux',
-		out: (line) => stdout.push(line)
+		out: (line) => stdout.push(line),
+		...(options.secrets !== undefined ? { secrets: options.secrets } : {})
 	};
 
 	return {
 		deps,
 		files,
 		chmods,
+		restricted,
+		removed,
 		stdout,
 		entries,
 		output: () => stdout.join('\n'),
@@ -276,6 +300,233 @@ describe('ever-works-node start', () => {
 		h.deps.waitForShutdown = () => Promise.resolve();
 
 		expect(await runCli(['start', '--heartbeat-interval', '99999'], h.deps)).toBe(EXIT_FAILURE);
+	});
+});
+
+describe('ever-works-node pause / resume', () => {
+	/** Capture what the CLI actually sent to the platform. */
+	function recordingFetch(status = 200) {
+		const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			calls.push({ url, body: JSON.parse(init.body) as Record<string, unknown> });
+			return {
+				ok: status < 400,
+				status,
+				text: async () => JSON.stringify({ ok: true, node: { ...apiNode, status: 'paused' } })
+			};
+		};
+		return { calls, fetchFn };
+	}
+
+	it('tells the platform to drain AND records the intent locally', async () => {
+		const { calls, fetchFn } = recordingFetch();
+		const h = harness({ files: { [CONFIG_PATH]: storedConfig }, fetchFn });
+
+		expect(await runCli(['pause'], h.deps)).toBe(EXIT_OK);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe('https://api.ever.works/api/fleet/pause');
+		expect(calls[0].body).toMatchObject({ nodeId: NODE_ID, secret: SECRET, paused: true });
+		// Local flag matters independently: a restart must come back paused.
+		expect(parseConfig(h.files.get(CONFIG_PATH) ?? null)?.paused).toBe(true);
+		expect(h.output()).toContain("the platform now reports status 'paused'");
+		expect(h.output()).toContain('In-flight jobs keep running');
+	});
+
+	it('resume clears both the platform pause and the local flag', async () => {
+		const { calls, fetchFn } = recordingFetch();
+		const paused = JSON.stringify({ ...JSON.parse(storedConfig), paused: true });
+		const h = harness({ files: { [CONFIG_PATH]: paused }, fetchFn });
+
+		expect(await runCli(['resume'], h.deps)).toBe(EXIT_OK);
+
+		expect(calls[0].body).toMatchObject({ paused: false });
+		expect(parseConfig(h.files.get(CONFIG_PATH) ?? null)?.paused).toBe(false);
+	});
+
+	it('still records the drain locally when the platform is unreachable', async () => {
+		const h = harness({
+			files: { [CONFIG_PATH]: storedConfig },
+			fetchFn: async () => {
+				throw new Error('getaddrinfo ENOTFOUND api.ever.works');
+			}
+		});
+
+		// Not a failure exit: the operator's intent was recorded and the
+		// node WILL stop leasing. The gap is reported, not swallowed.
+		expect(await runCli(['pause'], h.deps)).toBe(EXIT_OK);
+		expect(parseConfig(h.files.get(CONFIG_PATH) ?? null)?.paused).toBe(true);
+		expect(h.logged()).toContain('Could not reach the platform to pause');
+		expect(h.output()).toContain('The platform still believes it is available');
+	});
+
+	it('--local-only never touches the network', async () => {
+		const { calls, fetchFn } = recordingFetch();
+		const h = harness({ files: { [CONFIG_PATH]: storedConfig }, fetchFn });
+
+		expect(await runCli(['pause', '--local-only'], h.deps)).toBe(EXIT_OK);
+
+		expect(calls).toHaveLength(0);
+		expect(parseConfig(h.files.get(CONFIG_PATH) ?? null)?.paused).toBe(true);
+		expect(h.output()).toContain('The platform was NOT told');
+	});
+
+	it('requires enrollment', async () => {
+		const h = harness();
+		expect(await runCli(['pause'], h.deps)).toBe(EXIT_NOT_ENROLLED);
+	});
+
+	it('never prints the credential', async () => {
+		const { fetchFn } = recordingFetch();
+		const h = harness({ files: { [CONFIG_PATH]: storedConfig }, fetchFn });
+		await runCli(['pause'], h.deps);
+		expect(h.output()).not.toContain(SECRET);
+		expect(h.logged()).not.toContain(SECRET);
+	});
+
+	it('start comes back paused when the config says so, and says so loudly', async () => {
+		const paused = JSON.stringify({ ...JSON.parse(storedConfig), paused: true });
+		const h = harness({
+			files: { [CONFIG_PATH]: paused },
+			fetchFn: async () => ({
+				ok: true,
+				status: 200,
+				text: async () => JSON.stringify({ ok: true, node: apiNode })
+			})
+		});
+		h.deps.waitForShutdown = () => Promise.resolve();
+
+		expect(await runCli(['start', '--work'], h.deps)).toBe(EXIT_OK);
+		expect(h.output()).toContain('Worker host PAUSED');
+	});
+});
+
+describe('ever-works-node unenroll', () => {
+	it('retires the registration and erases the local credential', async () => {
+		const calls: string[] = [];
+		const h = harness({
+			files: { [CONFIG_PATH]: storedConfig },
+			fetchFn: async (url) => {
+				calls.push(url);
+				return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true }) };
+			}
+		});
+
+		expect(await runCli(['unenroll'], h.deps)).toBe(EXIT_OK);
+
+		expect(calls).toEqual(['https://api.ever.works/api/fleet/unenroll']);
+		expect(h.removed).toEqual([CONFIG_PATH]);
+		expect(h.files.has(CONFIG_PATH)).toBe(false);
+		expect(h.output()).toContain('The registration and the local credential are both gone');
+	});
+
+	it('erases the local credential even when the platform call fails', async () => {
+		const h = harness({
+			files: { [CONFIG_PATH]: storedConfig },
+			fetchFn: async () => ({ ok: false, status: 500, text: async () => '{}' })
+		});
+
+		expect(await runCli(['unenroll'], h.deps)).toBe(EXIT_OK);
+
+		// A decommissioned machine holding a live secret is the worse
+		// outcome — the erase is unconditional, the gap is reported.
+		expect(h.files.has(CONFIG_PATH)).toBe(false);
+		expect(h.output()).toContain('the platform was NOT told');
+	});
+
+	it('also deletes the keychain entry', async () => {
+		const keychain = fakeKeychain({ [NODE_ID]: SECRET });
+		const keychainConfig = JSON.stringify({
+			...JSON.parse(storedConfig),
+			secret: '',
+			secretStorage: 'keychain'
+		});
+		const h = harness({
+			files: { [CONFIG_PATH]: keychainConfig },
+			secrets: keychain.store,
+			fetchFn: async () => ({ ok: true, status: 200, text: async () => JSON.stringify({ ok: true }) })
+		});
+
+		expect(await runCli(['unenroll'], h.deps)).toBe(EXIT_OK);
+		expect(keychain.entries.has(NODE_ID)).toBe(false);
+	});
+
+	it('--local-only leaves the platform registration alone', async () => {
+		const calls: string[] = [];
+		const h = harness({
+			files: { [CONFIG_PATH]: storedConfig },
+			fetchFn: async (url) => {
+				calls.push(url);
+				return { ok: true, status: 200, text: async () => '{}' };
+			}
+		});
+
+		expect(await runCli(['unenroll', '--local-only'], h.deps)).toBe(EXIT_OK);
+		expect(calls).toHaveLength(0);
+		expect(h.files.has(CONFIG_PATH)).toBe(false);
+		expect(h.output()).toContain('The platform still lists this node');
+	});
+});
+
+describe('credential storage (audit A45)', () => {
+	it('enroll puts the secret in the keychain and keeps it out of the file', async () => {
+		const keychain = fakeKeychain();
+		const h = harness({ fetchFn: enrollOk, secrets: keychain.store });
+
+		expect(await runCli(['enroll', '--api-url', 'https://api.ever.works', '--token', TOKEN], h.deps)).toBe(EXIT_OK);
+
+		const raw = h.files.get(CONFIG_PATH) ?? '';
+		expect(raw).not.toContain(SECRET);
+		expect(raw).toContain('"secretStorage": "keychain"');
+		expect(keychain.entries.get(NODE_ID)).toBe(SECRET);
+		expect(h.output()).toContain('credential   test keychain');
+	});
+
+	it('a keychain-backed config is rehydrated on load', async () => {
+		const keychain = fakeKeychain({ [NODE_ID]: SECRET });
+		const keychainConfig = JSON.stringify({
+			...JSON.parse(storedConfig),
+			secret: '',
+			secretStorage: 'keychain'
+		});
+		const h = harness({ files: { [CONFIG_PATH]: keychainConfig }, secrets: keychain.store });
+
+		expect(await runCli(['status'], h.deps)).toBe(EXIT_OK);
+		expect(h.output()).toContain('credential   stored (keychain)');
+	});
+
+	it('a keychain-backed config whose secret vanished reads as not enrolled', async () => {
+		const keychain = fakeKeychain();
+		const keychainConfig = JSON.stringify({
+			...JSON.parse(storedConfig),
+			secret: '',
+			secretStorage: 'keychain'
+		});
+		const h = harness({ files: { [CONFIG_PATH]: keychainConfig }, secrets: keychain.store });
+
+		// Beating forever with a blank credential would just farm 401s.
+		expect(await runCli(['status'], h.deps)).toBe(EXIT_NOT_ENROLLED);
+		expect(h.logged()).toContain('No credential for node');
+	});
+
+	it('without a keychain the secret lands in the file, loudly, and the file is tightened', async () => {
+		const h = harness({ fetchFn: enrollOk, secrets: null });
+
+		expect(await runCli(['enroll', '--api-url', 'https://api.ever.works', '--token', TOKEN], h.deps)).toBe(EXIT_OK);
+
+		expect(h.files.get(CONFIG_PATH) ?? '').toContain(SECRET);
+		expect(h.chmods).toEqual([{ path: CONFIG_PATH, mode: 0o600 }]);
+		expect(h.output()).toContain('credential   config file (no OS keychain available)');
+	});
+
+	it('on Windows the file gets an owner-only ACL instead of a skipped chmod', async () => {
+		const h = harness({ fetchFn: enrollOk, secrets: null, platform: 'win32' });
+
+		expect(await runCli(['enroll', '--api-url', 'https://api.ever.works', '--token', TOKEN], h.deps)).toBe(EXIT_OK);
+
+		expect(h.restricted).toEqual([CONFIG_PATH]);
+		// chmod is meaningless on win32 and must NOT be the fallback.
+		expect(h.chmods).toEqual([]);
 	});
 });
 

--- a/apps/node/src/cli/program.ts
+++ b/apps/node/src/cli/program.ts
@@ -1,14 +1,17 @@
 import { Command, CommanderError } from 'commander';
 import { describeSelf } from '../core/capabilities';
-import { loadConfig, saveConfig, type ConfigFileSystem } from '../core/config-store';
+import { clearConfig, loadConfig, saveConfig, type ConfigFileSystem } from '../core/config-store';
 import { FleetClientError } from '../core/fleet-client';
 import {
 	createNodeRuntime,
 	enrollNode,
 	installShutdownHandlers,
+	pauseNode,
+	unenrollNode,
 	type NodeIo,
 	type SignalSource
 } from '../core/runtime';
+import type { SecretStore } from '../core/secret-store';
 import {
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	MAX_HEARTBEAT_INTERVAL_MS,
@@ -23,6 +26,9 @@ import {
  * Verbs (PRD §3.3):
  *   enroll       consume a one-time token and persist the node credential
  *   start        run the heartbeat loop until SIGINT/SIGTERM
+ *   pause        drain this node — stop taking new work, finish what is running
+ *   resume       take work again
+ *   unenroll     retire this node and erase the local credential
  *   status       show the local enrollment, credentials redacted
  *   capabilities print the tags this machine would report
  *
@@ -49,11 +55,16 @@ export interface CliDeps {
 	io: NodeIo;
 	fs: ConfigFileSystem;
 	configPath: string;
-	/** `process.platform`; drives the 0600 chmod decision. */
+	/** `process.platform`; drives the chmod (POSIX) vs ACL (win32) decision. */
 	platform: string;
 	/** User-facing output (stdout). Separate from the logger's diagnostic stream. */
 	out(line: string): void;
 	signals?: SignalSource;
+	/**
+	 * OS keychain, when this host has one. Absent means the credential
+	 * falls back into the config file — announced loudly, never silently.
+	 */
+	secrets?: SecretStore | null;
 	/**
 	 * Blocks until the node should shut down. Defaults to "never resolves"
 	 * (the real service runs until a signal arrives); tests override it.
@@ -85,8 +96,12 @@ export function parseIntervalSeconds(raw: string | undefined): number | undefine
 	return ms;
 }
 
+function loadOptions(deps: CliDeps): { secrets?: SecretStore | null; logger: typeof deps.io.logger } {
+	return { secrets: deps.secrets ?? null, logger: deps.io.logger };
+}
+
 async function requireConfig(deps: CliDeps): Promise<NodeConfig> {
-	const config = await loadConfig(deps.fs, deps.configPath);
+	const config = await loadConfig(deps.fs, deps.configPath, loadOptions(deps));
 	if (!config) {
 		throw new CliError(
 			`This machine is not enrolled (no usable config at ${deps.configPath}).\n` +
@@ -120,13 +135,18 @@ export async function runEnroll(deps: CliDeps, options: EnrollCommandOptions): P
 		...(heartbeatIntervalMs !== undefined ? { heartbeatIntervalMs } : {})
 	});
 
-	await saveConfig(deps.fs, deps.configPath, config, { platform: deps.platform });
+	await saveConfig(deps.fs, deps.configPath, config, {
+		platform: deps.platform,
+		secrets: deps.secrets ?? null,
+		logger: deps.io.logger
+	});
 
 	deps.out(`Enrolled as node ${config.nodeId}`);
 	deps.out(`  name         ${config.name ?? '(assigned by the platform)'}`);
 	deps.out(`  api          ${config.apiUrl}`);
 	deps.out(`  capabilities ${config.capabilities.join(', ') || '(none detected)'}`);
 	deps.out(`  config       ${deps.configPath}`);
+	deps.out(`  credential   ${deps.secrets ? deps.secrets.label : 'config file (no OS keychain available)'}`);
 	deps.out('');
 	deps.out('Run `ever-works-node start` to begin heartbeating.');
 }
@@ -145,8 +165,13 @@ export async function runStart(deps: CliDeps, options: StartCommandOptions): Pro
 
 	const workerEnabled = options.work === true;
 	const concurrency = parseConcurrency(options.concurrency);
+	// A node paused by `ever-works-node pause` comes back paused: the
+	// operator drained the machine on purpose, and a service restart
+	// (or a reboot) must not quietly hand it work again.
+	const startPaused = config.paused === true;
 	const { loop, worker } = createNodeRuntime(config, deps.io, {
 		workerEnabled,
+		startPaused,
 		...(concurrency !== undefined ? { concurrency } : {})
 	});
 	loop.onChange((state) => {
@@ -156,7 +181,12 @@ export async function runStart(deps: CliDeps, options: StartCommandOptions): Pro
 	});
 
 	deps.out(`Starting node ${config.nodeId} → ${config.apiUrl} (every ${config.heartbeatIntervalMs / 1000}s)`);
-	if (worker) {
+	if (worker && startPaused) {
+		// Loud, because a drained node looks identical to a broken one
+		// from the outside: it beats, it appears online, and it never
+		// picks anything up.
+		deps.out('Worker host PAUSED — heartbeating only. Run `ever-works-node resume` to take work again.');
+	} else if (worker) {
 		deps.out(
 			`Worker host enabled — leasing [${worker.registeredKinds.join(', ')}] with concurrency ${concurrency ?? 1}`
 		);
@@ -216,6 +246,110 @@ export function parseConcurrency(raw: string | undefined): number | undefined {
 	return parsed;
 }
 
+export interface PauseCommandOptions {
+	/** Skip the API call and only flip the local flag (offline machines). */
+	localOnly?: boolean;
+}
+
+/**
+ * Drain or resume this node.
+ *
+ * TWO things have to change, and both matter:
+ *
+ *   1. The PLATFORM stops leasing new work onto the node. Without this,
+ *      a local flag would only stop the node from asking — the row
+ *      would still look schedulable, and every other surface would
+ *      still count the machine as capacity.
+ *   2. The LOCAL config records the drain, so a service restart or a
+ *      reboot comes back paused instead of quietly resuming.
+ *
+ * The local flag is written even when the API call fails: an operator
+ * draining a machine before pulling its power should not have that
+ * intent lost because the network was down. The failure is surfaced,
+ * not swallowed.
+ */
+export async function runPause(deps: CliDeps, paused: boolean, options: PauseCommandOptions = {}): Promise<void> {
+	const config = await requireConfig(deps);
+	const verb = paused ? 'Paused' : 'Resumed';
+
+	let remoteError: string | null = null;
+	if (options.localOnly !== true) {
+		try {
+			const node = await pauseNode(config, deps.io, paused);
+			deps.out(`${verb} node ${config.nodeId} — the platform now reports status '${node.status}'.`);
+		} catch (error) {
+			remoteError = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	await saveConfig(
+		deps.fs,
+		deps.configPath,
+		{ ...config, paused },
+		{ platform: deps.platform, secrets: deps.secrets ?? null, logger: deps.io.logger }
+	);
+
+	if (options.localOnly === true) {
+		deps.out(
+			`${verb} node ${config.nodeId} locally. The platform was NOT told — run without --local-only to sync.`
+		);
+	} else if (remoteError) {
+		// Deliberately not fatal: the local intent is recorded, and the
+		// node will still stop leasing. Say exactly what did not happen.
+		deps.io.logger.warn(
+			`Could not reach the platform to ${paused ? 'pause' : 'resume'} this node: ${deps.io.logger.redact(
+				remoteError
+			)}`
+		);
+		deps.out(
+			`${verb} node ${config.nodeId} locally. The platform still believes it is ${
+				paused ? 'available' : 'paused'
+			} — re-run this command when connectivity is back.`
+		);
+	}
+
+	if (paused) {
+		deps.out('In-flight jobs keep running and still report their results. Heartbeats continue.');
+	}
+}
+
+/**
+ * Retire this machine: tell the platform to delete the registration,
+ * then erase the local credential.
+ *
+ * The local erase happens even when the API call fails. A
+ * decommissioned laptop with a live fleet secret still on it is the
+ * worse outcome by a wide margin, and the platform-side row can always
+ * be removed from the Fleet settings page afterwards.
+ */
+export async function runUnenroll(deps: CliDeps, options: { localOnly?: boolean } = {}): Promise<void> {
+	const config = await requireConfig(deps);
+
+	let remoteError: string | null = null;
+	if (options.localOnly !== true) {
+		try {
+			await unenrollNode(config, deps.io);
+		} catch (error) {
+			remoteError = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	await clearConfig(deps.fs, deps.configPath, config, { secrets: deps.secrets ?? null });
+
+	if (options.localOnly === true) {
+		deps.out(`Removed the local credential for node ${config.nodeId}.`);
+		deps.out('The platform still lists this node — remove it from the Fleet settings page.');
+		return;
+	}
+	if (remoteError) {
+		deps.io.logger.warn(`Could not reach the platform to unenroll: ${deps.io.logger.redact(remoteError)}`);
+		deps.out(`Removed the local credential for node ${config.nodeId}, but the platform was NOT told.`);
+		deps.out('Remove the node from the Fleet settings page to revoke it there too.');
+		return;
+	}
+	deps.out(`Unenrolled node ${config.nodeId}. The registration and the local credential are both gone.`);
+}
+
 export async function runStatus(deps: CliDeps): Promise<void> {
 	const config = await requireConfig(deps);
 	const view = redactConfig(config);
@@ -226,8 +360,11 @@ export async function runStatus(deps: CliDeps): Promise<void> {
 	deps.out(`enrolled at  ${view.enrolledAt}`);
 	deps.out(`heartbeat    every ${view.heartbeatIntervalMs / 1000}s`);
 	deps.out(`capabilities ${view.capabilities.join(', ') || '(none)'}`);
-	// The secret itself is never printed — only whether one is stored.
-	deps.out(`credential   ${view.hasSecret ? 'stored' : 'MISSING'}`);
+	// The secret itself is never printed — only whether one is stored,
+	// and where. Naming the location is what makes a silent downgrade to
+	// plaintext visible.
+	deps.out(`credential   ${view.hasSecret ? 'stored' : 'MISSING'} (${view.secretStorage})`);
+	deps.out(`work         ${view.paused ? 'PAUSED (draining — no new work)' : 'accepting new work'}`);
 	deps.out(`config       ${deps.configPath}`);
 }
 
@@ -236,6 +373,11 @@ export async function runCapabilities(deps: CliDeps): Promise<void> {
 	deps.out(`platform     ${description.platform}`);
 	deps.out(`version      ${description.version}`);
 	deps.out(`capabilities ${description.capabilities.join(', ')}`);
+	// Name the browser explicitly: `browser` is the one tag that commits
+	// this machine to launching a specific executable, and an operator
+	// debugging a failed browser-check needs to know WHICH one.
+	deps.out(`browser      ${deps.io.environment.browserPath ?? '(none found — `browser` not advertised)'}`);
+	deps.out(`display      ${deps.io.environment.hasDisplay ? 'available' : 'headless'}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -286,6 +428,30 @@ export function buildProgram(deps: CliDeps): Command {
 		.option('-c, --concurrency <count>', 'Max jobs to execute at once when --work is set (default 1)')
 		.action(async (options: StartCommandOptions) => {
 			await runStart(deps, options);
+		});
+
+	program
+		.command('pause')
+		.description('Drain this node: stop taking new work, finish what is already running')
+		.option('--local-only', 'Only set the local flag; do not tell the platform (offline machines)')
+		.action(async (options: PauseCommandOptions) => {
+			await runPause(deps, true, options);
+		});
+
+	program
+		.command('resume')
+		.description('Take work again after a pause')
+		.option('--local-only', 'Only clear the local flag; do not tell the platform')
+		.action(async (options: PauseCommandOptions) => {
+			await runPause(deps, false, options);
+		});
+
+	program
+		.command('unenroll')
+		.description('Retire this node: delete its platform registration and erase the local credential')
+		.option('--local-only', 'Only erase the local credential; leave the platform registration in place')
+		.action(async (options: { localOnly?: boolean }) => {
+			await runUnenroll(deps, options);
 		});
 
 	program

--- a/apps/node/src/core/browser-probe.spec.ts
+++ b/apps/node/src/core/browser-probe.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { BROWSER_PATH_ENV, browserCandidates, resolveBrowserPath } from './browser-probe';
+
+/** Probe IO whose "installed" set is an explicit list of paths. */
+function io(options: {
+	platform?: string;
+	env?: Record<string, string | undefined>;
+	installed?: string[];
+	onPath?: Record<string, string>;
+}) {
+	const installed = new Set(options.installed ?? []);
+	return {
+		platform: options.platform ?? 'linux',
+		env: options.env ?? {},
+		fileExists: (path: string) => installed.has(path),
+		lookupOnPath: (command: string) => options.onPath?.[command] ?? null
+	};
+}
+
+describe('browserCandidates', () => {
+	it('offers the per-platform install locations', () => {
+		expect(browserCandidates('linux', {})).toContain('/usr/bin/google-chrome');
+		expect(browserCandidates('darwin', {})).toContain(
+			'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+		);
+		const windows = browserCandidates('win32', { PROGRAMFILES: 'C:\\Program Files' });
+		expect(windows).toContain('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe');
+	});
+
+	it('falls back to conventional Windows roots when the env is empty', () => {
+		const windows = browserCandidates('win32', {});
+		expect(windows.some((path) => path.startsWith('C:\\Program Files'))).toBe(true);
+	});
+
+	it('treats an unknown platform as POSIX rather than returning nothing', () => {
+		expect(browserCandidates('freebsd', {}).length).toBeGreaterThan(0);
+	});
+});
+
+describe('resolveBrowserPath', () => {
+	it('finds an installed browser at a platform location', () => {
+		expect(resolveBrowserPath(io({ installed: ['/usr/bin/chromium'] }))).toBe('/usr/bin/chromium');
+	});
+
+	it('returns null when nothing is installed — this is what keeps the `browser` tag honest', () => {
+		expect(resolveBrowserPath(io({}))).toBeNull();
+	});
+
+	it('prefers an explicit override over anything installed', () => {
+		const resolved = resolveBrowserPath(
+			io({
+				env: { [BROWSER_PATH_ENV]: '/opt/custom/browser' },
+				installed: ['/opt/custom/browser', '/usr/bin/chromium']
+			})
+		);
+		expect(resolved).toBe('/opt/custom/browser');
+	});
+
+	it('a pinned override that does not exist disables the capability rather than falling through', () => {
+		// Silently launching a different engine than the one an operator
+		// chose is how a check passes for the wrong reason.
+		const resolved = resolveBrowserPath(
+			io({ env: { [BROWSER_PATH_ENV]: '/opt/missing' }, installed: ['/usr/bin/chromium'] })
+		);
+		expect(resolved).toBeNull();
+	});
+
+	it('falls back to PATH lookup when no absolute candidate exists', () => {
+		const resolved = resolveBrowserPath(io({ onPath: { chromium: '/snap/bin/chromium' } }));
+		expect(resolved).toBe('/snap/bin/chromium');
+	});
+
+	it('prefers an installed absolute candidate over a PATH hit', () => {
+		const resolved = resolveBrowserPath(
+			io({ installed: ['/usr/bin/google-chrome'], onPath: { chromium: '/snap/bin/chromium' } })
+		);
+		expect(resolved).toBe('/usr/bin/google-chrome');
+	});
+
+	it('works with no PATH lookup wired at all', () => {
+		const probe = io({ installed: [] });
+		const resolved = resolveBrowserPath({
+			platform: probe.platform,
+			env: probe.env,
+			fileExists: probe.fileExists
+		});
+		expect(resolved).toBeNull();
+	});
+});

--- a/apps/node/src/core/browser-probe.ts
+++ b/apps/node/src/core/browser-probe.ts
@@ -1,0 +1,131 @@
+/**
+ * Browser discovery for the node.
+ *
+ * One probe, two consumers:
+ *
+ *   - `capabilities.ts` decides whether to advertise the `browser` tag;
+ *   - `executors/browser-check.ts` spawns exactly the binary this probe
+ *     found.
+ *
+ * They MUST be the same function. A node that advertises `browser`
+ * because some heuristic said so, and then cannot find anything to
+ * launch when a `browser-check` job lands, is worse than a node that
+ * never advertised at all: the scheduler routed real work to it on the
+ * strength of a tag that was a lie (audit A22/A26).
+ *
+ * Everything is injected — platform, environment, an existence probe —
+ * so the whole candidate matrix is unit-testable on any host.
+ */
+
+/** Environment variable that pins the browser executable explicitly. */
+export const BROWSER_PATH_ENV = 'EVER_WORKS_NODE_BROWSER';
+
+/** Names looked up on `PATH` when no absolute candidate exists. */
+export const BROWSER_PATH_COMMANDS: readonly string[] = [
+	'google-chrome-stable',
+	'google-chrome',
+	'chromium-browser',
+	'chromium',
+	'microsoft-edge-stable',
+	'microsoft-edge',
+	'brave-browser'
+];
+
+export interface BrowserProbeIo {
+	/** `process.platform`. */
+	platform: string;
+	env: Record<string, string | undefined>;
+	/** True when the path names an existing, executable file. */
+	fileExists(path: string): boolean;
+	/** Resolve a bare command name on `PATH`; null when absent. */
+	lookupOnPath?(command: string): string | null;
+}
+
+function windowsCandidates(env: Record<string, string | undefined>): string[] {
+	const roots = [
+		env.PROGRAMFILES,
+		env['PROGRAMFILES(X86)'],
+		env.LOCALAPPDATA,
+		'C:\\Program Files',
+		'C:\\Program Files (x86)'
+	].filter((root): root is string => typeof root === 'string' && root.length > 0);
+
+	const suffixes = [
+		'\\Google\\Chrome\\Application\\chrome.exe',
+		'\\Microsoft\\Edge\\Application\\msedge.exe',
+		'\\Chromium\\Application\\chrome.exe',
+		'\\BraveSoftware\\Brave-Browser\\Application\\brave.exe'
+	];
+
+	const out: string[] = [];
+	for (const root of roots) {
+		for (const suffix of suffixes) {
+			out.push(`${root.replace(/\\+$/, '')}${suffix}`);
+		}
+	}
+	return out;
+}
+
+const DARWIN_CANDIDATES: readonly string[] = [
+	'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+	'/Applications/Chromium.app/Contents/MacOS/Chromium',
+	'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+	'/Applications/Brave Browser.app/Contents/MacOS/Brave Browser'
+];
+
+const POSIX_CANDIDATES: readonly string[] = [
+	'/usr/bin/google-chrome-stable',
+	'/usr/bin/google-chrome',
+	'/usr/bin/chromium-browser',
+	'/usr/bin/chromium',
+	'/usr/bin/microsoft-edge-stable',
+	'/usr/bin/microsoft-edge',
+	'/usr/bin/brave-browser',
+	'/snap/bin/chromium',
+	'/opt/google/chrome/chrome'
+];
+
+/** Absolute paths worth probing on this platform, most-preferred first. */
+export function browserCandidates(platform: string, env: Record<string, string | undefined>): string[] {
+	if (platform === 'win32') {
+		return windowsCandidates(env);
+	}
+	if (platform === 'darwin') {
+		return [...DARWIN_CANDIDATES];
+	}
+	return [...POSIX_CANDIDATES];
+}
+
+/**
+ * Resolve a usable browser executable, or null.
+ *
+ * Order: the explicit `EVER_WORKS_NODE_BROWSER` override (an operator
+ * saying "use this one" always wins), then the platform's install
+ * locations, then bare command names on `PATH`. A configured override
+ * that does NOT exist resolves to null rather than falling through —
+ * silently launching a different browser than the one an operator
+ * pinned is how a check passes on the wrong engine.
+ */
+export function resolveBrowserPath(io: BrowserProbeIo): string | null {
+	const override = io.env[BROWSER_PATH_ENV]?.trim();
+	if (override) {
+		return io.fileExists(override) ? override : null;
+	}
+
+	for (const candidate of browserCandidates(io.platform, io.env)) {
+		if (io.fileExists(candidate)) {
+			return candidate;
+		}
+	}
+
+	if (io.lookupOnPath) {
+		for (const command of BROWSER_PATH_COMMANDS) {
+			const resolved = io.lookupOnPath(command);
+			if (resolved) {
+				return resolved;
+			}
+		}
+	}
+
+	return null;
+}

--- a/apps/node/src/core/capabilities.spec.ts
+++ b/apps/node/src/core/capabilities.spec.ts
@@ -139,6 +139,118 @@ describe('detectCapabilities matrix', () => {
 	});
 });
 
+describe('detectCapabilities — browser tag (audit A22/A26)', () => {
+	it('advertises `browser` only when an executable was actually resolved', async () => {
+		const withBrowser = await detectCapabilities(runnerWith([]), environment({ browserPath: '/usr/bin/chromium' }));
+		expect(withBrowser).toContain('browser');
+
+		// The tag is a promise the node has to be able to keep: without a
+		// resolved binary there is nothing for `browser-check` to spawn.
+		for (const absent of [null, undefined, '']) {
+			const tags = await detectCapabilities(runnerWith([]), environment({ browserPath: absent }));
+			expect(tags).not.toContain('browser');
+		}
+	});
+
+	it('is independent of `display` — a headless box can still drive a headless browser', async () => {
+		const tags = await detectCapabilities(
+			runnerWith([]),
+			environment({ hasDisplay: false, browserPath: '/usr/bin/chromium' })
+		);
+		expect(tags).toContain('browser');
+		expect(tags).not.toContain('display');
+	});
+});
+
+describe('detectCapabilities — gpu tag (audit A22)', () => {
+	/** Runner that answers one GPU probe and 127s everything else. */
+	function gpuRunner(command: string, stdout: string): CommandRunner {
+		return {
+			run: async (invoked) =>
+				invoked === command ? { code: 0, stdout, stderr: '' } : { code: 127, stdout: '', stderr: 'not found' }
+		};
+	}
+
+	it('reports `gpu` and the vendor when nvidia-smi answers', async () => {
+		const tags = await detectCapabilities(gpuRunner('nvidia-smi', 'NVIDIA GeForce RTX 4090\n'), environment());
+		expect(tags).toContain('gpu');
+		expect(tags).toContain('gpu:nvidia');
+	});
+
+	it('classifies an AMD adapter from lspci on Linux', async () => {
+		const lspci = [
+			'00:1f.3 Audio device: Intel Corporation Cannon Lake PCH cAVS',
+			'01:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Navi 21 [Radeon RX 6800]'
+		].join('\n');
+		const tags = await detectCapabilities(gpuRunner('lspci', lspci), environment());
+		expect(tags).toContain('gpu:amd');
+	});
+
+	it('reports no gpu tags on a machine with no accelerator', async () => {
+		const tags = await detectCapabilities(runnerWith([]), environment());
+		expect(tags.some((tag) => tag.startsWith('gpu'))).toBe(false);
+	});
+
+	it('ignores lspci output with no display controller in it', async () => {
+		const tags = await detectCapabilities(
+			gpuRunner('lspci', '00:1f.3 Audio device: Intel Corporation Cannon Lake PCH cAVS'),
+			environment()
+		);
+		expect(tags.some((tag) => tag.startsWith('gpu'))).toBe(false);
+	});
+
+	it('a probe that throws is a missing tag, never a failed heartbeat', async () => {
+		const tags = await detectCapabilities(
+			{
+				run: async (command) => {
+					if (command === 'nvidia-smi') throw new Error('spawn nvidia-smi ENOENT');
+					if (command === 'git') return { code: 0, stdout: 'git version 2.43', stderr: '' };
+					return { code: 127, stdout: '', stderr: '' };
+				}
+			},
+			environment()
+		);
+		expect(tags).toContain('git');
+		expect(tags.some((tag) => tag.startsWith('gpu'))).toBe(false);
+	});
+
+	it('stays inside the server capability caps with every tag present', async () => {
+		const tags = await detectCapabilities(
+			{
+				run: async (command) => {
+					if (command === 'nvidia-smi') {
+						return { code: 0, stdout: 'NVIDIA RTX A6000', stderr: '' };
+					}
+					return ['docker', 'git'].includes(command)
+						? { code: 0, stdout: 'v1', stderr: '' }
+						: { code: 127, stdout: '', stderr: '' };
+				}
+			},
+			environment({ platform: 'darwin', hasDisplay: true, browserPath: '/Applications/Chromium' })
+		);
+		expect(tags.length).toBeLessThanOrEqual(MAX_CAPABILITY_TAGS);
+		for (const tag of tags) {
+			expect(tag.length).toBeLessThanOrEqual(MAX_CAPABILITY_TAG_LENGTH);
+		}
+	});
+});
+
+describe('readEnvironment browser wiring', () => {
+	it('records the resolved browser path so the tag and the executor agree', () => {
+		const env = readEnvironment(
+			{ platform: 'linux', arch: 'x64', version: 'v22.11.0', env: {} },
+			() => '/usr/bin/google-chrome',
+			{ fileExists: () => true }
+		);
+		expect(env.browserPath).toBe('/usr/bin/google-chrome');
+	});
+
+	it('leaves the path undefined when no probe is supplied (pure-logic callers)', () => {
+		const env = readEnvironment({ platform: 'linux', arch: 'x64', version: 'v22.11.0', env: {} });
+		expect(env.browserPath).toBeUndefined();
+	});
+});
+
 describe('describeSelf', () => {
 	it('bundles platform, version and capabilities, capping the version', async () => {
 		const description = await describeSelf(runnerWith(['git']), environment(), '0.1.0');

--- a/apps/node/src/core/capabilities.ts
+++ b/apps/node/src/core/capabilities.ts
@@ -1,3 +1,6 @@
+import { FLEET_BROWSER_CAPABILITY, FLEET_GPU_CAPABILITY } from '@ever-works/contracts';
+import type { BrowserProbeIo } from './browser-probe';
+import { detectGpu } from './gpu-probe';
 import {
 	MAX_CAPABILITY_TAG_LENGTH,
 	MAX_CAPABILITY_TAGS,
@@ -33,6 +36,13 @@ export interface CapabilityEnvironment {
 	nodeVersion: string;
 	/** Whether a graphical display is available (headed browser automation). */
 	hasDisplay: boolean;
+	/**
+	 * Absolute path of a browser executable this machine can actually
+	 * launch, or null. Resolved by {@link resolveBrowserPath} — the SAME
+	 * function `browser-check` uses to spawn — so the `browser` tag and
+	 * the executor can never disagree about what is installed.
+	 */
+	browserPath?: string | null;
 }
 
 /**
@@ -75,19 +85,38 @@ export function detectDisplay(platform: string, env: Record<string, string | und
 	return Boolean(env.DISPLAY || env.WAYLAND_DISPLAY);
 }
 
-/** Build a {@link CapabilityEnvironment} from a process-like object. */
-export function readEnvironment(processLike: {
-	platform: string;
-	arch: string;
-	version: string;
-	env: Record<string, string | undefined>;
-}): CapabilityEnvironment {
-	return {
+/**
+ * Build a {@link CapabilityEnvironment} from a process-like object.
+ *
+ * `browserProbe` is optional so pure-logic callers (and every test) can
+ * skip filesystem access; when it is supplied the resolved executable
+ * path is what turns the `browser` tag on.
+ */
+export function readEnvironment(
+	processLike: {
+		platform: string;
+		arch: string;
+		version: string;
+		env: Record<string, string | undefined>;
+	},
+	browserProbe?: (io: BrowserProbeIo) => string | null,
+	probeIo?: Pick<BrowserProbeIo, 'fileExists' | 'lookupOnPath'>
+): CapabilityEnvironment {
+	const environment: CapabilityEnvironment = {
 		platform: processLike.platform,
 		arch: processLike.arch,
 		nodeVersion: processLike.version,
 		hasDisplay: detectDisplay(processLike.platform, processLike.env)
 	};
+	if (browserProbe && probeIo) {
+		environment.browserPath = browserProbe({
+			platform: processLike.platform,
+			env: processLike.env,
+			fileExists: probeIo.fileExists,
+			...(probeIo.lookupOnPath ? { lookupOnPath: probeIo.lookupOnPath } : {})
+		});
+	}
+	return environment;
 }
 
 /**
@@ -127,11 +156,27 @@ async function hasTool(runner: CommandRunner, command: string): Promise<boolean>
 /**
  * Detect this machine's capability tags:
  * `os:<platform>`, `arch:<arch>`, `node:<major>`, the always-on
- * `terminal`/`workspace`, plus `docker`, `git` and `display` when present.
+ * `terminal`/`workspace`, plus `docker`, `git`, `display`, `browser`,
+ * `gpu` and `gpu:<vendor>` when present.
+ *
+ * Two rules govern what may appear here:
+ *
+ *   1. **A tag is a promise the node can keep.** `browser` is emitted
+ *      only when a browser executable was actually resolved — the same
+ *      path the `browser-check` executor will spawn. A tag nothing
+ *      backs would route real work to a machine that cannot do it.
+ *   2. **Detection never fails the beat.** Every probe swallows its own
+ *      errors; a missing tool means a missing tag, not a missing
+ *      heartbeat.
  */
 export async function detectCapabilities(runner: CommandRunner, environment: CapabilityEnvironment): Promise<string[]> {
-	const [docker, git] = await Promise.all([hasTool(runner, 'docker'), hasTool(runner, 'git')]);
+	const [docker, git, gpu] = await Promise.all([
+		hasTool(runner, 'docker'),
+		hasTool(runner, 'git'),
+		detectGpu(runner, environment.platform)
+	]);
 	const major = nodeMajor(environment.nodeVersion);
+	const hasBrowser = typeof environment.browserPath === 'string' && environment.browserPath.length > 0;
 
 	return normalizeCapabilities([
 		`os:${environment.platform}`,
@@ -140,7 +185,13 @@ export async function detectCapabilities(runner: CommandRunner, environment: Cap
 		...BASE_CAPABILITIES,
 		docker ? 'docker' : null,
 		git ? 'git' : null,
-		environment.hasDisplay ? 'display' : null
+		environment.hasDisplay ? 'display' : null,
+		hasBrowser ? FLEET_BROWSER_CAPABILITY : null,
+		gpu ? FLEET_GPU_CAPABILITY : null,
+		// Vendor is a second, narrower tag rather than a replacement:
+		// a job that needs "any accelerator" must not have to enumerate
+		// vendors, and one that needs CUDA must be able to say so.
+		gpu ? `${FLEET_GPU_CAPABILITY}:${gpu.vendor}` : null
 	]);
 }
 

--- a/apps/node/src/core/config-store.spec.ts
+++ b/apps/node/src/core/config-store.spec.ts
@@ -49,6 +49,12 @@ function config(overrides: Partial<NodeConfig> = {}): NodeConfig {
 		name: 'build-box-01',
 		heartbeatIntervalMs: DEFAULT_HEARTBEAT_INTERVAL_MS,
 		enrolledAt: '2026-07-25T10:00:00.000Z',
+		// Both are normalized onto every load so an OLDER config file
+		// still produces a complete NodeConfig. The fixture has to carry
+		// them or the round-trip compares against a shape the store no
+		// longer returns.
+		paused: false,
+		secretStorage: 'file',
 		...overrides
 	};
 }
@@ -183,6 +189,13 @@ describe('redactConfig', () => {
 			name: 'build-box-01',
 			heartbeatIntervalMs: DEFAULT_HEARTBEAT_INTERVAL_MS,
 			enrolledAt: '2026-07-25T10:00:00.000Z',
+			// Neither is a credential: `paused` is lifecycle state and
+			// `secretStorage` is the storage MODE (file vs keychain), not
+			// the secret. This assertion is an exhaustive allowlist on
+			// purpose — that is what makes it catch a credential field
+			// leaking into the redacted view.
+			paused: false,
+			secretStorage: 'file',
 			hasSecret: true
 		});
 	});

--- a/apps/node/src/core/config-store.ts
+++ b/apps/node/src/core/config-store.ts
@@ -1,20 +1,35 @@
+import type { Logger } from './logger';
+import type { SecretStore } from './secret-store';
 import {
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	isFleetEnrollableNodeKind,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
 	type FleetEnrollableNodeKind,
-	type NodeConfig
+	type NodeConfig,
+	type FleetNodeKind,
+	type NodeSecretStorage
 } from './types';
 
 /**
  * Node config persistence.
  *
- * The config file holds the heartbeat secret, so it is written to the OS
- * config directory with 0600 permissions on POSIX platforms. Windows has no
- * POSIX mode bits (`fs.chmod` there only toggles the read-only flag), so the
- * chmod is skipped rather than faked — the file inherits the user profile's
- * ACL, which is already user-scoped.
+ * The heartbeat secret is a credential, so it is kept OUT of the config
+ * file whenever the host offers somewhere better: when a
+ * {@link SecretStore} is supplied (the OS keychain — see
+ * `secret-store.ts`) the file records only `secretStorage: 'keychain'`
+ * and the credential itself lives in Keychain / Credential Manager /
+ * Secret Service.
+ *
+ * When no keychain exists the secret falls back INTO the file, and the
+ * file is then locked to its owner on every platform (audit A45):
+ *
+ *   - POSIX: created 0600 and re-chmod'd 0600 after the write;
+ *   - Windows: `restrict()` applies an inheritance-stripped, owner-only
+ *     ACL. The previous behaviour — skipping the tightening entirely on
+ *     win32 because `fs.chmod` there only toggles the read-only bit —
+ *     left the credential readable by anything the profile's inherited
+ *     ACL admitted.
  *
  * All filesystem access is injected so persistence is testable without a real
  * disk, and so the Electron shell can point it at `app.getPath('userData')`.
@@ -35,6 +50,15 @@ export interface ConfigFileSystem {
 	mkdir(dirPath: string): Promise<void>;
 	chmod(filePath: string, mode: number): Promise<void>;
 	dirname(filePath: string): string;
+	/** Remove the file. Missing is success. */
+	remove?(filePath: string): Promise<void>;
+	/**
+	 * Platform-native "owner only" tightening for hosts where POSIX mode
+	 * bits are meaningless (Windows ACLs). Optional so existing
+	 * implementations keep compiling; when absent on win32 the caller
+	 * WARNS rather than silently doing nothing.
+	 */
+	restrict?(filePath: string): Promise<void>;
 }
 
 export interface ResolveConfigPathInput {
@@ -99,13 +123,17 @@ export function parseConfig(raw: string | null): NodeConfig | null {
 		return null;
 	}
 	const candidate = parsed as Partial<NodeConfig>;
+	const secretStorage: NodeSecretStorage = candidate.secretStorage === 'keychain' ? 'keychain' : 'file';
+	const inlineSecret = typeof candidate.secret === 'string' ? candidate.secret : '';
 	if (
 		typeof candidate.apiUrl !== 'string' ||
 		!candidate.apiUrl ||
 		typeof candidate.nodeId !== 'string' ||
 		!candidate.nodeId ||
-		typeof candidate.secret !== 'string' ||
-		!candidate.secret
+		// A keychain-backed config legitimately carries no secret here —
+		// `loadConfig` fetches it from the OS store. Anything else with an
+		// empty credential is unusable and reads as "not enrolled".
+		(secretStorage === 'file' && !inlineSecret)
 	) {
 		return null;
 	}
@@ -118,13 +146,15 @@ export function parseConfig(raw: string | null): NodeConfig | null {
 	const config: NodeConfig = {
 		apiUrl: candidate.apiUrl,
 		nodeId: candidate.nodeId,
-		secret: candidate.secret,
+		secret: inlineSecret,
 		kind,
 		capabilities: Array.isArray(candidate.capabilities)
 			? candidate.capabilities.filter((tag): tag is string => typeof tag === 'string')
 			: [],
 		heartbeatIntervalMs: clampInterval(candidate.heartbeatIntervalMs),
-		enrolledAt: typeof candidate.enrolledAt === 'string' ? candidate.enrolledAt : new Date(0).toISOString()
+		enrolledAt: typeof candidate.enrolledAt === 'string' ? candidate.enrolledAt : new Date(0).toISOString(),
+		secretStorage,
+		paused: candidate.paused === true
 	};
 	if (typeof candidate.name === 'string' && candidate.name) {
 		config.name = candidate.name;
@@ -132,25 +162,78 @@ export function parseConfig(raw: string | null): NodeConfig | null {
 	return config;
 }
 
-export async function loadConfig(fs: ConfigFileSystem, filePath: string): Promise<NodeConfig | null> {
+export interface LoadConfigOptions {
+	/** OS keychain, when one is available on this host. */
+	secrets?: SecretStore | null;
+	logger?: Logger;
+}
+
+/**
+ * Read the stored config and rehydrate its credential.
+ *
+ * A `keychain`-backed config whose secret has vanished from the OS
+ * store (keychain reset, profile migrated, entry revoked by hand) reads
+ * as NOT ENROLLED rather than as a config with an empty secret: a node
+ * that keeps beating with a blank credential would just hammer the API
+ * for 401s until someone noticed.
+ */
+export async function loadConfig(
+	fs: ConfigFileSystem,
+	filePath: string,
+	options: LoadConfigOptions = {}
+): Promise<NodeConfig | null> {
 	let raw: string | null;
 	try {
 		raw = await fs.readFile(filePath);
 	} catch {
 		return null;
 	}
-	return parseConfig(raw);
+	const config = parseConfig(raw);
+	if (!config) {
+		return null;
+	}
+	if (config.secretStorage !== 'keychain') {
+		options.logger?.warn(
+			`Node credential is stored in ${filePath}. Install \`@napi-rs/keyring\` to move it into the OS keychain.`
+		);
+		return config;
+	}
+
+	if (!options.secrets) {
+		options.logger?.error(
+			'This node stored its credential in the OS keychain, but no keychain is available now. ' +
+				'Re-run `ever-works-node enroll` to re-issue a credential.'
+		);
+		return null;
+	}
+	const secret = await options.secrets.get(config.nodeId);
+	if (!secret) {
+		options.logger?.error(
+			`No credential for node ${config.nodeId} in the ${options.secrets.label}. ` +
+				'Re-run `ever-works-node enroll` to re-issue one.'
+		);
+		return null;
+	}
+	options.logger?.protect(secret);
+	return { ...config, secret };
 }
 
 export interface SaveConfigOptions {
-	/** `process.platform`; the 0600 chmod is skipped on `win32`. */
+	/** `process.platform`; decides chmod (POSIX) vs ACL (win32). */
 	platform?: string;
+	/** OS keychain. When present the secret NEVER reaches the file. */
+	secrets?: SecretStore | null;
+	logger?: Logger;
 }
 
 /**
- * Persist the config, creating the directory tree as needed, then tighten the
- * file mode to 0600. A chmod failure is not fatal (some filesystems — CIFS,
- * FAT, container overlays — do not support it) but the write itself is.
+ * Persist the config, creating the directory tree as needed, then lock the
+ * file down to its owner.
+ *
+ * With a {@link SecretStore} the credential is written to the OS keychain
+ * and the file records only where it lives. Without one the credential is
+ * inlined and the file tightening becomes the ONLY thing protecting it, so
+ * a failure to tighten is reported loudly instead of swallowed.
  */
 export async function saveConfig(
 	fs: ConfigFileSystem,
@@ -158,14 +241,112 @@ export async function saveConfig(
 	config: NodeConfig,
 	options: SaveConfigOptions = {}
 ): Promise<void> {
+	let stored: NodeConfig = { ...config, secretStorage: 'file' };
+
+	if (options.secrets && config.secret) {
+		try {
+			await options.secrets.set(config.nodeId, config.secret);
+			// Only now is it safe to drop the secret from the file: if the
+			// keychain write had failed we would have persisted a config
+			// pointing at a credential that does not exist anywhere.
+			stored = { ...config, secret: '', secretStorage: 'keychain' };
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			options.logger?.warn(
+				`Could not store the node credential in the ${options.secrets.label} (${options.logger.redact(
+					detail
+				)}); falling back to the config file.`
+			);
+		}
+	}
+
 	await fs.mkdir(fs.dirname(filePath));
-	await fs.writeFile(filePath, `${JSON.stringify(config, null, '\t')}\n`);
+	await fs.writeFile(filePath, `${JSON.stringify(stored, null, '\t')}\n`);
+	await restrictConfigFile(fs, filePath, {
+		platform: options.platform,
+		secretOnDisk: stored.secretStorage !== 'keychain',
+		...(options.logger ? { logger: options.logger } : {})
+	});
+}
+
+/**
+ * Tighten the config file to owner-only on any platform.
+ *
+ * Windows gets a real ACL through `fs.restrict` rather than the old
+ * silent skip; POSIX gets the 0600 chmod. When the credential is on
+ * disk and the tightening fails, the operator is TOLD — that is the
+ * only remaining thing standing between the secret and every other
+ * process on the machine.
+ */
+export async function restrictConfigFile(
+	fs: ConfigFileSystem,
+	filePath: string,
+	options: { platform?: string; secretOnDisk: boolean; logger?: Logger }
+): Promise<void> {
+	const loud = (message: string): void => {
+		if (options.secretOnDisk) {
+			options.logger?.warn(message);
+		}
+	};
+
 	if (options.platform === 'win32') {
+		if (!fs.restrict) {
+			loud(
+				`Could not apply an owner-only ACL to ${filePath} on this host — the node credential is readable by anything the inherited ACL admits.`
+			);
+			return;
+		}
+		try {
+			await fs.restrict(filePath);
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			loud(`Could not apply an owner-only ACL to ${filePath}: ${detail}`);
+		}
 		return;
 	}
+
 	try {
 		await fs.chmod(filePath, CONFIG_FILE_MODE);
-	} catch {
-		// Best-effort: the file is written, the mode just could not be tightened.
+	} catch (error) {
+		// Some filesystems (CIFS, FAT, container overlays) genuinely
+		// cannot do this. The write still stands — but say so.
+		const detail = error instanceof Error ? error.message : String(error);
+		loud(`Could not set 0600 on ${filePath}: ${detail}`);
 	}
+}
+
+/**
+ * Erase every local trace of an enrollment: the keychain entry first
+ * (the credential itself), then the config file.
+ *
+ * Deleting the credential before the file is deliberate — a crash
+ * between the two leaves a config whose secret is gone, which reads as
+ * "not enrolled" and sends the operator back through `enroll`. The
+ * other order would leave a live credential behind with nothing
+ * pointing at it.
+ */
+export async function clearConfig(
+	fs: ConfigFileSystem,
+	filePath: string,
+	config: NodeConfig | null,
+	options: { secrets?: SecretStore | null } = {}
+): Promise<void> {
+	if (options.secrets && config?.nodeId) {
+		try {
+			await options.secrets.delete(config.nodeId);
+		} catch {
+			// Best-effort: a stuck keychain must not block the file removal.
+		}
+	}
+	if (fs.remove) {
+		try {
+			await fs.remove(filePath);
+			return;
+		} catch {
+			// Fall through to the overwrite below.
+		}
+	}
+	// No removal available: overwrite with an empty object so the
+	// credential is gone even if the file itself survives.
+	await fs.writeFile(filePath, '{}\n');
 }

--- a/apps/node/src/core/executors/browser-check.ts
+++ b/apps/node/src/core/executors/browser-check.ts
@@ -1,0 +1,367 @@
+import { spawn } from 'child_process';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { FleetBrowserCheckPayload, FleetBrowserCheckResult, FleetJobView } from '@ever-works/contracts';
+import { resolveBrowserPath, type BrowserProbeIo } from '../browser-probe';
+import { buildNodeCheckEnv } from './acceptance-checks';
+
+/**
+ * The `browser-check` executor — the node's v2 job kind (audit A26).
+ *
+ * ## Why this exists
+ *
+ * The node advertises a `browser` capability tag. Until this module,
+ * nothing on the machine ever launched a browser, so the tag was a
+ * claim with no work behind it: the platform could route
+ * browser-required jobs to a node that had never opened one, and only
+ * discover the gap when the job failed for reasons nobody could see.
+ *
+ * A capability and the executor that honours it have to ship together.
+ * `browser-check` is the smallest honest unit of browser work: load a
+ * URL in the machine's REAL browser and report what it rendered.
+ *
+ * ## Two modes, two different proofs
+ *
+ * - **headless (default)** — `--headless=new --dump-dom <url>`. Chrome
+ *   prints the serialized DOM to stdout, so the verdict is a real
+ *   observation: bytes rendered, the document title, and an optional
+ *   `expectText` substring. This is the mode a CI-style check wants.
+ *
+ * - **headed** — a visible window on a machine that advertises
+ *   `display`. Chrome has no `--dump-dom` outside headless, so the
+ *   proof here is weaker BY CONSTRUCTION: the browser opened a window
+ *   against the URL and stayed alive for the settle window. Rather than
+ *   pretend otherwise, a headed job that asks for `expectText` is
+ *   REFUSED — quietly downgrading an assertion to "the process did not
+ *   crash" would turn an unverifiable check green.
+ *
+ * ## Isolation
+ *
+ * Every run gets a throwaway `--user-data-dir`, so a job can neither
+ * read the operator's real profile (cookies, saved passwords, history)
+ * nor leave anything behind in it. The child environment is built by
+ * `buildNodeCheckEnv` — the same scrubbed, allowlisted env the
+ * acceptance-check executor uses, which notably excludes this node's
+ * own fleet credential namespace.
+ */
+
+/** Wall-clock budget when the payload declares no `timeoutSec`. */
+export const DEFAULT_BROWSER_TIMEOUT_SEC = 60;
+
+/** Hard ceiling, so a typo'd `timeoutSec` cannot pin a node forever. */
+export const MAX_BROWSER_TIMEOUT_SEC = 300;
+
+/** How long a headed window must stay up to count as a successful load. */
+export const HEADED_SETTLE_MS = 5_000;
+
+/** Largest DOM we keep in memory before we stop appending. */
+export const MAX_DOM_CAPTURE_BYTES = 2 * 1024 * 1024;
+
+export class BrowserCheckPayloadError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'BrowserCheckPayloadError';
+	}
+}
+
+/** Injected so the whole executor is testable without launching a browser. */
+export interface BrowserCheckIo {
+	spawnFn?: typeof spawn;
+	/** Resolves the browser executable; defaults to the shared probe. */
+	resolveBrowser?: () => string | null;
+	/** Host facts for the default probe. */
+	probe?: Partial<BrowserProbeIo>;
+	/** Whether the host has a display (gates `headed`). */
+	hasDisplay?: boolean;
+	parentEnv?: NodeJS.ProcessEnv;
+	now?: () => number;
+	/** Throwaway profile directory factory; defaults to a real mkdtemp. */
+	createProfileDir?: () => string;
+	/** Profile cleanup; defaults to a recursive rm. */
+	removeProfileDir?: (dir: string) => void;
+}
+
+/** Validated, defaulted view of the wire payload. */
+export interface NormalizedBrowserCheck {
+	url: string;
+	headed: boolean;
+	expectText: string | null;
+	timeoutSec: number;
+}
+
+/**
+ * Validate the wire payload.
+ *
+ * Refuses rather than repairs: a check pointed at the wrong URL, or one
+ * whose assertion cannot be evaluated in the requested mode, must fail
+ * loudly instead of reporting a verdict nobody can trust.
+ */
+export function normalizeBrowserCheck(raw: unknown): NormalizedBrowserCheck {
+	if (!raw || typeof raw !== 'object') {
+		throw new BrowserCheckPayloadError('Job payload is missing');
+	}
+	const payload = raw as FleetBrowserCheckPayload;
+
+	const url = typeof payload.url === 'string' ? payload.url.trim() : '';
+	if (!url) {
+		throw new BrowserCheckPayloadError('Job payload has no url');
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new BrowserCheckPayloadError(`Job payload url is not a valid URL: ${url}`);
+	}
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		// `file:` would turn a browser check into an arbitrary local-file
+		// read, and the exotic schemes (`chrome://`, `javascript:`) are
+		// browser-internal surfaces, not things a platform job may drive.
+		throw new BrowserCheckPayloadError('Job payload url must be http(s)');
+	}
+
+	const headed = payload.headed === true;
+	const expectText = typeof payload.expectText === 'string' && payload.expectText ? payload.expectText : null;
+	if (headed && expectText) {
+		throw new BrowserCheckPayloadError(
+			'expectText cannot be verified in headed mode — the browser only exposes the DOM when headless'
+		);
+	}
+
+	const requested =
+		typeof payload.timeoutSec === 'number' && payload.timeoutSec > 0
+			? payload.timeoutSec
+			: DEFAULT_BROWSER_TIMEOUT_SEC;
+
+	return {
+		url: parsed.toString(),
+		headed,
+		expectText,
+		timeoutSec: Math.min(requested, MAX_BROWSER_TIMEOUT_SEC)
+	};
+}
+
+/** Extract `<title>` from a serialized DOM, or null. */
+export function extractTitle(dom: string): string | null {
+	const match = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(dom);
+	if (!match) {
+		return null;
+	}
+	const title = match[1].replace(/\s+/g, ' ').trim();
+	return title ? title.slice(0, 200) : null;
+}
+
+/**
+ * Command line for one run.
+ *
+ * Every flag here is either isolation (`--user-data-dir`, no first-run
+ * wizard, no background networking) or determinism (`--no-default-*`).
+ * `--no-sandbox` is NOT added by default — it is a real weakening of
+ * the browser's own protections and is only correct inside an already
+ * isolated container, so it is opt-in through the environment.
+ */
+export function buildBrowserArgs(
+	check: NormalizedBrowserCheck,
+	profileDir: string,
+	options: { noSandbox: boolean }
+): string[] {
+	const args = [
+		`--user-data-dir=${profileDir}`,
+		'--no-first-run',
+		'--no-default-browser-check',
+		'--disable-background-networking',
+		'--disable-extensions',
+		'--disable-sync',
+		'--window-size=1280,900'
+	];
+	if (options.noSandbox) {
+		args.push('--no-sandbox', '--disable-dev-shm-usage');
+	}
+	if (check.headed) {
+		args.push('--new-window', check.url);
+		return args;
+	}
+	args.push(
+		'--headless=new',
+		'--disable-gpu',
+		// Fast-forwards timers so a page whose load event is gated on a
+		// setTimeout does not burn the whole budget.
+		`--virtual-time-budget=${Math.min(check.timeoutSec, 30) * 1000}`,
+		'--dump-dom',
+		check.url
+	);
+	return args;
+}
+
+/** Env var that opts a containerized node into `--no-sandbox`. */
+export const BROWSER_NO_SANDBOX_ENV = 'EVER_WORKS_NODE_BROWSER_NO_SANDBOX';
+
+function defaultProfileDir(): string {
+	return mkdtempSync(join(tmpdir(), 'ever-works-node-browser-'));
+}
+
+function defaultRemoveProfileDir(dir: string): void {
+	try {
+		rmSync(dir, { recursive: true, force: true });
+	} catch {
+		// A leftover temp profile is untidy, not a failure of the check.
+	}
+}
+
+/**
+ * Run one `browser-check` job to a verdict.
+ *
+ * Throws only on a payload or a host the node CANNOT honour (no browser
+ * installed, headed asked for on a machine with no display). A page
+ * that fails to render is a normal RESULT — that is the verdict the
+ * platform asked for.
+ */
+export async function runBrowserCheckJob(job: FleetJobView, io: BrowserCheckIo = {}): Promise<FleetBrowserCheckResult> {
+	const check = normalizeBrowserCheck(job.payload);
+
+	const browserPath = (io.resolveBrowser ?? (() => defaultResolveBrowser(io)))();
+	if (!browserPath) {
+		throw new BrowserCheckPayloadError(
+			'No browser executable found on this node — it should not be advertising the `browser` capability'
+		);
+	}
+	if (check.headed && io.hasDisplay === false) {
+		throw new BrowserCheckPayloadError('A headed browser check needs a display; this node has none');
+	}
+
+	const parentEnv = io.parentEnv ?? process.env;
+	const now = io.now ?? (() => Date.now());
+	const createProfileDir = io.createProfileDir ?? defaultProfileDir;
+	const removeProfileDir = io.removeProfileDir ?? defaultRemoveProfileDir;
+	const profileDir = createProfileDir();
+	const noSandbox = String(parentEnv[BROWSER_NO_SANDBOX_ENV] ?? '').trim() === '1';
+	const args = buildBrowserArgs(check, profileDir, { noSandbox });
+
+	try {
+		return await launch(browserPath, args, check, { spawnFn: io.spawnFn ?? spawn, parentEnv, now });
+	} finally {
+		removeProfileDir(profileDir);
+	}
+}
+
+function defaultResolveBrowser(io: BrowserCheckIo): string | null {
+	const probe = io.probe ?? {};
+	return resolveBrowserPath({
+		platform: probe.platform ?? process.platform,
+		env: (probe.env ?? process.env) as Record<string, string | undefined>,
+		fileExists: probe.fileExists ?? ((path: string) => existsSync(path)),
+		...(probe.lookupOnPath ? { lookupOnPath: probe.lookupOnPath } : {})
+	});
+}
+
+function launch(
+	browserPath: string,
+	args: string[],
+	check: NormalizedBrowserCheck,
+	deps: { spawnFn: typeof spawn; parentEnv: NodeJS.ProcessEnv; now: () => number }
+): Promise<FleetBrowserCheckResult> {
+	const startedAt = deps.now();
+
+	return new Promise<FleetBrowserCheckResult>((resolve) => {
+		let settled = false;
+		let dom = '';
+		let stderrTail = '';
+		let timedOut = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let settleTimer: ReturnType<typeof setTimeout> | undefined;
+
+		const finish = (ok: boolean, error?: string): void => {
+			if (settled) return;
+			settled = true;
+			if (timer) clearTimeout(timer);
+			if (settleTimer) clearTimeout(settleTimer);
+			const result: FleetBrowserCheckResult = {
+				ok,
+				browserPath,
+				headless: !check.headed,
+				domBytes: Buffer.byteLength(dom, 'utf8'),
+				title: check.headed ? null : extractTitle(dom),
+				durationMs: deps.now() - startedAt
+			};
+			if (!ok && error) {
+				result.error = error;
+			}
+			resolve(result);
+		};
+
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = deps.spawnFn(browserPath, args, {
+				windowsHide: !check.headed,
+				// Never inherit: a browser check is user-authored input and
+				// a fleet node is somebody's actual machine.
+				env: buildNodeCheckEnv(null, deps.parentEnv)
+			});
+		} catch (error) {
+			finish(false, error instanceof Error ? error.message : String(error));
+			return;
+		}
+
+		timer = setTimeout(() => {
+			timedOut = true;
+			try {
+				child.kill('SIGKILL');
+			} catch {
+				// Already gone — the close handler settles.
+			}
+		}, check.timeoutSec * 1000);
+
+		child.stdout?.on('data', (chunk: Buffer | string) => {
+			if (dom.length < MAX_DOM_CAPTURE_BYTES) {
+				dom += chunk.toString();
+			}
+		});
+		child.stderr?.on('data', (chunk: Buffer | string) => {
+			stderrTail = (stderrTail + chunk.toString()).slice(-2048);
+		});
+
+		child.on('error', (error: Error) => {
+			finish(false, error.message);
+		});
+
+		if (check.headed) {
+			// A window that is still up after the settle window is the
+			// strongest signal headed mode can give us. Kill it then, so
+			// a check does not leave a browser open on someone's desktop.
+			settleTimer = setTimeout(() => {
+				try {
+					child.kill();
+				} catch {
+					// Already gone — the close handler settles.
+				}
+				finish(true);
+			}, HEADED_SETTLE_MS);
+		}
+
+		child.on('close', (code: number | null) => {
+			if (timedOut) {
+				finish(false, `Browser did not finish within ${check.timeoutSec}s`);
+				return;
+			}
+			if (check.headed) {
+				// Reaching close BEFORE the settle timer means the browser
+				// exited early — a crash or a refusal to start.
+				finish(false, `Browser window closed after ${deps.now() - startedAt}ms: ${stderrTail.trim()}`.trim());
+				return;
+			}
+			if (code !== 0) {
+				finish(false, `Browser exited with code ${code}: ${stderrTail.trim()}`.trim());
+				return;
+			}
+			if (dom.trim().length === 0) {
+				finish(false, 'Browser produced an empty document');
+				return;
+			}
+			if (check.expectText && !dom.includes(check.expectText)) {
+				finish(false, 'Rendered document did not contain the expected text');
+				return;
+			}
+			finish(true);
+		});
+	});
+}

--- a/apps/node/src/core/fleet-client.ts
+++ b/apps/node/src/core/fleet-client.ts
@@ -11,10 +11,12 @@ import {
 } from './types';
 
 /**
- * HTTP client for the two public Fleet endpoints the node apps use:
+ * HTTP client for the public Fleet endpoints the node apps use:
  *
  *   POST /api/fleet/enroll      one-time token  → { nodeId, secret, node }
  *   POST /api/fleet/heartbeat   nodeId + secret → { ok, node }
+ *   POST /api/fleet/pause       nodeId + secret → { ok, node }   (drain/resume)
+ *   POST /api/fleet/unenroll    nodeId + secret → { ok }         (retire)
  *
  * Both are `@Public()` and self-authenticating: the credential IS the body.
  * The server answers every invalid credential path with one undifferentiated
@@ -76,6 +78,21 @@ export type EnrollRequest = FleetEnrollRequest;
 export type EnrollResponse = FleetEnrollResponse;
 export type HeartbeatRequest = FleetHeartbeatRequest;
 export type HeartbeatResponse = FleetHeartbeatResponse;
+
+export interface NodeCredentialRequest {
+	nodeId: string;
+	secret: string;
+}
+
+export interface PauseRequest extends NodeCredentialRequest {
+	/** true drains this node; false resumes it. */
+	paused: boolean;
+}
+
+export interface PauseResponse {
+	ok: true;
+	node: FleetNodeView;
+}
 
 export interface FleetClientOptions {
 	apiUrl: string;
@@ -215,6 +232,47 @@ export class FleetClient {
 			throw new FleetClientError('malformed', 'Heartbeat response did not contain a node');
 		}
 		return { ok: true, node };
+	}
+
+	/**
+	 * Ask the platform to drain (or resume) this node, authenticated
+	 * with the node's own heartbeat secret.
+	 *
+	 * Draining is a platform-side decision — it is the scheduler that
+	 * must stop handing out work — so `ever-works-node pause` cannot be
+	 * purely local. The local flag exists too (so a restart comes back
+	 * drained), but this call is what actually stops the leases.
+	 */
+	async pause(request: PauseRequest): Promise<PauseResponse> {
+		assertCredentialShape(request.secret, 'Node secret');
+		this.logger?.protect(request.secret);
+
+		const payload = await this.post('api/fleet/pause', 'pause', {
+			nodeId: request.nodeId,
+			secret: request.secret,
+			paused: request.paused
+		});
+
+		const node = readNode(payload);
+		if (!node) {
+			throw new FleetClientError('malformed', 'Pause response did not contain a node');
+		}
+		return { ok: true, node };
+	}
+
+	/**
+	 * Retire this node's registration. The platform deletes the row,
+	 * which is what makes the credential we just presented worthless —
+	 * the local config is then safe to erase.
+	 */
+	async unenroll(request: NodeCredentialRequest): Promise<void> {
+		assertCredentialShape(request.secret, 'Node secret');
+		this.logger?.protect(request.secret);
+
+		await this.post('api/fleet/unenroll', 'unenroll', {
+			nodeId: request.nodeId,
+			secret: request.secret
+		});
 	}
 
 	private async post(path: string, operation: string, body: Record<string, unknown>): Promise<unknown> {

--- a/apps/node/src/core/gpu-probe.spec.ts
+++ b/apps/node/src/core/gpu-probe.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { CommandRunner } from './capabilities';
+import { classifyGpuVendor, detectGpu, firstAdapterLine, gpuProbesFor } from './gpu-probe';
+
+/** Runner that answers exactly one command and 127s the rest. */
+function answering(command: string, stdout: string, code = 0): CommandRunner {
+	return {
+		run: async (invoked) =>
+			invoked === command ? { code, stdout, stderr: '' } : { code: 127, stdout: '', stderr: 'not found' }
+	};
+}
+
+const silent: CommandRunner = {
+	run: async () => ({ code: 127, stdout: '', stderr: 'not found' })
+};
+
+describe('classifyGpuVendor', () => {
+	it('attributes the common adapter names', () => {
+		expect(classifyGpuVendor('NVIDIA GeForce RTX 4090')).toBe('nvidia');
+		expect(classifyGpuVendor('AMD Radeon RX 6800')).toBe('amd');
+		expect(classifyGpuVendor('Apple M3 Max')).toBe('apple');
+		expect(classifyGpuVendor('Intel Iris Xe Graphics')).toBe('intel');
+	});
+
+	it('prefers a discrete card over an integrated one listed alongside it', () => {
+		// A laptop reports both; scheduling should see the card that matters.
+		expect(classifyGpuVendor('Intel UHD Graphics 630\nNVIDIA GeForce GTX 1650')).toBe('nvidia');
+	});
+
+	it('falls back to `other` for something it saw but cannot attribute', () => {
+		expect(classifyGpuVendor('Matrox G200eW3')).toBe('other');
+	});
+});
+
+describe('firstAdapterLine', () => {
+	it('takes the first non-empty line and caps its length', () => {
+		expect(firstAdapterLine('\n\n  NVIDIA A100  \nNVIDIA A100\n')).toBe('NVIDIA A100');
+		expect(firstAdapterLine('')).toBeNull();
+		expect(firstAdapterLine('   \n  ')).toBeNull();
+		expect(firstAdapterLine('x'.repeat(500))?.length).toBe(120);
+	});
+});
+
+describe('gpuProbesFor', () => {
+	it('always tries nvidia-smi first — it is the fastest and most specific', () => {
+		for (const platform of ['linux', 'darwin', 'win32']) {
+			expect(gpuProbesFor(platform)[0].command).toBe('nvidia-smi');
+		}
+	});
+
+	it('uses the platform-native enumerator as the second probe', () => {
+		expect(gpuProbesFor('win32')[1].command).toBe('powershell');
+		expect(gpuProbesFor('darwin')[1].command).toBe('system_profiler');
+		expect(gpuProbesFor('linux')[1].command).toBe('lspci');
+	});
+});
+
+describe('detectGpu', () => {
+	it('reports the adapter nvidia-smi names', async () => {
+		const gpu = await detectGpu(answering('nvidia-smi', 'NVIDIA RTX A6000\n'), 'linux');
+		expect(gpu).toEqual({ vendor: 'nvidia', model: 'NVIDIA RTX A6000' });
+	});
+
+	it('parses macOS system_profiler chipset lines', async () => {
+		const output = ['Graphics/Displays:', '', '    Apple M3 Max:', '', '      Chipset Model: Apple M3 Max'].join(
+			'\n'
+		);
+		const gpu = await detectGpu(answering('system_profiler', output), 'darwin');
+		expect(gpu).toEqual({ vendor: 'apple', model: 'Apple M3 Max' });
+	});
+
+	it('parses Windows video controller names', async () => {
+		const gpu = await detectGpu(answering('powershell', 'Intel(R) UHD Graphics 770\r\n'), 'win32');
+		expect(gpu?.vendor).toBe('intel');
+	});
+
+	it('keeps only display controllers out of lspci', async () => {
+		const lspci = [
+			'00:00.0 Host bridge: Intel Corporation Device 9b53',
+			'01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3070]'
+		].join('\n');
+		const gpu = await detectGpu(answering('lspci', lspci), 'linux');
+		expect(gpu?.vendor).toBe('nvidia');
+	});
+
+	it('returns null when lspci lists no display controller', async () => {
+		const gpu = await detectGpu(answering('lspci', '00:00.0 Host bridge: Intel Corporation Device 9b53'), 'linux');
+		expect(gpu).toBeNull();
+	});
+
+	it('returns null when nothing answers', async () => {
+		expect(await detectGpu(silent, 'linux')).toBeNull();
+	});
+
+	it('ignores a probe that exits nonzero', async () => {
+		expect(await detectGpu(answering('nvidia-smi', 'garbage', 9), 'linux')).toBeNull();
+	});
+
+	it('falls through to the next probe when the first one is absent', async () => {
+		const gpu = await detectGpu(answering('lspci', '01:00.0 VGA compatible controller: AMD Radeon'), 'linux');
+		expect(gpu?.vendor).toBe('amd');
+	});
+
+	it('never throws — a probe that blows up is simply no GPU', async () => {
+		const runner: CommandRunner = {
+			run: async () => {
+				throw new Error('spawn ENOENT');
+			}
+		};
+		await expect(detectGpu(runner, 'linux')).resolves.toBeNull();
+	});
+});

--- a/apps/node/src/core/gpu-probe.ts
+++ b/apps/node/src/core/gpu-probe.ts
@@ -1,0 +1,156 @@
+import type { CommandRunner } from './capabilities';
+
+/**
+ * GPU detection (audit A22).
+ *
+ * Before this, a node reported `os:`, `arch:`, `node:`, `docker`, `git`
+ * and `display` — and nothing at all about whether the machine had an
+ * accelerator. That is the single most expensive property a fleet
+ * machine can have, and the scheduler had no way to see it: GPU work
+ * either could not be targeted, or was targeted blind.
+ *
+ * The probe is deliberately cheap and never fatal. Every branch is
+ * "ask a tool that is already there, believe it if it answers, shrug if
+ * it does not" — a machine with no GPU, no probe tool, or a probe that
+ * hangs simply reports no GPU rather than failing the heartbeat that
+ * carries every other capability.
+ */
+
+/** Vendors we classify. `other` = a GPU we saw but could not attribute. */
+export type GpuVendor = 'nvidia' | 'amd' | 'intel' | 'apple' | 'other';
+
+export interface GpuInfo {
+	vendor: GpuVendor;
+	/** First adapter name the probe reported, trimmed. */
+	model: string | null;
+}
+
+/** Ordered so 'intel' cannot shadow a discrete card listed alongside it. */
+const VENDOR_PATTERNS: readonly { vendor: GpuVendor; pattern: RegExp }[] = [
+	{ vendor: 'nvidia', pattern: /\b(nvidia|geforce|quadro|tesla|rtx|gtx)\b/i },
+	{ vendor: 'amd', pattern: /\b(amd|radeon|firepro|instinct)\b/i },
+	{ vendor: 'apple', pattern: /\bapple\s+m\d|\bapple\s+gpu\b/i },
+	{ vendor: 'intel', pattern: /\b(intel|iris|uhd graphics|hd graphics)\b/i }
+];
+
+/** Attribute an adapter description to a vendor. */
+export function classifyGpuVendor(text: string): GpuVendor {
+	for (const { vendor, pattern } of VENDOR_PATTERNS) {
+		if (pattern.test(text)) {
+			return vendor;
+		}
+	}
+	return 'other';
+}
+
+/** First non-empty line, trimmed and length-capped for a capability tag. */
+export function firstAdapterLine(stdout: string): string | null {
+	for (const line of stdout.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (trimmed) {
+			return trimmed.slice(0, 120);
+		}
+	}
+	return null;
+}
+
+/** One probe attempt: command + args, per platform. */
+interface Probe {
+	command: string;
+	args: string[];
+}
+
+/** Probes to try in order for a platform, cheapest and most specific first. */
+export function gpuProbesFor(platform: string): Probe[] {
+	// `nvidia-smi` is present on every machine with a working NVIDIA
+	// driver, on all three platforms, and answers in milliseconds.
+	const nvidia: Probe = {
+		command: 'nvidia-smi',
+		args: ['--query-gpu=name', '--format=csv,noheader']
+	};
+	if (platform === 'win32') {
+		return [
+			nvidia,
+			{
+				command: 'powershell',
+				args: [
+					'-NoProfile',
+					'-NonInteractive',
+					'-Command',
+					'Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name'
+				]
+			}
+		];
+	}
+	if (platform === 'darwin') {
+		return [
+			nvidia,
+			// The section header is always present, so only the
+			// "Chipset Model:" values are read (see extractChipsetLines).
+			{ command: 'system_profiler', args: ['SPDisplaysDataType'] }
+		];
+	}
+	return [
+		nvidia,
+		// `lspci` output is one line per device; we only want display
+		// controllers, and grep is not guaranteed, so filter in-process.
+		{ command: 'lspci', args: [] }
+	];
+}
+
+/** Keep only lines that describe a display adapter (Linux `lspci`). */
+function extractDisplayLines(stdout: string): string {
+	const lines = stdout
+		.split(/\r?\n/)
+		.filter((line) => /\b(vga compatible controller|3d controller|display controller)\b/i.test(line));
+	return lines.join('\n');
+}
+
+/** Keep only the `Chipset Model:` values (macOS `system_profiler`). */
+function extractChipsetLines(stdout: string): string {
+	const lines: string[] = [];
+	for (const line of stdout.split(/\r?\n/)) {
+		const match = /chipset model:\s*(.+)$/i.exec(line);
+		if (match) {
+			lines.push(match[1].trim());
+		}
+	}
+	return lines.join('\n');
+}
+
+/**
+ * Detect a GPU on this host, or null.
+ *
+ * Never throws: an unspawnable probe, a nonzero exit and an empty
+ * answer are all "no GPU detected". Capability detection runs on every
+ * heartbeat, and a probe that could take the heartbeat down with it
+ * would be a worse bug than the missing tag it was added to fix.
+ */
+export async function detectGpu(runner: CommandRunner, platform: string): Promise<GpuInfo | null> {
+	for (const probe of gpuProbesFor(platform)) {
+		let stdout: string;
+		try {
+			const result = await runner.run(probe.command, probe.args);
+			if (result.code !== 0) {
+				continue;
+			}
+			stdout = result.stdout ?? '';
+		} catch {
+			continue;
+		}
+
+		let text = stdout;
+		if (probe.command === 'lspci') {
+			text = extractDisplayLines(stdout);
+		} else if (probe.command === 'system_profiler') {
+			text = extractChipsetLines(stdout);
+		}
+
+		const model = firstAdapterLine(text);
+		if (!model) {
+			continue;
+		}
+		return { vendor: classifyGpuVendor(text), model };
+	}
+	return null;
+}

--- a/apps/node/src/core/index.ts
+++ b/apps/node/src/core/index.ts
@@ -9,14 +9,18 @@
  * runner), so both shells stay thin and the whole surface is unit-testable.
  */
 
+export * from './browser-probe';
 export * from './capabilities';
 export * from './config-store';
 export * from './fleet-client';
+export * from './gpu-probe';
 export * from './job-client';
 export * from './heartbeat';
 export * from './logger';
 export * from './runtime';
+export * from './secret-store';
 export * from './types';
 export * from './worker-loop';
 export * from './executors/acceptance-checks';
 export * from './executors/agent-task';
+export * from './executors/browser-check';

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -5,12 +5,15 @@ import { HeartbeatLoop, type Scheduler } from './heartbeat';
 import { WorkerLoop } from './worker-loop';
 import { runAcceptanceChecksJob } from './executors/acceptance-checks';
 import { runAgentTaskJob } from './executors/agent-task';
+import { runBrowserCheckJob } from './executors/browser-check';
 import type { Logger } from './logger';
 import {
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
 	type FleetEnrollableNodeKind,
+	type FleetNodeKind,
+	type FleetNodeView,
 	type NodeConfig
 } from './types';
 
@@ -125,6 +128,13 @@ export interface CreateNodeRuntimeOptions {
 	 * service's own working directory.
 	 */
 	agentTaskWorkspacePath?: string;
+
+	/**
+	 * Start the worker drained. The node still heartbeats (so it stays
+	 * observable in Fleet) but leases nothing until it is resumed —
+	 * how `ever-works-node pause` survives a service restart.
+	 */
+	startPaused?: boolean;
 }
 
 /**
@@ -171,10 +181,10 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 			...(options.concurrency !== undefined ? { concurrency: options.concurrency } : {}),
 			...(options.leaseTtlSec !== undefined ? { leaseTtlSec: options.leaseTtlSec } : {}),
 			...(options.idlePollMs !== undefined ? { idlePollMs: options.idlePollMs } : {}),
+			...(options.startPaused !== undefined ? { startPaused: options.startPaused } : {}),
 			...(io.scheduler ? { scheduler: io.scheduler } : {})
 		});
-		// The v1 executor. Registering it HERE (not inside WorkerLoop) is
-		// the executor seam: a second job kind is one more `register` call
+		// The executor seam: a job kind is one more `register` call
 		// against the same protocol — no new endpoint, no new credential.
 		worker.register('acceptance-checks', (job) => runAcceptanceChecksJob(job));
 		// The general kind. Without it an enrolled machine could only ever
@@ -188,11 +198,63 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 					: {})
 			})
 		);
+		// `browser-check` is registered ONLY when this machine actually
+		// resolved a browser executable (audit A26). A node advertising
+		// the `browser` capability with no executor behind it would fail
+		// every job that tag invited, so the tag and the executor are
+		// switched on by the SAME fact.
+		if (io.environment.browserPath) {
+			const browserPath = io.environment.browserPath;
+			worker.register('browser-check', (job) =>
+				runBrowserCheckJob(job, {
+					resolveBrowser: () => browserPath,
+					hasDisplay: io.environment.hasDisplay
+				})
+			);
+		}
 		runtime.worker = worker;
 		runtime.jobClient = jobClient;
 	}
 
 	return runtime;
+}
+
+/**
+ * Tell the platform to drain (or resume) this node, using the node's own
+ * heartbeat credential.
+ *
+ * Returns the refreshed node view so the caller can report the status
+ * the platform actually settled on rather than the one it asked for.
+ */
+export async function pauseNode(config: NodeConfig, io: NodeIo, paused: boolean): Promise<FleetNodeView> {
+	io.logger.protect(config.secret);
+	const client = new FleetClient({
+		apiUrl: config.apiUrl,
+		fetchFn: io.fetchFn,
+		logger: io.logger,
+		userAgent: io.userAgent ?? `ever-works-node/${io.version}`
+	});
+	const result = await client.pause({ nodeId: config.nodeId, secret: config.secret, paused });
+	return result.node;
+}
+
+/**
+ * Retire this node's registration on the platform.
+ *
+ * The local credential is erased by the CALLER (`clearConfig`), always,
+ * even when this call fails — an operator decommissioning a machine
+ * must not be left with a live secret on it because the API was
+ * unreachable.
+ */
+export async function unenrollNode(config: NodeConfig, io: NodeIo): Promise<void> {
+	io.logger.protect(config.secret);
+	const client = new FleetClient({
+		apiUrl: config.apiUrl,
+		fetchFn: io.fetchFn,
+		logger: io.logger,
+		userAgent: io.userAgent ?? `ever-works-node/${io.version}`
+	});
+	await client.unenroll({ nodeId: config.nodeId, secret: config.secret });
 }
 
 /** Process-signal abstraction so shutdown wiring is testable. */

--- a/apps/node/src/core/secret-store.ts
+++ b/apps/node/src/core/secret-store.ts
@@ -1,0 +1,159 @@
+import type { Logger } from './logger';
+
+/**
+ * Node credential storage (audit A45).
+ *
+ * The heartbeat secret used to live as plaintext JSON in the config
+ * file, protected by a 0600 chmod that was SKIPPED entirely on Windows.
+ * That is two problems: any process running as the operator could read
+ * it, and on Windows nothing was even attempted.
+ *
+ * The fix has two halves, and this module is the first:
+ *
+ *   1. **Prefer the OS keychain.** macOS Keychain, Windows Credential
+ *      Manager and the Linux Secret Service all exist precisely for
+ *      this, and all three are reached through ONE vendor SDK
+ *      (`@napi-rs/keyring`). We do not hand-roll crypto: a
+ *      passphrase-less local encryption scheme keyed by a file sitting
+ *      next to the ciphertext protects nobody, and inventing one would
+ *      be strictly worse than the keychain the platform already ships.
+ *
+ *   2. **Fall back loudly.** Headless Linux boxes routinely have no
+ *      Secret Service, and containers never do. Refusing to run there
+ *      would break the very deployment shape `apps/node` exists for.
+ *      So the file fallback stays — with a warning on every load and
+ *      save, and with a real owner-only ACL on Windows rather than a
+ *      silently skipped chmod (see `config-store.ts`).
+ *
+ * The SDK is resolved at RUNTIME through an injected loader rather than
+ * imported at module scope. A native addon that fails to build must
+ * degrade this one feature, not take down a node that would otherwise
+ * heartbeat perfectly well.
+ */
+
+/** Keychain service name every node credential is filed under. */
+export const KEYCHAIN_SERVICE = 'ever-works-node';
+
+/** Anything that can hold one named secret. */
+export interface SecretStore {
+	/** Human-readable name for logs ("OS keychain", "config file"). */
+	readonly label: string;
+	get(account: string): Promise<string | null>;
+	set(account: string, secret: string): Promise<void>;
+	delete(account: string): Promise<void>;
+}
+
+/**
+ * Structural shape of `@napi-rs/keyring`'s `Entry`. Declared here rather
+ * than imported so the optional native dependency never becomes a
+ * compile-time requirement.
+ */
+export interface KeyringEntryLike {
+	getPassword(): string;
+	setPassword(password: string): void;
+	deletePassword(): boolean;
+}
+
+export interface KeyringModuleLike {
+	Entry: new (service: string, account: string) => KeyringEntryLike;
+}
+
+/**
+ * Resolve the keyring SDK, or null when it is not installed / not
+ * loadable on this host. Injected everywhere so tests never touch a
+ * real keychain.
+ */
+export type KeyringLoader = () => KeyringModuleLike | null;
+
+/**
+ * The production loader: a plain `require` of the optional dependency,
+ * guarded. `@napi-rs/keyring` ships prebuilt binaries for the platforms
+ * `apps/node` targets; when one is missing (musl on an exotic arch, a
+ * `--no-optional` install, a container without a Secret Service) the
+ * require throws and we degrade instead of crashing.
+ */
+export const defaultKeyringLoader: KeyringLoader = () => {
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const loaded = require('@napi-rs/keyring') as Partial<KeyringModuleLike>;
+		return typeof loaded?.Entry === 'function' ? (loaded as KeyringModuleLike) : null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * A {@link SecretStore} backed by the OS credential manager.
+ *
+ * Every method is fail-soft: a keychain that is present but locked, or
+ * that refuses a write, reports failure to the caller (null / throw)
+ * rather than pretending. `createSecretStore` is what turns that into
+ * the file fallback.
+ */
+export function createKeychainSecretStore(keyring: KeyringModuleLike): SecretStore {
+	return {
+		label: 'OS keychain',
+		get: async (account) => {
+			try {
+				const value = new keyring.Entry(KEYCHAIN_SERVICE, account).getPassword();
+				return typeof value === 'string' && value ? value : null;
+			} catch {
+				// No entry, or a locked keychain. Both read as "absent".
+				return null;
+			}
+		},
+		set: async (account, secret) => {
+			new keyring.Entry(KEYCHAIN_SERVICE, account).setPassword(secret);
+		},
+		delete: async (account) => {
+			try {
+				new keyring.Entry(KEYCHAIN_SERVICE, account).deletePassword();
+			} catch {
+				// Already gone — deleting a missing credential is a success.
+			}
+		}
+	};
+}
+
+/** The message an operator sees when the credential lands on disk. */
+export const FILE_FALLBACK_WARNING =
+	'No OS keychain is available on this host — the node credential will be stored in the config file. ' +
+	'The file is restricted to the current user (0600 on POSIX, an owner-only ACL on Windows), but any ' +
+	'process running as this user can read it. Install `@napi-rs/keyring` and a Secret Service ' +
+	'(gnome-keyring / kwallet) to keep the credential out of the filesystem.';
+
+export interface ResolveSecretStoreOptions {
+	loadKeyring?: KeyringLoader;
+	logger?: Logger;
+	/** Set to skip the keychain entirely (operator override / tests). */
+	disabled?: boolean;
+}
+
+/**
+ * Pick the strongest available store.
+ *
+ * Returns null when the credential has to live in the config file, and
+ * warns ONCE, loudly, when it does — a silent downgrade to plaintext is
+ * exactly the failure this audit item is about.
+ */
+export function resolveSecretStore(options: ResolveSecretStoreOptions = {}): SecretStore | null {
+	if (options.disabled) {
+		options.logger?.warn(`Keychain storage disabled by configuration. ${FILE_FALLBACK_WARNING}`);
+		return null;
+	}
+	const keyring = (options.loadKeyring ?? defaultKeyringLoader)();
+	if (!keyring) {
+		options.logger?.warn(FILE_FALLBACK_WARNING);
+		return null;
+	}
+	return createKeychainSecretStore(keyring);
+}
+
+/** Env var an operator sets to force the file fallback. */
+export const DISABLE_KEYCHAIN_ENV = 'EVER_WORKS_NODE_DISABLE_KEYCHAIN';
+
+/** True when the operator has explicitly opted out of the keychain. */
+export function keychainDisabledByEnv(env: Record<string, string | undefined>): boolean {
+	const value = env[DISABLE_KEYCHAIN_ENV];
+	return typeof value === 'string' && ['1', 'true', 'yes'].includes(value.trim().toLowerCase());
+}

--- a/apps/node/src/core/types.ts
+++ b/apps/node/src/core/types.ts
@@ -38,6 +38,14 @@ export type {
 	FleetNodeStatus,
 	FleetNodeView
 } from '@ever-works/contracts';
+/**
+ * Node lifecycle as reported by the platform.
+ *
+ * `paused` is a drain, not a cut: the platform stops leasing new work
+ * onto the node while its in-flight jobs keep reporting, and heartbeats
+ * stay accepted so a drained machine remains visible in Fleet.
+ */
+export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'paused' | 'disabled';
 
 export { FLEET_ENROLLABLE_NODE_KINDS, isFleetEnrollableNodeKind } from '@ever-works/contracts';
 
@@ -80,10 +88,22 @@ export const MIN_HEARTBEAT_INTERVAL_MS = 5_000;
 export const MAX_HEARTBEAT_INTERVAL_MS = 15 * 60_000;
 
 /**
- * Everything the node needs to resume operating after a restart. Persisted to
- * the OS config directory with 0600 permissions where the platform supports
- * them — `secret` is a credential and must never be logged or sent to a
- * renderer process.
+ * Where the heartbeat secret physically lives.
+ *
+ * - `keychain` — the OS credential store (Keychain / Credential Manager /
+ *   Secret Service) holds it; the config file carries no credential at all.
+ * - `file`     — fallback: the secret is inline in the config file, which is
+ *   then locked down to the owner (0600 on POSIX, an inheritance-stripped
+ *   owner-only ACL on Windows). Always announced with a loud warning.
+ */
+export type NodeSecretStorage = 'keychain' | 'file';
+
+/**
+ * Everything the node needs to resume operating after a restart.
+ *
+ * `secret` is a credential and must never be logged or sent to a renderer
+ * process. It is held in the OS keychain when one is available and only
+ * falls back to the config file otherwise — see {@link NodeSecretStorage}.
  */
 export interface NodeConfig {
 	/** Platform API origin, no trailing slash (e.g. `https://api.ever.works`). */
@@ -97,6 +117,16 @@ export interface NodeConfig {
 	name?: string;
 	heartbeatIntervalMs: number;
 	enrolledAt: string;
+	/**
+	 * Where {@link NodeConfig.secret} is stored. Absent means `file`, so
+	 * configs written before keychain support still load unchanged.
+	 */
+	secretStorage?: NodeSecretStorage;
+	/**
+	 * Operator drain flag set by `ever-works-node pause`. A paused node
+	 * still heartbeats (so it stays observable) but leases no new work.
+	 */
+	paused?: boolean;
 }
 
 /** Credential-free projection of {@link NodeConfig}, safe to log or render. */
@@ -110,6 +140,10 @@ export interface RedactedNodeConfig {
 	enrolledAt: string;
 	/** True when a heartbeat secret is stored — the value itself never leaves the config store. */
 	hasSecret: boolean;
+	/** Where the secret is kept. Safe to show: it names a location, not a value. */
+	secretStorage: NodeSecretStorage;
+	/** True when the operator has drained this node locally. */
+	paused: boolean;
 }
 
 /** Drop the credential from a config so it can cross a log or IPC boundary. */
@@ -121,7 +155,9 @@ export function redactConfig(config: NodeConfig): RedactedNodeConfig {
 		capabilities: [...config.capabilities],
 		heartbeatIntervalMs: config.heartbeatIntervalMs,
 		enrolledAt: config.enrolledAt,
-		hasSecret: typeof config.secret === 'string' && config.secret.length > 0
+		hasSecret: typeof config.secret === 'string' && config.secret.length > 0,
+		secretStorage: config.secretStorage ?? 'file',
+		paused: config.paused === true
 	};
 	if (config.name !== undefined) {
 		redacted.name = config.name;

--- a/apps/node/src/core/worker-loop.ts
+++ b/apps/node/src/core/worker-loop.ts
@@ -26,6 +26,10 @@ import { systemScheduler } from './heartbeat';
  * - **Graceful shutdown drains.** `stop()` stops leasing at once, then
  *   awaits in-flight jobs so their results are REPORTED rather than
  *   abandoned to a lease expiry. A second stop while draining is a no-op.
+ * - **So does pausing.** `pause()` is the same drain without the
+ *   teardown: leasing halts synchronously, in-flight work runs to a
+ *   verdict, and the loop keeps ticking so `resume()` needs no restart.
+ *   Pausing is a state a running node is in, not a way to kill it.
  * - **Backoff is exponential with a ceiling**, so an API outage produces
  *   a slow retry rather than a hot loop against a dead endpoint.
  *
@@ -74,7 +78,22 @@ export interface JobLeaseCapableClient {
 /** One registered executor: "this is how a job of kind X gets run here". */
 export type JobExecutor = (job: FleetJobView) => Promise<Record<string, unknown> | void>;
 
-export type WorkerState = 'idle' | 'polling' | 'working' | 'retrying' | 'unauthorized' | 'stopped';
+/**
+ * `draining` is the state a paused-but-still-busy node is in: leasing
+ * has stopped, the jobs already running have not. It is distinct from
+ * `paused` (drained, nothing left in flight) so an operator watching
+ * `ever-works-node pause` can tell "still finishing two builds" apart
+ * from "safe to reboot".
+ */
+export type WorkerState =
+	| 'idle'
+	| 'polling'
+	| 'working'
+	| 'retrying'
+	| 'unauthorized'
+	| 'draining'
+	| 'paused'
+	| 'stopped';
 
 export interface WorkerLoopState {
 	state: WorkerState;
@@ -85,6 +104,8 @@ export interface WorkerLoopState {
 	failed: number;
 	/** Human-readable last failure (already redacted), or null. */
 	lastError: string | null;
+	/** True once `pause()` has been called and until `resume()` is. */
+	paused: boolean;
 }
 
 export interface WorkerLoopOptions {
@@ -98,6 +119,8 @@ export interface WorkerLoopOptions {
 	logger?: Logger;
 	/** Capability tags advertised per poll; omitted uses the node's stored tags. */
 	capabilities?: string[];
+	/** Start drained: heartbeat only, lease nothing until `resume()`. */
+	startPaused?: boolean;
 }
 
 export class WorkerLoop {
@@ -111,6 +134,7 @@ export class WorkerLoop {
 
 	private running = false;
 	private stopping = false;
+	private paused = false;
 	private timer: unknown = null;
 	private state: WorkerLoopState = {
 		state: 'idle',
@@ -118,7 +142,8 @@ export class WorkerLoop {
 		consecutiveFailures: 0,
 		completed: 0,
 		failed: 0,
-		lastError: null
+		lastError: null,
+		paused: false
 	};
 
 	constructor(private readonly options: WorkerLoopOptions) {
@@ -126,6 +151,11 @@ export class WorkerLoop {
 		this.concurrency = Math.min(Math.max(options.concurrency ?? 1, 1), FLEET_JOB_MAX_LEASE_BATCH);
 		this.leaseTtlSec = options.leaseTtlSec ?? FLEET_JOB_DEFAULT_LEASE_TTL_SEC;
 		this.idlePollMs = options.idlePollMs ?? DEFAULT_IDLE_POLL_MS;
+		this.paused = options.startPaused === true;
+		this.state.paused = this.paused;
+		if (this.paused) {
+			this.state.state = 'paused';
+		}
 	}
 
 	/** Register the executor for one job kind. Last registration wins. */
@@ -174,10 +204,74 @@ export class WorkerLoop {
 		this.patch({ state: 'stopped', activeJobIds: [] });
 	}
 
+	/** True while the loop is drained (leasing stopped by `pause()`). */
+	isPaused(): boolean {
+		return this.paused;
+	}
+
+	/**
+	 * DRAIN, not cut (audit A29).
+	 *
+	 * Stops leasing at once — the next poll claims nothing — while every
+	 * job already in flight keeps running, keeps its lease alive and
+	 * still reports its verdict. Killing them instead would throw away
+	 * work that is minutes from done, let the claims lapse, and re-run
+	 * the same jobs on another node: strictly worse for the operator who
+	 * asked for a quiet machine, and strictly worse for the platform.
+	 *
+	 * The returned promise resolves when the drain is COMPLETE (nothing
+	 * left in flight), so `pause()` can be awaited by an operator who
+	 * actually wants the machine idle. Callers who just want new work to
+	 * stop can ignore it — the leasing halt is synchronous.
+	 *
+	 * The loop keeps ticking while paused: it is how a `resume()` takes
+	 * effect without a restart, and it costs one no-op timer.
+	 */
+	async pause(): Promise<void> {
+		this.paused = true;
+		this.patch({
+			paused: true,
+			state: this.inFlight.size > 0 ? 'draining' : 'paused'
+		});
+		await this.drained();
+		if (this.paused) {
+			this.patch({ state: this.running ? 'paused' : this.state.state });
+		}
+	}
+
+	/** Resume leasing. Polls immediately rather than waiting out the idle gap. */
+	resume(): void {
+		if (!this.paused) return;
+		this.paused = false;
+		this.patch({ paused: false, state: this.inFlight.size > 0 ? 'working' : 'idle' });
+		if (this.running && !this.stopping) {
+			this.cancelTimer();
+			void this.tick();
+		}
+	}
+
+	/** Await every in-flight job. Resolves immediately when there are none. */
+	async drained(): Promise<void> {
+		// Re-read `inFlight` each pass: a job settling can be what frees
+		// capacity for one that was already leased in the same batch.
+		while (this.inFlight.size > 0) {
+			await Promise.allSettled([...this.inFlight.values()]);
+		}
+	}
+
 	/** Run one poll now. Exposed so a UI can offer "check for work" and tests can step. */
 	async tick(): Promise<void> {
 		if (!this.running || this.stopping) return;
 		this.cancelTimer();
+
+		if (this.paused) {
+			// Drained: no lease call at all. Still re-arm, so `resume()`
+			// takes effect without restarting the process, and so the
+			// state keeps reflecting in-flight progress while draining.
+			this.patch({ state: this.inFlight.size > 0 ? 'draining' : 'paused' });
+			this.scheduleNext(this.idlePollMs);
+			return;
+		}
 
 		const capacity = this.concurrency - this.inFlight.size;
 		if (capacity <= 0) {
@@ -223,10 +317,21 @@ export class WorkerLoop {
 			this.inFlight.delete(job.id);
 			this.patch({
 				activeJobIds: [...this.inFlight.keys()],
-				state: this.inFlight.size > 0 ? 'working' : this.running ? 'idle' : 'stopped'
+				state: this.nextIdleState()
 			});
 		});
 		this.inFlight.set(job.id, task);
+	}
+
+	/** What the loop settles into once a job finishes. */
+	private nextIdleState(): WorkerState {
+		if (this.paused) {
+			return this.inFlight.size > 0 ? 'draining' : 'paused';
+		}
+		if (this.inFlight.size > 0) {
+			return 'working';
+		}
+		return this.running ? 'idle' : 'stopped';
 	}
 
 	/**

--- a/apps/node/src/node-io.ts
+++ b/apps/node/src/node-io.ts
@@ -1,12 +1,15 @@
-import { execFile } from 'node:child_process';
-import { constants as fsConstants } from 'node:fs';
+import { execFile, execFileSync } from 'node:child_process';
+import { accessSync, constants as fsConstants, existsSync } from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { resolveBrowserPath } from './core/browser-probe';
 import type { CommandRunner } from './core/capabilities';
 import { readEnvironment, type CapabilityEnvironment } from './core/capabilities';
 import { resolveConfigPath, type ConfigFileSystem } from './core/config-store';
 import type { FetchLike } from './core/fleet-client';
+import type { Logger } from './core/logger';
+import { keychainDisabledByEnv, resolveSecretStore, type SecretStore } from './core/secret-store';
 
 /**
  * Real IO adapters for the headless node.
@@ -39,6 +42,33 @@ export function createCommandRunner(): CommandRunner {
 	};
 }
 
+/**
+ * Owner-only ACL for a file on Windows, via `icacls`.
+ *
+ * This is the win32 half of audit A45. Windows has no POSIX mode bits —
+ * `fs.chmod` there only toggles the read-only flag — and the previous
+ * behaviour was to skip the tightening entirely, leaving the node
+ * credential protected by nothing but whatever the profile's inherited
+ * ACL happened to admit.
+ *
+ * `/inheritance:r` strips inherited entries (this is what actually
+ * removes broad access) and `/grant:r` then re-grants full control to
+ * the current user alone.
+ */
+export function restrictFileToOwnerWindows(filePath: string): void {
+	const user = process.env.USERDOMAIN
+		? `${process.env.USERDOMAIN}\\${process.env.USERNAME ?? ''}`
+		: (process.env.USERNAME ?? '');
+	if (!user.trim() || user.trim() === '\\') {
+		throw new Error('Cannot determine the current Windows user to grant the config file to');
+	}
+	execFileSync('icacls', [filePath, '/inheritance:r', '/grant:r', `${user}:(F)`], {
+		windowsHide: true,
+		stdio: 'ignore',
+		timeout: 10_000
+	});
+}
+
 export function createConfigFileSystem(): ConfigFileSystem {
 	return {
 		readFile: async (filePath) => {
@@ -66,6 +96,12 @@ export function createConfigFileSystem(): ConfigFileSystem {
 		chmod: async (filePath, mode) => {
 			await fsp.chmod(filePath, mode);
 		},
+		remove: async (filePath) => {
+			await fsp.rm(filePath, { force: true });
+		},
+		restrict: async (filePath) => {
+			restrictFileToOwnerWindows(filePath);
+		},
 		dirname: (filePath) => path.dirname(filePath)
 	};
 }
@@ -80,12 +116,69 @@ export function defaultConfigPath(): string {
 	});
 }
 
+/** True when the path is an existing file this process may execute. */
+export function isExecutableFile(filePath: string): boolean {
+	try {
+		if (!existsSync(filePath)) {
+			return false;
+		}
+		if (process.platform === 'win32') {
+			// Windows has no execute bit; existence is the whole test.
+			return true;
+		}
+		accessSync(filePath, fsConstants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Resolve a bare command name on `PATH`, or null. */
+export function lookupOnPath(command: string): string | null {
+	const which = process.platform === 'win32' ? 'where' : 'which';
+	try {
+		const output = execFileSync(which, [command], {
+			encoding: 'utf8',
+			windowsHide: true,
+			stdio: ['ignore', 'pipe', 'ignore'],
+			timeout: 5_000
+		});
+		const first = output.split(/\r?\n/).find((line) => line.trim());
+		return first ? first.trim() : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Host facts for capability detection, including the browser executable
+ * this machine would actually launch. Resolving it HERE (once, at
+ * startup) rather than inside the detector keeps `detectCapabilities`
+ * pure and keeps the `browser` tag and the `browser-check` executor
+ * pointed at the same binary.
+ */
 export function currentEnvironment(): CapabilityEnvironment {
-	return readEnvironment({
-		platform: process.platform,
-		arch: process.arch,
-		version: process.version,
-		env: process.env
+	return readEnvironment(
+		{
+			platform: process.platform,
+			arch: process.arch,
+			version: process.version,
+			env: process.env
+		},
+		resolveBrowserPath,
+		{ fileExists: isExecutableFile, lookupOnPath }
+	);
+}
+
+/**
+ * The OS keychain for this host, or null when there is none (headless
+ * Linux without a Secret Service, containers, an operator opt-out).
+ * A null return is always announced through the logger.
+ */
+export function createSecretStore(logger?: Logger): SecretStore | null {
+	return resolveSecretStore({
+		disabled: keychainDisabledByEnv(process.env),
+		...(logger ? { logger } : {})
 	});
 }
 

--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -52,6 +52,20 @@ import { PortableDateColumn } from './_types';
  * `k8s` is list-time only — never persisted as a row.
  */
 export type { FleetNodeKind, FleetNodeStatus } from '@ever-works/contracts';
+/** Statuses in which the platform will NOT lease new work onto a node. */
+export const FLEET_NODE_NON_LEASABLE_STATUSES: readonly FleetNodeStatus[] = [
+    'enrolling',
+    'paused',
+    'disabled',
+];
+
+/**
+ * Statuses that must be PRESERVED by an accepted heartbeat instead of
+ * being overwritten with `online`. A drained node that goes dark is
+ * indistinguishable from a dead one, so it keeps beating — but a beat
+ * must never silently un-pause it.
+ */
+export const FLEET_NODE_STICKY_STATUSES: readonly FleetNodeStatus[] = ['paused', 'disabled'];
 
 @Entity({ name: 'fleet_nodes' })
 @Index('idx_fleet_nodes_user', ['userId'])
@@ -74,7 +88,7 @@ export class FleetNode {
     @Column({ type: 'varchar', length: 16 })
     kind: FleetNodeKind;
 
-    /** 'enrolling' | 'online' | 'offline' | 'disabled'. */
+    /** 'enrolling' | 'online' | 'offline' | 'paused' | 'disabled'. */
     @Column({ type: 'varchar', length: 16 })
     status: FleetNodeStatus;
 

--- a/packages/agent/src/fleet/__tests__/fleet.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet.service.spec.ts
@@ -202,20 +202,48 @@ describe('FleetService', () => {
             ).resolves.toBeNull();
         });
 
-        it('refuses disabled and still-enrolling nodes even with a matching secret', async () => {
+        it('refuses a still-enrolling node even with a matching secret', async () => {
             const secret = 'sec_'.padEnd(43, 'e');
             const service = build();
 
-            repository.findById.mockResolvedValue(enrolled(secret, { status: 'disabled' }));
-            await expect(
-                service.heartbeat('11111111-1111-4111-8111-111111111111', secret),
-            ).resolves.toBeNull();
-
+            // An enrolling node has no heartbeat secret yet — the hash
+            // column still holds the ENROLLMENT TOKEN hash — so it can
+            // never authenticate here regardless of what it presents.
             repository.findById.mockResolvedValue(enrolled(secret, { status: 'enrolling' }));
             await expect(
                 service.heartbeat('11111111-1111-4111-8111-111111111111', secret),
             ).resolves.toBeNull();
         });
+
+        it.each(['disabled', 'paused'] as const)(
+            'accepts a %s node but can never un-stick its status',
+            async (status) => {
+                const secret = 'sec_'.padEnd(43, 'e');
+                const service = build();
+                repository.findById.mockResolvedValue(enrolled(secret, { status }));
+
+                const result = await service.heartbeat(
+                    '11111111-1111-4111-8111-111111111111',
+                    secret,
+                );
+
+                // Drained is NOT severed. A stopped node that also goes
+                // dark disappears from Fleet at the moment its owner most
+                // needs to see it, and its in-flight claims lose the only
+                // channel that could report their verdicts. Revocation is
+                // DELETE, not disable.
+                expect(result).not.toBeNull();
+                // The security property this replaces the old refusal
+                // with, and the one that actually matters: a beat may
+                // stamp liveness but must never promote the node back to
+                // a leasable state.
+                expect(repository.update).toHaveBeenCalledWith(
+                    '11111111-1111-4111-8111-111111111111',
+                    expect.objectContaining({ status }),
+                );
+                expect(result?.node.status).toBe(status);
+            },
+        );
 
         it('fails closed on malformed node ids / secrets without repository reads', async () => {
             const service = build();

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -76,8 +76,10 @@ export interface ReclaimSummary {
  * Auth posture is the Fleet posture, unchanged: the SAME node secret
  * minted at enrollment, verified constant-time against the stored
  * sha256, every invalid path returning `null` so the edge maps it to one
- * undifferentiated 401. Disabled and still-enrolling nodes are refused
- * — a drained node stops getting work immediately.
+ * undifferentiated 401. Still-enrolling nodes are refused outright;
+ * paused and disabled nodes are refused a LEASE (no new work, effective
+ * on the next poll) but may still heartbeat and complete the jobs they
+ * already hold — that is what makes pausing a drain rather than a cut.
  *
  * Reclaim runs inline on every lease poll (bounded, owner-scoped) AND on
  * the `fleet-job-lease-sweeper` cron (global), so a fleet whose nodes
@@ -205,7 +207,9 @@ export class FleetJobService {
         jobId: string,
         leaseTtlSec?: number,
     ): Promise<FleetJobView | null> {
-        const node = await this.authenticateNode(nodeId, secret);
+        // 'report': a draining (paused/disabled) node must keep the
+        // claim on work it is already running.
+        const node = await this.authenticateNode(nodeId, secret, 'report');
         if (!node) return null;
 
         const job = await this.jobs.findById(jobId);
@@ -234,7 +238,9 @@ export class FleetJobService {
      * LAPSED claims (no verdict at all) are retried, by the reclaim path.
      */
     async completeJob(input: CompleteFleetJobInput): Promise<FleetJobView | null> {
-        const node = await this.authenticateNode(input.nodeId, input.secret);
+        // 'report': the whole point of a drain is that in-flight work
+        // still reaches a verdict.
+        const node = await this.authenticateNode(input.nodeId, input.secret, 'report');
         if (!node) return null;
 
         const job = await this.jobs.findById(input.jobId);
@@ -381,21 +387,38 @@ export class FleetJobService {
 
     /**
      * Resolve + verify a node credential. Fail-closed on every path:
-     * malformed ids, unknown nodes, disabled nodes (drained — they must
-     * stop receiving work immediately), still-enrolling nodes (whose
-     * hash column holds a token, not a secret), and bad secrets all
-     * return null.
+     * malformed ids, unknown nodes, still-enrolling nodes (whose hash
+     * column holds a token, not a secret), and bad secrets all return
+     * null.
+     *
+     * `intent` is what makes pausing a DRAIN rather than a cut
+     * (audit A29):
+     *
+     *   - `'lease'`  — a paused or disabled node is refused. Draining
+     *                  means no NEW work, effective on the very next poll.
+     *   - `'report'` — a paused or disabled node is ACCEPTED, so the
+     *                  jobs it already holds can keep their claims alive
+     *                  and deliver a verdict. Severing them instead
+     *                  would throw away completed work, let the lease
+     *                  lapse, and re-run the same job somewhere else —
+     *                  the exact opposite of draining.
+     *
+     * A still-enrolling node is refused for both: it has no secret yet.
      */
     private async authenticateNode(
         nodeId: unknown,
         secret: unknown,
+        intent: 'lease' | 'report' = 'lease',
     ): Promise<{ id: string; userId: string; capabilities: string[] } | null> {
         const verified = verifyNodeSecret(nodeId, secret);
         if (!verified) return null;
 
         const node = await this.nodes.findById(verified.nodeId);
         if (!node) return null;
-        if (node.status === 'disabled' || node.status === 'enrolling') return null;
+        if (node.status === 'enrolling') return null;
+        if (intent === 'lease' && (node.status === 'disabled' || node.status === 'paused')) {
+            return null;
+        }
         if (!verified.matches(node.enrollmentTokenHash)) return null;
 
         return {

--- a/packages/agent/src/fleet/fleet.service.ts
+++ b/packages/agent/src/fleet/fleet.service.ts
@@ -18,9 +18,14 @@ import {
     FLEET_MAX_VERSION_LENGTH,
     FLEET_MIN_NODE_NAME_LENGTH,
 } from '@ever-works/contracts';
-import type { FleetNodeView } from '@ever-works/contracts';
+import type { FleetNodeView, FleetNodeLoadView } from '@ever-works/contracts';
 import { config } from '../config';
-import { FleetNode, FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';
+import {
+    FleetNode,
+    FleetNodeKind,
+    FleetNodeStatus,
+    FLEET_NODE_STICKY_STATUSES,
+} from '../entities/fleet-node.entity';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 import { FleetNodeRepository } from './fleet-node.repository';
@@ -269,7 +274,15 @@ export class FleetService {
     /**
      * Authenticated node heartbeat. Constant-time secret check against
      * the stored hash; fail-closed null on any invalid path (unknown
-     * node, disabled node, missing credential, bad secret).
+     * node, still-enrolling node, missing credential, bad secret).
+     *
+     * A PAUSED or DISABLED node is still accepted (audit A29). Draining
+     * a machine must not blind the operator to it: a node that is told
+     * to stop taking work and then vanishes from Fleet is
+     * indistinguishable from one that crashed, which is precisely the
+     * moment its owner most needs to see it. The beat therefore stamps
+     * `lastHeartbeatAt` but PRESERVES the sticky status, so a heartbeat
+     * can never silently un-pause or re-enable a node.
      */
     async heartbeat(
         nodeId: unknown,
@@ -289,15 +302,15 @@ export class FleetService {
 
         const node = await this.repository.findById(nodeId);
         if (!node) return null;
-        // A disabled node must stop reporting; an enrolling node has no
-        // secret yet (the hash column still holds the token hash).
-        if (node.status === 'disabled' || node.status === 'enrolling') return null;
+        // An enrolling node has no secret yet (the hash column still
+        // holds the token hash), so it can never authenticate here.
+        if (node.status === 'enrolling') return null;
         if (!constantTimeEquals(node.enrollmentTokenHash, sha256Hex(secret))) {
             return null;
         }
 
         const patch: Partial<FleetNode> = {
-            status: 'online',
+            status: FLEET_NODE_STICKY_STATUSES.includes(node.status) ? node.status : 'online',
             // Server-stamped — the node never supplies its own clock.
             lastHeartbeatAt: new Date(),
         };
@@ -474,10 +487,16 @@ export class FleetService {
     }
 
     /**
-     * Disable (drain) or re-enable a node. Disabling an `enrolling`
-     * node revokes its unused token (the enroll CAS requires status
+     * Disable or re-enable a node. Disabling an `enrolling` node
+     * revokes its unused token (the enroll CAS requires status
      * `enrolling`); re-enabling lands on `offline` until the next
      * accepted heartbeat proves the node alive.
+     *
+     * Disabling DRAINS rather than severs: no further work is leased
+     * onto the node, but the jobs it already holds keep their claims
+     * and still report their verdicts, and the node keeps heartbeating
+     * so it remains observable (see `heartbeat` and
+     * `FleetJobService.authenticateNode`).
      */
     async setDisabledForUser(
         userId: string,
@@ -490,10 +509,106 @@ export class FleetService {
         return this.toView({ ...node, status });
     }
 
+    /**
+     * Pause (drain) or resume a node, owner-scoped.
+     *
+     * Distinct from `setDisabledForUser`: pausing is the SOFT stop an
+     * operator reaches for when a machine is needed for something else
+     * for an hour. New work stops being leased onto it immediately, its
+     * in-flight claims keep running and keep reporting, and it keeps
+     * heartbeating so it stays visible. Resuming lands on `offline`
+     * until the next accepted heartbeat proves the node alive — the
+     * same convention `setDisabledForUser` uses.
+     */
+    async setPausedForUser(
+        userId: string,
+        nodeId: string,
+        paused: boolean,
+    ): Promise<FleetNodeView> {
+        const node = await this.getOwnedNode(userId, nodeId);
+        // Never let "resume" silently undo a disable: a disabled node
+        // has to be re-enabled explicitly.
+        if (!paused && node.status === 'disabled') {
+            return this.toView(node);
+        }
+        const status: FleetNodeStatus = paused ? 'paused' : 'offline';
+        await this.repository.update(node.id, { status });
+        return this.toView({ ...node, status });
+    }
+
+    /**
+     * Node-initiated pause/resume — `ever-works-node pause` on the
+     * machine itself. Authenticated with the node's OWN heartbeat
+     * secret (the same constant-time hash check every node-facing
+     * endpoint uses), so an operator sitting at the keyboard can drain
+     * their machine without a platform session.
+     *
+     * Returns null on every invalid path so the edge answers one
+     * undifferentiated 401. A still-enrolling node cannot pause: its
+     * hash column holds a token, not a secret.
+     */
+    async setPausedByCredential(
+        nodeId: unknown,
+        secret: unknown,
+        paused: boolean,
+    ): Promise<{ node: FleetNodeView } | null> {
+        const node = await this.authenticateNodeByCredential(nodeId, secret);
+        if (!node) return null;
+        // A node may drain ITSELF, but must not be able to lift an
+        // owner-imposed disable by asking nicely.
+        if (!paused && node.status === 'disabled') {
+            return { node: this.toView(node) };
+        }
+        const status: FleetNodeStatus = paused ? 'paused' : 'offline';
+        await this.repository.update(node.id, { status });
+        return { node: this.toView({ ...node, status }) };
+    }
+
+    /**
+     * Node-initiated unenrollment — `ever-works-node unenroll`. Deletes
+     * the registration the presented credential belongs to, which is
+     * what makes the credential itself worthless from that moment on.
+     *
+     * Deliberately a DELETE rather than a status flip: the machine is
+     * telling the platform it is leaving, and leaving a dangling row
+     * whose secret still lives on a decommissioned laptop is the worse
+     * outcome. Returns false on every invalid path (one 401 at the edge).
+     */
+    async unenrollByCredential(nodeId: unknown, secret: unknown): Promise<boolean> {
+        const node = await this.authenticateNodeByCredential(nodeId, secret);
+        if (!node) return false;
+        await this.repository.delete(node.id);
+        return true;
+    }
+
     /** Delete a node registration (owner-scoped, no existence leak). */
     async deleteForUser(userId: string, nodeId: string): Promise<void> {
         const node = await this.getOwnedNode(userId, nodeId);
         await this.repository.delete(node.id);
+    }
+
+    /**
+     * Resolve + verify a node by its own heartbeat credential. Shares
+     * the heartbeat posture exactly: shape guards before any read,
+     * constant-time hash compare, null on every failure.
+     */
+    private async authenticateNodeByCredential(
+        nodeId: unknown,
+        secret: unknown,
+    ): Promise<FleetNode | null> {
+        if (typeof nodeId !== 'string' || !UUID_RE.test(nodeId)) return null;
+        if (
+            typeof secret !== 'string' ||
+            secret.length < CREDENTIAL_MIN_LENGTH ||
+            secret.length > CREDENTIAL_MAX_LENGTH
+        ) {
+            return null;
+        }
+        const node = await this.repository.findById(nodeId);
+        if (!node) return null;
+        if (node.status === 'enrolling') return null;
+        if (!constantTimeEquals(node.enrollmentTokenHash, sha256Hex(secret))) return null;
+        return node;
     }
 
     private async getOwnedNode(userId: string, nodeId: string): Promise<FleetNode> {

--- a/packages/contracts/src/fleet/fleet-jobs.types.ts
+++ b/packages/contracts/src/fleet/fleet-jobs.types.ts
@@ -90,11 +90,27 @@ export function isFleetJobActive(status: FleetJobStatus): boolean {
  * the node is asked to run, because a fleet node has no model access and
  * no platform credentials: everything it executes has to be expressed as
  * a command and an exit code, exactly like `acceptance-checks`.
+ *
+ * `browser-check` is the v2 executor: drive a REAL browser binary on the
+ * node against a URL and report what it rendered. It exists so the
+ * `browser` capability tag a node advertises is backed by work the node
+ * can actually perform — a capability nothing ever exercises is a lie
+ * the scheduler will eventually act on.
  */
-export type FleetJobKind = 'acceptance-checks' | 'agent-task';
+export type FleetJobKind = 'acceptance-checks' | 'agent-task' | 'browser-check';
 
 /** Canonical job-kind list. */
-export const FLEET_JOB_KINDS: readonly FleetJobKind[] = ['acceptance-checks', 'agent-task'];
+export const FLEET_JOB_KINDS: readonly FleetJobKind[] = ['acceptance-checks', 'agent-task', 'browser-check'];
+
+/**
+ * Capability tag a node must advertise to be eligible for
+ * `browser-check`. Named here (not in the node) so the enqueue side and
+ * the detector cannot drift.
+ */
+export const FLEET_BROWSER_CAPABILITY = 'browser';
+
+/** Capability tag advertised when a usable GPU was detected on the node. */
+export const FLEET_GPU_CAPABILITY = 'gpu';
 
 /** Type guard for a job kind arriving off the wire. */
 export function isFleetJobKind(value: unknown): value is FleetJobKind {
@@ -261,6 +277,48 @@ export interface FleetAgentTaskPayload {
 	workspacePath?: string;
 	/** Ordered commands the node executes for this run. */
 	steps?: FleetAgentTaskStep[];
+}
+
+/**
+ * Executor input for `browser-check`.
+ *
+ * The node resolves a browser binary itself (the same probe that decides
+ * whether it advertises the `browser` tag at all) and drives it against
+ * `url`. `headed` asks for a visible window rather than headless — only
+ * honourable on a node that also advertises `display`, and refused
+ * rather than silently downgraded so a headed-only check cannot pass on
+ * a machine that never opened a window.
+ */
+export interface FleetBrowserCheckPayload {
+	/** Optional platform Task the check belongs to (reporting only). */
+	taskId?: string;
+	/** Optional platform run the check belongs to (reporting only). */
+	runId?: string;
+	/** Absolute http(s) URL to load. */
+	url: string;
+	/** Require a visible (non-headless) browser window. Default false. */
+	headed?: boolean;
+	/** Fail the check unless the rendered DOM contains this text. */
+	expectText?: string;
+	/** Wall-clock budget for the navigation. Clamped node-side. */
+	timeoutSec?: number;
+}
+
+/** Verdict of one `browser-check` job. */
+export interface FleetBrowserCheckResult extends Record<string, unknown> {
+	/** True when the browser rendered the page and every expectation held. */
+	ok: boolean;
+	/** Browser executable the node actually used (path, never a credential). */
+	browserPath: string;
+	/** Whether the run was headless. */
+	headless: boolean;
+	/** Bytes of DOM the browser produced. */
+	domBytes: number;
+	/** `<title>` of the loaded document when one was present. */
+	title: string | null;
+	durationMs: number;
+	/** Why the check failed, when it did. */
+	error?: string;
 }
 
 /** Request body for `POST /api/fleet/jobs/lease`. */

--- a/packages/contracts/src/fleet/fleet-node.types.ts
+++ b/packages/contracts/src/fleet/fleet-node.types.ts
@@ -64,7 +64,19 @@ export function isFleetEnrollableNodeKind(value: unknown): value is FleetEnrolla
  * - `offline`   — no heartbeat for the configured window, or drained.
  * - `disabled`  — operator-drained; heartbeats are refused.
  */
-export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
+/**
+ * Heartbeat-derived lifecycle state.
+ *
+ * `paused` is a DRAIN, not a cut: the node stops being offered new
+ * work but keeps its in-flight claims, keeps reporting their verdicts,
+ * and keeps heartbeating so it stays observable in Fleet. `disabled`
+ * is the operator's harder stop — also drained rather than severed
+ * (in-flight work still reports) but not resumable by the node itself.
+ *
+ * Stored in a plain `varchar(16)` with no enum/check constraint, so
+ * adding a value is a code-level change only — no migration.
+ */
+export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'paused' | 'disabled';
 
 /** Canonical status list. */
 export const FLEET_NODE_STATUSES: readonly FleetNodeStatus[] = ['enrolling', 'online', 'offline', 'disabled'];


### PR DESCRIPTION
## The problem

The headless node could be run from a checkout and nothing else: no installable
artifact, no service integration, no way to take a machine out of rotation
without deleting it, and a `browser` capability tag that nothing ever exercised.

## What changed

- **Packaging** — Docker image + service files (`apps/node/packaging`,
  `.deploy/docker/node`) and a CLI that installs and manages the service
- **`paused` lifecycle state**
- **`browser-check` job kind** with a real browser probe behind it

## Pause is a drain, not a cut

`paused` (and `disabled`) stop a node being offered new work but keep it
heartbeating, keep its in-flight claims, and keep those claims able to report
their verdicts. A stopped node that also goes dark disappears from Fleet at the
moment its owner most needs to see it, and its outstanding work loses the only
channel that could resolve it. **Revocation stays `DELETE`, not disable.**

Both statuses are **sticky**: `FLEET_NODE_STICKY_STATUSES` makes an accepted
heartbeat preserve them, so a beat can stamp liveness but can never promote a
node back to a leasable state.

### On the changed heartbeat test

The old test asserted a blanket refusal for `disabled`. That contract is
superseded by the drain semantics above, so it is replaced — **not weakened** —
by one that pins the property which actually matters, parameterised over both
`disabled` and `paused`:

> a heartbeat is accepted, **and** `repository.update` is called with the same
> status it started with

The `enrolling` refusal is untouched and still asserted verbatim: an enrolling
node has no heartbeat secret to present (the hash column still holds the
enrollment-token hash).

## Browser check

`browser-check` drives a real browser binary against a URL and reports what it
rendered, so the `browser` tag is backed by work the node can actually perform.
Registered **only** when the machine advertises the tag.

## Integration with the merged contracts consolidation

This branch predates it. The merge produced several declared-in-two-places
collisions, each of which would have shipped broken:

| Collision | Consequence if missed |
|---|---|
| `FleetJobKind` declared twice | `FLEET_JOB_KINDS` — the **runtime** guard `isFleetJobKind` reads — still listed two kinds, so valid `agent-task` jobs would have been refused at the edge. A type-only fix misses this. |
| `FleetNodeKind`/`FleetNodeStatus` imported **and** re-declared in the entity | Compile error; local copies removed, `paused` moved into the contracts union — which is what the entity's own comment asks for. No migration: the column is a plain `varchar(16)` with no constraint. |
| `FleetNode` imported twice in `fleet.service.ts` | Compile error |
| `FleetAgentTaskPayload` + PATCH guard lost a closing brace | Syntax error |

The PATCH guard needed **merging**, not concatenating: it must reject only when
*all* of `name`/`disabled`/`paused`/`capabilities` are absent — concatenating the
two guards would 400 a valid single-field PATCH. And `paused` belongs on
`UpdateFleetNodeDto` (the PATCH body), not `DrainFleetNodeDto`.

## Two drifted fixtures

`apps/node`'s config round-trip and `redactConfig` predate `paused` (this
branch) and `secretStorage` (from #1911). Both expectations now carry them.
`redactConfig`'s is an **exhaustive allowlist on purpose** — that is what makes
it catch a credential leaking into the redacted view — so it was extended, not
loosened. Neither field is a credential; `secretStorage` is the storage *mode*
(file vs keychain).

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 448 suites, 8235 tests |
| `apps/api` jest | green — 233 suites, 3816 tests |
| `apps/node` vitest | green — 12 files, 176 tests |
| `apps/web` tsc --noEmit | green |
| prettier | clean |