### PR TITLE
feat(desktop): package the app and make it self-contained

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,176 @@
+name: Desktop App Build
+
+# Builds the Ever Works Desktop Electron app for Windows, macOS and Linux and
+# uploads the installers as workflow artifacts.
+#
+# Code signing (A11): certificates are read from repository secrets and mapped
+# to env vars by the `Resolve code signing` step below. When those secrets are
+# absent — which is always the case for forks and for pull requests from forks,
+# because GitHub does not expose secrets to them — `scripts/package-app.js`
+# degrades to an UNSIGNED build and prints a loud `::warning`. Packaging never
+# fails just because signing material is missing.
+#
+# Self-contained runtime (A7): `pnpm --filter ever-works-desktop bundle` stages
+# the built API + Next.js standalone server into `apps/desktop/bundle/`, which
+# electron-builder copies into `resources/app-bundle`. That is what makes an
+# installed app runnable without the developer's monorepo checkout. Staging the
+# payload requires a full platform build, so it runs on the Linux cell for
+# pushes and manual dispatches (and on every cell when explicitly requested) —
+# pull-request cells build the shell alone to keep PR feedback fast, and the
+# resulting app then reports that local-stack mode is unavailable.
+
+on:
+  push:
+    branches: [main, develop, stage]
+    paths:
+      - 'apps/desktop/**'
+      - '.github/workflows/desktop-build.yml'
+  pull_request:
+    branches: [main, develop, stage]
+    paths:
+      - 'apps/desktop/**'
+      - '.github/workflows/desktop-build.yml'
+  workflow_dispatch:
+    inputs:
+      bundle_runtime:
+        description: 'Stage the self-contained platform runtime into the installers (slow — full platform build on every OS)'
+        type: boolean
+        default: false
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_OPTIONS: --max-old-space-size=6144
+
+jobs:
+  build:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      # One red OS should not hide the state of the other two.
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux
+            runner: ubuntu-latest
+            target: linux
+            artifacts: |
+              apps/desktop/release/*.AppImage
+              apps/desktop/release/*.deb
+          - label: windows
+            runner: windows-latest
+            target: win
+            artifacts: |
+              apps/desktop/release/*.exe
+          - label: macos
+            runner: macos-latest
+            target: mac
+            artifacts: |
+              apps/desktop/release/*.dmg
+              apps/desktop/release/*.zip
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v3
+        with:
+          version: 10.33.3
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The repo does not allow-list `electron` in `onlyBuiltDependencies`, so
+      # its postinstall never runs and the platform binary is not downloaded.
+      # electron-builder needs it to package. Idempotent.
+      - name: Download the Electron binary
+        working-directory: apps/desktop
+        run: node node_modules/electron/install.js
+
+      - name: Build the desktop shell
+        run: pnpm --filter ever-works-desktop build
+
+      - name: Test the desktop shell
+        run: pnpm --filter ever-works-desktop test
+
+      # ---------------------------------------------------------------------
+      # Self-contained runtime payload (A7)
+      # ---------------------------------------------------------------------
+      - name: Decide whether to stage the platform runtime
+        id: bundle
+        shell: bash
+        run: |
+          if [ "${{ inputs.bundle_runtime }}" = "true" ]; then
+            echo "stage=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ matrix.target }}" = "linux" ]; then
+            # Cost gate: a full platform build per OS is expensive. Prove the
+            # bundled path on Linux for pushes; use the workflow_dispatch input
+            # to produce fully self-contained installers for all three.
+            echo "stage=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stage=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # `NEXT_BUILD_OUTPUT=standalone` makes the Next.js build emit the
+      # self-contained server the bundle ships (see apps/web/next.config.ts).
+      - name: Build the platform (API + standalone web)
+        if: steps.bundle.outputs.stage == 'true'
+        env:
+          NEXT_BUILD_OUTPUT: standalone
+        run: pnpm build
+
+      - name: Stage the self-contained runtime payload
+        if: steps.bundle.outputs.stage == 'true'
+        run: pnpm --filter ever-works-desktop bundle
+
+      - name: Write a placeholder runtime manifest
+        if: steps.bundle.outputs.stage != 'true'
+        run: pnpm --filter ever-works-desktop bundle:skip
+
+      # ---------------------------------------------------------------------
+      # Packaging + code signing (A11)
+      # ---------------------------------------------------------------------
+      # Secrets are passed as env vars, never as command arguments (arguments
+      # are visible in process listings). `scripts/package-app.js` decides what
+      # to do with them and prints only their NAMES when something is missing.
+      # Forks / PRs from forks receive empty strings here, which is the
+      # supported unsigned path.
+      - name: Package installers
+        working-directory: apps/desktop
+        env:
+          DESKTOP_WINDOWS_CERTIFICATE_BASE64: ${{ secrets.DESKTOP_WINDOWS_CERTIFICATE_BASE64 }}
+          DESKTOP_WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.DESKTOP_WINDOWS_CERTIFICATE_PASSWORD }}
+          DESKTOP_MACOS_CERTIFICATE_BASE64: ${{ secrets.DESKTOP_MACOS_CERTIFICATE_BASE64 }}
+          DESKTOP_MACOS_CERTIFICATE_PASSWORD: ${{ secrets.DESKTOP_MACOS_CERTIFICATE_PASSWORD }}
+          DESKTOP_APPLE_ID: ${{ secrets.DESKTOP_APPLE_ID }}
+          DESKTOP_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DESKTOP_APPLE_APP_SPECIFIC_PASSWORD }}
+          DESKTOP_APPLE_TEAM_ID: ${{ secrets.DESKTOP_APPLE_TEAM_ID }}
+        run: node scripts/package-app.js --os ${{ matrix.target }}
+
+      - name: List produced artifacts
+        shell: bash
+        run: ls -la apps/desktop/release || true
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: ever-works-desktop-${{ matrix.label }}
+          path: ${{ matrix.artifacts }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ apps/api/openapi.json
 api.log
 web.log
 api-mem.log
+
+# Desktop packaging output: electron-builder installers and the staged
+# self-contained runtime payload (apps/desktop/scripts/prepare-bundle.js).
+apps/desktop/release
+apps/desktop/bundle
+apps/desktop-node/release

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,53 +1,125 @@
 # Ever Works Desktop App (`apps/desktop`)
 
-All-in-one Electron shell for running the full Ever Works platform locally:
+Electron shell for Ever Works. It runs in one of two **modes**, chosen in the first-launch install
+wizard:
 
-1. **Install wizard** (first launch): prerequisite check (Node.js >= 22, pnpm, optional Docker) →
-   job-runtime selection (BullMQ · pg-boss · Temporal · Trigger.dev · Inngest — the platform's
-   `job-runtime-*` plugin family) → env file generation (+ optional
-   `docker compose -f docker-compose.infra.yml up -d`) → service boot.
-2. **Service supervisor**: starts/stops the local API (:3100) and web (:3000) as child processes
-   with restart-on-crash backoff, log ring buffers and `/api/health` polling; controllable from a
-   tray menu.
-3. **Embedded web UI**: once healthy, the main window loads `http://localhost:3000` so the
-   existing web onboarding wizard runs as-is.
+- **Local stack** (`local-stack`) — the all-in-one install: the app supervises its own API (:3100)
+  and web (:3000) services, with an install wizard for prerequisites, job runtime and database.
+- **Client** (`remote-client`) — the app runs nothing locally and connects to an Ever Works
+  instance that already exists somewhere else (your self-hosted deployment, a team server, the
+  hosted platform). The window becomes a native client for that instance.
+
+## Wizard flow
+
+```
+local-stack   welcome → mode → prereq → runtime → env → boot → open
+remote-client welcome → mode → remote → open
+```
+
+1. **mode** — pick local stack vs. client. Local stack is disabled (with the reason shown) when the
+   install has neither a bundled runtime nor a monorepo checkout.
+2. **remote** (client mode) — enter the instance URL; the API URL is derived (`app.<domain>` →
+   `api.<domain>`, otherwise the same base URL) and stays editable. `Test connection` probes
+   `<apiUrl>/api/health` and only a successful probe unlocks the step. Plain-HTTP instances are
+   accepted but flagged. URLs carrying credentials are rejected outright.
+3. **prereq / runtime / env / boot** (local stack) — unchanged: prerequisite check → job-runtime
+   selection (BullMQ · pg-boss · Temporal · Trigger.dev · Inngest · Fleet nodes) → env file
+   generation (+ optional `docker compose -f docker-compose.infra.yml up -d`) → service boot.
+
+## Self-contained installs
+
+Installers ship a **runtime payload** at `resources/app-bundle`, staged by
+`scripts/prepare-bundle.js`:
+
+```
+bundle/
+  bundle-manifest.json   # schema, version, api/web entry points
+  api/                   # `pnpm deploy` output: dist/ + production node_modules (+ plugins/)
+  web/                   # Next.js standalone server + .next/static + public/
+```
+
+`src/services/runtime-layout.ts` resolves, in order:
+
+1. the bundled payload next to the packaged app,
+2. an explicit `EVER_WORKS_REPO_ROOT` checkout,
+3. the development checkout two levels above the app path,
+
+and reports `unavailable` (with the reason) when none apply, which the wizard surfaces instead of
+spawning a command that will never exist.
+
+Bundled services run on **Electron's own Node.js** (`ELECTRON_RUN_AS_NODE=1`), so a bundled install
+needs no monorepo checkout, no Node.js and no pnpm on the machine — the prerequisite step
+downgrades both toolchain checks to informational in that case.
+
+When the platform build output is not staged (fast PR packaging runs), `prepare-bundle.js` writes a
+`bundled: false` manifest and warns loudly; packaging still succeeds and the resulting app offers
+client mode.
 
 ## Layout
 
 - `src/main/` — Electron main process (single-instance lock, window + tray, IPC wiring, secure
   defaults: `contextIsolation` on, `nodeIntegration` off, sandboxed preload).
 - `src/main/preload.ts` — minimal typed IPC bridge (`window.everworks`).
-- `src/services/` — pure, unit-tested logic: `process-manager.ts`, `runtime-setup.ts`,
-  `prereq-check.ts`, `health.ts`.
+- `src/services/` — pure, unit-tested logic: `process-manager.ts`, `runtime-layout.ts`,
+  `remote-connection.ts`, `runtime-setup.ts`, `prereq-check.ts`, `health.ts`, `signing-plan.ts`.
 - `src/renderer/` — small React/Vite UI for the pre-boot wizard + status screen only.
 - `src/shared/` — IPC contract + runtime catalog shared across processes.
+- `scripts/` — `prepare-bundle.js` (runtime payload staging) and `package-app.js`
+  (electron-builder + code signing).
 
 ## Commands
 
 ```bash
-pnpm --filter ever-works-desktop build   # tsc type-check + main-process build + vite renderer build
-pnpm --filter ever-works-desktop test    # vitest unit tests
-pnpm --filter ever-works-desktop dev     # vite dev server for the wizard UI (browser, no bridge)
-pnpm --filter ever-works-desktop start   # electron . (requires the Electron binary, see below)
-pnpm --filter ever-works-desktop dist    # electron-builder packages (win/mac/linux, unsigned)
+pnpm --filter ever-works-desktop build     # tsc type-check + main-process build + vite renderer build
+pnpm --filter ever-works-desktop test      # vitest unit tests
+pnpm --filter ever-works-desktop dev       # vite dev server for the wizard UI (browser, no bridge)
+pnpm --filter ever-works-desktop start     # electron . (requires the Electron binary, see below)
+pnpm --filter ever-works-desktop bundle    # stage the self-contained runtime payload
+pnpm --filter ever-works-desktop package   # electron-builder with the resolved signing plan
+pnpm --filter ever-works-desktop dist      # electron-builder directly (no signing plan resolution)
 ```
+
+A fully self-contained installer is `build` → platform build with `NEXT_BUILD_OUTPUT=standalone` →
+`bundle` → `package`.
+
+## Code signing
+
+Certificates never live in the repository. `src/services/signing-plan.ts` (unit-tested) resolves a
+plan from the environment; `scripts/package-app.js` applies it and
+`.github/workflows/desktop-build.yml` supplies the values from repository secrets:
+
+| Secret                                 | Effect                                     |
+| -------------------------------------- | ------------------------------------------ |
+| `DESKTOP_WINDOWS_CERTIFICATE_BASE64`   | Windows signing (with the password secret) |
+| `DESKTOP_WINDOWS_CERTIFICATE_PASSWORD` | ⇧                                          |
+| `DESKTOP_MACOS_CERTIFICATE_BASE64`     | macOS signing (with the password secret)   |
+| `DESKTOP_MACOS_CERTIFICATE_PASSWORD`   | ⇧                                          |
+| `DESKTOP_APPLE_ID`                     | macOS notarization (all three required)    |
+| `DESKTOP_APPLE_APP_SPECIFIC_PASSWORD`  | ⇧                                          |
+| `DESKTOP_APPLE_TEAM_ID`                | ⇧                                          |
+
+With any of them missing the build **degrades to unsigned** and prints a loud `::warning` naming the
+missing secrets (never their values). That keeps forks and pull requests — which never receive
+secrets — building. Linux artifacts are unsigned by design.
+
+## CI
+
+`.github/workflows/desktop-build.yml` builds Windows, macOS and Linux installers on every push and
+pull request that touches `apps/desktop/**`, and uploads them as workflow artifacts
+(`ever-works-desktop-<os>`). The bundled runtime payload is staged on the Linux cell for pushes;
+`workflow_dispatch` with `bundle_runtime: true` stages it on all three.
 
 ## Notes
 
 - **Electron binary**: pnpm ignores install scripts by default in this repo, so the Electron
-  binary is not downloaded automatically. Before `start`/`dist`, run `pnpm approve-builds` and
+  binary is not downloaded automatically. Before `start`/`package`, run `pnpm approve-builds` and
   allow `electron` (one-time), or run `node node_modules/electron/install.js`.
 - **Excluded from the default root build**: like `apps/docs`, this app is filtered out of root
   `pnpm build` / `pnpm build:apps` to keep the platform build lean; build it explicitly with the
   filter commands above (root `pnpm build:all` includes it).
-- **Repo root resolution**: the supervisor runs services from the monorepo checkout (two levels
-  up in development); packaged installs set `EVER_WORKS_REPO_ROOT`.
-- **Packaging is unsigned by design** — signing + auto-update channels are a later hardening
-  milestone of the Desktop epic.
 
 ## Follow-ups
 
-- Electron e2e (smoke-launch the shell, drive the wizard via Playwright's `_electron`) is
-  deliberately not part of this scaffold — unit tests cover the pure logic; an e2e suite lands
-  with the packaging CI milestone.
-- Bundled dist builds of API/web (no repo checkout required) per PRD M6.
+- Electron e2e (smoke-launch the shell, drive the wizard via Playwright's `_electron`) — unit tests
+  cover the pure logic today.
+- Auto-update channels on top of the now-signed artifacts.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,8 +1,14 @@
 # electron-builder configuration for the Ever Works Desktop App.
 #
-# Deliberately unsigned: no codeSign / notarize / certificate settings here.
-# Signing + auto-update channels are a follow-up hardening milestone (PRD M9);
-# CI packaging wires signing secrets outside the repo when that lands.
+# Code signing is NOT configured in this file on purpose — certificates never
+# live in the repository. `scripts/package-app.js` resolves a signing plan from
+# the environment (repository secrets, exported by
+# `.github/workflows/desktop-build.yml`) and hands electron-builder the right
+# CSC_* variables plus `-c.mac.notarize=<bool>`. With no secrets present the
+# build degrades to an UNSIGNED installer and prints a loud warning, so forks
+# and pull requests still produce artifacts.
+#
+# See `src/services/signing-plan.ts` for the exact secret names and rules.
 appId: works.ever.desktop
 productName: Ever Works Desktop
 copyright: Copyright © 2026 Ever Co. LTD
@@ -15,9 +21,23 @@ files:
   - dist/**
   - package.json
 
+# Self-contained runtime payload (see `scripts/prepare-bundle.js`): the built
+# API and the Next.js standalone web server together with their production
+# dependencies. Copied to `resources/app-bundle`, where
+# `src/services/runtime-layout.ts` finds it via `bundle-manifest.json`. The
+# app runs both entry points on Electron's own Node.js, so an installed app
+# needs no monorepo checkout, Node.js or pnpm on the user's machine.
+#
+# `prepare-bundle.js` ALWAYS creates `bundle/` (with a `bundled: false`
+# manifest when the platform build output was not staged), so this copy never
+# breaks packaging.
+extraResources:
+  - from: bundle
+    to: app-bundle
+
 asar: true
-# The desktop app spawns the platform's own workspace processes; nothing in
-# this package needs a native rebuild at package time.
+# The desktop shell itself has no native dependencies; the bundled runtime
+# payload is prepared outside electron-builder.
 npmRebuild: false
 
 win:
@@ -33,6 +53,9 @@ mac:
     - dmg
     - zip
   category: public.app-category.developer-tools
+  # Overridden to `true` by the packaging script when Apple notarization
+  # credentials are present in the environment.
+  notarize: false
 
 linux:
   target:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,10 +16,14 @@
 		"start": "electron .",
 		"dist": "electron-builder --config electron-builder.yml",
 		"dist:dir": "electron-builder --config electron-builder.yml --dir",
+		"bundle": "node scripts/prepare-bundle.js",
+		"bundle:skip": "node scripts/prepare-bundle.js --skip",
+		"package": "node scripts/package-app.js",
+		"package:dir": "node scripts/package-app.js --dir",
 		"type-check": "tsc --noEmit",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"clean": "rm -rf dist release"
+		"clean": "rm -rf dist release bundle"
 	},
 	"devDependencies": {
 		"@types/node": "^22.19.11",

--- a/apps/desktop/scripts/package-app.js
+++ b/apps/desktop/scripts/package-app.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * Package the desktop app with electron-builder, applying the code-signing
+ * plan resolved from the environment.
+ *
+ * Signing material lives only in repository secrets; the packaging workflow
+ * exports them as env vars. When they are absent — forks, pull requests from
+ * forks, local builds — the plan degrades to an UNSIGNED build and prints a
+ * loud warning rather than failing, so anyone can still build installers.
+ *
+ * Secret VALUES are never printed: only the names of what is missing.
+ *
+ * Usage:
+ *   node scripts/package-app.js                 # current platform
+ *   node scripts/package-app.js --os linux      # explicit target
+ *   node scripts/package-app.js --os mac --dir  # unpacked directory only
+ */
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DESKTOP_DIR = path.resolve(__dirname, '..');
+const SIGNING_PLAN_MODULE = path.join(DESKTOP_DIR, 'dist', 'services', 'signing-plan.js');
+
+function fail(message) {
+	console.error(`::error title=Desktop packaging::${message}`);
+	process.exit(1);
+}
+
+/** Absolute path to electron-builder's CLI entry, read from its own `bin` field. */
+function resolveElectronBuilderCli() {
+	try {
+		const pkgPath = require.resolve('electron-builder/package.json', { paths: [DESKTOP_DIR] });
+		const bin = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).bin;
+		const relative = typeof bin === 'string' ? bin : bin['electron-builder'];
+		return path.join(path.dirname(pkgPath), relative);
+	} catch (error) {
+		fail(`electron-builder is not installed in apps/desktop: ${error.message}`);
+		return '';
+	}
+}
+
+function parseArgs(argv) {
+	const args = { os: undefined, dir: false, passthrough: [] };
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === '--os') {
+			args.os = argv[index + 1];
+			index += 1;
+		} else if (arg.startsWith('--os=')) {
+			args.os = arg.slice('--os='.length);
+		} else if (arg === '--dir') {
+			args.dir = true;
+		} else {
+			args.passthrough.push(arg);
+		}
+	}
+	return args;
+}
+
+function main() {
+	if (!fs.existsSync(SIGNING_PLAN_MODULE)) {
+		fail(`${SIGNING_PLAN_MODULE} not found — run \`pnpm --filter ever-works-desktop build\` before packaging.`);
+	}
+
+	// Compiled from src/services/signing-plan.ts, which is unit-tested.
+	const { resolveSigningPlan, platformToTargetOs, describeSigningPlan } = require(SIGNING_PLAN_MODULE);
+
+	const args = parseArgs(process.argv.slice(2));
+	const targetOs = args.os || platformToTargetOs(process.platform);
+	if (!['win', 'mac', 'linux'].includes(targetOs)) {
+		fail(`Unknown target OS "${targetOs}" — expected win, mac or linux.`);
+	}
+
+	const plan = resolveSigningPlan(targetOs, process.env);
+	console.log(`[package-app] ${describeSigningPlan(plan)}`);
+	if (plan.warning) {
+		console.warn(`::warning title=Desktop code signing::${plan.warning}`);
+		console.warn(`[package-app] ${plan.warning}`);
+	}
+
+	const builderArgs = ['--config', 'electron-builder.yml', `--${targetOs}`];
+	if (args.dir) {
+		builderArgs.push('--dir');
+	}
+	builderArgs.push(...plan.configArgs, ...args.passthrough);
+
+	// Spawn electron-builder's CLI entry with the current Node binary rather
+	// than the `.cmd`/shell wrapper: Node refuses to spawn `.cmd` files without
+	// `shell: true`, and a shell would re-parse the arguments.
+	const cli = resolveElectronBuilderCli();
+	console.log(`[package-app] node ${path.basename(cli)} ${builderArgs.join(' ')}`);
+	const result = spawnSync(process.execPath, [cli, ...builderArgs], {
+		cwd: DESKTOP_DIR,
+		stdio: 'inherit',
+		env: { ...process.env, ...plan.env }
+	});
+
+	if (result.error) {
+		fail(`electron-builder could not be started: ${result.error.message}`);
+	}
+	process.exit(result.status === null ? 1 : result.status);
+}
+
+main();

--- a/apps/desktop/scripts/prepare-bundle.js
+++ b/apps/desktop/scripts/prepare-bundle.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * Stage the SELF-CONTAINED runtime payload the installer ships.
+ *
+ * Before this existed, an installed desktop app still needed the developer's
+ * monorepo checkout (plus Node.js and pnpm) on the user's machine: it resolved
+ * the repo root two levels above the app and ran `pnpm dev:api` / `pnpm dev:web`
+ * from it. That is not something you can hand to a user.
+ *
+ * This script assembles `apps/desktop/bundle/`:
+ *
+ *   bundle/
+ *     bundle-manifest.json   <- describes what is inside (see runtime-layout.ts)
+ *     api/                   <- `pnpm deploy` output: dist/ + production node_modules
+ *     web/                   <- Next.js standalone server + static assets
+ *
+ * electron-builder copies that directory into `resources/app-bundle`, and the
+ * app runs both entry points on Electron's own embedded Node.js
+ * (`ELECTRON_RUN_AS_NODE`), so the install needs no host toolchain at all.
+ *
+ * DEGRADED MODE: when the platform build output is not present (a fast PR
+ * packaging run, or a fork that skipped the platform build), the script writes
+ * a `bundled: false` manifest and exits 0 with a LOUD warning. Packaging still
+ * succeeds — the resulting app simply reports that local-stack mode is
+ * unavailable and offers client mode instead.
+ *
+ * Usage:
+ *   node scripts/prepare-bundle.js              # stage everything that is available
+ *   node scripts/prepare-bundle.js --skip       # write a placeholder manifest only
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DESKTOP_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(DESKTOP_DIR, '..', '..');
+const BUNDLE_DIR = path.join(DESKTOP_DIR, 'bundle');
+const MANIFEST_PATH = path.join(BUNDLE_DIR, 'bundle-manifest.json');
+
+const API_ENTRY = path.join('api', 'dist', 'main.js');
+const API_CWD = 'api';
+/** Next.js standalone keeps the monorepo layout inside the output directory. */
+const WEB_ENTRY = path.join('web', 'apps', 'web', 'server.js');
+const WEB_CWD = path.join('web', 'apps', 'web');
+
+function log(message) {
+	console.log(`[prepare-bundle] ${message}`);
+}
+
+function warn(message) {
+	// GitHub Actions renders `::warning` in the run summary; harmless locally.
+	console.warn(`::warning title=Desktop runtime bundle::${message}`);
+	console.warn(`[prepare-bundle] WARNING: ${message}`);
+}
+
+function version() {
+	try {
+		return JSON.parse(fs.readFileSync(path.join(DESKTOP_DIR, 'package.json'), 'utf8')).version || '0.0.0';
+	} catch {
+		return '0.0.0';
+	}
+}
+
+function writeManifest(manifest) {
+	fs.mkdirSync(BUNDLE_DIR, { recursive: true });
+	fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, '\t')}\n`, 'utf8');
+	log(`wrote ${MANIFEST_PATH}`);
+}
+
+function writePlaceholder(notes) {
+	writeManifest({
+		schema: 1,
+		bundled: false,
+		version: version(),
+		generatedAt: new Date().toISOString(),
+		notes
+	});
+	warn(
+		`Packaged WITHOUT a platform runtime: ${notes}. The installer will build, but local-stack mode will be unavailable in the installed app (client mode still works).`
+	);
+}
+
+function rmrf(target) {
+	fs.rmSync(target, { recursive: true, force: true });
+}
+
+function copyDir(from, to) {
+	fs.mkdirSync(path.dirname(to), { recursive: true });
+	fs.cpSync(from, to, { recursive: true, dereference: true });
+}
+
+/**
+ * `pnpm deploy` produces a standalone directory with real (non-symlinked)
+ * production dependencies — the only supported way to lift one workspace
+ * package out of a pnpm monorepo.
+ */
+function deployApi(target) {
+	// `--legacy` is required by pnpm 10 unless the workspace opts into
+	// `inject-workspace-packages`. Install scripts stay ENABLED so native
+	// dependencies (better-sqlite3, bcrypt) are built for the target platform.
+	const args = ['deploy', '--filter=ever-works-api', '--prod', '--legacy', target];
+	// Prefer pnpm's own JS entry (set when this script runs through a pnpm
+	// script): Node refuses to spawn `pnpm.cmd` on Windows without a shell,
+	// and a shell would re-parse the arguments.
+	const pnpmJs = process.env.npm_execpath;
+	if (pnpmJs && pnpmJs.endsWith('.cjs')) {
+		execFileSync(process.execPath, [pnpmJs, ...args], { cwd: REPO_ROOT, stdio: 'inherit' });
+		return;
+	}
+	execFileSync(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', args, {
+		cwd: REPO_ROOT,
+		stdio: 'inherit',
+		shell: process.platform === 'win32'
+	});
+}
+
+function stageApi() {
+	const apiDist = path.join(REPO_ROOT, 'apps', 'api', 'dist', 'main.js');
+	if (!fs.existsSync(apiDist)) {
+		return { ok: false, reason: 'apps/api/dist/main.js is missing — run `pnpm build:api` first' };
+	}
+
+	const target = path.join(BUNDLE_DIR, API_CWD);
+	rmrf(target);
+	try {
+		deployApi(target);
+	} catch (error) {
+		return { ok: false, reason: `pnpm deploy of ever-works-api failed: ${error.message}` };
+	}
+
+	// `pnpm deploy` copies the package's published files; make sure the built
+	// output is present even when `files`/`.npmignore` excluded it.
+	const deployedEntry = path.join(target, 'dist', 'main.js');
+	if (!fs.existsSync(deployedEntry)) {
+		copyDir(path.join(REPO_ROOT, 'apps', 'api', 'dist'), path.join(target, 'dist'));
+	}
+	if (!fs.existsSync(deployedEntry)) {
+		return { ok: false, reason: 'the deployed API package has no dist/main.js' };
+	}
+
+	// Plugins are loaded from disk at runtime; ship them next to the API.
+	const plugins = path.join(REPO_ROOT, 'plugins');
+	if (fs.existsSync(plugins)) {
+		copyDir(plugins, path.join(target, 'plugins'));
+	}
+	log(`staged API runtime at ${target}`);
+	return { ok: true };
+}
+
+function stageWeb() {
+	const standalone = path.join(REPO_ROOT, 'apps', 'web', '.next', 'standalone');
+	const serverEntry = path.join(standalone, 'apps', 'web', 'server.js');
+	if (!fs.existsSync(serverEntry)) {
+		return {
+			ok: false,
+			reason: 'apps/web/.next/standalone/apps/web/server.js is missing — build the web app with NEXT_BUILD_OUTPUT=standalone'
+		};
+	}
+
+	const target = path.join(BUNDLE_DIR, 'web');
+	rmrf(target);
+	copyDir(standalone, target);
+
+	// The standalone server does not include the static assets or `public/`.
+	const staticFrom = path.join(REPO_ROOT, 'apps', 'web', '.next', 'static');
+	if (fs.existsSync(staticFrom)) {
+		copyDir(staticFrom, path.join(target, 'apps', 'web', '.next', 'static'));
+	}
+	const publicFrom = path.join(REPO_ROOT, 'apps', 'web', 'public');
+	if (fs.existsSync(publicFrom)) {
+		copyDir(publicFrom, path.join(target, 'apps', 'web', 'public'));
+	}
+	log(`staged web runtime at ${target}`);
+	return { ok: true };
+}
+
+function main() {
+	const skip = process.argv.includes('--skip');
+	log(`repo root: ${REPO_ROOT}`);
+	log(`bundle dir: ${BUNDLE_DIR} (${os.platform()})`);
+
+	if (skip) {
+		rmrf(BUNDLE_DIR);
+		writePlaceholder('staging was explicitly skipped (--skip)');
+		return;
+	}
+
+	const api = stageApi();
+	if (!api.ok) {
+		writePlaceholder(api.reason);
+		return;
+	}
+	const web = stageWeb();
+	if (!web.ok) {
+		writePlaceholder(web.reason);
+		return;
+	}
+
+	writeManifest({
+		schema: 1,
+		bundled: true,
+		version: version(),
+		generatedAt: new Date().toISOString(),
+		api: { entry: API_ENTRY.split(path.sep).join('/'), cwd: API_CWD },
+		web: { entry: WEB_ENTRY.split(path.sep).join('/'), cwd: WEB_CWD.split(path.sep).join('/') }
+	});
+	log('runtime bundle is complete — the installer will be self-contained.');
+}
+
+main();

--- a/apps/desktop/src/main/config-store.ts
+++ b/apps/desktop/src/main/config-store.ts
@@ -1,15 +1,24 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { DesktopConfig } from '../shared/ipc-contract';
+import { DEFAULT_DESKTOP_MODE } from '../shared/ipc-contract';
 
-export const DEFAULT_CONFIG: DesktopConfig = { wizardCompleted: false };
+export const DEFAULT_CONFIG: DesktopConfig = { wizardCompleted: false, mode: DEFAULT_DESKTOP_MODE };
 
-/** Load the desktop config JSON; corrupt or missing files fall back to defaults. */
+/**
+ * Load the desktop config JSON; corrupt or missing files fall back to defaults.
+ * Configs written before client mode existed have no `mode` — they resolve to
+ * the local stack, which is exactly what they were.
+ */
 export function loadConfig(filePath: string): DesktopConfig {
 	try {
 		const raw = fs.readFileSync(filePath, 'utf8');
 		const parsed = JSON.parse(raw) as Partial<DesktopConfig>;
-		return { ...DEFAULT_CONFIG, ...parsed };
+		const merged = { ...DEFAULT_CONFIG, ...parsed };
+		if (merged.mode !== 'local-stack' && merged.mode !== 'remote-client') {
+			merged.mode = DEFAULT_CONFIG.mode;
+		}
+		return merged;
 	} catch {
 		return { ...DEFAULT_CONFIG };
 	}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2,13 +2,22 @@ import { BrowserWindow, app, ipcMain, shell } from 'electron';
 import { execFile, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { DesktopConfig, RuntimeSelection, ServiceId } from '../shared/ipc-contract';
+import type {
+	DesktopConfig,
+	DesktopMode,
+	RemoteConnectionInput,
+	RuntimeSelection,
+	ServiceId
+} from '../shared/ipc-contract';
 import { IpcChannels } from '../shared/ipc-contract';
 import { JOB_RUNTIMES } from '../shared/runtimes';
 import { API_HEALTH_URL, WEB_APP_URL, waitForHealthy } from '../services/health';
-import { ProcessManager, resolveServiceCommand } from '../services/process-manager';
+import { ProcessManager } from '../services/process-manager';
 import type { CommandRunner } from '../services/prereq-check';
 import { checkPrerequisites } from '../services/prereq-check';
+import { allowedOriginsFor, probeRemote, resolveRemoteConnection } from '../services/remote-connection';
+import type { LayoutIo, LayoutProbeInput, RuntimeLayout } from '../services/runtime-layout';
+import { resolveRuntimeLayout, resolveServiceLaunch, toLayoutSummary } from '../services/runtime-layout';
 import type { RuntimeSetupIo } from '../services/runtime-setup';
 import { applyRuntimeSelection, detectDocker } from '../services/runtime-setup';
 import { loadConfig, saveConfig } from './config-store';
@@ -18,17 +27,36 @@ import { createTray } from './tray';
 // Paths & state
 // ---------------------------------------------------------------------------
 
+const layoutIo: LayoutIo = {
+	exists: (candidate) => fs.existsSync(candidate),
+	readFile: (candidate) => {
+		try {
+			return fs.readFileSync(candidate, 'utf8');
+		} catch {
+			return undefined;
+		}
+	},
+	join: (...segments) => path.resolve(path.join(...segments))
+};
+
 /**
- * The monorepo root the supervised services run from. In development
- * (`electron .` from apps/desktop) the app path is apps/desktop, so the root
- * is two levels up. Packaged installs must point EVER_WORKS_REPO_ROOT at a
- * platform checkout until bundled dist builds ship (PRD M6 follow-up).
+ * Where the supervised services come from for THIS install.
+ *
+ * Packaged installers ship a self-contained runtime payload under
+ * `resources/app-bundle`, so an installed app needs neither a monorepo
+ * checkout nor Node.js/pnpm on the host. Developer runs and installs that
+ * explicitly point `EVER_WORKS_REPO_ROOT` at a checkout keep the old
+ * run-from-source behavior.
  */
-function resolveRepoRoot(): string {
-	if (process.env.EVER_WORKS_REPO_ROOT) {
-		return path.resolve(process.env.EVER_WORKS_REPO_ROOT);
+function resolveLayout(): RuntimeLayout {
+	const input: LayoutProbeInput = { appPath: app.getAppPath() };
+	if (app.isPackaged && process.resourcesPath) {
+		input.resourcesPath = process.resourcesPath;
 	}
-	return path.resolve(app.getAppPath(), '..', '..');
+	if (process.env.EVER_WORKS_REPO_ROOT) {
+		input.envRepoRoot = path.resolve(process.env.EVER_WORKS_REPO_ROOT);
+	}
+	return resolveRuntimeLayout(layoutIo, input);
 }
 
 const runCommand: CommandRunner['run'] = (command, args) =>
@@ -99,13 +127,23 @@ if (!app.requestSingleInstanceLock()) {
 // ---------------------------------------------------------------------------
 
 function bootstrap(): void {
-	const repoRoot = resolveRepoRoot();
+	const layout = resolveLayout();
 	const userData = app.getPath('userData');
 	const configPath = path.join(userData, 'desktop-config.json');
 	const envFilePath = path.join(userData, 'ever-works-desktop.env');
 	const sqliteDbPath = path.join(userData, 'ever-works.db');
 
 	let config: DesktopConfig = loadConfig(configPath);
+
+	if (layout.kind === 'unavailable') {
+		// Loud, actionable degradation: local-stack mode cannot start anything.
+		// Client mode still works, which is exactly what the wizard offers next.
+		console.error(
+			`[ever-works-desktop] No platform runtime available (${layout.reason ?? 'unknown reason'}). ` +
+				'Local-stack mode is disabled for this install — either reinstall a build that bundles the runtime, ' +
+				'set EVER_WORKS_REPO_ROOT to a monorepo checkout, or use client mode to connect to a remote instance.'
+		);
+	}
 
 	const manager = new ProcessManager({
 		spawnFn: (command, args, options) =>
@@ -141,16 +179,35 @@ function bootstrap(): void {
 		return entries;
 	};
 
-	const ensureServices = (): void => {
+	const ensureServices = (): boolean => {
 		if (manager.all().length > 0) {
-			return;
+			return true;
 		}
 		const env = envEntries();
-		const exists = (candidate: string) => fs.existsSync(candidate);
-		const api = resolveServiceCommand('api', repoRoot, exists, path.join);
-		const web = resolveServiceCommand('web', repoRoot, exists, path.join);
-		manager.create({ id: 'api', ...api, env, readyPattern: /Nest application successfully started|listening/i });
-		manager.create({ id: 'web', ...web, env, readyPattern: /ready|started server|compiled/i });
+		const api = resolveServiceLaunch('api', layout, layoutIo, { nodeExecPath: process.execPath });
+		const web = resolveServiceLaunch('web', layout, layoutIo, { nodeExecPath: process.execPath });
+		if (!api || !web) {
+			console.error(
+				'[ever-works-desktop] Cannot start the local stack: no runtime payload and no monorepo checkout.'
+			);
+			return false;
+		}
+		manager.create({
+			id: 'api',
+			command: api.command,
+			args: api.args,
+			cwd: api.cwd,
+			env: { ...env, ...api.env },
+			readyPattern: /Nest application successfully started|listening/i
+		});
+		manager.create({
+			id: 'web',
+			command: web.command,
+			args: web.args,
+			cwd: web.cwd,
+			env: { ...env, ...web.env },
+			readyPattern: /ready|started server|compiled/i
+		});
 		for (const service of manager.all()) {
 			service.onStatusChange(() => {
 				mainWindow?.webContents.send(IpcChannels.statusEvent, manager.statuses());
@@ -159,10 +216,17 @@ function bootstrap(): void {
 				mainWindow?.webContents.send(IpcChannels.logEvent, entry);
 			});
 		}
+		return true;
 	};
 
 	const startServices = (): void => {
-		ensureServices();
+		if (config.mode === 'remote-client') {
+			// Client mode supervises nothing — the platform runs elsewhere.
+			return;
+		}
+		if (!ensureServices()) {
+			return;
+		}
 		manager.startAll();
 		// Flip per-service health flags as the local endpoints come up.
 		void waitForHealthy(API_HEALTH_URL, { fetchFn: (url) => fetch(url) }).then((healthy) => {
@@ -177,23 +241,73 @@ function bootstrap(): void {
 		await manager.stopAll();
 	};
 
+	/** The URL the main window shows once setup is done. */
+	const appUrl = (): string =>
+		config.mode === 'remote-client' && config.remote ? config.remote.webUrl : WEB_APP_URL;
+
+	// Keep navigation inside the app: the local wizard bundle plus whichever
+	// instance this install targets — the two local service origins in
+	// local-stack mode, or the remote instance's origins in client mode.
+	// Everything else opens in the OS browser.
+	let allowedOrigins = new Set<string>();
+
+	const refreshAllowedOrigins = (): void => {
+		allowedOrigins = new Set(
+			allowedOriginsFor(config.mode === 'remote-client' ? config.remote : undefined, [
+				WEB_APP_URL,
+				'http://localhost:3100'
+			])
+		);
+	};
+
+	refreshAllowedOrigins();
+
 	// -----------------------------------------------------------------------
 	// IPC surface (the wizard/status renderer talks to this via the preload)
 	// -----------------------------------------------------------------------
 
-	ipcMain.handle(IpcChannels.checkPrereqs, () => checkPrerequisites(commandRunner));
+	ipcMain.handle(IpcChannels.checkPrereqs, () =>
+		checkPrerequisites(commandRunner, { requireHostToolchain: layout.requiresHostToolchain })
+	);
 	ipcMain.handle(IpcChannels.listRuntimes, () => JOB_RUNTIMES);
 	ipcMain.handle(IpcChannels.detectDocker, () => detectDocker(runtimeSetupIo));
+	ipcMain.handle(IpcChannels.getRuntimeLayout, () => toLayoutSummary(layout));
 	ipcMain.handle(IpcChannels.applyRuntime, async (_event, selection: RuntimeSelection) => {
 		const result = await applyRuntimeSelection(runtimeSetupIo, {
 			selection,
 			envFilePath,
-			repoRoot,
+			// Only used as the cwd for `docker compose -f docker-compose.infra.yml`,
+			// which is a repo-checkout affordance; bundled installs default to the
+			// embedded SQLite database and never take that path.
+			repoRoot: layout.repoRoot ?? layout.bundleRoot ?? app.getAppPath(),
 			sqliteDbPath
 		});
 		config = { ...config, selection, envFilePath };
 		saveConfig(configPath, config);
 		return { envFilePath: result.envFilePath, keys: Object.keys(result.entries) };
+	});
+	ipcMain.handle(IpcChannels.setMode, (_event, mode: DesktopMode) => {
+		config = { ...config, mode };
+		saveConfig(configPath, config);
+		refreshAllowedOrigins();
+		return config;
+	});
+	ipcMain.handle(IpcChannels.testRemote, async (_event, input: RemoteConnectionInput) => {
+		const resolution = resolveRemoteConnection(input);
+		if (!resolution.ok) {
+			return { ok: false, message: resolution.errors.join(' ') };
+		}
+		return probeRemote(resolution.connection, (url) => fetch(url));
+	});
+	ipcMain.handle(IpcChannels.saveRemote, (_event, input: RemoteConnectionInput) => {
+		const resolution = resolveRemoteConnection(input);
+		if (!resolution.ok) {
+			throw new Error(resolution.errors.join(' '));
+		}
+		config = { ...config, mode: 'remote-client', remote: resolution.connection };
+		saveConfig(configPath, config);
+		refreshAllowedOrigins();
+		return resolution.connection;
 	});
 	ipcMain.handle(IpcChannels.completeWizard, () => {
 		config = { ...config, wizardCompleted: true };
@@ -206,7 +320,7 @@ function bootstrap(): void {
 	ipcMain.handle(IpcChannels.getStatus, () => manager.statuses());
 	ipcMain.handle(IpcChannels.getLogs, (_event, id: ServiceId) => manager.get(id)?.logs.toArray() ?? []);
 	ipcMain.handle(IpcChannels.openWebApp, () => {
-		mainWindow?.loadURL(WEB_APP_URL);
+		void mainWindow?.loadURL(appUrl());
 	});
 
 	// -----------------------------------------------------------------------
@@ -229,9 +343,6 @@ function bootstrap(): void {
 	});
 	mainWindow = window;
 
-	// Keep navigation inside the app: local wizard bundle + the two local
-	// service origins. Everything else opens in the OS browser.
-	const allowedOrigins = new Set(['http://localhost:3000', 'http://localhost:3100']);
 	window.webContents.setWindowOpenHandler(({ url }) => {
 		void shell.openExternal(url);
 		return { action: 'deny' };

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -1,5 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { DesktopBridge, LogEntry, RuntimeSelection, ServiceId, ServiceStatus } from '../shared/ipc-contract';
+import type {
+	DesktopBridge,
+	DesktopMode,
+	LogEntry,
+	RemoteConnectionInput,
+	RuntimeSelection,
+	ServiceId,
+	ServiceStatus
+} from '../shared/ipc-contract';
 
 // IMPORTANT: this preload runs sandboxed — it cannot require local modules,
 // so channel names are inlined as string literals. Keep them in sync with
@@ -11,8 +19,12 @@ const bridge: DesktopBridge = {
 	listRuntimes: () => ipcRenderer.invoke('wizard:list-runtimes'),
 	detectDocker: () => ipcRenderer.invoke('wizard:detect-docker'),
 	applyRuntime: (selection: RuntimeSelection) => ipcRenderer.invoke('wizard:apply-runtime', selection),
+	setMode: (mode: DesktopMode) => ipcRenderer.invoke('wizard:set-mode', mode),
+	testRemote: (input: RemoteConnectionInput) => ipcRenderer.invoke('wizard:test-remote', input),
+	saveRemote: (input: RemoteConnectionInput) => ipcRenderer.invoke('wizard:save-remote', input),
 	completeWizard: () => ipcRenderer.invoke('wizard:complete'),
 	getConfig: () => ipcRenderer.invoke('config:get'),
+	getRuntimeLayout: () => ipcRenderer.invoke('app:runtime-layout'),
 	startServices: () => ipcRenderer.invoke('services:start'),
 	stopServices: () => ipcRenderer.invoke('services:stop'),
 	restartService: (id: ServiceId) => ipcRenderer.invoke('services:restart', id),

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -32,8 +32,15 @@ export function App() {
 	}
 
 	if (!config.wizardCompleted) {
-		return <WizardView bridge={bridge} onCompleted={() => setConfig({ ...config, wizardCompleted: true })} />;
+		return (
+			<WizardView
+				bridge={bridge}
+				onCompleted={() =>
+					void bridge.getConfig().then((next) => setConfig({ ...next, wizardCompleted: true }))
+				}
+			/>
+		);
 	}
 
-	return <StatusScreen bridge={bridge} />;
+	return <StatusScreen bridge={bridge} config={config} />;
 }

--- a/apps/desktop/src/renderer/StatusScreen.tsx
+++ b/apps/desktop/src/renderer/StatusScreen.tsx
@@ -1,17 +1,22 @@
 import { useEffect, useState } from 'react';
-import type { DesktopBridge, LogEntry, ServiceId, ServiceStatus } from '../shared/ipc-contract';
+import type { DesktopBridge, DesktopConfig, LogEntry, ServiceId, ServiceStatus } from '../shared/ipc-contract';
 
 interface StatusScreenProps {
 	bridge: DesktopBridge;
+	config: DesktopConfig;
 }
 
 /** Service status + log panes shown when the wizard is already complete. */
-export function StatusScreen({ bridge }: StatusScreenProps) {
+export function StatusScreen({ bridge, config }: StatusScreenProps) {
 	const [statuses, setStatuses] = useState<ServiceStatus[]>([]);
 	const [activeService, setActiveService] = useState<ServiceId>('api');
 	const [logs, setLogs] = useState<LogEntry[]>([]);
+	const isRemote = config.mode === 'remote-client';
 
 	useEffect(() => {
+		if (isRemote) {
+			return;
+		}
 		void bridge.getStatus().then(setStatuses);
 		const offStatus = bridge.onStatus(setStatuses);
 		const poll = setInterval(() => void bridge.getStatus().then(setStatuses), 3000);
@@ -19,9 +24,12 @@ export function StatusScreen({ bridge }: StatusScreenProps) {
 			offStatus();
 			clearInterval(poll);
 		};
-	}, [bridge]);
+	}, [bridge, isRemote]);
 
 	useEffect(() => {
+		if (isRemote) {
+			return;
+		}
 		void bridge.getLogs(activeService).then(setLogs);
 		const offLog = bridge.onLog((entry) => {
 			if (entry.serviceId === activeService) {
@@ -29,7 +37,35 @@ export function StatusScreen({ bridge }: StatusScreenProps) {
 			}
 		});
 		return offLog;
-	}, [bridge, activeService]);
+	}, [bridge, activeService, isRemote]);
+
+	if (isRemote) {
+		return (
+			<div className="shell">
+				<h1>Ever Works Desktop</h1>
+				<p className="muted">Client mode — connected to a remote instance</p>
+
+				<div className="panel">
+					<div className="check-row">
+						<span className="badge ok">Remote</span>
+						<span>{config.remote?.label ?? config.remote?.webUrl ?? 'Not configured'}</span>
+					</div>
+					{config.remote && (
+						<div className="check-row">
+							<span className="badge">API</span>
+							<span className="muted">{config.remote.apiUrl}</span>
+						</div>
+					)}
+					<p className="muted" style={{ marginTop: 12 }}>
+						No services run on this machine in client mode. The platform runs on the instance above.
+					</p>
+					<div className="actions">
+						<button onClick={() => void bridge.openWebApp()}>Open Ever Works</button>
+					</div>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="shell">

--- a/apps/desktop/src/renderer/wizard/WizardView.tsx
+++ b/apps/desktop/src/renderer/wizard/WizardView.tsx
@@ -2,8 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
 	DatabaseChoice,
 	DesktopBridge,
+	DesktopMode,
 	PrereqCheckResult,
+	RemoteConnection,
+	RemoteProbeResult,
 	RuntimeDescriptor,
+	RuntimeLayoutSummary,
 	RuntimeSelection,
 	ServiceStatus
 } from '../../shared/ipc-contract';
@@ -14,8 +18,25 @@ interface WizardViewProps {
 	onCompleted(): void;
 }
 
+const MODE_CHOICES: Array<{ id: DesktopMode; name: string; description: string }> = [
+	{
+		id: 'local-stack',
+		name: 'Run Ever Works on this machine',
+		description:
+			'All-in-one install: this app supervises its own API and web services and stores everything locally. Pick your job runtime and database in the next steps.'
+	},
+	{
+		id: 'remote-client',
+		name: 'Connect to an existing Ever Works instance',
+		description:
+			'Client mode: nothing runs locally. Point the app at an instance that is already running — your own self-hosted deployment, your team server, or the hosted platform — and use it as a native desktop client.'
+	}
+];
+
 export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 	const [step, setStep] = useState<WizardStepId>('welcome');
+	const [mode, setMode] = useState<DesktopMode | undefined>();
+	const [layout, setLayout] = useState<RuntimeLayoutSummary | undefined>();
 	const [prereqResults, setPrereqResults] = useState<PrereqCheckResult[] | undefined>();
 	const [runtimes, setRuntimes] = useState<RuntimeDescriptor[]>([]);
 	const [dockerAvailable, setDockerAvailable] = useState<boolean | undefined>();
@@ -25,16 +46,37 @@ export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 	const [statuses, setStatuses] = useState<ServiceStatus[]>([]);
 	const [bootLog, setBootLog] = useState<string[]>([]);
 
+	// Client-mode state.
+	const [remoteWebUrl, setRemoteWebUrl] = useState('');
+	const [remoteApiUrl, setRemoteApiUrl] = useState('');
+	const [remoteLabel, setRemoteLabel] = useState('');
+	const [remoteProbe, setRemoteProbe] = useState<RemoteProbeResult | undefined>();
+	const [remoteConnection, setRemoteConnection] = useState<RemoteConnection | undefined>();
+	const [remoteBusy, setRemoteBusy] = useState(false);
+
 	const servicesHealthy = statuses.length > 0 && statuses.every((status) => status.healthy);
 	const progress = useMemo(
-		() => ({ prereqResults, selection, envWritten, servicesHealthy }),
-		[prereqResults, selection, envWritten, servicesHealthy]
+		() => ({
+			mode,
+			prereqResults,
+			selection,
+			envWritten,
+			servicesHealthy,
+			remoteConnection,
+			remoteVerified: remoteProbe?.ok === true
+		}),
+		[mode, prereqResults, selection, envWritten, servicesHealthy, remoteConnection, remoteProbe]
 	);
 	const steps = computeStepList(progress);
+	const localStackUnavailable = layout?.kind === 'unavailable';
 
 	const runPrereqs = useCallback(() => {
 		void bridge.checkPrereqs().then(setPrereqResults);
 		void bridge.detectDocker().then((result) => setDockerAvailable(result.available));
+	}, [bridge]);
+
+	useEffect(() => {
+		void bridge.getRuntimeLayout().then(setLayout);
 	}, [bridge]);
 
 	useEffect(() => {
@@ -61,6 +103,11 @@ export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 			clearInterval(poll);
 		};
 	}, [step, bridge]);
+
+	const chooseMode = (next: DesktopMode) => {
+		setMode(next);
+		void bridge.setMode(next);
+	};
 
 	const selectRuntime = (runtime: RuntimeDescriptor) => {
 		const values: Record<string, string> = {};
@@ -91,6 +138,23 @@ export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 		}
 	};
 
+	const testRemote = async () => {
+		setRemoteBusy(true);
+		setRemoteConnection(undefined);
+		try {
+			const input = { webUrl: remoteWebUrl, apiUrl: remoteApiUrl, label: remoteLabel };
+			const probe = await bridge.testRemote(input);
+			setRemoteProbe(probe);
+			if (probe.ok) {
+				setRemoteConnection(await bridge.saveRemote(input));
+			}
+		} catch (error) {
+			setRemoteProbe({ ok: false, message: (error as Error).message });
+		} finally {
+			setRemoteBusy(false);
+		}
+	};
+
 	const openApp = async () => {
 		await bridge.completeWizard();
 		onCompleted();
@@ -102,7 +166,7 @@ export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 	return (
 		<div className="shell">
 			<h1>Ever Works Desktop</h1>
-			<p className="muted">All-in-one install: run the full platform on this machine.</p>
+			<p className="muted">Run the platform on this machine, or use it as a client for an instance you have.</p>
 
 			<div className="steps-nav">
 				{steps.map((candidate) => (
@@ -122,10 +186,129 @@ export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 					<>
 						<h2>Welcome</h2>
 						<p className="muted">
-							This wizard checks prerequisites, lets you pick the AI-agent job runtime, writes the local
-							configuration, then boots the platform (API on :3100, web on :3000) and opens the existing
-							web onboarding.
+							This wizard sets up how this machine talks to Ever Works. You can run the whole platform
+							locally — this app supervises the API and web services for you — or connect to an instance
+							that already runs somewhere else and use this window as a native client.
 						</p>
+					</>
+				)}
+
+				{step === 'mode' && (
+					<>
+						<h2>How do you want to run Ever Works?</h2>
+						{MODE_CHOICES.map((choice) => {
+							const disabled = choice.id === 'local-stack' && localStackUnavailable;
+							return (
+								<div
+									key={choice.id}
+									className={`runtime-card ${mode === choice.id ? 'selected' : ''}`}
+									style={disabled ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
+									onClick={() => {
+										if (!disabled) {
+											chooseMode(choice.id);
+										}
+									}}
+								>
+									<div>
+										<strong>{choice.name}</strong>{' '}
+										{choice.id === 'local-stack' && layout?.kind === 'bundled' && (
+											<span className="badge ok">Bundled runtime</span>
+										)}
+										{choice.id === 'local-stack' && layout?.kind === 'repo' && (
+											<span className="badge warn">From source checkout</span>
+										)}
+										{disabled && <span className="badge err">Unavailable</span>}
+									</div>
+									<span className="muted">{choice.description}</span>
+								</div>
+							);
+						})}
+						{localStackUnavailable && (
+							<p className="muted" style={{ marginTop: 12 }}>
+								This build has no bundled platform runtime and no monorepo checkout was found
+								{layout?.reason ? ` (${layout.reason})` : ''}. Client mode still works — connect to an
+								instance you already run.
+							</p>
+						)}
+						{layout?.kind === 'repo' && (
+							<p className="muted" style={{ marginTop: 12 }}>
+								Running from the source checkout at {layout.repoRoot} — Node.js and pnpm are required on
+								this machine.
+							</p>
+						)}
+						{layout?.kind === 'bundled' && (
+							<p className="muted" style={{ marginTop: 12 }}>
+								This install ships its own platform runtime (bundle {layout.bundleVersion}) — no source
+								checkout, Node.js or pnpm needed.
+							</p>
+						)}
+					</>
+				)}
+
+				{step === 'remote' && (
+					<>
+						<h2>Connect to your Ever Works instance</h2>
+						<p className="muted">
+							Enter the address of the instance you want this desktop app to use. Nothing is started
+							locally; sign-in happens in the instance&apos;s own web UI.
+						</p>
+						<label className="field">
+							<span>Instance URL *</span>
+							<input
+								type="text"
+								value={remoteWebUrl}
+								placeholder="https://app.example.com"
+								onChange={(event) => {
+									setRemoteWebUrl(event.target.value);
+									setRemoteProbe(undefined);
+									setRemoteConnection(undefined);
+								}}
+							/>
+						</label>
+						<label className="field">
+							<span>API URL (optional — derived from the instance URL when blank)</span>
+							<input
+								type="text"
+								value={remoteApiUrl}
+								placeholder="https://api.example.com"
+								onChange={(event) => {
+									setRemoteApiUrl(event.target.value);
+									setRemoteProbe(undefined);
+									setRemoteConnection(undefined);
+								}}
+							/>
+						</label>
+						<label className="field">
+							<span>Label (optional)</span>
+							<input
+								type="text"
+								value={remoteLabel}
+								placeholder="Production"
+								onChange={(event) => setRemoteLabel(event.target.value)}
+							/>
+						</label>
+						<div className="actions">
+							<button onClick={() => void testRemote()} disabled={remoteBusy || remoteWebUrl === ''}>
+								{remoteBusy ? 'Checking…' : 'Test connection'}
+							</button>
+						</div>
+						{remoteProbe && (
+							<div className="check-row">
+								<span className={`badge ${remoteProbe.ok ? 'ok' : 'err'}`}>
+									{remoteProbe.ok ? 'Reachable' : 'Failed'}
+								</span>
+								<span className="muted">
+									{remoteProbe.ok
+										? `Instance responded${remoteProbe.version ? ` (version ${remoteProbe.version})` : ''}.`
+										: remoteProbe.message}
+								</span>
+							</div>
+						)}
+						{remoteConnection && (
+							<p className="muted" style={{ marginTop: 12 }}>
+								Saved: {remoteConnection.webUrl} (API {remoteConnection.apiUrl})
+							</p>
+						)}
 					</>
 				)}
 
@@ -303,8 +486,9 @@ export function WizardView({ bridge, onCompleted }: WizardViewProps) {
 					<>
 						<h2>Ready</h2>
 						<p className="muted">
-							The local platform is up. Continue into the Ever Works web onboarding to finish setting up
-							your workspace.
+							{mode === 'remote-client'
+								? `Connected to ${remoteConnection?.label ?? remoteConnection?.webUrl ?? 'your instance'}. Continue to sign in and use Ever Works.`
+								: 'The local platform is up. Continue into the Ever Works web onboarding to finish setting up your workspace.'}
 						</p>
 						<div className="actions">
 							<button onClick={() => void openApp()}>Open Ever Works</button>

--- a/apps/desktop/src/renderer/wizard/steps.spec.ts
+++ b/apps/desktop/src/renderer/wizard/steps.spec.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import type { PrereqCheckResult, RuntimeSelection } from '../../shared/ipc-contract';
+import type { PrereqCheckResult, RemoteConnection, RuntimeSelection } from '../../shared/ipc-contract';
 import type { WizardProgress } from './steps';
 import {
+	LOCAL_WIZARD_STEPS,
+	REMOTE_WIZARD_STEPS,
 	WIZARD_STEPS,
 	canAdvance,
 	computeStepList,
 	firstIncompleteStep,
+	isRemoteMode,
 	nextStep,
 	previousStep,
+	remoteReady,
 	selectionValid
 } from './steps';
 
@@ -29,14 +33,33 @@ function bullmqSelection(overrides: Partial<RuntimeSelection> = {}): RuntimeSele
 	};
 }
 
+const remote: RemoteConnection = { webUrl: 'https://app.example.com', apiUrl: 'https://api.example.com' };
+
+/** Local-stack progress (the default flow) with the mode already chosen. */
 function progress(overrides: Partial<WizardProgress> = {}): WizardProgress {
-	return { envWritten: false, servicesHealthy: false, ...overrides };
+	return { mode: 'local-stack', envWritten: false, servicesHealthy: false, ...overrides };
+}
+
+function remoteProgress(overrides: Partial<WizardProgress> = {}): WizardProgress {
+	return { mode: 'remote-client', envWritten: false, servicesHealthy: false, ...overrides };
 }
 
 describe('computeStepList', () => {
-	it('runs welcome → prereq → runtime → env → boot → open', () => {
-		expect(computeStepList(progress())).toEqual(['welcome', 'prereq', 'runtime', 'env', 'boot', 'open']);
-		expect(WIZARD_STEPS).toHaveLength(6);
+	it('runs welcome → mode → prereq → runtime → env → boot → open for the local stack', () => {
+		expect(computeStepList(progress())).toEqual(['welcome', 'mode', 'prereq', 'runtime', 'env', 'boot', 'open']);
+		expect(WIZARD_STEPS).toEqual(LOCAL_WIZARD_STEPS);
+		expect(LOCAL_WIZARD_STEPS).toHaveLength(7);
+	});
+
+	it('skips the whole local-stack setup in client mode', () => {
+		expect(computeStepList(remoteProgress())).toEqual(['welcome', 'mode', 'remote', 'open']);
+		expect(REMOTE_WIZARD_STEPS).toHaveLength(4);
+	});
+
+	it('defaults to the local flow before a mode is chosen', () => {
+		const undecided: WizardProgress = { envWritten: false, servicesHealthy: false };
+		expect(isRemoteMode(undecided)).toBe(false);
+		expect(computeStepList(undecided)).toEqual([...LOCAL_WIZARD_STEPS]);
 	});
 });
 
@@ -80,6 +103,12 @@ describe('selectionValid', () => {
 });
 
 describe('canAdvance / nextStep gating', () => {
+	it('blocks the mode step until a mode is picked', () => {
+		expect(canAdvance('mode', { envWritten: false, servicesHealthy: false })).toBe(false);
+		expect(canAdvance('mode', progress())).toBe(true);
+		expect(canAdvance('mode', remoteProgress())).toBe(true);
+	});
+
 	it('blocks the prereq step until required prerequisites pass (docker stays optional)', () => {
 		expect(canAdvance('prereq', progress())).toBe(false);
 		expect(canAdvance('prereq', progress({ prereqResults: prereqs(false) }))).toBe(false);
@@ -87,19 +116,36 @@ describe('canAdvance / nextStep gating', () => {
 		expect(nextStep('prereq', progress({ prereqResults: prereqs(false) }))).toBeNull();
 	});
 
-	it('walks the happy path in order once each condition is met', () => {
+	it('walks the local happy path in order once each condition is met', () => {
 		const complete = progress({
 			prereqResults: prereqs(true, true),
 			selection: bullmqSelection(),
 			envWritten: true,
 			servicesHealthy: true
 		});
-		expect(nextStep('welcome', complete)).toBe('prereq');
+		expect(nextStep('welcome', complete)).toBe('mode');
+		expect(nextStep('mode', complete)).toBe('prereq');
 		expect(nextStep('prereq', complete)).toBe('runtime');
 		expect(nextStep('runtime', complete)).toBe('env');
 		expect(nextStep('env', complete)).toBe('boot');
 		expect(nextStep('boot', complete)).toBe('open');
 		expect(nextStep('open', complete)).toBeNull();
+	});
+
+	it('walks the client-mode path welcome → mode → remote → open', () => {
+		const complete = remoteProgress({ remoteConnection: remote, remoteVerified: true });
+		expect(nextStep('welcome', complete)).toBe('mode');
+		expect(nextStep('mode', complete)).toBe('remote');
+		expect(nextStep('remote', complete)).toBe('open');
+		expect(nextStep('open', complete)).toBeNull();
+	});
+
+	it('blocks the remote step until the instance answered its health probe', () => {
+		expect(remoteReady(remoteProgress())).toBe(false);
+		expect(remoteReady(remoteProgress({ remoteConnection: remote }))).toBe(false);
+		expect(remoteReady(remoteProgress({ remoteConnection: remote, remoteVerified: true }))).toBe(true);
+		expect(canAdvance('remote', remoteProgress({ remoteConnection: remote }))).toBe(false);
+		expect(nextStep('remote', remoteProgress({ remoteConnection: remote }))).toBeNull();
 	});
 
 	it('blocks env until written and boot until services are healthy', () => {
@@ -112,11 +158,14 @@ describe('canAdvance / nextStep gating', () => {
 
 	it('supports going back except from the first step', () => {
 		expect(previousStep('welcome', progress())).toBeNull();
+		expect(previousStep('mode', progress())).toBe('welcome');
 		expect(previousStep('runtime', progress())).toBe('prereq');
 		expect(previousStep('open', progress())).toBe('boot');
+		expect(previousStep('open', remoteProgress())).toBe('remote');
 	});
 
 	it('resumes at the first incomplete step', () => {
+		expect(firstIncompleteStep({ envWritten: false, servicesHealthy: false })).toBe('mode');
 		expect(firstIncompleteStep(progress())).toBe('prereq');
 		expect(firstIncompleteStep(progress({ prereqResults: prereqs(true) }))).toBe('runtime');
 		expect(
@@ -134,5 +183,10 @@ describe('canAdvance / nextStep gating', () => {
 				})
 			)
 		).toBe('open');
+	});
+
+	it('resumes a client-mode wizard at the remote step until it is verified', () => {
+		expect(firstIncompleteStep(remoteProgress())).toBe('remote');
+		expect(firstIncompleteStep(remoteProgress({ remoteConnection: remote, remoteVerified: true }))).toBe('open');
 	});
 });

--- a/apps/desktop/src/renderer/wizard/steps.ts
+++ b/apps/desktop/src/renderer/wizard/steps.ts
@@ -1,28 +1,50 @@
-import type { PrereqCheckResult, RuntimeSelection } from '../../shared/ipc-contract';
+import type { DesktopMode, PrereqCheckResult, RemoteConnection, RuntimeSelection } from '../../shared/ipc-contract';
 import { getRuntime } from '../../shared/runtimes';
 import { requiredPrereqsOk } from '../../services/prereq-check';
 
 /**
- * Pure sequencing logic for the pre-boot install wizard:
- * welcome → prereq check → runtime select → env write → boot → open app.
+ * Pure sequencing logic for the pre-boot install wizard.
+ *
+ * The wizard branches on the deployment mode chosen in the `mode` step:
+ *
+ * - `local-stack`  welcome → mode → prereq → runtime → env → boot → open
+ * - `remote-client` welcome → mode → remote → open
+ *
  * Mirrors the web onboarding's computeStepList pattern so desktop-only steps
  * can slot in later without new machinery.
  */
 
-export const WIZARD_STEPS = ['welcome', 'prereq', 'runtime', 'env', 'boot', 'open'] as const;
-export type WizardStepId = (typeof WIZARD_STEPS)[number];
+/** Steps of the all-in-one local install. */
+export const LOCAL_WIZARD_STEPS = ['welcome', 'mode', 'prereq', 'runtime', 'env', 'boot', 'open'] as const;
+
+/** Steps of the client-mode install (connect to an instance that already runs elsewhere). */
+export const REMOTE_WIZARD_STEPS = ['welcome', 'mode', 'remote', 'open'] as const;
+
+/** Default (local-stack) flow. */
+export const WIZARD_STEPS = LOCAL_WIZARD_STEPS;
+
+export type WizardStepId = (typeof LOCAL_WIZARD_STEPS)[number] | (typeof REMOTE_WIZARD_STEPS)[number];
 
 export interface WizardProgress {
+	/** Undefined until the user picks a mode in the `mode` step. */
+	mode?: DesktopMode;
 	prereqResults?: PrereqCheckResult[];
 	selection?: RuntimeSelection;
 	envWritten: boolean;
 	servicesHealthy: boolean;
+	/** Remote instance the user entered (client mode only). */
+	remoteConnection?: RemoteConnection;
+	/** True once the remote instance answered its health probe. */
+	remoteVerified?: boolean;
 }
 
-export function computeStepList(_progress: WizardProgress): WizardStepId[] {
-	// All steps always apply today; conditional runtime-config sub-steps hook
-	// in here later (same extension point the web wizard uses).
-	return [...WIZARD_STEPS];
+/** Which flow a progress snapshot is on. Local is the default until a mode is chosen. */
+export function isRemoteMode(progress: WizardProgress): boolean {
+	return progress.mode === 'remote-client';
+}
+
+export function computeStepList(progress: WizardProgress): WizardStepId[] {
+	return isRemoteMode(progress) ? [...REMOTE_WIZARD_STEPS] : [...LOCAL_WIZARD_STEPS];
 }
 
 /** A selection is valid when the runtime exists, required fields resolve to a value, and the DB choice is coherent. */
@@ -52,11 +74,20 @@ export function selectionValid(selection: RuntimeSelection | undefined): boolean
 	return true;
 }
 
+/** A remote step is complete once a connection was resolved AND its health probe succeeded. */
+export function remoteReady(progress: WizardProgress): boolean {
+	return Boolean(progress.remoteConnection) && progress.remoteVerified === true;
+}
+
 /** Whether the given step's completion condition is met (i.e. the user may advance past it). */
 export function canAdvance(step: WizardStepId, progress: WizardProgress): boolean {
 	switch (step) {
 		case 'welcome':
 			return true;
+		case 'mode':
+			return progress.mode !== undefined;
+		case 'remote':
+			return remoteReady(progress);
 		case 'prereq':
 			return requiredPrereqsOk(progress.prereqResults);
 		case 'runtime':

--- a/apps/desktop/src/services/prereq-check.spec.ts
+++ b/apps/desktop/src/services/prereq-check.spec.ts
@@ -78,6 +78,27 @@ describe('checkPrerequisites', () => {
 		expect(requiredPrereqsOk(results)).toBe(true);
 	});
 
+	it('stops requiring the host toolchain when the install ships a bundled runtime', async () => {
+		const results = await checkPrerequisites(
+			runnerWith({
+				node: new Error('ENOENT'),
+				pnpm: new Error('ENOENT'),
+				docker: new Error('ENOENT')
+			}),
+			{ requireHostToolchain: false }
+		);
+		const node = results.find((result) => result.id === 'node');
+		const pnpm = results.find((result) => result.id === 'pnpm');
+		expect(node?.required).toBe(false);
+		expect(node?.found).toBe(false);
+		expect(node?.ok).toBe(true);
+		expect(node?.message).toContain('bundled platform runtime');
+		expect(pnpm?.required).toBe(false);
+		expect(pnpm?.ok).toBe(true);
+		// A machine with no Node.js and no pnpm can still complete the wizard.
+		expect(requiredPrereqsOk(results)).toBe(true);
+	});
+
 	it('treats a non-zero exit code as not found', async () => {
 		const results = await checkPrerequisites(
 			runnerWith({

--- a/apps/desktop/src/services/prereq-check.ts
+++ b/apps/desktop/src/services/prereq-check.ts
@@ -38,41 +38,68 @@ async function probe(
 	}
 }
 
+export interface PrereqCheckOptions {
+	/**
+	 * Whether the local stack will be run from a monorepo checkout, which needs
+	 * Node.js + pnpm on PATH. Installs that ship a bundled runtime payload run
+	 * the services on the app's own embedded Node.js, so both tools become
+	 * informational rather than blocking. Defaults to `true` (repo layout).
+	 */
+	requireHostToolchain?: boolean;
+}
+
 /**
  * Check the wizard prerequisites: Node.js >= 22 and pnpm are required to run
- * the platform from source; Docker is optional and only gates the
- * docker-compose infra choice.
+ * the platform from a source checkout; Docker is optional and only gates the
+ * docker-compose infra choice. With a bundled runtime payload the toolchain
+ * checks are reported but not required — see {@link PrereqCheckOptions}.
  */
-export async function checkPrerequisites(runner: CommandRunner): Promise<PrereqCheckResult[]> {
+export async function checkPrerequisites(
+	runner: CommandRunner,
+	options: PrereqCheckOptions = {}
+): Promise<PrereqCheckResult[]> {
+	const requireHostToolchain = options.requireHostToolchain ?? true;
 	const [node, pnpm, docker] = await Promise.all([
 		probe(runner, 'node', ['--version']),
 		probe(runner, 'pnpm', ['--version']),
 		probe(runner, 'docker', ['--version'])
 	]);
 
-	const nodeOk = node.found && nodeVersionSatisfies(node.version);
+	const nodeFound = node.found && nodeVersionSatisfies(node.version);
+	// With a bundled runtime the app supplies its own Node.js, so the host
+	// toolchain never blocks: report it, mark it satisfied, explain why.
+	const nodeOk = requireHostToolchain ? nodeFound : true;
+	const pnpmOk = requireHostToolchain ? pnpm.found : true;
+	const bundledNote = 'not needed — this install runs the bundled platform runtime';
+
 	return [
 		{
 			id: 'node',
-			label: `Node.js >= ${MIN_NODE_MAJOR}`,
-			required: true,
+			label: requireHostToolchain ? `Node.js >= ${MIN_NODE_MAJOR}` : `Node.js >= ${MIN_NODE_MAJOR} (optional)`,
+			required: requireHostToolchain,
 			found: node.found,
 			version: node.version,
 			ok: nodeOk,
-			message: node.found
-				? nodeOk
-					? undefined
-					: `Node.js ${node.version ?? '?'} found but >= ${MIN_NODE_MAJOR} is required`
-				: 'Node.js was not found on PATH'
+			message: !requireHostToolchain
+				? bundledNote
+				: node.found
+					? nodeFound
+						? undefined
+						: `Node.js ${node.version ?? '?'} found but >= ${MIN_NODE_MAJOR} is required`
+					: 'Node.js was not found on PATH'
 		},
 		{
 			id: 'pnpm',
-			label: 'pnpm',
-			required: true,
+			label: requireHostToolchain ? 'pnpm' : 'pnpm (optional)',
+			required: requireHostToolchain,
 			found: pnpm.found,
 			version: pnpm.version,
-			ok: pnpm.found,
-			message: pnpm.found ? undefined : 'pnpm was not found on PATH (npm install -g pnpm)'
+			ok: pnpmOk,
+			message: !requireHostToolchain
+				? bundledNote
+				: pnpm.found
+					? undefined
+					: 'pnpm was not found on PATH (npm install -g pnpm)'
 		},
 		{
 			id: 'docker',

--- a/apps/desktop/src/services/remote-connection.spec.ts
+++ b/apps/desktop/src/services/remote-connection.spec.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type { RemoteConnection } from '../shared/ipc-contract';
+import type { ProbeFetch } from './remote-connection';
+import {
+	allowedOriginsFor,
+	deriveApiUrl,
+	isInsecureRemote,
+	normalizeBaseUrl,
+	probeRemote,
+	remoteHealthUrl,
+	resolveRemoteConnection
+} from './remote-connection';
+
+describe('normalizeBaseUrl', () => {
+	it('assumes https for a bare host and strips trailing slashes / query / hash', () => {
+		expect(normalizeBaseUrl('app.example.com')).toBe('https://app.example.com');
+		expect(normalizeBaseUrl(' https://app.example.com/// ')).toBe('https://app.example.com');
+		expect(normalizeBaseUrl('https://app.example.com/base/?x=1#frag')).toBe('https://app.example.com/base');
+	});
+
+	it('keeps an explicit http scheme and a port', () => {
+		expect(normalizeBaseUrl('http://localhost:3000')).toBe('http://localhost:3000');
+	});
+
+	it('rejects empty, unparseable, non-http and credential-bearing URLs', () => {
+		expect(normalizeBaseUrl('')).toBeUndefined();
+		expect(normalizeBaseUrl('   ')).toBeUndefined();
+		expect(normalizeBaseUrl(undefined)).toBeUndefined();
+		expect(normalizeBaseUrl('ftp://example.com')).toBeUndefined();
+		expect(normalizeBaseUrl('file:///etc/passwd')).toBeUndefined();
+		expect(normalizeBaseUrl('https://user:secret@example.com')).toBeUndefined();
+	});
+});
+
+describe('deriveApiUrl', () => {
+	it('maps app.<domain> to api.<domain>', () => {
+		expect(deriveApiUrl('https://app.ever.works')).toBe('https://api.ever.works');
+		expect(deriveApiUrl('app.example.co.uk')).toBe('https://api.example.co.uk');
+	});
+
+	it('falls back to the same origin for single-origin and local installs', () => {
+		expect(deriveApiUrl('http://localhost:3000')).toBe('http://localhost:3000');
+		expect(deriveApiUrl('https://works.internal')).toBe('https://works.internal');
+	});
+
+	it('returns undefined for an unusable URL', () => {
+		expect(deriveApiUrl('not a url at all ///')).toBeUndefined();
+	});
+});
+
+describe('isInsecureRemote', () => {
+	it('flags plain http to a non-loopback host only', () => {
+		expect(isInsecureRemote('http://example.com')).toBe(true);
+		expect(isInsecureRemote('http://localhost:3000')).toBe(false);
+		expect(isInsecureRemote('http://127.0.0.1:3000')).toBe(false);
+		expect(isInsecureRemote('https://example.com')).toBe(false);
+	});
+});
+
+describe('resolveRemoteConnection', () => {
+	it('derives the API URL and reports no warnings for an https instance', () => {
+		const result = resolveRemoteConnection({ webUrl: 'https://app.example.com/' });
+		expect(result.ok).toBe(true);
+		if (!result.ok) {
+			return;
+		}
+		expect(result.connection).toEqual({ webUrl: 'https://app.example.com', apiUrl: 'https://api.example.com' });
+		expect(result.warnings).toEqual([]);
+	});
+
+	it('prefers an explicitly entered API URL over the derived one', () => {
+		const result = resolveRemoteConnection({
+			webUrl: 'https://app.example.com',
+			apiUrl: 'https://backend.example.com/api-root/',
+			label: '  Staging  '
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) {
+			return;
+		}
+		expect(result.connection.apiUrl).toBe('https://backend.example.com/api-root');
+		expect(result.connection.label).toBe('Staging');
+	});
+
+	it('warns (but does not block) on plain HTTP to a remote host', () => {
+		const result = resolveRemoteConnection({ webUrl: 'http://works.internal' });
+		expect(result.ok).toBe(true);
+		if (!result.ok) {
+			return;
+		}
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).toContain('not encrypted');
+	});
+
+	it('rejects a missing or malformed instance URL', () => {
+		expect(resolveRemoteConnection(undefined).ok).toBe(false);
+		expect(resolveRemoteConnection({ webUrl: '' }).ok).toBe(false);
+		const bad = resolveRemoteConnection({ webUrl: 'ftp://example.com' });
+		expect(bad.ok).toBe(false);
+		if (bad.ok) {
+			return;
+		}
+		expect(bad.errors[0]).toContain('instance URL');
+	});
+
+	it('rejects a malformed explicit API URL', () => {
+		const result = resolveRemoteConnection({ webUrl: 'https://app.example.com', apiUrl: 'ftp://nope' });
+		expect(result.ok).toBe(false);
+		if (result.ok) {
+			return;
+		}
+		expect(result.errors).toContain('The API URL is not a valid http/https URL.');
+	});
+});
+
+describe('probeRemote', () => {
+	const connection: RemoteConnection = { webUrl: 'https://app.example.com', apiUrl: 'https://api.example.com' };
+
+	it('builds the health URL from the API base', () => {
+		expect(remoteHealthUrl(connection)).toBe('https://api.example.com/api/health');
+	});
+
+	it('reports ok and the reported version on a healthy response', async () => {
+		const fetchFn: ProbeFetch = async (url) => {
+			expect(url).toBe('https://api.example.com/api/health');
+			return { ok: true, status: 200, json: async () => ({ version: '1.2.3' }) };
+		};
+		await expect(probeRemote(connection, fetchFn)).resolves.toEqual({ ok: true, status: 200, version: '1.2.3' });
+	});
+
+	it('tolerates a health payload without a version', async () => {
+		const fetchFn: ProbeFetch = async () => ({ ok: true, status: 200, json: async () => ({ status: 'up' }) });
+		await expect(probeRemote(connection, fetchFn)).resolves.toEqual({ ok: true, status: 200 });
+	});
+
+	it('tolerates a health payload that is not JSON', async () => {
+		const fetchFn: ProbeFetch = async () => ({
+			ok: true,
+			status: 200,
+			json: async () => {
+				throw new Error('not json');
+			}
+		});
+		await expect(probeRemote(connection, fetchFn)).resolves.toEqual({ ok: true, status: 200 });
+	});
+
+	it('surfaces a non-2xx status', async () => {
+		const fetchFn: ProbeFetch = async () => ({ ok: false, status: 502 });
+		const result = await probeRemote(connection, fetchFn);
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(502);
+		expect(result.message).toContain('502');
+	});
+
+	it('never throws on a transport failure', async () => {
+		const fetchFn: ProbeFetch = async () => {
+			throw new Error('ENOTFOUND');
+		};
+		const result = await probeRemote(connection, fetchFn);
+		expect(result.ok).toBe(false);
+		expect(result.message).toContain('ENOTFOUND');
+	});
+});
+
+describe('allowedOriginsFor', () => {
+	const localOrigins = ['http://localhost:3000', 'http://localhost:3100'];
+
+	it('keeps the local service origins when there is no remote connection', () => {
+		expect(allowedOriginsFor(undefined, localOrigins)).toEqual(localOrigins);
+	});
+
+	it('swaps in the remote web + api origins in client mode', () => {
+		expect(
+			allowedOriginsFor({ webUrl: 'https://app.example.com/x', apiUrl: 'https://api.example.com' }, localOrigins)
+		).toEqual(['https://app.example.com', 'https://api.example.com']);
+	});
+
+	it('collapses a single-origin instance to one entry', () => {
+		expect(
+			allowedOriginsFor({ webUrl: 'https://works.internal', apiUrl: 'https://works.internal' }, localOrigins)
+		).toEqual(['https://works.internal']);
+	});
+});

--- a/apps/desktop/src/services/remote-connection.ts
+++ b/apps/desktop/src/services/remote-connection.ts
@@ -1,0 +1,216 @@
+import type { RemoteConnection, RemoteConnectionInput, RemoteProbeResult } from '../shared/ipc-contract';
+
+/**
+ * Client mode: resolving and probing a REMOTE Ever Works instance.
+ *
+ * The desktop shell can either run its own stack (`local-stack`) or act as a
+ * native client onto an instance that already runs somewhere else
+ * (`remote-client`). Everything in this module is pure/injected so the URL
+ * resolution rules and the reachability probe are unit-testable without a
+ * network or an Electron runtime.
+ */
+
+/** Health endpoint the probe hits, relative to the resolved API base URL. */
+export const REMOTE_HEALTH_PATH = '/api/health';
+
+/** Loopback hostnames for which plain `http://` is not flagged as insecure. */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+export interface ResolvedRemoteConnection {
+	ok: true;
+	connection: RemoteConnection;
+	/** Non-blocking advisories (e.g. plain HTTP to a non-loopback host). */
+	warnings: string[];
+}
+
+export interface RejectedRemoteConnection {
+	ok: false;
+	errors: string[];
+}
+
+export type RemoteResolution = ResolvedRemoteConnection | RejectedRemoteConnection;
+
+function stripTrailingSlashes(value: string): string {
+	return value.replace(/\/+$/, '');
+}
+
+/**
+ * Normalize a user-typed instance URL: trims whitespace, tolerates a missing
+ * scheme (assumes `https://`), rejects non-HTTP schemes, and drops trailing
+ * slashes so joins stay predictable. Returns `undefined` when unusable.
+ */
+export function normalizeBaseUrl(raw: string | undefined): string | undefined {
+	const trimmed = (raw ?? '').trim();
+	if (trimmed === '') {
+		return undefined;
+	}
+	const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+	let url: URL;
+	try {
+		url = new URL(withScheme);
+	} catch {
+		return undefined;
+	}
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		return undefined;
+	}
+	if (url.hostname === '') {
+		return undefined;
+	}
+	// Credentials in the URL would end up persisted in the desktop config file
+	// and echoed into logs — refuse them outright rather than silently strip.
+	if (url.username !== '' || url.password !== '') {
+		return undefined;
+	}
+	url.hash = '';
+	url.search = '';
+	return stripTrailingSlashes(url.toString());
+}
+
+/**
+ * Best-effort API base URL for an instance whose web URL is known.
+ *
+ * Ever Works deployments front the web app on `app.<domain>` and the API on
+ * `api.<domain>`; everything else (self-hosted single-origin installs, local
+ * ports) is assumed to serve the API from the same base URL. Always shown to
+ * the user as an editable field — this is a default, not a constraint.
+ */
+export function deriveApiUrl(webUrl: string): string | undefined {
+	const normalized = normalizeBaseUrl(webUrl);
+	if (!normalized) {
+		return undefined;
+	}
+	const url = new URL(normalized);
+	if (url.hostname.startsWith('app.') && url.hostname.length > 'app.'.length) {
+		url.hostname = `api.${url.hostname.slice('app.'.length)}`;
+		return stripTrailingSlashes(url.toString());
+	}
+	return stripTrailingSlashes(normalized);
+}
+
+/** True when the URL sends traffic in the clear to something that is not loopback. */
+export function isInsecureRemote(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === 'http:' && !LOOPBACK_HOSTS.has(parsed.hostname);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Validate + normalize a remote connection the user typed into the wizard.
+ * Resolution order for the API URL: explicit value → derived from the web URL.
+ */
+export function resolveRemoteConnection(input: RemoteConnectionInput | undefined): RemoteResolution {
+	const errors: string[] = [];
+
+	const webUrl = normalizeBaseUrl(input?.webUrl);
+	if (!webUrl) {
+		errors.push('Enter the instance URL, e.g. https://app.example.com (http/https only, no credentials).');
+	}
+
+	const apiCandidate = (input?.apiUrl ?? '').trim();
+	let apiUrl: string | undefined;
+	if (apiCandidate !== '') {
+		apiUrl = normalizeBaseUrl(apiCandidate);
+		if (!apiUrl) {
+			errors.push('The API URL is not a valid http/https URL.');
+		}
+	} else if (webUrl) {
+		apiUrl = deriveApiUrl(webUrl);
+	}
+
+	if (errors.length > 0 || !webUrl || !apiUrl) {
+		return { ok: false, errors: errors.length > 0 ? errors : ['Could not resolve the remote instance URLs.'] };
+	}
+
+	const warnings: string[] = [];
+	if (isInsecureRemote(webUrl) || isInsecureRemote(apiUrl)) {
+		warnings.push(
+			'This instance is reached over plain HTTP — session cookies and API traffic are not encrypted in transit.'
+		);
+	}
+
+	const label = (input?.label ?? '').trim();
+	const connection: RemoteConnection = { webUrl, apiUrl };
+	if (label !== '') {
+		connection.label = label;
+	}
+	return { ok: true, connection, warnings };
+}
+
+/** Minimal fetch shape the probe needs (injected so tests stay offline). */
+export type ProbeFetch = (url: string) => Promise<{
+	ok: boolean;
+	status: number;
+	json?: () => Promise<unknown>;
+}>;
+
+function readVersion(payload: unknown): string | undefined {
+	if (typeof payload !== 'object' || payload === null) {
+		return undefined;
+	}
+	const record = payload as Record<string, unknown>;
+	const candidate = record.version ?? record.sha ?? record.build;
+	return typeof candidate === 'string' && candidate !== '' ? candidate : undefined;
+}
+
+/** Build the health URL for a resolved connection. */
+export function remoteHealthUrl(connection: RemoteConnection): string {
+	return `${stripTrailingSlashes(connection.apiUrl)}${REMOTE_HEALTH_PATH}`;
+}
+
+/**
+ * Probe a remote instance's health endpoint. Never throws: transport failures
+ * come back as `{ ok: false, message }` so the wizard can render them.
+ */
+export async function probeRemote(connection: RemoteConnection, fetchFn: ProbeFetch): Promise<RemoteProbeResult> {
+	const url = remoteHealthUrl(connection);
+	try {
+		const response = await fetchFn(url);
+		if (!response.ok) {
+			return {
+				ok: false,
+				status: response.status,
+				message: `${url} responded with HTTP ${response.status}.`
+			};
+		}
+		let version: string | undefined;
+		if (response.json) {
+			try {
+				version = readVersion(await response.json());
+			} catch {
+				version = undefined;
+			}
+		}
+		const result: RemoteProbeResult = { ok: true, status: response.status };
+		if (version !== undefined) {
+			result.version = version;
+		}
+		return result;
+	} catch (error) {
+		return { ok: false, message: `Could not reach ${url}: ${(error as Error).message}` };
+	}
+}
+
+/**
+ * Origins the main window may navigate to for a given mode. Local mode keeps
+ * the two supervised service origins; client mode swaps in the remote
+ * instance's web + API origins so external links still open in the OS browser.
+ */
+export function allowedOriginsFor(connection: RemoteConnection | undefined, localOrigins: string[]): string[] {
+	if (!connection) {
+		return [...localOrigins];
+	}
+	const origins = new Set<string>();
+	for (const candidate of [connection.webUrl, connection.apiUrl]) {
+		try {
+			origins.add(new URL(candidate).origin);
+		} catch {
+			// Ignore unparseable persisted values — navigation simply stays blocked.
+		}
+	}
+	return [...origins];
+}

--- a/apps/desktop/src/services/runtime-layout.spec.ts
+++ b/apps/desktop/src/services/runtime-layout.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import type { BundleManifest, LayoutIo } from './runtime-layout';
+import {
+	BUNDLE_DIR_NAME,
+	BUNDLE_MANIFEST_NAME,
+	REPO_MARKER,
+	parseBundleManifest,
+	resolveRuntimeLayout,
+	resolveServiceLaunch,
+	toLayoutSummary
+} from './runtime-layout';
+
+/** Deliberately POSIX-ish join with `..` collapsing, so tests are platform-independent. */
+function join(...segments: string[]): string {
+	const parts: string[] = [];
+	for (const segment of segments.join('/').split('/')) {
+		if (segment === '' || segment === '.') {
+			continue;
+		}
+		if (segment === '..') {
+			parts.pop();
+			continue;
+		}
+		parts.push(segment);
+	}
+	return `/${parts.join('/')}`;
+}
+
+function ioWith(files: Record<string, string>): LayoutIo {
+	return {
+		exists: (path: string) => Object.prototype.hasOwnProperty.call(files, path),
+		readFile: (path: string) => files[path],
+		join
+	};
+}
+
+const manifest: BundleManifest = {
+	schema: 1,
+	bundled: true,
+	version: '0.1.0',
+	generatedAt: '2026-07-26T00:00:00.000Z',
+	api: { entry: 'api/dist/main.js', cwd: 'api' },
+	web: { entry: 'web/apps/web/server.js', cwd: 'web/apps/web' }
+};
+
+const bundledFiles = {
+	[join('/opt/app/resources', BUNDLE_DIR_NAME, BUNDLE_MANIFEST_NAME)]: JSON.stringify(manifest)
+};
+
+describe('parseBundleManifest', () => {
+	it('parses a well-formed manifest', () => {
+		expect(parseBundleManifest(JSON.stringify(manifest))).toEqual(manifest);
+	});
+
+	it('rejects missing, non-JSON, non-object and future-schema payloads', () => {
+		expect(parseBundleManifest(undefined)).toBeUndefined();
+		expect(parseBundleManifest('{not json')).toBeUndefined();
+		expect(parseBundleManifest('"a string"')).toBeUndefined();
+		expect(parseBundleManifest(JSON.stringify({ ...manifest, schema: 99 }))).toBeUndefined();
+		expect(parseBundleManifest(JSON.stringify({ bundled: true }))).toBeUndefined();
+	});
+
+	it('drops malformed service entries rather than trusting them', () => {
+		const parsed = parseBundleManifest(JSON.stringify({ ...manifest, api: { entry: '' }, web: 42 }));
+		expect(parsed?.api).toBeUndefined();
+		expect(parsed?.web).toBeUndefined();
+	});
+});
+
+describe('resolveRuntimeLayout', () => {
+	it('prefers the bundled runtime payload shipped inside the installer', () => {
+		const layout = resolveRuntimeLayout(ioWith(bundledFiles), {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar'
+		});
+		expect(layout.kind).toBe('bundled');
+		expect(layout.bundleRoot).toBe('/opt/app/resources/app-bundle');
+		expect(layout.bundleVersion).toBe('0.1.0');
+		expect(layout.requiresHostToolchain).toBe(false);
+	});
+
+	it('falls back to EVER_WORKS_REPO_ROOT when the installer has no payload', () => {
+		const layout = resolveRuntimeLayout(ioWith({ [join('/checkout', REPO_MARKER)]: 'packages:' }), {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar',
+			envRepoRoot: '/checkout'
+		});
+		expect(layout.kind).toBe('repo');
+		expect(layout.repoRoot).toBe('/checkout');
+		expect(layout.requiresHostToolchain).toBe(true);
+	});
+
+	it('falls back to the development checkout two levels above the app path', () => {
+		const layout = resolveRuntimeLayout(ioWith({ [join('/repo', REPO_MARKER)]: 'packages:' }), {
+			appPath: '/repo/apps/desktop'
+		});
+		expect(layout.kind).toBe('repo');
+		expect(layout.repoRoot).toBe('/repo');
+	});
+
+	it('reports unavailable with an explanation when nothing is present', () => {
+		const layout = resolveRuntimeLayout(ioWith({}), {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar',
+			envRepoRoot: '/nope'
+		});
+		expect(layout.kind).toBe('unavailable');
+		expect(layout.reason).toContain('no runtime payload');
+		expect(layout.reason).toContain('EVER_WORKS_REPO_ROOT=/nope');
+		expect(layout.requiresHostToolchain).toBe(false);
+	});
+
+	it('explains a placeholder manifest emitted by an unbundled packaging run', () => {
+		const files = {
+			[join('/opt/app/resources', BUNDLE_DIR_NAME, BUNDLE_MANIFEST_NAME)]: JSON.stringify({
+				schema: 1,
+				bundled: false,
+				version: '0.1.0',
+				generatedAt: '',
+				notes: 'platform build output was not staged'
+			})
+		};
+		const layout = resolveRuntimeLayout(ioWith(files), {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar'
+		});
+		expect(layout.kind).toBe('unavailable');
+		expect(layout.reason).toContain('packaged without a runtime payload');
+		expect(layout.reason).toContain('platform build output was not staged');
+	});
+
+	it('rejects a bundled manifest missing one of the two service entries', () => {
+		const files = {
+			[join('/opt/app/resources', BUNDLE_DIR_NAME, BUNDLE_MANIFEST_NAME)]: JSON.stringify({
+				...manifest,
+				web: undefined
+			})
+		};
+		const layout = resolveRuntimeLayout(ioWith(files), {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar'
+		});
+		expect(layout.kind).toBe('unavailable');
+		expect(layout.reason).toContain('missing the api or web entry');
+	});
+});
+
+describe('toLayoutSummary', () => {
+	it('drops the internal manifest but keeps the IPC-visible fields', () => {
+		const layout = resolveRuntimeLayout(ioWith(bundledFiles), {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar'
+		});
+		const summary = toLayoutSummary(layout);
+		expect(summary).toEqual({
+			kind: 'bundled',
+			bundleRoot: '/opt/app/resources/app-bundle',
+			bundleVersion: '0.1.0',
+			requiresHostToolchain: false
+		});
+		expect('manifest' in summary).toBe(false);
+	});
+});
+
+describe('resolveServiceLaunch', () => {
+	const io = ioWith(bundledFiles);
+
+	it('runs bundled services on the app own Node.js runtime — no host toolchain', () => {
+		const layout = resolveRuntimeLayout(io, {
+			resourcesPath: '/opt/app/resources',
+			appPath: '/opt/app/resources/app.asar'
+		});
+		expect(resolveServiceLaunch('api', layout, io, { nodeExecPath: '/opt/app/everworks' })).toEqual({
+			command: '/opt/app/everworks',
+			args: ['/opt/app/resources/app-bundle/api/dist/main.js'],
+			cwd: '/opt/app/resources/app-bundle/api',
+			env: { ELECTRON_RUN_AS_NODE: '1' }
+		});
+		expect(resolveServiceLaunch('web', layout, io, { nodeExecPath: '/opt/app/everworks' })).toEqual({
+			command: '/opt/app/everworks',
+			args: ['/opt/app/resources/app-bundle/web/apps/web/server.js'],
+			cwd: '/opt/app/resources/app-bundle/web/apps/web',
+			env: { ELECTRON_RUN_AS_NODE: '1' }
+		});
+	});
+
+	it('keeps the repo-checkout launch behavior for developer runs', () => {
+		const repoIo = ioWith({ [join('/repo', REPO_MARKER)]: 'packages:' });
+		const layout = resolveRuntimeLayout(repoIo, { appPath: '/repo/apps/desktop' });
+		expect(resolveServiceLaunch('api', layout, repoIo, { nodeExecPath: '/bin/electron' })).toEqual({
+			command: 'pnpm',
+			args: ['dev:api'],
+			cwd: '/repo'
+		});
+	});
+
+	it('returns undefined when no runtime is available at all', () => {
+		const emptyIo = ioWith({});
+		const layout = resolveRuntimeLayout(emptyIo, { appPath: '/nowhere/apps/desktop' });
+		expect(layout.kind).toBe('unavailable');
+		expect(resolveServiceLaunch('api', layout, emptyIo, { nodeExecPath: '/bin/electron' })).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/services/runtime-layout.ts
+++ b/apps/desktop/src/services/runtime-layout.ts
@@ -1,0 +1,244 @@
+import type { RuntimeLayoutSummary, ServiceId } from '../shared/ipc-contract';
+import { resolveServiceCommand } from './process-manager';
+
+/**
+ * Where the supervised local services actually live.
+ *
+ * The desktop app used to require a full monorepo checkout on the user's
+ * machine: it resolved the repo root two levels above the app path and ran
+ * `pnpm dev:api` / `pnpm dev:web` from it. An installed app on a machine with
+ * no source tree (and no Node.js/pnpm) therefore could not start anything.
+ *
+ * Installers now ship a self-contained runtime payload under
+ * `resources/app-bundle` (built API + Next.js standalone server + their
+ * production dependencies) described by a `bundle-manifest.json`. This module
+ * resolves, in order:
+ *
+ *   1. the bundled payload next to the packaged app,
+ *   2. an explicit `EVER_WORKS_REPO_ROOT` checkout,
+ *   3. the development checkout two levels up from the app path,
+ *
+ * and reports `unavailable` (with a reason) when none apply, so the UI can say
+ * so loudly instead of spawning a command that will never exist.
+ */
+
+/** Directory name the installer places the runtime payload under, inside `resources`. */
+export const BUNDLE_DIR_NAME = 'app-bundle';
+
+/** Manifest file at the root of the bundle payload. */
+export const BUNDLE_MANIFEST_NAME = 'bundle-manifest.json';
+
+/** Marker file proving a directory is an Ever Works monorepo checkout. */
+export const REPO_MARKER = 'pnpm-workspace.yaml';
+
+/** Current bundle manifest schema version. */
+export const BUNDLE_MANIFEST_SCHEMA = 1;
+
+export interface BundleServiceEntry {
+	/** Entry script, relative to the bundle root. */
+	entry: string;
+	/** Working directory for the process, relative to the bundle root. */
+	cwd: string;
+}
+
+export interface BundleManifest {
+	schema: number;
+	/** False for placeholder manifests emitted when no runtime payload was staged. */
+	bundled: boolean;
+	version: string;
+	generatedAt: string;
+	api?: BundleServiceEntry;
+	web?: BundleServiceEntry;
+	notes?: string;
+}
+
+function isServiceEntry(value: unknown): value is BundleServiceEntry {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+	const record = value as Record<string, unknown>;
+	return typeof record.entry === 'string' && record.entry !== '' && typeof record.cwd === 'string';
+}
+
+/** Parse + shape-check a manifest. Returns `undefined` for anything unusable. */
+export function parseBundleManifest(raw: string | undefined): BundleManifest | undefined {
+	if (!raw) {
+		return undefined;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (typeof parsed !== 'object' || parsed === null) {
+		return undefined;
+	}
+	const record = parsed as Record<string, unknown>;
+	if (typeof record.schema !== 'number' || record.schema > BUNDLE_MANIFEST_SCHEMA) {
+		return undefined;
+	}
+	const manifest: BundleManifest = {
+		schema: record.schema,
+		bundled: record.bundled === true,
+		version: typeof record.version === 'string' ? record.version : 'unknown',
+		generatedAt: typeof record.generatedAt === 'string' ? record.generatedAt : ''
+	};
+	if (isServiceEntry(record.api)) {
+		manifest.api = record.api;
+	}
+	if (isServiceEntry(record.web)) {
+		manifest.web = record.web;
+	}
+	if (typeof record.notes === 'string') {
+		manifest.notes = record.notes;
+	}
+	return manifest;
+}
+
+/** Filesystem + path abstraction so layout resolution is testable with fakes. */
+export interface LayoutIo {
+	exists(path: string): boolean;
+	readFile(path: string): string | undefined;
+	join(...segments: string[]): string;
+}
+
+export interface LayoutProbeInput {
+	/** `process.resourcesPath` — only present in a packaged app. */
+	resourcesPath?: string;
+	/** `app.getAppPath()`. */
+	appPath: string;
+	/** `EVER_WORKS_REPO_ROOT` override, when set. */
+	envRepoRoot?: string;
+}
+
+export interface RuntimeLayout extends RuntimeLayoutSummary {
+	manifest?: BundleManifest;
+}
+
+function repoLayout(repoRoot: string, reason: string): RuntimeLayout {
+	return { kind: 'repo', repoRoot, reason, requiresHostToolchain: true };
+}
+
+/**
+ * Resolve which runtime layout this install should use. Pure apart from the
+ * injected {@link LayoutIo}.
+ */
+export function resolveRuntimeLayout(io: LayoutIo, input: LayoutProbeInput): RuntimeLayout {
+	const reasons: string[] = [];
+
+	if (input.resourcesPath) {
+		const bundleRoot = io.join(input.resourcesPath, BUNDLE_DIR_NAME);
+		const manifestPath = io.join(bundleRoot, BUNDLE_MANIFEST_NAME);
+		if (io.exists(manifestPath)) {
+			const manifest = parseBundleManifest(io.readFile(manifestPath));
+			if (!manifest) {
+				reasons.push(`bundle manifest at ${manifestPath} is unreadable or of an unsupported schema`);
+			} else if (!manifest.bundled) {
+				reasons.push(
+					`installer was packaged without a runtime payload${manifest.notes ? ` (${manifest.notes})` : ''}`
+				);
+			} else if (!manifest.api || !manifest.web) {
+				reasons.push('bundle manifest is missing the api or web entry');
+			} else {
+				return {
+					kind: 'bundled',
+					bundleRoot,
+					bundleVersion: manifest.version,
+					manifest,
+					requiresHostToolchain: false
+				};
+			}
+		} else {
+			reasons.push(`no runtime payload at ${bundleRoot}`);
+		}
+	}
+
+	if (input.envRepoRoot) {
+		if (io.exists(io.join(input.envRepoRoot, REPO_MARKER))) {
+			return repoLayout(input.envRepoRoot, 'using the EVER_WORKS_REPO_ROOT checkout');
+		}
+		reasons.push(`EVER_WORKS_REPO_ROOT=${input.envRepoRoot} is not an Ever Works checkout`);
+	}
+
+	const devRoot = io.join(input.appPath, '..', '..');
+	if (io.exists(io.join(devRoot, REPO_MARKER))) {
+		return repoLayout(devRoot, 'using the development monorepo checkout next to the app');
+	}
+	reasons.push(`no monorepo checkout at ${devRoot}`);
+
+	return {
+		kind: 'unavailable',
+		reason: reasons.join('; '),
+		requiresHostToolchain: false
+	};
+}
+
+/** Drop the internal manifest before sending a layout across IPC. */
+export function toLayoutSummary(layout: RuntimeLayout): RuntimeLayoutSummary {
+	const summary: RuntimeLayoutSummary = {
+		kind: layout.kind,
+		requiresHostToolchain: layout.requiresHostToolchain
+	};
+	if (layout.bundleRoot !== undefined) {
+		summary.bundleRoot = layout.bundleRoot;
+	}
+	if (layout.repoRoot !== undefined) {
+		summary.repoRoot = layout.repoRoot;
+	}
+	if (layout.bundleVersion !== undefined) {
+		summary.bundleVersion = layout.bundleVersion;
+	}
+	if (layout.reason !== undefined) {
+		summary.reason = layout.reason;
+	}
+	return summary;
+}
+
+export interface ServiceLaunch {
+	command: string;
+	args: string[];
+	cwd: string;
+	/** Extra env for this process (merged over the generated env file entries). */
+	env?: Record<string, string>;
+}
+
+export interface ServiceLaunchOptions {
+	/**
+	 * Executable used to run bundled JavaScript. In a packaged app this is
+	 * `process.execPath` (the Electron binary) run with `ELECTRON_RUN_AS_NODE`,
+	 * which is why a bundled install needs no Node.js on the host.
+	 */
+	nodeExecPath: string;
+}
+
+/**
+ * How to launch a service for the resolved layout. `undefined` means the
+ * layout cannot run that service at all (callers surface this to the user).
+ */
+export function resolveServiceLaunch(
+	id: ServiceId,
+	layout: RuntimeLayout,
+	io: LayoutIo,
+	options: ServiceLaunchOptions
+): ServiceLaunch | undefined {
+	if (layout.kind === 'bundled' && layout.bundleRoot && layout.manifest) {
+		const entry = id === 'api' ? layout.manifest.api : layout.manifest.web;
+		if (!entry) {
+			return undefined;
+		}
+		return {
+			command: options.nodeExecPath,
+			args: [io.join(layout.bundleRoot, entry.entry)],
+			cwd: io.join(layout.bundleRoot, entry.cwd),
+			// Runs the Electron binary as a plain Node.js runtime.
+			env: { ELECTRON_RUN_AS_NODE: '1' }
+		};
+	}
+
+	if (layout.kind === 'repo' && layout.repoRoot) {
+		return resolveServiceCommand(id, layout.repoRoot, io.exists, io.join);
+	}
+
+	return undefined;
+}

--- a/apps/desktop/src/services/signing-plan.spec.ts
+++ b/apps/desktop/src/services/signing-plan.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+	SIGNING_ENV_VARS,
+	describeSigningPlan,
+	platformToTargetOs,
+	resolveSigningPlan,
+	type SigningPlan
+} from './signing-plan';
+
+const WIN_SECRETS = {
+	[SIGNING_ENV_VARS.windowsCertificate]: 'base64-cert-content',
+	[SIGNING_ENV_VARS.windowsCertificatePassword]: 'pw'
+};
+
+const MAC_SECRETS = {
+	[SIGNING_ENV_VARS.macCertificate]: 'base64-cert-content',
+	[SIGNING_ENV_VARS.macCertificatePassword]: 'pw'
+};
+
+const NOTARIZE_SECRETS = {
+	[SIGNING_ENV_VARS.appleId]: 'releases@example.com',
+	[SIGNING_ENV_VARS.appleAppSpecificPassword]: 'abcd-efgh-ijkl-mnop',
+	[SIGNING_ENV_VARS.appleTeamId]: 'TEAM123456'
+};
+
+/** No plan may ever echo a secret VALUE into its human-facing strings. */
+function assertNoSecretLeak(plan: SigningPlan): void {
+	const text = [plan.warning ?? '', describeSigningPlan(plan), ...plan.configArgs, ...plan.missing].join(' ');
+	for (const secret of ['base64-cert-content', 'pw', 'abcd-efgh-ijkl-mnop', 'releases@example.com']) {
+		expect(text).not.toContain(secret);
+	}
+}
+
+describe('platformToTargetOs', () => {
+	it('maps node platforms to packaging targets', () => {
+		expect(platformToTargetOs('win32')).toBe('win');
+		expect(platformToTargetOs('darwin')).toBe('mac');
+		expect(platformToTargetOs('linux')).toBe('linux');
+		expect(platformToTargetOs('freebsd')).toBe('linux');
+	});
+});
+
+describe('resolveSigningPlan — Windows', () => {
+	it('signs when both certificate secrets are present', () => {
+		const plan = resolveSigningPlan('win', WIN_SECRETS);
+		expect(plan.signed).toBe(true);
+		expect(plan.env.WIN_CSC_LINK).toBe('base64-cert-content');
+		expect(plan.env.WIN_CSC_KEY_PASSWORD).toBe('pw');
+		expect(plan.warning).toBeUndefined();
+		assertNoSecretLeak(plan);
+	});
+
+	it('degrades to an unsigned build with a loud warning when secrets are absent', () => {
+		const plan = resolveSigningPlan('win', {});
+		expect(plan.signed).toBe(false);
+		expect(plan.missing).toEqual([
+			SIGNING_ENV_VARS.windowsCertificate,
+			SIGNING_ENV_VARS.windowsCertificatePassword
+		]);
+		expect(plan.warning).toContain('UNSIGNED BUILD (win)');
+		expect(plan.warning).toContain(SIGNING_ENV_VARS.windowsCertificate);
+		// Never let a certificate that happens to sit in the build machine's
+		// store get picked up implicitly.
+		expect(plan.env.CSC_IDENTITY_AUTO_DISCOVERY).toBe('false');
+		assertNoSecretLeak(plan);
+	});
+
+	it('treats a blank secret as absent (empty repository secret on a fork)', () => {
+		const plan = resolveSigningPlan('win', { ...WIN_SECRETS, [SIGNING_ENV_VARS.windowsCertificate]: '   ' });
+		expect(plan.signed).toBe(false);
+		expect(plan.missing).toEqual([SIGNING_ENV_VARS.windowsCertificate]);
+	});
+});
+
+describe('resolveSigningPlan — macOS', () => {
+	it('signs and notarizes with the full secret set', () => {
+		const plan = resolveSigningPlan('mac', { ...MAC_SECRETS, ...NOTARIZE_SECRETS });
+		expect(plan.signed).toBe(true);
+		expect(plan.notarize).toBe(true);
+		expect(plan.configArgs).toEqual(['-c.mac.notarize=true']);
+		expect(plan.env.CSC_LINK).toBe('base64-cert-content');
+		expect(plan.env.APPLE_TEAM_ID).toBe('TEAM123456');
+		expect(plan.warning).toBeUndefined();
+		assertNoSecretLeak(plan);
+	});
+
+	it('signs without notarizing when the Apple credentials are missing, and says so', () => {
+		const plan = resolveSigningPlan('mac', MAC_SECRETS);
+		expect(plan.signed).toBe(true);
+		expect(plan.notarize).toBe(false);
+		expect(plan.configArgs).toEqual(['-c.mac.notarize=false']);
+		expect(plan.env.APPLE_ID).toBeUndefined();
+		expect(plan.warning).toContain('SIGNED BUT NOT NOTARIZED');
+		expect(plan.missing).toEqual([
+			SIGNING_ENV_VARS.appleId,
+			SIGNING_ENV_VARS.appleAppSpecificPassword,
+			SIGNING_ENV_VARS.appleTeamId
+		]);
+		assertNoSecretLeak(plan);
+	});
+
+	it('degrades to unsigned (notarization forced off) without a certificate', () => {
+		const plan = resolveSigningPlan('mac', NOTARIZE_SECRETS);
+		expect(plan.signed).toBe(false);
+		expect(plan.notarize).toBe(false);
+		expect(plan.configArgs).toEqual(['-c.mac.notarize=false']);
+		expect(plan.env.CSC_IDENTITY_AUTO_DISCOVERY).toBe('false');
+		expect(plan.warning).toContain('UNSIGNED BUILD (mac)');
+		assertNoSecretLeak(plan);
+	});
+});
+
+describe('resolveSigningPlan — Linux', () => {
+	it('is unsigned by design and never warns', () => {
+		const plan = resolveSigningPlan('linux', { ...WIN_SECRETS, ...MAC_SECRETS });
+		expect(plan.supported).toBe(false);
+		expect(plan.signed).toBe(false);
+		expect(plan.warning).toBeUndefined();
+		expect(plan.env).toEqual({});
+		expect(describeSigningPlan(plan)).toContain('does not apply');
+	});
+});
+
+describe('describeSigningPlan', () => {
+	it('summarizes each outcome without leaking values', () => {
+		expect(describeSigningPlan(resolveSigningPlan('win', WIN_SECRETS))).toBe(
+			'[win] signing: ENABLED, notarization: DISABLED.'
+		);
+		expect(describeSigningPlan(resolveSigningPlan('mac', { ...MAC_SECRETS, ...NOTARIZE_SECRETS }))).toBe(
+			'[mac] signing: ENABLED, notarization: ENABLED.'
+		);
+		expect(describeSigningPlan(resolveSigningPlan('win', {}))).toBe(
+			'[win] signing: DISABLED (degraded to an unsigned build).'
+		);
+	});
+});

--- a/apps/desktop/src/services/signing-plan.ts
+++ b/apps/desktop/src/services/signing-plan.ts
@@ -1,0 +1,182 @@
+/**
+ * Code-signing resolution for packaged desktop builds.
+ *
+ * Signing material never lives in the repository: CI injects it from
+ * repository secrets. This module turns whatever is present in the environment
+ * into an explicit plan — which env vars electron-builder should see, which
+ * config overrides to pass, and (crucially) a LOUD warning when a build
+ * degrades to unsigned so nobody ships an unsigned installer by accident.
+ *
+ * Forks and pull requests from forks never receive secrets, so the unsigned
+ * path is a first-class, supported outcome rather than a failure.
+ *
+ * Values are never logged — only the NAMES of the variables involved.
+ */
+
+export type SigningTargetOs = 'win' | 'mac' | 'linux';
+
+/** Repository secrets, mapped to env var names by the packaging workflow. */
+export const SIGNING_ENV_VARS = {
+	windowsCertificate: 'DESKTOP_WINDOWS_CERTIFICATE_BASE64',
+	windowsCertificatePassword: 'DESKTOP_WINDOWS_CERTIFICATE_PASSWORD',
+	macCertificate: 'DESKTOP_MACOS_CERTIFICATE_BASE64',
+	macCertificatePassword: 'DESKTOP_MACOS_CERTIFICATE_PASSWORD',
+	appleId: 'DESKTOP_APPLE_ID',
+	appleAppSpecificPassword: 'DESKTOP_APPLE_APP_SPECIFIC_PASSWORD',
+	appleTeamId: 'DESKTOP_APPLE_TEAM_ID'
+} as const;
+
+export interface SigningPlan {
+	os: SigningTargetOs;
+	/** True when electron-builder will actually sign the artifacts. */
+	signed: boolean;
+	/** True when macOS notarization credentials are also present. */
+	notarize: boolean;
+	/** False for platforms where signing does not apply (Linux). */
+	supported: boolean;
+	/** Env vars to hand electron-builder (values copied from the source env). */
+	env: Record<string, string>;
+	/** Extra `-c.<path>=<value>` CLI arguments. */
+	configArgs: string[];
+	/** Names of the missing secrets that caused a degrade (never values). */
+	missing: string[];
+	/** Loud, human-readable line to print when the build degrades to unsigned. */
+	warning?: string;
+}
+
+type EnvLike = Record<string, string | undefined>;
+
+function present(env: EnvLike, name: string): boolean {
+	const value = env[name];
+	return typeof value === 'string' && value.trim() !== '';
+}
+
+function missingOf(env: EnvLike, names: string[]): string[] {
+	return names.filter((name) => !present(env, name));
+}
+
+function unsignedWarning(os: SigningTargetOs, missing: string[]): string {
+	return [
+		`UNSIGNED BUILD (${os}): code-signing secrets are not available, so the installer will NOT be signed.`,
+		`Missing repository secrets: ${missing.join(', ')}.`,
+		'Users will see an OS publisher warning. This is expected for forks and pull requests;',
+		'release builds must run with the signing secrets configured.'
+	].join(' ');
+}
+
+/**
+ * Resolve the signing plan for one target OS from an environment snapshot.
+ * Pure: no filesystem, no process access.
+ */
+export function resolveSigningPlan(os: SigningTargetOs, env: EnvLike): SigningPlan {
+	if (os === 'linux') {
+		// electron-builder does not sign AppImage/deb artifacts; nothing to degrade.
+		return { os, signed: false, notarize: false, supported: false, env: {}, configArgs: [], missing: [] };
+	}
+
+	if (os === 'win') {
+		const required = [SIGNING_ENV_VARS.windowsCertificate, SIGNING_ENV_VARS.windowsCertificatePassword];
+		const missing = missingOf(env, required);
+		if (missing.length > 0) {
+			return {
+				os,
+				signed: false,
+				notarize: false,
+				supported: true,
+				// Stops electron-builder from picking up an unrelated certificate
+				// that happens to be installed on the build machine.
+				env: { CSC_IDENTITY_AUTO_DISCOVERY: 'false' },
+				configArgs: [],
+				missing,
+				warning: unsignedWarning(os, missing)
+			};
+		}
+		return {
+			os,
+			signed: true,
+			notarize: false,
+			supported: true,
+			env: {
+				// electron-builder accepts base64 certificate content directly in *_CSC_LINK.
+				WIN_CSC_LINK: env[SIGNING_ENV_VARS.windowsCertificate] as string,
+				WIN_CSC_KEY_PASSWORD: env[SIGNING_ENV_VARS.windowsCertificatePassword] as string
+			},
+			configArgs: [],
+			missing: []
+		};
+	}
+
+	const required = [SIGNING_ENV_VARS.macCertificate, SIGNING_ENV_VARS.macCertificatePassword];
+	const missing = missingOf(env, required);
+	if (missing.length > 0) {
+		return {
+			os,
+			signed: false,
+			notarize: false,
+			supported: true,
+			env: { CSC_IDENTITY_AUTO_DISCOVERY: 'false' },
+			configArgs: ['-c.mac.notarize=false'],
+			missing,
+			warning: unsignedWarning(os, missing)
+		};
+	}
+
+	const notarizeVars = [
+		SIGNING_ENV_VARS.appleId,
+		SIGNING_ENV_VARS.appleAppSpecificPassword,
+		SIGNING_ENV_VARS.appleTeamId
+	];
+	const notarizeMissing = missingOf(env, notarizeVars);
+	const notarize = notarizeMissing.length === 0;
+
+	const plan: SigningPlan = {
+		os,
+		signed: true,
+		notarize,
+		supported: true,
+		env: {
+			CSC_LINK: env[SIGNING_ENV_VARS.macCertificate] as string,
+			CSC_KEY_PASSWORD: env[SIGNING_ENV_VARS.macCertificatePassword] as string
+		},
+		configArgs: [`-c.mac.notarize=${notarize}`],
+		missing: notarizeMissing
+	};
+
+	if (notarize) {
+		plan.env.APPLE_ID = env[SIGNING_ENV_VARS.appleId] as string;
+		plan.env.APPLE_APP_SPECIFIC_PASSWORD = env[SIGNING_ENV_VARS.appleAppSpecificPassword] as string;
+		plan.env.APPLE_TEAM_ID = env[SIGNING_ENV_VARS.appleTeamId] as string;
+	} else {
+		plan.warning = [
+			'SIGNED BUT NOT NOTARIZED (mac): the app is code-signed, but Apple notarization credentials are absent,',
+			`so Gatekeeper will still warn on first launch. Missing repository secrets: ${notarizeMissing.join(', ')}.`
+		].join(' ');
+	}
+
+	return plan;
+}
+
+/** Map a Node.js `process.platform` value to a packaging target OS. */
+export function platformToTargetOs(platform: string): SigningTargetOs {
+	if (platform === 'win32') {
+		return 'win';
+	}
+	if (platform === 'darwin') {
+		return 'mac';
+	}
+	return 'linux';
+}
+
+/** One-line, secret-free summary of a plan, suitable for CI logs. */
+export function describeSigningPlan(plan: SigningPlan): string {
+	if (!plan.supported) {
+		return `[${plan.os}] code signing does not apply to this platform — artifacts are unsigned by design.`;
+	}
+	if (plan.signed && plan.notarize) {
+		return `[${plan.os}] signing: ENABLED, notarization: ENABLED.`;
+	}
+	if (plan.signed) {
+		return `[${plan.os}] signing: ENABLED, notarization: DISABLED.`;
+	}
+	return `[${plan.os}] signing: DISABLED (degraded to an unsigned build).`;
+}

--- a/apps/desktop/src/shared/ipc-contract.ts
+++ b/apps/desktop/src/shared/ipc-contract.ts
@@ -21,6 +21,69 @@ export type RuntimeId =
 /** Local services supervised by the desktop shell. */
 export type ServiceId = 'api' | 'web';
 
+/**
+ * How this install runs the platform.
+ *
+ * - `local-stack` — the desktop shell supervises its own API + web processes
+ *   (the original all-in-one behavior).
+ * - `remote-client` — no local stack at all: the shell is a native window onto
+ *   an Ever Works instance that already runs somewhere else (self-hosted, a
+ *   colleague's server, the hosted platform).
+ */
+export type DesktopMode = 'local-stack' | 'remote-client';
+
+export const DEFAULT_DESKTOP_MODE: DesktopMode = 'local-stack';
+
+/** User-entered remote instance details, before normalization/validation. */
+export interface RemoteConnectionInput {
+	/** Instance URL the window loads, e.g. `https://app.example.com`. */
+	webUrl: string;
+	/** API base URL. Derived from {@link webUrl} when omitted. */
+	apiUrl?: string;
+	/** Optional display label for the status screen. */
+	label?: string;
+}
+
+/** A normalized, validated remote instance the shell can connect to. */
+export interface RemoteConnection {
+	webUrl: string;
+	apiUrl: string;
+	label?: string;
+}
+
+/** Result of probing a remote instance's health endpoint. */
+export interface RemoteProbeResult {
+	ok: boolean;
+	status?: number;
+	/** Reported platform version, when the health payload exposes one. */
+	version?: string;
+	message?: string;
+}
+
+/**
+ * Where the supervised local services come from.
+ *
+ * - `bundled` — a self-contained runtime payload shipped inside the installer
+ *   (`resources/app-bundle`). No monorepo checkout, Node.js or pnpm needed.
+ * - `repo` — a developer monorepo checkout (dev runs, or `EVER_WORKS_REPO_ROOT`).
+ * - `unavailable` — neither is present; local-stack mode cannot start.
+ */
+export type RuntimeLayoutKind = 'bundled' | 'repo' | 'unavailable';
+
+export interface RuntimeLayoutSummary {
+	kind: RuntimeLayoutKind;
+	/** Absolute root of the bundled payload (`bundled` only). */
+	bundleRoot?: string;
+	/** Absolute monorepo checkout root (`repo` only). */
+	repoRoot?: string;
+	/** Version recorded in the bundle manifest (`bundled` only). */
+	bundleVersion?: string;
+	/** Why the layout resolved this way — always populated for `unavailable`. */
+	reason?: string;
+	/** True when the local stack needs Node.js + pnpm on PATH (repo layout). */
+	requiresHostToolchain: boolean;
+}
+
 /** Lifecycle states of a supervised child process. */
 export type ProcessState = 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'crashed' | 'failed';
 
@@ -87,8 +150,12 @@ export interface LogEntry {
 
 export interface DesktopConfig {
 	wizardCompleted: boolean;
+	/** Local stack vs. remote client. Defaults to {@link DEFAULT_DESKTOP_MODE}. */
+	mode: DesktopMode;
 	selection?: RuntimeSelection;
 	envFilePath?: string;
+	/** Only meaningful when `mode === 'remote-client'`. */
+	remote?: RemoteConnection;
 }
 
 export const IpcChannels = {
@@ -96,8 +163,12 @@ export const IpcChannels = {
 	listRuntimes: 'wizard:list-runtimes',
 	detectDocker: 'wizard:detect-docker',
 	applyRuntime: 'wizard:apply-runtime',
+	setMode: 'wizard:set-mode',
+	testRemote: 'wizard:test-remote',
+	saveRemote: 'wizard:save-remote',
 	completeWizard: 'wizard:complete',
 	getConfig: 'config:get',
+	getRuntimeLayout: 'app:runtime-layout',
 	startServices: 'services:start',
 	stopServices: 'services:stop',
 	restartService: 'services:restart',
@@ -114,8 +185,16 @@ export interface DesktopBridge {
 	listRuntimes(): Promise<RuntimeDescriptor[]>;
 	detectDocker(): Promise<{ available: boolean; version?: string }>;
 	applyRuntime(selection: RuntimeSelection): Promise<{ envFilePath: string; keys: string[] }>;
+	/** Switch between the local stack and remote-client modes. */
+	setMode(mode: DesktopMode): Promise<DesktopConfig>;
+	/** Validate + probe a remote instance without persisting it. */
+	testRemote(input: RemoteConnectionInput): Promise<RemoteProbeResult>;
+	/** Persist the remote instance the shell should connect to. */
+	saveRemote(input: RemoteConnectionInput): Promise<RemoteConnection>;
 	completeWizard(): Promise<void>;
 	getConfig(): Promise<DesktopConfig>;
+	/** Where the local services come from (bundled payload, repo checkout, or nothing). */
+	getRuntimeLayout(): Promise<RuntimeLayoutSummary>;
 	startServices(): Promise<void>;
 	stopServices(): Promise<void>;
 	restartService(id: ServiceId): Promise<void>;


### PR DESCRIPTION
## The problem

The desktop node could be run from a checkout but **not installed**. No signed
installer, no CI producing one, and the app assumed a developer toolchain was
already on the machine — so the "thin connected agent app" a non-technical owner
is supposed to install did not exist as an artifact.

## What changed

- **electron-builder packaging** (`electron-builder.yml`, `scripts/package-app.js`)
- **`prepare-bundle.js`** — stages a self-contained runtime payload so the
  installed app does not depend on a system Node being present
- **`desktop-build.yml`** CI workflow that actually produces the installers
- **`remote-connection` service** — the wizard needs to reach a platform that is
  not `localhost`, which was previously assumed

## Prereq check

Now reports *what* is missing rather than failing opaquely. For a non-developer
that is the difference between "this app is broken" and "install X, then retry".

## Merge

One trivial `.gitignore` conflict (dev-server logs vs. desktop packaging output)
— both sides kept.

## Gates

| Gate | Result |
|---|---|
| `apps/desktop` tsc --noEmit | green |
| `apps/desktop` vitest | green — 8 files, 100 tests |
| `pnpm build --filter=ever-works-api` | green (regression check) |
| prettier | clean |

API/agent/web gates not re-run: this branch touches only `apps/desktop`,
`.github/workflows` and `.gitignore`.