### PR TITLE
feat(plugin): browser-automation capability, provider and agent tool

### DIFF
--- a/apps/api/src/agents/agents.module.spec.ts
+++ b/apps/api/src/agents/agents.module.spec.ts
@@ -214,6 +214,9 @@ describe('api-side AgentsModule — domain chat-tool wiring', () => {
             'digest',
             'meetings',
             'fleet',
+            // Audit G22 — headless browsing. Bound with only `read`, so the
+            // capability's page-driving `act` is unreachable from chat.
+            'browser',
             'prReview',
             'mergePolicy',
         ]);

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -84,6 +84,7 @@ import {
     ContentExtractorFacadeService,
     AiFacadeService,
     GitFacadeService,
+    BrowserAutomationFacadeService,
 } from '@ever-works/agent/facades';
 // FU-2 — `AgentsController` injects `SkillBindingRepository` (for the
 // `GET /api/agents/:id/skills` rollup) and `PluginUsageRepository` (for
@@ -740,6 +741,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 MergePolicyService,
                 WorkOwnershipService,
                 AgentRepository,
+                BrowserAutomationFacadeService,
             ],
             useFactory: (
                 tasksService: TasksService,
@@ -755,6 +757,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 mergePolicy: MergePolicyService,
                 workOwnership: WorkOwnershipService,
                 agents: AgentRepository,
+                browser: BrowserAutomationFacadeService,
             ): AgentDomainToolSources => ({
                 // All three membership repositories are bound: the
                 // commentOnTask gate is fail-closed and DENIES every call
@@ -764,6 +767,9 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 digest: { digestService: digest },
                 meetings: { repository: meetings },
                 fleet: { service: fleet },
+                // Audit G22 — headless browsing. Only `read` is passed, so the
+                // capability's page-driving `act` is unreachable from chat.
+                browser: { facade: browser },
                 prReview: { prReviewService: prReview },
                 mergePolicy: {
                     service: mergePolicy,

--- a/packages/agent/src/agents/agent-domain-tool-sources.ts
+++ b/packages/agent/src/agents/agent-domain-tool-sources.ts
@@ -12,6 +12,7 @@ import type { FleetService } from '../fleet/fleet.service';
 import type { PrReviewToolService } from '../pr-review/agent-pr-review-tools';
 import type { MergePolicyResolveInput, MergePolicyService } from '../policy/merge-policy.service';
 import type { ResolveMergePolicyArgs } from '../policy/agent-merge-policy-tools';
+import type { BrowserAutomationFacadeService } from '../facades/browser-automation.facade';
 
 /**
  * Domain chat-tool sources — the ONE injection seam that lets
@@ -97,6 +98,15 @@ export interface AgentMergePolicyToolSource {
  * reach, and `resolveAllowedTools` registers exactly the corresponding
  * tools.
  */
+/**
+ * Headless browsing (audit item G22). Read-only by construction — the
+ * source carries only `read`, so no wiring mistake can hand the model the
+ * capability's page-driving `act` method.
+ */
+export interface AgentBrowserToolSource {
+    facade: Pick<BrowserAutomationFacadeService, 'read'>;
+}
+
 export interface AgentDomainToolSources {
     tasks?: AgentTaskToolSource;
     ingest?: AgentIngestToolSource;
@@ -105,4 +115,5 @@ export interface AgentDomainToolSources {
     fleet?: AgentFleetToolSource;
     prReview?: AgentPrReviewToolSource;
     mergePolicy?: AgentMergePolicyToolSource;
+    browser?: AgentBrowserToolSource;
 }

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -46,6 +46,7 @@ import { buildIngestEventTools } from '../ingest/agent-ingest-tools';
 import { buildDigestTools } from '../digest/agent-digest-tools';
 import { buildMeetingTools } from '../meetings/agent-meeting-tools';
 import { buildFleetTools } from '../fleet/agent-fleet-tools';
+import { buildBrowserTools } from '../facades/agent-browser-tools';
 import { buildPrReviewTools } from '../pr-review/agent-pr-review-tools';
 import { buildMergePolicyTools } from '../policy/agent-merge-policy-tools';
 // Security: lexical SSRF guard reused by the model-controlled URL tools
@@ -376,6 +377,16 @@ export class AgentToolService {
         if (sources.fleet) {
             const fleet = sources.fleet;
             add('fleet', () => buildFleetTools({ userId: agent.userId, service: fleet.service }));
+        }
+
+        // Fetching an arbitrary URL IS an outbound network call, so it
+        // rides the same permission gate as the other external-tool
+        // surfaces rather than being available to every agent.
+        if (agent.permissions?.canCallExternalTools && sources.browser) {
+            const browser = sources.browser;
+            add('browser', () =>
+                buildBrowserTools({ userId: agent.userId, facade: browser.facade }),
+            );
         }
 
         // Outbound network call + a comment posted on someone's PR —

--- a/packages/agent/src/facades/__tests__/browser-automation.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/browser-automation.facade.spec.ts
@@ -1,0 +1,247 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BrowserAutomationFacadeService } from '../browser-automation.facade';
+import { buildBrowserTools } from '../agent-browser-tools';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import type { IBrowserAutomationPlugin, PluginManifest } from '@ever-works/plugin';
+
+describe('BrowserAutomationFacadeService', () => {
+    let service: BrowserAutomationFacadeService;
+    let registry: jest.Mocked<PluginRegistryService>;
+    let settingsService: jest.Mocked<PluginSettingsService>;
+
+    const facadeOptions = { userId: 'test-user' };
+
+    const handle = {
+        sessionId: 'session-1',
+        policy: {
+            allowedHosts: ['example.com'],
+            subresourcePolicy: 'public-only' as const,
+            allowPrivateNetwork: false,
+            timeoutMs: 30_000,
+            headless: true,
+        },
+    };
+
+    const createMockPlugin = (): jest.Mocked<IBrowserAutomationPlugin> =>
+        ({
+            id: 'browser-automation',
+            name: 'Browser Automation',
+            version: '1.0.0',
+            category: 'utility',
+            capabilities: ['browser-automation'],
+            settingsSchema: { type: 'object', properties: {} },
+            providerName: 'Playwright',
+            onLoad: jest.fn(),
+            onUnload: jest.fn(),
+            open: jest.fn().mockResolvedValue(handle),
+            navigate: jest.fn().mockResolvedValue({
+                url: 'https://example.com/final',
+                status: 200,
+                title: 'Example',
+                redirectChain: ['https://example.com', 'https://example.com/final'],
+                blockedRequests: [
+                    { url: 'https://ads.test/x.js', reason: 'host-not-allowed', navigation: false },
+                ],
+            }),
+            extract: jest.fn().mockResolvedValue({ values: ['hello'], truncated: false }),
+            screenshot: jest
+                .fn()
+                .mockResolvedValue({ base64: 'aGk=', contentType: 'image/png', bytes: 2 }),
+            act: jest.fn(),
+            close: jest.fn().mockResolvedValue(undefined),
+        }) as unknown as jest.Mocked<IBrowserAutomationPlugin>;
+
+    const register = (plugin: IBrowserAutomationPlugin): RegisteredPlugin =>
+        ({
+            plugin: plugin as any,
+            manifest: {
+                id: plugin.id,
+                name: plugin.name,
+                version: plugin.version,
+                description: 'Test plugin',
+                category: plugin.category,
+                capabilities: ['browser-automation'],
+            } as PluginManifest,
+            state: 'loaded',
+            builtIn: false,
+            stateHistory: [],
+            registeredAt: Date.now(),
+        }) as RegisteredPlugin;
+
+    let plugin: jest.Mocked<IBrowserAutomationPlugin>;
+
+    beforeEach(async () => {
+        plugin = createMockPlugin();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BrowserAutomationFacadeService,
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        get: jest.fn(),
+                        getByCapability: jest.fn().mockReturnValue([register(plugin)]),
+                        isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+                    },
+                },
+                {
+                    provide: PluginSettingsService,
+                    useValue: { getSettings: jest.fn().mockResolvedValue({}) },
+                },
+            ],
+        }).compile();
+
+        service = module.get(BrowserAutomationFacadeService);
+        registry = module.get(PluginRegistryService);
+        settingsService = module.get(PluginSettingsService);
+    });
+
+    describe('read', () => {
+        it('opens, navigates, extracts and closes in one call', async () => {
+            const result = await service.read({ url: 'https://example.com' }, facadeOptions);
+
+            expect(plugin.open).toHaveBeenCalledTimes(1);
+            expect(plugin.navigate).toHaveBeenCalledWith(handle, 'https://example.com');
+            expect(plugin.extract).toHaveBeenCalledWith(handle, { format: 'text' });
+            expect(plugin.close).toHaveBeenCalledWith(handle);
+
+            expect(result.url).toBe('https://example.com/final');
+            expect(result.values).toEqual(['hello']);
+            expect(result.redirectChain).toHaveLength(2);
+        });
+
+        it('surfaces blocked sub-resources rather than swallowing them', async () => {
+            // "The page looked empty" and "half the page was refused" are
+            // different answers; the caller has to be able to tell.
+            const result = await service.read({ url: 'https://example.com' }, facadeOptions);
+            expect(result.blockedRequests).toHaveLength(1);
+            expect(result.blockedRequests[0].url).toBe('https://ads.test/x.js');
+        });
+
+        it('closes the session even when navigation is refused', async () => {
+            plugin.navigate.mockRejectedValueOnce(
+                new Error('navigation blocked: host-not-allowed'),
+            );
+
+            await expect(service.read({ url: 'https://evil.test' }, facadeOptions)).rejects.toThrow(
+                'navigation blocked',
+            );
+
+            // The whole reason `read` is one-shot: an unhappy path must not
+            // leak a browser context.
+            expect(plugin.close).toHaveBeenCalledWith(handle);
+        });
+
+        it('does not let a failed close mask the real result', async () => {
+            plugin.close.mockRejectedValueOnce(new Error('context already gone'));
+
+            await expect(
+                service.read({ url: 'https://example.com' }, facadeOptions),
+            ).resolves.toMatchObject({ values: ['hello'] });
+        });
+
+        it('injects resolved settings into the session spec', async () => {
+            settingsService.getSettings.mockResolvedValueOnce({ allowedHosts: 'example.com' });
+
+            await service.read({ url: 'https://example.com' }, facadeOptions);
+
+            expect(plugin.open).toHaveBeenCalledWith(
+                expect.objectContaining({ settings: { allowedHosts: 'example.com' } }),
+            );
+        });
+    });
+
+    describe('capture', () => {
+        it('returns the shot alongside the post-redirect URL and closes', async () => {
+            const result = await service.capture(
+                { url: 'https://example.com', screenshot: { fullPage: true } },
+                facadeOptions,
+            );
+
+            expect(plugin.screenshot).toHaveBeenCalledWith(handle, { fullPage: true });
+            expect(result).toMatchObject({
+                contentType: 'image/png',
+                url: 'https://example.com/final',
+            });
+            expect(plugin.close).toHaveBeenCalledWith(handle);
+        });
+    });
+
+    describe('isAvailable', () => {
+        it('is false when no browser-automation plugin is loaded', () => {
+            registry.getByCapability.mockReturnValue([]);
+            expect(service.isAvailable()).toBe(false);
+        });
+
+        it('is true when one is', () => {
+            expect(service.isAvailable()).toBe(true);
+        });
+    });
+});
+
+describe('buildBrowserTools', () => {
+    const read = jest.fn().mockResolvedValue({
+        url: 'https://example.com',
+        status: 200,
+        title: 'Example',
+        redirectChain: [],
+        values: ['hi'],
+        truncated: false,
+        blockedRequests: [],
+    });
+    const tools = () => buildBrowserTools({ userId: 'u1', facade: { read } as any });
+
+    beforeEach(() => read.mockClear());
+
+    it('exposes exactly one, read-only tool', () => {
+        const names = tools().map((t) => t.name);
+        // `act` is on the capability but deliberately not offered: driving a
+        // page can submit forms and trip irreversible actions.
+        expect(names).toEqual(['browse_url']);
+    });
+
+    it('scopes the read to the owning user', async () => {
+        await tools()[0].invoke({ url: 'https://example.com' });
+        expect(read).toHaveBeenCalledWith(expect.anything(), { userId: 'u1' });
+    });
+
+    it('refuses a non-http scheme before reaching the provider', async () => {
+        const result = await tools()[0].invoke({ url: 'file:///etc/passwd' });
+        expect(result).toEqual({ error: 'url must be an absolute http(s) URL' });
+        expect(read).not.toHaveBeenCalled();
+    });
+
+    it('requires a url', async () => {
+        expect(await tools()[0].invoke({})).toEqual({ error: 'url is required' });
+        expect(await tools()[0].invoke({ url: '   ' })).toEqual({ error: 'url is required' });
+        expect(read).not.toHaveBeenCalled();
+    });
+
+    it('requires an attribute name when format is attribute', async () => {
+        const result = await tools()[0].invoke({
+            url: 'https://example.com',
+            format: 'attribute',
+        });
+        expect(result).toEqual({ error: 'attribute is required when format is "attribute"' });
+        expect(read).not.toHaveBeenCalled();
+    });
+
+    it('falls back to text for an unrecognized format and clamps the limit', async () => {
+        await tools()[0].invoke({ url: 'https://example.com', format: 'pdf', limit: 9999 });
+        expect(read).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: expect.objectContaining({ format: 'text', limit: 100 }),
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('reports a provider refusal as a tool error, not a throw', async () => {
+        read.mockRejectedValueOnce(new Error('navigation blocked: host-not-allowed'));
+        const result = await tools()[0].invoke({ url: 'https://internal.test' });
+        expect(result).toEqual({ error: 'navigation blocked: host-not-allowed' });
+    });
+});

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -3,6 +3,7 @@ import { FacadesModule } from '../facades.module';
 import { AiFacadeService } from '../ai.facade';
 import { SearchFacadeService } from '../search.facade';
 import { ScreenshotFacadeService } from '../screenshot.facade';
+import { BrowserAutomationFacadeService } from '../browser-automation.facade';
 import { ContentExtractorFacadeService } from '../content-extractor.facade';
 import { DataSourceFacadeService } from '../data-source.facade';
 import { GitFacadeService } from '../git.facade';
@@ -39,6 +40,7 @@ describe('FacadesModule + barrel re-exports', () => {
         AiFacadeService,
         SearchFacadeService,
         ScreenshotFacadeService,
+        BrowserAutomationFacadeService,
         ContentExtractorFacadeService,
         DataSourceFacadeService,
         GitFacadeService,
@@ -117,6 +119,9 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(facadesBarrel.AiFacadeService).toBe(AiFacadeService);
             expect(facadesBarrel.SearchFacadeService).toBe(SearchFacadeService);
             expect(facadesBarrel.ScreenshotFacadeService).toBe(ScreenshotFacadeService);
+            expect(facadesBarrel.BrowserAutomationFacadeService).toBe(
+                BrowserAutomationFacadeService,
+            );
             expect(facadesBarrel.ContentExtractorFacadeService).toBe(ContentExtractorFacadeService);
             expect(facadesBarrel.DataSourceFacadeService).toBe(DataSourceFacadeService);
             expect(facadesBarrel.GitFacadeService).toBe(GitFacadeService);
@@ -193,6 +198,8 @@ describe('FacadesModule + barrel re-exports', () => {
                     'AiFacadeError',
                     'AiFacadeService',
                     'BaseFacadeService',
+                    'BrowserAutomationFacadeError',
+                    'BrowserAutomationFacadeService',
                     'CodeEditFacadeService',
                     'ContentExtractorFacadeError',
                     'ContentExtractorFacadeService',

--- a/packages/agent/src/facades/agent-browser-tools.ts
+++ b/packages/agent/src/facades/agent-browser-tools.ts
@@ -1,0 +1,130 @@
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type {
+    BrowserAutomationFacadeService,
+    BrowserReadResult,
+} from './browser-automation.facade';
+
+/**
+ * Browser-automation chat tool (audit item G22) — the reachable end of the
+ * `browser-automation` capability.
+ *
+ * Keyword slots: "open this page", "read that URL", "what does <site> say",
+ * "grab the text/links from …" route here.
+ *
+ * Deliberately ONE tool, and a read-only one. `act` (click/fill/press)
+ * exists on the capability but is not offered to the model: driving a page
+ * on the user's behalf can submit forms and trip irreversible actions, and
+ * that needs its own confirmation design rather than arriving as a side
+ * effect of exposing browsing. Screenshot capture is likewise left to the
+ * existing `screenshot` capability, which already has a facade, budget
+ * accounting and a UI.
+ *
+ * Mirrors `fleet/agent-fleet-tools.ts`: a descriptor factory over a
+ * type-only import, concatenated by `resolveAllowedTools`.
+ */
+
+export interface BrowseUrlArgs {
+    /** Absolute http(s) URL. Refused unless the operator allowlisted its host. */
+    url?: string;
+    /** Optional CSS selector; omitted reads the whole document. */
+    selector?: string;
+    /** `text` (default), `html`, or `attribute`. */
+    format?: string;
+    /** Attribute name — required when `format` is `attribute`. */
+    attribute?: string;
+    /** Max matched nodes to return (default 20, capped at 100). */
+    limit?: number;
+}
+
+const VALID_FORMATS = ['text', 'html', 'attribute'] as const;
+type BrowseFormat = (typeof VALID_FORMATS)[number];
+
+export interface BrowseUrlResult {
+    page?: BrowserReadResult;
+    error?: string;
+}
+
+export function buildBrowserTools(args: {
+    /** Owner scope — settings and provider resolution run as this user. */
+    userId: string;
+    facade: Pick<BrowserAutomationFacadeService, 'read'>;
+}): TaskToolDescriptor[] {
+    return [
+        {
+            name: 'browse_url',
+            description:
+                'Open a web page in a headless browser and read it — the final URL after redirects, the page title, and the text/HTML/attributes matched by an optional CSS selector. Use for pages that need JavaScript to render, where a plain fetch returns an empty shell. Navigation is restricted to an operator-configured host allowlist, so a refusal means the host is not allowed, not that the page is down. Read-only: this cannot click, type or submit anything.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    url: {
+                        type: 'string',
+                        description: 'Absolute http(s) URL to open.',
+                    },
+                    selector: {
+                        type: 'string',
+                        description: 'Optional CSS selector. Omit to read the whole document.',
+                    },
+                    format: {
+                        type: 'string',
+                        description:
+                            'What to read from each match: text (default), html, or attribute.',
+                    },
+                    attribute: {
+                        type: 'string',
+                        description:
+                            'Attribute name to read. Required when format is "attribute" (e.g. "href").',
+                    },
+                    limit: {
+                        type: 'integer',
+                        description: 'Max matched nodes to return (default 20, capped at 100).',
+                    },
+                },
+                required: ['url'],
+            },
+            invoke: async (raw) => {
+                const a = (raw ?? {}) as BrowseUrlArgs;
+                const url = typeof a.url === 'string' ? a.url.trim() : '';
+                if (!url) {
+                    return { error: 'url is required' };
+                }
+                // Scheme check here is a usability guard, not the security
+                // boundary — the provider's allowlist and SSRF guard are.
+                // It exists so `file:///etc/passwd` comes back as a clear
+                // refusal instead of a provider stack trace.
+                if (!/^https?:\/\//i.test(url)) {
+                    return { error: 'url must be an absolute http(s) URL' };
+                }
+
+                const format: BrowseFormat = (VALID_FORMATS as readonly string[]).includes(
+                    a.format ?? '',
+                )
+                    ? (a.format as BrowseFormat)
+                    : 'text';
+                if (format === 'attribute' && !a.attribute) {
+                    return { error: 'attribute is required when format is "attribute"' };
+                }
+
+                const limit = Math.min(Math.max(Number(a.limit) || 20, 1), 100);
+
+                try {
+                    const page = await args.facade.read(
+                        {
+                            url,
+                            query: {
+                                selector: a.selector,
+                                format,
+                                attribute: a.attribute,
+                                limit,
+                            },
+                        },
+                        { userId: args.userId },
+                    );
+                    return { page };
+                } catch (err) {
+                    return { error: err instanceof Error ? err.message : String(err) };
+                }
+            },
+        } satisfies TaskToolDescriptor<BrowseUrlArgs, BrowseUrlResult>,
+    ];
+}

--- a/packages/agent/src/facades/browser-automation.facade.ts
+++ b/packages/agent/src/facades/browser-automation.facade.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type {
+    IBrowserAutomationPlugin,
+    BrowserExtractQuery,
+    BrowserExtractResult,
+    BrowserNavigateResult,
+    BrowserScreenshotRequest,
+    BrowserScreenshotResult,
+    BrowserSessionSpec,
+    FacadeOptions,
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
+import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
+import { BaseFacadeService, FacadeError } from './base.facade';
+
+export class BrowserAutomationFacadeError extends FacadeError {
+    constructor(message: string, operation: string, provider?: string, cause?: Error) {
+        super(message, operation, provider, cause);
+        this.name = 'BrowserAutomationFacadeError';
+    }
+}
+
+/** What one `read` produces: where we ended up, and what was on the page. */
+export interface BrowserReadResult {
+    /** Final URL after every ALLOWED redirect hop. */
+    readonly url: string;
+    readonly status: number | null;
+    readonly title: string;
+    readonly redirectChain: readonly string[];
+    readonly values: readonly string[];
+    readonly truncated: boolean;
+    /**
+     * Sub-resource requests the navigation policy refused. Surfaced rather
+     * than swallowed: "the page looked empty" and "half the page was
+     * blocked" are different answers and the caller must be able to tell.
+     */
+    readonly blockedRequests: BrowserNavigateResult['blockedRequests'];
+}
+
+/**
+ * Browser-automation facade (audit item G22) — the platform-side consumer
+ * of the `browser-automation` capability.
+ *
+ * ## Why the surface is `read`/`capture` and not the raw plugin
+ *
+ * The plugin interface is session-based (`open` → navigate/extract/act →
+ * `close`), which is right for the provider and wrong for callers: every
+ * caller would own a session lifetime, and a caller that throws between
+ * `open` and `close` leaks a browser context. Both methods here are
+ * one-shot and close the session in a `finally`, so a leaked context needs
+ * the provider itself to fail, not merely an unhappy path in a caller.
+ *
+ * `act` is deliberately NOT exposed yet. Reading a page and driving a page
+ * are different risk profiles — the second can submit forms and click
+ * through irreversible actions on the user's behalf — and nothing in the
+ * platform has asked for it. The capability keeps the method so a future
+ * caller can add a facade method with its own gating; it is not reachable
+ * by omission rather than by an unreviewed default.
+ *
+ * Navigation safety is the provider's contract (default-deny allowlist,
+ * re-checked on every redirect hop, SSRF guard). This facade does not
+ * re-implement it — it resolves settings and lets a blocked navigation
+ * throw.
+ */
+@Injectable()
+export class BrowserAutomationFacadeService extends BaseFacadeService {
+    protected readonly logger = new Logger(BrowserAutomationFacadeService.name);
+    protected readonly CAPABILITY = PLUGIN_CAPABILITIES.BROWSER_AUTOMATION;
+
+    constructor(
+        registry: PluginRegistryService,
+        settingsService: PluginSettingsService,
+        @Optional() workPluginRepository?: WorkPluginRepository,
+    ) {
+        super(registry, settingsService, workPluginRepository);
+    }
+
+    /**
+     * Open, navigate, extract, close. The whole point of the one-shot
+     * shape: the session cannot outlive the call.
+     */
+    async read(
+        options: {
+            readonly url: string;
+            readonly query?: BrowserExtractQuery;
+            readonly session?: Omit<BrowserSessionSpec, 'settings'>;
+        },
+        facadeOptions: FacadeOptions,
+    ): Promise<BrowserReadResult> {
+        const plugin = await this.resolvePlugin<IBrowserAutomationPlugin>(
+            facadeOptions.providerOverride,
+            facadeOptions.userId,
+            facadeOptions.workId,
+        );
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+
+        const handle = await plugin.open({ ...options.session, settings });
+        try {
+            const navigation = await plugin.navigate(handle, options.url);
+            const extracted: BrowserExtractResult = await plugin.extract(
+                handle,
+                options.query ?? { format: 'text' },
+            );
+            return {
+                url: navigation.url,
+                status: navigation.status,
+                title: navigation.title,
+                redirectChain: navigation.redirectChain,
+                values: extracted.values,
+                truncated: extracted.truncated,
+                blockedRequests: navigation.blockedRequests,
+            };
+        } finally {
+            await this.closeQuietly(plugin, handle);
+        }
+    }
+
+    /** Open, navigate, screenshot, close. Same one-shot contract as `read`. */
+    async capture(
+        options: {
+            readonly url: string;
+            readonly screenshot?: BrowserScreenshotRequest;
+            readonly session?: Omit<BrowserSessionSpec, 'settings'>;
+        },
+        facadeOptions: FacadeOptions,
+    ): Promise<BrowserScreenshotResult & { readonly url: string }> {
+        const plugin = await this.resolvePlugin<IBrowserAutomationPlugin>(
+            facadeOptions.providerOverride,
+            facadeOptions.userId,
+            facadeOptions.workId,
+        );
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+
+        const handle = await plugin.open({ ...options.session, settings });
+        try {
+            const navigation = await plugin.navigate(handle, options.url);
+            const shot = await plugin.screenshot(handle, options.screenshot);
+            return { ...shot, url: navigation.url };
+        } finally {
+            await this.closeQuietly(plugin, handle);
+        }
+    }
+
+    isAvailable(): boolean {
+        return this.isConfigured();
+    }
+
+    /**
+     * A failed `close` must not replace the caller's real error (or its
+     * real result) with a teardown error — the session is already beyond
+     * our reach at that point and the only useful action is to say so.
+     */
+    private async closeQuietly(
+        plugin: IBrowserAutomationPlugin,
+        handle: Awaited<ReturnType<IBrowserAutomationPlugin['open']>>,
+    ): Promise<void> {
+        try {
+            await plugin.close(handle);
+        } catch (error) {
+            this.logger.warn(
+                `Failed to close browser session ${handle.sessionId} on ${plugin.id}: ` +
+                    `${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+}

--- a/packages/agent/src/facades/facades.module.ts
+++ b/packages/agent/src/facades/facades.module.ts
@@ -7,6 +7,7 @@ import { PolicyModule } from '../policy/policy.module';
 import { AiFacadeService } from './ai.facade';
 import { SearchFacadeService } from './search.facade';
 import { ScreenshotFacadeService } from './screenshot.facade';
+import { BrowserAutomationFacadeService } from './browser-automation.facade';
 import { ContentExtractorFacadeService } from './content-extractor.facade';
 import { DataSourceFacadeService } from './data-source.facade';
 import { GitFacadeService } from './git.facade';
@@ -28,6 +29,7 @@ const FACADES = [
     AiFacadeService,
     SearchFacadeService,
     ScreenshotFacadeService,
+    BrowserAutomationFacadeService,
     ContentExtractorFacadeService,
     DataSourceFacadeService,
     GitFacadeService,

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -32,6 +32,11 @@ export type { SearchFacadeOptions } from '@ever-works/plugin';
 
 // Screenshot Facade
 export { ScreenshotFacadeService, ScreenshotFacadeError } from './screenshot.facade';
+export {
+    BrowserAutomationFacadeService,
+    BrowserAutomationFacadeError,
+    type BrowserReadResult,
+} from './browser-automation.facade';
 
 // Content Extractor Facade
 export {

--- a/packages/plugin/src/contracts/__tests__/browser-automation.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/browser-automation.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+	BrowserAutomationNotProvisionedError,
+	BrowserNavigationBlockedError,
+	isBrowserAutomationPlugin,
+	type BrowserBlockReason
+} from '../capabilities/browser-automation.interface.js';
+import { ALL_PLUGIN_CAPABILITIES, PLUGIN_CAPABILITIES } from '../facade-capabilities.js';
+import type { IPlugin } from '../plugin.interface.js';
+
+describe('browser-automation capability (audit item G22)', () => {
+	it('registers `browser-automation` in the capability registry', () => {
+		expect(PLUGIN_CAPABILITIES.BROWSER_AUTOMATION).toBe('browser-automation');
+		expect(ALL_PLUGIN_CAPABILITIES).toContain('browser-automation');
+	});
+
+	it('isBrowserAutomationPlugin guards on the declared capability', () => {
+		const yes = { capabilities: ['browser-automation'] } as unknown as IPlugin;
+		const no = { capabilities: ['screenshot'] } as unknown as IPlugin;
+		expect(isBrowserAutomationPlugin(yes)).toBe(true);
+		expect(isBrowserAutomationPlugin(no)).toBe(false);
+	});
+
+	it('BrowserNavigationBlockedError keeps its stable cross-package name and code', () => {
+		const err = new BrowserNavigationBlockedError('not_allowlisted', 'https://evil.test/');
+		expect(err.name).toBe('BrowserNavigationBlockedError');
+		expect(err.code).toBe('not_allowlisted');
+		expect(err.url).toBe('https://evil.test/');
+		expect(err.message).toContain('not_allowlisted');
+	});
+
+	it('BrowserNavigationBlockedError honours a caller-supplied message', () => {
+		const err = new BrowserNavigationBlockedError('dns_private_ip', 'https://a.test/', 'resolved to 127.0.0.1');
+		expect(err.message).toBe('resolved to 127.0.0.1');
+		expect(err.code).toBe('dns_private_ip');
+	});
+
+	it('covers every documented block reason', () => {
+		const reasons: BrowserBlockReason[] = [
+			'invalid_url',
+			'scheme_blocked',
+			'credentials_in_url',
+			'private_address',
+			'not_allowlisted',
+			'dns_private_ip',
+			'dns_lookup_failed'
+		];
+		for (const reason of reasons) {
+			expect(new BrowserNavigationBlockedError(reason, 'https://a.test/').code).toBe(reason);
+		}
+	});
+
+	it('BrowserAutomationNotProvisionedError keeps its stable cross-package name', () => {
+		const err = new BrowserAutomationNotProvisionedError();
+		expect(err.name).toBe('BrowserAutomationNotProvisionedError');
+		expect(err.message).toContain('not provisioned');
+		expect(new BrowserAutomationNotProvisionedError('no chromium').message).toBe('no chromium');
+	});
+});

--- a/packages/plugin/src/contracts/capabilities/browser-automation.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/browser-automation.interface.ts
@@ -1,0 +1,248 @@
+import type { IPlugin } from '../plugin.interface.js';
+import type { PluginSettings } from '../../settings/settings.types.js';
+
+/**
+ * Browser-automation capability — pluggable headless-browser drivers
+ * (capability `browser-automation`).
+ *
+ * The four verbs are deliberately the whole surface:
+ *
+ *  - `navigate` — go to a URL and report where you actually ended up
+ *    (final URL + the full redirect chain, so a caller can audit it).
+ *  - `extract`  — pull structured text / HTML / attributes out of the
+ *    rendered DOM via CSS selectors.
+ *  - `screenshot` — capture the page (or one element) as base64 bytes.
+ *  - `act` — a bounded list of interaction steps (click / fill / select
+ *    / press / hover / wait) executed in order.
+ *
+ * ## Security posture (non-negotiable for every implementation)
+ *
+ * A headless browser reachable from server-side code is an SSRF engine
+ * with a JavaScript runtime attached. Implementations MUST therefore:
+ *
+ *  1. Run **headless by default**. Headed mode is opt-in configuration,
+ *     never an implicit default.
+ *  2. Enforce a **default-deny navigation allowlist**: with no allowed
+ *     hosts configured, EVERY navigation is refused. There is no
+ *     "allow anything" fallback.
+ *  3. Refuse private / loopback / link-local / cloud-metadata targets
+ *     regardless of the allowlist, unless the operator has explicitly
+ *     opted into private-network access AND pinned an explicit host
+ *     list (never a wildcard).
+ *  4. **Never follow a redirect outside the allowlist.** The allowlist
+ *     is re-evaluated for every hop, not just the URL the caller typed.
+ *  5. Enforce a configurable wall-clock timeout on every operation.
+ *
+ * Refusals are reported by throwing {@link BrowserNavigationBlockedError}
+ * with a stable discriminated `code` — never a silent empty result.
+ */
+
+/** Why a URL was refused. Stable, matched by value (never by message). */
+export type BrowserBlockReason =
+	/** Not parseable as a URL at all. */
+	| 'invalid_url'
+	/** Scheme other than http/https (file:, data:, chrome:, view-source:, …). */
+	| 'scheme_blocked'
+	/** URL carried embedded `user:password@` credentials. */
+	| 'credentials_in_url'
+	/** Literal private / loopback / link-local / cloud-metadata address. */
+	| 'private_address'
+	/** Host is not covered by the configured allowlist (incl. empty allowlist). */
+	| 'not_allowlisted'
+	/** Hostname resolved to a private address (DNS-rebinding defence). */
+	| 'dns_private_ip'
+	/** Hostname could not be resolved — fail closed, never fail open. */
+	| 'dns_lookup_failed';
+
+/**
+ * Thrown when a browser-automation provider refuses to reach a URL.
+ * Matched BY NAME across packages (bundlers break `instanceof` across
+ * dual CJS/ESM copies), so the `name` is pinned in the constructor.
+ */
+export class BrowserNavigationBlockedError extends Error {
+	readonly code: BrowserBlockReason;
+	/** The refused URL, with any embedded credentials already stripped. */
+	readonly url: string;
+
+	constructor(code: BrowserBlockReason, url: string, message?: string) {
+		super(message ?? `Navigation to ${url} refused: ${code}`);
+		this.name = 'BrowserNavigationBlockedError';
+		this.code = code;
+		this.url = url;
+	}
+}
+
+/**
+ * Thrown when the provider cannot operate in this runtime (browser
+ * binary missing, driver package absent, sandbox forbids launching).
+ * Loud + actionable — never a silent no-op.
+ */
+export class BrowserAutomationNotProvisionedError extends Error {
+	constructor(message?: string) {
+		super(message ?? 'Browser automation provider is not provisioned in this runtime.');
+		this.name = 'BrowserAutomationNotProvisionedError';
+	}
+}
+
+/**
+ * Effective navigation policy for one session. Resolved by the provider
+ * from its settings; surfaced on the handle so a caller can assert what
+ * it actually got instead of trusting a default.
+ */
+export interface BrowserNavigationPolicy {
+	/**
+	 * Host patterns that may be navigated to. Empty means DENY ALL —
+	 * that is the safe default, not a misconfiguration to paper over.
+	 *
+	 * Supported forms: `example.com` (exact host), `*.example.com` (any
+	 * subdomain, apex NOT included), either optionally suffixed with
+	 * `:<port>` to pin the port, and the bare `*` meaning "any PUBLIC
+	 * host" (private/loopback/metadata stay blocked).
+	 */
+	readonly allowedHosts: readonly string[];
+	/**
+	 * How non-document (sub-resource) requests are treated:
+	 *  - `allowlist`   — subresources must match `allowedHosts` too.
+	 *  - `public-only` — subresources may hit any PUBLIC host, but
+	 *    private/loopback/metadata targets stay blocked (default: a page
+	 *    whose CDN assets are blocked renders as a broken screenshot).
+	 */
+	readonly subresourcePolicy: 'allowlist' | 'public-only';
+	/**
+	 * Escape hatch for automating internal staging hosts. Default false.
+	 * When true the allowlist MUST be explicit — combining it with the
+	 * bare `*` pattern is refused outright rather than silently opening
+	 * the whole internal network.
+	 */
+	readonly allowPrivateNetwork: boolean;
+	/** Wall-clock budget applied to navigation and each action. */
+	readonly timeoutMs: number;
+	/** True unless the operator explicitly opted into a headed browser. */
+	readonly headless: boolean;
+}
+
+/** A request the provider refused mid-page-load. */
+export interface BrowserBlockedRequest {
+	readonly url: string;
+	readonly reason: BrowserBlockReason;
+	/** True when the refused request was a top-level navigation/redirect. */
+	readonly navigation: boolean;
+}
+
+/** Inputs to open one browser session. */
+export interface BrowserSessionSpec {
+	/** Resolved plugin settings injected by the caller/facade. */
+	readonly settings?: PluginSettings;
+	/** Per-session timeout override; clamped to the provider's bounds. */
+	readonly timeoutMs?: number;
+	readonly viewport?: { readonly width: number; readonly height: number };
+	readonly userAgent?: string;
+	/** Extra allowlist entries for this session, ANDed with the settings. */
+	readonly extraAllowedHosts?: readonly string[];
+}
+
+/** Handle to a live session. Opaque to callers apart from these fields. */
+export interface BrowserSessionHandle {
+	readonly sessionId: string;
+	/** The policy actually in force — assert on this, don't assume. */
+	readonly policy: BrowserNavigationPolicy;
+}
+
+export interface BrowserNavigateResult {
+	/** Final URL after every ALLOWED redirect hop. */
+	readonly url: string;
+	readonly status: number | null;
+	readonly title: string;
+	/**
+	 * Every hop, oldest first, ending at {@link url}. Each entry passed
+	 * the allowlist — a hop that did not is an error, not a log line.
+	 */
+	readonly redirectChain: readonly string[];
+	/** Sub-resource requests refused while the page loaded. */
+	readonly blockedRequests: readonly BrowserBlockedRequest[];
+}
+
+export interface BrowserExtractQuery {
+	/** CSS selector. Omitted means the whole document. */
+	readonly selector?: string;
+	readonly format: 'text' | 'html' | 'attribute';
+	/** Attribute name — required when `format` is `attribute`. */
+	readonly attribute?: string;
+	/** Hard cap on returned nodes (provider clamps to its own maximum). */
+	readonly limit?: number;
+}
+
+export interface BrowserExtractResult {
+	readonly values: readonly string[];
+	/** True when more nodes matched than `limit` allowed through. */
+	readonly truncated: boolean;
+}
+
+export type BrowserActionKind = 'click' | 'fill' | 'select' | 'press' | 'hover' | 'wait';
+
+export interface BrowserActStep {
+	readonly kind: BrowserActionKind;
+	/** CSS selector — required for every kind except `wait` with `timeoutMs`. */
+	readonly selector?: string;
+	/** Text for `fill`, option value for `select`. */
+	readonly value?: string;
+	/** Key name for `press` (e.g. `Enter`, `Control+A`). */
+	readonly key?: string;
+	/** Per-step override; still clamped by the session timeout. */
+	readonly timeoutMs?: number;
+}
+
+export interface BrowserActResult {
+	/** How many steps ran to completion. */
+	readonly performed: number;
+	/** URL after the steps — an action may have triggered a navigation. */
+	readonly url: string;
+	readonly blockedRequests: readonly BrowserBlockedRequest[];
+}
+
+export interface BrowserScreenshotRequest {
+	readonly fullPage?: boolean;
+	readonly format?: 'png' | 'jpeg';
+	/** JPEG quality 1-100; ignored for PNG. */
+	readonly quality?: number;
+	/** Capture one element instead of the viewport/page. */
+	readonly selector?: string;
+}
+
+export interface BrowserScreenshotResult {
+	readonly base64: string;
+	readonly contentType: 'image/png' | 'image/jpeg';
+	readonly bytes: number;
+}
+
+/** Browser-automation plugin interface — capability `browser-automation`. */
+export interface IBrowserAutomationPlugin extends IPlugin {
+	readonly providerName: string;
+
+	/** Launch/lease a browser context. Headless unless configured otherwise. */
+	open(spec?: BrowserSessionSpec): Promise<BrowserSessionHandle>;
+
+	/**
+	 * Navigate. MUST re-check the allowlist on every redirect hop and
+	 * throw {@link BrowserNavigationBlockedError} rather than land on an
+	 * off-allowlist URL.
+	 */
+	navigate(handle: BrowserSessionHandle, url: string): Promise<BrowserNavigateResult>;
+
+	extract(handle: BrowserSessionHandle, query: BrowserExtractQuery): Promise<BrowserExtractResult>;
+
+	screenshot(handle: BrowserSessionHandle, request?: BrowserScreenshotRequest): Promise<BrowserScreenshotResult>;
+
+	act(handle: BrowserSessionHandle, steps: readonly BrowserActStep[]): Promise<BrowserActResult>;
+
+	/** Route EVERY teardown through here (close context → release browser). */
+	close(handle: BrowserSessionHandle): Promise<void>;
+
+	/** Cheap readiness probe — is a browser actually launchable here? */
+	probe?(settings?: PluginSettings): Promise<{ ok: boolean; detail?: string }>;
+}
+
+/** Type guard — true when a plugin declares the `browser-automation` capability. */
+export function isBrowserAutomationPlugin(plugin: IPlugin): plugin is IBrowserAutomationPlugin {
+	return plugin.capabilities.includes('browser-automation');
+}

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -32,6 +32,11 @@ export * from './connector.interface.js';
 export * from './agent-memory.interface.js';
 export * from './terminal-stream.interface.js';
 export * from './workspace.interface.js';
+// Headless browser drivers (audit item G22) — navigate / extract /
+// screenshot / act behind a default-deny navigation allowlist that is
+// re-checked on every redirect hop. First-party implementation:
+// `@ever-works/browser-automation-plugin` (Playwright).
+export * from './browser-automation.interface.js';
 // Event-ingest spine (Wave 6) — pull-model event sources feeding the
 // normalized `IngestedEventEnvelope` pipeline (webhook push lands with
 // each concrete connector). See `event-source.interface.ts`.

--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -76,6 +76,12 @@ export const PLUGIN_CAPABILITIES = {
 	TERMINAL_STREAM: 'terminal-stream',
 	// Isolated git working contexts for agent Tasks (Wave 2).
 	WORKSPACE: 'workspace',
+	// Headless browser drivers (audit item G22). navigate / extract /
+	// screenshot / act, headless by default, behind a default-deny
+	// navigation allowlist re-checked on every redirect hop. First-party:
+	// `browser-automation` (Playwright). See
+	// capabilities/browser-automation.interface.ts.
+	BROWSER_AUTOMATION: 'browser-automation',
 	// Event-ingest spine (Wave 6) — plugins that pull/push normalized
 	// external events into the platform ingest pipeline. See
 	// capabilities/event-source.interface.ts.

--- a/packages/plugins/browser-automation/README.md
+++ b/packages/plugins/browser-automation/README.md
@@ -1,0 +1,87 @@
+# @ever-works/browser-automation-plugin
+
+Headless browser automation for Ever Works — navigate, extract, screenshot and act on web pages via Playwright, behind a default-deny navigation allowlist that is re-checked on every redirect hop.
+
+## Plugin metadata
+
+| Field        | Value                 |
+| ------------ | --------------------- |
+| ID           | `browser-automation`  |
+| Category     | `utility`             |
+| Capabilities | `browser-automation`  |
+| Provider     | Playwright (Chromium) |
+| Author       | Ever Works Team       |
+| License      | AGPL-3.0              |
+| Built-in     | yes                   |
+
+## What it does
+
+Drives a headless Chromium and exposes exactly four verbs through the `browser-automation` capability:
+
+| Verb         | Purpose                                                                              |
+| ------------ | ------------------------------------------------------------------------------------ |
+| `navigate`   | Go to a URL; returns the final URL, HTTP status, title and the **full redirect chain** |
+| `extract`    | Pull `text` / `html` / `attribute` values out of the rendered DOM by CSS selector      |
+| `screenshot` | Capture the viewport, the full page, or one element as base64 PNG/JPEG                 |
+| `act`        | Run a bounded ordered list of `click` / `fill` / `select` / `press` / `hover` / `wait` |
+
+Sessions are opened with `open()` and **must** be released with `close()`. The last closed session shuts the shared browser down.
+
+## Security posture
+
+A headless browser reachable from server-side code is an SSRF engine with a JavaScript runtime attached. The following are enforced by the plugin, not by convention:
+
+- **Headless by default.** Only an explicit `headless: false` in settings produces a headed browser.
+- **Default-deny allowlist.** An empty `allowedHosts` refuses **every** navigation. There is no implicit "allow anything" path.
+- **Redirects are re-checked on every hop.** A Playwright route guard aborts any document request outside the allowlist, and a post-navigation audit walks the `redirectedFrom()` chain — a hop that somehow got through still fails the call rather than returning attacker-controlled content. The final landing URL is verified too, including after an `act()` step navigates.
+- **SSRF guard underneath the allowlist.** Private, loopback, link-local, CGNAT and cloud-metadata targets (including `169.254.169.254` and its DNS aliases) are refused on both the literal URL and the DNS resolution, so an allowlisted hostname that *resolves* to `127.0.0.1` is refused (DNS-rebinding defence).
+- **Fail closed.** An unresolvable host, an unparseable resolved address, and a URL carrying embedded `user:password@` credentials are all refusals — never optimistic retries.
+- **Configurable timeout** applied to navigation and to every action, clamped to 1 000–120 000 ms.
+
+Every refusal throws `BrowserNavigationBlockedError` with a stable `code`: `invalid_url`, `scheme_blocked`, `credentials_in_url`, `private_address`, `not_allowlisted`, `dns_private_ip`, `dns_lookup_failed`. Credentials are stripped from the reported URL and message.
+
+## Allowlist syntax
+
+| Pattern             | Matches                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| `example.com`       | that host exactly (**not** its subdomains), on any port                  |
+| `*.example.com`     | any subdomain (`a.example.com`, `a.b.example.com`) but **not** the apex  |
+| `example.com:8443`  | that host, only on port 8443                                             |
+| `*`                 | any **public** host — private/internal targets stay blocked              |
+
+Anything else (a scheme, a path, an `@`, an embedded wildcard) is rejected as a configuration error rather than interpreted loosely.
+
+## Settings
+
+- **`allowedHosts`** (array of strings, default `[]`) — the navigation allowlist. Empty means every navigation is refused. Falls back to `PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS` (comma-separated) when unset.
+- **`timeoutMs`** (number, default `30000`) — wall-clock budget for navigation and each action; clamped to 1 000–120 000.
+- **`headless`** (boolean, default `true`) — leave enabled on any server runtime.
+- **`subresourcePolicy`** (`public-only` | `allowlist`, default `public-only`) — `public-only` lets a page load assets from any public host while still blocking internal targets; `allowlist` restricts assets to `allowedHosts` too.
+- **`allowPrivateNetwork`** (boolean, default `false`) — advanced escape hatch for automating internal staging hosts. Requires an explicit host list: the `*` entry is dropped while this is on, so it can never open the whole internal network.
+- **`executablePath`** — absolute path to a Chromium binary; falls back to `PLUGIN_BROWSER_AUTOMATION_EXECUTABLE_PATH`, then to the Playwright-managed browser.
+- **`channel`** — optional Playwright channel (`chrome`, `msedge`) instead of the bundled Chromium.
+
+## Runtime requirements
+
+`playwright-core` is an **optional** dependency loaded through a runtime dynamic import, and Chromium must be present on the host. A runtime without either degrades to a loud `BrowserAutomationNotProvisionedError` — it never crashes at module load. `probe()` and `healthCheck()` report the degraded state (and also flag an empty allowlist, which would make the plugin useless in practice).
+
+## Troubleshooting
+
+| Symptom                                                   | Likely cause                                              | Fix                                                                             |
+| --------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `BrowserNavigationBlockedError` with `not_allowlisted`    | The host (or a redirect hop) is not in `allowedHosts`     | Add the host — including any host the site redirects through                     |
+| `BrowserNavigationBlockedError` with `private_address`    | Target is loopback/private/link-local/cloud-metadata      | Intentional. Use `allowPrivateNetwork` with an explicit host list if you must    |
+| `BrowserNavigationBlockedError` with `dns_private_ip`     | An allowlisted name resolves to an internal address       | Intentional (rebinding defence). Verify the DNS record                          |
+| `BrowserAutomationNotProvisionedError` at `open()`        | `playwright-core` or the Chromium binary is missing       | Install `playwright-core` and a Chromium build, or set `executablePath`         |
+| Screenshot renders without styling                        | Assets were blocked by `subresourcePolicy: 'allowlist'`   | Switch to `public-only`, or allowlist the asset hosts                           |
+| Timeouts on slow pages                                    | 30 s default budget                                       | Raise `timeoutMs` (max 120 000)                                                 |
+
+## Local development
+
+```bash
+cd packages/plugins/browser-automation
+pnpm build     # tsc --noEmit && tsup
+npx vitest run # unit tests, incl. the SSRF-refusal suite (no real browser is launched)
+```
+
+The unit tests inject a fake Playwright module and a deterministic DNS resolver, so they never launch a browser and never touch the network.

--- a/packages/plugins/browser-automation/package.json
+++ b/packages/plugins/browser-automation/package.json
@@ -1,0 +1,86 @@
+{
+	"name": "@ever-works/browser-automation-plugin",
+	"version": "1.0.0",
+	"description": "Headless browser automation for Ever Works - navigate, extract, screenshot and act on web pages via Playwright, behind a default-deny navigation allowlist that is re-checked on every redirect hop",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"optionalDependencies": {
+		"playwright-core": "^1.59.1"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "browser-automation",
+			"name": "Browser Automation",
+			"version": "1.0.0",
+			"category": "utility",
+			"capabilities": [
+				"browser-automation"
+			],
+			"description": "Drives a headless Chromium via Playwright: navigate, extract text/HTML/attributes by CSS selector, capture screenshots, and run bounded interaction steps. Every navigation and every redirect hop is checked against a default-deny host allowlist and an SSRF guard, so the browser can never be pointed at internal hosts.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"systemPlugin": false,
+			"builtIn": false,
+			"visibility": "public",
+			"defaultForCapabilities": [
+				"browser-automation"
+			],
+			"envVars": [
+				{
+					"name": "PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS",
+					"required": false,
+					"secret": false,
+					"description": "Comma-separated navigation allowlist (e.g. 'example.com,*.example.org'). Empty means every navigation is refused."
+				},
+				{
+					"name": "PLUGIN_BROWSER_AUTOMATION_EXECUTABLE_PATH",
+					"required": false,
+					"secret": false,
+					"description": "Absolute path to a Chromium binary. Defaults to the Playwright-managed browser."
+				}
+			],
+			"distribution": "registry"
+		}
+	},
+	"private": false,
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/browser-automation/src/__tests__/browser-automation.plugin.spec.ts
+++ b/packages/plugins/browser-automation/src/__tests__/browser-automation.plugin.spec.ts
@@ -1,0 +1,784 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { PluginContext } from '@ever-works/plugin';
+import { BrowserAutomationNotProvisionedError, BrowserNavigationBlockedError } from '@ever-works/plugin';
+import BrowserAutomationDefaultExport, { BrowserAutomationPlugin } from '../index.js';
+import type { PwLocator, PwPage, PwRequest, PwResponse, PwRoute } from '../playwright.types.js';
+import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS } from '../navigation-policy.js';
+
+// ── fakes ───────────────────────────────────────────────────────────
+// A real browser is never launched: the plugin loads Playwright through
+// an injected module loader, so these structural fakes stand in for it.
+
+interface NodeSpec {
+	text?: string;
+	html?: string;
+	attributes?: Record<string, string>;
+}
+
+class FakeLocator implements PwLocator {
+	constructor(
+		private readonly page: FakePage,
+		private readonly selector: string,
+		private readonly nodes: NodeSpec[]
+	) {}
+
+	async all(): Promise<PwLocator[]> {
+		return this.nodes.map((node) => new FakeLocator(this.page, this.selector, [node]));
+	}
+	async count(): Promise<number> {
+		return this.nodes.length;
+	}
+	first(): PwLocator {
+		return new FakeLocator(this.page, this.selector, this.nodes.slice(0, 1));
+	}
+	async innerText(): Promise<string> {
+		return this.nodes[0]?.text ?? '';
+	}
+	async textContent(): Promise<string | null> {
+		return this.nodes[0]?.text ?? null;
+	}
+	async innerHTML(): Promise<string> {
+		return this.nodes[0]?.html ?? '';
+	}
+	async getAttribute(name: string): Promise<string | null> {
+		return this.nodes[0]?.attributes?.[name] ?? null;
+	}
+	async click(): Promise<void> {
+		this.page.performed.push(`click:${this.selector}`);
+		if (this.page.clickNavigatesTo) this.page.currentUrl = this.page.clickNavigatesTo;
+	}
+	async fill(value: string): Promise<void> {
+		this.page.performed.push(`fill:${this.selector}=${value}`);
+	}
+	async selectOption(values: string): Promise<string[]> {
+		this.page.performed.push(`select:${this.selector}=${values}`);
+		return [values];
+	}
+	async press(key: string): Promise<void> {
+		this.page.performed.push(`press:${this.selector}:${key}`);
+	}
+	async hover(): Promise<void> {
+		this.page.performed.push(`hover:${this.selector}`);
+	}
+	async waitFor(): Promise<void> {
+		this.page.performed.push(`waitFor:${this.selector}`);
+	}
+	async screenshot(): Promise<Buffer> {
+		this.page.performed.push(`screenshot:${this.selector}`);
+		return Buffer.from('element-shot');
+	}
+}
+
+class FakeRequest implements PwRequest {
+	constructor(
+		private readonly href: string,
+		private readonly kind: string,
+		private readonly previous: FakeRequest | null
+	) {}
+	url(): string {
+		return this.href;
+	}
+	resourceType(): string {
+		return this.kind;
+	}
+	isNavigationRequest(): boolean {
+		return this.kind === 'document';
+	}
+	redirectedFrom(): PwRequest | null {
+		return this.previous;
+	}
+}
+
+class FakeRoute implements PwRoute {
+	aborted: string | null = null;
+	continued = false;
+	constructor(private readonly req: PwRequest) {}
+	request(): PwRequest {
+		return this.req;
+	}
+	async abort(errorCode?: string): Promise<void> {
+		this.aborted = errorCode ?? 'failed';
+	}
+	async continue(): Promise<void> {
+		this.continued = true;
+	}
+}
+
+class FakePage implements PwPage {
+	currentUrl = 'about:blank';
+	closed = false;
+	defaultTimeout = 0;
+	defaultNavigationTimeout = 0;
+	readonly performed: string[] = [];
+	readonly gotoCalls: string[] = [];
+	readonly waits: number[] = [];
+	routeHandler: ((route: PwRoute) => Promise<void> | void) | null = null;
+	/** Hops the fake navigation "took", oldest first; last is the landing URL. */
+	hops: string[] | null = null;
+	/** Requests fed through the route guard while `goto` is in flight. */
+	duringNavigation: { url: string; type: string }[] = [];
+	/** Routes the guard saw during the last `goto`, for assertions. */
+	readonly seenRoutes: FakeRoute[] = [];
+	gotoError: Error | null = null;
+	clickNavigatesTo: string | null = null;
+	nodes: Record<string, NodeSpec[]> = {};
+	documentHtml = '<html><body>fake</body></html>';
+	pageTitle = 'Fake Page';
+	responseStatus = 200;
+
+	async route(_pattern: string, handler: (route: PwRoute) => Promise<void> | void): Promise<void> {
+		this.routeHandler = handler;
+	}
+	async goto(url: string): Promise<PwResponse | null> {
+		this.gotoCalls.push(url);
+		// Playwright fires the route handler for every request the page
+		// makes mid-navigation, redirect hops included.
+		for (const pending of this.duringNavigation) {
+			const route = new FakeRoute(new FakeRequest(pending.url, pending.type, null));
+			await this.routeHandler?.(route);
+			this.seenRoutes.push(route);
+		}
+		if (this.gotoError) throw this.gotoError;
+		const chain = this.hops ?? [url];
+		this.currentUrl = chain[chain.length - 1];
+		let request: FakeRequest | null = null;
+		for (const hop of chain) {
+			request = new FakeRequest(hop, 'document', request);
+		}
+		const finalRequest = request as FakeRequest;
+		const status = this.responseStatus;
+		return {
+			url: () => this.currentUrl,
+			status: () => status,
+			request: () => finalRequest
+		};
+	}
+	url(): string {
+		return this.currentUrl;
+	}
+	async title(): Promise<string> {
+		return this.pageTitle;
+	}
+	async content(): Promise<string> {
+		return this.documentHtml;
+	}
+	locator(selector: string): PwLocator {
+		if (selector === 'body' && !this.nodes.body) {
+			return new FakeLocator(this, 'body', [{ text: 'body text' }]);
+		}
+		return new FakeLocator(this, selector, this.nodes[selector] ?? []);
+	}
+	setDefaultTimeout(timeout: number): void {
+		this.defaultTimeout = timeout;
+	}
+	setDefaultNavigationTimeout(timeout: number): void {
+		this.defaultNavigationTimeout = timeout;
+	}
+	async screenshot(options?: { type?: 'png' | 'jpeg'; fullPage?: boolean }): Promise<Buffer> {
+		this.performed.push(`page-screenshot:${options?.type ?? 'png'}:${options?.fullPage === true}`);
+		return Buffer.from('page-shot');
+	}
+	async waitForTimeout(timeout: number): Promise<void> {
+		this.waits.push(timeout);
+	}
+	async close(): Promise<void> {
+		this.closed = true;
+	}
+}
+
+class FakeContext {
+	closed = false;
+	readonly pages: FakePage[] = [];
+	constructor(readonly options: unknown) {}
+	async newPage(): Promise<PwPage> {
+		const page = new FakePage();
+		this.pages.push(page);
+		return page;
+	}
+	async close(): Promise<void> {
+		this.closed = true;
+	}
+}
+
+class FakeBrowser {
+	closed = false;
+	readonly contexts: FakeContext[] = [];
+	constructor(readonly launchOptions: Record<string, unknown>) {}
+	async newContext(options?: unknown): Promise<FakeContext> {
+		const context = new FakeContext(options);
+		this.contexts.push(context);
+		return context;
+	}
+	async close(): Promise<void> {
+		this.closed = true;
+	}
+	isConnected(): boolean {
+		return !this.closed;
+	}
+}
+
+class FakePlaywright {
+	readonly browsers: FakeBrowser[] = [];
+	launchError: Error | null = null;
+	readonly chromium = {
+		launch: async (options?: Record<string, unknown>) => {
+			if (this.launchError) throw this.launchError;
+			const browser = new FakeBrowser(options ?? {});
+			this.browsers.push(browser);
+			return browser;
+		}
+	};
+}
+
+const publicDns = { dnsResolver: async () => [{ address: '93.184.216.34', family: 4 }] };
+
+function makePlugin(): { plugin: BrowserAutomationPlugin; playwright: FakePlaywright } {
+	const playwright = new FakePlaywright();
+	const plugin = new BrowserAutomationPlugin(async () => playwright, publicDns);
+	return { plugin, playwright };
+}
+
+function lastPage(playwright: FakePlaywright): FakePage {
+	const browser = playwright.browsers[playwright.browsers.length - 1];
+	const context = browser.contexts[browser.contexts.length - 1];
+	return context.pages[context.pages.length - 1];
+}
+
+const ALLOW_EXAMPLE = { allowedHosts: ['example.com', '*.example.com'] };
+
+const silentContext = (): PluginContext =>
+	({
+		logger: { log: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined }
+	}) as unknown as PluginContext;
+
+// The deployment-level allowlist env var must never leak into these
+// specs — default-deny is exactly what several of them assert.
+beforeEach(() => {
+	delete process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS;
+});
+
+// ── specs ───────────────────────────────────────────────────────────
+
+describe('plugin shape', () => {
+	it('has a DEFAULT EXPORT (the loader rejects a plugin without one)', () => {
+		expect(BrowserAutomationDefaultExport).toBe(BrowserAutomationPlugin);
+		expect(typeof BrowserAutomationDefaultExport).toBe('function');
+	});
+
+	it('declares the browser-automation capability and a settings schema', () => {
+		const { plugin } = makePlugin();
+		expect(plugin.id).toBe('browser-automation');
+		expect(plugin.category).toBe('utility');
+		expect(plugin.capabilities).toContain('browser-automation');
+		expect(plugin.settingsSchema.properties?.allowedHosts).toBeDefined();
+		expect(plugin.settingsSchema.properties?.timeoutMs).toBeDefined();
+		expect(plugin.settingsSchema.properties?.headless).toBeDefined();
+	});
+
+	it('reports a manifest that matches the instance', () => {
+		const { plugin } = makePlugin();
+		const manifest = plugin.getManifest();
+		expect(manifest.id).toBe(plugin.id);
+		expect(manifest.capabilities).toEqual(['browser-automation']);
+		expect(manifest.defaultForCapabilities).toEqual(['browser-automation']);
+	});
+});
+
+describe('open', () => {
+	it('launches HEADLESS by default', async () => {
+		const { plugin, playwright } = makePlugin();
+		await plugin.open({ settings: ALLOW_EXAMPLE });
+		expect(playwright.browsers[0].launchOptions.headless).toBe(true);
+	});
+
+	it('only runs headed when settings explicitly say so', async () => {
+		const { plugin, playwright } = makePlugin();
+		await plugin.open({ settings: { ...ALLOW_EXAMPLE, headless: false } });
+		expect(playwright.browsers[0].launchOptions.headless).toBe(false);
+	});
+
+	it('surfaces the resolved policy on the handle', async () => {
+		const { plugin } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE, timeoutMs: 5_000 });
+		expect(handle.policy).toEqual({
+			allowedHosts: ['example.com', '*.example.com'],
+			subresourcePolicy: 'public-only',
+			allowPrivateNetwork: false,
+			timeoutMs: 5_000,
+			headless: true
+		});
+		expect(handle.sessionId).toEqual(expect.any(String));
+	});
+
+	it('applies the clamped timeout to the page defaults', async () => {
+		const { plugin, playwright } = makePlugin();
+		await plugin.open({ settings: ALLOW_EXAMPLE, timeoutMs: 999_999 });
+		const page = lastPage(playwright);
+		expect(page.defaultTimeout).toBe(MAX_TIMEOUT_MS);
+		expect(page.defaultNavigationTimeout).toBe(MAX_TIMEOUT_MS);
+	});
+
+	it('reuses one browser across sessions and closes it with the last one', async () => {
+		const { plugin, playwright } = makePlugin();
+		const a = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const b = await plugin.open({ settings: ALLOW_EXAMPLE });
+		expect(playwright.browsers).toHaveLength(1);
+
+		await plugin.close(a);
+		expect(playwright.browsers[0].closed).toBe(false);
+		await plugin.close(b);
+		expect(playwright.browsers[0].closed).toBe(true);
+	});
+
+	it('degrades LOUDLY when Playwright is not installed', async () => {
+		const plugin = new BrowserAutomationPlugin(async () => {
+			throw new Error('Cannot find module');
+		}, publicDns);
+		await expect(plugin.open({ settings: ALLOW_EXAMPLE })).rejects.toBeInstanceOf(
+			BrowserAutomationNotProvisionedError
+		);
+	});
+
+	it('degrades LOUDLY when the module exposes no chromium launcher', async () => {
+		const plugin = new BrowserAutomationPlugin(async () => ({}), publicDns);
+		await expect(plugin.open({ settings: ALLOW_EXAMPLE })).rejects.toBeInstanceOf(
+			BrowserAutomationNotProvisionedError
+		);
+	});
+
+	it('accepts a CJS-interop module wrapped in `default`', async () => {
+		const playwright = new FakePlaywright();
+		const plugin = new BrowserAutomationPlugin(async () => ({ default: playwright }), publicDns);
+		await expect(plugin.open({ settings: ALLOW_EXAMPLE })).resolves.toBeDefined();
+	});
+
+	it('degrades LOUDLY when Chromium refuses to launch', async () => {
+		const { plugin, playwright } = makePlugin();
+		playwright.launchError = new Error('no sandbox');
+		await expect(plugin.open({ settings: ALLOW_EXAMPLE })).rejects.toBeInstanceOf(
+			BrowserAutomationNotProvisionedError
+		);
+	});
+});
+
+describe('navigate', () => {
+	let plugin: BrowserAutomationPlugin;
+	let playwright: FakePlaywright;
+
+	beforeEach(() => {
+		({ plugin, playwright } = makePlugin());
+	});
+
+	it('navigates to an allowlisted URL and reports where it landed', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const result = await plugin.navigate(handle, 'https://example.com/start');
+		expect(result.url).toBe('https://example.com/start');
+		expect(result.status).toBe(200);
+		expect(result.title).toBe('Fake Page');
+		expect(result.redirectChain).toEqual(['https://example.com/start']);
+	});
+
+	it('reports the full redirect chain when every hop is allowlisted', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).hops = ['https://example.com/a', 'https://www.example.com/b'];
+		const result = await plugin.navigate(handle, 'https://example.com/a');
+		expect(result.redirectChain).toEqual(['https://example.com/a', 'https://www.example.com/b']);
+		expect(result.url).toBe('https://www.example.com/b');
+	});
+
+	// ── SSRF / allowlist refusals ───────────────────────────────────
+	it('REFUSES an off-allowlist URL before the browser touches the network', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		await expect(plugin.navigate(handle, 'https://evil.test/')).rejects.toMatchObject({
+			name: 'BrowserNavigationBlockedError',
+			code: 'not_allowlisted'
+		});
+		expect(lastPage(playwright).gotoCalls).toEqual([]);
+	});
+
+	it('REFUSES an internal host even with a wildcard allowlist (SSRF)', async () => {
+		const handle = await plugin.open({ settings: { allowedHosts: ['*'] } });
+		await expect(plugin.navigate(handle, 'http://169.254.169.254/latest/meta-data/')).rejects.toMatchObject({
+			code: 'private_address'
+		});
+		expect(lastPage(playwright).gotoCalls).toEqual([]);
+	});
+
+	it('REFUSES everything when nothing is allowlisted (default-deny)', async () => {
+		const handle = await plugin.open({ settings: {} });
+		await expect(plugin.navigate(handle, 'https://example.com/')).rejects.toMatchObject({
+			code: 'not_allowlisted'
+		});
+	});
+
+	it('REFUSES a hostname that resolves to a private address (DNS rebinding)', async () => {
+		const rebinding = new BrowserAutomationPlugin(async () => new FakePlaywright(), {
+			dnsResolver: async () => [{ address: '127.0.0.1', family: 4 }]
+		});
+		const handle = await rebinding.open({ settings: { allowedHosts: ['*'] } });
+		await expect(rebinding.navigate(handle, 'https://rebind.example.test/')).rejects.toMatchObject({
+			code: 'dns_private_ip'
+		});
+	});
+
+	it('NEVER lands on a redirect hop outside the allowlist', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).hops = ['https://example.com/a', 'https://evil.test/pwned'];
+		await expect(plugin.navigate(handle, 'https://example.com/a')).rejects.toMatchObject({
+			name: 'BrowserNavigationBlockedError',
+			code: 'not_allowlisted'
+		});
+	});
+
+	it('NEVER lands on an internal redirect hop', async () => {
+		const handle = await plugin.open({ settings: { allowedHosts: ['*'] } });
+		lastPage(playwright).hops = ['https://example.com/a', 'http://169.254.169.254/latest/'];
+		await expect(plugin.navigate(handle, 'https://example.com/a')).rejects.toMatchObject({
+			code: 'private_address'
+		});
+	});
+
+	it('reports the route guard reason when an aborted redirect surfaces as a goto failure', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const page = lastPage(playwright);
+		// The guard aborts the redirect hop, so Chromium reports the whole
+		// navigation as a network failure.
+		page.duringNavigation = [{ url: 'https://evil.test/pwned', type: 'document' }];
+		page.gotoError = new Error('net::ERR_FAILED');
+
+		const error = await plugin.navigate(handle, 'https://example.com/a').catch((err: unknown) => err);
+		expect(error).toBeInstanceOf(BrowserNavigationBlockedError);
+		expect((error as BrowserNavigationBlockedError).code).toBe('not_allowlisted');
+	});
+
+	it('rethrows a genuine navigation failure untouched', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).gotoError = new Error('net::ERR_CONNECTION_RESET');
+		await expect(plugin.navigate(handle, 'https://example.com/a')).rejects.toThrow('net::ERR_CONNECTION_RESET');
+	});
+
+	it('throws for an unknown/closed session handle', async () => {
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		await plugin.close(handle);
+		await expect(plugin.navigate(handle, 'https://example.com/')).rejects.toBeInstanceOf(
+			BrowserAutomationNotProvisionedError
+		);
+	});
+});
+
+describe('route guard', () => {
+	it('aborts an off-allowlist DOCUMENT request and records it as a navigation refusal', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const page = lastPage(playwright);
+		page.duringNavigation = [{ url: 'https://evil.test/', type: 'document' }];
+
+		const result = await plugin.navigate(handle, 'https://example.com/ok');
+		expect(page.seenRoutes[0].aborted).toBe('blockedbyclient');
+		expect(page.seenRoutes[0].continued).toBe(false);
+		expect(result.blockedRequests).toEqual([
+			{ url: 'https://evil.test/', reason: 'not_allowlisted', navigation: true }
+		]);
+	});
+
+	it('allows a PUBLIC sub-resource under the default public-only policy', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const page = lastPage(playwright);
+		page.duringNavigation = [{ url: 'https://cdn.other.test/app.js', type: 'script' }];
+
+		const result = await plugin.navigate(handle, 'https://example.com/ok');
+		expect(page.seenRoutes[0].continued).toBe(true);
+		expect(page.seenRoutes[0].aborted).toBeNull();
+		expect(result.blockedRequests).toEqual([]);
+	});
+
+	it('aborts an INTERNAL sub-resource even under public-only (SSRF)', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).duringNavigation = [{ url: 'http://127.0.0.1:9200/_cat/indices', type: 'xhr' }];
+
+		const result = await plugin.navigate(handle, 'https://example.com/ok');
+		expect(result.blockedRequests).toEqual([
+			{ url: 'http://127.0.0.1:9200/_cat/indices', reason: 'private_address', navigation: false }
+		]);
+	});
+
+	it('aborts a cross-host sub-resource when the policy is allowlist-strict', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: { ...ALLOW_EXAMPLE, subresourcePolicy: 'allowlist' } });
+		lastPage(playwright).duringNavigation = [{ url: 'https://cdn.other.test/app.js', type: 'script' }];
+
+		const result = await plugin.navigate(handle, 'https://example.com/ok');
+		expect(result.blockedRequests).toEqual([
+			{ url: 'https://cdn.other.test/app.js', reason: 'not_allowlisted', navigation: false }
+		]);
+	});
+
+	it('redacts credentials out of a recorded refusal', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).duringNavigation = [{ url: 'https://user:secret@evil.test/', type: 'document' }];
+
+		const result = await plugin.navigate(handle, 'https://example.com/ok');
+		expect(result.blockedRequests[0].url).not.toContain('secret');
+	});
+
+	it('drains recorded refusals so they are reported exactly once', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).duringNavigation = [{ url: 'https://evil.test/', type: 'document' }];
+
+		const first = await plugin.navigate(handle, 'https://example.com/ok');
+		expect(first.blockedRequests).toHaveLength(1);
+		const second = await plugin.act(handle, []);
+		expect(second.blockedRequests).toEqual([]);
+	});
+});
+
+describe('extract', () => {
+	it('returns per-node text for a selector', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).nodes = { h2: [{ text: 'One' }, { text: 'Two' }] };
+		await expect(plugin.extract(handle, { selector: 'h2', format: 'text' })).resolves.toEqual({
+			values: ['One', 'Two'],
+			truncated: false
+		});
+	});
+
+	it('returns inner HTML per node', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).nodes = { '.card': [{ html: '<b>hi</b>' }] };
+		await expect(plugin.extract(handle, { selector: '.card', format: 'html' })).resolves.toEqual({
+			values: ['<b>hi</b>'],
+			truncated: false
+		});
+	});
+
+	it('returns an attribute per node and empty string for a missing one', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).nodes = { a: [{ attributes: { href: '/x' } }, {}] };
+		await expect(
+			plugin.extract(handle, { selector: 'a', format: 'attribute', attribute: 'href' })
+		).resolves.toEqual({ values: ['/x', ''], truncated: false });
+	});
+
+	it('honours the limit and flags truncation', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).nodes = { li: [{ text: 'a' }, { text: 'b' }, { text: 'c' }] };
+		await expect(plugin.extract(handle, { selector: 'li', format: 'text', limit: 2 })).resolves.toEqual({
+			values: ['a', 'b'],
+			truncated: true
+		});
+	});
+
+	it('falls back to the whole document when no selector is given', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).documentHtml = '<html>doc</html>';
+		await expect(plugin.extract(handle, { format: 'html' })).resolves.toEqual({
+			values: ['<html>doc</html>'],
+			truncated: false
+		});
+		await expect(plugin.extract(handle, { format: 'text' })).resolves.toEqual({
+			values: ['body text'],
+			truncated: false
+		});
+	});
+
+	it('rejects an attribute query with no attribute name or no selector', async () => {
+		const { plugin } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		await expect(plugin.extract(handle, { selector: 'a', format: 'attribute' })).rejects.toBeInstanceOf(TypeError);
+		await expect(plugin.extract(handle, { format: 'attribute', attribute: 'href' })).rejects.toBeInstanceOf(
+			TypeError
+		);
+	});
+});
+
+describe('screenshot', () => {
+	it('captures the page as base64 PNG by default', async () => {
+		const { plugin } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const shot = await plugin.screenshot(handle);
+		expect(shot.contentType).toBe('image/png');
+		expect(Buffer.from(shot.base64, 'base64').toString()).toBe('page-shot');
+		expect(shot.bytes).toBe(Buffer.from('page-shot').byteLength);
+	});
+
+	it('captures JPEG with a clamped quality and honours fullPage', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		await plugin.screenshot(handle, { format: 'jpeg', quality: 5_000, fullPage: true });
+		expect(lastPage(playwright).performed).toContain('page-screenshot:jpeg:true');
+	});
+
+	it('captures a single element when a selector is given', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).nodes = { '#hero': [{}] };
+		const shot = await plugin.screenshot(handle, { selector: '#hero' });
+		expect(Buffer.from(shot.base64, 'base64').toString()).toBe('element-shot');
+	});
+});
+
+describe('act', () => {
+	it('runs each step in order', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const page = lastPage(playwright);
+		page.currentUrl = 'https://example.com/form';
+		page.nodes = { '#q': [{}], '#go': [{}], '#sel': [{}] };
+
+		const result = await plugin.act(handle, [
+			{ kind: 'fill', selector: '#q', value: 'hello' },
+			{ kind: 'select', selector: '#sel', value: 'b' },
+			{ kind: 'press', selector: '#q', key: 'Enter' },
+			{ kind: 'hover', selector: '#go' },
+			{ kind: 'click', selector: '#go' },
+			{ kind: 'wait', selector: '#go' }
+		]);
+
+		expect(result.performed).toBe(6);
+		expect(page.performed).toEqual([
+			'fill:#q=hello',
+			'select:#sel=b',
+			'press:#q:Enter',
+			'hover:#go',
+			'click:#go',
+			'waitFor:#go'
+		]);
+	});
+
+	it('treats a selector-less wait as a plain delay clamped by the policy', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).currentUrl = 'https://example.com/';
+		await plugin.act(handle, [{ kind: 'wait', timeoutMs: 999_999 }]);
+		expect(lastPage(playwright).waits).toEqual([MAX_TIMEOUT_MS]);
+	});
+
+	it('returns early for an empty step list', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).currentUrl = 'https://example.com/';
+		await expect(plugin.act(handle, [])).resolves.toMatchObject({ performed: 0 });
+	});
+
+	it('rejects more steps than the cap allows', async () => {
+		const { plugin } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const steps = Array.from({ length: 51 }, () => ({ kind: 'click' as const, selector: '#x' }));
+		await expect(plugin.act(handle, steps)).rejects.toBeInstanceOf(RangeError);
+	});
+
+	it('rejects steps missing their required inputs', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		lastPage(playwright).nodes = { '#x': [{}] };
+		await expect(plugin.act(handle, [{ kind: 'click' }])).rejects.toBeInstanceOf(TypeError);
+		await expect(plugin.act(handle, [{ kind: 'select', selector: '#x' }])).rejects.toBeInstanceOf(TypeError);
+		await expect(plugin.act(handle, [{ kind: 'press', selector: '#x' }])).rejects.toBeInstanceOf(TypeError);
+	});
+
+	it('REFUSES the result when a click navigated off the allowlist', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const page = lastPage(playwright);
+		page.currentUrl = 'https://example.com/';
+		page.nodes = { '#out': [{}] };
+		page.clickNavigatesTo = 'http://127.0.0.1:8080/admin';
+
+		await expect(plugin.act(handle, [{ kind: 'click', selector: '#out' }])).rejects.toMatchObject({
+			name: 'BrowserNavigationBlockedError',
+			code: 'private_address'
+		});
+	});
+});
+
+describe('close / lifecycle', () => {
+	it('closes the page and context, and is a no-op for an unknown handle', async () => {
+		const { plugin, playwright } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		const page = lastPage(playwright);
+		const context = playwright.browsers[0].contexts[0];
+
+		await plugin.close(handle);
+		expect(page.closed).toBe(true);
+		expect(context.closed).toBe(true);
+
+		await expect(plugin.close(handle)).resolves.toBeUndefined();
+	});
+
+	it('onUnload tears every session down', async () => {
+		const { plugin, playwright } = makePlugin();
+		await plugin.onLoad(silentContext());
+		await plugin.open({ settings: ALLOW_EXAMPLE });
+		await plugin.open({ settings: ALLOW_EXAMPLE });
+		await plugin.onUnload();
+		expect(playwright.browsers[0].closed).toBe(true);
+		expect(playwright.browsers[0].contexts.every((ctx) => ctx.closed)).toBe(true);
+	});
+
+	it('probe reports the empty-allowlist posture as not-ok', async () => {
+		const { plugin } = makePlugin();
+		await expect(plugin.probe({})).resolves.toMatchObject({ ok: false });
+		await expect(plugin.probe(ALLOW_EXAMPLE)).resolves.toMatchObject({ ok: true });
+	});
+
+	it('probe reports a missing Playwright install as not-ok', async () => {
+		const plugin = new BrowserAutomationPlugin(async () => {
+			throw new Error('Cannot find module');
+		}, publicDns);
+		await expect(plugin.probe(ALLOW_EXAMPLE)).resolves.toMatchObject({ ok: false });
+	});
+
+	it('healthCheck degrades rather than throwing', async () => {
+		const { plugin } = makePlugin();
+		const health = await plugin.healthCheck();
+		expect(health.status).toBe('degraded');
+		expect(health.checkedAt).toEqual(expect.any(Number));
+	});
+});
+
+describe('validateSettings', () => {
+	it('accepts a sane configuration', () => {
+		const { plugin } = makePlugin();
+		expect(plugin.validateSettings({ allowedHosts: ['example.com', '*.example.com'] })).toMatchObject({
+			valid: true
+		});
+	});
+
+	it('rejects malformed host patterns', () => {
+		const { plugin } = makePlugin();
+		const result = plugin.validateSettings({ allowedHosts: ['https://example.com'] });
+		expect(result.valid).toBe(false);
+		expect(result.errors?.[0]).toMatchObject({ path: 'allowedHosts', code: 'invalid_host_pattern' });
+	});
+
+	it('rejects the wildcard combined with private-network access', () => {
+		const { plugin } = makePlugin();
+		const result = plugin.validateSettings({ allowedHosts: ['*'], allowPrivateNetwork: true });
+		expect(result.valid).toBe(false);
+		expect(result.errors?.[0]).toMatchObject({ code: 'wildcard_with_private_network' });
+	});
+
+	it('warns (but does not fail) on an empty allowlist and on headed mode', () => {
+		const { plugin } = makePlugin();
+		const result = plugin.validateSettings({ allowedHosts: [], headless: false });
+		expect(result.valid).toBe(true);
+		expect(result.warnings?.map((warning) => warning.code)).toEqual(['empty_allowlist', 'headed_browser']);
+	});
+});
+
+describe('defaults', () => {
+	it('uses the documented default timeout when nothing is configured', async () => {
+		const { plugin } = makePlugin();
+		const handle = await plugin.open({ settings: ALLOW_EXAMPLE });
+		expect(handle.policy.timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+	});
+});

--- a/packages/plugins/browser-automation/src/__tests__/navigation-policy.spec.ts
+++ b/packages/plugins/browser-automation/src/__tests__/navigation-policy.spec.ts
@@ -1,0 +1,459 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { BrowserNavigationBlockedError, type BrowserNavigationPolicy } from '@ever-works/plugin';
+import {
+	DEFAULT_TIMEOUT_MS,
+	MAX_TIMEOUT_MS,
+	MIN_TIMEOUT_MS,
+	assertUrlAllowed,
+	clampTimeout,
+	classifyUrl,
+	collectInvalidHostPatterns,
+	isHostAllowed,
+	isInternalHostname,
+	normalizeHost,
+	parseHostPattern,
+	parseHostPatterns,
+	redactUrl,
+	resolveNavigationPolicy
+} from '../navigation-policy.js';
+
+function policy(overrides: Partial<BrowserNavigationPolicy> = {}): BrowserNavigationPolicy {
+	return {
+		allowedHosts: ['example.com'],
+		subresourcePolicy: 'public-only',
+		allowPrivateNetwork: false,
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+		headless: true,
+		...overrides
+	};
+}
+
+/** DNS stub that never touches the network. */
+const resolvesTo = (address: string, family = 4) => ({
+	dnsResolver: async () => [{ address, family }]
+});
+
+const originalEnv = process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS;
+
+afterEach(() => {
+	if (originalEnv === undefined) {
+		delete process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS;
+	} else {
+		process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS = originalEnv;
+	}
+});
+
+describe('normalizeHost', () => {
+	it('lowercases, unwraps IPv6 brackets and drops the FQDN trailing dot', () => {
+		expect(normalizeHost('EXAMPLE.com.')).toBe('example.com');
+		expect(normalizeHost('[::1]')).toBe('::1');
+		expect(normalizeHost('  Example.COM..  ')).toBe('example.com');
+	});
+});
+
+describe('parseHostPattern', () => {
+	it('accepts bare hosts, subdomain wildcards, the bare wildcard and pinned ports', () => {
+		expect(parseHostPattern('example.com')).toEqual({ host: 'example.com', port: null });
+		expect(parseHostPattern('*.example.com')).toEqual({ host: '*.example.com', port: null });
+		expect(parseHostPattern('*')).toEqual({ host: '*', port: null });
+		expect(parseHostPattern('example.com:8443')).toEqual({ host: 'example.com', port: '8443' });
+		expect(parseHostPattern('[::1]:8080')).toEqual({ host: '::1', port: '8080' });
+	});
+
+	it('refuses anything that is not a bare host pattern', () => {
+		expect(parseHostPattern('https://example.com')).toBeNull();
+		expect(parseHostPattern('example.com/path')).toBeNull();
+		expect(parseHostPattern('user@example.com')).toBeNull();
+		expect(parseHostPattern('example .com')).toBeNull();
+		expect(parseHostPattern('')).toBeNull();
+		expect(parseHostPattern('   ')).toBeNull();
+	});
+
+	it('refuses out-of-range and non-numeric ports', () => {
+		expect(parseHostPattern('example.com:0')).toBeNull();
+		expect(parseHostPattern('example.com:99999')).toBeNull();
+		expect(parseHostPattern('example.com:abc')).toBeNull();
+	});
+
+	it('refuses wildcards that are not a whole host or a leading label', () => {
+		expect(parseHostPattern('ex*ample.com')).toBeNull();
+		expect(parseHostPattern('example.*')).toBeNull();
+		// `*.` must not collapse into the everything-wildcard once the
+		// trailing-dot normalizer has run.
+		expect(parseHostPattern('*.')).toBeNull();
+	});
+
+	it('accepts a port-pinned bare wildcard', () => {
+		expect(parseHostPattern('*:8080')).toEqual({ host: '*', port: '8080' });
+		expect(isHostAllowed('anything.test', '8080', ['*:8080'])).toBe(true);
+		expect(isHostAllowed('anything.test', '443', ['*:8080'])).toBe(false);
+	});
+});
+
+describe('parseHostPatterns / collectInvalidHostPatterns', () => {
+	it('accepts arrays and comma/newline-separated strings', () => {
+		expect(parseHostPatterns(['Example.com', '*.EXAMPLE.org'])).toEqual(['example.com', '*.example.org']);
+		expect(parseHostPatterns('example.com, *.example.org\nother.test')).toEqual([
+			'example.com',
+			'*.example.org',
+			'other.test'
+		]);
+	});
+
+	it('drops invalid entries instead of widening them, and reports them separately', () => {
+		expect(parseHostPatterns(['example.com', 'https://evil.test'])).toEqual(['example.com']);
+		expect(collectInvalidHostPatterns(['example.com', 'https://evil.test'])).toEqual(['https://evil.test']);
+	});
+
+	it('returns an empty list for unusable input', () => {
+		expect(parseHostPatterns(undefined)).toEqual([]);
+		expect(parseHostPatterns(42)).toEqual([]);
+		expect(parseHostPatterns({})).toEqual([]);
+	});
+});
+
+describe('isHostAllowed', () => {
+	it('matches exact hosts only — no implicit subdomain widening', () => {
+		expect(isHostAllowed('example.com', '443', ['example.com'])).toBe(true);
+		expect(isHostAllowed('sub.example.com', '443', ['example.com'])).toBe(false);
+	});
+
+	it('matches subdomains under *. but never the apex', () => {
+		expect(isHostAllowed('sub.example.com', '443', ['*.example.com'])).toBe(true);
+		expect(isHostAllowed('deep.sub.example.com', '443', ['*.example.com'])).toBe(true);
+		expect(isHostAllowed('example.com', '443', ['*.example.com'])).toBe(false);
+	});
+
+	it('does not let a lookalike suffix sneak past the wildcard', () => {
+		expect(isHostAllowed('notexample.com', '443', ['*.example.com'])).toBe(false);
+		expect(isHostAllowed('example.com.evil.test', '443', ['*.example.com'])).toBe(false);
+	});
+
+	it('honours a pinned port and ignores port when unpinned', () => {
+		expect(isHostAllowed('example.com', '8443', ['example.com:8443'])).toBe(true);
+		expect(isHostAllowed('example.com', '443', ['example.com:8443'])).toBe(false);
+		expect(isHostAllowed('example.com', '8443', ['example.com'])).toBe(true);
+	});
+});
+
+describe('isInternalHostname', () => {
+	it.each([
+		'localhost',
+		'LOCALHOST',
+		'localhost.',
+		'localhost.localdomain',
+		'ip6-localhost',
+		'api.localhost',
+		'printer.local',
+		'db.internal',
+		'router.home.arpa',
+		'wiki.intranet'
+	])('treats %s as internal', (host) => {
+		expect(isInternalHostname(host)).toBe(true);
+	});
+
+	it.each(['example.com', 'localhost.example.com', 'local.example.com', 'internal.example.com'])(
+		'treats %s as external',
+		(host) => {
+			expect(isInternalHostname(host)).toBe(false);
+		}
+	);
+});
+
+describe('clampTimeout', () => {
+	it('clamps into the supported band and falls back on nonsense', () => {
+		expect(clampTimeout(5_000)).toBe(5_000);
+		expect(clampTimeout(1)).toBe(MIN_TIMEOUT_MS);
+		expect(clampTimeout(10_000_000)).toBe(MAX_TIMEOUT_MS);
+		expect(clampTimeout('nope')).toBe(DEFAULT_TIMEOUT_MS);
+		expect(clampTimeout(undefined, 7_000)).toBe(7_000);
+		expect(clampTimeout(-5, 7_000)).toBe(7_000);
+	});
+});
+
+describe('resolveNavigationPolicy', () => {
+	it('is DEFAULT-DENY: no configuration means an empty allowlist', () => {
+		delete process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS;
+		expect(resolveNavigationPolicy().allowedHosts).toEqual([]);
+		expect(resolveNavigationPolicy({}).allowedHosts).toEqual([]);
+	});
+
+	it('is headless by default and only an explicit false turns it off', () => {
+		expect(resolveNavigationPolicy({}).headless).toBe(true);
+		expect(resolveNavigationPolicy({ headless: true }).headless).toBe(true);
+		expect(resolveNavigationPolicy({ headless: 'no' }).headless).toBe(true);
+		expect(resolveNavigationPolicy({ headless: false }).headless).toBe(false);
+	});
+
+	it('reads the deployment env allowlist when settings carry none', () => {
+		process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS = 'env.example.com, *.env.example.org';
+		expect(resolveNavigationPolicy().allowedHosts).toEqual(['env.example.com', '*.env.example.org']);
+	});
+
+	it('merges per-session extra hosts and de-duplicates', () => {
+		const resolved = resolveNavigationPolicy(
+			{ allowedHosts: ['example.com'] },
+			{
+				extraAllowedHosts: ['example.com', 'extra.test']
+			}
+		);
+		expect(resolved.allowedHosts).toEqual(['example.com', 'extra.test']);
+	});
+
+	it('DROPS the bare "*" entry when private-network access is enabled', () => {
+		const resolved = resolveNavigationPolicy({
+			allowedHosts: ['*', 'internal.test'],
+			allowPrivateNetwork: true
+		});
+		expect(resolved.allowedHosts).toEqual(['internal.test']);
+		expect(resolved.allowPrivateNetwork).toBe(true);
+	});
+
+	it('keeps "*" when private-network access is off', () => {
+		expect(resolveNavigationPolicy({ allowedHosts: ['*'] }).allowedHosts).toEqual(['*']);
+	});
+
+	it('clamps the timeout and lets the session spec override settings', () => {
+		expect(resolveNavigationPolicy({ timeoutMs: 999_999 }).timeoutMs).toBe(MAX_TIMEOUT_MS);
+		expect(resolveNavigationPolicy({ timeoutMs: 5_000 }, { timeoutMs: 9_000 }).timeoutMs).toBe(9_000);
+	});
+
+	it('defaults the sub-resource policy to public-only', () => {
+		expect(resolveNavigationPolicy({}).subresourcePolicy).toBe('public-only');
+		expect(resolveNavigationPolicy({ subresourcePolicy: 'allowlist' }).subresourcePolicy).toBe('allowlist');
+		expect(resolveNavigationPolicy({ subresourcePolicy: 'anything-else' }).subresourcePolicy).toBe('public-only');
+	});
+});
+
+describe('classifyUrl', () => {
+	it('allows an allowlisted public host', () => {
+		const verdict = classifyUrl('https://example.com/page', policy(), 'document');
+		expect(verdict).toMatchObject({ allowed: true, host: 'example.com', dnsCheckRequired: true });
+	});
+
+	it('refuses an unparseable URL', () => {
+		expect(classifyUrl('not a url', policy(), 'document')).toMatchObject({
+			allowed: false,
+			reason: 'invalid_url'
+		});
+	});
+
+	it.each(['file:///etc/passwd', 'data:text/html,<h1>x</h1>', 'ftp://example.com/x', 'javascript:alert(1)'])(
+		'refuses non-HTTP scheme %s',
+		(url) => {
+			expect(classifyUrl(url, policy({ allowedHosts: ['*'] }), 'document')).toMatchObject({
+				allowed: false,
+				reason: 'scheme_blocked'
+			});
+		}
+	);
+
+	it('refuses URLs carrying embedded credentials (the allowed.com@evil.tld trick)', () => {
+		expect(
+			classifyUrl('https://example.com@evil.test/', policy({ allowedHosts: ['*'] }), 'document')
+		).toMatchObject({ allowed: false, reason: 'credentials_in_url' });
+	});
+
+	it('refuses an off-allowlist host', () => {
+		expect(classifyUrl('https://evil.test/', policy(), 'document')).toMatchObject({
+			allowed: false,
+			reason: 'not_allowlisted'
+		});
+	});
+
+	it('refuses EVERYTHING when the allowlist is empty (default-deny)', () => {
+		expect(classifyUrl('https://example.com/', policy({ allowedHosts: [] }), 'document')).toMatchObject({
+			allowed: false,
+			reason: 'not_allowlisted'
+		});
+	});
+
+	// ── SSRF refusals ───────────────────────────────────────────────
+	it.each([
+		['http://127.0.0.1:8080/admin', 'loopback'],
+		['http://localhost:3000/', 'localhost'],
+		['http://10.1.2.3/', 'RFC1918 10/8'],
+		['http://192.168.1.1/', 'RFC1918 192.168/16'],
+		['http://172.16.0.9/', 'RFC1918 172.16/12'],
+		['http://169.254.169.254/latest/meta-data/', 'cloud metadata IMDS'],
+		['http://metadata.google.internal/computeMetadata/v1/', 'GCP metadata alias'],
+		['http://[::1]:9000/', 'IPv6 loopback'],
+		['http://[fd00::1]/', 'IPv6 unique-local'],
+		['http://[fe82::1]/', 'IPv6 link-local beyond fe80'],
+		['http://0.0.0.0/', 'unspecified'],
+		['http://100.64.0.1/', 'CGNAT']
+	])('refuses %s (%s) even with a wildcard allowlist', (url) => {
+		expect(classifyUrl(url, policy({ allowedHosts: ['*'] }), 'document')).toMatchObject({
+			allowed: false,
+			reason: 'private_address'
+		});
+	});
+
+	it('refuses the trailing-dot form of a metadata hostname', () => {
+		expect(
+			classifyUrl(
+				'http://metadata.google.internal./computeMetadata/v1/',
+				policy({ allowedHosts: ['*'] }),
+				'document'
+			)
+		).toMatchObject({ allowed: false, reason: 'private_address' });
+	});
+
+	it('lets an explicitly-listed internal host through only when allowPrivateNetwork is on', () => {
+		const locked = policy({ allowedHosts: ['10.1.2.3'] });
+		expect(classifyUrl('http://10.1.2.3/', locked, 'document')).toMatchObject({
+			allowed: false,
+			reason: 'private_address'
+		});
+
+		const opened = policy({ allowedHosts: ['10.1.2.3'], allowPrivateNetwork: true });
+		expect(classifyUrl('http://10.1.2.3/', opened, 'document')).toMatchObject({ allowed: true });
+		// Literal IPs skip the DNS re-check — there is no name to rebind.
+		expect(classifyUrl('http://10.1.2.3/', opened, 'document')).toMatchObject({ dnsCheckRequired: false });
+	});
+
+	it('still refuses an UNLISTED internal host when allowPrivateNetwork is on', () => {
+		const opened = policy({ allowedHosts: ['10.1.2.3'], allowPrivateNetwork: true });
+		expect(classifyUrl('http://10.9.9.9/', opened, 'document')).toMatchObject({
+			allowed: false,
+			reason: 'not_allowlisted'
+		});
+	});
+
+	describe('sub-resources', () => {
+		it('public-only lets any PUBLIC host load assets', () => {
+			expect(classifyUrl('https://cdn.other.test/app.js', policy(), 'subresource')).toMatchObject({
+				allowed: true
+			});
+		});
+
+		it('public-only still refuses INTERNAL asset targets', () => {
+			expect(classifyUrl('http://127.0.0.1:9200/_cat/indices', policy(), 'subresource')).toMatchObject({
+				allowed: false,
+				reason: 'private_address'
+			});
+		});
+
+		it('public-only refuses internal assets even when allowPrivateNetwork is on', () => {
+			const opened = policy({ allowedHosts: ['10.1.2.3'], allowPrivateNetwork: true });
+			expect(classifyUrl('http://10.1.2.3/asset.js', opened, 'subresource')).toMatchObject({
+				allowed: false,
+				reason: 'private_address'
+			});
+		});
+
+		it('allowlist mode constrains assets to the same allowlist', () => {
+			const strict = policy({ subresourcePolicy: 'allowlist' });
+			expect(classifyUrl('https://cdn.other.test/app.js', strict, 'subresource')).toMatchObject({
+				allowed: false,
+				reason: 'not_allowlisted'
+			});
+			expect(classifyUrl('https://example.com/app.js', strict, 'subresource')).toMatchObject({ allowed: true });
+		});
+	});
+});
+
+describe('redactUrl', () => {
+	it('strips embedded credentials so they never reach a log or an error', () => {
+		expect(redactUrl('https://user:secret@example.com/path')).toBe('https://example.com/path');
+		expect(redactUrl('https://user:secret@example.com/path')).not.toContain('secret');
+	});
+
+	it('truncates unparseable input instead of throwing', () => {
+		expect(redactUrl('not a url')).toBe('not a url');
+		expect(redactUrl('x'.repeat(1000))).toHaveLength(256);
+	});
+});
+
+describe('assertUrlAllowed', () => {
+	it('resolves for an allowlisted host that resolves to a public address', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', resolvesTo('93.184.216.34'))
+		).resolves.toBeUndefined();
+	});
+
+	it('throws BrowserNavigationBlockedError with a stable code for a lexical refusal', async () => {
+		await expect(
+			assertUrlAllowed('https://evil.test/', policy(), 'document', resolvesTo('93.184.216.34'))
+		).rejects.toMatchObject({ name: 'BrowserNavigationBlockedError', code: 'not_allowlisted' });
+	});
+
+	// ── the SSRF-refusal test the capability exists for ─────────────
+	it('refuses an allowlisted hostname that RESOLVES to a private address (DNS rebinding)', async () => {
+		const rebinding = policy({ allowedHosts: ['*'] });
+		await expect(
+			assertUrlAllowed('https://rebind.example.test/', rebinding, 'document', resolvesTo('127.0.0.1'))
+		).rejects.toMatchObject({ name: 'BrowserNavigationBlockedError', code: 'dns_private_ip' });
+	});
+
+	it('refuses when the metadata IP hides behind an allowlisted name', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', resolvesTo('169.254.169.254'))
+		).rejects.toMatchObject({ code: 'dns_private_ip' });
+	});
+
+	it('refuses when ANY resolved address is private, not just the first', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', {
+				dnsResolver: async () => [
+					{ address: '93.184.216.34', family: 4 },
+					{ address: '10.0.0.7', family: 4 }
+				]
+			})
+		).rejects.toMatchObject({ code: 'dns_private_ip' });
+	});
+
+	it('refuses a private IPv6 resolution', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', resolvesTo('::1', 6))
+		).rejects.toMatchObject({ code: 'dns_private_ip' });
+	});
+
+	it('classifies by the ADDRESS, not the reported family (a lying stub cannot skip the check)', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', resolvesTo('127.0.0.1', 6))
+		).rejects.toMatchObject({ code: 'dns_private_ip' });
+	});
+
+	it('fails CLOSED when DNS lookup throws', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', {
+				dnsResolver: async () => {
+					throw new Error('ENOTFOUND');
+				}
+			})
+		).rejects.toMatchObject({ code: 'dns_lookup_failed' });
+	});
+
+	it('fails CLOSED when DNS returns nothing', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', { dnsResolver: async () => [] })
+		).rejects.toMatchObject({ code: 'dns_lookup_failed' });
+	});
+
+	it('fails CLOSED on an unparseable resolved address', async () => {
+		await expect(
+			assertUrlAllowed('https://example.com/', policy(), 'document', resolvesTo('not-an-ip'))
+		).rejects.toMatchObject({ code: 'dns_private_ip' });
+	});
+
+	it('skips the DNS round-trip for literal IPs', async () => {
+		let calls = 0;
+		await assertUrlAllowed('https://93.184.216.34/', policy({ allowedHosts: ['93.184.216.34'] }), 'document', {
+			dnsResolver: async () => {
+				calls += 1;
+				return [{ address: '93.184.216.34', family: 4 }];
+			}
+		});
+		expect(calls).toBe(0);
+	});
+
+	it('redacts credentials out of the thrown error', async () => {
+		const error = await assertUrlAllowed('https://user:secret@evil.test/', policy(), 'document').catch(
+			(err: unknown) => err as BrowserNavigationBlockedError
+		);
+		expect(error).toBeInstanceOf(BrowserNavigationBlockedError);
+		expect(error.url).not.toContain('secret');
+		expect(error.message).not.toContain('secret');
+	});
+});

--- a/packages/plugins/browser-automation/src/browser-automation.plugin.ts
+++ b/packages/plugins/browser-automation/src/browser-automation.plugin.ts
@@ -1,0 +1,666 @@
+import { randomUUID } from 'node:crypto';
+import type {
+	BrowserActResult,
+	BrowserActStep,
+	BrowserBlockedRequest,
+	BrowserExtractQuery,
+	BrowserExtractResult,
+	BrowserNavigateResult,
+	BrowserNavigationPolicy,
+	BrowserScreenshotRequest,
+	BrowserScreenshotResult,
+	BrowserSessionHandle,
+	BrowserSessionSpec,
+	IBrowserAutomationPlugin,
+	IPlugin,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	PluginHealthCheck,
+	PluginManifest,
+	PluginSettings,
+	ValidationError,
+	ValidationResult
+} from '@ever-works/plugin';
+import { BrowserAutomationNotProvisionedError, BrowserNavigationBlockedError } from '@ever-works/plugin';
+import {
+	MAX_ACT_STEPS,
+	MAX_EXTRACT_NODES,
+	assertUrlAllowed,
+	classifyUrl,
+	clampTimeout,
+	collectInvalidHostPatterns,
+	parseHostPattern,
+	redactUrl,
+	resolveNavigationPolicy,
+	type UrlGuardDeps
+} from './navigation-policy.js';
+import {
+	defaultModuleLoader,
+	type ModuleLoader,
+	type PlaywrightModuleLike,
+	type PwBrowser,
+	type PwBrowserContext,
+	type PwPage,
+	type PwRequest,
+	type PwResponse
+} from './playwright.types.js';
+
+const PLAYWRIGHT_MODULE = 'playwright-core';
+
+/** Live per-session state. Never handed to callers — the handle is opaque. */
+interface Session {
+	readonly id: string;
+	readonly policy: BrowserNavigationPolicy;
+	readonly context: PwBrowserContext;
+	readonly page: PwPage;
+	/** Requests the route guard refused, drained by each verb's result. */
+	blocked: BrowserBlockedRequest[];
+}
+
+/**
+ * `browser-automation` — first-party headless-browser provider (audit
+ * item G22), driving Chromium through Playwright.
+ *
+ * Four verbs — `navigate`, `extract`, `screenshot`, `act` — behind one
+ * security posture that is not optional:
+ *
+ *  - **Headless by default.** `settings.headless` must be explicitly
+ *    `false` to get a headed browser.
+ *  - **Default-deny allowlist.** No configured hosts means every
+ *    navigation is refused. There is no "allow anything" fallback path.
+ *  - **Redirects are re-checked, every hop.** A Playwright route guard
+ *    aborts any document request whose URL falls outside the allowlist,
+ *    and the post-navigation audit walks `redirectedFrom()` back to the
+ *    origin so a hop that somehow slipped through still fails the call
+ *    instead of silently returning attacker-controlled content.
+ *  - **SSRF guard underneath the allowlist.** Private / loopback /
+ *    link-local / cloud-metadata targets are refused on both the lexical
+ *    URL and the DNS resolution (rebinding defence), and an unresolvable
+ *    host fails CLOSED.
+ *  - **Configurable timeout** on navigation and on every action.
+ *
+ * Playwright itself is an OPTIONAL dependency loaded through a runtime
+ * dynamic import: a runtime without a browser degrades to a loud
+ * {@link BrowserAutomationNotProvisionedError}, never a module-load crash.
+ */
+export class BrowserAutomationPlugin implements IPlugin, IBrowserAutomationPlugin {
+	readonly id = 'browser-automation';
+	readonly name = 'Browser Automation';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'utility';
+	readonly capabilities: readonly string[] = ['browser-automation'];
+	readonly providerName = 'Playwright (Chromium)';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			allowedHosts: {
+				type: 'array',
+				title: 'Navigation allowlist',
+				description:
+					'Hosts the browser may navigate to. Supports "example.com", "*.example.com" (subdomains only), an optional ":port" suffix, and "*" for any PUBLIC host. EMPTY MEANS EVERY NAVIGATION IS REFUSED — this is the default and it is deliberate.',
+				items: { type: 'string' },
+				default: []
+			},
+			timeoutMs: {
+				type: 'number',
+				title: 'Timeout (ms)',
+				description: 'Wall-clock budget for navigation and for each action. Clamped to 1000-120000 ms.',
+				default: 30000,
+				minimum: 1000,
+				maximum: 120000
+			},
+			headless: {
+				type: 'boolean',
+				title: 'Headless',
+				description:
+					'Run the browser without a visible window. Leave enabled unless you are debugging locally.',
+				default: true
+			},
+			subresourcePolicy: {
+				type: 'string',
+				title: 'Sub-resource policy',
+				description:
+					'"public-only" lets a page load assets from any public host (private/internal targets stay blocked). "allowlist" additionally restricts every asset to the navigation allowlist.',
+				enum: ['public-only', 'allowlist'],
+				default: 'public-only'
+			},
+			allowPrivateNetwork: {
+				type: 'boolean',
+				title: 'Allow private network (advanced)',
+				description:
+					'Permit navigation to private/internal addresses. Requires an explicit host allowlist — the "*" entry is ignored while this is on, so this can never open the whole internal network.',
+				default: false
+			},
+			executablePath: {
+				type: 'string',
+				title: 'Chromium executable path',
+				description: 'Absolute path to a Chromium binary. Leave empty to use the Playwright-managed browser.'
+			},
+			channel: {
+				type: 'string',
+				title: 'Browser channel',
+				description: 'Optional Playwright channel (e.g. "chrome", "msedge") instead of the bundled Chromium.'
+			}
+		}
+	};
+
+	private context?: PluginContext;
+	private browser: PwBrowser | null = null;
+	private readonly sessions = new Map<string, Session>();
+
+	constructor(
+		private readonly loadModule: ModuleLoader = defaultModuleLoader,
+		private readonly guardDeps: UrlGuardDeps = {}
+	) {}
+
+	// ── IBrowserAutomationPlugin ────────────────────────────────────
+
+	async open(spec?: BrowserSessionSpec): Promise<BrowserSessionHandle> {
+		const policy = resolveNavigationPolicy(spec?.settings, spec);
+		this.warnOnWildcardWithPrivateNetwork(spec?.settings);
+
+		const browser = await this.ensureBrowser(spec?.settings, policy);
+		const context = await browser.newContext({
+			userAgent: spec?.userAgent,
+			viewport: spec?.viewport ? { width: spec.viewport.width, height: spec.viewport.height } : undefined
+		});
+		const page = await context.newPage();
+		page.setDefaultTimeout(policy.timeoutMs);
+		page.setDefaultNavigationTimeout(policy.timeoutMs);
+
+		const session: Session = { id: randomUUID(), policy, context, page, blocked: [] };
+		await this.installRouteGuard(session);
+		this.sessions.set(session.id, session);
+
+		return { sessionId: session.id, policy };
+	}
+
+	async navigate(handle: BrowserSessionHandle, url: string): Promise<BrowserNavigateResult> {
+		const session = this.requireSession(handle);
+
+		// Guard BEFORE the browser ever touches the network. The route
+		// guard below is the second line, not the first.
+		await assertUrlAllowed(url, session.policy, 'document', this.guardDeps);
+
+		session.blocked = [];
+		let response: PwResponse | null;
+		try {
+			response = await session.page.goto(url, {
+				timeout: session.policy.timeoutMs,
+				waitUntil: 'domcontentloaded'
+			});
+		} catch (error) {
+			// An aborted redirect surfaces as a navigation failure. If the
+			// route guard recorded a refusal, report THAT — the caller
+			// needs the reason, not "net::ERR_FAILED".
+			const refusal = session.blocked.find((entry) => entry.navigation);
+			if (refusal) {
+				throw new BrowserNavigationBlockedError(refusal.reason, refusal.url);
+			}
+			throw error;
+		}
+
+		const redirectChain = collectRedirectChain(response, url);
+
+		// Belt-and-braces: audit every hop the browser actually took. A
+		// hop that got past the route guard must still fail the call
+		// rather than hand back off-allowlist content.
+		for (const hop of redirectChain) {
+			const verdict = classifyUrl(hop, session.policy, 'document');
+			if (!verdict.allowed) {
+				throw new BrowserNavigationBlockedError(verdict.reason, redactUrl(hop));
+			}
+		}
+		const finalUrl = session.page.url();
+		const finalVerdict = classifyUrl(finalUrl, session.policy, 'document');
+		if (!finalVerdict.allowed) {
+			throw new BrowserNavigationBlockedError(finalVerdict.reason, redactUrl(finalUrl));
+		}
+
+		return {
+			url: finalUrl,
+			status: response ? response.status() : null,
+			title: await session.page.title(),
+			redirectChain,
+			blockedRequests: this.drainBlocked(session)
+		};
+	}
+
+	async extract(handle: BrowserSessionHandle, query: BrowserExtractQuery): Promise<BrowserExtractResult> {
+		const session = this.requireSession(handle);
+		const timeout = session.policy.timeoutMs;
+
+		if (query.format === 'attribute' && !query.attribute) {
+			throw new TypeError('extract(format: "attribute") requires an `attribute` name.');
+		}
+
+		const limit = Math.min(MAX_EXTRACT_NODES, Math.max(1, Math.trunc(query.limit ?? MAX_EXTRACT_NODES)));
+
+		if (!query.selector) {
+			// Whole-document shortcut — no selector, no per-node loop.
+			if (query.format === 'html') {
+				return { values: [await session.page.content()], truncated: false };
+			}
+			if (query.format === 'text') {
+				return { values: [await session.page.locator('body').innerText({ timeout })], truncated: false };
+			}
+			throw new TypeError('extract(format: "attribute") requires a `selector`.');
+		}
+
+		const nodes = await session.page.locator(query.selector).all();
+		const selected = nodes.slice(0, limit);
+		const values: string[] = [];
+		for (const node of selected) {
+			if (query.format === 'text') {
+				values.push((await node.textContent({ timeout })) ?? '');
+			} else if (query.format === 'html') {
+				values.push(await node.innerHTML({ timeout }));
+			} else {
+				values.push((await node.getAttribute(query.attribute as string, { timeout })) ?? '');
+			}
+		}
+
+		return { values, truncated: nodes.length > selected.length };
+	}
+
+	async screenshot(
+		handle: BrowserSessionHandle,
+		request?: BrowserScreenshotRequest
+	): Promise<BrowserScreenshotResult> {
+		const session = this.requireSession(handle);
+		const timeout = session.policy.timeoutMs;
+		const format = request?.format === 'jpeg' ? 'jpeg' : 'png';
+		const quality = format === 'jpeg' ? clampQuality(request?.quality) : undefined;
+
+		const buffer = request?.selector
+			? await session.page.locator(request.selector).first().screenshot({ timeout, type: format, quality })
+			: await session.page.screenshot({
+					timeout,
+					type: format,
+					quality,
+					fullPage: request?.fullPage === true
+				});
+
+		const bytes = Buffer.from(buffer);
+		return {
+			base64: bytes.toString('base64'),
+			contentType: format === 'jpeg' ? 'image/jpeg' : 'image/png',
+			bytes: bytes.byteLength
+		};
+	}
+
+	async act(handle: BrowserSessionHandle, steps: readonly BrowserActStep[]): Promise<BrowserActResult> {
+		const session = this.requireSession(handle);
+		if (!Array.isArray(steps) || steps.length === 0) {
+			return { performed: 0, url: session.page.url(), blockedRequests: this.drainBlocked(session) };
+		}
+		if (steps.length > MAX_ACT_STEPS) {
+			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${steps.length}).`);
+		}
+
+		let performed = 0;
+		for (const step of steps) {
+			const timeout = clampTimeout(step.timeoutMs, session.policy.timeoutMs);
+
+			if (step.kind === 'wait' && !step.selector) {
+				await session.page.waitForTimeout(timeout);
+				performed += 1;
+				continue;
+			}
+			if (!step.selector) {
+				throw new TypeError(`act() step "${step.kind}" requires a \`selector\`.`);
+			}
+
+			const locator = session.page.locator(step.selector).first();
+			switch (step.kind) {
+				case 'click':
+					await locator.click({ timeout });
+					break;
+				case 'fill':
+					await locator.fill(step.value ?? '', { timeout });
+					break;
+				case 'select':
+					if (step.value === undefined) {
+						throw new TypeError('act() step "select" requires a `value`.');
+					}
+					await locator.selectOption(step.value, { timeout });
+					break;
+				case 'press':
+					if (!step.key) {
+						throw new TypeError('act() step "press" requires a `key`.');
+					}
+					await locator.press(step.key, { timeout });
+					break;
+				case 'hover':
+					await locator.hover({ timeout });
+					break;
+				case 'wait':
+					await locator.waitFor({ timeout, state: 'visible' });
+					break;
+				default: {
+					const unknownKind: never = step.kind;
+					throw new TypeError(`act() received an unsupported step kind: ${String(unknownKind)}`);
+				}
+			}
+			performed += 1;
+		}
+
+		// An action may have navigated. The allowlist applies just the
+		// same — a click that lands off-allowlist is a refusal.
+		const url = session.page.url();
+		const verdict = classifyUrl(url, session.policy, 'document');
+		if (!verdict.allowed) {
+			throw new BrowserNavigationBlockedError(verdict.reason, redactUrl(url));
+		}
+
+		return { performed, url, blockedRequests: this.drainBlocked(session) };
+	}
+
+	async close(handle: BrowserSessionHandle): Promise<void> {
+		const session = this.sessions.get(handle.sessionId);
+		if (!session) return;
+		this.sessions.delete(handle.sessionId);
+		try {
+			await session.page.close();
+		} catch {
+			// Page may already be gone — teardown is best-effort by design.
+		}
+		try {
+			await session.context.close();
+		} catch {
+			// Same: never let cleanup mask the caller's real outcome.
+		}
+		if (this.sessions.size === 0) {
+			await this.closeBrowser();
+		}
+	}
+
+	async probe(settings?: PluginSettings): Promise<{ ok: boolean; detail?: string }> {
+		const policy = resolveNavigationPolicy(settings);
+		try {
+			await this.loadPlaywright();
+		} catch (error) {
+			return { ok: false, detail: error instanceof Error ? error.message : String(error) };
+		}
+		if (policy.allowedHosts.length === 0) {
+			return {
+				ok: false,
+				detail: 'Playwright is available but the navigation allowlist is empty — every navigation will be refused.'
+			};
+		}
+		return {
+			ok: true,
+			detail: `Playwright available; ${policy.allowedHosts.length} allowlist entries configured.`
+		};
+	}
+
+	// ── settings validation ─────────────────────────────────────────
+
+	validateSettings(settings: Record<string, unknown>): ValidationResult {
+		const errors: ValidationError[] = [];
+		const warnings: ValidationError[] = [];
+
+		for (const entry of collectInvalidHostPatterns(settings.allowedHosts)) {
+			errors.push({
+				path: 'allowedHosts',
+				code: 'invalid_host_pattern',
+				actual: entry,
+				message: `"${entry}" is not a valid host pattern. Use "example.com", "*.example.com", an optional ":port" suffix, or "*".`
+			});
+		}
+
+		if (settings.allowPrivateNetwork === true) {
+			const hasWildcard = toStringList(settings.allowedHosts).some(
+				(entry) => parseHostPattern(entry)?.host === '*'
+			);
+			if (hasWildcard) {
+				errors.push({
+					path: 'allowPrivateNetwork',
+					code: 'wildcard_with_private_network',
+					message:
+						'Private-network access requires an explicit host allowlist. Remove the "*" entry, or turn private-network access off.'
+				});
+			}
+		}
+
+		if (toStringList(settings.allowedHosts).length === 0 && !process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS) {
+			warnings.push({
+				path: 'allowedHosts',
+				code: 'empty_allowlist',
+				message:
+					'The allowlist is empty, so every navigation will be refused. Add the hosts you intend to automate.'
+			});
+		}
+
+		if (settings.headless === false) {
+			warnings.push({
+				path: 'headless',
+				code: 'headed_browser',
+				message: 'Headed mode is for local debugging only — server runtimes should keep the browser headless.'
+			});
+		}
+
+		return { valid: errors.length === 0, errors, warnings };
+	}
+
+	// ── route guard ─────────────────────────────────────────────────
+
+	/**
+	 * Intercept every request the page makes. Playwright re-fires the
+	 * handler for each redirect hop, which is exactly what makes
+	 * "never follow a redirect outside the allowlist" enforceable rather
+	 * than aspirational.
+	 */
+	private async installRouteGuard(session: Session): Promise<void> {
+		await session.page.route('**/*', async (route) => {
+			const request = route.request();
+			const url = request.url();
+			const navigation = isDocumentRequest(request);
+			try {
+				await assertUrlAllowed(url, session.policy, navigation ? 'document' : 'subresource', this.guardDeps);
+			} catch (error) {
+				const reason = error instanceof BrowserNavigationBlockedError ? error.code : 'invalid_url';
+				session.blocked.push({ url: redactUrl(url), reason, navigation });
+				await route.abort('blockedbyclient');
+				return;
+			}
+			await route.continue();
+		});
+	}
+
+	private drainBlocked(session: Session): BrowserBlockedRequest[] {
+		const drained = session.blocked;
+		session.blocked = [];
+		return drained;
+	}
+
+	// ── browser lifecycle ───────────────────────────────────────────
+
+	private async ensureBrowser(
+		settings: PluginSettings | undefined,
+		policy: BrowserNavigationPolicy
+	): Promise<PwBrowser> {
+		if (this.browser && this.browser.isConnected?.() !== false) {
+			return this.browser;
+		}
+		const playwright = await this.loadPlaywright();
+		const raw = (settings ?? {}) as Record<string, unknown>;
+		const executablePath =
+			typeof raw.executablePath === 'string' && raw.executablePath.trim()
+				? raw.executablePath.trim()
+				: process.env.PLUGIN_BROWSER_AUTOMATION_EXECUTABLE_PATH;
+		const channel = typeof raw.channel === 'string' && raw.channel.trim() ? raw.channel.trim() : undefined;
+
+		try {
+			this.browser = await playwright.chromium.launch({
+				headless: policy.headless,
+				timeout: policy.timeoutMs,
+				executablePath,
+				channel
+			});
+		} catch (error) {
+			throw new BrowserAutomationNotProvisionedError(
+				`Chromium failed to launch: ${error instanceof Error ? error.message : String(error)}`
+			);
+		}
+		return this.browser;
+	}
+
+	private async loadPlaywright(): Promise<PlaywrightModuleLike> {
+		let loaded: unknown;
+		try {
+			loaded = await this.loadModule(PLAYWRIGHT_MODULE);
+		} catch (error) {
+			throw new BrowserAutomationNotProvisionedError(
+				`Playwright is not installed in this runtime (${
+					error instanceof Error ? error.message : String(error)
+				}). Install "${PLAYWRIGHT_MODULE}" and a Chromium build to enable browser automation.`
+			);
+		}
+		const candidate = loaded as { chromium?: unknown; default?: { chromium?: unknown } };
+		// CJS interop: a required module may arrive wrapped in `default`.
+		const chromium = candidate?.chromium ?? candidate?.default?.chromium;
+		if (!chromium || typeof (chromium as { launch?: unknown }).launch !== 'function') {
+			throw new BrowserAutomationNotProvisionedError(
+				`"${PLAYWRIGHT_MODULE}" loaded but exposes no usable chromium launcher.`
+			);
+		}
+		return { chromium } as PlaywrightModuleLike;
+	}
+
+	private async closeBrowser(): Promise<void> {
+		const browser = this.browser;
+		this.browser = null;
+		if (!browser) return;
+		try {
+			await browser.close();
+		} catch {
+			// Best-effort: a browser that already died is not an error here.
+		}
+	}
+
+	private requireSession(handle: BrowserSessionHandle): Session {
+		const session = this.sessions.get(handle?.sessionId ?? '');
+		if (!session) {
+			throw new BrowserAutomationNotProvisionedError(
+				`Unknown browser session "${handle?.sessionId ?? '<none>'}" — it was never opened, or has already been closed.`
+			);
+		}
+		return session;
+	}
+
+	private warnOnWildcardWithPrivateNetwork(settings: PluginSettings | undefined): void {
+		const raw = (settings ?? {}) as Record<string, unknown>;
+		if (raw.allowPrivateNetwork !== true) return;
+		if (!toStringList(raw.allowedHosts).some((entry) => parseHostPattern(entry)?.host === '*')) return;
+		this.context?.logger?.warn?.(
+			'browser-automation: the "*" allowlist entry is IGNORED while private-network access is enabled — list the internal hosts explicitly.'
+		);
+	}
+
+	// ── IPlugin lifecycle ───────────────────────────────────────────
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log(
+			'browser-automation loaded (headless Chromium via Playwright; default-deny navigation allowlist).'
+		);
+	}
+
+	async onUnload(): Promise<void> {
+		for (const session of [...this.sessions.values()]) {
+			await this.close({ sessionId: session.id, policy: session.policy });
+		}
+		await this.closeBrowser();
+		this.context = undefined;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		const probe = await this.probe();
+		return {
+			status: probe.ok ? 'healthy' : 'degraded',
+			message: probe.detail ?? 'ok',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description:
+				'Headless Chromium automation: navigate, extract, screenshot and act, behind a default-deny navigation allowlist re-checked on every redirect hop.',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			// Distributed through the registry, not baked into the image:
+			// the driver needs a Chromium build the base image does not
+			// carry, so it is installed on enable.
+			builtIn: false,
+			distribution: 'registry',
+			defaultForCapabilities: ['browser-automation'],
+			icon: { type: 'lucide', value: 'Globe', backgroundColor: '#0f172a' }
+		};
+	}
+}
+
+// ── module-local helpers ────────────────────────────────────────────
+
+/**
+ * Playwright reports `isNavigationRequest()` for top-level AND iframe
+ * document loads. Both are treated as navigations here: an iframe that
+ * pulls an internal URL is exactly the SSRF the allowlist exists to stop.
+ */
+function isDocumentRequest(request: PwRequest): boolean {
+	try {
+		return request.isNavigationRequest() || request.resourceType() === 'document';
+	} catch {
+		// A request object can go stale mid-teardown; treat it as the
+		// stricter kind rather than waving it through.
+		return true;
+	}
+}
+
+/**
+ * Walk `redirectedFrom()` back to the first request, returning the hops
+ * oldest-first. Falls back to the requested URL when the response (or
+ * the chain) is unavailable.
+ */
+function collectRedirectChain(response: PwResponse | null, requestedUrl: string): string[] {
+	if (!response) return [requestedUrl];
+	const chain: string[] = [];
+	let cursor: PwRequest | null = response.request();
+	const seen = new Set<string>();
+	while (cursor) {
+		const url = cursor.url();
+		// Defensive: a malformed chain must not spin forever.
+		if (seen.has(url)) break;
+		seen.add(url);
+		chain.unshift(url);
+		cursor = typeof cursor.redirectedFrom === 'function' ? cursor.redirectedFrom() : null;
+	}
+	return chain.length > 0 ? chain : [requestedUrl];
+}
+
+function clampQuality(value: unknown): number | undefined {
+	const numeric = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(numeric)) return undefined;
+	return Math.min(100, Math.max(1, Math.trunc(numeric)));
+}
+
+function toStringList(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.filter((entry): entry is string => typeof entry === 'string');
+	}
+	if (typeof value === 'string') {
+		return value
+			.split(/[\n,]/)
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0);
+	}
+	return [];
+}
+
+export default BrowserAutomationPlugin;

--- a/packages/plugins/browser-automation/src/index.ts
+++ b/packages/plugins/browser-automation/src/index.ts
@@ -1,0 +1,19 @@
+import { BrowserAutomationPlugin } from './browser-automation.plugin.js';
+
+export { BrowserAutomationPlugin };
+export * from './navigation-policy.js';
+export type {
+	ModuleLoader,
+	PlaywrightModuleLike,
+	PwBrowser,
+	PwBrowserContext,
+	PwLocator,
+	PwPage,
+	PwRequest,
+	PwResponse,
+	PwRoute
+} from './playwright.types.js';
+
+// The loader rejects a plugin without a default export at onLoad
+// ("Exported value is not a valid plugin") — this line is load-bearing.
+export default BrowserAutomationPlugin;

--- a/packages/plugins/browser-automation/src/navigation-policy.ts
+++ b/packages/plugins/browser-automation/src/navigation-policy.ts
@@ -1,0 +1,412 @@
+import { isIP } from 'node:net';
+import * as dns from 'node:dns';
+import type {
+	BrowserBlockReason,
+	BrowserNavigationPolicy,
+	BrowserSessionSpec,
+	PluginSettings
+} from '@ever-works/plugin';
+import { BrowserNavigationBlockedError } from '@ever-works/plugin';
+import {
+	isPrivateIPv4,
+	isPrivateIPv6,
+	isSafeWebhookUrl,
+	type DnsResolver
+} from '@ever-works/plugin/helpers/ssrf-guard';
+
+/** Wall-clock budget applied to navigation and to each action. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const MIN_TIMEOUT_MS = 1_000;
+export const MAX_TIMEOUT_MS = 120_000;
+
+/** Upper bound on nodes returned by one `extract` call. */
+export const MAX_EXTRACT_NODES = 500;
+/** Upper bound on steps accepted by one `act` call. */
+export const MAX_ACT_STEPS = 50;
+
+/**
+ * The bare `*` pattern — "any PUBLIC host". Private / loopback /
+ * link-local / cloud-metadata targets stay blocked underneath it, and it
+ * is refused outright when `allowPrivateNetwork` is on (see
+ * {@link resolveNavigationPolicy}).
+ */
+const WILDCARD_ALL = '*';
+
+/** A parsed allowlist entry: host matcher plus an optional pinned port. */
+export interface HostPattern {
+	/** `*`, `*.example.com`, `example.com`, or a literal IP. */
+	readonly host: string;
+	/** Pinned port as a string, or null when any port is acceptable. */
+	readonly port: string | null;
+}
+
+/**
+ * Normalize a hostname for comparison: lowercase, brackets stripped off
+ * IPv6 literals, and the FQDN trailing dot removed (`example.com.` and
+ * `example.com` are the same host — treating them differently is a
+ * classic allowlist bypass).
+ */
+export function normalizeHost(rawHost: string): string {
+	let host = rawHost.trim().toLowerCase();
+	if (host.startsWith('[') && host.endsWith(']')) {
+		host = host.slice(1, -1);
+	}
+	while (host.endsWith('.')) {
+		host = host.slice(0, -1);
+	}
+	return host;
+}
+
+/**
+ * Parse one allowlist entry. Returns null for anything that is not a
+ * bare host pattern — a scheme, a path, or an empty string is a
+ * configuration mistake and must NEVER be interpreted loosely.
+ */
+export function parseHostPattern(raw: string): HostPattern | null {
+	const trimmed = raw.trim().toLowerCase();
+	if (!trimmed) return null;
+	if (trimmed.includes('://') || trimmed.includes('/') || trimmed.includes('@') || trimmed.includes(' ')) {
+		return null;
+	}
+	if (trimmed === WILDCARD_ALL) return { host: WILDCARD_ALL, port: null };
+
+	let hostPart = trimmed;
+	let port: string | null = null;
+
+	if (hostPart.startsWith('[')) {
+		// Bracketed IPv6 literal, optionally `]:port`.
+		const close = hostPart.indexOf(']');
+		if (close === -1) return null;
+		const tail = hostPart.slice(close + 1);
+		if (tail.startsWith(':')) {
+			port = tail.slice(1);
+			hostPart = hostPart.slice(0, close + 1);
+		} else if (tail.length > 0) {
+			return null;
+		}
+	} else {
+		const colon = hostPart.lastIndexOf(':');
+		// A colon that is not the port separator means an unbracketed IPv6
+		// literal — ambiguous, so refuse rather than guess.
+		if (colon !== -1) {
+			const maybePort = hostPart.slice(colon + 1);
+			if (!/^\d{1,5}$/.test(maybePort)) return null;
+			port = maybePort;
+			hostPart = hostPart.slice(0, colon);
+		}
+	}
+
+	if (port !== null && (!/^\d{1,5}$/.test(port) || Number(port) < 1 || Number(port) > 65535)) {
+		return null;
+	}
+
+	const host = normalizeHost(hostPart);
+	if (!host) return null;
+	// `*` is only meaningful as the whole host or as a leading `*.` label.
+	if (host.includes('*') && host !== WILDCARD_ALL && !host.startsWith('*.')) return null;
+	// Guard the normalizer's own trailing-dot strip: `*.` must NOT quietly
+	// collapse into the everything-wildcard. Only a literally-bare `*`
+	// (optionally with a pinned port) means "any public host".
+	if (host === WILDCARD_ALL && hostPart !== WILDCARD_ALL) return null;
+
+	return { host, port };
+}
+
+/**
+ * Accepts an array, a comma/newline-separated string, or undefined and
+ * returns the entries that parsed cleanly. Invalid entries are DROPPED
+ * (never coerced into something broader) and reported separately by
+ * {@link collectInvalidHostPatterns} so settings validation can be loud.
+ */
+export function parseHostPatterns(raw: unknown): string[] {
+	const entries = toEntryList(raw);
+	return entries.filter((entry) => parseHostPattern(entry) !== null).map((entry) => entry.trim().toLowerCase());
+}
+
+/** The entries that did NOT parse — surfaced by `validateSettings`. */
+export function collectInvalidHostPatterns(raw: unknown): string[] {
+	return toEntryList(raw).filter((entry) => parseHostPattern(entry) === null);
+}
+
+function toEntryList(raw: unknown): string[] {
+	if (Array.isArray(raw)) {
+		return raw.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+	}
+	if (typeof raw === 'string') {
+		return raw
+			.split(/[\n,]/)
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0);
+	}
+	return [];
+}
+
+/** Effective port for a URL, defaulting by scheme when none is explicit. */
+function effectivePort(url: URL): string {
+	if (url.port) return url.port;
+	return url.protocol === 'https:' ? '443' : '80';
+}
+
+/** `scheme://host[:port]/` with the hostname already normalized. */
+function normalizedOrigin(url: URL, host: string): string {
+	const literal = isIP(host) === 6 ? `[${host}]` : host;
+	return `${url.protocol}//${literal}${url.port ? `:${url.port}` : ''}/`;
+}
+
+/**
+ * Names that always mean "this machine / this network". The shared
+ * `isSafeWebhookUrl` guard only knows literal IPs and cloud-metadata
+ * aliases, so `http://localhost:3000/` would sail straight past it —
+ * these are the lexical complement. The DNS re-check catches them again
+ * at resolve time; this list is what makes the SYNCHRONOUS redirect
+ * audit able to refuse them too.
+ */
+const INTERNAL_HOSTNAMES = new Set([
+	'localhost',
+	'localhost.localdomain',
+	'ip6-localhost',
+	'ip6-loopback',
+	'broadcasthost'
+]);
+
+/** Reserved / non-delegated suffixes that never denote a public host. */
+const INTERNAL_SUFFIXES = ['.localhost', '.localdomain', '.local', '.internal', '.home.arpa', '.intranet'];
+
+/** True when a hostname is a known loopback / internal-network name. */
+export function isInternalHostname(host: string): boolean {
+	const normalized = normalizeHost(host);
+	if (INTERNAL_HOSTNAMES.has(normalized)) return true;
+	return INTERNAL_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
+/** True when `host`/`port` are covered by a single parsed pattern. */
+export function matchesHostPattern(host: string, port: string, pattern: HostPattern): boolean {
+	if (pattern.port !== null && pattern.port !== port) return false;
+	if (pattern.host === WILDCARD_ALL) return true;
+	if (pattern.host.startsWith('*.')) {
+		// `*.example.com` covers sub.example.com but NOT the apex — an
+		// apex that should be reachable has to be listed explicitly.
+		const suffix = pattern.host.slice(1);
+		return host.endsWith(suffix) && host.length > suffix.length;
+	}
+	return host === normalizeHost(pattern.host);
+}
+
+/** True when `host`/`port` are covered by ANY entry in the allowlist. */
+export function isHostAllowed(host: string, port: string, allowedHosts: readonly string[]): boolean {
+	for (const entry of allowedHosts) {
+		const pattern = parseHostPattern(entry);
+		if (pattern && matchesHostPattern(host, port, pattern)) return true;
+	}
+	return false;
+}
+
+/** Clamp a caller/settings timeout into the supported band. */
+export function clampTimeout(value: unknown, fallback = DEFAULT_TIMEOUT_MS): number {
+	const numeric = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(numeric) || numeric <= 0) return fallback;
+	return Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, Math.trunc(numeric)));
+}
+
+/**
+ * Build the effective policy for a session from plugin settings plus
+ * per-session overrides.
+ *
+ * Two rules are load-bearing and deliberately not configurable away:
+ *
+ *  1. **Default deny.** No configured hosts ⇒ empty allowlist ⇒ every
+ *     navigation is refused. There is no implicit "allow everything".
+ *  2. **`allowPrivateNetwork` never combines with `*`.** Opting into the
+ *     internal network requires naming the hosts; the wildcard entry is
+ *     dropped in that mode so the escape hatch cannot become
+ *     "the browser may reach anything on the cluster network".
+ */
+export function resolveNavigationPolicy(
+	settings?: PluginSettings,
+	spec?: Pick<BrowserSessionSpec, 'timeoutMs' | 'extraAllowedHosts'>
+): BrowserNavigationPolicy {
+	const raw = (settings ?? {}) as Record<string, unknown>;
+
+	const fromSettings = parseHostPatterns(raw.allowedHosts ?? readEnvAllowlist());
+	const fromSpec = parseHostPatterns(spec?.extraAllowedHosts);
+	const allowPrivateNetwork = raw.allowPrivateNetwork === true;
+
+	let allowedHosts = dedupe([...fromSettings, ...fromSpec]);
+	if (allowPrivateNetwork) {
+		allowedHosts = allowedHosts.filter((entry) => parseHostPattern(entry)?.host !== WILDCARD_ALL);
+	}
+
+	const subresourcePolicy = raw.subresourcePolicy === 'allowlist' ? 'allowlist' : 'public-only';
+	// Headless is the default and stays the default: only an explicit
+	// `headless: false` in settings turns it off.
+	const headless = raw.headless !== false;
+
+	return {
+		allowedHosts,
+		subresourcePolicy,
+		allowPrivateNetwork,
+		timeoutMs: clampTimeout(spec?.timeoutMs ?? raw.timeoutMs),
+		headless
+	};
+}
+
+/**
+ * `PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS` — deployment-level allowlist
+ * used when nothing is configured through settings. Still default-deny:
+ * an unset variable yields an empty list.
+ */
+function readEnvAllowlist(): string {
+	return process.env.PLUGIN_BROWSER_AUTOMATION_ALLOWED_HOSTS ?? '';
+}
+
+function dedupe(entries: string[]): string[] {
+	return [...new Set(entries)];
+}
+
+/** Whether a URL is a top-level navigation or a page sub-resource. */
+export type RequestKind = 'document' | 'subresource';
+
+export type UrlVerdict =
+	| { readonly allowed: true; readonly host: string; readonly dnsCheckRequired: boolean }
+	| { readonly allowed: false; readonly reason: BrowserBlockReason; readonly host?: string };
+
+/**
+ * Synchronous, lexical verdict for one URL. Ordered cheapest-first so a
+ * malformed or non-HTTP URL never reaches the network stack.
+ */
+export function classifyUrl(rawUrl: string, policy: BrowserNavigationPolicy, kind: RequestKind): UrlVerdict {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return { allowed: false, reason: 'invalid_url' };
+	}
+
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		return { allowed: false, reason: 'scheme_blocked' };
+	}
+
+	// Embedded `user:pass@` is both a credential leak and a well-known
+	// allowlist-parser confusion trick (`https://allowed.com@evil.tld`).
+	if (url.username || url.password) {
+		return { allowed: false, reason: 'credentials_in_url' };
+	}
+
+	const host = normalizeHost(url.hostname);
+	if (!host) {
+		return { allowed: false, reason: 'invalid_url' };
+	}
+
+	// The private-network escape hatch applies to top-level navigation,
+	// and to sub-resources only when they are allowlist-constrained too.
+	// A `public-only` sub-resource is NEVER allowed to reach the internal
+	// network, whatever the document policy is.
+	const privateAllowed =
+		policy.allowPrivateNetwork && (kind === 'document' || policy.subresourcePolicy === 'allowlist');
+
+	// Hand the guard a NORMALIZED origin: the trailing-dot FQDN form
+	// (`metadata.google.internal.`) would otherwise miss the guard's
+	// metadata-hostname set while still resolving to the same host.
+	if (!privateAllowed && (isInternalHostname(host) || !isSafeWebhookUrl(normalizedOrigin(url, host)))) {
+		return { allowed: false, reason: 'private_address', host };
+	}
+
+	const allowlistApplies = kind === 'document' || policy.subresourcePolicy === 'allowlist';
+	if (allowlistApplies && !isHostAllowed(host, effectivePort(url), policy.allowedHosts)) {
+		return { allowed: false, reason: 'not_allowlisted', host };
+	}
+
+	// Literal IPs already went through the lexical guard above; only
+	// hostnames need the DNS-rebinding re-check.
+	return { allowed: true, host, dnsCheckRequired: !privateAllowed && isIP(host) === 0 };
+}
+
+/**
+ * Injection seam so tests never touch real DNS. Production callers omit
+ * it and get {@link defaultDnsResolver} — the guard is ON by default and
+ * has to be deliberately replaced, never accidentally skipped.
+ */
+export interface UrlGuardDeps {
+	readonly dnsResolver?: DnsResolver;
+}
+
+/** `dns.promises.lookup(host, { all: true })`. */
+export const defaultDnsResolver: DnsResolver = (hostname) => dns.promises.lookup(hostname, { all: true });
+
+/**
+ * Strip credentials out of a URL before it lands in an error message or
+ * a log line. Falls back to a truncated raw string for unparseable input.
+ */
+export function redactUrl(rawUrl: string): string {
+	try {
+		const url = new URL(rawUrl);
+		url.username = '';
+		url.password = '';
+		return url.toString();
+	} catch {
+		return rawUrl.slice(0, 256);
+	}
+}
+
+/**
+ * Full guard: lexical verdict, then a DNS re-check that refuses any
+ * hostname resolving to a private address (rebinding defence). Fails
+ * CLOSED — an unresolvable host is refused, never optimistically tried.
+ *
+ * Throws {@link BrowserNavigationBlockedError} with a stable `code`.
+ */
+export async function assertUrlAllowed(
+	rawUrl: string,
+	policy: BrowserNavigationPolicy,
+	kind: RequestKind,
+	deps?: UrlGuardDeps
+): Promise<void> {
+	const verdict = classifyUrl(rawUrl, policy, kind);
+	if (!verdict.allowed) {
+		throw new BrowserNavigationBlockedError(verdict.reason, redactUrl(rawUrl));
+	}
+	if (!verdict.dnsCheckRequired) return;
+
+	const resolver = deps?.dnsResolver ?? defaultDnsResolver;
+
+	let addresses: Awaited<ReturnType<DnsResolver>>;
+	try {
+		addresses = await resolver(verdict.host);
+	} catch (error) {
+		throw new BrowserNavigationBlockedError(
+			'dns_lookup_failed',
+			redactUrl(rawUrl),
+			`DNS lookup failed for ${verdict.host}: ${error instanceof Error ? error.message : String(error)}`
+		);
+	}
+
+	if (!Array.isArray(addresses) || addresses.length === 0) {
+		throw new BrowserNavigationBlockedError(
+			'dns_lookup_failed',
+			redactUrl(rawUrl),
+			`DNS lookup returned no addresses for ${verdict.host}`
+		);
+	}
+
+	for (const entry of addresses) {
+		// Every returned address must be public — Happy Eyeballs / DNS
+		// round-robin means "one of them is public" is not good enough.
+		// Classify by the ADDRESS, not the reported `family`: a resolver
+		// stub that reports the wrong family must not skip a check.
+		const kindOfIp = isIP(entry.address);
+		const isPrivate =
+			kindOfIp === 6
+				? isPrivateIPv6(entry.address)
+				: kindOfIp === 4
+					? isPrivateIPv4(entry.address)
+					: // Unparseable address — fail closed.
+						true;
+		if (isPrivate) {
+			throw new BrowserNavigationBlockedError(
+				'dns_private_ip',
+				redactUrl(rawUrl),
+				`${verdict.host} resolved to private address ${entry.address}`
+			);
+		}
+	}
+}

--- a/packages/plugins/browser-automation/src/playwright.types.ts
+++ b/packages/plugins/browser-automation/src/playwright.types.ts
@@ -1,0 +1,109 @@
+/**
+ * Minimal STRUCTURAL view of the Playwright surface this plugin drives.
+ *
+ * Typed locally on purpose: `playwright-core` is an optional dependency
+ * loaded through a runtime dynamic import, so a deployment without a
+ * browser must still type-check, bundle, and load — it degrades to a
+ * `BrowserAutomationNotProvisionedError` instead of crashing at import.
+ *
+ * Only the members actually used are declared; everything Playwright
+ * offers beyond them is intentionally out of reach of this plugin.
+ */
+
+export interface PwRequest {
+	url(): string;
+	resourceType(): string;
+	isNavigationRequest(): boolean;
+	/** Previous hop of a redirect chain, or null at the start. */
+	redirectedFrom(): PwRequest | null;
+}
+
+export interface PwResponse {
+	url(): string;
+	status(): number;
+	request(): PwRequest;
+}
+
+export interface PwRoute {
+	request(): PwRequest;
+	abort(errorCode?: string): Promise<void>;
+	continue(): Promise<void>;
+}
+
+export interface PwLocator {
+	all(): Promise<PwLocator[]>;
+	count(): Promise<number>;
+	first(): PwLocator;
+	innerText(options?: { timeout?: number }): Promise<string>;
+	textContent(options?: { timeout?: number }): Promise<string | null>;
+	innerHTML(options?: { timeout?: number }): Promise<string>;
+	getAttribute(name: string, options?: { timeout?: number }): Promise<string | null>;
+	click(options?: { timeout?: number }): Promise<void>;
+	fill(value: string, options?: { timeout?: number }): Promise<void>;
+	selectOption(values: string, options?: { timeout?: number }): Promise<string[]>;
+	press(key: string, options?: { timeout?: number }): Promise<void>;
+	hover(options?: { timeout?: number }): Promise<void>;
+	waitFor(options?: { timeout?: number; state?: 'attached' | 'detached' | 'visible' | 'hidden' }): Promise<void>;
+	screenshot(options?: { timeout?: number; type?: 'png' | 'jpeg'; quality?: number }): Promise<Buffer>;
+}
+
+export interface PwPage {
+	route(pattern: string, handler: (route: PwRoute) => Promise<void> | void): Promise<void>;
+	goto(
+		url: string,
+		options?: { timeout?: number; waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit' }
+	): Promise<PwResponse | null>;
+	url(): string;
+	title(): Promise<string>;
+	content(): Promise<string>;
+	locator(selector: string): PwLocator;
+	setDefaultTimeout(timeout: number): void;
+	setDefaultNavigationTimeout(timeout: number): void;
+	screenshot(options?: {
+		timeout?: number;
+		fullPage?: boolean;
+		type?: 'png' | 'jpeg';
+		quality?: number;
+	}): Promise<Buffer>;
+	waitForTimeout(timeout: number): Promise<void>;
+	close(): Promise<void>;
+}
+
+export interface PwBrowserContext {
+	newPage(): Promise<PwPage>;
+	close(): Promise<void>;
+}
+
+export interface PwBrowser {
+	newContext(options?: {
+		userAgent?: string;
+		viewport?: { width: number; height: number } | null;
+		ignoreHTTPSErrors?: boolean;
+		javaScriptEnabled?: boolean;
+	}): Promise<PwBrowserContext>;
+	close(): Promise<void>;
+	isConnected?(): boolean;
+}
+
+export interface PwBrowserType {
+	launch(options?: {
+		headless?: boolean;
+		executablePath?: string;
+		channel?: string;
+		timeout?: number;
+		args?: string[];
+	}): Promise<PwBrowser>;
+}
+
+export interface PlaywrightModuleLike {
+	chromium: PwBrowserType;
+}
+
+/**
+ * Loader seam. Production resolves `playwright-core` through a runtime
+ * dynamic import with a NON-LITERAL specifier so no bundler traces it;
+ * tests inject a fake and never launch a real browser.
+ */
+export type ModuleLoader = (specifier: string) => Promise<unknown>;
+
+export const defaultModuleLoader: ModuleLoader = (specifier) => import(specifier);

--- a/packages/plugins/browser-automation/tsconfig.json
+++ b/packages/plugins/browser-automation/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/browser-automation/tsup.config.ts
+++ b/packages/plugins/browser-automation/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	// Playwright is loaded through a RUNTIME dynamic import so esbuild
+	// never traces it: the deployed image may not carry a browser, and
+	// absence is a SUPPORTED degradation (BrowserAutomationNotProvisioned)
+	// rather than a module-load crash.
+	external: ['playwright-core'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/browser-automation/vitest.config.ts
+++ b/packages/plugins/browser-automation/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			reporter: ['text', 'json', 'html'],
+			exclude: ['node_modules/', 'dist/']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)
+        version: 2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
@@ -291,16 +291,16 @@ importers:
         version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -616,13 +616,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1097,13 +1097,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1268,7 +1268,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1563,6 +1563,28 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/browser-automation:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+    optionalDependencies:
+      playwright-core:
+        specifier: ^1.59.1
+        version: 1.59.1
 
   packages/plugins/claude-code:
     devDependencies:
@@ -22533,17 +22555,6 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
-  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      jsonc-parser: 3.3.1
-      picomatch: 4.0.4
-      rxjs: 7.8.1
-      source-map: 0.7.4
-    optionalDependencies:
-      chokidar: 3.6.0
-
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -22565,16 +22576,6 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -27143,7 +27144,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.4.1(express@5.2.1)
+      express-rate-limit: 8.4.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -27167,7 +27168,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.4.1(express@5.2.1)
+      express-rate-limit: 8.4.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -27191,7 +27192,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.4.1(express@5.2.1)
+      express-rate-limit: 8.4.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -27215,7 +27216,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.4.1(express@5.2.1)
+      express-rate-limit: 8.4.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -27489,7 +27490,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)':
+  '@nestjs-modules/mailer@2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -27508,7 +27509,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.2
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@3.6.0)
+      nunjucks: 3.2.4(chokidar@4.0.3)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -27535,36 +27536,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
-      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      cli-table3: 0.6.5
-      commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
-      glob: 13.0.6
-      node-emoji: 1.11.0
-      ora: 5.4.1
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-      typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
-      webpack-node-externals: 3.0.0
-    optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -27593,7 +27565,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -27604,17 +27576,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -27717,17 +27689,6 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
-
-  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -31303,25 +31264,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
-    dependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.2.2
-      commander: 8.3.0
-      minimatch: 10.2.5
-      piscina: 4.9.3
-      semver: 7.8.1
-      slash: 3.0.0
-      source-map: 0.7.6
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      chokidar: 3.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -36339,7 +36281,7 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.4.1(express@5.2.1):
+  express-rate-limit@8.4.1(express@5.2.1(supports-color@10.2.2)):
     dependencies:
       express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.2.0
@@ -40946,13 +40888,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@3.6.0):
+  nunjucks@3.2.4(chokidar@4.0.3):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
     optional: true
 
   nypm@0.5.4:


### PR DESCRIPTION
Audit item **G22**. The platform could screenshot a URL and it could fetch a URL, but it could not **read** a page that needs JavaScript to render — a plain fetch of an SPA returns an empty shell.

## Capability (`packages/plugin`)

`browser-automation`: session-based `open` → navigate / extract / screenshot / act → `close`.

The navigation contract is the interesting part, and it is **default-deny**:

- an empty allowlist refuses every navigation — the safe default, not a misconfiguration to paper over;
- the allowlist is re-checked on **every redirect hop**, so a permitted host cannot bounce the browser somewhere it was never allowed to go;
- `allowPrivateNetwork` exists for internal staging hosts but **refuses to combine with the bare `*` pattern**, rather than silently opening the whole internal network;
- refused sub-resources are reported, not swallowed — "the page looked empty" and "half the page was blocked" are different answers.

## Provider

`@ever-works/browser-automation-plugin` — Playwright over that contract. `playwright-core` is an `optionalDependency`, so a runtime that never enables the plugin doesn't pay for a browser download.

## Consumers — the part that was missing

The capability and provider arrived with **zero production callers**, so the feature shipped inert. This PR adds the chain:

| layer | what |
|---|---|
| `BrowserAutomationFacadeService` | one-shot `read` / `capture` |
| `FacadesModule` | provider + barrel export |
| `AgentDomainToolSources.browser` | `Pick<…, 'read'>` |
| api `AgentsModule` | binds the facade into the bundle |
| `resolveAllowedTools` | registers the tool behind `canCallExternalTools` |
| `browse_url` | what the model actually sees |

**Why the facade isn't just the plugin.** The session API is right for the provider and wrong for callers: every caller would own a session lifetime, and any caller that throws between `open` and `close` leaks a browser context. Both facade methods close in a `finally`, so a leak now requires the provider itself to fail. A failed close is logged and never allowed to replace the caller's real error or real result.

**`act` is deliberately not exposed.** Reading a page and driving a page are different risk profiles — the second can submit forms and trip irreversible actions on the user's behalf — and that needs its own confirmation design rather than arriving as a side effect of exposing browsing. The source bundle carries `Pick<BrowserAutomationFacadeService, 'read'>`, so this is enforced by the type rather than by remembering.

Gated behind `canCallExternalTools` because fetching an arbitrary URL **is** an outbound network call, and should not be available to every agent by default.

## Gates (all green, run locally on the merged tree)

| gate | result |
|---|---|
| `pnpm build --filter=ever-works-api` | 15/15 |
| `packages/agent` jest | 449 suites, 8250 tests |
| `apps/api` jest | 234 suites, 3828 tests |
| `packages/plugin` vitest | 25 files, 303 tests |
| `browser-automation` vitest | 2 files, 132 tests |
| `apps/web` tsc | clean |
| prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)