### PR TITLE
feat(onboarding,node): desktop-first wizard bucket and node resource limits

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/__tests__/desktop-wizard-seed.service.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/__tests__/desktop-wizard-seed.service.spec.ts
@@ -1,0 +1,195 @@
+import { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { config } from '../../../config/constants';
+import { TenantJobRuntimeService } from '../tenant-job-runtime.service';
+
+/**
+ * A9 — the desktop install wizard's runtime choice is PERSISTED to
+ * `tenant_job_runtime_config`.
+ *
+ * Before this, the wizard collected a runtime, wrote it into an env file, and
+ * the platform never recorded it anywhere a human or an admin API could see.
+ * The choice existed only as a string in a dotenv file on one laptop.
+ *
+ * The tests below pin the three things that make the lazy seed safe to run on
+ * every deployment: it is INERT without the desktop env var, it NEVER
+ * overwrites a row the tenant already has, and a failure degrades to the
+ * pre-existing synthetic-inherit response instead of a 500.
+ */
+
+const TENANT = '11111111-2222-4333-8444-555555555555';
+const ENV_KEY = 'EVER_WORKS_DESKTOP_JOB_RUNTIME';
+
+type ConfigRow = TenantJobRuntimeConfig;
+
+describe('TenantJobRuntimeService — desktop install wizard seed (A9)', () => {
+    let service: TenantJobRuntimeService;
+    let configRepo: { findOne: jest.Mock; create: jest.Mock; save: jest.Mock };
+    let auditRepo: { create: jest.Mock; save: jest.Mock };
+    const originalEnv = process.env[ENV_KEY];
+
+    beforeEach(() => {
+        configRepo = {
+            findOne: jest.fn(),
+            create: jest.fn((row) => row as ConfigRow),
+            save: jest.fn(
+                async (row) => ({ createdAt: null, updatedAt: null, ...row }) as ConfigRow,
+            ),
+        };
+        auditRepo = {
+            create: jest.fn((row) => row),
+            save: jest.fn(async (row) => row),
+        };
+        service = new TenantJobRuntimeService(
+            configRepo as never,
+            auditRepo as never,
+            { bumpVersion: jest.fn() } as unknown as CredentialVersionService,
+            undefined as never,
+            undefined as never,
+        );
+    });
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env[ENV_KEY];
+        } else {
+            process.env[ENV_KEY] = originalEnv;
+        }
+        jest.restoreAllMocks();
+    });
+
+    describe('config.tenantJobRuntime.getDesktopWizardProviderId', () => {
+        it('accepts both the plugin id and the bare provider id', () => {
+            process.env[ENV_KEY] = 'job-runtime-bullmq';
+            expect(config.tenantJobRuntime.getDesktopWizardProviderId()).toBe('bullmq');
+
+            process.env[ENV_KEY] = 'pgboss';
+            expect(config.tenantJobRuntime.getDesktopWizardProviderId()).toBe('pgboss');
+
+            process.env[ENV_KEY] = '  JOB-RUNTIME-NODE  ';
+            expect(config.tenantJobRuntime.getDesktopWizardProviderId()).toBe('node');
+        });
+
+        it('returns null for an unset value or an unknown runtime', () => {
+            delete process.env[ENV_KEY];
+            expect(config.tenantJobRuntime.getDesktopWizardProviderId()).toBeNull();
+
+            process.env[ENV_KEY] = '   ';
+            expect(config.tenantJobRuntime.getDesktopWizardProviderId()).toBeNull();
+
+            // A typo must be a no-op, never a row with a bogus providerId.
+            process.env[ENV_KEY] = 'job-runtime-bulmq';
+            expect(config.tenantJobRuntime.getDesktopWizardProviderId()).toBeNull();
+        });
+    });
+
+    describe('seedFromDesktopWizard', () => {
+        it('writes the wizard choice as the tenant overlay row', async () => {
+            process.env[ENV_KEY] = 'job-runtime-bullmq';
+
+            const seeded = await service.seedFromDesktopWizard(TENANT);
+
+            expect(seeded).not.toBeNull();
+            expect(configRepo.save).toHaveBeenCalledTimes(1);
+            expect(configRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tenantId: TENANT,
+                    providerId: 'bullmq',
+                    // `inherit`: the desktop's credentials come from the same
+                    // env the API already reads, so we record the CHOICE
+                    // without asserting a tenant credential pointer.
+                    mode: 'inherit',
+                    credentialsSecretRef: null,
+                    enabled: true,
+                    createdBy: null,
+                }),
+            );
+        });
+
+        it('leaves an audit trail attributing the row to the installer, not a user', async () => {
+            process.env[ENV_KEY] = 'pgboss';
+
+            await service.seedFromDesktopWizard(TENANT);
+
+            expect(auditRepo.save).toHaveBeenCalledTimes(1);
+            expect(auditRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tenantId: TENANT,
+                    action: 'desktop_wizard_seed',
+                    actorUserId: null,
+                    before: null,
+                }),
+            );
+        });
+
+        it('does nothing at all on a deployment with no desktop wizard', async () => {
+            delete process.env[ENV_KEY];
+
+            expect(await service.seedFromDesktopWizard(TENANT)).toBeNull();
+            expect(configRepo.save).not.toHaveBeenCalled();
+            expect(auditRepo.save).not.toHaveBeenCalled();
+        });
+
+        it('never surfaces a write failure — the read path must not 500', async () => {
+            process.env[ENV_KEY] = 'bullmq';
+            configRepo.save.mockRejectedValueOnce(new Error('unique violation'));
+
+            await expect(service.seedFromDesktopWizard(TENANT)).resolves.toBeNull();
+        });
+    });
+
+    describe('getConfig materialises the choice lazily', () => {
+        it('returns the seeded provider the first time a tenant reads its overlay', async () => {
+            process.env[ENV_KEY] = 'job-runtime-node';
+            configRepo.findOne.mockResolvedValue(null);
+
+            const response = await service.getConfig(TENANT);
+
+            expect(response.providerId).toBe('node');
+            expect(response.mode).toBe('inherit');
+            expect(response.tenantId).toBe(TENANT);
+        });
+
+        it('NEVER clobbers a runtime the tenant already chose in Settings', async () => {
+            process.env[ENV_KEY] = 'bullmq';
+            configRepo.findOne.mockResolvedValue({
+                tenantId: TENANT,
+                providerId: 'temporal',
+                mode: 'override',
+                credentialsSecretRef: 'inline:abcd',
+                credentialVersion: 3,
+                enabled: true,
+                createdBy: 'user-1',
+                createdAt: null,
+                updatedAt: null,
+            } as unknown as ConfigRow);
+
+            const response = await service.getConfig(TENANT);
+
+            expect(response.providerId).toBe('temporal');
+            expect(configRepo.save).not.toHaveBeenCalled();
+        });
+
+        it('still returns the synthetic inherit default when there is nothing to seed', async () => {
+            delete process.env[ENV_KEY];
+            configRepo.findOne.mockResolvedValue(null);
+
+            const response = await service.getConfig(TENANT);
+
+            expect(response).toEqual(
+                expect.objectContaining({ tenantId: TENANT, providerId: null, mode: 'inherit' }),
+            );
+        });
+
+        it('falls back to the synthetic default when the seed write fails', async () => {
+            process.env[ENV_KEY] = 'bullmq';
+            configRepo.findOne.mockResolvedValue(null);
+            configRepo.save.mockRejectedValueOnce(new Error('unique violation'));
+
+            const response = await service.getConfig(TENANT);
+
+            expect(response.providerId).toBeNull();
+            expect(response.mode).toBe('inherit');
+        });
+    });
+});

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.service.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.service.ts
@@ -116,9 +116,85 @@ export class TenantJobRuntimeService {
     async getConfig(tenantId: string): Promise<TenantJobRuntimeConfigResponseDto> {
         const row = await this.configRepository.findOne({ where: { tenantId } });
         if (!row) {
+            // A9 — a desktop install may have a runtime choice waiting to be
+            // recorded against this tenant. Returns null on every other kind
+            // of deployment, which keeps the original behaviour byte-exact.
+            const seeded = await this.seedFromDesktopWizard(tenantId);
+            if (seeded) {
+                return this.toResponse(seeded);
+            }
             return this.toSyntheticInherit(tenantId);
         }
         return this.toResponse(row);
+    }
+
+    /**
+     * A9 — persist the DESKTOP install wizard's runtime choice into
+     * `tenant_job_runtime_config`.
+     *
+     * ## Why it happens here
+     *
+     * The desktop wizard collects a runtime before the platform has a user,
+     * let alone a tenant: it writes the env file, THEN boots the API, and only
+     * later does somebody sign up. There is no moment during the wizard when
+     * an authenticated `PUT /config` could be made. So the choice rides in on
+     * `EVER_WORKS_DESKTOP_JOB_RUNTIME` and is materialised lazily, the first
+     * time a tenant reads its own overlay — by which point the tenant exists
+     * and we know exactly which row to write.
+     *
+     * ## Invariants
+     *
+     * - **Never clobbers.** Only called when the tenant has NO row. An
+     *   operator who has since picked a runtime in Settings keeps it; the
+     *   install-time default does not come back to overwrite them.
+     * - **`mode: 'inherit'`.** The desktop's credentials live in the same env
+     *   file the API already reads, so this records WHICH provider was chosen
+     *   without asserting a tenant-scoped credential pointer that does not
+     *   exist. Resolution behaviour is therefore unchanged; the row is a
+     *   faithful record of the wizard's answer.
+     * - **Best effort.** A failure here must not turn a settings-page read
+     *   into a 500 — the caller falls back to the synthetic inherit default.
+     *
+     * Returns the seeded row, or null when there was nothing to seed.
+     */
+    async seedFromDesktopWizard(tenantId: string): Promise<TenantJobRuntimeConfig | null> {
+        const providerId = config.tenantJobRuntime.getDesktopWizardProviderId();
+        if (!providerId) {
+            return null;
+        }
+        try {
+            const fresh = this.configRepository.create({
+                tenantId,
+                providerId,
+                mode: 'inherit' as const,
+                credentialsSecretRef: null,
+                credentialVersion: 1,
+                enabled: true,
+                // No actor: this is the installer's answer, not a user's.
+                createdBy: null,
+            });
+            const saved = await this.configRepository.save(fresh);
+            await this.emitAudit({
+                tenantId,
+                actorUserId: null,
+                action: 'desktop_wizard_seed',
+                before: null,
+                after: this.redactRowForAudit(saved),
+                credentialVersion: saved.credentialVersion,
+            });
+            this.logger.log(
+                `Recorded the desktop install wizard's job runtime '${providerId}' for tenant ${tenantId}`,
+            );
+            return saved;
+        } catch (error) {
+            // Losing a race with a concurrent write is the expected failure:
+            // whoever won already wrote a row, and the next read returns it.
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(
+                `Could not record the desktop wizard job runtime for tenant ${tenantId}: ${message}`,
+            );
+            return null;
+        }
     }
 
     /**

--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -271,6 +271,35 @@ export const config = {
         isPerTenantGatingEnabled: (): boolean =>
             (process.env.EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING ?? 'false').toLowerCase() ===
             'true',
+
+        /**
+         * A9 — the job runtime the DESKTOP install wizard collected, read
+         * from the env file the desktop shell generates
+         * (`EVER_WORKS_DESKTOP_JOB_RUNTIME`, written by
+         * `apps/desktop/src/services/runtime-setup.ts`).
+         *
+         * The wizard runs before anybody has signed in, so it cannot call
+         * the tenant-overlay admin API itself. This is the handoff: the
+         * value lands in the env of the API process the desktop shell
+         * supervises, and `TenantJobRuntimeService` materialises the
+         * `tenant_job_runtime_config` row for the tenant once one exists.
+         *
+         * Accepts both the plugin id (`job-runtime-bullmq`) and the bare
+         * provider id (`bullmq`); anything not in the bundled list returns
+         * null so a typo is a no-op rather than a bad row. Unset — i.e.
+         * every non-desktop deployment — is also null, which makes this
+         * whole path invisible to SaaS and k8s installs.
+         */
+        getDesktopWizardProviderId: (): string | null => {
+            const raw = (process.env.EVER_WORKS_DESKTOP_JOB_RUNTIME ?? '').trim().toLowerCase();
+            if (raw === '') {
+                return null;
+            }
+            const providerId = raw.replace(/^job-runtime-/, '');
+            return (BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS as readonly string[]).includes(providerId)
+                ? providerId
+                : null;
+        },
     },
 
     features: {

--- a/apps/api/src/onboarding/dto/onboarding-state.dto.ts
+++ b/apps/api/src/onboarding/dto/onboarding-state.dto.ts
@@ -18,6 +18,7 @@ import type {
     OnboardingDbChoice,
     OnboardingDeployChoice,
     OnboardingProfile,
+    OnboardingDesktopChoice,
     OnboardingStorageChoice,
     OnboardingWizardStateV2,
     OnboardingCatalogResponse,
@@ -43,6 +44,9 @@ const DEPLOY_CHOICES: readonly OnboardingDeployChoice[] = ['ever-works', 'vercel
 
 const DB_CHOICES: readonly OnboardingDbChoice[] = ['ever-works-db', 'custom'];
 
+// A8 — desktop-first bucket: where the user actually runs Ever Works.
+const DESKTOP_CHOICES: readonly OnboardingDesktopChoice[] = ['cloud', 'desktop', 'own-nodes'];
+
 class AiChoicePatchDto {
     @ApiProperty({ enum: AI_CHOICES })
     @IsIn(AI_CHOICES)
@@ -65,6 +69,12 @@ class DbChoicePatchDto {
     @ApiProperty({ enum: DB_CHOICES })
     @IsIn(DB_CHOICES)
     choice!: OnboardingDbChoice;
+}
+
+class DesktopChoicePatchDto {
+    @ApiProperty({ enum: DESKTOP_CHOICES })
+    @IsIn(DESKTOP_CHOICES)
+    choice!: OnboardingDesktopChoice;
 }
 
 // Wave 11 — "What do you do" profile answers. Ids come from the typed
@@ -125,6 +135,14 @@ export class OnboardingStatePatchInnerDto {
     @ValidateNested()
     @Type(() => DeployChoicePatchDto)
     deploy?: DeployChoicePatchDto;
+
+    // A8 — desktop-first bucket. Additive and optional: a client that never
+    // sends it keeps the persisted value (or the `cloud` default).
+    @ApiPropertyOptional({ type: DesktopChoicePatchDto })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => DesktopChoicePatchDto)
+    desktop?: DesktopChoicePatchDto;
 
     // Security: bound array size and element length to prevent large-payload DoS writes to onboarding_state column
     @ApiPropertyOptional({ type: [String] })
@@ -203,7 +221,10 @@ export class OnboardingCatalogResponseDto implements OnboardingCatalogResponse {
     deploy!: OnboardingCatalogResponse['deploy'];
 
     @ApiProperty()
+    desktop!: OnboardingCatalogResponse['desktop'];
+
+    @ApiProperty()
     plugins!: OnboardingCatalogResponse['plugins'];
 }
 
-export { AI_CHOICES, STORAGE_CHOICES, DB_CHOICES, DEPLOY_CHOICES };
+export { AI_CHOICES, STORAGE_CHOICES, DB_CHOICES, DEPLOY_CHOICES, DESKTOP_CHOICES };

--- a/apps/api/src/onboarding/onboarding-catalog.service.ts
+++ b/apps/api/src/onboarding/onboarding-catalog.service.ts
@@ -8,6 +8,7 @@ import type {
     OnboardingStorageChoice,
     OnboardingDbChoice,
     OnboardingDeployChoice,
+    OnboardingDesktopChoice,
     OnboardingPluginCard,
 } from '@ever-works/contracts/api';
 
@@ -200,6 +201,40 @@ export class OnboardingCatalogService {
             },
         ];
 
+        // A8 — the desktop-first bucket. Unlike the four above it names no
+        // provider and reserves no plugin id: it records WHERE Ever Works
+        // runs, which is what decides the guidance the wizard's last step
+        // gives (see `ONBOARDING_DESKTOP_NEXT_STEPS`). All three are always
+        // available — none of them depends on a feature flag or a key.
+        const desktop: ReadonlyArray<OnboardingCard<OnboardingDesktopChoice>> = [
+            {
+                choice: 'cloud',
+                title: 'The hosted platform',
+                description: 'Everything runs on Ever Works. Nothing to install.',
+                default: true,
+                available: true,
+                badges: ['default'],
+            },
+            {
+                choice: 'desktop',
+                title: 'On my machine',
+                description:
+                    'Ever Works Desktop runs the API and web app locally and supervises them for you.',
+                default: false,
+                available: true,
+                badges: [],
+            },
+            {
+                choice: 'own-nodes',
+                title: 'On my own machines',
+                description:
+                    'The platform runs wherever you like, but your machines execute the work — enroll them as Fleet nodes.',
+                default: false,
+                available: true,
+                badges: [],
+            },
+        ];
+
         const reservedPluginIds = new Set<string>(
             [
                 ...ai.map((c) => c.pluginId),
@@ -212,7 +247,7 @@ export class OnboardingCatalogService {
 
         const plugins = this.collectPluginsStepCards(reservedPluginIds);
 
-        return { ai, storage, db, deploy, plugins };
+        return { ai, storage, db, deploy, desktop, plugins };
     }
 
     private collectPluginsStepCards(reservedPluginIds: Set<string>): OnboardingPluginCard[] {

--- a/apps/api/src/onboarding/onboarding-state.service.ts
+++ b/apps/api/src/onboarding/onboarding-state.service.ts
@@ -266,6 +266,12 @@ function normaliseState(raw: OnboardingWizardStateV2 | null | undefined): Onboar
         storage: { choice: raw.storage?.choice ?? ONBOARDING_DEFAULT_STATE.storage.choice },
         db: { choice: raw.db?.choice ?? ONBOARDING_DEFAULT_STATE.db.choice },
         deploy: { choice: raw.deploy?.choice ?? ONBOARDING_DEFAULT_STATE.deploy.choice },
+        // A8 — desktop-first bucket. A state blob written before this bucket
+        // existed has no `desktop` key and reads as the `cloud` default, so
+        // upgrading never changes an existing user's first-run path.
+        desktop: {
+            choice: raw.desktop?.choice ?? ONBOARDING_DEFAULT_STATE.desktop?.choice ?? 'cloud',
+        },
         skippedSteps: Array.isArray(raw.skippedSteps) ? [...raw.skippedSteps] : [],
         pluginsReviewed: raw.pluginsReviewed === true,
         // EW-722: contract-declared optional `prompt` (EW-617 G4) round-trips
@@ -320,6 +326,18 @@ function mergeState(
             choice: patch.db?.choice ?? current.db?.choice ?? ONBOARDING_DEFAULT_STATE.db.choice,
         },
         deploy: { choice: patch.deploy?.choice ?? current.deploy.choice },
+        // A8 — desktop bucket. It has to be merged here as well as
+        // normalised on read: a merge that omitted it would drop the user's
+        // choice on the next unrelated patch, and — because the idempotence
+        // check compares the normalised current against the merged next —
+        // would also make every no-op patch write.
+        desktop: {
+            choice:
+                patch.desktop?.choice ??
+                current.desktop?.choice ??
+                ONBOARDING_DEFAULT_STATE.desktop?.choice ??
+                'cloud',
+        },
         skippedSteps: Array.isArray(patch.skippedSteps)
             ? [...patch.skippedSteps]
             : [...current.skippedSteps],

--- a/apps/desktop-node/src/main/identity.spec.ts
+++ b/apps/desktop-node/src/main/identity.spec.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import type { HeartbeatState, NodeConfig } from 'ever-works-node';
-import { CLOUD_API_URL, LOCAL_DESKTOP_API_URL, type EnrollRequest } from '../shared/ipc-contract';
-import { enrollRequestValid, resolveEnrollApiUrl, toIdentityView, toStatusView } from './identity';
+import type { HeartbeatState, NodeConfig, WorkerLoopState } from 'ever-works-node';
+import { CLOUD_API_URL, IDLE_WORKER_STATUS, LOCAL_DESKTOP_API_URL, type EnrollRequest } from '../shared/ipc-contract';
+import {
+	authenticateRequestValid,
+	enrollRequestValid,
+	requestedEnrollMode,
+	resolveEnrollApiUrl,
+	resolveNodeName,
+	toIdentityView,
+	toStatusView,
+	toWorkerStatusView
+} from './identity';
 
 const SECRET = 'ZmFrZS1zZWNyZXQtdmFsdWUtZm9yLXVuaXQtdGVzdHM';
 const TOKEN = 'ZmFrZS1lbnJvbGxtZW50LXRva2VuLWZvci10ZXN0aW5n';
@@ -51,14 +60,30 @@ describe('toIdentityView', () => {
 			apiUrl: CLOUD_API_URL,
 			kind: 'desktop-node',
 			capabilities: ['os:win32', 'docker', 'display'],
+			limits: { maxConcurrentJobs: 1, maxCpuPercent: null, maxMemoryMb: null },
 			name: 'my-laptop',
 			heartbeatIntervalMs: 60_000,
 			enrolledAt: '2026-07-25T10:00:00.000Z'
 		});
 	});
 
+	it('carries the operator capability opt-in and resource ceilings', () => {
+		const view = toIdentityView(
+			config({
+				capabilitySelection: ['docker'],
+				limits: { maxConcurrentJobs: 4, maxCpuPercent: 70, maxMemoryMb: 8_192 }
+			})
+		);
+		expect(view.capabilitySelection).toEqual(['docker']);
+		expect(view.limits).toEqual({ maxConcurrentJobs: 4, maxCpuPercent: 70, maxMemoryMb: 8_192 });
+	});
+
 	it('reports a clean not-enrolled view when there is no config', () => {
-		expect(toIdentityView(null)).toEqual({ enrolled: false, capabilities: [] });
+		expect(toIdentityView(null)).toEqual({
+			enrolled: false,
+			capabilities: [],
+			limits: { maxConcurrentJobs: 1, maxCpuPercent: null, maxMemoryMb: null }
+		});
 	});
 
 	it('omits the optional label rather than emitting undefined', () => {
@@ -93,8 +118,29 @@ describe('toStatusView', () => {
 			consecutiveFailures: 0,
 			nextAttemptInMs: 60_000,
 			lastError: null,
-			platformStatus: 'online'
+			platformStatus: 'online',
+			worker: IDLE_WORKER_STATUS
 		});
+	});
+
+	it('shows a connected node that the operator has paused (A18)', () => {
+		// "Connected but paused" is exactly the state pause/resume produces,
+		// and the two loops are independent — so it has to be representable.
+		const worker = toWorkerStatusView({
+			state: 'paused',
+			activeJobIds: [],
+			consecutiveFailures: 0,
+			completed: 7,
+			failed: 1,
+			lastError: null,
+			paused: true,
+			throttleReason: null
+		});
+		const view = toStatusView(state(), worker);
+
+		expect(view.state).toBe('connected');
+		expect(view.worker.paused).toBe(true);
+		expect(view.worker.completed).toBe(7);
 	});
 
 	it('carries the failure detail and backoff while retrying', () => {
@@ -141,11 +187,66 @@ describe('resolveEnrollApiUrl (main-side re-validation)', () => {
 	});
 });
 
+describe('toWorkerStatusView', () => {
+	it('reports a disabled worker when the node only reports liveness', () => {
+		expect(toWorkerStatusView(null)).toEqual(IDLE_WORKER_STATUS);
+		expect(toWorkerStatusView(undefined).enabled).toBe(false);
+	});
+
+	it('surfaces the throttle reason so the operator sees WHY nothing is running', () => {
+		const state: WorkerLoopState = {
+			state: 'throttled',
+			activeJobIds: [],
+			consecutiveFailures: 0,
+			completed: 0,
+			failed: 0,
+			lastError: null,
+			paused: false,
+			throttleReason: 'host CPU 95% is at or above the 80% ceiling'
+		};
+		const view = toWorkerStatusView(state);
+		expect(view.enabled).toBe(true);
+		expect(view.state).toBe('throttled');
+		expect(view.throttleReason).toContain('CPU');
+	});
+});
+
 describe('enrollRequestValid', () => {
-	it('accepts a complete request and rejects a bad token or unusable host', () => {
+	it('accepts a complete token request and rejects a bad token or unusable host', () => {
 		expect(enrollRequestValid({ host: 'cloud', token: TOKEN })).toBe(true);
 		expect(enrollRequestValid({ host: 'cloud', token: 'short' })).toBe(false);
 		expect(enrollRequestValid({ host: 'self-hosted', token: TOKEN })).toBe(false);
 		expect(enrollRequestValid({ host: 'cloud' } as EnrollRequest)).toBe(false);
+	});
+
+	it('re-validates the sign-in leg main-side — the renderer is not a trust boundary', () => {
+		expect(requestedEnrollMode({ host: 'cloud', mode: 'sign-in', email: 'a@b.co', password: 'pw' })).toBe(
+			'sign-in'
+		);
+		expect(enrollRequestValid({ host: 'cloud', mode: 'sign-in', email: 'a@b.co', password: 'pw' })).toBe(true);
+		expect(enrollRequestValid({ host: 'cloud', mode: 'sign-in', email: 'a@b.co' })).toBe(false);
+		expect(enrollRequestValid({ host: 'cloud', mode: 'sign-in', email: 'nope', password: 'pw' })).toBe(false);
+		// A renderer cannot smuggle a token past the sign-in leg's checks.
+		expect(enrollRequestValid({ host: 'cloud', mode: 'sign-in', token: TOKEN })).toBe(false);
+	});
+
+	it('defaults to the token leg when no mode is declared', () => {
+		expect(requestedEnrollMode({ host: 'cloud', token: TOKEN })).toBe('token');
+	});
+});
+
+describe('authenticateRequestValid', () => {
+	it('requires a usable host and plausible credentials', () => {
+		expect(authenticateRequestValid({ host: 'cloud', email: 'a@b.co', password: 'pw' })).toBe(true);
+		expect(authenticateRequestValid({ host: 'self-hosted', email: 'a@b.co', password: 'pw' })).toBe(false);
+		expect(authenticateRequestValid({ host: 'cloud', email: '', password: 'pw' })).toBe(false);
+	});
+});
+
+describe('resolveNodeName', () => {
+	it('uses the operator label, falling back to a stable non-identifying default', () => {
+		expect(resolveNodeName({ host: 'cloud', name: '  Studio Mac ' })).toBe('Studio Mac');
+		expect(resolveNodeName({ host: 'cloud' })).toBe('Desktop Node');
+		expect(resolveNodeName({ host: 'cloud', name: '   ' })).toBe('Desktop Node');
 	});
 });

--- a/apps/desktop-node/src/main/identity.ts
+++ b/apps/desktop-node/src/main/identity.ts
@@ -1,10 +1,22 @@
-import { normalizeApiUrl, redactConfig, type HeartbeatState, type NodeConfig } from 'ever-works-node';
+import {
+	clampResourceLimits,
+	credentialsLookUsable,
+	normalizeApiUrl,
+	redactConfig,
+	type HeartbeatState,
+	type NodeConfig,
+	type WorkerLoopState
+} from 'ever-works-node';
 import {
 	API_HOST_OPTIONS,
+	IDLE_WORKER_STATUS,
 	MIN_TOKEN_LENGTH,
+	type AuthenticateRequest,
 	type ConnectionStatusView,
+	type EnrollMode,
 	type EnrollRequest,
-	type NodeIdentityView
+	type NodeIdentityView,
+	type WorkerStatusView
 } from '../shared/ipc-contract';
 
 /**
@@ -17,12 +29,16 @@ import {
  * is built on the core's `redactConfig` and structurally cannot carry it.
  */
 
-export const NOT_ENROLLED: NodeIdentityView = { enrolled: false, capabilities: [] };
+export const NOT_ENROLLED: NodeIdentityView = {
+	enrolled: false,
+	capabilities: [],
+	limits: clampResourceLimits(null)
+};
 
 /** Project the stored config into the renderer-safe identity view. */
 export function toIdentityView(config: NodeConfig | null): NodeIdentityView {
 	if (!config) {
-		return { ...NOT_ENROLLED };
+		return { ...NOT_ENROLLED, limits: clampResourceLimits(null) };
 	}
 	const redacted = redactConfig(config);
 	const view: NodeIdentityView = {
@@ -31,24 +47,51 @@ export function toIdentityView(config: NodeConfig | null): NodeIdentityView {
 		apiUrl: redacted.apiUrl,
 		kind: redacted.kind,
 		capabilities: redacted.capabilities,
+		limits: redacted.limits,
 		heartbeatIntervalMs: redacted.heartbeatIntervalMs,
 		enrolledAt: redacted.enrolledAt
 	};
+	if (redacted.capabilitySelection !== undefined) {
+		view.capabilitySelection = redacted.capabilitySelection;
+	}
 	if (redacted.name !== undefined) {
 		view.name = redacted.name;
 	}
 	return view;
 }
 
-/** Project the heartbeat loop's state into the status view. */
-export function toStatusView(state: HeartbeatState): ConnectionStatusView {
+/** Project the worker loop's state into the renderer-safe work view (A18). */
+export function toWorkerStatusView(state: WorkerLoopState | null | undefined): WorkerStatusView {
+	if (!state) {
+		return { ...IDLE_WORKER_STATUS };
+	}
+	return {
+		enabled: true,
+		paused: state.paused,
+		state: state.state,
+		activeJobCount: state.activeJobIds.length,
+		completed: state.completed,
+		failed: state.failed,
+		throttleReason: state.throttleReason
+	};
+}
+
+/**
+ * Project the heartbeat loop's state into the status view.
+ *
+ * `worker` is passed in rather than derived: the heartbeat and the worker are
+ * independent loops, and the status window must be able to show "connected but
+ * paused" — the exact state pause/resume produces.
+ */
+export function toStatusView(state: HeartbeatState, worker?: WorkerStatusView): ConnectionStatusView {
 	return {
 		state: state.state,
 		lastHeartbeatAt: state.lastHeartbeatAt,
 		consecutiveFailures: state.consecutiveFailures,
 		nextAttemptInMs: state.nextAttemptInMs,
 		lastError: state.lastError,
-		platformStatus: state.node?.status ?? null
+		platformStatus: state.node?.status ?? null,
+		worker: worker ?? { ...IDLE_WORKER_STATUS }
 	};
 }
 
@@ -58,7 +101,8 @@ export const IDLE_STATUS: ConnectionStatusView = {
 	consecutiveFailures: 0,
 	nextAttemptInMs: null,
 	lastError: null,
-	platformStatus: null
+	platformStatus: null,
+	worker: { ...IDLE_WORKER_STATUS }
 };
 
 /**
@@ -70,7 +114,7 @@ export const IDLE_STATUS: ConnectionStatusView = {
  * core's `normalizeApiUrl`. Returns null when the request cannot produce a
  * usable URL.
  */
-export function resolveEnrollApiUrl(request: EnrollRequest): string | null {
+export function resolveEnrollApiUrl(request: EnrollRequest | AuthenticateRequest): string | null {
 	const option = API_HOST_OPTIONS.find((candidate) => candidate.id === request.host);
 	if (!option) {
 		return null;
@@ -86,11 +130,39 @@ export function resolveEnrollApiUrl(request: EnrollRequest): string | null {
 	}
 }
 
-/** Main-side token shape check — mirrors the API's credential bounds. */
+/** The enrollment mode the main process will actually run. Defaults to `token`. */
+export function requestedEnrollMode(request: EnrollRequest): EnrollMode {
+	return request?.mode === 'sign-in' ? 'sign-in' : 'token';
+}
+
+/**
+ * Main-side credential shape check.
+ *
+ * The renderer already validates its own inputs, but a renderer is never a
+ * trust boundary — so both legs (pasted token, sign-in) are re-checked here
+ * against the same bounds the API enforces.
+ */
 export function enrollRequestValid(request: EnrollRequest): boolean {
-	return (
-		typeof request?.token === 'string' &&
-		request.token.trim().length >= MIN_TOKEN_LENGTH &&
-		resolveEnrollApiUrl(request) !== null
-	);
+	if (resolveEnrollApiUrl(request) === null) {
+		return false;
+	}
+	if (requestedEnrollMode(request) === 'sign-in') {
+		return credentialsLookUsable(request.email, request.password);
+	}
+	return typeof request?.token === 'string' && request.token.trim().length >= MIN_TOKEN_LENGTH;
+}
+
+/** Main-side sign-in shape check (A14). */
+export function authenticateRequestValid(request: AuthenticateRequest): boolean {
+	return resolveEnrollApiUrl(request) !== null && credentialsLookUsable(request?.email, request?.password);
+}
+
+/**
+ * Node name registered with the platform when the app mints its own token.
+ * Falls back to a stable, non-identifying label rather than anything derived
+ * from the host — an operator who wants their hostname in Fleet can type it.
+ */
+export function resolveNodeName(request: EnrollRequest): string {
+	const label = request.name?.trim();
+	return label && label.length > 0 ? label : 'Desktop Node';
 }

--- a/apps/desktop-node/src/main/main.ts
+++ b/apps/desktop-node/src/main/main.ts
@@ -3,13 +3,17 @@ import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import {
 	NODE_APP_VERSION,
+	PlatformAuthClient,
+	clampResourceLimits,
 	createBufferedLogger,
 	createCommandRunner,
 	createConfigFileSystem,
 	createNodeRuntime,
+	createResourceProbe,
 	currentEnvironment,
 	describeSelf,
 	enrollNode,
+	enrollNodeWithCredentials,
 	loadConfig,
 	saveConfig,
 	systemFetch,
@@ -18,9 +22,27 @@ import {
 	type NodeIo,
 	type NodeRuntime
 } from 'ever-works-node';
-import type { ConnectionStatusView, EnrollRequest, EnrollOutcome, NodeIdentityView } from '../shared/ipc-contract';
-import { API_HOST_OPTIONS, IpcChannels } from '../shared/ipc-contract';
-import { IDLE_STATUS, enrollRequestValid, resolveEnrollApiUrl, toIdentityView, toStatusView } from './identity';
+import type {
+	AuthenticateOutcome,
+	AuthenticateRequest,
+	ConnectionStatusView,
+	EnrollRequest,
+	EnrollOutcome,
+	NodeIdentityView,
+	WorkerStatusView
+} from '../shared/ipc-contract';
+import { API_HOST_OPTIONS, IDLE_WORKER_STATUS, IpcChannels } from '../shared/ipc-contract';
+import {
+	IDLE_STATUS,
+	authenticateRequestValid,
+	enrollRequestValid,
+	requestedEnrollMode,
+	resolveEnrollApiUrl,
+	resolveNodeName,
+	toIdentityView,
+	toStatusView,
+	toWorkerStatusView
+} from './identity';
 import { createTray } from './tray';
 
 /**
@@ -79,9 +101,14 @@ function bootstrap(): void {
 	};
 
 	const fs = createConfigFileSystem();
+	const resourceProbe = createResourceProbe();
 	let config: NodeConfig | null = null;
 	let runtime: NodeRuntime | null = null;
 	let status: ConnectionStatusView = { ...IDLE_STATUS };
+	let workerStatus: WorkerStatusView = { ...IDLE_WORKER_STATUS };
+	// Survives disconnect/reconnect: an operator who paused the node expects it
+	// to still be paused after a reconnect, not quietly back at work.
+	let pausedByOperator = false;
 
 	const publishStatus = (next: ConnectionStatusView): void => {
 		status = next;
@@ -89,14 +116,31 @@ function bootstrap(): void {
 		tray?.update(next);
 	};
 
+	/** Re-emit the current status with a refreshed worker projection. */
+	const republish = (): void => publishStatus({ ...status, worker: workerStatus });
+
 	const connect = (): void => {
 		if (!config || runtime) {
 			return;
 		}
-		const created = createNodeRuntime(config, io);
-		created.loop.onChange((state) => publishStatus(toStatusView(state)));
+		const created = createNodeRuntime(config, io, {
+			// A desktop node exists to DO work; the ceilings the operator set
+			// in the wizard are what makes that safe to enable by default.
+			workerEnabled: true,
+			limits: clampResourceLimits(config.limits),
+			resourceProbe,
+			startPaused: pausedByOperator
+		});
+		created.loop.onChange((state) => publishStatus(toStatusView(state, workerStatus)));
+		created.worker?.onChange((state) => {
+			workerStatus = toWorkerStatusView(state);
+			pausedByOperator = state.paused;
+			republish();
+		});
+		workerStatus = toWorkerStatusView(created.worker?.getState());
 		runtime = created;
 		void created.loop.start();
+		void created.worker?.start();
 	};
 
 	const disconnect = async (): Promise<void> => {
@@ -106,14 +150,80 @@ function bootstrap(): void {
 		const current = runtime;
 		runtime = null;
 		current.loop.stop();
-		await current.loop.settled();
-		publishStatus({ ...IDLE_STATUS, state: 'stopped' });
+		// Drains: in-flight jobs report their verdicts instead of being
+		// abandoned to a lease expiry.
+		await Promise.all([current.loop.settled(), current.worker?.stop() ?? Promise.resolve()]);
+		workerStatus = { ...IDLE_WORKER_STATUS, paused: pausedByOperator };
+		publishStatus({ ...IDLE_STATUS, state: 'stopped', worker: workerStatus });
+	};
+
+	/**
+	 * A18 — pause/resume, wired to the worker loop's real state rather than a
+	 * UI-only flag. Pausing stops LEASING; the heartbeat keeps running so the
+	 * node stays visible in Fleet, and jobs already executing still finish and
+	 * report.
+	 */
+	const pause = (): void => {
+		pausedByOperator = true;
+		if (runtime?.worker) {
+			runtime.worker.pause();
+			return;
+		}
+		// Not connected yet: remember the intent so `connect()` starts paused.
+		workerStatus = { ...workerStatus, paused: true };
+		republish();
+	};
+
+	const resume = (): void => {
+		pausedByOperator = false;
+		if (runtime?.worker) {
+			runtime.worker.resume();
+			return;
+		}
+		workerStatus = { ...workerStatus, paused: false };
+		republish();
+	};
+
+	/**
+	 * A14 — verify platform credentials without enrolling. Lets the wizard
+	 * fail fast on a typo instead of surfacing it several steps later.
+	 */
+	const authenticate = async (request: AuthenticateRequest): Promise<AuthenticateOutcome> => {
+		if (!authenticateRequestValid(request)) {
+			return { ok: false, error: 'Choose an API host and enter your email and password.' };
+		}
+		const apiUrl = resolveEnrollApiUrl(request);
+		if (!apiUrl) {
+			return { ok: false, error: 'That API URL is not usable.' };
+		}
+		try {
+			const auth = new PlatformAuthClient({
+				apiUrl,
+				fetchFn: io.fetchFn,
+				logger,
+				userAgent: io.userAgent
+			});
+			const session = await auth.signIn(request.email, request.password);
+			logger.info(`Signed in to ${apiUrl}`);
+			return { ok: true, ...(session.email ? { email: session.email } : {}) };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const safe = logger.redact(message);
+			logger.warn(`Sign-in failed: ${safe}`);
+			return { ok: false, error: safe };
+		}
 	};
 
 	const enroll = async (request: EnrollRequest): Promise<EnrollOutcome> => {
 		// The renderer is not a trust boundary: re-validate here.
 		if (!enrollRequestValid(request)) {
-			return { ok: false, error: 'Choose an API host and paste a complete enrollment token.' };
+			return {
+				ok: false,
+				error:
+					requestedEnrollMode(request) === 'sign-in'
+						? 'Choose an API host and enter your email and password.'
+						: 'Choose an API host and paste a complete enrollment token.'
+			};
 		}
 		const apiUrl = resolveEnrollApiUrl(request);
 		if (!apiUrl) {
@@ -122,15 +232,28 @@ function bootstrap(): void {
 
 		try {
 			await disconnect();
-			const enrolled = await enrollNode({
+			// Both legs converge on the same single-use-token protocol; only
+			// the way the token is OBTAINED differs (A14).
+			const common = {
 				...io,
 				apiUrl,
-				token: request.token.trim(),
-				kind: 'desktop-node',
-				...(request.name ? { name: request.name } : {})
-			});
+				kind: 'desktop-node' as const,
+				...(request.name ? { name: request.name } : {}),
+				...(request.capabilities ? { capabilitySelection: request.capabilities } : {}),
+				...(request.limits ? { limits: request.limits } : {})
+			};
+			const enrolled =
+				requestedEnrollMode(request) === 'sign-in'
+					? await enrollNodeWithCredentials({
+							...common,
+							email: (request.email ?? '').trim(),
+							password: request.password ?? '',
+							nodeName: resolveNodeName(request)
+						})
+					: await enrollNode({ ...common, token: (request.token ?? '').trim() });
 			await saveConfig(fs, configPath, enrolled, { platform: process.platform });
 			config = enrolled;
+			pausedByOperator = false;
 			connect();
 			return { ok: true, identity: toIdentityView(config) };
 		} catch (error) {
@@ -150,6 +273,8 @@ function bootstrap(): void {
 	const unenroll = async (): Promise<void> => {
 		await disconnect();
 		config = null;
+		pausedByOperator = false;
+		workerStatus = { ...IDLE_WORKER_STATUS };
 		try {
 			await fsp.rm(configPath, { force: true });
 		} catch (error) {
@@ -165,13 +290,18 @@ function bootstrap(): void {
 
 	ipcMain.handle(IpcChannels.listApiHosts, () => API_HOST_OPTIONS);
 	ipcMain.handle(IpcChannels.detectCapabilities, async () => {
+		// Unfiltered: the wizard needs the full detected set to render the
+		// capability CHOICES, and the operator's opt-in is applied later.
 		const description = await describeSelf(io.runner, io.environment, io.version);
 		return description.capabilities;
 	});
+	ipcMain.handle(IpcChannels.authenticate, (_event, request: AuthenticateRequest) => authenticate(request));
 	ipcMain.handle(IpcChannels.enroll, (_event, request: EnrollRequest) => enroll(request));
 	ipcMain.handle(IpcChannels.getConfig, (): NodeIdentityView => toIdentityView(config));
 	ipcMain.handle(IpcChannels.connect, () => connect());
 	ipcMain.handle(IpcChannels.disconnect, () => disconnect());
+	ipcMain.handle(IpcChannels.pause, () => pause());
+	ipcMain.handle(IpcChannels.resume, () => resume());
 	ipcMain.handle(IpcChannels.getStatus, () => status);
 	ipcMain.handle(IpcChannels.getLogs, () => logger.entries());
 	ipcMain.handle(IpcChannels.unenroll, () => unenroll());
@@ -233,6 +363,8 @@ function bootstrap(): void {
 		},
 		onConnect: () => connect(),
 		onDisconnect: () => void disconnect(),
+		onPause: () => pause(),
+		onResume: () => resume(),
 		onQuit: () => {
 			quitting = true;
 			app.quit();

--- a/apps/desktop-node/src/main/preload.ts
+++ b/apps/desktop-node/src/main/preload.ts
@@ -1,21 +1,31 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { ConnectionStatusView, DesktopNodeBridge, EnrollRequest, LogEntry } from '../shared/ipc-contract';
+import type {
+	AuthenticateRequest,
+	ConnectionStatusView,
+	DesktopNodeBridge,
+	EnrollRequest,
+	LogEntry
+} from '../shared/ipc-contract';
 
 // IMPORTANT: this preload runs sandboxed — it cannot require local modules,
 // so channel names are inlined as string literals. Keep them in sync with
 // `IpcChannels` in src/shared/ipc-contract.ts (types are erased at compile
 // time, so the type-only import above is sandbox-safe).
 //
-// The bridge is deliberately narrow: the renderer can ASK to enroll (sending a
-// token in) but can never read a credential back out.
+// The bridge is deliberately narrow: the renderer can ASK to authenticate or
+// enroll (sending a password or token IN) but can never read a credential back
+// out — every outcome type is credential-free by construction.
 
 const bridge: DesktopNodeBridge = {
 	listApiHosts: () => ipcRenderer.invoke('wizard:list-api-hosts'),
 	detectCapabilities: () => ipcRenderer.invoke('wizard:detect-capabilities'),
+	authenticate: (request: AuthenticateRequest) => ipcRenderer.invoke('wizard:authenticate', request),
 	enroll: (request: EnrollRequest) => ipcRenderer.invoke('wizard:enroll', request),
 	getConfig: () => ipcRenderer.invoke('config:get'),
 	connect: () => ipcRenderer.invoke('node:connect'),
 	disconnect: () => ipcRenderer.invoke('node:disconnect'),
+	pause: () => ipcRenderer.invoke('node:pause'),
+	resume: () => ipcRenderer.invoke('node:resume'),
 	getStatus: () => ipcRenderer.invoke('node:status'),
 	getLogs: () => ipcRenderer.invoke('node:logs'),
 	unenroll: () => ipcRenderer.invoke('node:unenroll'),

--- a/apps/desktop-node/src/main/tray.ts
+++ b/apps/desktop-node/src/main/tray.ts
@@ -11,6 +11,10 @@ export interface TrayHandlers {
 	onShow(): void;
 	onConnect(): void;
 	onDisconnect(): void;
+	/** Stop leasing new work without disconnecting (A18). */
+	onPause(): void;
+	/** Resume leasing after a pause (A18). */
+	onResume(): void;
 	onQuit(): void;
 }
 
@@ -27,15 +31,31 @@ export function createTray(handlers: TrayHandlers): NodeTray {
 	const render = (status?: ConnectionStatusView): void => {
 		const summary = status ? describeStatus(status) : 'Not connected';
 		const connected = isLive(status);
-		tray.setToolTip(`Ever Works Desktop Node — ${summary}`);
+		const paused = status?.worker.paused === true;
+		const active = status?.worker.activeJobCount ?? 0;
+		// The tray is where an operator reaches for "stop taking work, now" —
+		// so it says what the node is actually doing, not just whether it is
+		// connected.
+		const workLine = paused
+			? active > 0
+				? `Work: paused (finishing ${active})`
+				: 'Work: paused'
+			: active > 0
+				? `Work: running ${active}`
+				: 'Work: idle';
+		tray.setToolTip(`Ever Works Desktop Node — ${summary}${paused ? ' (paused)' : ''}`);
 		tray.setContextMenu(
 			Menu.buildFromTemplate([
 				{ label: `Status: ${summary}`, enabled: false },
+				{ label: workLine, enabled: false },
 				{ type: 'separator' },
 				{ label: 'Open Desktop Node', click: () => handlers.onShow() },
 				{ type: 'separator' },
 				{ label: 'Connect', enabled: !connected, click: () => handlers.onConnect() },
 				{ label: 'Disconnect', enabled: connected, click: () => handlers.onDisconnect() },
+				{ type: 'separator' },
+				{ label: 'Pause work', enabled: !paused, click: () => handlers.onPause() },
+				{ label: 'Resume work', enabled: paused, click: () => handlers.onResume() },
 				{ type: 'separator' },
 				{ label: 'Quit', click: () => handlers.onQuit() }
 			])

--- a/apps/desktop-node/src/renderer/StatusScreen.tsx
+++ b/apps/desktop-node/src/renderer/StatusScreen.tsx
@@ -31,6 +31,10 @@ export function StatusScreen({ bridge, identity, onUnenrolled }: StatusScreenPro
 	}, [bridge]);
 
 	const live = isLive(status);
+	// A18 — driven off the worker loop's real state, not a local UI flag, so
+	// the button always agrees with what the node is actually doing.
+	const worker = status?.worker;
+	const paused = worker?.paused === true;
 
 	return (
 		<div className="shell">
@@ -42,6 +46,11 @@ export function StatusScreen({ bridge, identity, onUnenrolled }: StatusScreenPro
 				</span>
 				<span className="muted">{identity.name ?? identity.nodeId}</span>
 				{status?.platformStatus && <span className="muted">platform: {status.platformStatus}</span>}
+				{worker?.enabled && (
+					<span className={`badge ${paused ? 'warn' : 'ok'}`}>
+						{paused ? 'work paused' : `work ${worker.state}`}
+					</span>
+				)}
 			</div>
 
 			<div className="panel">
@@ -66,8 +75,27 @@ export function StatusScreen({ bridge, identity, onUnenrolled }: StatusScreenPro
 							))}
 						</div>
 					</dd>
+					<dt>Resource limits</dt>
+					<dd>
+						{identity.limits.maxConcurrentJobs} job(s) at once
+						{identity.limits.maxCpuPercent === null
+							? ', no CPU ceiling'
+							: `, CPU below ${identity.limits.maxCpuPercent}%`}
+						{identity.limits.maxMemoryMb === null
+							? ', no memory ceiling'
+							: `, memory in use below ${identity.limits.maxMemoryMb}MB`}
+					</dd>
+					{worker?.enabled && (
+						<>
+							<dt>Work</dt>
+							<dd>
+								{worker.activeJobCount} running · {worker.completed} completed · {worker.failed} failed
+							</dd>
+						</>
+					)}
 				</dl>
 
+				{worker?.throttleReason && <p className="muted">Not leasing new work: {worker.throttleReason}.</p>}
 				{status?.lastError && <div className="error-note">{status.lastError}</div>}
 			</div>
 
@@ -78,6 +106,13 @@ export function StatusScreen({ bridge, identity, onUnenrolled }: StatusScreenPro
 				<button className="secondary" disabled={!live} onClick={() => void bridge.disconnect()}>
 					Disconnect
 				</button>
+				{paused ? (
+					<button onClick={() => void bridge.resume()}>Resume work</button>
+				) : (
+					<button className="secondary" onClick={() => void bridge.pause()}>
+						Pause work
+					</button>
+				)}
 				<button
 					className="secondary"
 					onClick={() => {
@@ -88,8 +123,9 @@ export function StatusScreen({ bridge, identity, onUnenrolled }: StatusScreenPro
 				</button>
 			</div>
 			<p className="muted">
-				Un-enrolling only forgets the local credential — the node stays in the Fleet page until it is revoked
-				there.
+				Pausing stops this machine leasing NEW work — the node stays online and jobs already running still
+				finish and report. Un-enrolling only forgets the local credential; the node stays in the Fleet page
+				until it is revoked there.
 			</p>
 
 			<div className="panel">

--- a/apps/desktop-node/src/renderer/wizard/WizardView.tsx
+++ b/apps/desktop-node/src/renderer/wizard/WizardView.tsx
@@ -1,11 +1,22 @@
 import { useEffect, useState } from 'react';
-import type { ApiHostOption, DesktopNodeBridge, NodeIdentityView } from '../../shared/ipc-contract';
+import type { ApiHostOption, DesktopNodeBridge, NodeIdentityView, NodeResourceLimits } from '../../shared/ipc-contract';
+import {
+	DEFAULT_LIMITS_VIEW,
+	MAX_CONCURRENCY,
+	MAX_CPU_CEILING,
+	MIN_CONCURRENCY,
+	MIN_CPU_CEILING,
+	MIN_MEMORY_CEILING_MB
+} from '../../shared/ipc-contract';
 import {
 	canAdvance,
 	computeStepList,
+	enrollMode,
 	nextStep,
+	normalizeLimits,
 	previousStep,
 	resolveApiUrl,
+	signInInputValid,
 	type WizardProgress,
 	type WizardStepId
 } from './steps';
@@ -18,37 +29,97 @@ interface WizardViewProps {
 const STEP_TITLES: Record<WizardStepId, string> = {
 	welcome: 'Welcome',
 	host: 'Choose your API host',
-	token: 'Paste your enrollment token',
+	token: 'Connect your account',
+	capabilities: 'Choose what this machine offers',
+	limits: 'Set resource limits',
 	enroll: 'Enroll this machine',
 	running: 'Running'
 };
 
+/** Tags that describe the machine itself — always advertised, never a choice. */
+function isIdentityTag(tag: string): boolean {
+	return tag.startsWith('os:') || tag.startsWith('arch:') || tag.startsWith('node:');
+}
+
 /**
- * Setup wizard: welcome → API host → token → enroll → running.
- * All sequencing decisions live in `steps.ts`; this component only renders
- * them and calls the bridge.
+ * Setup wizard: welcome → API host → credentials → capabilities → limits →
+ * enroll → running. All sequencing decisions live in `steps.ts`; this component
+ * only renders them and calls the bridge.
  */
 export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 	const [step, setStep] = useState<WizardStepId>('welcome');
 	const [progress, setProgress] = useState<WizardProgress>({ enrolled: false });
 	const [hosts, setHosts] = useState<ApiHostOption[]>([]);
-	const [capabilities, setCapabilities] = useState<string[]>([]);
+	const [detected, setDetected] = useState<string[]>([]);
 	const [name, setName] = useState('');
 	const [error, setError] = useState<string | null>(null);
 	const [busy, setBusy] = useState(false);
+	const [signedInAs, setSignedInAs] = useState<string | null>(null);
 
 	useEffect(() => {
 		void bridge.listApiHosts().then(setHosts);
-		void bridge.detectCapabilities().then(setCapabilities);
+		void bridge.detectCapabilities().then((tags) => {
+			setDetected(tags);
+			// Default the offer to everything detected: the step is a chance to
+			// narrow, not a wall of unchecked boxes standing between the
+			// operator and a working node.
+			setProgress((current) =>
+				current.capabilities === undefined ? { ...current, capabilities: [...tags] } : current
+			);
+		});
 	}, [bridge]);
 
 	const steps = computeStepList(progress);
 	const apiUrl = resolveApiUrl(progress);
+	const mode = enrollMode(progress);
+	const selectable = detected.filter((tag) => !isIdentityTag(tag));
+	const identityTags = detected.filter(isIdentityTag);
+	const limits = progress.limits ?? DEFAULT_LIMITS_VIEW;
 
 	const advance = () => {
 		const next = nextStep(step, progress);
 		if (next) {
 			setStep(next);
+		}
+	};
+
+	const patchLimits = (patch: Partial<NodeResourceLimits>) =>
+		setProgress((current) => ({
+			...current,
+			limits: normalizeLimits({ ...(current.limits ?? DEFAULT_LIMITS_VIEW), ...patch })
+		}));
+
+	const toggleCapability = (tag: string) =>
+		setProgress((current) => {
+			const chosen = current.capabilities ?? [];
+			return {
+				...current,
+				capabilities: chosen.includes(tag) ? chosen.filter((entry) => entry !== tag) : [...chosen, tag]
+			};
+		});
+
+	// A14 — verify credentials here so a typo fails at this step rather than
+	// three steps later during enrollment.
+	const runSignIn = async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			const outcome = await bridge.authenticate({
+				host: progress.host as ApiHostOption['id'],
+				...(progress.customApiUrl ? { apiUrl: progress.customApiUrl } : {}),
+				email: progress.email ?? '',
+				password: progress.password ?? ''
+			});
+			if (!outcome.ok) {
+				setSignedInAs(null);
+				setProgress((current) => ({ ...current, signedIn: false }));
+				setError(outcome.error ?? 'Sign-in failed.');
+				return;
+			}
+			setSignedInAs(outcome.email ?? progress.email ?? null);
+			setProgress((current) => ({ ...current, signedIn: true }));
+		} finally {
+			setBusy(false);
 		}
 	};
 
@@ -59,14 +130,21 @@ export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 			const outcome = await bridge.enroll({
 				host: progress.host as ApiHostOption['id'],
 				...(progress.customApiUrl ? { apiUrl: progress.customApiUrl } : {}),
-				token: progress.token ?? '',
-				...(name.trim() ? { name: name.trim() } : {})
+				mode,
+				...(mode === 'sign-in'
+					? { email: progress.email ?? '', password: progress.password ?? '' }
+					: { token: progress.token ?? '' }),
+				...(name.trim() ? { name: name.trim() } : {}),
+				...(progress.capabilities ? { capabilities: progress.capabilities } : {}),
+				limits: normalizeLimits(limits)
 			});
 			if (!outcome.ok || !outcome.identity) {
 				setError(outcome.error ?? 'Enrollment failed.');
 				return;
 			}
-			setProgress((current) => ({ ...current, enrolled: true }));
+			// Drop the password from renderer state the moment it is no longer
+			// needed — it never had to outlive the request.
+			setProgress((current) => ({ ...current, enrolled: true, password: '' }));
 			setStep('running');
 			onEnrolled(outcome.identity);
 		} finally {
@@ -104,7 +182,7 @@ export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 						</p>
 						<p className="muted">Detected capabilities:</p>
 						<div className="tags">
-							{capabilities.map((tag) => (
+							{detected.map((tag) => (
 								<span className="badge" key={tag}>
 									{tag}
 								</span>
@@ -145,23 +223,189 @@ export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 
 				{step === 'token' && (
 					<>
-						<p className="muted">
-							Open the platform’s Fleet settings page, choose “Add node”, and copy the one-time enrollment
-							token. It is single-use and expires 15 minutes after it is issued.
-						</p>
-						<label className="field">
-							<span>Enrollment token</span>
-							<input
-								type="password"
-								value={progress.token ?? ''}
-								onChange={(event) =>
-									setProgress((current) => ({ ...current, token: event.target.value }))
+						<div className="steps-nav">
+							<button
+								className={mode === 'sign-in' ? '' : 'secondary'}
+								onClick={() =>
+									setProgress((current) => ({ ...current, mode: 'sign-in', signedIn: false }))
 								}
-							/>
-						</label>
+							>
+								Sign in
+							</button>
+							<button
+								className={mode === 'token' ? '' : 'secondary'}
+								onClick={() => setProgress((current) => ({ ...current, mode: 'token' }))}
+							>
+								Paste a token
+							</button>
+						</div>
+
+						{mode === 'sign-in' ? (
+							<>
+								<p className="muted">
+									Sign in with your Ever Works account and this app will issue its own one-time
+									enrollment token — no copying anything between windows.
+								</p>
+								<label className="field">
+									<span>Email</span>
+									<input
+										type="email"
+										autoComplete="username"
+										value={progress.email ?? ''}
+										onChange={(event) =>
+											setProgress((current) => ({
+												...current,
+												email: event.target.value,
+												signedIn: false
+											}))
+										}
+									/>
+								</label>
+								<label className="field">
+									<span>Password</span>
+									<input
+										type="password"
+										autoComplete="current-password"
+										value={progress.password ?? ''}
+										onChange={(event) =>
+											setProgress((current) => ({
+												...current,
+												password: event.target.value,
+												signedIn: false
+											}))
+										}
+									/>
+								</label>
+								<div className="actions">
+									<button
+										disabled={busy || !signInInputValid(progress)}
+										onClick={() => void runSignIn()}
+									>
+										{busy ? 'Signing in…' : 'Sign in'}
+									</button>
+								</div>
+								{progress.signedIn && (
+									<p className="muted">Signed in{signedInAs ? ` as ${signedInAs}` : ''}.</p>
+								)}
+							</>
+						) : (
+							<>
+								<p className="muted">
+									Open the platform’s Fleet settings page, choose “Add node”, and copy the one-time
+									enrollment token. It is single-use and expires 15 minutes after it is issued.
+								</p>
+								<label className="field">
+									<span>Enrollment token</span>
+									<input
+										type="password"
+										value={progress.token ?? ''}
+										onChange={(event) =>
+											setProgress((current) => ({ ...current, token: event.target.value }))
+										}
+									/>
+								</label>
+							</>
+						)}
+
 						<label className="field">
 							<span>Local label (optional)</span>
 							<input type="text" value={name} onChange={(event) => setName(event.target.value)} />
+						</label>
+						{error && <div className="error-note">{error}</div>}
+					</>
+				)}
+
+				{step === 'capabilities' && (
+					<>
+						<p className="muted">
+							Pick what this machine offers the platform. Unchecking a capability means work that needs it
+							is never scheduled here — including after you install the tool later.
+						</p>
+						{selectable.length === 0 ? (
+							<p className="muted">Nothing optional was detected on this machine.</p>
+						) : (
+							selectable.map((tag) => (
+								<label className="field" key={tag}>
+									<span>
+										<input
+											type="checkbox"
+											checked={(progress.capabilities ?? []).includes(tag)}
+											onChange={() => toggleCapability(tag)}
+										/>{' '}
+										{tag}
+									</span>
+								</label>
+							))
+						)}
+						<p className="muted">Always reported (machine identity):</p>
+						<div className="tags">
+							{identityTags.map((tag) => (
+								<span className="badge" key={tag}>
+									{tag}
+								</span>
+							))}
+						</div>
+					</>
+				)}
+
+				{step === 'limits' && (
+					<>
+						<p className="muted">
+							Ceilings this machine enforces on itself. The platform is never asked to respect them — the
+							node simply stops leasing new work when a ceiling is reached. Jobs already running always
+							finish and report.
+						</p>
+						<label className="field">
+							<span>Max jobs at once</span>
+							<input
+								type="number"
+								min={MIN_CONCURRENCY}
+								max={MAX_CONCURRENCY}
+								value={limits.maxConcurrentJobs}
+								onChange={(event) => patchLimits({ maxConcurrentJobs: Number(event.target.value) })}
+							/>
+						</label>
+						<label className="field">
+							<span>
+								<input
+									type="checkbox"
+									checked={limits.maxCpuPercent !== null}
+									onChange={(event) =>
+										patchLimits({ maxCpuPercent: event.target.checked ? 80 : null })
+									}
+								/>{' '}
+								Pause new work above a CPU ceiling
+							</span>
+							{limits.maxCpuPercent !== null && (
+								<input
+									type="number"
+									min={MIN_CPU_CEILING}
+									max={MAX_CPU_CEILING}
+									value={limits.maxCpuPercent}
+									onChange={(event) => patchLimits({ maxCpuPercent: Number(event.target.value) })}
+								/>
+							)}
+						</label>
+						<label className="field">
+							<span>
+								<input
+									type="checkbox"
+									checked={limits.maxMemoryMb !== null}
+									onChange={(event) =>
+										patchLimits({ maxMemoryMb: event.target.checked ? 4096 : null })
+									}
+								/>{' '}
+								Pause new work above a memory ceiling (MB in use)
+							</span>
+							{limits.maxMemoryMb !== null && (
+								<input
+									type="number"
+									min={MIN_MEMORY_CEILING_MB}
+									step={256}
+									value={limits.maxMemoryMb}
+									onChange={(event) => patchLimits({ maxMemoryMb: Number(event.target.value) })}
+								/>
+							)}
 						</label>
 					</>
 				)}
@@ -169,16 +413,22 @@ export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 				{step === 'enroll' && (
 					<>
 						<p className="muted">
-							Ready to enroll against <strong>{apiUrl}</strong> with{' '}
-							{capabilities.length || 'no detected'} capability tags.
+							Ready to enroll against <strong>{apiUrl}</strong>
+							{mode === 'sign-in' ? ' using your signed-in account' : ' with your pasted token'}.
 						</p>
+						<p className="muted">Offering:</p>
 						<div className="tags">
-							{capabilities.map((tag) => (
+							{[...identityTags, ...(progress.capabilities ?? [])].map((tag) => (
 								<span className="badge" key={tag}>
 									{tag}
 								</span>
 							))}
 						</div>
+						<p className="muted">
+							Up to {limits.maxConcurrentJobs} job(s) at once
+							{limits.maxCpuPercent === null ? '' : `, CPU below ${limits.maxCpuPercent}%`}
+							{limits.maxMemoryMb === null ? '' : `, memory in use below ${limits.maxMemoryMb}MB`}.
+						</p>
 						{error && <div className="error-note">{error}</div>}
 						<div className="actions">
 							<button disabled={busy} onClick={() => void runEnrollment()}>
@@ -191,7 +441,7 @@ export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 				{step === 'running' && (
 					<p className="muted">
 						Enrolled. This machine now appears in the Fleet settings page and will report a heartbeat
-						continuously.
+						continuously. You can pause work at any time from the status window or the tray.
 					</p>
 				)}
 			</div>

--- a/apps/desktop-node/src/renderer/wizard/steps.spec.ts
+++ b/apps/desktop-node/src/renderer/wizard/steps.spec.ts
@@ -1,28 +1,47 @@
 import { describe, expect, it } from 'vitest';
-import { CLOUD_API_URL, LOCAL_DESKTOP_API_URL } from '../../shared/ipc-contract';
+import { CLOUD_API_URL, LOCAL_DESKTOP_API_URL, type NodeResourceLimits } from '../../shared/ipc-contract';
 import {
 	WIZARD_STEPS,
 	canAdvance,
 	computeStepList,
+	credentialsValid,
+	enrollMode,
 	firstIncompleteStep,
 	hostSelectionValid,
+	limitsValid,
 	nextStep,
+	normalizeLimits,
 	previousStep,
 	resolveApiUrl,
+	signInInputValid,
 	tokenValid,
 	type WizardProgress
 } from './steps';
 
 const TOKEN = 'ZmFrZS1lbnJvbGxtZW50LXRva2VuLWZvci10ZXN0aW5n';
+const LIMITS: NodeResourceLimits = { maxConcurrentJobs: 2, maxCpuPercent: null, maxMemoryMb: null };
 
 function progress(overrides: Partial<WizardProgress> = {}): WizardProgress {
 	return { enrolled: false, ...overrides };
 }
 
+/** Everything answered — used wherever a test only cares about one gate. */
+function complete(overrides: Partial<WizardProgress> = {}): WizardProgress {
+	return progress({ host: 'cloud', token: TOKEN, capabilities: ['terminal'], limits: LIMITS, ...overrides });
+}
+
 describe('computeStepList', () => {
-	it('runs welcome → host → token → enroll → running', () => {
-		expect(computeStepList(progress())).toEqual(['welcome', 'host', 'token', 'enroll', 'running']);
-		expect(WIZARD_STEPS).toHaveLength(5);
+	it('runs welcome → host → credentials → capabilities → limits → enroll → running', () => {
+		expect(computeStepList(progress())).toEqual([
+			'welcome',
+			'host',
+			'token',
+			'capabilities',
+			'limits',
+			'enroll',
+			'running'
+		]);
+		expect(WIZARD_STEPS).toHaveLength(7);
 	});
 });
 
@@ -79,26 +98,41 @@ describe('canAdvance / nextStep gating', () => {
 		expect(nextStep('host', progress())).toBeNull();
 	});
 
-	it('blocks the token step until a plausible token is pasted', () => {
-		const base = progress({ host: 'cloud' });
+	it('blocks the credentials step until a plausible token is pasted', () => {
+		const base = progress({ host: 'cloud', capabilities: [], limits: LIMITS });
 		expect(nextStep('token', base)).toBeNull();
 		expect(nextStep('token', { ...base, token: 'nope' })).toBeNull();
-		expect(nextStep('token', { ...base, token: TOKEN })).toBe('enroll');
+		expect(nextStep('token', { ...base, token: TOKEN })).toBe('capabilities');
+	});
+
+	it('blocks the capabilities step until the operator has actually chosen', () => {
+		// `undefined` = never visited; `[]` = "identity only", a real choice.
+		expect(canAdvance('capabilities', complete({ capabilities: undefined }))).toBe(false);
+		expect(canAdvance('capabilities', complete({ capabilities: [] }))).toBe(true);
+	});
+
+	it('blocks the limits step until the ceilings are coherent', () => {
+		expect(canAdvance('limits', complete({ limits: undefined }))).toBe(false);
+		expect(canAdvance('limits', complete({ limits: LIMITS }))).toBe(true);
+		// A number the node would silently clamp is not an answer the operator
+		// gave — make them look at the real one.
+		expect(canAdvance('limits', complete({ limits: { ...LIMITS, maxConcurrentJobs: 99 } }))).toBe(false);
 	});
 
 	it('blocks the enroll step until the platform has accepted the node', () => {
-		const base = progress({ host: 'cloud', token: TOKEN });
-		expect(nextStep('enroll', base)).toBeNull();
-		expect(nextStep('enroll', { ...base, enrolled: true })).toBe('running');
+		expect(nextStep('enroll', complete())).toBeNull();
+		expect(nextStep('enroll', complete({ enrolled: true }))).toBe('running');
 	});
 
 	it('walks the happy path in order once each condition is met', () => {
-		const complete = progress({ host: 'cloud', token: TOKEN, enrolled: true });
-		expect(nextStep('welcome', complete)).toBe('host');
-		expect(nextStep('host', complete)).toBe('token');
-		expect(nextStep('token', complete)).toBe('enroll');
-		expect(nextStep('enroll', complete)).toBe('running');
-		expect(nextStep('running', complete)).toBeNull();
+		const answered = complete({ enrolled: true });
+		expect(nextStep('welcome', answered)).toBe('host');
+		expect(nextStep('host', answered)).toBe('token');
+		expect(nextStep('token', answered)).toBe('capabilities');
+		expect(nextStep('capabilities', answered)).toBe('limits');
+		expect(nextStep('limits', answered)).toBe('enroll');
+		expect(nextStep('enroll', answered)).toBe('running');
+		expect(nextStep('running', answered)).toBeNull();
 	});
 
 	it('supports going back except from the first step', () => {
@@ -108,11 +142,62 @@ describe('canAdvance / nextStep gating', () => {
 	});
 });
 
+describe('enrollMode / credentialsValid (A14 — authenticate leg)', () => {
+	it('defaults to the paste-a-token mode so existing muscle memory still works', () => {
+		expect(enrollMode(progress())).toBe('token');
+		expect(credentialsValid(progress({ token: TOKEN }))).toBe(true);
+	});
+
+	it('requires a VERIFIED sign-in, not just a filled-in form', () => {
+		const typed = progress({ mode: 'sign-in', email: 'a@b.co', password: 'pw' });
+		expect(signInInputValid(typed)).toBe(true);
+		// A filled form is not proof: the main process has to have checked it,
+		// or a wrong password surfaces three steps later as "enrollment failed".
+		expect(credentialsValid(typed)).toBe(false);
+		expect(credentialsValid({ ...typed, signedIn: true })).toBe(true);
+	});
+
+	it('ignores a pasted token once the operator switched to signing in', () => {
+		expect(credentialsValid(progress({ mode: 'sign-in', token: TOKEN }))).toBe(false);
+	});
+
+	it('rejects obviously unusable sign-in input up front', () => {
+		expect(signInInputValid(progress({ mode: 'sign-in' }))).toBe(false);
+		expect(signInInputValid(progress({ mode: 'sign-in', email: 'nope', password: 'pw' }))).toBe(false);
+		expect(signInInputValid(progress({ mode: 'sign-in', email: 'a@b.co', password: '' }))).toBe(false);
+	});
+});
+
+describe('normalizeLimits / limitsValid (A16 — resource ceilings)', () => {
+	it('clamps concurrency into the range the node actually supports', () => {
+		expect(normalizeLimits({ maxConcurrentJobs: 0 }).maxConcurrentJobs).toBe(1);
+		expect(normalizeLimits({ maxConcurrentJobs: 99 }).maxConcurrentJobs).toBe(16);
+	});
+
+	it('treats an absent or nonsense ceiling as "no ceiling"', () => {
+		expect(normalizeLimits({}).maxCpuPercent).toBeNull();
+		expect(normalizeLimits({ maxMemoryMb: Number.NaN }).maxMemoryMb).toBeNull();
+	});
+
+	it('raises a too-small ceiling to the floor rather than idling the node', () => {
+		expect(normalizeLimits({ maxCpuPercent: 1 }).maxCpuPercent).toBe(5);
+		expect(normalizeLimits({ maxMemoryMb: 10 }).maxMemoryMb).toBe(256);
+	});
+
+	it('accepts only values that survive normalization unchanged', () => {
+		expect(limitsValid(undefined)).toBe(false);
+		expect(limitsValid(LIMITS)).toBe(true);
+		expect(limitsValid({ maxConcurrentJobs: 1, maxCpuPercent: 1, maxMemoryMb: null })).toBe(false);
+	});
+});
+
 describe('firstIncompleteStep', () => {
 	it('resumes at the first unmet condition', () => {
 		expect(firstIncompleteStep(progress())).toBe('host');
 		expect(firstIncompleteStep(progress({ host: 'cloud' }))).toBe('token');
-		expect(firstIncompleteStep(progress({ host: 'cloud', token: TOKEN }))).toBe('enroll');
-		expect(firstIncompleteStep(progress({ host: 'cloud', token: TOKEN, enrolled: true }))).toBe('running');
+		expect(firstIncompleteStep(progress({ host: 'cloud', token: TOKEN }))).toBe('capabilities');
+		expect(firstIncompleteStep(progress({ host: 'cloud', token: TOKEN, capabilities: [] }))).toBe('limits');
+		expect(firstIncompleteStep(complete())).toBe('enroll');
+		expect(firstIncompleteStep(complete({ enrolled: true }))).toBe('running');
 	});
 });

--- a/apps/desktop-node/src/renderer/wizard/steps.ts
+++ b/apps/desktop-node/src/renderer/wizard/steps.ts
@@ -1,29 +1,67 @@
-import { API_HOST_OPTIONS, MAX_TOKEN_LENGTH, MIN_TOKEN_LENGTH, type ApiHostChoice } from '../../shared/ipc-contract';
+import {
+	API_HOST_OPTIONS,
+	DEFAULT_LIMITS_VIEW,
+	MAX_CONCURRENCY,
+	MAX_CPU_CEILING,
+	MAX_TOKEN_LENGTH,
+	MIN_CONCURRENCY,
+	MIN_CPU_CEILING,
+	MIN_MEMORY_CEILING_MB,
+	MIN_TOKEN_LENGTH,
+	type ApiHostChoice,
+	type EnrollMode,
+	type NodeResourceLimits
+} from '../../shared/ipc-contract';
 
 /**
  * Pure sequencing logic for the Desktop Node setup wizard:
- * welcome → API host → enrollment token → enroll → running.
+ * welcome → API host → credentials → capabilities → limits → enroll → running.
  *
  * Mirrors `apps/desktop`'s `computeStepList` pattern (itself modelled on the
- * web onboarding wizard) so later steps — capability selection and resource
- * limits, PRD §3.2 steps 3-4 — slot in without new machinery.
+ * web onboarding wizard).
+ *
+ * The `credentials` step covers BOTH ways onto a fleet (A14):
+ *   - `token`   paste a one-time token issued in Fleet settings (original)
+ *   - `sign-in` sign in here and let the app mint the token itself
+ * They are two ways to obtain the same single-use token — the enroll protocol
+ * is identical either way.
+ *
+ * The `capabilities` (A15) and `limits` (A16) steps are what turn "this machine
+ * is enrolled" into "this machine offers exactly this much": the operator
+ * decides which detected capabilities to advertise and how much of the machine
+ * the platform may consume.
  */
 
-export const WIZARD_STEPS = ['welcome', 'host', 'token', 'enroll', 'running'] as const;
+export const WIZARD_STEPS = ['welcome', 'host', 'token', 'capabilities', 'limits', 'enroll', 'running'] as const;
 export type WizardStepId = (typeof WIZARD_STEPS)[number];
 
 export interface WizardProgress {
 	host?: ApiHostChoice;
 	/** Only meaningful when `host === 'self-hosted'`. */
 	customApiUrl?: string;
+	/** How this machine will prove it may join (A14). Defaults to `token`. */
+	mode?: EnrollMode;
 	token?: string;
+	/** Only meaningful when `mode === 'sign-in'`. */
+	email?: string;
+	/** Only meaningful when `mode === 'sign-in'`. Never leaves the process. */
+	password?: string;
+	/** Flipped once the main process has verified the credentials. */
+	signedIn?: boolean;
+	/**
+	 * Capability tags the operator chose to offer (A15). `undefined` means the
+	 * step has not been visited yet and everything detected will be advertised.
+	 */
+	capabilities?: string[];
+	/** Resource ceilings this machine will enforce on itself (A16). */
+	limits?: NodeResourceLimits;
 	/** Flipped once the platform has accepted the enrollment. */
 	enrolled: boolean;
 }
 
 export function computeStepList(_progress: WizardProgress): WizardStepId[] {
-	// Every step always applies today; the conditional capability/limits
-	// sub-steps hook in here (same extension point the web wizard uses).
+	// Every step always applies today; further conditional sub-steps hook in
+	// here (same extension point the web wizard uses).
 	return [...WIZARD_STEPS];
 }
 
@@ -59,6 +97,11 @@ export function hostSelectionValid(progress: WizardProgress): boolean {
 	return resolveApiUrl(progress) !== null;
 }
 
+/** The enrollment mode in force; `token` remains the default. */
+export function enrollMode(progress: WizardProgress): EnrollMode {
+	return progress.mode === 'sign-in' ? 'sign-in' : 'token';
+}
+
 /**
  * Local shape check on the pasted token, matching the credential bounds the
  * API enforces — so an obviously truncated paste is caught before it burns the
@@ -72,7 +115,75 @@ export function tokenValid(token: string | undefined): boolean {
 	return trimmed.length >= MIN_TOKEN_LENGTH && trimmed.length <= MAX_TOKEN_LENGTH;
 }
 
-/** Whether the given step's completion condition is met. */
+/**
+ * Local shape check on the sign-in form. Deliberately loose — the platform
+ * owns email validation — so the operator gets an instant answer on obviously
+ * empty input rather than a round trip.
+ */
+export function signInInputValid(progress: WizardProgress): boolean {
+	const email = progress.email?.trim() ?? '';
+	const password = progress.password ?? '';
+	return email.length >= 3 && email.includes('@') && password.length > 0;
+}
+
+/**
+ * Whether the credentials step is satisfied. In `sign-in` mode a filled-in
+ * form is not enough: the main process must have actually verified it
+ * (`signedIn`), so a wrong password is caught at the credentials step rather
+ * than surfacing three steps later as a mysterious enroll failure.
+ */
+export function credentialsValid(progress: WizardProgress): boolean {
+	return enrollMode(progress) === 'sign-in' ? progress.signedIn === true : tokenValid(progress.token);
+}
+
+/**
+ * Coerce a partially-filled limits form into a coherent set of ceilings.
+ * Mirrors the core's `clampResourceLimits` so what the wizard shows is exactly
+ * what the node will enforce.
+ */
+export function normalizeLimits(input: Partial<NodeResourceLimits> | undefined): NodeResourceLimits {
+	const concurrency = Number(input?.maxConcurrentJobs);
+	const cpu = input?.maxCpuPercent;
+	const memory = input?.maxMemoryMb;
+	return {
+		maxConcurrentJobs: Number.isFinite(concurrency)
+			? Math.min(Math.max(Math.round(concurrency), MIN_CONCURRENCY), MAX_CONCURRENCY)
+			: DEFAULT_LIMITS_VIEW.maxConcurrentJobs,
+		maxCpuPercent:
+			typeof cpu === 'number' && Number.isFinite(cpu)
+				? Math.min(Math.max(Math.round(cpu), MIN_CPU_CEILING), MAX_CPU_CEILING)
+				: null,
+		maxMemoryMb:
+			typeof memory === 'number' && Number.isFinite(memory)
+				? Math.max(Math.round(memory), MIN_MEMORY_CEILING_MB)
+				: null
+	};
+}
+
+/**
+ * A limits selection is valid when it normalizes to itself — i.e. the operator
+ * is looking at exactly the numbers the node will apply, with no silent
+ * clamping between the form and the config file.
+ */
+export function limitsValid(limits: NodeResourceLimits | undefined): boolean {
+	if (!limits) {
+		return false;
+	}
+	const normalized = normalizeLimits(limits);
+	return (
+		normalized.maxConcurrentJobs === limits.maxConcurrentJobs &&
+		normalized.maxCpuPercent === limits.maxCpuPercent &&
+		normalized.maxMemoryMb === limits.maxMemoryMb
+	);
+}
+
+/**
+ * Whether the given step's completion condition is met.
+ *
+ * The capabilities step is intentionally always passable: offering NOTHING but
+ * the machine's identity tags is a legitimate choice (visibility-only
+ * enrollment), and refusing to advance would make that choice unreachable.
+ */
 export function canAdvance(step: WizardStepId, progress: WizardProgress): boolean {
 	switch (step) {
 		case 'welcome':
@@ -80,7 +191,11 @@ export function canAdvance(step: WizardStepId, progress: WizardProgress): boolea
 		case 'host':
 			return hostSelectionValid(progress);
 		case 'token':
-			return tokenValid(progress.token);
+			return credentialsValid(progress);
+		case 'capabilities':
+			return Array.isArray(progress.capabilities);
+		case 'limits':
+			return limitsValid(progress.limits);
 		case 'enroll':
 			return progress.enrolled;
 		case 'running':

--- a/apps/desktop-node/src/shared/ipc-contract.ts
+++ b/apps/desktop-node/src/shared/ipc-contract.ts
@@ -1,4 +1,11 @@
-import type { ConnectionState, FleetNodeKind, FleetNodeStatus, LogEntry } from 'ever-works-node';
+import type {
+	ConnectionState,
+	FleetNodeKind,
+	FleetNodeStatus,
+	LogEntry,
+	NodeResourceLimits,
+	WorkerLoopState
+} from 'ever-works-node';
 
 /**
  * Typed IPC contract shared by the Electron main process, the preload bridge
@@ -15,7 +22,7 @@ import type { ConnectionState, FleetNodeKind, FleetNodeStatus, LogEntry } from '
  * above is erased at compile time and is therefore sandbox-safe.)
  */
 
-export type { ConnectionState, LogEntry };
+export type { ConnectionState, LogEntry, NodeResourceLimits, WorkerLoopState };
 
 /** Where this node's control plane lives (PRD §3.2 wizard step 1). */
 export type ApiHostChoice = 'local-desktop' | 'self-hosted' | 'cloud';
@@ -66,6 +73,26 @@ export const API_HOST_OPTIONS: ApiHostOption[] = [
 	}
 ];
 
+/**
+ * Resource ceilings the wizard collects (PRD §3.2 step 4) and this machine
+ * enforces on itself. Mirrors the core's `NodeResourceLimits` as a plain
+ * renderer-safe shape.
+ */
+export const DEFAULT_LIMITS_VIEW: NodeResourceLimits = {
+	maxConcurrentJobs: 1,
+	maxCpuPercent: null,
+	maxMemoryMb: null
+};
+
+/** Concurrency bounds mirrored from the core (`MIN/MAX_CONCURRENT_JOBS`). */
+export const MIN_CONCURRENCY = 1;
+export const MAX_CONCURRENCY = 16;
+/** CPU ceiling bounds mirrored from the core (`MIN/MAX_CPU_PERCENT`). */
+export const MIN_CPU_CEILING = 5;
+export const MAX_CPU_CEILING = 100;
+/** Memory ceiling floor mirrored from the core (`MIN_MEMORY_MB`). */
+export const MIN_MEMORY_CEILING_MB = 256;
+
 /** Credential-free view of the local enrollment, safe to send to the renderer. */
 export interface NodeIdentityView {
 	enrolled: boolean;
@@ -74,9 +101,37 @@ export interface NodeIdentityView {
 	name?: string;
 	kind?: FleetNodeKind;
 	capabilities: string[];
+	/** Operator's capability opt-in; absent = "everything detected". */
+	capabilitySelection?: string[];
+	/** Ceilings this node enforces on itself. */
+	limits: NodeResourceLimits;
 	heartbeatIntervalMs?: number;
 	enrolledAt?: string;
 }
+
+/** Work-execution view rendered next to the connection status (A18). */
+export interface WorkerStatusView {
+	/** False when this node was enrolled for visibility only. */
+	enabled: boolean;
+	/** True while the operator has paused leasing. */
+	paused: boolean;
+	state: WorkerLoopState['state'] | 'disabled';
+	activeJobCount: number;
+	completed: number;
+	failed: number;
+	/** Why the loop last declined to lease on resource grounds, or null. */
+	throttleReason: string | null;
+}
+
+export const IDLE_WORKER_STATUS: WorkerStatusView = {
+	enabled: false,
+	paused: false,
+	state: 'disabled',
+	activeJobCount: 0,
+	completed: 0,
+	failed: 0,
+	throttleReason: null
+};
 
 /** Live connection status rendered by the status window and the tray. */
 export interface ConnectionStatusView {
@@ -89,31 +144,79 @@ export interface ConnectionStatusView {
 	lastError: string | null;
 	/** Node status as the platform sees it, from the last heartbeat response. */
 	platformStatus: FleetNodeStatus | null;
+	/** Work execution state — pause/resume is driven off this (A18). */
+	worker: WorkerStatusView;
 }
 
-/** Wizard → main enrollment request. The token is write-only across this bridge. */
+/**
+ * How the wizard obtained the right to enroll:
+ *   - `token`    the operator pasted a one-time token from Fleet settings
+ *   - `sign-in`  the operator signed in and the app minted the token itself
+ */
+export type EnrollMode = 'token' | 'sign-in';
+
+/**
+ * Wizard → main enrollment request. Credentials are write-only across this
+ * bridge: neither the token nor the password can ever be read back out.
+ */
 export interface EnrollRequest {
 	host: ApiHostChoice;
 	/** Required when `host === 'self-hosted'`; ignored otherwise. */
 	apiUrl?: string;
-	token: string;
+	mode?: EnrollMode;
+	/** Required when `mode` is `token` (the default). */
+	token?: string;
+	/** Required when `mode === 'sign-in'`. */
+	email?: string;
+	/**
+	 * Required when `mode === 'sign-in'`. Used for exactly one request in the
+	 * main process and never stored, logged, or echoed back.
+	 */
+	password?: string;
 	name?: string;
+	/**
+	 * Capability tags this machine offers (A15). Omitted = advertise
+	 * everything detected.
+	 */
+	capabilities?: string[];
+	/** Resource ceilings this machine enforces on itself (A16). */
+	limits?: NodeResourceLimits;
 }
 
 export interface EnrollOutcome {
 	ok: boolean;
 	identity?: NodeIdentityView;
-	/** Operator-facing failure reason; never contains the token. */
+	/** Operator-facing failure reason; never contains the token or password. */
+	error?: string;
+}
+
+/** Wizard → main sign-in request (A14). The password is write-only. */
+export interface AuthenticateRequest {
+	host: ApiHostChoice;
+	/** Required when `host === 'self-hosted'`; ignored otherwise. */
+	apiUrl?: string;
+	email: string;
+	password: string;
+}
+
+export interface AuthenticateOutcome {
+	ok: boolean;
+	/** Echoed back so the wizard can confirm WHICH account signed in. */
+	email?: string;
+	/** Operator-facing failure reason; never contains the password. */
 	error?: string;
 }
 
 export const IpcChannels = {
 	listApiHosts: 'wizard:list-api-hosts',
 	detectCapabilities: 'wizard:detect-capabilities',
+	authenticate: 'wizard:authenticate',
 	enroll: 'wizard:enroll',
 	getConfig: 'config:get',
 	connect: 'node:connect',
 	disconnect: 'node:disconnect',
+	pause: 'node:pause',
+	resume: 'node:resume',
 	getStatus: 'node:status',
 	getLogs: 'node:logs',
 	unenroll: 'node:unenroll',
@@ -125,10 +228,20 @@ export const IpcChannels = {
 export interface DesktopNodeBridge {
 	listApiHosts(): Promise<ApiHostOption[]>;
 	detectCapabilities(): Promise<string[]>;
+	/**
+	 * Verify the operator's platform credentials without enrolling yet, so
+	 * the wizard can fail fast on a typo before it collects capabilities and
+	 * limits. The password never comes back across this bridge.
+	 */
+	authenticate(request: AuthenticateRequest): Promise<AuthenticateOutcome>;
 	enroll(request: EnrollRequest): Promise<EnrollOutcome>;
 	getConfig(): Promise<NodeIdentityView>;
 	connect(): Promise<void>;
 	disconnect(): Promise<void>;
+	/** Stop leasing new work; in-flight jobs still finish and report (A18). */
+	pause(): Promise<void>;
+	/** Resume leasing after a pause (A18). */
+	resume(): Promise<void>;
 	getStatus(): Promise<ConnectionStatusView>;
 	getLogs(): Promise<LogEntry[]>;
 	unenroll(): Promise<void>;

--- a/apps/desktop/src/services/runtime-setup.ts
+++ b/apps/desktop/src/services/runtime-setup.ts
@@ -24,12 +24,32 @@ export const ENV_FILE_HEADER = [
 ].join('\n');
 
 /**
- * Desktop-owned marker recording which job runtime the user picked. The
- * platform persists the actual selection through the tenant job-runtime
- * config (providerId) once the API is up; this env entry keeps the choice
- * available to the supervisor before first boot.
+ * Desktop-owned marker recording which job runtime the user picked.
+ *
+ * This is what the API reads at boot to persist the wizard's choice into
+ * `tenant_job_runtime_config` (A9): the install wizard runs BEFORE anybody has
+ * signed in, so there is no session it could use to call the admin API. The
+ * env file is the handoff — the wizard writes the choice here, and the API
+ * materialises the overlay row for the tenant the moment one exists.
  */
 export const DESKTOP_RUNTIME_ENV_KEY = 'EVER_WORKS_DESKTOP_JOB_RUNTIME';
+
+/**
+ * The platform-global runtime selector (ADR-015 / EW-683). Written alongside
+ * the desktop marker so the supervised API actually BOOTS on the runtime the
+ * user chose — without it the wizard's choice was cosmetic until somebody
+ * edited the env file by hand.
+ */
+export const PLATFORM_RUNTIME_ENV_KEY = 'EVER_WORKS_JOB_RUNTIME';
+
+/**
+ * Map a `job-runtime-*` plugin id to the provider id used by the platform's
+ * runtime selector and by `tenant_job_runtime_config.providerId`
+ * (`trigger | temporal | bullmq | pgboss | inngest | node`).
+ */
+export function toJobRuntimeProviderId(runtimeId: string): string {
+	return runtimeId.replace(/^job-runtime-/, '');
+}
 
 /**
  * Translate the wizard's runtime selection into concrete env file entries:
@@ -70,6 +90,7 @@ export function buildEnvEntries(selection: RuntimeSelection, options: BuildEnvOp
 	}
 
 	entries[DESKTOP_RUNTIME_ENV_KEY] = runtime.id;
+	entries[PLATFORM_RUNTIME_ENV_KEY] = toJobRuntimeProviderId(runtime.id);
 
 	for (const field of runtime.fields) {
 		const value = selection.values[field.key] ?? field.defaultValue;

--- a/apps/node/src/cli.ts
+++ b/apps/node/src/cli.ts
@@ -5,6 +5,7 @@ import {
 	createCommandRunner,
 	createConfigFileSystem,
 	createSecretStore,
+	createResourceProbe,
 	currentEnvironment,
 	defaultConfigPath,
 	systemFetch
@@ -35,6 +36,9 @@ function buildDeps(): CliDeps {
 		// Null when this host has no keychain — `resolveSecretStore`
 		// warns on that path rather than downgrading in silence.
 		secrets: createSecretStore(logger),
+		// Backs the CPU/memory admission gate. Harmless when no ceilings are
+		// configured — the worker loop skips sampling entirely in that case.
+		resourceProbe: createResourceProbe(),
 		out: (line) => process.stdout.write(`${line}\n`),
 		signals: {
 			on: (signal, handler) => {

--- a/apps/node/src/cli/program.ts
+++ b/apps/node/src/cli/program.ts
@@ -12,12 +12,20 @@ import {
 	type SignalSource
 } from '../core/runtime';
 import type { SecretStore } from '../core/secret-store';
+import type { ResourceProbe } from '../core/resource-limits';
 import {
+	clampResourceLimits,
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
+	MAX_CONCURRENT_JOBS,
+	MAX_CPU_PERCENT,
 	MAX_HEARTBEAT_INTERVAL_MS,
+	MIN_CONCURRENT_JOBS,
+	MIN_CPU_PERCENT,
 	MIN_HEARTBEAT_INTERVAL_MS,
+	MIN_MEMORY_MB,
 	redactConfig,
-	type NodeConfig
+	type NodeConfig,
+	type NodeResourceLimits
 } from '../core/types';
 
 /**
@@ -70,6 +78,11 @@ export interface CliDeps {
 	 * (the real service runs until a signal arrives); tests override it.
 	 */
 	waitForShutdown?(): Promise<void>;
+	/**
+	 * Host sampler for the CPU/memory admission gate. Optional: without it
+	 * only the concurrency ceiling is enforced.
+	 */
+	resourceProbe?: ResourceProbe;
 }
 
 /**
@@ -122,17 +135,82 @@ export interface EnrollCommandOptions {
 	token: string;
 	name?: string;
 	heartbeatInterval?: string;
+	/** Comma-separated capability opt-in (A15). Omitted = offer everything detected. */
+	capabilities?: string;
+	/** Resource ceilings (A16). */
+	concurrency?: string;
+	maxCpu?: string;
+	maxMemory?: string;
+}
+
+/** Parse `--capabilities a,b,c` into a tag list; blank entries are dropped. */
+export function parseCapabilityList(raw: string | undefined): string[] | undefined {
+	if (raw === undefined) {
+		return undefined;
+	}
+	return raw
+		.split(',')
+		.map((tag) => tag.trim())
+		.filter((tag) => tag.length > 0);
+}
+
+/** Parse one bounded numeric flag, refusing (never silently clamping) bad input. */
+function parseBounded(raw: string | undefined, flag: string, min: number, max: number): number | undefined {
+	if (raw === undefined) {
+		return undefined;
+	}
+	const value = Number(raw);
+	if (!Number.isFinite(value) || !Number.isInteger(value)) {
+		throw new CliError(`${flag} must be a whole number (got "${raw}")`);
+	}
+	if (value < min || value > max) {
+		throw new CliError(`${flag} must be between ${min} and ${max} (got ${value})`);
+	}
+	return value;
+}
+
+/** Build the resource-limit overrides implied by the CLI flags, if any. */
+export function parseLimitFlags(options: {
+	concurrency?: string;
+	maxCpu?: string;
+	maxMemory?: string;
+}): Partial<NodeResourceLimits> | undefined {
+	const maxConcurrentJobs = parseBounded(
+		options.concurrency,
+		'--concurrency',
+		MIN_CONCURRENT_JOBS,
+		MAX_CONCURRENT_JOBS
+	);
+	const maxCpuPercent = parseBounded(options.maxCpu, '--max-cpu', MIN_CPU_PERCENT, MAX_CPU_PERCENT);
+	const maxMemoryMb = parseBounded(options.maxMemory, '--max-memory', MIN_MEMORY_MB, Number.MAX_SAFE_INTEGER);
+
+	const limits: Partial<NodeResourceLimits> = {};
+	if (maxConcurrentJobs !== undefined) limits.maxConcurrentJobs = maxConcurrentJobs;
+	if (maxCpuPercent !== undefined) limits.maxCpuPercent = maxCpuPercent;
+	if (maxMemoryMb !== undefined) limits.maxMemoryMb = maxMemoryMb;
+	return Object.keys(limits).length > 0 ? limits : undefined;
+}
+
+function describeLimits(limits: NodeResourceLimits): string {
+	const parts = [`${limits.maxConcurrentJobs} concurrent job(s)`];
+	parts.push(limits.maxCpuPercent === null ? 'no CPU ceiling' : `CPU < ${limits.maxCpuPercent}%`);
+	parts.push(limits.maxMemoryMb === null ? 'no memory ceiling' : `memory < ${limits.maxMemoryMb}MB`);
+	return parts.join(', ');
 }
 
 export async function runEnroll(deps: CliDeps, options: EnrollCommandOptions): Promise<void> {
 	const heartbeatIntervalMs = parseIntervalSeconds(options.heartbeatInterval);
+	const capabilitySelection = parseCapabilityList(options.capabilities);
+	const limits = parseLimitFlags(options);
 	const config = await enrollNode({
 		...deps.io,
 		apiUrl: options.apiUrl,
 		token: options.token,
 		kind: 'node',
 		...(options.name !== undefined ? { name: options.name } : {}),
-		...(heartbeatIntervalMs !== undefined ? { heartbeatIntervalMs } : {})
+		...(heartbeatIntervalMs !== undefined ? { heartbeatIntervalMs } : {}),
+		...(capabilitySelection !== undefined ? { capabilitySelection } : {}),
+		...(limits !== undefined ? { limits } : {})
 	});
 
 	await saveConfig(deps.fs, deps.configPath, config, {
@@ -145,6 +223,7 @@ export async function runEnroll(deps: CliDeps, options: EnrollCommandOptions): P
 	deps.out(`  name         ${config.name ?? '(assigned by the platform)'}`);
 	deps.out(`  api          ${config.apiUrl}`);
 	deps.out(`  capabilities ${config.capabilities.join(', ') || '(none detected)'}`);
+	deps.out(`  limits       ${describeLimits(clampResourceLimits(config.limits))}`);
 	deps.out(`  config       ${deps.configPath}`);
 	deps.out(`  credential   ${deps.secrets ? deps.secrets.label : 'config file (no OS keychain available)'}`);
 	deps.out('');
@@ -156,6 +235,8 @@ export interface StartCommandOptions {
 	/** Opt in to leasing and executing platform work on this machine. */
 	work?: boolean;
 	concurrency?: string;
+	maxCpu?: string;
+	maxMemory?: string;
 }
 
 export async function runStart(deps: CliDeps, options: StartCommandOptions): Promise<void> {
@@ -164,15 +245,25 @@ export async function runStart(deps: CliDeps, options: StartCommandOptions): Pro
 	const config: NodeConfig = override === undefined ? stored : { ...stored, heartbeatIntervalMs: override };
 
 	const workerEnabled = options.work === true;
-	const concurrency = parseConcurrency(options.concurrency);
 	// A node paused by `ever-works-node pause` comes back paused: the
 	// operator drained the machine on purpose, and a service restart
 	// (or a reboot) must not quietly hand it work again.
 	const startPaused = config.paused === true;
+	// `--concurrency` is the legacy single knob; `limits` supersedes it,
+	// so it is folded in as the concurrency ceiling rather than passed
+	// alongside — two sources for one number is how they drift.
+	const concurrency = parseConcurrency(options.concurrency);
+	const limitOverrides = parseLimitFlags(options);
+	const effectiveLimits = clampResourceLimits({
+		...(concurrency !== undefined ? { maxConcurrentJobs: concurrency } : {}),
+		...(config.limits ?? {}),
+		...(limitOverrides ?? {})
+	});
 	const { loop, worker } = createNodeRuntime(config, deps.io, {
 		workerEnabled,
 		startPaused,
-		...(concurrency !== undefined ? { concurrency } : {})
+		limits: effectiveLimits,
+		...(deps.resourceProbe ? { resourceProbe: deps.resourceProbe } : {})
 	});
 	loop.onChange((state) => {
 		if (state.state === 'connected') {
@@ -188,7 +279,7 @@ export async function runStart(deps: CliDeps, options: StartCommandOptions): Pro
 		deps.out('Worker host PAUSED — heartbeating only. Run `ever-works-node resume` to take work again.');
 	} else if (worker) {
 		deps.out(
-			`Worker host enabled — leasing [${worker.registeredKinds.join(', ')}] with concurrency ${concurrency ?? 1}`
+			`Worker host enabled — leasing [${worker.registeredKinds.join(', ')}] within ${describeLimits(effectiveLimits)}`
 		);
 	} else {
 		// Say so explicitly: an operator who expected this machine to run
@@ -365,6 +456,12 @@ export async function runStatus(deps: CliDeps): Promise<void> {
 	// plaintext visible.
 	deps.out(`credential   ${view.hasSecret ? 'stored' : 'MISSING'} (${view.secretStorage})`);
 	deps.out(`work         ${view.paused ? 'PAUSED (draining — no new work)' : 'accepting new work'}`);
+	deps.out(
+		`offering     ${view.capabilitySelection ? view.capabilitySelection.join(', ') || '(identity only)' : '(everything detected)'}`
+	);
+	deps.out(`limits       ${describeLimits(view.limits)}`);
+	// The secret itself is never printed — only whether one is stored.
+	deps.out(`credential   ${view.hasSecret ? 'stored' : 'MISSING'}`);
 	deps.out(`config       ${deps.configPath}`);
 }
 
@@ -416,6 +513,22 @@ export function buildProgram(deps: CliDeps): Command {
 			'-i, --heartbeat-interval <seconds>',
 			`Heartbeat cadence in seconds (default ${DEFAULT_HEARTBEAT_INTERVAL_MS / 1000})`
 		)
+		.option(
+			'--capabilities <tags>',
+			'Comma-separated capability tags to OFFER (default: everything detected). Machine identity tags (os/arch/node) are always advertised.'
+		)
+		.option(
+			'-c, --concurrency <count>',
+			`Max jobs to execute at once (${MIN_CONCURRENT_JOBS}-${MAX_CONCURRENT_JOBS})`
+		)
+		.option(
+			'--max-cpu <percent>',
+			`Refuse new work while host CPU is at or above this percent (${MIN_CPU_PERCENT}-${MAX_CPU_PERCENT})`
+		)
+		.option(
+			'--max-memory <mb>',
+			`Refuse new work while host memory in use is at or above this many MB (min ${MIN_MEMORY_MB})`
+		)
 		.action(async (options: EnrollCommandOptions) => {
 			await runEnroll(deps, options);
 		});
@@ -425,7 +538,12 @@ export function buildProgram(deps: CliDeps): Command {
 		.description('Run the heartbeat loop (and, with --work, the job worker host) until SIGINT/SIGTERM')
 		.option('-i, --heartbeat-interval <seconds>', 'Override the stored heartbeat cadence, in seconds')
 		.option('-w, --work', 'Lease and execute platform work on this machine (off by default)')
-		.option('-c, --concurrency <count>', 'Max jobs to execute at once when --work is set (default 1)')
+		.option(
+			'-c, --concurrency <count>',
+			'Max jobs to execute at once when --work is set (overrides the stored limit)'
+		)
+		.option('--max-cpu <percent>', 'Override the stored CPU admission ceiling, in percent')
+		.option('--max-memory <mb>', 'Override the stored memory admission ceiling, in MB')
 		.action(async (options: StartCommandOptions) => {
 			await runStart(deps, options);
 		});

--- a/apps/node/src/core/auth-client.spec.ts
+++ b/apps/node/src/core/auth-client.spec.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PlatformAuthClient, credentialsLookUsable } from './auth-client';
+import { FleetClientError, type FetchLike } from './fleet-client';
+import { createLogger } from './logger';
+
+/**
+ * The authenticate leg (A14).
+ *
+ * What matters here is not that two HTTP calls happen — it is that the
+ * password goes exactly one place and comes back nowhere, that the minted
+ * token is protected the instant it exists, and that a rejected sign-in
+ * produces a client-authored message rather than echoing whatever the
+ * server said about the account.
+ */
+
+function jsonResponse(status: number, body: unknown) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		text: async () => JSON.stringify(body)
+	};
+}
+
+function recordingFetch(handler: (url: string, init: Parameters<FetchLike>[1]) => ReturnType<FetchLike>): {
+	fetchFn: FetchLike;
+	calls: Array<{ url: string; init: Parameters<FetchLike>[1] }>;
+} {
+	const calls: Array<{ url: string; init: Parameters<FetchLike>[1] }> = [];
+	return {
+		calls,
+		fetchFn: (url, init) => {
+			calls.push({ url, init });
+			return handler(url, init);
+		}
+	};
+}
+
+describe('credentialsLookUsable', () => {
+	it('accepts a plausible address with a password', () => {
+		expect(credentialsLookUsable('someone@example.com', 'hunter2')).toBe(true);
+	});
+
+	it('refuses input that cannot possibly be an address, or an empty password', () => {
+		expect(credentialsLookUsable('', 'pw')).toBe(false);
+		expect(credentialsLookUsable('nope', 'pw')).toBe(false);
+		expect(credentialsLookUsable('someone@example.com', '')).toBe(false);
+		expect(credentialsLookUsable(undefined, undefined)).toBe(false);
+	});
+});
+
+describe('PlatformAuthClient.signIn', () => {
+	it('posts the credentials once and returns the session token', async () => {
+		const { fetchFn, calls } = recordingFetch(async () =>
+			jsonResponse(200, { access_token: 'session-token-value', user: { id: 'u1', email: 'a@b.co' } })
+		);
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		const result = await client.signIn(' a@b.co ', 'hunter2');
+
+		expect(result.sessionToken).toBe('session-token-value');
+		expect(result.userId).toBe('u1');
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe('https://api.example.com/api/auth/login');
+		expect(JSON.parse(calls[0].init.body)).toEqual({ email: 'a@b.co', password: 'hunter2' });
+	});
+
+	it('registers the session token with the logger so it can never be printed', async () => {
+		const logger = createLogger({ sink: () => undefined });
+		const { fetchFn } = recordingFetch(async () => jsonResponse(200, { access_token: 'super-secret-session' }));
+		const client = new PlatformAuthClient({
+			apiUrl: 'https://api.example.com',
+			fetchFn,
+			logger,
+			timeoutMs: 0
+		});
+
+		await client.signIn('a@b.co', 'pw');
+
+		expect(logger.redact('token is super-secret-session')).not.toContain('super-secret-session');
+	});
+
+	it('refuses obviously empty input without making a request', async () => {
+		const { fetchFn, calls } = recordingFetch(async () => jsonResponse(200, {}));
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		await expect(client.signIn('', '')).rejects.toBeInstanceOf(FleetClientError);
+		expect(calls).toHaveLength(0);
+	});
+
+	it('turns a 401 into a client-authored message, never the server body', async () => {
+		const { fetchFn } = recordingFetch(async () => jsonResponse(401, { message: 'no user with email a@b.co' }));
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		await expect(client.signIn('a@b.co', 'pw')).rejects.toMatchObject({
+			kind: 'unauthorized'
+		});
+		await expect(client.signIn('a@b.co', 'pw')).rejects.not.toMatchObject({
+			message: expect.stringContaining('no user with email')
+		});
+	});
+
+	it('fails loudly when the response carries no token', async () => {
+		const { fetchFn } = recordingFetch(async () => jsonResponse(200, { user: { id: 'u1' } }));
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		await expect(client.signIn('a@b.co', 'pw')).rejects.toMatchObject({ kind: 'malformed' });
+	});
+});
+
+describe('PlatformAuthClient.createEnrollmentToken', () => {
+	it('sends the session token as a bearer credential and returns the minted token', async () => {
+		const { fetchFn, calls } = recordingFetch(async () => jsonResponse(201, { token: 'one-time-token' }));
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		const token = await client.createEnrollmentToken('session-value', {
+			name: '  My laptop ',
+			kind: 'desktop-node'
+		});
+
+		expect(token).toBe('one-time-token');
+		expect(calls[0].url).toBe('https://api.example.com/api/fleet/nodes/enrollment-token');
+		expect(calls[0].init.headers.Authorization).toBe('Bearer session-value');
+		expect(JSON.parse(calls[0].init.body)).toEqual({ name: 'My laptop', kind: 'desktop-node' });
+	});
+
+	it('protects the minted token immediately', async () => {
+		const logger = createLogger({ sink: () => undefined });
+		const { fetchFn } = recordingFetch(async () => jsonResponse(201, { token: 'mintedtokenvalue' }));
+		const client = new PlatformAuthClient({
+			apiUrl: 'https://api.example.com',
+			fetchFn,
+			logger,
+			timeoutMs: 0
+		});
+
+		await client.createEnrollmentToken('session-value', { name: 'n', kind: 'node' });
+
+		expect(logger.redact('token mintedtokenvalue')).not.toContain('mintedtokenvalue');
+	});
+
+	it('refuses a blank node name without calling the API', async () => {
+		const { fetchFn, calls } = recordingFetch(async () => jsonResponse(201, { token: 't' }));
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		await expect(client.createEnrollmentToken('s', { name: '   ', kind: 'node' })).rejects.toMatchObject({
+			kind: 'invalid-request'
+		});
+		expect(calls).toHaveLength(0);
+	});
+
+	it('maps 403 to a message about permissions rather than credentials', async () => {
+		const { fetchFn } = recordingFetch(async () => jsonResponse(403, {}));
+		const client = new PlatformAuthClient({ apiUrl: 'https://api.example.com', fetchFn, timeoutMs: 0 });
+
+		await expect(client.createEnrollmentToken('s', { name: 'n', kind: 'node' })).rejects.toMatchObject({
+			kind: 'forbidden'
+		});
+	});
+});
+
+describe('sign-in never leaks the password', () => {
+	it('keeps the password out of every logged line, including failures', async () => {
+		const logger = createLogger({ sink: () => undefined });
+		const lines: string[] = [];
+		const spy = vi.spyOn(logger, 'redact');
+		const { fetchFn } = recordingFetch(async () => {
+			throw new Error('connect ECONNREFUSED');
+		});
+		const client = new PlatformAuthClient({
+			apiUrl: 'https://api.example.com',
+			fetchFn,
+			logger,
+			timeoutMs: 0
+		});
+
+		await expect(client.signIn('a@b.co', 'my-secret-password')).rejects.toBeInstanceOf(FleetClientError);
+
+		for (const call of spy.mock.calls) {
+			lines.push(String(call[0]));
+		}
+		expect(lines.join('\n')).not.toContain('my-secret-password');
+	});
+});

--- a/apps/node/src/core/auth-client.ts
+++ b/apps/node/src/core/auth-client.ts
@@ -1,0 +1,239 @@
+import { FleetClientError, joinUrl, normalizeApiUrl, type FetchLike, type FetchRequestInit } from './fleet-client';
+import type { Logger } from './logger';
+import type { FleetNodeKind } from './types';
+
+/**
+ * The *authenticate* leg of enrollment (PRD §3.2 — "sign in instead of
+ * pasting").
+ *
+ * Before this, the only way onto a fleet was: open the web app, issue a
+ * one-time token in Fleet settings, copy it, alt-tab, paste it. That is fine
+ * for one machine and miserable for ten — and it pushes a single-use
+ * credential through the clipboard, which is the least protected place on the
+ * machine.
+ *
+ * This client lets the node do the same two calls the human was doing by hand:
+ *
+ *   POST /api/auth/login                    email + password → session token
+ *   POST /api/fleet/nodes/enrollment-token  session token   → enrollment token
+ *
+ * The enrollment token is then consumed by the ordinary `POST /api/fleet/enroll`
+ * path, so the server-side protocol is completely unchanged — this is a nicer
+ * way to OBTAIN the token, not a new way to enroll.
+ *
+ * ## Credential handling
+ *
+ * - The password is used for exactly one request and is never stored,
+ *   persisted, or logged. Callers pass it straight through from the form.
+ * - The session token and the minted enrollment token are registered with the
+ *   logger (`protect`) the moment they exist, so neither can appear in a log
+ *   line or an error message.
+ * - Only the long-lived heartbeat secret is ever written to disk, by the
+ *   existing `saveConfig` path. Nothing here persists anything.
+ */
+
+/** Result of a successful sign-in. The token is short-lived and in-memory only. */
+export interface SignInResult {
+	sessionToken: string;
+	userId: string | null;
+	email: string | null;
+}
+
+export interface PlatformAuthClientOptions {
+	apiUrl: string;
+	fetchFn: FetchLike;
+	logger?: Logger;
+	/** Sent as `User-Agent` — the production edge 403s default/absent agents. */
+	userAgent?: string;
+	/** Per-request timeout; 0 disables the abort signal (used in tests). */
+	timeoutMs?: number;
+}
+
+export const DEFAULT_AUTH_TIMEOUT_MS = 20_000;
+
+/** Local shape check so an obviously empty form never leaves the machine. */
+export function credentialsLookUsable(email: string | undefined, password: string | undefined): boolean {
+	if (typeof email !== 'string' || typeof password !== 'string') {
+		return false;
+	}
+	const trimmed = email.trim();
+	// Deliberately loose: the server owns email validation. We only refuse
+	// input that cannot possibly be an address, so the user gets an instant
+	// answer instead of a round trip.
+	return trimmed.length >= 3 && trimmed.includes('@') && password.length > 0;
+}
+
+export class PlatformAuthClient {
+	private readonly apiUrl: string;
+	private readonly fetchFn: FetchLike;
+	private readonly logger: Logger | undefined;
+	private readonly userAgent: string;
+	private readonly timeoutMs: number;
+
+	constructor(options: PlatformAuthClientOptions) {
+		this.apiUrl = normalizeApiUrl(options.apiUrl);
+		this.fetchFn = options.fetchFn;
+		this.logger = options.logger;
+		this.userAgent = options.userAgent ?? 'ever-works-node';
+		this.timeoutMs = options.timeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
+	}
+
+	get baseUrl(): string {
+		return this.apiUrl;
+	}
+
+	/**
+	 * Exchange email + password for a session token.
+	 *
+	 * The password is passed straight into the request body and dropped: it is
+	 * never held in a field, never logged, never written anywhere.
+	 */
+	async signIn(email: string, password: string): Promise<SignInResult> {
+		if (!credentialsLookUsable(email, password)) {
+			throw new FleetClientError('invalid-request', 'Enter the email and password of your Ever Works account');
+		}
+
+		const payload = await this.post('api/auth/login', 'sign-in', { email: email.trim(), password }, null);
+
+		const sessionToken = firstString(payload, ['access_token', 'accessToken', 'token']);
+		if (!sessionToken) {
+			throw new FleetClientError('malformed', 'Sign-in response did not contain a session token');
+		}
+		// Protect BEFORE anything else can touch it.
+		this.logger?.protect(sessionToken);
+
+		const user = readObject(payload, 'user');
+		return {
+			sessionToken,
+			userId: user ? firstString(user, ['id']) : null,
+			email: user ? firstString(user, ['email']) : null
+		};
+	}
+
+	/**
+	 * Mint a one-time enrollment token for this machine using a session token.
+	 *
+	 * Mirrors what the Fleet settings page's "Add node" button does; the
+	 * returned token has the same 15-minute, single-use semantics.
+	 */
+	async createEnrollmentToken(sessionToken: string, request: { name: string; kind: FleetNodeKind }): Promise<string> {
+		const name = request.name.trim();
+		if (!name) {
+			throw new FleetClientError('invalid-request', 'A node name is required to mint an enrollment token');
+		}
+		this.logger?.protect(sessionToken);
+
+		const payload = await this.post(
+			'api/fleet/nodes/enrollment-token',
+			'enrollment-token',
+			{ name, kind: request.kind },
+			sessionToken
+		);
+
+		const token = firstString(payload, ['token', 'enrollmentToken']);
+		if (!token) {
+			throw new FleetClientError('malformed', 'Enrollment-token response did not contain a token');
+		}
+		this.logger?.protect(token);
+		return token;
+	}
+
+	private async post(
+		path: string,
+		operation: string,
+		body: Record<string, unknown>,
+		bearer: string | null
+	): Promise<unknown> {
+		const url = joinUrl(this.apiUrl, path);
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+			'User-Agent': this.userAgent
+		};
+		if (bearer) {
+			headers.Authorization = `Bearer ${bearer}`;
+		}
+		const init: FetchRequestInit = { method: 'POST', headers, body: JSON.stringify(body) };
+		if (this.timeoutMs > 0 && typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+			init.signal = AbortSignal.timeout(this.timeoutMs);
+		}
+
+		let response;
+		try {
+			response = await this.fetchFn(url, init);
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			throw new FleetClientError('network', `Could not reach ${url}: ${this.logger?.redact(detail) ?? detail}`);
+		}
+
+		if (!response.ok) {
+			throw authErrorForStatus(response.status, operation);
+		}
+
+		let raw: string;
+		try {
+			raw = await response.text();
+		} catch {
+			throw new FleetClientError('malformed', 'Could not read the API response body');
+		}
+		try {
+			return JSON.parse(raw) as unknown;
+		} catch {
+			throw new FleetClientError('malformed', 'API response was not valid JSON');
+		}
+	}
+}
+
+/**
+ * Status → stable, client-authored message. Server bodies are never echoed:
+ * a login endpoint's error text is exactly the kind of thing that leaks
+ * whether an account exists.
+ */
+function authErrorForStatus(status: number, operation: string): FleetClientError {
+	if (status === 401) {
+		return new FleetClientError(
+			'unauthorized',
+			operation === 'sign-in'
+				? 'Sign-in was rejected — check the email and password for this API host'
+				: 'The session was rejected — sign in again',
+			status
+		);
+	}
+	if (status === 403) {
+		return new FleetClientError(
+			'forbidden',
+			'The API refused the request (403) — this account may not be allowed to add fleet nodes',
+			status
+		);
+	}
+	if (status === 429) {
+		return new FleetClientError('rate-limited', 'Too many attempts — wait a minute and try again', status);
+	}
+	if (status >= 400 && status < 500) {
+		return new FleetClientError('invalid-request', `Request rejected by the API (HTTP ${status})`, status);
+	}
+	return new FleetClientError('server', `API error (HTTP ${status})`, status);
+}
+
+function readObject(payload: unknown, key: string): Record<string, unknown> | null {
+	if (!payload || typeof payload !== 'object') {
+		return null;
+	}
+	const value = (payload as Record<string, unknown>)[key];
+	return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+/** First non-empty string among `keys`, searched in order. */
+function firstString(payload: unknown, keys: readonly string[]): string | null {
+	if (!payload || typeof payload !== 'object') {
+		return null;
+	}
+	const record = payload as Record<string, unknown>;
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === 'string' && value) {
+			return value;
+		}
+	}
+	return null;
+}

--- a/apps/node/src/core/capabilities.ts
+++ b/apps/node/src/core/capabilities.ts
@@ -195,15 +195,68 @@ export async function detectCapabilities(runner: CommandRunner, environment: Cap
 	]);
 }
 
-/** Full self-description for an enroll or heartbeat request. */
+/**
+ * Tag families that describe WHAT this machine IS rather than what it OFFERS.
+ * They are never withheld: the scheduler needs `os:`/`arch:`/`node:` to place
+ * work correctly, and hiding them would produce silent mis-placement rather
+ * than a smaller offer.
+ */
+const IDENTITY_TAG_PREFIXES = ['os:', 'arch:', 'node:'] as const;
+
+/** True when a tag is machine identity (always advertised) rather than an offer. */
+export function isIdentityCapability(tag: string): boolean {
+	return IDENTITY_TAG_PREFIXES.some((prefix) => tag.startsWith(prefix));
+}
+
+/**
+ * The tags an operator is actually allowed to choose between — everything the
+ * detector found minus the identity tags. This is what the wizard's capability
+ * step renders as checkboxes.
+ */
+export function selectableCapabilities(detected: readonly string[]): string[] {
+	return detected.filter((tag) => !isIdentityCapability(tag));
+}
+
+/**
+ * Apply the operator's capability opt-in (PRD §3.2 step 3).
+ *
+ * Semantics, in order of precedence:
+ *   1. `selection === undefined | null` → advertise everything detected
+ *      (byte-identical to the pre-selection behaviour, so an older config
+ *      keeps working).
+ *   2. otherwise → advertise identity tags plus the intersection of
+ *      `detected` and `selection`.
+ *
+ * The intersection direction matters: a selection can only ever SHRINK what
+ * the node offers. An operator cannot advertise `docker` on a machine without
+ * Docker by editing the config, and — the case that motivates this — a machine
+ * that later gains Docker does not start attracting Docker work unless its
+ * owner opted into that tag.
+ */
+export function applyCapabilitySelection(detected: readonly string[], selection?: readonly string[] | null): string[] {
+	if (selection === undefined || selection === null) {
+		return normalizeCapabilities([...detected]);
+	}
+	const chosen = new Set(normalizeCapabilities([...selection]));
+	return normalizeCapabilities(detected.filter((tag) => isIdentityCapability(tag) || chosen.has(tag)));
+}
+
+/**
+ * Full self-description for an enroll or heartbeat request.
+ *
+ * `selection` is the operator's capability opt-in; omitting it preserves the
+ * original "advertise everything detected" behaviour.
+ */
 export async function describeSelf(
 	runner: CommandRunner,
 	environment: CapabilityEnvironment,
-	version: string
+	version: string,
+	selection?: readonly string[] | null
 ): Promise<Required<NodeSelfDescription>> {
+	const detected = await detectCapabilities(runner, environment);
 	return {
 		platform: describePlatform(environment),
 		version: version.slice(0, MAX_VERSION_LENGTH),
-		capabilities: await detectCapabilities(runner, environment)
+		capabilities: applyCapabilitySelection(detected, selection)
 	};
 }

--- a/apps/node/src/core/capability-selection.spec.ts
+++ b/apps/node/src/core/capability-selection.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+	applyCapabilitySelection,
+	describeSelf,
+	isIdentityCapability,
+	selectableCapabilities,
+	type CapabilityEnvironment,
+	type CommandRunner
+} from './capabilities';
+import { parseConfig } from './config-store';
+import { clampResourceLimits, redactConfig, type NodeConfig } from './types';
+
+/**
+ * Capability selection (A15) and the config round-trip for the wizard's new
+ * answers.
+ *
+ * The property that matters: a selection can only ever SHRINK what a machine
+ * offers. The dangerous direction is the other one — a laptop that quietly
+ * starts advertising `docker` because somebody installed Docker Desktop, and
+ * therefore quietly starts being handed container work its owner never agreed
+ * to run.
+ */
+
+function runner(available: Set<string>): CommandRunner {
+	return {
+		run: async (command) => ({
+			code: available.has(command) ? 0 : 1,
+			stdout: available.has(command) ? '1.0.0' : '',
+			stderr: ''
+		})
+	};
+}
+
+const linuxEnvironment: CapabilityEnvironment = {
+	platform: 'linux',
+	arch: 'x64',
+	nodeVersion: 'v22.11.0',
+	hasDisplay: false
+};
+
+describe('isIdentityCapability', () => {
+	it('treats os/arch/node tags as machine identity, everything else as an offer', () => {
+		expect(isIdentityCapability('os:linux')).toBe(true);
+		expect(isIdentityCapability('arch:x64')).toBe(true);
+		expect(isIdentityCapability('node:22')).toBe(true);
+		expect(isIdentityCapability('docker')).toBe(false);
+		expect(isIdentityCapability('terminal')).toBe(false);
+	});
+});
+
+describe('selectableCapabilities', () => {
+	it('offers only the non-identity tags as choices', () => {
+		expect(selectableCapabilities(['os:linux', 'arch:x64', 'terminal', 'docker'])).toEqual(['terminal', 'docker']);
+	});
+});
+
+describe('applyCapabilitySelection', () => {
+	const detected = ['os:linux', 'arch:x64', 'node:22', 'terminal', 'workspace', 'docker', 'git'];
+
+	it('advertises everything detected when no selection was recorded', () => {
+		expect(applyCapabilitySelection(detected, undefined)).toEqual(detected);
+		expect(applyCapabilitySelection(detected, null)).toEqual(detected);
+	});
+
+	it('narrows the offer to the chosen tags, keeping machine identity', () => {
+		expect(applyCapabilitySelection(detected, ['terminal', 'git'])).toEqual([
+			'os:linux',
+			'arch:x64',
+			'node:22',
+			'terminal',
+			'git'
+		]);
+	});
+
+	it('an empty selection means "identity only" — a legitimate visibility-only node', () => {
+		expect(applyCapabilitySelection(detected, [])).toEqual(['os:linux', 'arch:x64', 'node:22']);
+	});
+
+	it('cannot ADD a capability the machine does not have', () => {
+		// The whole point: selection intersects, it never unions.
+		expect(applyCapabilitySelection(['os:linux', 'terminal'], ['terminal', 'docker'])).toEqual([
+			'os:linux',
+			'terminal'
+		]);
+	});
+});
+
+describe('describeSelf with a selection', () => {
+	it('reports every detected tag when no selection is supplied', async () => {
+		const description = await describeSelf(runner(new Set(['docker', 'git'])), linuxEnvironment, '1.2.3');
+		expect(description.capabilities).toContain('docker');
+		expect(description.capabilities).toContain('git');
+	});
+
+	it('withholds a capability the operator did not offer, even once the tool exists', async () => {
+		// Docker IS installed; the owner just never offered it.
+		const description = await describeSelf(runner(new Set(['docker', 'git'])), linuxEnvironment, '1.2.3', [
+			'terminal',
+			'workspace',
+			'git'
+		]);
+		expect(description.capabilities).not.toContain('docker');
+		expect(description.capabilities).toContain('git');
+		// Identity survives so the scheduler can still place work correctly.
+		expect(description.capabilities).toContain('os:linux');
+	});
+});
+
+describe('config round-trip for capability selection and limits', () => {
+	const base: NodeConfig = {
+		apiUrl: 'https://api.example.com',
+		nodeId: 'node-1',
+		secret: 'a'.repeat(32),
+		kind: 'desktop-node',
+		capabilities: ['os:linux', 'terminal'],
+		heartbeatIntervalMs: 60_000,
+		enrolledAt: new Date(0).toISOString()
+	};
+
+	it('persists and re-reads the operator selection and ceilings', () => {
+		const stored: NodeConfig = {
+			...base,
+			capabilitySelection: ['terminal'],
+			limits: { maxConcurrentJobs: 3, maxCpuPercent: 70, maxMemoryMb: 8_192 }
+		};
+		const parsed = parseConfig(JSON.stringify(stored));
+
+		expect(parsed?.capabilitySelection).toEqual(['terminal']);
+		expect(parsed?.limits).toEqual({ maxConcurrentJobs: 3, maxCpuPercent: 70, maxMemoryMb: 8_192 });
+	});
+
+	it('reads a pre-limits config as the conservative default, never a wider one', () => {
+		const parsed = parseConfig(JSON.stringify(base));
+		expect(parsed?.limits).toEqual(clampResourceLimits(null));
+		// No selection recorded stays ABSENT — distinct from an empty one.
+		expect(parsed?.capabilitySelection).toBeUndefined();
+	});
+
+	it('preserves the difference between "no selection" and "an empty selection"', () => {
+		const empty = parseConfig(JSON.stringify({ ...base, capabilitySelection: [] }));
+		expect(empty?.capabilitySelection).toEqual([]);
+	});
+
+	it('clamps a hand-edited out-of-range limit rather than trusting it', () => {
+		const parsed = parseConfig(
+			JSON.stringify({ ...base, limits: { maxConcurrentJobs: 9_999, maxCpuPercent: 0, maxMemoryMb: 1 } })
+		);
+		expect(parsed?.limits?.maxConcurrentJobs).toBe(16);
+		expect(parsed?.limits?.maxCpuPercent).toBe(5);
+		expect(parsed?.limits?.maxMemoryMb).toBe(256);
+	});
+
+	it('exposes limits and selection through the redacted view, still without the secret', () => {
+		const view = redactConfig({
+			...base,
+			capabilitySelection: ['terminal'],
+			limits: { maxConcurrentJobs: 2, maxCpuPercent: null, maxMemoryMb: null }
+		});
+		expect(view.limits.maxConcurrentJobs).toBe(2);
+		expect(view.capabilitySelection).toEqual(['terminal']);
+		expect(JSON.stringify(view)).not.toContain(base.secret);
+	});
+});

--- a/apps/node/src/core/config-store.spec.ts
+++ b/apps/node/src/core/config-store.spec.ts
@@ -8,7 +8,7 @@ import {
 	saveConfig,
 	type ConfigFileSystem
 } from './config-store';
-import { DEFAULT_HEARTBEAT_INTERVAL_MS, redactConfig, type NodeConfig } from './types';
+import { clampResourceLimits, DEFAULT_HEARTBEAT_INTERVAL_MS, redactConfig, type NodeConfig } from './types';
 
 const SECRET = 'ZmFrZS1zZWNyZXQtdmFsdWUtZm9yLXVuaXQtdGVzdHM';
 
@@ -49,12 +49,13 @@ function config(overrides: Partial<NodeConfig> = {}): NodeConfig {
 		name: 'build-box-01',
 		heartbeatIntervalMs: DEFAULT_HEARTBEAT_INTERVAL_MS,
 		enrolledAt: '2026-07-25T10:00:00.000Z',
-		// Both are normalized onto every load so an OLDER config file
+		// All three are normalized onto every load so an OLDER config file
 		// still produces a complete NodeConfig. The fixture has to carry
 		// them or the round-trip compares against a shape the store no
 		// longer returns.
 		paused: false,
 		secretStorage: 'file',
+		limits: clampResourceLimits(undefined),
 		...overrides
 	};
 }
@@ -189,13 +190,15 @@ describe('redactConfig', () => {
 			name: 'build-box-01',
 			heartbeatIntervalMs: DEFAULT_HEARTBEAT_INTERVAL_MS,
 			enrolledAt: '2026-07-25T10:00:00.000Z',
-			// Neither is a credential: `paused` is lifecycle state and
-			// `secretStorage` is the storage MODE (file vs keychain), not
-			// the secret. This assertion is an exhaustive allowlist on
-			// purpose — that is what makes it catch a credential field
-			// leaking into the redacted view.
+			// None of these is a credential: `paused` is lifecycle state,
+			// `secretStorage` is the storage MODE (file vs keychain) rather
+			// than the secret, and `limits` is a capacity policy. This
+			// assertion is an exhaustive allowlist on purpose — that is
+			// what makes it catch a credential field leaking into the
+			// redacted view.
 			paused: false,
 			secretStorage: 'file',
+			limits: clampResourceLimits(undefined),
 			hasSecret: true
 		});
 	});

--- a/apps/node/src/core/config-store.ts
+++ b/apps/node/src/core/config-store.ts
@@ -1,13 +1,13 @@
 import type { Logger } from './logger';
 import type { SecretStore } from './secret-store';
 import {
+	clampResourceLimits,
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	isFleetEnrollableNodeKind,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
 	type FleetEnrollableNodeKind,
 	type NodeConfig,
-	type FleetNodeKind,
 	type NodeSecretStorage
 } from './types';
 
@@ -151,11 +151,22 @@ export function parseConfig(raw: string | null): NodeConfig | null {
 		capabilities: Array.isArray(candidate.capabilities)
 			? candidate.capabilities.filter((tag): tag is string => typeof tag === 'string')
 			: [],
+		// A config written before limits existed reads as the conservative
+		// default, so upgrading the app never widens what a node will do.
+		limits: clampResourceLimits(candidate.limits),
 		heartbeatIntervalMs: clampInterval(candidate.heartbeatIntervalMs),
 		enrolledAt: typeof candidate.enrolledAt === 'string' ? candidate.enrolledAt : new Date(0).toISOString(),
 		secretStorage,
 		paused: candidate.paused === true
 	};
+	// Distinguish "no selection recorded" (advertise everything detected)
+	// from "an empty selection" (offer only the identity tags) — dropping
+	// the key entirely is the only way to mean the former.
+	if (Array.isArray(candidate.capabilitySelection)) {
+		config.capabilitySelection = candidate.capabilitySelection.filter(
+			(tag): tag is string => typeof tag === 'string'
+		);
+	}
 	if (typeof candidate.name === 'string' && candidate.name) {
 		config.name = candidate.name;
 	}

--- a/apps/node/src/core/index.ts
+++ b/apps/node/src/core/index.ts
@@ -10,8 +10,10 @@
  */
 
 export * from './browser-probe';
+export * from './auth-client';
 export * from './capabilities';
 export * from './config-store';
+export * from './resource-limits';
 export * from './fleet-client';
 export * from './gpu-probe';
 export * from './job-client';

--- a/apps/node/src/core/resource-limits.spec.ts
+++ b/apps/node/src/core/resource-limits.spec.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FleetJobView } from '@ever-works/contracts';
+import type { Scheduler } from './heartbeat';
+import { ADMIT, admitByResourceLimits, hasAdmissionCeilings, type ResourceSample } from './resource-limits';
+import { clampResourceLimits, DEFAULT_RESOURCE_LIMITS } from './types';
+import { WorkerLoop, type JobLeaseCapableClient } from './worker-loop';
+
+/**
+ * Resource limits (A16) and pause/resume (A18).
+ *
+ * The point of these tests is that the ceilings are HONOURED, not merely
+ * stored: a node whose owner said "one job, and not while I'm compiling"
+ * must actually refuse to lease a second job, and must actually stop
+ * leasing when the machine is busy. Storing the number and then leasing
+ * anyway would be worse than not offering the setting at all.
+ */
+
+/** Records requested delays and fires callbacks on demand. */
+function controllableScheduler(): Scheduler & { delays: number[]; runNext(): void; pending: number } {
+	const queue: Array<{ id: number; callback: () => void }> = [];
+	const delays: number[] = [];
+	let nextId = 1;
+
+	return {
+		delays,
+		get pending(): number {
+			return queue.length;
+		},
+		setTimeout(callback: () => void, ms: number): unknown {
+			delays.push(ms);
+			const id = nextId++;
+			queue.push({ id, callback });
+			return id;
+		},
+		clearTimeout(handle: unknown): void {
+			const index = queue.findIndex((entry) => entry.id === handle);
+			if (index >= 0) queue.splice(index, 1);
+		},
+		runNext(): void {
+			queue.shift()?.callback();
+		}
+	};
+}
+
+function job(overrides: Partial<FleetJobView> = {}): FleetJobView {
+	return {
+		id: 'job-1',
+		kind: 'acceptance-checks',
+		status: 'leased',
+		nodeId: 'node-1',
+		requiredCapabilities: [],
+		payload: { workspacePath: '/w', checks: [] },
+		leaseExpiresAt: null,
+		attempts: 1,
+		maxAttempts: 3,
+		createdAt: null,
+		startedAt: null,
+		completedAt: null,
+		...overrides
+	};
+}
+
+/** Client that records every lease request so we can assert on `max`. */
+function recordingClient(batches: FleetJobView[][]): JobLeaseCapableClient & {
+	leaseRequests: Array<{ max?: number }>;
+	complete: ReturnType<typeof vi.fn>;
+} {
+	let index = 0;
+	const leaseRequests: Array<{ max?: number }> = [];
+	const complete = vi.fn(async () => true);
+	const client = {
+		leaseRequests,
+		complete,
+		heartbeat: vi.fn(async () => true),
+		lease: async (request: { max?: number }) => {
+			leaseRequests.push(request);
+			const next = batches[Math.min(index, batches.length - 1)] ?? [];
+			index += 1;
+			return next;
+		}
+	};
+	return client as never;
+}
+
+function sample(overrides: Partial<ResourceSample> = {}): ResourceSample {
+	return { cpuPercent: 10, usedMemoryMb: 2_000, totalMemoryMb: 16_000, ...overrides };
+}
+
+describe('clampResourceLimits', () => {
+	it('defaults to one job and no CPU/memory ceiling', () => {
+		expect(clampResourceLimits(undefined)).toEqual(DEFAULT_RESOURCE_LIMITS);
+		expect(clampResourceLimits(null)).toEqual(DEFAULT_RESOURCE_LIMITS);
+	});
+
+	it('clamps concurrency into the supported range instead of throwing', () => {
+		expect(clampResourceLimits({ maxConcurrentJobs: 0 }).maxConcurrentJobs).toBe(1);
+		expect(clampResourceLimits({ maxConcurrentJobs: 999 }).maxConcurrentJobs).toBe(16);
+		expect(clampResourceLimits({ maxConcurrentJobs: 4.6 }).maxConcurrentJobs).toBe(5);
+	});
+
+	it('treats a nonsense ceiling as "no ceiling" rather than a hard block', () => {
+		expect(clampResourceLimits({ maxCpuPercent: Number.NaN }).maxCpuPercent).toBeNull();
+		expect(clampResourceLimits({ maxMemoryMb: Number.POSITIVE_INFINITY }).maxMemoryMb).toBeNull();
+	});
+
+	it('clamps a CPU ceiling below the floor up, not down to zero', () => {
+		// A 1% ceiling would idle the node forever; the floor is the safety.
+		expect(clampResourceLimits({ maxCpuPercent: 1 }).maxCpuPercent).toBe(5);
+	});
+});
+
+describe('admitByResourceLimits', () => {
+	it('admits when no ceiling is configured', () => {
+		expect(admitByResourceLimits({ maxCpuPercent: null, maxMemoryMb: null }, sample({ cpuPercent: 99 }))).toEqual(
+			ADMIT
+		);
+	});
+
+	it('refuses when CPU is at or above the ceiling, naming the reason', () => {
+		const decision = admitByResourceLimits({ maxCpuPercent: 80, maxMemoryMb: null }, sample({ cpuPercent: 92 }));
+		expect(decision.admit).toBe(false);
+		expect(decision.reason).toContain('CPU');
+		expect(decision.reason).toContain('80%');
+	});
+
+	it('refuses when memory in use is at or above the ceiling', () => {
+		const decision = admitByResourceLimits(
+			{ maxCpuPercent: null, maxMemoryMb: 4_096 },
+			sample({ usedMemoryMb: 4_096 })
+		);
+		expect(decision.admit).toBe(false);
+		expect(decision.reason).toContain('memory');
+	});
+
+	it('admits when the sample is missing — an unreadable probe must not idle the node', () => {
+		expect(admitByResourceLimits({ maxCpuPercent: 10, maxMemoryMb: 512 }, null)).toEqual(ADMIT);
+	});
+
+	it('knows when probing is worth the cost', () => {
+		expect(hasAdmissionCeilings({ maxCpuPercent: null, maxMemoryMb: null })).toBe(false);
+		expect(hasAdmissionCeilings({ maxCpuPercent: 50, maxMemoryMb: null })).toBe(true);
+	});
+});
+
+describe('WorkerLoop honours the operator resource limits', () => {
+	it('never leases more than maxConcurrentJobs at a time', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 3 })
+		});
+
+		await loop.start();
+
+		expect(loop.maxConcurrency).toBe(3);
+		expect(client.leaseRequests[0]?.max).toBe(3);
+		await loop.stop();
+	});
+
+	it('stops asking for work while jobs occupy the whole concurrency budget', async () => {
+		// One slot, one job that never finishes until we let it.
+		let release: () => void = () => undefined;
+		const blocked = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const client = recordingClient([[job()], []]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 1 })
+		});
+		loop.register('acceptance-checks', async () => {
+			await blocked;
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(loop.getState().activeJobIds).toHaveLength(1));
+
+		const callsWhileBusy = client.leaseRequests.length;
+		// Fire the follow-up poll: with the single slot occupied it must not
+		// reach the API at all.
+		scheduler.runNext();
+		expect(client.leaseRequests.length).toBe(callsWhileBusy);
+
+		release();
+		await loop.stop();
+	});
+
+	it('refuses to lease while the host is above the CPU ceiling, then resumes when it drops', async () => {
+		const client = recordingClient([[], []]);
+		const scheduler = controllableScheduler();
+		let cpu = 95;
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 2, maxCpuPercent: 80 }),
+			resourceProbe: { sample: () => sample({ cpuPercent: cpu }) }
+		});
+
+		await loop.start();
+
+		// Over the ceiling: visible as `throttled`, and NO lease call made.
+		expect(client.leaseRequests).toHaveLength(0);
+		expect(loop.getState().state).toBe('throttled');
+		expect(loop.getState().throttleReason).toContain('CPU');
+
+		// Machine calms down — the very next poll leases normally.
+		cpu = 12;
+		scheduler.runNext();
+		await vi.waitFor(() => expect(client.leaseRequests.length).toBe(1));
+		expect(loop.getState().throttleReason).toBeNull();
+
+		await loop.stop();
+	});
+
+	it('refuses to lease while the host is above the memory ceiling', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 2, maxMemoryMb: 4_096 }),
+			resourceProbe: { sample: () => sample({ usedMemoryMb: 8_000 }) }
+		});
+
+		await loop.start();
+
+		expect(client.leaseRequests).toHaveLength(0);
+		expect(loop.getState().throttleReason).toContain('memory');
+		await loop.stop();
+	});
+
+	it('leases anyway when the probe throws — a broken sampler must not strand the node', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 1, maxCpuPercent: 50 }),
+			resourceProbe: {
+				sample: () => {
+					throw new Error('/proc unreadable');
+				}
+			}
+		});
+
+		await loop.start();
+
+		expect(client.leaseRequests).toHaveLength(1);
+		expect(loop.getState().state).not.toBe('throttled');
+		await loop.stop();
+	});
+
+	it('skips sampling entirely when no CPU/memory ceiling is set', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const probe = { sample: vi.fn(() => sample()) };
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 2 }),
+			resourceProbe: probe
+		});
+
+		await loop.start();
+
+		expect(probe.sample).not.toHaveBeenCalled();
+		expect(client.leaseRequests).toHaveLength(1);
+		await loop.stop();
+	});
+
+	it('still honours the legacy `concurrency` option when no limits are supplied', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler, concurrency: 4 });
+
+		await loop.start();
+
+		expect(loop.maxConcurrency).toBe(4);
+		await loop.stop();
+	});
+});
+
+describe('WorkerLoop pause/resume', () => {
+	it('stops leasing while paused and starts again on resume', async () => {
+		const client = recordingClient([[], []]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler });
+
+		await loop.start();
+		expect(client.leaseRequests).toHaveLength(1);
+
+		loop.pause();
+		expect(loop.isPaused()).toBe(true);
+		expect(loop.getState().state).toBe('paused');
+		expect(loop.getState().paused).toBe(true);
+
+		// The contract is "no LEASE while paused", not "no timer". The loop
+		// deliberately keeps re-arming: that is what lets `resume()` take
+		// effect without restarting the process, and what keeps the state
+		// moving from `draining` to `paused` as the last in-flight job
+		// finishes. Draining a machine should not make it go quiet in Fleet.
+		//
+		// So the assertion is on the thing that actually matters — the tick
+		// runs and still declines to lease.
+		const leasesWhilePaused = client.leaseRequests.length;
+		scheduler.runNext();
+		await vi.waitFor(() => expect(loop.getState().paused).toBe(true));
+		expect(client.leaseRequests).toHaveLength(leasesWhilePaused);
+
+		loop.resume();
+		await vi.waitFor(() => expect(client.leaseRequests.length).toBe(2));
+		expect(loop.getState().paused).toBe(false);
+
+		await loop.stop();
+	});
+
+	it('starts paused when asked, without ever hitting the API', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler, startPaused: true });
+
+		await loop.start();
+
+		expect(client.leaseRequests).toHaveLength(0);
+		expect(loop.getState().paused).toBe(true);
+		await loop.stop();
+	});
+
+	it('lets an in-flight job finish and REPORT after a pause', async () => {
+		let release: () => void = () => undefined;
+		const blocked = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const client = recordingClient([[job()], []]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler });
+		loop.register('acceptance-checks', async () => {
+			await blocked;
+			return { ok: true };
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(loop.getState().activeJobIds).toHaveLength(1));
+
+		loop.pause();
+		release();
+
+		// Pausing must not turn finished work into a lease expiry.
+		await vi.waitFor(() =>
+			expect(client.complete).toHaveBeenCalledWith('job-1', expect.objectContaining({ success: true }))
+		);
+		await loop.stop();
+	});
+
+	it('is idempotent — a second pause or resume is a no-op', async () => {
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler });
+
+		await loop.start();
+		loop.pause();
+		loop.pause();
+		expect(loop.isPaused()).toBe(true);
+
+		loop.resume();
+		const after = client.leaseRequests.length;
+		loop.resume();
+		expect(client.leaseRequests.length).toBe(after);
+
+		await loop.stop();
+	});
+});

--- a/apps/node/src/core/resource-limits.ts
+++ b/apps/node/src/core/resource-limits.ts
@@ -1,0 +1,90 @@
+import type { NodeResourceLimits } from './types';
+
+/**
+ * Host resource sampling + the admission decision the worker loop makes
+ * before it leases new work.
+ *
+ * Split from `types.ts` so the *decision* stays pure (and therefore fully
+ * unit-testable without a machine under load) while the *sampling* lives
+ * behind an injected probe — `node-io.ts` supplies the real `node:os`-backed
+ * one, tests supply a fake, and the renderer never pulls either in.
+ */
+
+/** One observation of how busy the host is right now. */
+export interface ResourceSample {
+	/** Host CPU utilisation, 0-100. */
+	cpuPercent: number;
+	/** Host memory currently in use, in MB. */
+	usedMemoryMb: number;
+	/** Total host memory, in MB. Informational — used for log lines. */
+	totalMemoryMb: number;
+}
+
+/**
+ * Sampling seam. `sample()` may be async because a meaningful CPU reading
+ * needs two observations separated in time.
+ */
+export interface ResourceProbe {
+	sample(): Promise<ResourceSample> | ResourceSample;
+}
+
+/** Outcome of the admission check: either "go ahead" or "why not". */
+export interface AdmissionDecision {
+	admit: boolean;
+	/** Operator-facing reason when `admit` is false; null otherwise. */
+	reason: string | null;
+}
+
+export const ADMIT: AdmissionDecision = { admit: true, reason: null };
+
+/**
+ * Decide whether the node may lease MORE work right now.
+ *
+ * Rules:
+ *   - A dimension with a `null` ceiling never blocks.
+ *   - A sample that is missing / non-finite for a dimension never blocks:
+ *     an unreadable probe must not silently idle a node forever. The node
+ *     is the last line of defence, not the only one — the concurrency cap
+ *     is always enforced regardless.
+ *   - Otherwise the ceiling blocks when the sample is at or above it.
+ *
+ * NOTE the asymmetry with `maxConcurrentJobs`: concurrency is enforced by
+ * the loop's in-flight bookkeeping (a hard cap it can compute exactly),
+ * while CPU/memory are enforced here as an admission gate on a noisy
+ * observation. Treating a noisy reading as a hard cap would let one
+ * unrelated process on the machine wedge the node permanently.
+ */
+export function admitByResourceLimits(
+	limits: Pick<NodeResourceLimits, 'maxCpuPercent' | 'maxMemoryMb'>,
+	sample: ResourceSample | null | undefined
+): AdmissionDecision {
+	if (!sample) {
+		return ADMIT;
+	}
+	const { maxCpuPercent, maxMemoryMb } = limits;
+
+	if (typeof maxCpuPercent === 'number' && Number.isFinite(sample.cpuPercent)) {
+		if (sample.cpuPercent >= maxCpuPercent) {
+			return {
+				admit: false,
+				reason: `host CPU ${Math.round(sample.cpuPercent)}% is at or above the ${maxCpuPercent}% ceiling`
+			};
+		}
+	}
+
+	if (typeof maxMemoryMb === 'number' && Number.isFinite(sample.usedMemoryMb)) {
+		if (sample.usedMemoryMb >= maxMemoryMb) {
+			return {
+				admit: false,
+				reason: `host memory ${Math.round(sample.usedMemoryMb)}MB in use is at or above the ${maxMemoryMb}MB ceiling`
+			};
+		}
+	}
+
+	return ADMIT;
+}
+
+/** True when at least one CPU/memory ceiling is set (i.e. probing is worth it). */
+export function hasAdmissionCeilings(limits: Pick<NodeResourceLimits, 'maxCpuPercent' | 'maxMemoryMb'>): boolean {
+	return typeof limits.maxCpuPercent === 'number' || typeof limits.maxMemoryMb === 'number';
+}

--- a/apps/node/src/core/runtime.spec.ts
+++ b/apps/node/src/core/runtime.spec.ts
@@ -4,6 +4,7 @@ import type { FetchLike } from './fleet-client';
 import { createLogger, type LogEntry } from './logger';
 import { clampHeartbeatInterval, createNodeRuntime, enrollNode, installShutdownHandlers } from './runtime';
 import {
+	clampResourceLimits,
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
@@ -79,7 +80,11 @@ describe('enrollNode', () => {
 			capabilities: ['os:linux', 'arch:x64', 'node:22', 'terminal', 'workspace', 'git'],
 			name: 'build-box-01',
 			heartbeatIntervalMs: DEFAULT_HEARTBEAT_INTERVAL_MS,
-			enrolledAt: '2026-07-25T10:00:00.000Z'
+			enrolledAt: '2026-07-25T10:00:00.000Z',
+			// Enrollment writes the clamped limits so the very first run
+			// already has a capacity policy on disk rather than inheriting
+			// an implicit default that later drifts.
+			limits: clampResourceLimits(undefined)
 		});
 
 		// The whole enrollment conversation is logged — with neither credential in it.

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -1,20 +1,23 @@
+import { PlatformAuthClient } from './auth-client';
 import { describeSelf, type CapabilityEnvironment, type CommandRunner } from './capabilities';
 import { FleetClient, type FetchLike } from './fleet-client';
 import { FleetJobClient } from './job-client';
 import { HeartbeatLoop, type Scheduler } from './heartbeat';
+import type { ResourceProbe } from './resource-limits';
 import { WorkerLoop } from './worker-loop';
 import { runAcceptanceChecksJob } from './executors/acceptance-checks';
 import { runAgentTaskJob } from './executors/agent-task';
 import { runBrowserCheckJob } from './executors/browser-check';
 import type { Logger } from './logger';
 import {
+	clampResourceLimits,
 	DEFAULT_HEARTBEAT_INTERVAL_MS,
 	MAX_HEARTBEAT_INTERVAL_MS,
 	MIN_HEARTBEAT_INTERVAL_MS,
 	type FleetEnrollableNodeKind,
-	type FleetNodeKind,
 	type FleetNodeView,
-	type NodeConfig
+	type NodeConfig,
+	type NodeResourceLimits
 } from './types';
 
 /**
@@ -44,6 +47,13 @@ export interface EnrollNodeOptions extends NodeIo {
 	/** Local display label. Optional — defaults to the platform-assigned name. */
 	name?: string;
 	heartbeatIntervalMs?: number;
+	/**
+	 * Operator's capability opt-in (wizard step 3). Omitted means "advertise
+	 * everything detected"; supplied, it can only shrink the offer.
+	 */
+	capabilitySelection?: readonly string[];
+	/** Operator's resource ceilings (wizard step 4). Clamped before storage. */
+	limits?: Partial<NodeResourceLimits>;
 }
 
 /** Clamp an operator-supplied heartbeat interval into the supported range. */
@@ -74,28 +84,86 @@ export async function enrollNode(options: EnrollNodeOptions): Promise<NodeConfig
 		userAgent: options.userAgent ?? `ever-works-node/${options.version}`
 	});
 
-	const description = await describeSelf(options.runner, options.environment, options.version);
+	const description = await describeSelf(
+		options.runner,
+		options.environment,
+		options.version,
+		options.capabilitySelection ?? null
+	);
 	logger.info(`Enrolling with ${client.baseUrl} as ${description.platform} [${description.capabilities.join(', ')}]`);
 
 	const result = await client.enroll({ token: options.token, ...description });
 	logger.protect(result.secret);
 
+	const limits = clampResourceLimits(options.limits);
 	const config: NodeConfig = {
 		apiUrl: client.baseUrl,
 		nodeId: result.nodeId,
 		secret: result.secret,
 		kind: options.kind,
 		capabilities: description.capabilities,
+		limits,
 		heartbeatIntervalMs: clampHeartbeatInterval(options.heartbeatIntervalMs),
 		enrolledAt: new Date(options.now ? options.now() : Date.now()).toISOString()
 	};
+	if (options.capabilitySelection) {
+		config.capabilitySelection = [...options.capabilitySelection];
+	}
 	const label = options.name?.trim() || result.node.name;
 	if (label) {
 		config.name = label;
 	}
 
-	logger.info(`Enrolled as node ${result.nodeId} ("${config.name ?? 'unnamed'}")`);
+	logger.info(
+		`Enrolled as node ${result.nodeId} ("${config.name ?? 'unnamed'}") — ` +
+			`max ${limits.maxConcurrentJobs} concurrent job(s)`
+	);
 	return config;
+}
+
+export interface EnrollWithCredentialsOptions extends Omit<EnrollNodeOptions, 'token'> {
+	email: string;
+	/** Used for exactly one request; never stored, never logged. */
+	password: string;
+	/** Name registered with the platform when minting the token. */
+	nodeName: string;
+}
+
+/**
+ * The authenticate leg (A14): sign in, mint a one-time enrollment token, then
+ * run the ordinary {@link enrollNode} path with it.
+ *
+ * The single-use token still exists and is still consumed exactly once — this
+ * removes the clipboard from the loop, not the protocol step. The password
+ * lives only in this call frame; only the resulting heartbeat secret is ever
+ * persisted, by the caller's `saveConfig`.
+ */
+export async function enrollNodeWithCredentials(options: EnrollWithCredentialsOptions): Promise<NodeConfig> {
+	const { logger } = options;
+	const auth = new PlatformAuthClient({
+		apiUrl: options.apiUrl,
+		fetchFn: options.fetchFn,
+		logger,
+		userAgent: options.userAgent ?? `ever-works-node/${options.version}`
+	});
+
+	const session = await auth.signIn(options.email, options.password);
+	logger.info(`Signed in to ${auth.baseUrl}${session.email ? ` as ${session.email}` : ''}`);
+
+	const token = await auth.createEnrollmentToken(session.sessionToken, {
+		name: options.nodeName,
+		kind: options.kind
+	});
+	logger.info('Enrollment token minted for this machine');
+
+	const { email: _email, password: _password, nodeName, ...rest } = options;
+	return enrollNode({
+		...rest,
+		token,
+		// The local label defaults to the name we just registered, so the
+		// status window and the Fleet page agree without a second prompt.
+		...(rest.name ? {} : { name: nodeName })
+	});
 }
 
 export interface NodeRuntime {
@@ -118,8 +186,18 @@ export interface CreateNodeRuntimeOptions {
 	 * commands are two different consents, and the second is opt-in.
 	 */
 	workerEnabled?: boolean;
-	/** Max jobs in flight on this node. */
+	/**
+	 * Max jobs in flight on this node. Superseded by the stored
+	 * `config.limits.maxConcurrentJobs` when the node has limits.
+	 */
 	concurrency?: number;
+	/**
+	 * Override the stored resource ceilings. Normally omitted — the node's
+	 * own `config.limits` is the source of truth.
+	 */
+	limits?: Partial<NodeResourceLimits>;
+	/** Host sampler backing the CPU/memory admission gate. */
+	resourceProbe?: ResourceProbe;
 	leaseTtlSec?: number;
 	idlePollMs?: number;
 	/**
@@ -153,11 +231,14 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 		userAgent
 	});
 
+	// Re-detection stays intersected with the operator's opt-in, so a tool
+	// installed after enrollment never silently widens what this node offers.
+	const selection = config.capabilitySelection ?? null;
 	const loopOptions = {
 		client,
 		nodeId: config.nodeId,
 		secret: config.secret,
-		describe: () => describeSelf(io.runner, io.environment, io.version),
+		describe: () => describeSelf(io.runner, io.environment, io.version, selection),
 		intervalMs: clampHeartbeatInterval(config.heartbeatIntervalMs),
 		logger: io.logger,
 		...(io.scheduler ? { scheduler: io.scheduler } : {}),
@@ -175,10 +256,18 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 			logger: io.logger,
 			userAgent
 		});
+		// Precedence: explicit override → the node's stored limits → the
+		// legacy `concurrency` option → defaults.
+		const limits = clampResourceLimits(
+			options.limits ??
+				config.limits ??
+				(options.concurrency !== undefined ? { maxConcurrentJobs: options.concurrency } : null)
+		);
 		const worker = new WorkerLoop({
 			client: jobClient,
 			logger: io.logger,
-			...(options.concurrency !== undefined ? { concurrency: options.concurrency } : {}),
+			limits,
+			...(options.resourceProbe ? { resourceProbe: options.resourceProbe } : {}),
 			...(options.leaseTtlSec !== undefined ? { leaseTtlSec: options.leaseTtlSec } : {}),
 			...(options.idlePollMs !== undefined ? { idlePollMs: options.idlePollMs } : {}),
 			...(options.startPaused !== undefined ? { startPaused: options.startPaused } : {}),

--- a/apps/node/src/core/types.ts
+++ b/apps/node/src/core/types.ts
@@ -38,15 +38,6 @@ export type {
 	FleetNodeStatus,
 	FleetNodeView
 } from '@ever-works/contracts';
-/**
- * Node lifecycle as reported by the platform.
- *
- * `paused` is a drain, not a cut: the platform stops leasing new work
- * onto the node while its in-flight jobs keep reporting, and heartbeats
- * stay accepted so a drained machine remains visible in Fleet.
- */
-export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'paused' | 'disabled';
-
 export { FLEET_ENROLLABLE_NODE_KINDS, isFleetEnrollableNodeKind } from '@ever-works/contracts';
 
 /**
@@ -87,6 +78,94 @@ export const MAX_HEARTBEAT_BACKOFF_MS = FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS;
 export const MIN_HEARTBEAT_INTERVAL_MS = 5_000;
 export const MAX_HEARTBEAT_INTERVAL_MS = 15 * 60_000;
 
+// ---------------------------------------------------------------------------
+// Resource limits (wizard step 4 — "how much of this machine may be used")
+// ---------------------------------------------------------------------------
+
+/**
+ * Ceilings the operator sets on how much of THIS machine the platform may
+ * consume. They are enforced entirely on the node — the platform never learns
+ * them and never has to be trusted to respect them, which is the whole point:
+ * lending a machine has to be revocable and bounded from the machine's side.
+ *
+ * - `maxConcurrentJobs` is a hard cap on the worker loop's in-flight set.
+ * - `maxCpuPercent` / `maxMemoryMb` are *admission* ceilings: the loop refuses
+ *   to lease NEW work while the host is above them. They deliberately do NOT
+ *   kill running jobs — a job that is already executing has a lease the
+ *   platform is waiting on, and abandoning it mid-flight would just get the
+ *   work re-offered to the same over-loaded machine.
+ *
+ * `null` means "no ceiling for this dimension".
+ */
+export interface NodeResourceLimits {
+	maxConcurrentJobs: number;
+	/** Refuse to lease while host CPU utilisation exceeds this (1-100), or null. */
+	maxCpuPercent: number | null;
+	/** Refuse to lease while host memory IN USE exceeds this many MB, or null. */
+	maxMemoryMb: number | null;
+}
+
+/** Concurrency bounds. The upper bound matches the server's max lease batch. */
+export const MIN_CONCURRENT_JOBS = 1;
+export const MAX_CONCURRENT_JOBS = 16;
+
+/** CPU ceiling bounds, in percent of total host CPU. */
+export const MIN_CPU_PERCENT = 5;
+export const MAX_CPU_PERCENT = 100;
+
+/** Memory ceiling bounds, in MB of host memory in use. */
+export const MIN_MEMORY_MB = 256;
+export const MAX_MEMORY_MB = 1_024 * 1_024;
+
+/**
+ * Conservative default: one job at a time, no CPU/memory admission gate. A
+ * fresh node must behave exactly like it did before limits existed.
+ */
+export const DEFAULT_RESOURCE_LIMITS: NodeResourceLimits = {
+	maxConcurrentJobs: 1,
+	maxCpuPercent: null,
+	maxMemoryMb: null
+};
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return fallback;
+	}
+	return Math.min(Math.max(Math.round(value), min), max);
+}
+
+function clampOptional(value: unknown, min: number, max: number): number | null {
+	if (value === null || value === undefined) {
+		return null;
+	}
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return null;
+	}
+	return Math.min(Math.max(Math.round(value), min), max);
+}
+
+/**
+ * Coerce operator input (a wizard form, a CLI flag, a stored config written by
+ * an older build) into a coherent {@link NodeResourceLimits}. Nonsense never
+ * throws — it collapses to the default for that dimension, because a bad limit
+ * must not be the thing that stops a node from starting.
+ */
+export function clampResourceLimits(input: Partial<NodeResourceLimits> | null | undefined): NodeResourceLimits {
+	if (!input || typeof input !== 'object') {
+		return { ...DEFAULT_RESOURCE_LIMITS };
+	}
+	return {
+		maxConcurrentJobs: clampInt(
+			input.maxConcurrentJobs,
+			MIN_CONCURRENT_JOBS,
+			MAX_CONCURRENT_JOBS,
+			DEFAULT_RESOURCE_LIMITS.maxConcurrentJobs
+		),
+		maxCpuPercent: clampOptional(input.maxCpuPercent, MIN_CPU_PERCENT, MAX_CPU_PERCENT),
+		maxMemoryMb: clampOptional(input.maxMemoryMb, MIN_MEMORY_MB, MAX_MEMORY_MB)
+	};
+}
+
 /**
  * Where the heartbeat secret physically lives.
  *
@@ -113,6 +192,16 @@ export interface NodeConfig {
 	secret: string;
 	kind: FleetEnrollableNodeKind;
 	capabilities: string[];
+	/**
+	 * Operator's capability opt-in (wizard step 3). When present, only these
+	 * tags may be advertised: re-detection on each heartbeat is intersected
+	 * with this set, so installing Docker on a node whose owner did not offer
+	 * `docker` does NOT silently start attracting Docker work. Absent means
+	 * "advertise everything detected" — the pre-selection behaviour.
+	 */
+	capabilitySelection?: string[];
+	/** Ceilings this machine enforces on itself (wizard step 4). */
+	limits?: NodeResourceLimits;
 	/** Local display label; the authoritative name lives on the platform. */
 	name?: string;
 	heartbeatIntervalMs: number;
@@ -135,6 +224,8 @@ export interface RedactedNodeConfig {
 	nodeId: string;
 	kind: FleetEnrollableNodeKind;
 	capabilities: string[];
+	capabilitySelection?: string[];
+	limits: NodeResourceLimits;
 	name?: string;
 	heartbeatIntervalMs: number;
 	enrolledAt: string;
@@ -153,12 +244,16 @@ export function redactConfig(config: NodeConfig): RedactedNodeConfig {
 		nodeId: config.nodeId,
 		kind: config.kind,
 		capabilities: [...config.capabilities],
+		limits: clampResourceLimits(config.limits),
 		heartbeatIntervalMs: config.heartbeatIntervalMs,
 		enrolledAt: config.enrolledAt,
 		hasSecret: typeof config.secret === 'string' && config.secret.length > 0,
 		secretStorage: config.secretStorage ?? 'file',
 		paused: config.paused === true
 	};
+	if (config.capabilitySelection !== undefined) {
+		redacted.capabilitySelection = [...config.capabilitySelection];
+	}
 	if (config.name !== undefined) {
 		redacted.name = config.name;
 	}

--- a/apps/node/src/core/worker-loop.ts
+++ b/apps/node/src/core/worker-loop.ts
@@ -3,6 +3,8 @@ import { FLEET_JOB_DEFAULT_LEASE_TTL_SEC, FLEET_JOB_MAX_LEASE_BATCH } from '@eve
 import type { Logger } from './logger';
 import type { Scheduler } from './heartbeat';
 import { systemScheduler } from './heartbeat';
+import { admitByResourceLimits, hasAdmissionCeilings, type ResourceProbe } from './resource-limits';
+import { clampResourceLimits, type NodeResourceLimits } from './types';
 
 /**
  * The node worker host: lease → execute → report, forever, until stopped.
@@ -92,10 +94,21 @@ export type WorkerState =
 	| 'retrying'
 	| 'unauthorized'
 	| 'draining'
+	// Over an operator-set CPU/memory ceiling: the loop keeps running and
+	// keeps its in-flight jobs, it just does not lease MORE. Distinct from
+	// `paused`, which is a deliberate operator stop rather than the host
+	// protecting itself.
+	| 'throttled'
 	| 'paused'
 	| 'stopped';
 
 export interface WorkerLoopState {
+	/**
+	 * Why leasing is currently withheld by a resource ceiling, or null.
+	 * Surfaced so an idle-looking node can explain itself instead of
+	 * appearing broken.
+	 */
+	throttleReason?: string | null;
 	state: WorkerState;
 	/** Jobs currently executing on this node. */
 	activeJobIds: string[];
@@ -109,6 +122,10 @@ export interface WorkerLoopState {
 }
 
 export interface WorkerLoopOptions {
+	/** Operator-set CPU/memory ceilings. Wins over `concurrency`. */
+	limits?: NodeResourceLimits;
+	/** Host sampler backing the admission gate. Absent = no ceilings. */
+	resourceProbe?: ResourceProbe;
 	client: JobLeaseCapableClient;
 	/** Max jobs in flight on this node at once. */
 	concurrency?: number;
@@ -131,6 +148,8 @@ export class WorkerLoop {
 	private readonly concurrency: number;
 	private readonly leaseTtlSec: number;
 	private readonly idlePollMs: number;
+	private readonly limits: NodeResourceLimits;
+	private readonly resourceProbe: ResourceProbe | undefined;
 
 	private running = false;
 	private stopping = false;
@@ -143,7 +162,8 @@ export class WorkerLoop {
 		completed: 0,
 		failed: 0,
 		lastError: null,
-		paused: false
+		paused: false,
+		throttleReason: null
 	};
 
 	constructor(private readonly options: WorkerLoopOptions) {
@@ -151,6 +171,10 @@ export class WorkerLoop {
 		this.concurrency = Math.min(Math.max(options.concurrency ?? 1, 1), FLEET_JOB_MAX_LEASE_BATCH);
 		this.leaseTtlSec = options.leaseTtlSec ?? FLEET_JOB_DEFAULT_LEASE_TTL_SEC;
 		this.idlePollMs = options.idlePollMs ?? DEFAULT_IDLE_POLL_MS;
+		// `limits` wins over the legacy `concurrency` option so there is
+		// exactly one number in play once an operator has set limits.
+		this.limits = clampResourceLimits(options.limits ?? { maxConcurrentJobs: this.concurrency });
+		this.resourceProbe = options.resourceProbe;
 		this.paused = options.startPaused === true;
 		this.state.paused = this.paused;
 		if (this.paused) {
@@ -162,6 +186,16 @@ export class WorkerLoop {
 	register(kind: FleetJobKind, executor: JobExecutor): this {
 		this.executors.set(kind, executor);
 		return this;
+	}
+
+	/** The ceilings this loop is enforcing (already clamped). */
+	get resourceLimits(): NodeResourceLimits {
+		return { ...this.limits };
+	}
+
+	/** Max jobs this loop will ever run at once. */
+	get maxConcurrency(): number {
+		return this.limits.maxConcurrentJobs;
 	}
 
 	get registeredKinds(): FleetJobKind[] {
@@ -273,10 +307,29 @@ export class WorkerLoop {
 			return;
 		}
 
-		const capacity = this.concurrency - this.inFlight.size;
+		// `limits.maxConcurrentJobs` — not the legacy `concurrency` field.
+		// `limits` supersedes it (and is clamped), so reading the raw
+		// option here would silently ignore an operator's ceiling.
+		const capacity = this.limits.maxConcurrentJobs - this.inFlight.size;
 		if (capacity <= 0) {
 			this.scheduleNext(this.idlePollMs);
 			return;
+		}
+
+		// Admission gate: CPU / memory ceilings. Evaluated BEFORE the lease
+		// call so an over-loaded machine never claims work it then has to
+		// run badly — the platform re-offers it to a node with headroom.
+		const admission = await this.checkResourceAdmission();
+		if (!admission.admit) {
+			this.patch({
+				state: this.inFlight.size > 0 ? 'working' : 'throttled',
+				throttleReason: admission.reason
+			});
+			this.scheduleNext(this.idlePollMs);
+			return;
+		}
+		if (this.state.throttleReason != null) {
+			this.patch({ throttleReason: null });
 		}
 
 		this.patch({ state: this.inFlight.size > 0 ? 'working' : 'polling' });
@@ -324,6 +377,29 @@ export class WorkerLoop {
 	}
 
 	/** What the loop settles into once a job finishes. */
+	/**
+	 * Sample the host and decide whether more work may be admitted.
+	 *
+	 * A probe that throws or is absent ADMITS: the ceilings are a courtesy to
+	 * the machine's owner, and a broken sampler must degrade to "behave like
+	 * there were no ceiling", never to "this node is permanently idle".
+	 */
+	private async checkResourceAdmission(): Promise<{ admit: boolean; reason: string | null }> {
+		if (!this.resourceProbe || !hasAdmissionCeilings(this.limits)) {
+			return { admit: true, reason: null };
+		}
+		try {
+			const sample = await this.resourceProbe.sample();
+			return admitByResourceLimits(this.limits, sample);
+		} catch (error) {
+			const raw = error instanceof Error ? error.message : String(error);
+			this.options.logger?.warn(
+				`Resource probe failed, admitting work anyway: ${this.options.logger?.redact(raw) ?? raw}`
+			);
+			return { admit: true, reason: null };
+		}
+	}
+
 	private nextIdleState(): WorkerState {
 		if (this.paused) {
 			return this.inFlight.size > 0 ? 'draining' : 'paused';

--- a/apps/node/src/node-io.ts
+++ b/apps/node/src/node-io.ts
@@ -10,6 +10,7 @@ import { resolveConfigPath, type ConfigFileSystem } from './core/config-store';
 import type { FetchLike } from './core/fleet-client';
 import type { Logger } from './core/logger';
 import { keychainDisabledByEnv, resolveSecretStore, type SecretStore } from './core/secret-store';
+import type { ResourceProbe, ResourceSample } from './core/resource-limits';
 
 /**
  * Real IO adapters for the headless node.
@@ -180,6 +181,74 @@ export function createSecretStore(logger?: Logger): SecretStore | null {
 		disabled: keychainDisabledByEnv(process.env),
 		...(logger ? { logger } : {})
 	});
+}
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/** Snapshot of cumulative per-core CPU time, in milliseconds. */
+interface CpuTicks {
+	idleMs: number;
+	totalMs: number;
+}
+
+function readCpuTicks(): CpuTicks {
+	let idleMs = 0;
+	let totalMs = 0;
+	for (const cpu of os.cpus()) {
+		const times = cpu.times;
+		idleMs += times.idle;
+		totalMs += times.user + times.nice + times.sys + times.irq + times.idle;
+	}
+	return { idleMs, totalMs };
+}
+
+/**
+ * Real host sampler for the CPU/memory admission gate.
+ *
+ * CPU has to be measured as a DELTA — `os.cpus()` reports cumulative ticks
+ * since boot, so a single reading tells you the machine's lifetime average,
+ * not what it is doing now. We keep the previous reading and diff against it;
+ * the first call has no predecessor and reports 0%, which admits work. That is
+ * the right bias: a node should not refuse its very first job because it has
+ * not measured anything yet.
+ *
+ * `sampleWindowMs > 0` makes the first call take a real reading by waiting
+ * that long between two snapshots; the default 0 keeps `sample()` synchronous
+ * and relies on the delta between successive polls (which are seconds apart).
+ */
+export function createResourceProbe(options: { sampleWindowMs?: number } = {}): ResourceProbe {
+	const windowMs = Math.max(options.sampleWindowMs ?? 0, 0);
+	let previous: CpuTicks | null = null;
+
+	const measure = (current: CpuTicks, baseline: CpuTicks | null): number => {
+		if (!baseline) return 0;
+		const totalDelta = current.totalMs - baseline.totalMs;
+		const idleDelta = current.idleMs - baseline.idleMs;
+		if (totalDelta <= 0) return 0;
+		const busy = ((totalDelta - idleDelta) / totalDelta) * 100;
+		return Math.min(Math.max(busy, 0), 100);
+	};
+
+	return {
+		sample: async (): Promise<ResourceSample> => {
+			let baseline = previous;
+			if (windowMs > 0) {
+				baseline = readCpuTicks();
+				await new Promise((resolve) => setTimeout(resolve, windowMs));
+			}
+			const current = readCpuTicks();
+			const cpuPercent = measure(current, baseline);
+			previous = current;
+
+			const totalMemoryMb = os.totalmem() / BYTES_PER_MB;
+			const freeMemoryMb = os.freemem() / BYTES_PER_MB;
+			return {
+				cpuPercent,
+				usedMemoryMb: Math.max(totalMemoryMb - freeMemoryMb, 0),
+				totalMemoryMb
+			};
+		}
+	};
 }
 
 /** Node 22 ships a global fetch; the core only needs `ok`/`status`/`text()`. */

--- a/apps/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -21,6 +21,7 @@ const FALLBACK_CATALOG: OnboardingCatalogResponse = {
     storage: [],
     db: [],
     deploy: [],
+    desktop: [],
     plugins: [],
 };
 

--- a/apps/web/src/app/[locale]/onboarding/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/page.tsx
@@ -29,6 +29,7 @@ const FALLBACK_CATALOG: OnboardingCatalogResponse = {
     storage: [],
     db: [],
     deploy: [],
+    desktop: [],
     plugins: [],
 };
 const FALLBACK_STATE: OnboardingStateResponse = {

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -26,6 +26,7 @@ import type {
     OnboardingCatalogResponse,
     OnboardingDbChoice,
     OnboardingDeployChoice,
+    OnboardingDesktopChoice,
     OnboardingStateResponse,
     OnboardingStorageChoice,
 } from '@ever-works/contracts/api';
@@ -488,6 +489,18 @@ function StepBody({
                     onPlannedClick={(c) => flow.notePlannedClick('deploy', c)}
                 />
             );
+        case 'desktop-choice':
+            return (
+                <ChoiceStep
+                    title="Where Ever Works runs"
+                    description="This one is not about a provider — it decides what we point you at once the wizard is done."
+                    cards={catalog.desktop}
+                    selected={flow.state.desktop?.choice ?? 'cloud'}
+                    columns={3}
+                    onSelect={(choice) => flow.setDesktopChoice(choice as OnboardingDesktopChoice)}
+                    onPlannedClick={(c) => flow.notePlannedClick('desktop', c)}
+                />
+            );
         case 'deploy-config': {
             const pluginId = flow.state.deploy.choice; // 'vercel' | 'k8s'
             const plugin = pluginsById[pluginId] ?? null;
@@ -537,6 +550,7 @@ function StepBody({
                     onLeave={() => flow.finish()}
                     prompt={flow.state.prompt}
                     onPromptChange={flow.setPrompt}
+                    desktopChoice={flow.state.desktop?.choice}
                     onQuickCreate={
                         flow.state.prompt
                             ? async (prompt) => {
@@ -678,6 +692,8 @@ function labelForStep(step: WizardStep): string {
             return 'Your deployment';
         case 'deploy-config':
             return 'Configure deployment';
+        case 'desktop-choice':
+            return 'Where it runs';
         case 'profile':
             return 'What do you do';
         case 'communication':

--- a/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from 'react';
 import { ArrowRight, FolderPlus, Sparkles } from 'lucide-react';
+import { desktopNextStep, type OnboardingDesktopChoice } from '@ever-works/contracts/api';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 
@@ -26,6 +27,13 @@ export interface CreateWorkStepProps {
      * "Generate now".
      */
     readonly onPromptChange?: (value: string) => void;
+    /**
+     * A8 — the bucket the user picked on the "Where it runs" step. It decides
+     * the follow-on guidance rendered below the primary action: a desktop or
+     * own-nodes user is finished with the wizard but NOT finished setting up,
+     * and this is the only place the wizard can say so.
+     */
+    readonly desktopChoice?: OnboardingDesktopChoice;
 }
 
 /**
@@ -44,7 +52,11 @@ export function CreateWorkStep({
     prompt,
     onQuickCreate,
     onPromptChange,
+    desktopChoice,
 }: CreateWorkStepProps) {
+    // Defaults to the cloud path, which renders no extra guidance — so a user
+    // who never saw the bucket step sees exactly the previous screen.
+    const nextStep = desktopNextStep(desktopChoice);
     const trimmedPrompt = prompt?.trim() ?? '';
     // Latch the "generate" mode on first render. Once the step is entered via
     // the prompt hand-off it stays in generate mode for the component's
@@ -152,6 +164,27 @@ export function CreateWorkStep({
                         <ArrowRight className="w-4 h-4" />
                     </Link>
                 )}
+                {nextStep.href ? (
+                    <div
+                        data-testid="onboarding-desktop-next-step"
+                        className="mt-4 border-t border-border dark:border-border-dark pt-4"
+                    >
+                        <p className="text-sm font-medium text-text dark:text-text-dark">
+                            {nextStep.title}
+                        </p>
+                        <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+                            {nextStep.description}
+                        </p>
+                        <Link
+                            href={nextStep.href}
+                            onClick={onLeave}
+                            className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                        >
+                            {nextStep.title}
+                            <ArrowRight className="w-3.5 h-3.5" />
+                        </Link>
+                    </div>
+                ) : null}
             </div>
         </div>
     );

--- a/apps/web/src/components/onboarding/useOnboardingFlow.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.ts
@@ -7,6 +7,7 @@ import {
     type OnboardingCatalogResponse,
     type OnboardingDbChoice,
     type OnboardingDeployChoice,
+    type OnboardingDesktopChoice,
     type OnboardingStateResponse,
     type OnboardingStatePatchRequest,
     type OnboardingStorageChoice,
@@ -24,6 +25,7 @@ export type WizardStepKind =
     | 'db-choice'
     | 'deploy-choice'
     | 'deploy-config'
+    | 'desktop-choice'
     | 'profile'
     | 'communication'
     | 'plugins-catalog'
@@ -58,6 +60,10 @@ export function computeStepList(state: OnboardingWizardStateV2): WizardStep[] {
     if (state.deploy.choice === 'vercel' || state.deploy.choice === 'k8s') {
         steps.push({ kind: 'deploy-config', id: `deploy-config:${state.deploy.choice}` });
     }
+    // A8 — "where does this actually run". Asked after the four provider
+    // buckets because it is not a provider question: it decides the guidance
+    // the final step gives, not what gets provisioned.
+    steps.push({ kind: 'desktop-choice', id: 'desktop-choice' });
     // Profile — Wave 11 "What do you do" (roles + team size). Slotted
     // after the provider choices and before Communication; always
     // shown, always skippable — selections are suggestion hints only.
@@ -87,6 +93,7 @@ type FlowAction =
     | { type: 'setStorageChoice'; value: OnboardingStorageChoice }
     | { type: 'setDbChoice'; value: OnboardingDbChoice }
     | { type: 'setDeployChoice'; value: OnboardingDeployChoice }
+    | { type: 'setDesktopChoice'; value: OnboardingDesktopChoice }
     | { type: 'setPrompt'; value: string }
     | { type: 'toggleRole'; value: string }
     | { type: 'setTeamSize'; value: string }
@@ -148,6 +155,11 @@ function reduce(state: FlowReducerState, action: FlowAction): FlowReducerState {
             return {
                 ...state,
                 state: { ...state.state, deploy: { choice: action.value } },
+            };
+        case 'setDesktopChoice':
+            return {
+                ...state,
+                state: { ...state.state, desktop: { choice: action.value } },
             };
         case 'setPrompt':
             // EW-617 G4: prompt carried from landing-page input through the
@@ -241,6 +253,7 @@ export interface UseOnboardingFlowResult {
     readonly setStorageChoice: (value: OnboardingStorageChoice) => void;
     readonly setDbChoice: (value: OnboardingDbChoice) => void;
     readonly setDeployChoice: (value: OnboardingDeployChoice) => void;
+    readonly setDesktopChoice: (value: OnboardingDesktopChoice) => void;
     readonly setPluginsReviewed: (value: boolean) => void;
     readonly setPrompt: (value: string) => void;
     readonly toggleRole: (value: string) => void;
@@ -251,7 +264,10 @@ export interface UseOnboardingFlowResult {
     readonly refresh: () => void;
     readonly jumpTo: (index: number) => void;
     readonly finish: (options?: { dismissed?: boolean }) => void;
-    readonly notePlannedClick: (bucket: 'ai' | 'storage' | 'db' | 'deploy', choice: string) => void;
+    readonly notePlannedClick: (
+        bucket: 'ai' | 'storage' | 'db' | 'deploy' | 'desktop',
+        choice: string,
+    ) => void;
 }
 
 /**
@@ -358,6 +374,14 @@ export function useOnboardingFlow({
         [trackEvent],
     );
 
+    const setDesktopChoice = useCallback(
+        (value: OnboardingDesktopChoice) => {
+            trackEvent('onboarding_desktop_choice_selected', { choice: value });
+            dispatch({ type: 'setDesktopChoice', value });
+        },
+        [trackEvent],
+    );
+
     const setPluginsReviewed = useCallback(
         (value: boolean) => dispatch({ type: 'setPluginsReviewed', value }),
         [],
@@ -412,7 +436,7 @@ export function useOnboardingFlow({
     );
 
     const notePlannedClick = useCallback(
-        (bucket: 'ai' | 'storage' | 'db' | 'deploy', choice: string) =>
+        (bucket: 'ai' | 'storage' | 'db' | 'deploy' | 'desktop', choice: string) =>
             trackEvent('onboarding_planned_card_clicked', { bucket, choice }),
         [trackEvent],
     );
@@ -436,6 +460,7 @@ export function useOnboardingFlow({
         setStorageChoice,
         setDbChoice,
         setDeployChoice,
+        setDesktopChoice,
         setPluginsReviewed,
         setPrompt,
         toggleRole,
@@ -452,14 +477,28 @@ export function useOnboardingFlow({
 
 function stripVersion(state: OnboardingWizardStateV2) {
     // The patch endpoint deep-merges by field; `version` is server-managed.
-    const { lastStep, ai, storage, db, deploy, skippedSteps, pluginsReviewed, prompt, profile } =
-        state;
+    const {
+        lastStep,
+        ai,
+        storage,
+        db,
+        deploy,
+        desktop,
+        skippedSteps,
+        pluginsReviewed,
+        prompt,
+        profile,
+    } = state;
     return {
         lastStep,
         ai: { choice: ai.choice },
         storage: { choice: storage.choice },
         db: { choice: db.choice },
         deploy: { choice: deploy.choice },
+        // A8 — the desktop bucket saves on the same path as the other four.
+        // Falls back to the contract default so a state loaded from an older
+        // blob still round-trips a valid choice rather than dropping the key.
+        desktop: { choice: desktop?.choice ?? 'cloud' },
         skippedSteps: [...skippedSteps],
         pluginsReviewed,
         ...(prompt ? { prompt } : {}),

--- a/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
@@ -19,7 +19,7 @@ function initialReducerState() {
 }
 
 describe('computeStepList', () => {
-    it('returns the minimal 9-step list when every choice is the Ever Works default', () => {
+    it('returns the minimal 10-step list when every choice is the Ever Works default', () => {
         const list = computeStepList(ONBOARDING_DEFAULT_STATE);
         expect(list.map((s) => s.kind)).toEqual([
             'welcome',
@@ -27,6 +27,7 @@ describe('computeStepList', () => {
             'storage-choice',
             'db-choice',
             'deploy-choice',
+            'desktop-choice',
             'profile',
             'communication',
             'plugins-catalog',
@@ -71,7 +72,7 @@ describe('computeStepList', () => {
                 deploy: { choice: 'vercel' },
             }),
         );
-        expect(list).toHaveLength(12);
+        expect(list).toHaveLength(13);
         expect(list.map((s) => s.kind)).toEqual([
             'welcome',
             'ai-choice',
@@ -81,6 +82,7 @@ describe('computeStepList', () => {
             'db-choice',
             'deploy-choice',
             'deploy-config',
+            'desktop-choice',
             'profile',
             'communication',
             'plugins-catalog',
@@ -104,7 +106,12 @@ describe('computeStepList', () => {
         const full = computeStepList(defaultsWith({ deploy: { choice: 'vercel' } })).map(
             (s) => s.kind,
         );
-        expect(full.indexOf('profile')).toBe(full.indexOf('deploy-config') + 1);
+        // A8 — `desktop-choice` now sits between the provider steps and
+        // profile, so profile trails IT rather than deploy-config. The
+        // "immediately before Communication" half of the contract is what
+        // this test is really about and is unchanged.
+        expect(full.indexOf('desktop-choice')).toBe(full.indexOf('deploy-config') + 1);
+        expect(full.indexOf('profile')).toBe(full.indexOf('desktop-choice') + 1);
         expect(full.indexOf('profile')).toBe(full.indexOf('communication') - 1);
     });
 

--- a/packages/contracts/src/api/onboarding/index.ts
+++ b/packages/contracts/src/api/onboarding/index.ts
@@ -32,6 +32,7 @@ export type {
 	OnboardingStorageChoice,
 	OnboardingDbChoice,
 	OnboardingDeployChoice,
+	OnboardingDesktopChoice,
 	OnboardingWizardStateV2,
 	OnboardingStateResponse,
 	OnboardingStatePatchRequest,
@@ -42,9 +43,16 @@ export type {
 	OnboardingProfile,
 	OnboardingProfileOption,
 	OnboardingRoleId,
-	OnboardingTeamSizeId
+	OnboardingTeamSizeId,
+	OnboardingDesktopNextStep
 } from './wizard-state.js';
-export { ONBOARDING_DEFAULT_STATE, ROLE_OPTIONS, TEAM_SIZE_OPTIONS } from './wizard-state.js';
+export {
+	ONBOARDING_DEFAULT_STATE,
+	ROLE_OPTIONS,
+	TEAM_SIZE_OPTIONS,
+	ONBOARDING_DESKTOP_NEXT_STEPS,
+	desktopNextStep
+} from './wizard-state.js';
 export type {
 	OnboardingSeedAgentSuggestion,
 	OnboardingSeedSkillSuggestion,

--- a/packages/contracts/src/api/onboarding/wizard-state.ts
+++ b/packages/contracts/src/api/onboarding/wizard-state.ts
@@ -21,6 +21,23 @@ export type OnboardingDbChoice = 'ever-works-db' | 'custom';
 export type OnboardingDeployChoice = 'ever-works' | 'vercel' | 'k8s';
 
 /**
+ * A8 — where the user actually runs Ever Works, and therefore what their
+ * first run should look like.
+ *
+ * The other four buckets all ask "which provider": AI, storage, database,
+ * deployment. None of them ask the question a desktop-first user is actually
+ * living — "is this thing running on my machine, and are my machines part of
+ * it?" — so those users landed on a cloud-shaped first run and had to find
+ * Fleet and the node apps on their own.
+ *
+ *   - `cloud`      the hosted platform (default; unchanged behaviour)
+ *   - `desktop`    the all-in-one desktop app supervising a local stack
+ *   - `own-nodes`  the platform runs elsewhere, but this person's own
+ *                  machines execute the work (Fleet + node apps)
+ */
+export type OnboardingDesktopChoice = 'cloud' | 'desktop' | 'own-nodes';
+
+/**
  * Wave 11 — "What do you do" onboarding step. A generic option row:
  * stable kebab-case id + English display label + one-line description.
  * The web wizard renders these through i18n keys keyed by `id`; the
@@ -87,6 +104,12 @@ export interface OnboardingWizardStateV2 {
 	readonly storage: { readonly choice: OnboardingStorageChoice };
 	readonly db: { readonly choice: OnboardingDbChoice };
 	readonly deploy: { readonly choice: OnboardingDeployChoice };
+	/**
+	 * A8 — desktop-first bucket. Optional in the persisted shape so a state
+	 * blob written before this bucket existed keeps round-tripping; readers
+	 * fall back to {@link ONBOARDING_DEFAULT_STATE}'s `cloud`.
+	 */
+	readonly desktop?: { readonly choice: OnboardingDesktopChoice };
 	readonly skippedSteps: readonly string[];
 	readonly pluginsReviewed: boolean;
 	/**
@@ -139,6 +162,8 @@ export interface OnboardingStatePatchRequest {
 		readonly storage: Partial<{ choice: OnboardingStorageChoice }>;
 		readonly db: Partial<{ choice: OnboardingDbChoice }>;
 		readonly deploy: Partial<{ choice: OnboardingDeployChoice }>;
+		/** A8 — desktop-first bucket. */
+		readonly desktop: Partial<{ choice: OnboardingDesktopChoice }>;
 		readonly skippedSteps: readonly string[];
 		readonly pluginsReviewed: boolean;
 		/** Max 5 000 chars — enforced by `@MaxLength(5000)` in the server DTO. */
@@ -161,6 +186,8 @@ export interface OnboardingCatalogResponse {
 	readonly storage: ReadonlyArray<OnboardingCard<OnboardingStorageChoice>>;
 	readonly db: ReadonlyArray<OnboardingCard<OnboardingDbChoice>>;
 	readonly deploy: ReadonlyArray<OnboardingCard<OnboardingDeployChoice>>;
+	/** A8 — cards for the desktop-first bucket. */
+	readonly desktop: ReadonlyArray<OnboardingCard<OnboardingDesktopChoice>>;
 	/** Plugins to surface in the "Plugins & Integrations" wizard step. */
 	readonly plugins: ReadonlyArray<OnboardingPluginCard>;
 }
@@ -193,6 +220,48 @@ export const ONBOARDING_DEFAULT_STATE: OnboardingWizardStateV2 = {
 	storage: { choice: 'ever-works-git' },
 	db: { choice: 'ever-works-db' },
 	deploy: { choice: 'ever-works' },
+	desktop: { choice: 'cloud' },
 	skippedSteps: [],
 	pluginsReviewed: false
 };
+
+/**
+ * A8 — first-run guidance implied by the desktop bucket. Consumed by the web
+ * wizard's final step (and any other surface that wants to point a user at the
+ * right next thing) so "which shape am I running" actually changes what the
+ * user is told to do next, rather than being a stored preference nobody reads.
+ */
+export interface OnboardingDesktopNextStep {
+	readonly choice: OnboardingDesktopChoice;
+	readonly title: string;
+	readonly description: string;
+	/** In-app route to send the user to, when there is one. */
+	readonly href?: string;
+}
+
+export const ONBOARDING_DESKTOP_NEXT_STEPS: Readonly<Record<OnboardingDesktopChoice, OnboardingDesktopNextStep>> = {
+	cloud: {
+		choice: 'cloud',
+		title: 'Start building',
+		description: 'Everything runs on the hosted platform — create your first Work and go.'
+	},
+	desktop: {
+		choice: 'desktop',
+		title: 'Finish your desktop setup',
+		description:
+			'Ever Works Desktop supervises the API and web app on this machine. Check the services are healthy, then pick the job runtime you want them to use.',
+		href: '/settings/job-runtime'
+	},
+	'own-nodes': {
+		choice: 'own-nodes',
+		title: 'Add your first node',
+		description:
+			'Enroll the machines that should execute your work. Issue an enrollment token here, then run the Desktop Node app or the headless node on each machine.',
+		href: '/settings/fleet'
+	}
+};
+
+/** The guidance for a bucket choice, defaulting to the cloud path. */
+export function desktopNextStep(choice: OnboardingDesktopChoice | undefined): OnboardingDesktopNextStep {
+	return ONBOARDING_DESKTOP_NEXT_STEPS[choice ?? 'cloud'] ?? ONBOARDING_DESKTOP_NEXT_STEPS.cloud;
+}


### PR DESCRIPTION
Two additive capabilities built in a parallel worktree that was killed before its gates ran. Both are wired end to end here — neither ships as code nothing calls.

## A8 — "where does Ever Works run"

The wizard had four buckets (AI, storage, database, deployment) and every one asks the same shape of question: *which provider*. None asks the one a desktop-first user is actually living — *is this running on my machine, and are my machines part of it?* Those users got a cloud-shaped first run and had to find Fleet and the node apps on their own.

Adds a fifth bucket, `desktop` (`cloud` | `desktop` | `own-nodes`), from the contract through to the screen that consumes it:

- **contract** — `OnboardingDesktopChoice`, an *optional* `desktop` key on the persisted state (a blob written before this bucket keeps round-tripping and reads as `cloud`), and `ONBOARDING_DESKTOP_NEXT_STEPS` / `desktopNextStep()`.
- **API** — catalog cards, a validated patch DTO, and the fix that mattered: `mergeState` now merges the bucket. It was normalised on read but **not** on merge, which dropped the user's choice on the next unrelated patch *and* made every no-op patch write, because the idempotence check compares normalised-current against merged-next.
- **web** — a "Where it runs" step after the provider buckets, and the final step renders the guidance that choice implies. A `desktop` or `own-nodes` user is done with the wizard but **not** done setting up, and this is the only place the wizard can say so. `cloud` renders nothing extra, so a user who never saw the step sees exactly the previous screen.

## Node resource limits

`apps/node` gains a clamped `NodeResourceLimits` persisted in the node config and honoured by the worker loop's admission gate. Capacity now comes from `limits.maxConcurrentJobs`, and a probe reporting a loaded machine parks the loop in a new `throttled` state instead of leasing. **A probe that throws or is absent admits** — limits degrade to previous behaviour rather than stalling a node on a broken sensor. Enrollment writes the clamped limits so the first run already has a capacity policy on disk instead of inheriting an implicit default that later drifts.

Merged against develop's pause/drain machinery rather than over it: the loop keeps re-arming while paused, and the admission gate sits in front of the lease call, so pausing and throttling compose.

## Production callers

- `catalog.desktop` → `EverWorksOnboardingWizard` `desktop-choice` step
- `desktopNextStep()` → `CreateWorkStep` final-step guidance
- `state.desktop` → `useOnboardingFlow` reducer + `stripVersion` save path → `OnboardingStatePatchInnerDto` → `mergeState`
- `limits.maxConcurrentJobs` → `worker-loop.ts` capacity calc + `checkResourceAdmission`
- `clampResourceLimits` → `enrollNode`, `createNodeRuntime`, `parseConfig`

## Gates (all green, run locally on the merged tree)

| gate | result |
|---|---|
| `pnpm build --filter=ever-works-api` | 15/15 |
| `packages/agent` jest | 448 suites, 8235 tests |
| `apps/api` jest | 234 suites, 3826 tests |
| `apps/web` vitest | 134 files, 1336 tests |
| `apps/web` tsc + `next build` | clean |
| `apps/node` vitest | 221 |
| `apps/desktop` vitest | 100 |
| `apps/desktop-node` vitest | 47 |
| prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop-first onboarding choices for cloud, desktop, or self-hosted deployment.
  * Expanded the desktop node wizard with sign-in or token enrollment, capability selection, and resource-limit configuration.
  * Added pause/resume work controls in the status screen and system tray.
  * Added CPU, memory, and concurrency limits with worker throttling visibility.
  * Added secure credential verification and improved node status details.
  * Persisted selected runtime, capabilities, limits, and onboarding choices across sessions.

* **Bug Fixes**
  * Improved onboarding state persistence and compatibility with existing configurations.
  * Prevented sensitive credentials and tokens from appearing in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->