### PR TITLE
feat(plugins): HubSpot, Pipedrive, Bluesky and Mastodon connectors

### DIFF
--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -57,6 +57,16 @@ export const PLUGIN_CAPABILITIES = {
 	CONNECTOR_LINEAR: 'connector-linear',
 	CONNECTOR_NOTION: 'connector-notion',
 	CONNECTOR_MICROSOFT_365: 'connector-microsoft-365',
+	// CRM / enrichment connectors — first-party native connectors over
+	// the vendors' own Node SDKs. Outbound writes CRM records/notes,
+	// the event-source leg streams record changes into the ingest spine.
+	CONNECTOR_HUBSPOT: 'connector-hubspot',
+	CONNECTOR_PIPEDRIVE: 'connector-pipedrive',
+	// Social connectors — public-timeline surfaces. Outbound publishes a
+	// post; the event-source leg streams mentions/replies + the account's
+	// own timeline into the ingest spine.
+	CONNECTOR_BLUESKY: 'connector-bluesky',
+	CONNECTOR_MASTODON: 'connector-mastodon',
 	// Pluggable persistent memory for AI coding / generation agents.
 	// First-party implementation: `@ever-works/agentmemory-plugin`
 	// (talks to the `agentmemory` standalone Node server on :3111 —

--- a/packages/plugins/bluesky-connector/README.md
+++ b/packages/plugins/bluesky-connector/README.md
@@ -1,0 +1,51 @@
+# @ever-works/bluesky-connector-plugin
+
+First-party **Bluesky (AT Protocol) social connector** for the Ever Works
+platform, built on the official
+[`@atproto/api`](https://www.npmjs.com/package/@atproto/api) SDK.
+
+Capabilities: `connector`, `connector-bluesky`, `event-source`.
+
+## What it does
+
+- **Outbound** — `send()` publishes a post, or a threaded reply when the target
+  config carries `replyToUri` + `replyToCid` (an explicit `rootUri`/`rootCid`
+  overrides the thread root, otherwise the parent is used). Idempotent on
+  `messageRef`.
+- **Event source** — `pullEvents()` sweeps notifications (mentions, replies,
+  likes, reposts, follows) and then the connected account's own posts,
+  normalized into `IngestedEventEnvelope`s (`bluesky.notification` /
+  `bluesky.post`) for the event-ingest spine. Each envelope carries the public
+  `bsky.app` permalink as `sourceUrl` so Memory/Activity rows link back to the
+  origin. Neither AT Protocol endpoint filters by time, so each phase is
+  windowed client-side newest-first and stops at the first item older than the
+  watermark.
+- **Opt-in historical backfill** — `backfillDays` (default `0` = off, max 90)
+  widens the FIRST pull's window only, bounded to
+  `BLUESKY_BACKFILL_MAX_PAGES` pages per phase.
+
+## Degradation is loud, never silent
+
+- `verifyConnection()` reports missing credentials, an SSRF-unsafe PDS URL, and
+  login failures.
+- `send()` throws on missing credentials or a failed post.
+- `pullEvents()` throws `EventSourceNotConfiguredError` when the identifier or
+  app password is absent.
+
+## Settings
+
+| Key            | Notes                                                          |
+| -------------- | -------------------------------------------------------------- |
+| `identifier`   | Handle or DID of the connected account.                        |
+| `appPassword`  | App password — secret, env `BLUESKY_APP_PASSWORD`.             |
+| `service`      | PDS URL (defaults to `https://bsky.social`), SSRF-guarded.     |
+| `backfillDays` | Opt-in first-pull history window (0 = off, max 90).            |
+
+Always authenticate with a Bluesky **app password**, never the account
+password. No credential is hardcoded, logged, or written into an ingested
+envelope.
+
+## Testing
+
+Hermetic Vitest suite (`pnpm test`) — the SDK agent is stubbed through the
+`createAgent` seam; no network calls.

--- a/packages/plugins/bluesky-connector/package.json
+++ b/packages/plugins/bluesky-connector/package.json
@@ -1,0 +1,98 @@
+{
+	"name": "@ever-works/bluesky-connector-plugin",
+	"version": "1.0.0",
+	"description": "Bluesky social connector plugin for Ever Works platform (outbound posts via the official @atproto/api SDK, and event-source pull of mentions/replies plus the account's own timeline into the event-ingest pipeline, with opt-in historical backfill)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@atproto/api": "^0.20.34",
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "bluesky-connector",
+			"name": "Bluesky Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"connector-bluesky",
+				"event-source"
+			],
+			"description": "Bluesky (AT Protocol) social connector. Outbound publishes posts and threaded replies via the official @atproto/api SDK. Event-source pull ingests mentions/replies and the connected account's own posts since the last watermark into the platform event-ingest pipeline, with opt-in historical backfill (backfillDays, max 90).",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"identifier",
+					"appPassword"
+				],
+				"properties": {
+					"identifier": {
+						"type": "string",
+						"title": "Bluesky handle or DID (e.g. acme.bsky.social)"
+					},
+					"appPassword": {
+						"type": "string",
+						"title": "Bluesky app password (never your account password)",
+						"x-secret": true,
+						"x-envVar": "BLUESKY_APP_PASSWORD"
+					},
+					"service": {
+						"type": "string",
+						"title": "PDS service URL (defaults to https://bsky.social)",
+						"default": "https://bsky.social"
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/bluesky-connector/src/bluesky-connector-plugin.spec.ts
+++ b/packages/plugins/bluesky-connector/src/bluesky-connector-plugin.spec.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	BlueskyConnectorPlugin,
+	clampBackfillDays,
+	postUrlFromAtUri,
+	resolveCredentials,
+	BLUESKY_EVENT_TEXT_MAX_CHARS,
+	BLUESKY_BACKFILL_MAX_PAGES,
+	BLUESKY_DEFAULT_SERVICE
+} from './bluesky-connector-plugin.js';
+
+const loginMock = vi.fn();
+const postMock = vi.fn();
+const listNotificationsMock = vi.fn();
+const getAuthorFeedMock = vi.fn();
+const agentFactoryMock = vi.fn();
+
+/** Subclass overriding the agent seam so no real SDK call ever happens. */
+class TestBlueskyConnectorPlugin extends BlueskyConnectorPlugin {
+	protected override createAgent(service: string) {
+		agentFactoryMock(service);
+		return {
+			login: loginMock,
+			post: postMock,
+			listNotifications: listNotificationsMock,
+			getAuthorFeed: getAuthorFeedMock
+		};
+	}
+}
+
+const SETTINGS = { identifier: 'acme.bsky.social', appPassword: 'abcd-efgh-ijkl-mnop' };
+
+function emptyNotifications() {
+	return { data: { notifications: [] } };
+}
+
+function emptyFeed() {
+	return { data: { feed: [] } };
+}
+
+describe('BlueskyConnectorPlugin', () => {
+	let plugin: TestBlueskyConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestBlueskyConnectorPlugin();
+		loginMock.mockReset();
+		postMock.mockReset();
+		listNotificationsMock.mockReset();
+		getAuthorFeedMock.mockReset();
+		agentFactoryMock.mockReset();
+		loginMock.mockResolvedValue({ data: { did: 'did:plc:acme', handle: 'acme.bsky.social' } });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('declares the connector + connector-bluesky + event-source capabilities and poll metadata', () => {
+		expect(plugin.id).toBe('bluesky-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toContain('connector');
+		expect(plugin.capabilities).toContain('connector-bluesky');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('bluesky');
+		expect(plugin.connector.direction).toBe('outbound');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.outboundMessage).toBe(true);
+		expect(plugin.connector.flags.inbound).toBe(false);
+	});
+
+	it('marks appPassword as x-secret and bounds backfillDays to 0–90 in the settings schema', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.appPassword['x-secret']).toBe(true);
+		expect(props.appPassword['x-envVar']).toBe('BLUESKY_APP_PASSWORD');
+		expect(props.identifier['x-secret']).toBeUndefined();
+		expect(plugin.settingsSchema.required).toEqual(expect.arrayContaining(['identifier', 'appPassword']));
+		expect(props.backfillDays.default).toBe(0);
+		expect(props.backfillDays.maximum).toBe(90);
+	});
+
+	it('clampBackfillDays clamps to the 0–90 range and treats garbage as off', () => {
+		expect(clampBackfillDays(0)).toBe(0);
+		expect(clampBackfillDays(-5)).toBe(0);
+		expect(clampBackfillDays(30)).toBe(30);
+		expect(clampBackfillDays(500)).toBe(90);
+		expect(clampBackfillDays('nope')).toBe(0);
+	});
+
+	it('postUrlFromAtUri builds bsky.app permalinks and rejects non-post URIs', () => {
+		expect(postUrlFromAtUri('at://did:plc:x/app.bsky.feed.post/3kabc', 'acme.bsky.social')).toBe(
+			'https://bsky.app/profile/acme.bsky.social/post/3kabc'
+		);
+		expect(postUrlFromAtUri('at://did:plc:x/app.bsky.feed.post/3kabc')).toBe(
+			'https://bsky.app/profile/did%3Aplc%3Ax/post/3kabc'
+		);
+		expect(postUrlFromAtUri('at://did:plc:x/app.bsky.graph.follow/3k')).toBeUndefined();
+		expect(postUrlFromAtUri('https://example.com')).toBeUndefined();
+		expect(postUrlFromAtUri(undefined)).toBeUndefined();
+	});
+
+	it('resolveCredentials requires BOTH identifier and appPassword and defaults the service', () => {
+		expect(resolveCredentials({}, { settings: SETTINGS })).toEqual({
+			...SETTINGS,
+			service: BLUESKY_DEFAULT_SERVICE
+		});
+		expect(resolveCredentials({}, { settings: { identifier: 'a' } })).toBeUndefined();
+		expect(resolveCredentials({}, { settings: { appPassword: 'p' } })).toBeUndefined();
+		expect(resolveCredentials({ service: 'https://pds.acme.dev' }, { settings: SETTINGS })?.service).toBe(
+			'https://pds.acme.dev'
+		);
+	});
+
+	describe('verifyConnection', () => {
+		it('logs in and returns the resolved did/handle', async () => {
+			const res = await plugin.verifyConnection({}, { settings: SETTINGS });
+			expect(res.valid).toBe(true);
+			expect(res.details).toMatchObject({ did: 'did:plc:acme', handle: 'acme.bsky.social' });
+			expect(agentFactoryMock).toHaveBeenCalledWith(BLUESKY_DEFAULT_SERVICE);
+			expect(loginMock).toHaveBeenCalledWith({
+				identifier: SETTINGS.identifier,
+				password: SETTINGS.appPassword
+			});
+		});
+
+		it('degrades loudly (never silently) when credentials are missing', async () => {
+			const res = await plugin.verifyConnection({}, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/identifier and appPassword/);
+			expect(agentFactoryMock).not.toHaveBeenCalled();
+		});
+
+		it('refuses an SSRF-unsafe service URL instead of calling it', async () => {
+			const res = await plugin.verifyConnection({ service: 'http://169.254.169.254' }, { settings: SETTINGS });
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/unsafe service URL/);
+			expect(agentFactoryMock).not.toHaveBeenCalled();
+		});
+
+		it('reports a failed login', async () => {
+			loginMock.mockRejectedValueOnce({ message: 'Invalid identifier or password' });
+			const res = await plugin.verifyConnection({}, { settings: SETTINGS });
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/Invalid identifier or password/);
+		});
+	});
+
+	describe('send', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('publishes a post and returns its AT-URI', async () => {
+			postMock.mockResolvedValueOnce({ uri: 'at://did:plc:acme/app.bsky.feed.post/3k1', cid: 'cid1' });
+			const res = await plugin.send(
+				{ text: 'shipping today', messageRef: 'ref-1', attribution: { userId: 'u1' } },
+				options
+			);
+			expect(postMock).toHaveBeenCalledTimes(1);
+			expect(postMock.mock.calls[0][0].text).toBe('shipping today');
+			expect(postMock.mock.calls[0][0].reply).toBeUndefined();
+			expect(res.providerMessageId).toBe('at://did:plc:acme/app.bsky.feed.post/3k1');
+			expect(res.provider).toBe('bluesky-connector');
+		});
+
+		it('threads a reply when the target carries replyToUri + replyToCid', async () => {
+			postMock.mockResolvedValueOnce({ uri: 'at://did:plc:acme/app.bsky.feed.post/3k2' });
+			await plugin.send(
+				{
+					text: 'thanks!',
+					messageRef: 'ref-2',
+					attribution: { userId: 'u1' },
+					target: { replyToUri: 'at://did:plc:other/app.bsky.feed.post/parent', replyToCid: 'cid-parent' }
+				},
+				options
+			);
+			const record = postMock.mock.calls[0][0];
+			expect(record.reply.parent).toEqual({
+				uri: 'at://did:plc:other/app.bsky.feed.post/parent',
+				cid: 'cid-parent'
+			});
+			// Root defaults to the parent when no explicit thread root is given.
+			expect(record.reply.root).toEqual(record.reply.parent);
+		});
+
+		it('is idempotent on messageRef — a retry never double-posts', async () => {
+			postMock.mockResolvedValue({ uri: 'at://did:plc:acme/app.bsky.feed.post/3k3' });
+			const payload = { text: 'once only', messageRef: 'ref-dup', attribution: { userId: 'u1' } };
+			const first = await plugin.send(payload, options);
+			const second = await plugin.send(payload, options);
+			expect(postMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws when credentials are missing instead of silently no-oping', async () => {
+			await expect(
+				plugin.send({ text: 'x', messageRef: 'r', attribution: { userId: 'u1' } }, { connectorId: 'c' })
+			).rejects.toThrow(/identifier and appPassword are required/);
+			expect(postMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('pullEvents', () => {
+		it('throws EventSourceNotConfiguredError when the identifier is missing', async () => {
+			await expect(
+				plugin.pullEvents({ since: new Date(0).toISOString(), settings: { appPassword: 'p' } })
+			).rejects.toMatchObject({ name: 'EventSourceNotConfiguredError' });
+			expect(listNotificationsMock).not.toHaveBeenCalled();
+		});
+
+		it('throws EventSourceNotConfiguredError when the app password is missing', async () => {
+			await expect(
+				plugin.pullEvents({ since: new Date(0).toISOString(), settings: { identifier: 'a' } })
+			).rejects.toMatchObject({ name: 'EventSourceNotConfiguredError' });
+		});
+
+		it('first pull with backfill off uses a now-anchored window (no history)', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			listNotificationsMock.mockResolvedValueOnce({
+				data: {
+					notifications: [
+						{ uri: 'at://did:plc:a/app.bsky.feed.post/old', indexedAt: '2026-07-25T11:00:00.000Z' }
+					]
+				}
+			});
+			const res = await plugin.pullEvents({ since: new Date(0).toISOString(), settings: SETTINGS });
+			// The single item predates `now`, so the window excludes it entirely.
+			expect(res.events).toEqual([]);
+		});
+
+		it('first pull with backfillDays widens the window, clamped to 90 days', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			listNotificationsMock.mockResolvedValue({
+				data: {
+					notifications: [
+						{
+							uri: 'at://did:plc:a/app.bsky.feed.post/x',
+							reason: 'mention',
+							indexedAt: '2026-07-01T00:00:00.000Z'
+						}
+					]
+				}
+			});
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(res.events).toHaveLength(1);
+			expect(JSON.parse(res.nextCursor as string).s).toBe('2026-06-25T12:00:00.000Z');
+		});
+
+		it('normalizes notifications into bluesky.notification envelopes with capped text', async () => {
+			listNotificationsMock.mockResolvedValueOnce({
+				data: {
+					notifications: [
+						{
+							uri: 'at://did:plc:other/app.bsky.feed.post/3kmention',
+							cid: 'cid-1',
+							reason: 'mention',
+							reasonSubject: 'at://did:plc:acme/app.bsky.feed.post/3kroot',
+							author: { did: 'did:plc:other', handle: 'fan.bsky.social', displayName: 'Fan' },
+							record: { text: 'm'.repeat(BLUESKY_EVENT_TEXT_MAX_CHARS + 20) },
+							isRead: false,
+							indexedAt: '2026-07-22T10:00:00.000Z'
+						}
+					]
+				}
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.source).toBe('bluesky-connector');
+			expect(env.kind).toBe('bluesky.notification');
+			expect(env.sourceEventId).toBe(
+				'at://did:plc:other/app.bsky.feed.post/3kmention:mention:2026-07-22T10:00:00.000Z'
+			);
+			expect(env.actor).toEqual({ name: 'Fan', externalId: 'did:plc:other' });
+			expect(env.subject?.externalId).toBe('at://did:plc:acme/app.bsky.feed.post/3kroot');
+			expect(env.sourceUrl).toBe('https://bsky.app/profile/fan.bsky.social/post/3kmention');
+			expect((env.payload.text as string).length).toBe(BLUESKY_EVENT_TEXT_MAX_CHARS);
+			expect(env.payload.reason).toBe('mention');
+			// The app password must never leak into the envelope.
+			expect(JSON.stringify(res.events)).not.toContain(SETTINGS.appPassword);
+		});
+
+		it('stops the notification page at the first item older than the window', async () => {
+			listNotificationsMock.mockResolvedValueOnce({
+				data: {
+					notifications: [
+						{
+							uri: 'at://did:plc:a/app.bsky.feed.post/new',
+							reason: 'reply',
+							indexedAt: '2026-07-22T10:00:00.000Z'
+						},
+						{
+							uri: 'at://did:plc:a/app.bsky.feed.post/old',
+							reason: 'reply',
+							indexedAt: '2026-07-01T10:00:00.000Z'
+						}
+					],
+					cursor: 'page-2'
+				}
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toHaveLength(1);
+			// Window exhausted → the phase ends rather than paging further back.
+			expect(JSON.parse(res.nextCursor as string).p).toBe('author');
+		});
+
+		it('advances notifications → own posts → done across the sweep', async () => {
+			listNotificationsMock.mockResolvedValueOnce(emptyNotifications());
+			const afterNotifications = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: SETTINGS
+			});
+			expect(JSON.parse(afterNotifications.nextCursor as string).p).toBe('author');
+
+			getAuthorFeedMock.mockResolvedValueOnce(emptyFeed());
+			const afterAuthor = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterNotifications.nextCursor,
+				settings: SETTINGS
+			});
+			expect(getAuthorFeedMock).toHaveBeenCalledTimes(1);
+			expect(getAuthorFeedMock.mock.calls[0][0].actor).toBe('did:plc:acme');
+			expect(afterAuthor.nextCursor).toBeUndefined();
+		});
+
+		it('normalizes own posts into bluesky.post envelopes with engagement counts', async () => {
+			getAuthorFeedMock.mockResolvedValueOnce({
+				data: {
+					feed: [
+						{
+							post: {
+								uri: 'at://did:plc:acme/app.bsky.feed.post/3kown',
+								cid: 'cid-own',
+								author: { did: 'did:plc:acme', handle: 'acme.bsky.social' },
+								record: { text: 'we shipped', createdAt: '2026-07-22T09:00:00.000Z' },
+								replyCount: 2,
+								repostCount: 3,
+								likeCount: 7,
+								indexedAt: '2026-07-22T09:00:05.000Z'
+							}
+						}
+					]
+				}
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: JSON.stringify({ p: 'author', s: '2026-07-20T00:00:00.000Z', b: 0 }),
+				settings: SETTINGS
+			});
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.kind).toBe('bluesky.post');
+			expect(env.sourceUrl).toBe('https://bsky.app/profile/acme.bsky.social/post/3kown');
+			expect(env.payload).toMatchObject({ replyCount: 2, repostCount: 3, likeCount: 7 });
+		});
+
+		it('keeps the SAME window across pages of a running sweep', async () => {
+			listNotificationsMock.mockResolvedValueOnce({
+				data: {
+					notifications: [
+						{
+							uri: 'at://did:plc:a/app.bsky.feed.post/n1',
+							reason: 'like',
+							indexedAt: '2026-07-22T10:00:00.000Z'
+						}
+					],
+					cursor: 'page-2'
+				}
+			});
+			const first = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed).toMatchObject({ p: 'notifications', n: 'page-2', s: '2026-07-20T00:00:00.000Z' });
+
+			listNotificationsMock.mockResolvedValueOnce(emptyNotifications());
+			await plugin.pullEvents({
+				since: '2026-07-24T00:00:00.000Z', // a moved watermark must NOT shift the running sweep
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			expect(listNotificationsMock.mock.calls[1][0].cursor).toBe('page-2');
+		});
+
+		it('bounds backfill sweeps to the per-phase page budget', async () => {
+			listNotificationsMock.mockResolvedValueOnce({
+				data: {
+					notifications: [
+						{
+							uri: 'at://did:plc:a/app.bsky.feed.post/n',
+							reason: 'like',
+							indexedAt: '2026-06-01T10:00:00.000Z'
+						}
+					],
+					cursor: 'more'
+				}
+			});
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				cursor: JSON.stringify({
+					p: 'notifications',
+					n: 'page-n',
+					s: '2026-05-01T00:00:00.000Z',
+					f: 1,
+					b: BLUESKY_BACKFILL_MAX_PAGES - 1
+				}),
+				settings: { ...SETTINGS, backfillDays: 90 }
+			});
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed.p).toBe('author');
+			expect(parsed.n).toBeUndefined();
+			expect(parsed.b).toBe(0);
+		});
+
+		it('treats a malformed cursor as a fresh sweep instead of crashing', async () => {
+			listNotificationsMock.mockResolvedValueOnce(emptyNotifications());
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: 'not-json{{{',
+				settings: SETTINGS
+			});
+			expect(listNotificationsMock).toHaveBeenCalledTimes(1);
+			expect(res.events).toEqual([]);
+		});
+	});
+});

--- a/packages/plugins/bluesky-connector/src/bluesky-connector-plugin.ts
+++ b/packages/plugins/bluesky-connector/src/bluesky-connector-plugin.ts
@@ -1,0 +1,574 @@
+import { randomUUID } from 'node:crypto';
+import { AtpAgent } from '@atproto/api';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { isSafeWebhookUrl } from '@ever-works/plugin/helpers/ssrf-guard';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); a post body never needs
+ * more than this to be useful in Memory/Activities.
+ */
+export const BLUESKY_EVENT_TEXT_MAX_CHARS = 4000;
+
+/** Items requested per Bluesky page (notifications and feed alike). */
+export const BLUESKY_PULL_PAGE_SIZE = 50;
+
+/**
+ * Historical backfill bound: at most this many pages per phase
+ * (notifications, then the account's own posts) during the opt-in
+ * first-pull backfill, so a busy account can never turn activation
+ * into an unbounded crawl.
+ */
+export const BLUESKY_BACKFILL_MAX_PAGES = 10;
+
+/** Default AT Protocol PDS when the operator does not override it. */
+export const BLUESKY_DEFAULT_SERVICE = 'https://bsky.social';
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+function truncateText(text: string): string {
+	return text.length > BLUESKY_EVENT_TEXT_MAX_CHARS ? text.slice(0, BLUESKY_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/** Extract a readable message from an `@atproto/api` error. */
+function atprotoErrorMessage(err: unknown): string {
+	const e = err as { message?: string; error?: string; status?: number };
+	return e.message ?? e.error ?? (typeof e.status === 'number' ? `HTTP ${e.status}` : 'unknown error');
+}
+
+/** ISO string | Date | undefined → ISO 8601 (epoch on garbage). */
+function toIso(value: unknown): string {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === 'string') {
+		const ms = Date.parse(value);
+		if (Number.isFinite(ms)) return new Date(ms).toISOString();
+	}
+	return new Date(0).toISOString();
+}
+
+/**
+ * `at://<repo>/app.bsky.feed.post/<rkey>` → the public bsky.app
+ * permalink. Uses the author handle when known (nicer links) and falls
+ * back to the repo DID. Returns undefined for anything that is not a
+ * post AT-URI, so callers simply omit `sourceUrl`.
+ */
+export function postUrlFromAtUri(uri: string | undefined, handle?: string): string | undefined {
+	if (typeof uri !== 'string' || !uri.startsWith('at://')) return undefined;
+	const parts = uri.slice('at://'.length).split('/');
+	if (parts.length < 3) return undefined;
+	const [repo, collection, rkey] = parts;
+	if (collection !== 'app.bsky.feed.post' || !rkey) return undefined;
+	const actor = handle && handle.length > 0 ? handle : repo;
+	return `https://bsky.app/profile/${encodeURIComponent(actor)}/post/${encodeURIComponent(rkey)}`;
+}
+
+/**
+ * Opaque pull cursor. `p` is the sweep phase (notifications → the
+ * account's own posts), `n` the AT Protocol page cursor, `s` the
+ * effective since-watermark the sweep was started with (later pages of
+ * the same sweep keep the SAME window), `f` flags a first-pull backfill
+ * sweep and `b` counts pages used in the current phase (backfill page
+ * bound). Malformed input restarts the sweep — safe, the ingest
+ * pipeline dedupes on `(source, sourceEventId)`.
+ */
+interface BlueskyPullCursor {
+	p: 'notifications' | 'author';
+	n?: string;
+	s: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): BlueskyPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as BlueskyPullCursor;
+		if (parsed && (parsed.p === 'notifications' || parsed.p === 'author') && typeof parsed.s === 'string') {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal shape of an actor we consume. */
+interface BlueskyActor {
+	did?: string;
+	handle?: string;
+	displayName?: string;
+}
+
+/** Minimal shape of a notification we consume. */
+interface BlueskyNotification {
+	uri?: string;
+	cid?: string;
+	author?: BlueskyActor;
+	reason?: string;
+	reasonSubject?: string;
+	record?: { text?: string };
+	isRead?: boolean;
+	indexedAt?: string;
+}
+
+/** Minimal shape of an author-feed item we consume. */
+interface BlueskyFeedItem {
+	post?: {
+		uri?: string;
+		cid?: string;
+		author?: BlueskyActor;
+		record?: { text?: string; createdAt?: string };
+		replyCount?: number;
+		repostCount?: number;
+		likeCount?: number;
+		indexedAt?: string;
+	};
+}
+
+/** The subset of the `AtpAgent` surface this plugin calls. */
+interface BlueskyAgentLike {
+	login(input: { identifier: string; password: string }): Promise<{
+		data?: { did?: string; handle?: string };
+	}>;
+	post(record: Record<string, unknown>): Promise<{ uri?: string; cid?: string }>;
+	listNotifications(params: Record<string, unknown>): Promise<{
+		data?: { notifications?: BlueskyNotification[]; cursor?: string };
+	}>;
+	getAuthorFeed(params: Record<string, unknown>): Promise<{
+		data?: { feed?: BlueskyFeedItem[]; cursor?: string };
+	}>;
+}
+
+/** First non-empty trimmed string among the candidates. */
+function firstString(candidates: unknown[]): string | undefined {
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.trim().length > 0) return c.trim();
+	}
+	return undefined;
+}
+
+/** Resolved credentials for one call. */
+interface BlueskyCredentials {
+	identifier: string;
+	appPassword: string;
+	service: string;
+}
+
+/**
+ * Resolve credentials from the per-connection target config, falling
+ * back to the resolved plugin settings. Returns undefined (never a
+ * partial) so callers fail loudly with one clear message.
+ */
+export function resolveCredentials(
+	config: ChannelTargetConfig,
+	options: ConnectorCallOptions
+): BlueskyCredentials | undefined {
+	const identifier = firstString([config.identifier, options.settings?.identifier]);
+	const appPassword = firstString([config.appPassword, options.settings?.appPassword]);
+	if (!identifier || !appPassword) return undefined;
+	const service = firstString([config.service, options.settings?.service]) ?? BLUESKY_DEFAULT_SERVICE;
+	return { identifier, appPassword, service };
+}
+
+/**
+ * Bluesky (AT Protocol) social connector — first-party native connector.
+ *
+ * Outbound: `send` publishes a post — or a threaded reply when the
+ * target config carries `replyToUri`/`replyToCid` — through the
+ * official `@atproto/api` SDK using an app password (never the account
+ * password).
+ *
+ * Event source: `pullEvents` sweeps notifications (mentions, replies,
+ * likes, reposts, follows) then the connected account's own posts since
+ * the watermark, normalized into `IngestedEventEnvelope`s
+ * (`bluesky.notification` / `bluesky.post`, bsky.app permalink as
+ * `sourceUrl`) for the platform's event-ingest spine. Neither API can
+ * filter by time, so each phase is windowed client-side newest-first
+ * and stops at the first item older than the watermark. The opt-in
+ * historical backfill (`backfillDays`, default 0 = off, max 90) widens
+ * the FIRST pull's window only, with a per-phase page bound.
+ * Re-delivery across overlapping windows is fine — the ingest pipeline
+ * dedupes on `(source, sourceEventId)`.
+ *
+ * Unconfigured is always LOUD: `verifyConnection` reports the missing
+ * credentials, `send` throws, and `pullEvents` throws
+ * `EventSourceNotConfiguredError`. Nothing silently no-ops.
+ */
+export class BlueskyConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'bluesky-connector';
+	readonly name = 'Bluesky Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_BLUESKY,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'bluesky';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'outbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: true,
+			outboundRecord: false,
+			inbound: false,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['identifier', 'appPassword'],
+		properties: {
+			identifier: {
+				type: 'string',
+				title: 'Bluesky handle or DID (e.g. acme.bsky.social)'
+			},
+			appPassword: {
+				type: 'string',
+				title: 'Bluesky app password (never your account password)',
+				'x-secret': true,
+				'x-envVar': 'BLUESKY_APP_PASSWORD'
+			},
+			service: {
+				type: 'string',
+				title: 'PDS service URL (defaults to https://bsky.social)',
+				default: BLUESKY_DEFAULT_SERVICE
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			}
+		}
+	};
+
+	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; an agent is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.idempotencyCache.clear();
+	}
+
+	/** Testable seam — specs stub this; production uses the real SDK. */
+	protected createAgent(service: string): BlueskyAgentLike {
+		return new AtpAgent({ service }) as unknown as BlueskyAgentLike;
+	}
+
+	/**
+	 * Build an authenticated agent. The PDS URL is operator-supplied, so
+	 * it passes the shared SSRF guard before any request is issued.
+	 */
+	private async connect(
+		credentials: BlueskyCredentials
+	): Promise<{ agent: BlueskyAgentLike; did?: string; handle?: string }> {
+		if (!isSafeWebhookUrl(credentials.service)) {
+			throw new Error(`bluesky-connector: refusing to use an unsafe service URL '${credentials.service}'`);
+		}
+		const agent = this.createAgent(credentials.service);
+		const res = await agent.login({ identifier: credentials.identifier, password: credentials.appPassword });
+		return { agent, did: res?.data?.did, handle: res?.data?.handle };
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const credentials = resolveCredentials(config, options);
+		if (!credentials) {
+			return { valid: false, message: 'identifier and appPassword are required' };
+		}
+		try {
+			const { did, handle } = await this.connect(credentials);
+			return {
+				valid: true,
+				details: {
+					service: credentials.service,
+					...(did ? { did } : {}),
+					...(handle ? { handle } : {})
+				}
+			};
+		} catch (err) {
+			return { valid: false, message: `Bluesky login failed: ${atprotoErrorMessage(err)}` };
+		}
+	}
+
+	/** Outbound leg — publish a post (or a threaded reply). */
+	async send(payload: ChannelSendInput, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const config = payload.target ?? options.target ?? {};
+		const credentials = resolveCredentials(config, options);
+		if (!credentials) {
+			throw new Error(
+				'bluesky-connector: identifier and appPassword are required ' +
+					'(targetConfig.identifier/appPassword or settings.identifier/appPassword)'
+			);
+		}
+
+		const replyToUri = firstString([config.replyToUri]);
+		const replyToCid = firstString([config.replyToCid]);
+
+		// Idempotency: scope the key to connectorId + thread + messageRef with a
+		// NUL separator so components can't collide across tenants (mirrors the
+		// slack-connector hardening — this plugin is a module-level singleton).
+		const cacheKey = `${options.connectorId ?? ''}\0${replyToUri ?? ''}\0${payload.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let uri: string | undefined;
+		try {
+			const { agent } = await this.connect(credentials);
+			const record: Record<string, unknown> = {
+				text: payload.text,
+				createdAt: new Date().toISOString()
+			};
+			if (replyToUri && replyToCid) {
+				const rootUri = firstString([config.rootUri]) ?? replyToUri;
+				const rootCid = firstString([config.rootCid]) ?? replyToCid;
+				record.reply = {
+					root: { uri: rootUri, cid: rootCid },
+					parent: { uri: replyToUri, cid: replyToCid }
+				};
+			}
+			const res = await agent.post(record);
+			uri = typeof res?.uri === 'string' ? res.uri : undefined;
+		} catch (err) {
+			throw new Error(`Bluesky post failed: ${atprotoErrorMessage(err)}`);
+		}
+
+		const result: ChannelSendResult = {
+			provider: this.id,
+			providerMessageId: uri ?? `bluesky-${payload.messageRef}`,
+			deliveredAt: new Date()
+		};
+		this.idempotencyCache.set(cacheKey, result);
+		if (this.idempotencyCache.size > 500) {
+			const firstKey = this.idempotencyCache.keys().next().value;
+			if (firstKey) this.idempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one page of the current sweep phase (notifications → own
+	 * posts) since the effective watermark, normalized to envelopes. The
+	 * returned cursor resumes the same phase (AT Protocol page cursor) or
+	 * advances to the next; no cursor means the sweep is done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const identifier = input.settings?.identifier;
+		const appPassword = input.settings?.appPassword;
+		if (typeof identifier !== 'string' || identifier.length === 0) {
+			throw new EventSourceNotConfiguredError(
+				'bluesky-connector: settings.identifier is required to pull events'
+			);
+		}
+		if (typeof appPassword !== 'string' || appPassword.length === 0) {
+			throw new EventSourceNotConfiguredError(
+				'bluesky-connector: settings.appPassword is required to pull events'
+			);
+		}
+		const service = firstString([input.settings?.service]) ?? BLUESKY_DEFAULT_SERVICE;
+
+		const cursor = parsePullCursor(input.cursor);
+		let phase: 'notifications' | 'author';
+		let after: string | undefined;
+		let since: string;
+		let backfill: boolean;
+		let pagesUsed: number;
+
+		if (cursor) {
+			phase = cursor.p;
+			after = cursor.n;
+			since = cursor.s;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			if (firstPull) {
+				const start = backfillDays > 0 ? Date.now() - backfillDays * 86400_000 : Date.now();
+				since = new Date(start).toISOString();
+				backfill = backfillDays > 0;
+			} else {
+				since = new Date(sinceMs).toISOString();
+				backfill = false;
+			}
+			phase = 'notifications';
+			after = undefined;
+			pagesUsed = 0;
+		}
+
+		const { agent, did, handle } = await this.connect({ identifier, appPassword, service });
+		const sinceMs = Date.parse(since);
+		const events: IngestedEventEnvelope[] = [];
+		let nextPageCursor: string | undefined;
+		let stopSweep = false;
+
+		if (phase === 'notifications') {
+			const res = await agent.listNotifications({
+				limit: BLUESKY_PULL_PAGE_SIZE,
+				...(after ? { cursor: after } : {})
+			});
+			for (const notification of res?.data?.notifications ?? []) {
+				const indexedMs = Date.parse(notification.indexedAt ?? '');
+				if (Number.isFinite(indexedMs) && indexedMs < sinceMs) {
+					stopSweep = true;
+					break;
+				}
+				const envelope = this.normalizeNotification(notification);
+				if (envelope) events.push(envelope);
+			}
+			nextPageCursor = res?.data?.cursor;
+		} else {
+			const actor = did ?? handle ?? identifier;
+			const res = await agent.getAuthorFeed({
+				actor,
+				limit: BLUESKY_PULL_PAGE_SIZE,
+				...(after ? { cursor: after } : {})
+			});
+			for (const item of res?.data?.feed ?? []) {
+				const indexedMs = Date.parse(item.post?.indexedAt ?? '');
+				if (Number.isFinite(indexedMs) && indexedMs < sinceMs) {
+					stopSweep = true;
+					break;
+				}
+				const envelope = this.normalizePost(item);
+				if (envelope) events.push(envelope);
+			}
+			nextPageCursor = res?.data?.cursor;
+		}
+
+		pagesUsed += 1;
+		const pageBudgetExhausted = backfill && pagesUsed >= BLUESKY_BACKFILL_MAX_PAGES;
+
+		let next: BlueskyPullCursor | undefined;
+		if (!stopSweep && nextPageCursor && !pageBudgetExhausted) {
+			next = { p: phase, n: nextPageCursor, s: since, ...(backfill ? { f: 1 as const } : {}), b: pagesUsed };
+		} else if (phase === 'notifications') {
+			// Advance to the own-posts phase (page counter resets per phase).
+			next = { p: 'author', s: since, ...(backfill ? { f: 1 as const } : {}), b: 0 };
+		}
+
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	private normalizeNotification(notification: BlueskyNotification): IngestedEventEnvelope | null {
+		if (!notification.uri) return null;
+		const occurredAt = toIso(notification.indexedAt);
+		const reason = notification.reason ?? 'unknown';
+		const author = notification.author ?? {};
+		const text = typeof notification.record?.text === 'string' ? notification.record.text : undefined;
+		const sourceUrl = postUrlFromAtUri(notification.uri, author.handle);
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${notification.uri}:${reason}:${occurredAt}`,
+			kind: 'bluesky.notification',
+			occurredAt,
+			...(author.handle || author.displayName
+				? {
+						actor: {
+							name: author.displayName ?? author.handle ?? 'unknown',
+							...(author.did ? { externalId: author.did } : {})
+						}
+					}
+				: {}),
+			subject: {
+				type: 'post',
+				externalId: notification.reasonSubject ?? notification.uri,
+				...(text ? { title: truncateText(text) } : {})
+			},
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				reason,
+				uri: notification.uri,
+				...(notification.cid ? { cid: notification.cid } : {}),
+				...(notification.reasonSubject ? { reasonSubject: notification.reasonSubject } : {}),
+				...(author.did ? { authorDid: author.did } : {}),
+				...(author.handle ? { authorHandle: author.handle } : {}),
+				...(text ? { text: truncateText(text) } : {}),
+				...(typeof notification.isRead === 'boolean' ? { isRead: notification.isRead } : {}),
+				indexedAt: occurredAt
+			}
+		};
+	}
+
+	private normalizePost(item: BlueskyFeedItem): IngestedEventEnvelope | null {
+		const post = item.post;
+		if (!post?.uri) return null;
+		const occurredAt = toIso(post.indexedAt ?? post.record?.createdAt);
+		const author = post.author ?? {};
+		const text = typeof post.record?.text === 'string' ? post.record.text : undefined;
+		const sourceUrl = postUrlFromAtUri(post.uri, author.handle);
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${post.uri}:${occurredAt}`,
+			kind: 'bluesky.post',
+			occurredAt,
+			...(author.handle || author.displayName
+				? {
+						actor: {
+							name: author.displayName ?? author.handle ?? 'unknown',
+							...(author.did ? { externalId: author.did } : {})
+						}
+					}
+				: {}),
+			subject: {
+				type: 'post',
+				externalId: post.uri,
+				...(text ? { title: truncateText(text) } : {})
+			},
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				uri: post.uri,
+				...(post.cid ? { cid: post.cid } : {}),
+				...(author.did ? { authorDid: author.did } : {}),
+				...(author.handle ? { authorHandle: author.handle } : {}),
+				...(text ? { text: truncateText(text) } : {}),
+				...(typeof post.replyCount === 'number' ? { replyCount: post.replyCount } : {}),
+				...(typeof post.repostCount === 'number' ? { repostCount: post.repostCount } : {}),
+				...(typeof post.likeCount === 'number' ? { likeCount: post.likeCount } : {}),
+				...(post.record?.createdAt ? { createdAt: toIso(post.record.createdAt) } : {}),
+				indexedAt: occurredAt
+			}
+		};
+	}
+}
+
+export const blueskyConnectorPlugin = new BlueskyConnectorPlugin();

--- a/packages/plugins/bluesky-connector/src/index.ts
+++ b/packages/plugins/bluesky-connector/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @ever-works/bluesky-connector-plugin — Bluesky (AT Protocol) social
+ * connector. Outbound posts/threaded replies via the official
+ * `@atproto/api` SDK; `pullEvents` event-source leg (notifications then
+ * the account's own posts since the watermark, opt-in historical
+ * backfill) feeding the platform event-ingest spine.
+ */
+export {
+	BlueskyConnectorPlugin,
+	blueskyConnectorPlugin,
+	clampBackfillDays,
+	postUrlFromAtUri,
+	resolveCredentials,
+	BLUESKY_EVENT_TEXT_MAX_CHARS,
+	BLUESKY_PULL_PAGE_SIZE,
+	BLUESKY_BACKFILL_MAX_PAGES,
+	BLUESKY_DEFAULT_SERVICE
+} from './bluesky-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { BlueskyConnectorPlugin as default } from './bluesky-connector-plugin.js';

--- a/packages/plugins/bluesky-connector/tsconfig.json
+++ b/packages/plugins/bluesky-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/bluesky-connector/tsup.config.ts
+++ b/packages/plugins/bluesky-connector/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	// `@atproto/api` ships ESM only. The plugin loader resolves the
+	// package `main` (the CJS build), so leaving the SDK external would
+	// emit a `require()` of an ESM-only package. Bundling it into BOTH
+	// outputs keeps the CJS entry loadable on every supported runtime.
+	noExternal: ['@ever-works/plugin', '@atproto/api'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/bluesky-connector/vitest.config.ts
+++ b/packages/plugins/bluesky-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/hubspot-connector/README.md
+++ b/packages/plugins/hubspot-connector/README.md
@@ -1,0 +1,55 @@
+# @ever-works/hubspot-connector-plugin
+
+First-party **HubSpot CRM connector** for the Ever Works platform, built on the
+official [`@hubspot/api-client`](https://www.npmjs.com/package/@hubspot/api-client).
+
+Capabilities: `connector`, `connector-hubspot`, `event-source`.
+
+## What it does
+
+- **Outbound message** — `send()` appends a Note engagement to a CRM record
+  (`targetConfig.associatedObjectId` / `settings.defaultAssociatedObjectId`),
+  associated with the record's HubSpot-defined note association type,
+  idempotent on `messageRef`.
+- **Outbound record** — `createRecord()` writes a contact / company / deal (or
+  any custom object) via `crm.objects.basicApi.create`, idempotent on
+  `idempotencyKey`.
+- **Event source** — `pullEvents()` sweeps each configured CRM object type in
+  turn through the Search API, filtered server-side on that type's
+  last-modified property, normalized into `IngestedEventEnvelope`s
+  (`hubspot.contact` / `hubspot.company` / `hubspot.deal`, custom objects fall
+  back to `hubspot.record`) for the event-ingest spine. With a `portalId`
+  configured each envelope carries a record deep link as `sourceUrl` so
+  Memory/Activity rows link back to the origin.
+- **Opt-in historical backfill** — `backfillDays` (default `0` = off, max 90)
+  widens the FIRST pull's window only, bounded to
+  `HUBSPOT_BACKFILL_MAX_PAGES` search pages per object type.
+
+## Degradation is loud, never silent
+
+An unconfigured connector never quietly returns nothing:
+
+- `verifyConnection()` reports the missing `accessToken` (and surfaces the
+  HubSpot error body when the read probe fails, e.g. a missing scope).
+- `send()` / `createRecord()` throw on a missing token, a missing record id, or
+  an object type that has no note association (rather than writing an orphan
+  note).
+- `pullEvents()` throws `EventSourceNotConfiguredError`.
+
+## Settings
+
+| Key                         | Notes                                                                |
+| --------------------------- | -------------------------------------------------------------------- |
+| `accessToken`               | Private-app token — secret, env `HUBSPOT_ACCESS_TOKEN`.              |
+| `objectTypes`               | Comma-separated sweep list (contacts, companies, deals when empty).  |
+| `portalId`                  | Portal (hub) id — enables record deep links on every envelope.       |
+| `backfillDays`              | Opt-in first-pull history window (0 = off, max 90).                  |
+| `defaultObjectType`         | Default object type for `createRecord` + the verify probe.           |
+| `defaultAssociatedObjectId` | Default CRM record outbound notes attach to.                         |
+
+No credential is ever hardcoded, logged, or written into an ingested envelope.
+
+## Testing
+
+Hermetic Vitest suite (`pnpm test`) — the SDK client is stubbed through the
+`createClient` seam; no network calls.

--- a/packages/plugins/hubspot-connector/package.json
+++ b/packages/plugins/hubspot-connector/package.json
@@ -1,0 +1,106 @@
+{
+	"name": "@ever-works/hubspot-connector-plugin",
+	"version": "1.0.0",
+	"description": "HubSpot CRM connector plugin for Ever Works platform (outbound notes + record creation via the official @hubspot/api-client, and event-source pull of contact/company/deal changes into the event-ingest pipeline, with opt-in historical backfill)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*",
+		"@hubspot/api-client": "^14.0.1"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "hubspot-connector",
+			"name": "HubSpot Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"connector-hubspot",
+				"event-source"
+			],
+			"description": "HubSpot CRM connector. Outbound appends notes to CRM records and creates records (contacts/companies/deals) via the official @hubspot/api-client. Event-source pull ingests records created/updated since the last watermark into the platform event-ingest pipeline, with opt-in historical backfill (backfillDays, max 90).",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"accessToken"
+				],
+				"properties": {
+					"accessToken": {
+						"type": "string",
+						"title": "HubSpot private-app access token (pat-…)",
+						"x-secret": true,
+						"x-envVar": "HUBSPOT_ACCESS_TOKEN"
+					},
+					"objectTypes": {
+						"type": "string",
+						"title": "CRM object types to ingest (comma-separated; contacts, companies, deals when empty)",
+						"default": "contacts,companies,deals"
+					},
+					"portalId": {
+						"type": "string",
+						"title": "HubSpot portal (hub) id — enables deep links back to each record"
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					},
+					"defaultObjectType": {
+						"type": "string",
+						"title": "Default CRM object type for record writes",
+						"default": "contacts"
+					},
+					"defaultAssociatedObjectId": {
+						"type": "string",
+						"title": "Default CRM record id outbound notes are attached to"
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/hubspot-connector/src/hubspot-connector-plugin.spec.ts
+++ b/packages/plugins/hubspot-connector/src/hubspot-connector-plugin.spec.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	HubSpotConnectorPlugin,
+	clampBackfillDays,
+	objectMeta,
+	recordTitle,
+	resolveObjectTypes,
+	HUBSPOT_EVENT_TEXT_MAX_CHARS,
+	HUBSPOT_BACKFILL_MAX_PAGES,
+	HUBSPOT_DEFAULT_OBJECT_TYPES
+} from './hubspot-connector-plugin.js';
+
+const createMock = vi.fn();
+const getPageMock = vi.fn();
+const doSearchMock = vi.fn();
+const clientFactoryMock = vi.fn();
+
+/** Subclass overriding the client seam so no real SDK call ever happens. */
+class TestHubSpotConnectorPlugin extends HubSpotConnectorPlugin {
+	protected override createClient(accessToken: string) {
+		clientFactoryMock(accessToken);
+		return {
+			crm: {
+				objects: {
+					basicApi: { create: createMock, getPage: getPageMock },
+					searchApi: { doSearch: doSearchMock }
+				}
+			}
+		};
+	}
+}
+
+const SETTINGS = { accessToken: 'pat-na1-secret-123' };
+
+function emptyPage() {
+	return { results: [] };
+}
+
+describe('HubSpotConnectorPlugin', () => {
+	let plugin: TestHubSpotConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestHubSpotConnectorPlugin();
+		createMock.mockReset();
+		getPageMock.mockReset();
+		doSearchMock.mockReset();
+		clientFactoryMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('declares the connector + connector-hubspot + event-source capabilities and poll metadata', () => {
+		expect(plugin.id).toBe('hubspot-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toContain('connector');
+		expect(plugin.capabilities).toContain('connector-hubspot');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('hubspot');
+		expect(plugin.connector.direction).toBe('outbound');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.outboundMessage).toBe(true);
+		expect(plugin.connector.flags.outboundRecord).toBe(true);
+		expect(plugin.connector.flags.inbound).toBe(false);
+	});
+
+	it('marks accessToken as x-secret and bounds backfillDays to 0–90 in the settings schema', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.accessToken['x-secret']).toBe(true);
+		expect(props.accessToken['x-envVar']).toBe('HUBSPOT_ACCESS_TOKEN');
+		expect(plugin.settingsSchema.required).toContain('accessToken');
+		expect(props.backfillDays.default).toBe(0);
+		expect(props.backfillDays.minimum).toBe(0);
+		expect(props.backfillDays.maximum).toBe(90);
+	});
+
+	it('clampBackfillDays clamps to the 0–90 range and treats garbage as off', () => {
+		expect(clampBackfillDays(0)).toBe(0);
+		expect(clampBackfillDays(-5)).toBe(0);
+		expect(clampBackfillDays(30)).toBe(30);
+		expect(clampBackfillDays(90.9)).toBe(90);
+		expect(clampBackfillDays(500)).toBe(90);
+		expect(clampBackfillDays('nope')).toBe(0);
+		expect(clampBackfillDays(undefined)).toBe(0);
+	});
+
+	it('resolveObjectTypes defaults to contacts/companies/deals and parses a custom list', () => {
+		expect(resolveObjectTypes(undefined)).toEqual([...HUBSPOT_DEFAULT_OBJECT_TYPES]);
+		expect(resolveObjectTypes({ objectTypes: '   ' })).toEqual([...HUBSPOT_DEFAULT_OBJECT_TYPES]);
+		expect(resolveObjectTypes({ objectTypes: 'deals, tickets' })).toEqual(['deals', 'tickets']);
+	});
+
+	it('objectMeta falls back to the generic custom-object shape', () => {
+		expect(objectMeta('contacts').lastModifiedProperty).toBe('lastmodifieddate');
+		expect(objectMeta('deals').lastModifiedProperty).toBe('hs_lastmodifieddate');
+		const custom = objectMeta('p_widgets');
+		expect(custom.kind).toBe('hubspot.record');
+		expect(custom.noteAssociationTypeId).toBeUndefined();
+	});
+
+	it('recordTitle picks the per-type human label', () => {
+		expect(recordTitle('contacts', { firstname: 'Ada', lastname: 'Lovelace' })).toBe('Ada Lovelace');
+		expect(recordTitle('contacts', { email: 'ada@acme.dev' })).toBe('ada@acme.dev');
+		expect(recordTitle('companies', { name: 'Acme' })).toBe('Acme');
+		expect(recordTitle('deals', { dealname: 'Q3 renewal' })).toBe('Q3 renewal');
+		expect(recordTitle('deals', {})).toBeUndefined();
+	});
+
+	describe('verifyConnection', () => {
+		it('probes the first configured object type and returns its details', async () => {
+			getPageMock.mockResolvedValueOnce({ results: [{ id: '1' }] });
+			const res = await plugin.verifyConnection(
+				{ accessToken: 'pat-x' },
+				{ settings: { objectTypes: 'deals,contacts' } }
+			);
+			expect(res.valid).toBe(true);
+			expect(getPageMock).toHaveBeenCalledWith('deals', 1);
+			expect(res.details).toMatchObject({ probedObjectType: 'deals', sampled: 1 });
+			expect(clientFactoryMock).toHaveBeenCalledWith('pat-x');
+		});
+
+		it('degrades loudly (never silently) when the token is missing', async () => {
+			const res = await plugin.verifyConnection({}, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/accessToken/);
+			expect(clientFactoryMock).not.toHaveBeenCalled();
+		});
+
+		it('surfaces the HubSpot error body when the probe fails', async () => {
+			getPageMock.mockRejectedValueOnce({ body: { message: 'missing scope crm.objects.contacts.read' } });
+			const res = await plugin.verifyConnection({ accessToken: 'pat-x' }, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/missing scope/);
+		});
+	});
+
+	describe('send', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('creates a note associated with the resolved CRM record', async () => {
+			createMock.mockResolvedValueOnce({ id: 'note-9' });
+			const res = await plugin.send(
+				{
+					text: 'call summary',
+					messageRef: 'ref-1',
+					attribution: { userId: 'u1' },
+					target: { associatedObjectId: '501', associatedObjectType: 'deals' }
+				},
+				options
+			);
+			expect(createMock).toHaveBeenCalledTimes(1);
+			const [objectType, input] = createMock.mock.calls[0];
+			expect(objectType).toBe('notes');
+			expect(input.properties.hs_note_body).toBe('call summary');
+			expect(input.associations[0].to.id).toBe('501');
+			expect(input.associations[0].types[0].associationTypeId).toBe(214);
+			expect(res.provider).toBe('hubspot-connector');
+			expect(res.providerMessageId).toBe('note-9');
+		});
+
+		it('is idempotent on messageRef — a retry never double-posts', async () => {
+			createMock.mockResolvedValue({ id: 'note-1' });
+			const payload = {
+				text: 'once only',
+				messageRef: 'ref-dup',
+				attribution: { userId: 'u1' },
+				target: { associatedObjectId: '77' }
+			};
+			const first = await plugin.send(payload, options);
+			const second = await plugin.send(payload, options);
+			expect(createMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws a clear error when no CRM record id can be resolved', async () => {
+			await expect(
+				plugin.send({ text: 'x', messageRef: 'r', attribution: { userId: 'u1' } }, options)
+			).rejects.toThrow(/CRM record id is required/);
+			expect(createMock).not.toHaveBeenCalled();
+		});
+
+		it('refuses to write an orphan note for an object type without a note association', async () => {
+			await expect(
+				plugin.send(
+					{
+						text: 'x',
+						messageRef: 'r',
+						attribution: { userId: 'u1' },
+						target: { associatedObjectId: '9', associatedObjectType: 'p_widgets' }
+					},
+					options
+				)
+			).rejects.toThrow(/not supported for object type 'p_widgets'/);
+			expect(createMock).not.toHaveBeenCalled();
+		});
+
+		it('throws when the access token is missing instead of silently no-oping', async () => {
+			await expect(
+				plugin.send(
+					{
+						text: 'x',
+						messageRef: 'r',
+						attribution: { userId: 'u1' },
+						target: { associatedObjectId: '9' }
+					},
+					{ connectorId: 'c' }
+				)
+			).rejects.toThrow(/access token is required/);
+		});
+	});
+
+	describe('createRecord', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('creates the record for the requested collection and returns its id', async () => {
+			createMock.mockResolvedValueOnce({ id: 'rec-42' });
+			const res = await plugin.createRecord(
+				{ collection: 'companies', fields: { name: 'Acme' }, idempotencyKey: 'k-1' },
+				options
+			);
+			expect(createMock).toHaveBeenCalledWith('companies', { properties: { name: 'Acme' } });
+			expect(res).toEqual({ provider: 'hubspot-connector', recordId: 'rec-42' });
+		});
+
+		it('is idempotent on idempotencyKey', async () => {
+			createMock.mockResolvedValue({ id: 'rec-1' });
+			const input = { collection: 'contacts', fields: { email: 'a@b.dev' }, idempotencyKey: 'dup' };
+			const first = await plugin.createRecord(input, options);
+			const second = await plugin.createRecord(input, options);
+			expect(createMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws when HubSpot returns no record id', async () => {
+			createMock.mockResolvedValueOnce({});
+			await expect(
+				plugin.createRecord({ collection: 'contacts', fields: {}, idempotencyKey: 'k' }, options)
+			).rejects.toThrow(/no record id/);
+		});
+	});
+
+	describe('pullEvents', () => {
+		it('throws EventSourceNotConfiguredError when the access token is missing', async () => {
+			await expect(plugin.pullEvents({ since: new Date(0).toISOString(), settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
+			expect(doSearchMock).not.toHaveBeenCalled();
+		});
+
+		it('first pull with backfill off uses a now-anchored window (no history)', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			doSearchMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({ since: new Date(0).toISOString(), settings: SETTINGS });
+			const [objectType, request] = doSearchMock.mock.calls[0];
+			expect(objectType).toBe('contacts');
+			expect(request.filterGroups[0].filters[0].value).toBe(String(Date.parse('2026-07-25T12:00:00.000Z')));
+		});
+
+		it('first pull with backfillDays widens the window, clamped to 90 days', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			doSearchMock.mockResolvedValue(emptyPage());
+			await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(doSearchMock.mock.calls[0][1].filterGroups[0].filters[0].value).toBe(
+				String(Date.parse('2026-06-25T12:00:00.000Z'))
+			);
+
+			await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 500 }
+			});
+			expect(doSearchMock.mock.calls[1][1].filterGroups[0].filters[0].value).toBe(
+				String(Date.parse('2026-04-26T12:00:00.000Z'))
+			);
+		});
+
+		it('a non-first pull keeps the platform watermark as the window', async () => {
+			doSearchMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(doSearchMock.mock.calls[0][1].filterGroups[0].filters[0].value).toBe(
+				String(Date.parse('2026-07-20T00:00:00.000Z'))
+			);
+		});
+
+		it('normalizes records into typed envelopes with subject, deep link and capped payload', async () => {
+			doSearchMock.mockResolvedValueOnce({
+				results: [
+					{
+						id: '1001',
+						properties: {
+							firstname: 'Ada',
+							lastname: 'Lovelace',
+							email: 'ada@acme.dev',
+							company: 'c'.repeat(HUBSPOT_EVENT_TEXT_MAX_CHARS + 50),
+							createdate: '2026-07-21T10:00:00.000Z',
+							lastmodifieddate: '2026-07-22T10:00:00.000Z'
+						},
+						createdAt: new Date('2026-07-21T10:00:00.000Z'),
+						updatedAt: new Date('2026-07-22T10:00:00.000Z')
+					}
+				]
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, portalId: '12345678' }
+			});
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.source).toBe('hubspot-connector');
+			expect(env.kind).toBe('hubspot.contact');
+			expect(env.sourceEventId).toBe('contacts:1001:2026-07-22T10:00:00.000Z');
+			expect(env.occurredAt).toBe('2026-07-22T10:00:00.000Z');
+			expect(env.subject).toEqual({ type: 'crm-record', externalId: '1001', title: 'Ada Lovelace' });
+			expect(env.sourceUrl).toBe('https://app.hubspot.com/contacts/12345678/record/0-1/1001');
+			expect(env.payload.changeType).toBe('created');
+			const properties = env.payload.properties as Record<string, string>;
+			expect(properties.company.length).toBe(HUBSPOT_EVENT_TEXT_MAX_CHARS);
+			// The access token must never leak into the envelope.
+			expect(JSON.stringify(res.events)).not.toContain(SETTINGS.accessToken);
+		});
+
+		it('omits the deep link when no portalId is configured', async () => {
+			doSearchMock.mockResolvedValueOnce({
+				results: [{ id: '5', properties: {}, updatedAt: '2026-07-22T10:00:00.000Z' }]
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events[0].sourceUrl).toBeUndefined();
+		});
+
+		it('pages within an object type and keeps the SAME window across pages', async () => {
+			doSearchMock.mockResolvedValueOnce({ results: [], paging: { next: { after: '50' } } });
+			const first = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed).toMatchObject({ t: 'contacts', n: '50', s: '2026-07-20T00:00:00.000Z' });
+
+			doSearchMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-24T00:00:00.000Z', // a moved watermark must NOT shift the running sweep
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			const request = doSearchMock.mock.calls[1][1];
+			expect(request.after).toBe('50');
+			expect(request.filterGroups[0].filters[0].value).toBe(String(Date.parse('2026-07-20T00:00:00.000Z')));
+		});
+
+		it('advances contacts → companies → deals → done across the sweep', async () => {
+			doSearchMock.mockResolvedValue(emptyPage());
+			const afterContacts = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(JSON.parse(afterContacts.nextCursor as string).t).toBe('companies');
+
+			const afterCompanies = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterContacts.nextCursor,
+				settings: SETTINGS
+			});
+			expect(JSON.parse(afterCompanies.nextCursor as string).t).toBe('deals');
+
+			const afterDeals = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterCompanies.nextCursor,
+				settings: SETTINGS
+			});
+			expect(afterDeals.nextCursor).toBeUndefined();
+		});
+
+		it('bounds backfill sweeps to the per-phase page budget', async () => {
+			doSearchMock.mockResolvedValueOnce({ results: [], paging: { next: { after: '900' } } });
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				cursor: JSON.stringify({
+					t: 'contacts',
+					n: '850',
+					s: '2026-05-01T00:00:00.000Z',
+					f: 1,
+					b: HUBSPOT_BACKFILL_MAX_PAGES - 1
+				}),
+				settings: { ...SETTINGS, backfillDays: 90 }
+			});
+			// Budget hit mid-contacts: jump to the next type instead of paging on.
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed.t).toBe('companies');
+			expect(parsed.n).toBeUndefined();
+			expect(parsed.b).toBe(0);
+		});
+
+		it('restarts at the first type when the cursor names a type dropped from settings', async () => {
+			doSearchMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: JSON.stringify({ t: 'tickets', n: '10', s: '2026-07-20T00:00:00.000Z' }),
+				settings: SETTINGS
+			});
+			const [objectType, request] = doSearchMock.mock.calls[0];
+			expect(objectType).toBe('contacts');
+			expect(request.after).toBeUndefined();
+		});
+
+		it('treats a malformed cursor as a fresh sweep instead of crashing', async () => {
+			doSearchMock.mockResolvedValueOnce(emptyPage());
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: 'not-json{{{',
+				settings: SETTINGS
+			});
+			expect(doSearchMock).toHaveBeenCalledTimes(1);
+			expect(res.events).toEqual([]);
+		});
+	});
+});

--- a/packages/plugins/hubspot-connector/src/hubspot-connector-plugin.ts
+++ b/packages/plugins/hubspot-connector/src/hubspot-connector-plugin.ts
@@ -1,0 +1,656 @@
+import { randomUUID } from 'node:crypto';
+import { Client } from '@hubspot/api-client';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ConnectorRecordInput,
+	ConnectorRecordResult,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	PluginSettings,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); a CRM property value
+ * never needs more than this to be useful in Memory/Activities.
+ */
+export const HUBSPOT_EVENT_TEXT_MAX_CHARS = 4000;
+
+/** Records requested per HubSpot search page. */
+export const HUBSPOT_PULL_PAGE_SIZE = 50;
+
+/**
+ * Historical backfill bound: at most this many search pages per phase
+ * (per CRM object type) during the opt-in first-pull backfill, so a
+ * large portal can never turn activation into an unbounded crawl.
+ */
+export const HUBSPOT_BACKFILL_MAX_PAGES = 10;
+
+/** Object types swept when `objectTypes` is left empty. */
+export const HUBSPOT_DEFAULT_OBJECT_TYPES = ['contacts', 'companies', 'deals'] as const;
+
+/** Per-object-type ingest/deep-link metadata. */
+interface HubSpotObjectMeta {
+	/** Envelope `kind` (source-namespaced, singular). */
+	readonly kind: string;
+	/** Property carrying the record's last-modified timestamp. */
+	readonly lastModifiedProperty: string;
+	/** Properties requested from search (also the payload whitelist). */
+	readonly properties: readonly string[];
+	/** Numeric object-type id used in HubSpot record deep links. */
+	readonly objectTypeId?: string;
+	/**
+	 * `associationTypeId` for a HUBSPOT_DEFINED note → record
+	 * association. Absent means outbound notes are unsupported for the
+	 * type and `send` fails loudly rather than writing an orphan note.
+	 */
+	readonly noteAssociationTypeId?: number;
+}
+
+/**
+ * Known first-class CRM object types. Custom objects still work — they
+ * fall back to {@link GENERIC_OBJECT_META} (the `hs_lastmodifieddate`
+ * property every HubSpot object carries).
+ */
+export const HUBSPOT_OBJECT_META: Readonly<Record<string, HubSpotObjectMeta>> = {
+	contacts: {
+		kind: 'hubspot.contact',
+		lastModifiedProperty: 'lastmodifieddate',
+		properties: ['firstname', 'lastname', 'email', 'company', 'lifecyclestage', 'createdate', 'lastmodifieddate'],
+		objectTypeId: '0-1',
+		noteAssociationTypeId: 202
+	},
+	companies: {
+		kind: 'hubspot.company',
+		lastModifiedProperty: 'hs_lastmodifieddate',
+		properties: ['name', 'domain', 'industry', 'createdate', 'hs_lastmodifieddate'],
+		objectTypeId: '0-2',
+		noteAssociationTypeId: 190
+	},
+	deals: {
+		kind: 'hubspot.deal',
+		lastModifiedProperty: 'hs_lastmodifieddate',
+		properties: ['dealname', 'dealstage', 'amount', 'pipeline', 'createdate', 'hs_lastmodifieddate'],
+		objectTypeId: '0-3',
+		noteAssociationTypeId: 214
+	}
+};
+
+const GENERIC_OBJECT_META: HubSpotObjectMeta = {
+	kind: 'hubspot.record',
+	lastModifiedProperty: 'hs_lastmodifieddate',
+	properties: ['hs_object_id', 'createdate', 'hs_lastmodifieddate']
+};
+
+/** Metadata for a type, falling back to the generic custom-object shape. */
+export function objectMeta(objectType: string): HubSpotObjectMeta {
+	return HUBSPOT_OBJECT_META[objectType] ?? GENERIC_OBJECT_META;
+}
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+function truncateText(text: string): string {
+	return text.length > HUBSPOT_EVENT_TEXT_MAX_CHARS ? text.slice(0, HUBSPOT_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/** Parse the object-type list: comma/space separated → array (defaulted). */
+export function resolveObjectTypes(settings: PluginSettings | undefined): string[] {
+	const raw = settings?.objectTypes;
+	if (typeof raw === 'string' && raw.trim().length > 0) {
+		const parsed = raw
+			.split(/[\s,]+/)
+			.map((t) => t.trim())
+			.filter((t) => t.length > 0);
+		if (parsed.length > 0) return parsed;
+	}
+	return [...HUBSPOT_DEFAULT_OBJECT_TYPES];
+}
+
+/** Extract a readable message from a `@hubspot/api-client` error. */
+function hubspotErrorMessage(err: unknown): string {
+	const e = err as { message?: string; body?: { message?: string }; code?: number };
+	return e.body?.message ?? e.message ?? (typeof e.code === 'number' ? `HTTP ${e.code}` : 'unknown error');
+}
+
+/** Date | ISO string | epoch-ms | undefined → ISO 8601 (epoch on garbage). */
+function toIso(value: unknown): string {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
+	if (typeof value === 'string') {
+		const ms = Date.parse(value);
+		if (Number.isFinite(ms)) return new Date(ms).toISOString();
+	}
+	return new Date(0).toISOString();
+}
+
+/**
+ * Opaque pull cursor. `t` is the CRM object type the sweep is on, `n`
+ * HubSpot's own `paging.next.after`, `s` the effective since-watermark
+ * the sweep was started with (later pages of the same sweep keep the
+ * SAME window), `f` flags a first-pull backfill sweep and `b` counts
+ * pages used in the current phase (backfill page bound). Malformed
+ * input restarts the sweep — safe, the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ */
+interface HubSpotPullCursor {
+	t: string;
+	n?: string;
+	s: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): HubSpotPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as HubSpotPullCursor;
+		if (parsed && typeof parsed.t === 'string' && parsed.t.length > 0 && typeof parsed.s === 'string') {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal shape of a CRM record the search API returns. */
+interface HubSpotRecord {
+	id?: string;
+	properties?: Record<string, unknown>;
+	createdAt?: Date | string;
+	updatedAt?: Date | string;
+	archived?: boolean;
+}
+
+interface HubSpotSearchPage {
+	results?: HubSpotRecord[];
+	paging?: { next?: { after?: string } };
+}
+
+/** The subset of the `@hubspot/api-client` surface this plugin calls. */
+interface HubSpotClientLike {
+	crm: {
+		objects: {
+			basicApi: {
+				create(objectType: string, input: Record<string, unknown>): Promise<{ id?: string }>;
+				getPage(objectType: string, limit?: number): Promise<HubSpotSearchPage>;
+			};
+			searchApi: {
+				doSearch(objectType: string, request: Record<string, unknown>): Promise<HubSpotSearchPage>;
+			};
+		};
+	};
+}
+
+function resolveAccessToken(config: ChannelTargetConfig, options: ConnectorCallOptions): string | undefined {
+	const candidates = [config.accessToken, options.settings?.accessToken];
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	return undefined;
+}
+
+/** First non-empty string among the candidates. */
+function firstString(candidates: unknown[]): string | undefined {
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.trim().length > 0) return c.trim();
+	}
+	return undefined;
+}
+
+/**
+ * Resolve which CRM record an outbound note attaches to. A per-send
+ * `associatedObjectId` overrides the connection default; the resolved
+ * plugin `settings` default is the final fallback.
+ */
+export function resolveNoteTarget(
+	config: ChannelTargetConfig,
+	options: ConnectorCallOptions
+): { objectType: string; objectId: string } {
+	const objectId = firstString([
+		config.associatedObjectId,
+		config.defaultAssociatedObjectId,
+		options.settings?.defaultAssociatedObjectId
+	]);
+	if (!objectId) {
+		throw new Error(
+			'hubspot-connector: a CRM record id is required for an outbound note ' +
+				'(targetConfig.associatedObjectId or settings.defaultAssociatedObjectId)'
+		);
+	}
+	const objectType =
+		firstString([config.associatedObjectType, config.defaultObjectType, options.settings?.defaultObjectType]) ??
+		'contacts';
+	return { objectType, objectId };
+}
+
+/** Best-effort human title for a record, per object type. */
+export function recordTitle(objectType: string, properties: Record<string, unknown> | undefined): string | undefined {
+	const props = properties ?? {};
+	const str = (key: string): string | undefined => {
+		const value = props[key];
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+	};
+	if (objectType === 'contacts') {
+		const name = [str('firstname'), str('lastname')].filter(Boolean).join(' ').trim();
+		return name.length > 0 ? name : str('email');
+	}
+	if (objectType === 'companies') return str('name') ?? str('domain');
+	if (objectType === 'deals') return str('dealname');
+	return str('name');
+}
+
+/**
+ * HubSpot CRM connector — first-party native connector.
+ *
+ * Outbound: `send` appends a Note engagement to a CRM record and
+ * `createRecord` writes a contact / company / deal (or a custom
+ * object) through the official `@hubspot/api-client` (private-app
+ * token auth; the SDK pins the API host, so there is no SSRF surface).
+ *
+ * Event source: `pullEvents` sweeps each configured CRM object type in
+ * turn via the Search API, filtered server-side on the type's
+ * last-modified property, normalized into `IngestedEventEnvelope`s
+ * (`hubspot.contact` / `.company` / `.deal` / `.record`) for the
+ * platform's event-ingest spine. When a `portalId` is configured every
+ * envelope carries a record deep link as `sourceUrl`. The opt-in
+ * historical backfill (`backfillDays`, default 0 = off, max 90) widens
+ * the FIRST pull's window only, with a per-phase page bound so
+ * activation never becomes an unbounded crawl. Re-delivery across
+ * overlapping windows is fine — the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ *
+ * Unconfigured is always LOUD: `verifyConnection` reports the missing
+ * token, `send`/`createRecord` throw, and `pullEvents` throws
+ * `EventSourceNotConfiguredError`. Nothing silently no-ops.
+ */
+export class HubSpotConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'hubspot-connector';
+	readonly name = 'HubSpot Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_HUBSPOT,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'hubspot';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'outbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: true,
+			outboundRecord: true,
+			inbound: false,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['accessToken'],
+		properties: {
+			accessToken: {
+				type: 'string',
+				title: 'HubSpot private-app access token (pat-…)',
+				'x-secret': true,
+				'x-envVar': 'HUBSPOT_ACCESS_TOKEN'
+			},
+			objectTypes: {
+				type: 'string',
+				title: 'CRM object types to ingest (comma-separated; contacts, companies, deals when empty)',
+				default: 'contacts,companies,deals'
+			},
+			portalId: {
+				type: 'string',
+				title: 'HubSpot portal (hub) id — enables deep links back to each record'
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			},
+			defaultObjectType: {
+				type: 'string',
+				title: 'Default CRM object type for record writes',
+				default: 'contacts'
+			},
+			defaultAssociatedObjectId: {
+				type: 'string',
+				title: 'Default CRM record id outbound notes are attached to'
+			}
+		}
+	};
+
+	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+	private readonly recordIdempotencyCache = new Map<string, ConnectorRecordResult>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; a Client is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.idempotencyCache.clear();
+		this.recordIdempotencyCache.clear();
+	}
+
+	/** Testable seam — specs stub this; production uses the real SDK. */
+	protected createClient(accessToken: string): HubSpotClientLike {
+		return new Client({ accessToken }) as unknown as HubSpotClientLike;
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const accessToken = resolveAccessToken(config, options);
+		if (!accessToken) {
+			return { valid: false, message: 'accessToken is required' };
+		}
+		// Probe the FIRST configured object type rather than hardcoding
+		// contacts: a private app scoped only to deals must still verify.
+		const objectTypes = resolveObjectTypes(options.settings as PluginSettings | undefined);
+		const probeType = objectTypes[0];
+		try {
+			const page = await this.createClient(accessToken).crm.objects.basicApi.getPage(probeType, 1);
+			return {
+				valid: true,
+				details: {
+					probedObjectType: probeType,
+					objectTypes: objectTypes.join(','),
+					sampled: (page?.results ?? []).length
+				}
+			};
+		} catch (err) {
+			return {
+				valid: false,
+				message: `HubSpot ${probeType} read failed: ${hubspotErrorMessage(err)}`
+			};
+		}
+	}
+
+	/** Outbound leg — append a Note engagement to a CRM record. */
+	async send(payload: ChannelSendInput, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const config = payload.target ?? options.target ?? {};
+		const accessToken = resolveAccessToken(config, options);
+		if (!accessToken) {
+			throw new Error(
+				'hubspot-connector: an access token is required (targetConfig.accessToken or settings.accessToken)'
+			);
+		}
+		const { objectType, objectId } = resolveNoteTarget(config, options);
+		const associationTypeId = objectMeta(objectType).noteAssociationTypeId;
+		if (associationTypeId === undefined) {
+			throw new Error(
+				`hubspot-connector: outbound notes are not supported for object type '${objectType}' — ` +
+					`use one of ${Object.keys(HUBSPOT_OBJECT_META).join(', ')}`
+			);
+		}
+
+		// Idempotency: scope the key to connectorId + object + messageRef with a
+		// NUL separator so components can't collide across tenants (mirrors the
+		// slack-connector hardening — this plugin is a module-level singleton).
+		const cacheKey = `${options.connectorId ?? ''}\0${objectType}\0${objectId}\0${payload.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let noteId: string | undefined;
+		try {
+			const res = await this.createClient(accessToken).crm.objects.basicApi.create('notes', {
+				properties: {
+					hs_note_body: payload.text,
+					hs_timestamp: new Date().toISOString()
+				},
+				associations: [
+					{
+						to: { id: objectId },
+						types: [{ associationCategory: 'HUBSPOT_DEFINED', associationTypeId }]
+					}
+				]
+			});
+			noteId = typeof res?.id === 'string' ? res.id : undefined;
+		} catch (err) {
+			throw new Error(`HubSpot note create failed: ${hubspotErrorMessage(err)}`);
+		}
+
+		const result: ChannelSendResult = {
+			provider: this.id,
+			providerMessageId: noteId ?? `hubspot-${payload.messageRef}`,
+			deliveredAt: new Date()
+		};
+		this.rememberSend(cacheKey, result);
+		return result;
+	}
+
+	/** Outbound record leg — create a CRM record of any object type. */
+	async createRecord(record: ConnectorRecordInput, options: ConnectorCallOptions): Promise<ConnectorRecordResult> {
+		const config = options.target ?? {};
+		const accessToken = resolveAccessToken(config, options);
+		if (!accessToken) {
+			throw new Error(
+				'hubspot-connector: an access token is required (targetConfig.accessToken or settings.accessToken)'
+			);
+		}
+		const objectType =
+			firstString([record.collection, config.defaultObjectType, options.settings?.defaultObjectType]) ??
+			'contacts';
+
+		const cacheKey = `${options.connectorId ?? ''}\0${objectType}\0${record.idempotencyKey}`;
+		const cached = this.recordIdempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let recordId: string | undefined;
+		try {
+			const res = await this.createClient(accessToken).crm.objects.basicApi.create(objectType, {
+				properties: record.fields
+			});
+			recordId = typeof res?.id === 'string' ? res.id : undefined;
+		} catch (err) {
+			throw new Error(`HubSpot ${objectType} create failed: ${hubspotErrorMessage(err)}`);
+		}
+		if (!recordId) {
+			throw new Error(`HubSpot ${objectType} create returned no record id`);
+		}
+
+		const result: ConnectorRecordResult = { provider: this.id, recordId };
+		this.recordIdempotencyCache.set(cacheKey, result);
+		if (this.recordIdempotencyCache.size > 500) {
+			const firstKey = this.recordIdempotencyCache.keys().next().value;
+			if (firstKey) this.recordIdempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	private rememberSend(cacheKey: string, result: ChannelSendResult): void {
+		this.idempotencyCache.set(cacheKey, result);
+		if (this.idempotencyCache.size > 500) {
+			const firstKey = this.idempotencyCache.keys().next().value;
+			if (firstKey) this.idempotencyCache.delete(firstKey);
+		}
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one search page of the current object-type phase since the
+	 * effective watermark, normalized to envelopes. The returned cursor
+	 * resumes the same phase (HubSpot `after` token) or advances to the
+	 * next configured object type; no cursor means the sweep is done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const accessToken = input.settings?.accessToken;
+		if (typeof accessToken !== 'string' || accessToken.length === 0) {
+			throw new EventSourceNotConfiguredError(
+				'hubspot-connector: settings.accessToken is required to pull events'
+			);
+		}
+
+		const objectTypes = resolveObjectTypes(input.settings);
+		const cursor = parsePullCursor(input.cursor);
+		let objectType: string;
+		let after: string | undefined;
+		let since: string;
+		let backfill: boolean;
+		let pagesUsed: number;
+
+		if (cursor) {
+			objectType = cursor.t;
+			after = cursor.n;
+			since = cursor.s;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			if (firstPull) {
+				const start = backfillDays > 0 ? Date.now() - backfillDays * 86400_000 : Date.now();
+				since = new Date(start).toISOString();
+				backfill = backfillDays > 0;
+			} else {
+				since = new Date(sinceMs).toISOString();
+				backfill = false;
+			}
+			objectType = objectTypes[0];
+			after = undefined;
+			pagesUsed = 0;
+		}
+
+		// A type dropped from settings mid-sweep restarts at the first one.
+		let typeIndex = objectTypes.indexOf(objectType);
+		if (typeIndex === -1) {
+			typeIndex = 0;
+			objectType = objectTypes[0];
+			after = undefined;
+			pagesUsed = 0;
+		}
+
+		const meta = objectMeta(objectType);
+		const portalId = typeof input.settings?.portalId === 'string' ? input.settings.portalId : undefined;
+		const client = this.createClient(accessToken);
+
+		const page = await client.crm.objects.searchApi.doSearch(objectType, {
+			filterGroups: [
+				{
+					filters: [
+						{
+							propertyName: meta.lastModifiedProperty,
+							operator: 'GTE',
+							value: String(Date.parse(since))
+						}
+					]
+				}
+			],
+			// No `sorts`: the SDK types it as `string[]` while the API expects
+			// sort objects, and ordering is not load-bearing here — the
+			// server-side filter guarantees every matching record is visited
+			// across the `after` pages, and the ingest pipeline dedupes on
+			// `(source, sourceEventId)`.
+			properties: [...meta.properties],
+			limit: HUBSPOT_PULL_PAGE_SIZE,
+			...(after ? { after } : {})
+		});
+
+		const events: IngestedEventEnvelope[] = [];
+		for (const record of page.results ?? []) {
+			const envelope = this.normalizeRecord(record, objectType, since, portalId);
+			if (envelope) events.push(envelope);
+		}
+
+		const nextAfter = page.paging?.next?.after;
+		pagesUsed += 1;
+		const pageBudgetExhausted = backfill && pagesUsed >= HUBSPOT_BACKFILL_MAX_PAGES;
+
+		let next: HubSpotPullCursor | undefined;
+		if (nextAfter && !pageBudgetExhausted) {
+			next = { t: objectType, n: nextAfter, s: since, ...(backfill ? { f: 1 as const } : {}), b: pagesUsed };
+		} else if (typeIndex + 1 < objectTypes.length) {
+			// Advance to the next object type (page counter resets per phase).
+			next = { t: objectTypes[typeIndex + 1], s: since, ...(backfill ? { f: 1 as const } : {}), b: 0 };
+		}
+
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	private normalizeRecord(
+		record: HubSpotRecord,
+		objectType: string,
+		since: string,
+		portalId: string | undefined
+	): IngestedEventEnvelope | null {
+		if (!record.id) return null;
+		const meta = objectMeta(objectType);
+		const properties = record.properties ?? {};
+		const updatedAt = toIso(record.updatedAt ?? properties[meta.lastModifiedProperty] ?? record.createdAt);
+		const createdAt = toIso(record.createdAt ?? properties.createdate);
+		const changeType = Date.parse(createdAt) >= Date.parse(since) ? 'created' : 'updated';
+		const title = recordTitle(objectType, properties);
+		const sourceUrl =
+			portalId && meta.objectTypeId
+				? `https://app.hubspot.com/contacts/${encodeURIComponent(portalId)}/record/${meta.objectTypeId}/${encodeURIComponent(record.id)}`
+				: undefined;
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${objectType}:${record.id}:${updatedAt}`,
+			kind: meta.kind,
+			occurredAt: updatedAt,
+			subject: {
+				type: 'crm-record',
+				externalId: record.id,
+				...(title ? { title } : {})
+			},
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				objectType,
+				recordId: record.id,
+				changeType,
+				createdAt,
+				updatedAt,
+				...(record.archived === true ? { archived: true } : {}),
+				properties: this.sanitizeProperties(properties, meta)
+			}
+		};
+	}
+
+	/**
+	 * Payload properties are limited to the whitelist the sweep asked
+	 * for and each string value is capped, so a CRM record with a
+	 * huge free-text field can never blow the envelope byte budget.
+	 */
+	private sanitizeProperties(properties: Record<string, unknown>, meta: HubSpotObjectMeta): Record<string, unknown> {
+		const out: Record<string, unknown> = {};
+		for (const key of meta.properties) {
+			const value = properties[key];
+			if (value === undefined || value === null) continue;
+			out[key] = typeof value === 'string' ? truncateText(value) : value;
+		}
+		return out;
+	}
+}
+
+export const hubspotConnectorPlugin = new HubSpotConnectorPlugin();

--- a/packages/plugins/hubspot-connector/src/index.ts
+++ b/packages/plugins/hubspot-connector/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @ever-works/hubspot-connector-plugin — HubSpot CRM connector.
+ * Outbound notes + CRM record writes via the official
+ * `@hubspot/api-client`; `pullEvents` event-source leg (contacts,
+ * companies, deals since the watermark, opt-in historical backfill)
+ * feeding the platform event-ingest spine.
+ */
+export {
+	HubSpotConnectorPlugin,
+	hubspotConnectorPlugin,
+	clampBackfillDays,
+	objectMeta,
+	recordTitle,
+	resolveNoteTarget,
+	resolveObjectTypes,
+	HUBSPOT_EVENT_TEXT_MAX_CHARS,
+	HUBSPOT_PULL_PAGE_SIZE,
+	HUBSPOT_BACKFILL_MAX_PAGES,
+	HUBSPOT_DEFAULT_OBJECT_TYPES,
+	HUBSPOT_OBJECT_META
+} from './hubspot-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { HubSpotConnectorPlugin as default } from './hubspot-connector-plugin.js';

--- a/packages/plugins/hubspot-connector/tsconfig.json
+++ b/packages/plugins/hubspot-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/hubspot-connector/tsup.config.ts
+++ b/packages/plugins/hubspot-connector/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/hubspot-connector/vitest.config.ts
+++ b/packages/plugins/hubspot-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/mastodon-connector/README.md
+++ b/packages/plugins/mastodon-connector/README.md
@@ -1,0 +1,48 @@
+# @ever-works/mastodon-connector-plugin
+
+First-party **Mastodon social connector** for the Ever Works platform, built on
+the [`masto`](https://www.npmjs.com/package/masto) SDK (Mastodon ships no
+first-party JavaScript SDK; `masto` is the established client — the connector
+never hand-rolls REST calls).
+
+Capabilities: `connector`, `connector-mastodon`, `event-source`.
+
+## What it does
+
+- **Outbound** — `send()` publishes a status at the configured visibility, or a
+  threaded reply when the target config carries `inReplyToId`. Idempotent on
+  `messageRef`.
+- **Event source** — `pullEvents()` sweeps notifications (mentions, favourites,
+  boosts, follows) and then the connected account's own statuses, normalized
+  into `IngestedEventEnvelope`s (`mastodon.notification` / `mastodon.status`)
+  for the event-ingest spine. Status HTML is flattened to plain text; the
+  status permalink rides along as `sourceUrl`. Mastodon paginates by id, so
+  each phase walks `max_id` newest-first and stops at the first item older than
+  the watermark.
+- **Opt-in historical backfill** — `backfillDays` (default `0` = off, max 90)
+  widens the FIRST pull's window only, bounded to
+  `MASTODON_BACKFILL_MAX_PAGES` pages per phase.
+
+## Degradation is loud, never silent
+
+- `verifyConnection()` reports missing credentials, an SSRF-unsafe instance URL,
+  and failed credential verification.
+- `send()` throws on missing credentials or a failed status create.
+- `pullEvents()` throws `EventSourceNotConfiguredError` when the instance URL or
+  access token is absent, or when the token resolves to no account.
+
+## Settings
+
+| Key                 | Notes                                                     |
+| ------------------- | --------------------------------------------------------- |
+| `instanceUrl`       | Instance base URL — SSRF-guarded before every call.       |
+| `accessToken`       | Application token — secret, env `MASTODON_ACCESS_TOKEN`.  |
+| `defaultVisibility` | `public` \| `unlisted` \| `private` \| `direct`.          |
+| `backfillDays`      | Opt-in first-pull history window (0 = off, max 90).       |
+
+No credential is hardcoded, logged, or written into an ingested envelope.
+
+## Testing
+
+Hermetic Vitest suite (`pnpm test`) — the SDK client is stubbed through the
+`createClient` seam; no network calls.

--- a/packages/plugins/mastodon-connector/package.json
+++ b/packages/plugins/mastodon-connector/package.json
@@ -1,0 +1,104 @@
+{
+	"name": "@ever-works/mastodon-connector-plugin",
+	"version": "1.0.0",
+	"description": "Mastodon social connector plugin for Ever Works platform (outbound statuses via the masto SDK, and event-source pull of mentions/notifications plus the account's own statuses into the event-ingest pipeline, with opt-in historical backfill)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*",
+		"masto": "^7.12.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "mastodon-connector",
+			"name": "Mastodon Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"connector-mastodon",
+				"event-source"
+			],
+			"description": "Mastodon social connector. Outbound publishes statuses and threaded replies via the masto SDK against the operator's own instance (SSRF-guarded instance URL). Event-source pull ingests mention notifications and the connected account's own statuses since the last watermark into the platform event-ingest pipeline, with opt-in historical backfill (backfillDays, max 90).",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"instanceUrl",
+					"accessToken"
+				],
+				"properties": {
+					"instanceUrl": {
+						"type": "string",
+						"title": "Mastodon instance URL (e.g. https://mastodon.social)"
+					},
+					"accessToken": {
+						"type": "string",
+						"title": "Mastodon application access token",
+						"x-secret": true,
+						"x-envVar": "MASTODON_ACCESS_TOKEN"
+					},
+					"defaultVisibility": {
+						"type": "string",
+						"title": "Visibility applied to outbound statuses",
+						"default": "public",
+						"enum": [
+							"public",
+							"unlisted",
+							"private",
+							"direct"
+						]
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/mastodon-connector/src/index.ts
+++ b/packages/plugins/mastodon-connector/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @ever-works/mastodon-connector-plugin — Mastodon social connector.
+ * Outbound statuses/threaded replies via the `masto` SDK against the
+ * operator's own instance (SSRF-guarded URL); `pullEvents` event-source
+ * leg (notifications then the account's own statuses since the
+ * watermark, opt-in historical backfill) feeding the platform
+ * event-ingest spine.
+ */
+export {
+	MastodonConnectorPlugin,
+	mastodonConnectorPlugin,
+	clampBackfillDays,
+	resolveCredentials,
+	resolveVisibility,
+	stripStatusHtml,
+	MASTODON_EVENT_TEXT_MAX_CHARS,
+	MASTODON_PULL_PAGE_SIZE,
+	MASTODON_BACKFILL_MAX_PAGES,
+	MASTODON_VISIBILITIES
+} from './mastodon-connector-plugin.js';
+export type { MastodonVisibility } from './mastodon-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { MastodonConnectorPlugin as default } from './mastodon-connector-plugin.js';

--- a/packages/plugins/mastodon-connector/src/mastodon-connector-plugin.spec.ts
+++ b/packages/plugins/mastodon-connector/src/mastodon-connector-plugin.spec.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	MastodonConnectorPlugin,
+	clampBackfillDays,
+	resolveCredentials,
+	resolveVisibility,
+	stripStatusHtml,
+	MASTODON_EVENT_TEXT_MAX_CHARS,
+	MASTODON_PULL_PAGE_SIZE,
+	MASTODON_BACKFILL_MAX_PAGES
+} from './mastodon-connector-plugin.js';
+
+const verifyCredentialsMock = vi.fn();
+const statusesCreateMock = vi.fn();
+const notificationsListMock = vi.fn();
+const accountStatusesListMock = vi.fn();
+const selectMock = vi.fn();
+const clientFactoryMock = vi.fn();
+
+/** Subclass overriding the client seam so no real SDK call ever happens. */
+class TestMastodonConnectorPlugin extends MastodonConnectorPlugin {
+	protected override createClient(instanceUrl: string, accessToken: string) {
+		clientFactoryMock(instanceUrl, accessToken);
+		return {
+			v1: {
+				accounts: {
+					verifyCredentials: verifyCredentialsMock,
+					$select: (id: string) => {
+						selectMock(id);
+						return { statuses: { list: accountStatusesListMock } };
+					}
+				},
+				statuses: { create: statusesCreateMock },
+				notifications: { list: notificationsListMock }
+			}
+		};
+	}
+}
+
+const SETTINGS = { instanceUrl: 'https://mastodon.social', accessToken: 'mast-secret-token' };
+
+describe('MastodonConnectorPlugin', () => {
+	let plugin: TestMastodonConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestMastodonConnectorPlugin();
+		verifyCredentialsMock.mockReset();
+		statusesCreateMock.mockReset();
+		notificationsListMock.mockReset();
+		accountStatusesListMock.mockReset();
+		selectMock.mockReset();
+		clientFactoryMock.mockReset();
+		verifyCredentialsMock.mockResolvedValue({ id: 'acct-1', acct: 'acme', displayName: 'Acme' });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('declares the connector + connector-mastodon + event-source capabilities and poll metadata', () => {
+		expect(plugin.id).toBe('mastodon-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toContain('connector');
+		expect(plugin.capabilities).toContain('connector-mastodon');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('mastodon');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.outboundMessage).toBe(true);
+		expect(plugin.connector.flags.inbound).toBe(false);
+	});
+
+	it('marks accessToken as x-secret and bounds backfillDays to 0–90 in the settings schema', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.accessToken['x-secret']).toBe(true);
+		expect(props.accessToken['x-envVar']).toBe('MASTODON_ACCESS_TOKEN');
+		expect(props.instanceUrl['x-secret']).toBeUndefined();
+		expect(plugin.settingsSchema.required).toEqual(expect.arrayContaining(['instanceUrl', 'accessToken']));
+		expect(props.backfillDays.maximum).toBe(90);
+		expect(props.defaultVisibility.enum).toEqual(['public', 'unlisted', 'private', 'direct']);
+	});
+
+	it('clampBackfillDays clamps to the 0–90 range and treats garbage as off', () => {
+		expect(clampBackfillDays(0)).toBe(0);
+		expect(clampBackfillDays(45)).toBe(45);
+		expect(clampBackfillDays(500)).toBe(90);
+		expect(clampBackfillDays('nope')).toBe(0);
+	});
+
+	it('resolveVisibility accepts the documented values and falls back to public', () => {
+		expect(resolveVisibility('unlisted')).toBe('unlisted');
+		expect(resolveVisibility('DIRECT')).toBe('direct');
+		expect(resolveVisibility('nonsense')).toBe('public');
+		expect(resolveVisibility(undefined)).toBe('public');
+	});
+
+	it('stripStatusHtml turns status HTML into plain text', () => {
+		expect(stripStatusHtml('<p>hello <a href="#">world</a></p>')).toBe('hello world');
+		expect(stripStatusHtml('<p>one</p><p>two</p>')).toBe('one\n\ntwo');
+		expect(stripStatusHtml('a<br>b')).toBe('a\nb');
+		expect(stripStatusHtml('&lt;script&gt; &amp; &quot;q&quot;')).toBe('<script> & "q"');
+		expect(stripStatusHtml('<p></p>')).toBeUndefined();
+		expect(stripStatusHtml(undefined)).toBeUndefined();
+	});
+
+	it('resolveCredentials requires BOTH instanceUrl and accessToken', () => {
+		expect(resolveCredentials({}, { settings: SETTINGS })).toEqual(SETTINGS);
+		expect(resolveCredentials({}, { settings: { instanceUrl: 'https://x.dev' } })).toBeUndefined();
+		expect(resolveCredentials({}, { settings: { accessToken: 't' } })).toBeUndefined();
+	});
+
+	describe('verifyConnection', () => {
+		it('returns the verified account details', async () => {
+			const res = await plugin.verifyConnection({}, { settings: SETTINGS });
+			expect(res.valid).toBe(true);
+			expect(res.details).toMatchObject({ accountId: 'acct-1', acct: 'acme' });
+			expect(clientFactoryMock).toHaveBeenCalledWith(SETTINGS.instanceUrl, SETTINGS.accessToken);
+		});
+
+		it('degrades loudly (never silently) when credentials are missing', async () => {
+			const res = await plugin.verifyConnection({}, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/instanceUrl and accessToken/);
+			expect(clientFactoryMock).not.toHaveBeenCalled();
+		});
+
+		it('refuses an SSRF-unsafe instance URL instead of calling it', async () => {
+			const res = await plugin.verifyConnection(
+				{},
+				{ settings: { ...SETTINGS, instanceUrl: 'http://127.0.0.1:8080' } }
+			);
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/unsafe instance URL/);
+			expect(clientFactoryMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('send', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('publishes a status with the configured visibility', async () => {
+			statusesCreateMock.mockResolvedValueOnce({ id: 'status-9' });
+			const res = await plugin.send(
+				{ text: 'we shipped', messageRef: 'ref-1', attribution: { userId: 'u1' } },
+				{ ...options, settings: { ...SETTINGS, defaultVisibility: 'unlisted' } }
+			);
+			expect(statusesCreateMock).toHaveBeenCalledWith({ status: 'we shipped', visibility: 'unlisted' });
+			expect(res.providerMessageId).toBe('status-9');
+			expect(res.provider).toBe('mastodon-connector');
+		});
+
+		it('threads a reply when the target carries inReplyToId', async () => {
+			statusesCreateMock.mockResolvedValueOnce({ id: 'status-10' });
+			await plugin.send(
+				{
+					text: 'thanks!',
+					messageRef: 'ref-2',
+					attribution: { userId: 'u1' },
+					target: { inReplyToId: 'status-1' }
+				},
+				options
+			);
+			expect(statusesCreateMock.mock.calls[0][0].inReplyToId).toBe('status-1');
+		});
+
+		it('is idempotent on messageRef — a retry never double-posts', async () => {
+			statusesCreateMock.mockResolvedValue({ id: 'status-1' });
+			const payload = { text: 'once only', messageRef: 'ref-dup', attribution: { userId: 'u1' } };
+			const first = await plugin.send(payload, options);
+			const second = await plugin.send(payload, options);
+			expect(statusesCreateMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws when credentials are missing instead of silently no-oping', async () => {
+			await expect(
+				plugin.send({ text: 'x', messageRef: 'r', attribution: { userId: 'u1' } }, { connectorId: 'c' })
+			).rejects.toThrow(/instanceUrl and accessToken are required/);
+			expect(statusesCreateMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('pullEvents', () => {
+		it('throws EventSourceNotConfiguredError when the instance URL is missing', async () => {
+			await expect(
+				plugin.pullEvents({ since: new Date(0).toISOString(), settings: { accessToken: 't' } })
+			).rejects.toMatchObject({ name: 'EventSourceNotConfiguredError' });
+			expect(notificationsListMock).not.toHaveBeenCalled();
+		});
+
+		it('throws EventSourceNotConfiguredError when the access token is missing', async () => {
+			await expect(
+				plugin.pullEvents({ since: new Date(0).toISOString(), settings: { instanceUrl: 'https://x.dev' } })
+			).rejects.toMatchObject({ name: 'EventSourceNotConfiguredError' });
+		});
+
+		it('first pull with backfill off uses a now-anchored window (no history)', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			notificationsListMock.mockResolvedValueOnce([
+				{ id: 'n1', type: 'mention', createdAt: '2026-07-25T11:00:00.000Z' }
+			]);
+			const res = await plugin.pullEvents({ since: new Date(0).toISOString(), settings: SETTINGS });
+			expect(res.events).toEqual([]);
+			expect(JSON.parse(res.nextCursor as string).s).toBe('2026-07-25T12:00:00.000Z');
+		});
+
+		it('first pull with backfillDays widens the window, clamped to 90 days', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			notificationsListMock.mockResolvedValue([]);
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 500 }
+			});
+			expect(JSON.parse(res.nextCursor as string).s).toBe('2026-04-26T12:00:00.000Z');
+		});
+
+		it('normalizes notifications into mastodon.notification envelopes with capped text', async () => {
+			notificationsListMock.mockResolvedValueOnce([
+				{
+					id: 'n-1',
+					type: 'mention',
+					createdAt: '2026-07-22T10:00:00.000Z',
+					account: { id: 'a-2', acct: 'fan@example.social', displayName: 'Fan', url: 'https://x/@fan' },
+					status: {
+						id: 's-1',
+						url: 'https://mastodon.social/@fan/1',
+						content: `<p>${'m'.repeat(MASTODON_EVENT_TEXT_MAX_CHARS + 40)}</p>`
+					}
+				}
+			]);
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.source).toBe('mastodon-connector');
+			expect(env.kind).toBe('mastodon.notification');
+			expect(env.sourceEventId).toBe('notification:n-1');
+			expect(env.actor).toEqual({ name: 'Fan', externalId: 'a-2' });
+			expect(env.subject).toMatchObject({ type: 'status', externalId: 's-1' });
+			expect(env.sourceUrl).toBe('https://mastodon.social/@fan/1');
+			expect((env.payload.text as string).length).toBe(MASTODON_EVENT_TEXT_MAX_CHARS);
+			// The access token must never leak into the envelope.
+			expect(JSON.stringify(res.events)).not.toContain(SETTINGS.accessToken);
+		});
+
+		it('stops the page at the first item older than the window', async () => {
+			notificationsListMock.mockResolvedValueOnce([
+				{ id: 'n-new', type: 'favourite', createdAt: '2026-07-22T10:00:00.000Z' },
+				{ id: 'n-old', type: 'favourite', createdAt: '2026-07-01T10:00:00.000Z' }
+			]);
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toHaveLength(1);
+			expect(JSON.parse(res.nextCursor as string).p).toBe('statuses');
+		});
+
+		it('pages by max_id while the page is full and keeps the SAME window', async () => {
+			const fullPage = Array.from({ length: MASTODON_PULL_PAGE_SIZE }, (_, i) => ({
+				id: `n-${i}`,
+				type: 'mention',
+				createdAt: '2026-07-22T10:00:00.000Z'
+			}));
+			notificationsListMock.mockResolvedValueOnce(fullPage);
+			const first = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed).toMatchObject({
+				p: 'notifications',
+				n: `n-${MASTODON_PULL_PAGE_SIZE - 1}`,
+				s: '2026-07-20T00:00:00.000Z'
+			});
+
+			notificationsListMock.mockResolvedValueOnce([]);
+			await plugin.pullEvents({
+				since: '2026-07-24T00:00:00.000Z', // a moved watermark must NOT shift the running sweep
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			expect(notificationsListMock.mock.calls[1][0].maxId).toBe(`n-${MASTODON_PULL_PAGE_SIZE - 1}`);
+		});
+
+		it('advances notifications → own statuses → done across the sweep', async () => {
+			notificationsListMock.mockResolvedValueOnce([]);
+			const afterNotifications = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: SETTINGS
+			});
+			expect(JSON.parse(afterNotifications.nextCursor as string).p).toBe('statuses');
+
+			accountStatusesListMock.mockResolvedValueOnce([]);
+			const afterStatuses = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterNotifications.nextCursor,
+				settings: SETTINGS
+			});
+			expect(selectMock).toHaveBeenCalledWith('acct-1');
+			expect(afterStatuses.nextCursor).toBeUndefined();
+		});
+
+		it('normalizes own statuses into mastodon.status envelopes with engagement counts', async () => {
+			accountStatusesListMock.mockResolvedValueOnce([
+				{
+					id: 's-9',
+					uri: 'https://mastodon.social/users/acme/statuses/9',
+					url: 'https://mastodon.social/@acme/9',
+					content: '<p>release notes</p>',
+					createdAt: '2026-07-22T09:00:00.000Z',
+					visibility: 'public',
+					repliesCount: 1,
+					reblogsCount: 4,
+					favouritesCount: 9,
+					account: { id: 'acct-1', acct: 'acme' }
+				}
+			]);
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: JSON.stringify({ p: 'statuses', s: '2026-07-20T00:00:00.000Z', b: 0 }),
+				settings: SETTINGS
+			});
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.kind).toBe('mastodon.status');
+			expect(env.sourceEventId).toBe('status:s-9');
+			expect(env.sourceUrl).toBe('https://mastodon.social/@acme/9');
+			expect(env.payload).toMatchObject({ repliesCount: 1, reblogsCount: 4, favouritesCount: 9 });
+			expect(env.payload.text).toBe('release notes');
+		});
+
+		it('throws loudly when the token resolves to no account in the statuses phase', async () => {
+			verifyCredentialsMock.mockResolvedValueOnce({});
+			await expect(
+				plugin.pullEvents({
+					since: '2026-07-20T00:00:00.000Z',
+					cursor: JSON.stringify({ p: 'statuses', s: '2026-07-20T00:00:00.000Z', b: 0 }),
+					settings: SETTINGS
+				})
+			).rejects.toMatchObject({ name: 'EventSourceNotConfiguredError' });
+		});
+
+		it('bounds backfill sweeps to the per-phase page budget', async () => {
+			const fullPage = Array.from({ length: MASTODON_PULL_PAGE_SIZE }, (_, i) => ({
+				id: `n-${i}`,
+				type: 'mention',
+				createdAt: '2026-06-01T10:00:00.000Z'
+			}));
+			notificationsListMock.mockResolvedValueOnce(fullPage);
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				cursor: JSON.stringify({
+					p: 'notifications',
+					n: 'n-prev',
+					s: '2026-05-01T00:00:00.000Z',
+					f: 1,
+					b: MASTODON_BACKFILL_MAX_PAGES - 1
+				}),
+				settings: { ...SETTINGS, backfillDays: 90 }
+			});
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed.p).toBe('statuses');
+			expect(parsed.n).toBeUndefined();
+			expect(parsed.b).toBe(0);
+		});
+
+		it('treats a malformed cursor as a fresh sweep instead of crashing', async () => {
+			notificationsListMock.mockResolvedValueOnce([]);
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: 'not-json{{{',
+				settings: SETTINGS
+			});
+			expect(notificationsListMock).toHaveBeenCalledTimes(1);
+			expect(res.events).toEqual([]);
+		});
+	});
+});

--- a/packages/plugins/mastodon-connector/src/mastodon-connector-plugin.ts
+++ b/packages/plugins/mastodon-connector/src/mastodon-connector-plugin.ts
@@ -1,0 +1,583 @@
+import { randomUUID } from 'node:crypto';
+import { createRestAPIClient } from 'masto';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import { isSafeWebhookUrl } from '@ever-works/plugin/helpers/ssrf-guard';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); a status body never
+ * needs more than this to be useful in Memory/Activities.
+ */
+export const MASTODON_EVENT_TEXT_MAX_CHARS = 4000;
+
+/** Items requested per Mastodon page (notifications and statuses alike). */
+export const MASTODON_PULL_PAGE_SIZE = 40;
+
+/**
+ * Historical backfill bound: at most this many pages per phase
+ * (notifications, then the account's own statuses) during the opt-in
+ * first-pull backfill, so a busy account can never turn activation
+ * into an unbounded crawl.
+ */
+export const MASTODON_BACKFILL_MAX_PAGES = 10;
+
+/** Visibilities Mastodon accepts for an outbound status. */
+export const MASTODON_VISIBILITIES = ['public', 'unlisted', 'private', 'direct'] as const;
+export type MastodonVisibility = (typeof MASTODON_VISIBILITIES)[number];
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+function truncateText(text: string): string {
+	return text.length > MASTODON_EVENT_TEXT_MAX_CHARS ? text.slice(0, MASTODON_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/**
+ * Mastodon status bodies are HTML. Envelopes carry plain text (Memory
+ * observations and Activity rows are text surfaces), so block-level
+ * markup becomes newlines, remaining tags are dropped and the handful
+ * of entities Mastodon actually emits are decoded.
+ */
+export function stripStatusHtml(html: string | undefined): string | undefined {
+	if (typeof html !== 'string' || html.length === 0) return undefined;
+	const text = html
+		.replace(/<br\s*\/?>/gi, '\n')
+		.replace(/<\/p>/gi, '\n\n')
+		.replace(/<[^>]+>/g, '')
+		.replace(/&nbsp;/g, ' ')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&amp;/g, '&')
+		.trim();
+	return text.length > 0 ? text : undefined;
+}
+
+/** Normalize the configured visibility, defaulting to `public`. */
+export function resolveVisibility(value: unknown): MastodonVisibility {
+	if (typeof value === 'string') {
+		const candidate = value.trim().toLowerCase();
+		if ((MASTODON_VISIBILITIES as readonly string[]).includes(candidate)) {
+			return candidate as MastodonVisibility;
+		}
+	}
+	return 'public';
+}
+
+/** Extract a readable message from a `masto` error. */
+function mastodonErrorMessage(err: unknown): string {
+	const e = err as { message?: string; error?: string; statusCode?: number };
+	return e.message ?? e.error ?? (typeof e.statusCode === 'number' ? `HTTP ${e.statusCode}` : 'unknown error');
+}
+
+/** ISO string | Date | undefined → ISO 8601 (epoch on garbage). */
+function toIso(value: unknown): string {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === 'string') {
+		const ms = Date.parse(value);
+		if (Number.isFinite(ms)) return new Date(ms).toISOString();
+	}
+	return new Date(0).toISOString();
+}
+
+/**
+ * Opaque pull cursor. `p` is the sweep phase (notifications → the
+ * account's own statuses), `n` the Mastodon `max_id` page cursor, `s`
+ * the effective since-watermark the sweep was started with (later
+ * pages of the same sweep keep the SAME window), `f` flags a first-pull
+ * backfill sweep and `b` counts pages used in the current phase
+ * (backfill page bound). Malformed input restarts the sweep — safe, the
+ * ingest pipeline dedupes on `(source, sourceEventId)`.
+ */
+interface MastodonPullCursor {
+	p: 'notifications' | 'statuses';
+	n?: string;
+	s: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): MastodonPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as MastodonPullCursor;
+		if (parsed && (parsed.p === 'notifications' || parsed.p === 'statuses') && typeof parsed.s === 'string') {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal shape of an account we consume. */
+interface MastodonAccount {
+	id?: string;
+	username?: string;
+	acct?: string;
+	displayName?: string;
+	url?: string;
+}
+
+/** Minimal shape of a status we consume. */
+interface MastodonStatus {
+	id?: string;
+	uri?: string;
+	url?: string;
+	content?: string;
+	createdAt?: string;
+	repliesCount?: number;
+	reblogsCount?: number;
+	favouritesCount?: number;
+	visibility?: string;
+	account?: MastodonAccount;
+}
+
+/** Minimal shape of a notification we consume. */
+interface MastodonNotification {
+	id?: string;
+	type?: string;
+	createdAt?: string;
+	account?: MastodonAccount;
+	status?: MastodonStatus;
+}
+
+/** The subset of the `masto` REST surface this plugin calls. */
+interface MastodonClientLike {
+	v1: {
+		accounts: {
+			verifyCredentials(): Promise<MastodonAccount>;
+			$select(id: string): {
+				statuses: { list(params: Record<string, unknown>): Promise<MastodonStatus[]> };
+			};
+		};
+		statuses: { create(params: Record<string, unknown>): Promise<MastodonStatus> };
+		notifications: { list(params: Record<string, unknown>): Promise<MastodonNotification[]> };
+	};
+}
+
+/** First non-empty trimmed string among the candidates. */
+function firstString(candidates: unknown[]): string | undefined {
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.trim().length > 0) return c.trim();
+	}
+	return undefined;
+}
+
+/** Resolved credentials for one call. */
+interface MastodonCredentials {
+	instanceUrl: string;
+	accessToken: string;
+}
+
+/**
+ * Resolve credentials from the per-connection target config, falling
+ * back to the resolved plugin settings. Returns undefined (never a
+ * partial) so callers fail loudly with one clear message.
+ */
+export function resolveCredentials(
+	config: ChannelTargetConfig,
+	options: ConnectorCallOptions
+): MastodonCredentials | undefined {
+	const instanceUrl = firstString([config.instanceUrl, options.settings?.instanceUrl]);
+	const accessToken = firstString([config.accessToken, options.settings?.accessToken]);
+	if (!instanceUrl || !accessToken) return undefined;
+	return { instanceUrl, accessToken };
+}
+
+/**
+ * Mastodon social connector — first-party native connector.
+ *
+ * Outbound: `send` publishes a status — or a threaded reply when the
+ * target config carries `inReplyToId` — through the `masto` SDK against
+ * the operator's own instance. The instance URL is operator-supplied,
+ * so it passes the shared SSRF guard before any request is issued.
+ *
+ * Event source: `pullEvents` sweeps notifications (mentions, favourites,
+ * boosts, follows) then the connected account's own statuses since the
+ * watermark, normalized into `IngestedEventEnvelope`s
+ * (`mastodon.notification` / `mastodon.status`, the status permalink as
+ * `sourceUrl`) for the platform's event-ingest spine. Mastodon paginates
+ * by id rather than time, so each phase walks `max_id` newest-first and
+ * stops at the first item older than the watermark. The opt-in
+ * historical backfill (`backfillDays`, default 0 = off, max 90) widens
+ * the FIRST pull's window only, with a per-phase page bound.
+ * Re-delivery across overlapping windows is fine — the ingest pipeline
+ * dedupes on `(source, sourceEventId)`.
+ *
+ * Unconfigured is always LOUD: `verifyConnection` reports the missing
+ * credentials, `send` throws, and `pullEvents` throws
+ * `EventSourceNotConfiguredError`. Nothing silently no-ops.
+ */
+export class MastodonConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'mastodon-connector';
+	readonly name = 'Mastodon Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_MASTODON,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'mastodon';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'outbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: true,
+			outboundRecord: false,
+			inbound: false,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['instanceUrl', 'accessToken'],
+		properties: {
+			instanceUrl: {
+				type: 'string',
+				title: 'Mastodon instance URL (e.g. https://mastodon.social)'
+			},
+			accessToken: {
+				type: 'string',
+				title: 'Mastodon application access token',
+				'x-secret': true,
+				'x-envVar': 'MASTODON_ACCESS_TOKEN'
+			},
+			defaultVisibility: {
+				type: 'string',
+				title: 'Visibility applied to outbound statuses',
+				default: 'public',
+				enum: [...MASTODON_VISIBILITIES]
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			}
+		}
+	};
+
+	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; a client is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.idempotencyCache.clear();
+	}
+
+	/** Testable seam — specs stub this; production uses the real SDK. */
+	protected createClient(instanceUrl: string, accessToken: string): MastodonClientLike {
+		return createRestAPIClient({ url: instanceUrl, accessToken }) as unknown as MastodonClientLike;
+	}
+
+	/**
+	 * Build a client for the operator's instance. The instance URL is
+	 * user-supplied, so it passes the shared SSRF guard before any
+	 * request is issued.
+	 */
+	private connect(credentials: MastodonCredentials): MastodonClientLike {
+		if (!isSafeWebhookUrl(credentials.instanceUrl)) {
+			throw new Error(`mastodon-connector: refusing to use an unsafe instance URL '${credentials.instanceUrl}'`);
+		}
+		return this.createClient(credentials.instanceUrl, credentials.accessToken);
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const credentials = resolveCredentials(config, options);
+		if (!credentials) {
+			return { valid: false, message: 'instanceUrl and accessToken are required' };
+		}
+		try {
+			const account = await this.connect(credentials).v1.accounts.verifyCredentials();
+			return {
+				valid: true,
+				details: {
+					instanceUrl: credentials.instanceUrl,
+					...(account?.id ? { accountId: account.id } : {}),
+					...(account?.acct ? { acct: account.acct } : {}),
+					...(account?.displayName ? { displayName: account.displayName } : {})
+				}
+			};
+		} catch (err) {
+			return { valid: false, message: `Mastodon verifyCredentials failed: ${mastodonErrorMessage(err)}` };
+		}
+	}
+
+	/** Outbound leg — publish a status (or a threaded reply). */
+	async send(payload: ChannelSendInput, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const config = payload.target ?? options.target ?? {};
+		const credentials = resolveCredentials(config, options);
+		if (!credentials) {
+			throw new Error(
+				'mastodon-connector: instanceUrl and accessToken are required ' +
+					'(targetConfig.instanceUrl/accessToken or settings.instanceUrl/accessToken)'
+			);
+		}
+		const inReplyToId = firstString([config.inReplyToId]);
+		const visibility = resolveVisibility(config.visibility ?? options.settings?.defaultVisibility);
+
+		// Idempotency: scope the key to connectorId + thread + messageRef with a
+		// NUL separator so components can't collide across tenants (mirrors the
+		// slack-connector hardening — this plugin is a module-level singleton).
+		const cacheKey = `${options.connectorId ?? ''}\0${inReplyToId ?? ''}\0${payload.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let statusId: string | undefined;
+		try {
+			const status = await this.connect(credentials).v1.statuses.create({
+				status: payload.text,
+				visibility,
+				...(inReplyToId ? { inReplyToId } : {})
+			});
+			statusId = typeof status?.id === 'string' ? status.id : undefined;
+		} catch (err) {
+			throw new Error(`Mastodon status create failed: ${mastodonErrorMessage(err)}`);
+		}
+
+		const result: ChannelSendResult = {
+			provider: this.id,
+			providerMessageId: statusId ?? `mastodon-${payload.messageRef}`,
+			deliveredAt: new Date()
+		};
+		this.idempotencyCache.set(cacheKey, result);
+		if (this.idempotencyCache.size > 500) {
+			const firstKey = this.idempotencyCache.keys().next().value;
+			if (firstKey) this.idempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one page of the current sweep phase (notifications → own
+	 * statuses) since the effective watermark, normalized to envelopes.
+	 * The returned cursor resumes the same phase (Mastodon `max_id`) or
+	 * advances to the next; no cursor means the sweep is done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const instanceUrl = input.settings?.instanceUrl;
+		const accessToken = input.settings?.accessToken;
+		if (typeof instanceUrl !== 'string' || instanceUrl.length === 0) {
+			throw new EventSourceNotConfiguredError(
+				'mastodon-connector: settings.instanceUrl is required to pull events'
+			);
+		}
+		if (typeof accessToken !== 'string' || accessToken.length === 0) {
+			throw new EventSourceNotConfiguredError(
+				'mastodon-connector: settings.accessToken is required to pull events'
+			);
+		}
+
+		const cursor = parsePullCursor(input.cursor);
+		let phase: 'notifications' | 'statuses';
+		let maxId: string | undefined;
+		let since: string;
+		let backfill: boolean;
+		let pagesUsed: number;
+
+		if (cursor) {
+			phase = cursor.p;
+			maxId = cursor.n;
+			since = cursor.s;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			if (firstPull) {
+				const start = backfillDays > 0 ? Date.now() - backfillDays * 86400_000 : Date.now();
+				since = new Date(start).toISOString();
+				backfill = backfillDays > 0;
+			} else {
+				since = new Date(sinceMs).toISOString();
+				backfill = false;
+			}
+			phase = 'notifications';
+			maxId = undefined;
+			pagesUsed = 0;
+		}
+
+		const client = this.connect({ instanceUrl, accessToken });
+		const sinceMs = Date.parse(since);
+		const events: IngestedEventEnvelope[] = [];
+		let lastId: string | undefined;
+		let pageSize = 0;
+		let stopSweep = false;
+
+		if (phase === 'notifications') {
+			const notifications = await client.v1.notifications.list({
+				limit: MASTODON_PULL_PAGE_SIZE,
+				...(maxId ? { maxId } : {})
+			});
+			pageSize = notifications.length;
+			for (const notification of notifications) {
+				lastId = notification.id ?? lastId;
+				const createdMs = Date.parse(notification.createdAt ?? '');
+				if (Number.isFinite(createdMs) && createdMs < sinceMs) {
+					stopSweep = true;
+					break;
+				}
+				const envelope = this.normalizeNotification(notification);
+				if (envelope) events.push(envelope);
+			}
+		} else {
+			const account = await client.v1.accounts.verifyCredentials();
+			const accountId = account?.id;
+			if (!accountId) {
+				throw new EventSourceNotConfiguredError(
+					'mastodon-connector: the access token resolved to no account — re-authorize the application'
+				);
+			}
+			const statuses = await client.v1.accounts.$select(accountId).statuses.list({
+				limit: MASTODON_PULL_PAGE_SIZE,
+				...(maxId ? { maxId } : {})
+			});
+			pageSize = statuses.length;
+			for (const status of statuses) {
+				lastId = status.id ?? lastId;
+				const createdMs = Date.parse(status.createdAt ?? '');
+				if (Number.isFinite(createdMs) && createdMs < sinceMs) {
+					stopSweep = true;
+					break;
+				}
+				const envelope = this.normalizeStatus(status);
+				if (envelope) events.push(envelope);
+			}
+		}
+
+		pagesUsed += 1;
+		const pageBudgetExhausted = backfill && pagesUsed >= MASTODON_BACKFILL_MAX_PAGES;
+		// A short page means the timeline is exhausted; only a FULL page can
+		// have more behind it.
+		const mayHaveMore = pageSize >= MASTODON_PULL_PAGE_SIZE && lastId !== undefined;
+
+		let next: MastodonPullCursor | undefined;
+		if (!stopSweep && mayHaveMore && !pageBudgetExhausted) {
+			next = { p: phase, n: lastId, s: since, ...(backfill ? { f: 1 as const } : {}), b: pagesUsed };
+		} else if (phase === 'notifications') {
+			// Advance to the own-statuses phase (page counter resets per phase).
+			next = { p: 'statuses', s: since, ...(backfill ? { f: 1 as const } : {}), b: 0 };
+		}
+
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	private normalizeNotification(notification: MastodonNotification): IngestedEventEnvelope | null {
+		if (!notification.id) return null;
+		const occurredAt = toIso(notification.createdAt);
+		const type = notification.type ?? 'unknown';
+		const account = notification.account ?? {};
+		const text = stripStatusHtml(notification.status?.content);
+		const sourceUrl = notification.status?.url ?? account.url;
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `notification:${notification.id}`,
+			kind: 'mastodon.notification',
+			occurredAt,
+			...(account.acct || account.displayName
+				? {
+						actor: {
+							name: account.displayName ?? account.acct ?? 'unknown',
+							...(account.id ? { externalId: account.id } : {})
+						}
+					}
+				: {}),
+			subject: {
+				type: notification.status?.id ? 'status' : 'account',
+				externalId: notification.status?.id ?? account.id ?? notification.id,
+				...(text ? { title: truncateText(text) } : {})
+			},
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				notificationType: type,
+				notificationId: notification.id,
+				...(notification.status?.id ? { statusId: notification.status.id } : {}),
+				...(account.id ? { accountId: account.id } : {}),
+				...(account.acct ? { acct: account.acct } : {}),
+				...(text ? { text: truncateText(text) } : {}),
+				createdAt: occurredAt
+			}
+		};
+	}
+
+	private normalizeStatus(status: MastodonStatus): IngestedEventEnvelope | null {
+		if (!status.id) return null;
+		const occurredAt = toIso(status.createdAt);
+		const account = status.account ?? {};
+		const text = stripStatusHtml(status.content);
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `status:${status.id}`,
+			kind: 'mastodon.status',
+			occurredAt,
+			...(account.acct || account.displayName
+				? {
+						actor: {
+							name: account.displayName ?? account.acct ?? 'unknown',
+							...(account.id ? { externalId: account.id } : {})
+						}
+					}
+				: {}),
+			subject: {
+				type: 'status',
+				externalId: status.id,
+				...(text ? { title: truncateText(text) } : {})
+			},
+			...(status.url ? { sourceUrl: status.url } : {}),
+			payload: {
+				statusId: status.id,
+				...(status.uri ? { uri: status.uri } : {}),
+				...(status.visibility ? { visibility: status.visibility } : {}),
+				...(account.acct ? { acct: account.acct } : {}),
+				...(text ? { text: truncateText(text) } : {}),
+				...(typeof status.repliesCount === 'number' ? { repliesCount: status.repliesCount } : {}),
+				...(typeof status.reblogsCount === 'number' ? { reblogsCount: status.reblogsCount } : {}),
+				...(typeof status.favouritesCount === 'number' ? { favouritesCount: status.favouritesCount } : {}),
+				createdAt: occurredAt
+			}
+		};
+	}
+}
+
+export const mastodonConnectorPlugin = new MastodonConnectorPlugin();

--- a/packages/plugins/mastodon-connector/tsconfig.json
+++ b/packages/plugins/mastodon-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/mastodon-connector/tsup.config.ts
+++ b/packages/plugins/mastodon-connector/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/mastodon-connector/vitest.config.ts
+++ b/packages/plugins/mastodon-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/pipedrive-connector/README.md
+++ b/packages/plugins/pipedrive-connector/README.md
@@ -1,0 +1,50 @@
+# @ever-works/pipedrive-connector-plugin
+
+First-party **Pipedrive CRM connector** for the Ever Works platform, built on
+the official [`pipedrive`](https://www.npmjs.com/package/pipedrive) Node SDK.
+
+Capabilities: `connector`, `connector-pipedrive`, `event-source`.
+
+## What it does
+
+- **Outbound message** — `send()` appends a note to a deal (default), person or
+  organization (`targetConfig.recordId` + `recordType`, or
+  `settings.defaultDealId`), idempotent on `messageRef`.
+- **Outbound record** — `createRecord()` writes a deal / person / organization,
+  idempotent on `idempotencyKey`.
+- **Event source** — `pullEvents()` sweeps each configured entity type in turn
+  through Pipedrive's own `/recents` endpoint (its native "everything that
+  changed since this timestamp" API), normalized into `IngestedEventEnvelope`s
+  (`pipedrive.deal` / `pipedrive.person` / `pipedrive.organization`) for the
+  event-ingest spine. With a `companyDomain` configured each envelope carries a
+  record deep link as `sourceUrl`.
+- **Opt-in historical backfill** — `backfillDays` (default `0` = off, max 90)
+  widens the FIRST pull's window only, bounded to
+  `PIPEDRIVE_BACKFILL_MAX_PAGES` pages per entity type.
+
+## Degradation is loud, never silent
+
+- `verifyConnection()` reports the missing `apiToken` and surfaces the
+  Pipedrive error payload when the probe fails.
+- `send()` / `createRecord()` throw on a missing token, a missing record id, or
+  an unsupported collection.
+- `pullEvents()` throws `EventSourceNotConfiguredError`.
+
+## Settings
+
+| Key             | Notes                                                                |
+| --------------- | --------------------------------------------------------------------- |
+| `apiToken`      | API token — secret, env `PIPEDRIVE_API_TOKEN`.                       |
+| `entityTypes`   | Comma-separated sweep list (deals, persons, organizations by default). |
+| `companyDomain` | `acme` for `acme.pipedrive.com` — enables record deep links.         |
+| `backfillDays`  | Opt-in first-pull history window (0 = off, max 90).                  |
+| `defaultDealId` | Default deal outbound notes attach to.                               |
+
+Envelope payloads carry a per-entity field whitelist only — custom fields and
+nested expansions never ride along, and no credential is hardcoded, logged, or
+written into an envelope.
+
+## Testing
+
+Hermetic Vitest suite (`pnpm test`) — the SDK client is stubbed through the
+`createClient` seam; no network calls.

--- a/packages/plugins/pipedrive-connector/package.json
+++ b/packages/plugins/pipedrive-connector/package.json
@@ -1,0 +1,101 @@
+{
+	"name": "@ever-works/pipedrive-connector-plugin",
+	"version": "1.0.0",
+	"description": "Pipedrive CRM connector plugin for Ever Works platform (outbound notes + record creation via the official pipedrive Node SDK, and event-source pull of deal/person/organization changes into the event-ingest pipeline, with opt-in historical backfill)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*",
+		"pipedrive": "^33.5.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "pipedrive-connector",
+			"name": "Pipedrive Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"connector-pipedrive",
+				"event-source"
+			],
+			"description": "Pipedrive CRM connector. Outbound appends notes to deals/persons/organizations and creates records via the official pipedrive Node SDK. Event-source pull ingests records created/updated since the last watermark into the platform event-ingest pipeline, with opt-in historical backfill (backfillDays, max 90).",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"apiToken"
+				],
+				"properties": {
+					"apiToken": {
+						"type": "string",
+						"title": "Pipedrive API token",
+						"x-secret": true,
+						"x-envVar": "PIPEDRIVE_API_TOKEN"
+					},
+					"entityTypes": {
+						"type": "string",
+						"title": "Entity types to ingest (comma-separated; deals, persons, organizations when empty)",
+						"default": "deals,persons,organizations"
+					},
+					"companyDomain": {
+						"type": "string",
+						"title": "Pipedrive company domain (e.g. `acme` for acme.pipedrive.com) — enables deep links"
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					},
+					"defaultDealId": {
+						"type": "string",
+						"title": "Default deal id outbound notes are attached to"
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/pipedrive-connector/src/index.ts
+++ b/packages/plugins/pipedrive-connector/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @ever-works/pipedrive-connector-plugin — Pipedrive CRM connector.
+ * Outbound notes + record writes via the official `pipedrive` Node SDK;
+ * `pullEvents` event-source leg (deals, persons and organizations
+ * changed since the watermark via `/recents`, opt-in historical
+ * backfill) feeding the platform event-ingest spine.
+ */
+export {
+	PipedriveConnectorPlugin,
+	pipedriveConnectorPlugin,
+	asEntityType,
+	clampBackfillDays,
+	isoToPipedriveTime,
+	pipedriveTimeToIso,
+	resolveEntityTypes,
+	resolveNoteTarget,
+	PIPEDRIVE_EVENT_TEXT_MAX_CHARS,
+	PIPEDRIVE_PULL_PAGE_SIZE,
+	PIPEDRIVE_BACKFILL_MAX_PAGES,
+	PIPEDRIVE_ENTITY_TYPES,
+	PIPEDRIVE_ENTITY_META
+} from './pipedrive-connector-plugin.js';
+export type { PipedriveEntityType } from './pipedrive-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { PipedriveConnectorPlugin as default } from './pipedrive-connector-plugin.js';

--- a/packages/plugins/pipedrive-connector/src/pipedrive-connector-plugin.spec.ts
+++ b/packages/plugins/pipedrive-connector/src/pipedrive-connector-plugin.spec.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	PipedriveConnectorPlugin,
+	asEntityType,
+	clampBackfillDays,
+	isoToPipedriveTime,
+	pipedriveTimeToIso,
+	resolveEntityTypes,
+	PIPEDRIVE_EVENT_TEXT_MAX_CHARS,
+	PIPEDRIVE_BACKFILL_MAX_PAGES,
+	PIPEDRIVE_ENTITY_TYPES
+} from './pipedrive-connector-plugin.js';
+
+const getCurrentUserMock = vi.fn();
+const getRecentsMock = vi.fn();
+const addNoteMock = vi.fn();
+const addRecordMock = vi.fn();
+const clientFactoryMock = vi.fn();
+
+/** Subclass overriding the client seam so no real SDK call ever happens. */
+class TestPipedriveConnectorPlugin extends PipedriveConnectorPlugin {
+	protected override createClient(apiToken: string) {
+		clientFactoryMock(apiToken);
+		return {
+			getCurrentUser: getCurrentUserMock,
+			getRecents: getRecentsMock,
+			addNote: addNoteMock,
+			addRecord: addRecordMock
+		};
+	}
+}
+
+const SETTINGS = { apiToken: 'pd-secret-token' };
+
+function emptyPage() {
+	return { data: [], additional_data: { pagination: { more_items_in_collection: false } } };
+}
+
+describe('PipedriveConnectorPlugin', () => {
+	let plugin: TestPipedriveConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestPipedriveConnectorPlugin();
+		getCurrentUserMock.mockReset();
+		getRecentsMock.mockReset();
+		addNoteMock.mockReset();
+		addRecordMock.mockReset();
+		clientFactoryMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('declares the connector + connector-pipedrive + event-source capabilities and poll metadata', () => {
+		expect(plugin.id).toBe('pipedrive-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toContain('connector');
+		expect(plugin.capabilities).toContain('connector-pipedrive');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('pipedrive');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.outboundMessage).toBe(true);
+		expect(plugin.connector.flags.outboundRecord).toBe(true);
+		expect(plugin.connector.flags.inbound).toBe(false);
+	});
+
+	it('marks apiToken as x-secret and bounds backfillDays to 0–90 in the settings schema', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.apiToken['x-secret']).toBe(true);
+		expect(props.apiToken['x-envVar']).toBe('PIPEDRIVE_API_TOKEN');
+		expect(plugin.settingsSchema.required).toContain('apiToken');
+		expect(props.backfillDays.minimum).toBe(0);
+		expect(props.backfillDays.maximum).toBe(90);
+	});
+
+	it('clampBackfillDays clamps to the 0–90 range and treats garbage as off', () => {
+		expect(clampBackfillDays(0)).toBe(0);
+		expect(clampBackfillDays(14)).toBe(14);
+		expect(clampBackfillDays(500)).toBe(90);
+		expect(clampBackfillDays('nope')).toBe(0);
+	});
+
+	it('resolveEntityTypes keeps sweep order, drops unknowns and defaults to all three', () => {
+		expect(resolveEntityTypes(undefined)).toEqual([...PIPEDRIVE_ENTITY_TYPES]);
+		expect(resolveEntityTypes({ entityTypes: 'organizations, deals' })).toEqual(['deals', 'organizations']);
+		expect(resolveEntityTypes({ entityTypes: 'nope' })).toEqual([...PIPEDRIVE_ENTITY_TYPES]);
+	});
+
+	it('asEntityType narrows only known types', () => {
+		expect(asEntityType('Deals')).toBe('deals');
+		expect(asEntityType('leads')).toBeUndefined();
+		expect(asEntityType(42)).toBeUndefined();
+	});
+
+	it('parses Pipedrive UTC timestamps without drifting to local time', () => {
+		expect(pipedriveTimeToIso('2026-07-22 10:00:00')).toBe('2026-07-22T10:00:00.000Z');
+		expect(pipedriveTimeToIso('2026-07-22T10:00:00Z')).toBe('2026-07-22T10:00:00.000Z');
+		expect(pipedriveTimeToIso('garbage')).toBe('1970-01-01T00:00:00.000Z');
+		expect(pipedriveTimeToIso(undefined)).toBe('1970-01-01T00:00:00.000Z');
+	});
+
+	it('isoToPipedriveTime renders the since_timestamp form the API expects', () => {
+		expect(isoToPipedriveTime('2026-07-22T10:00:00.000Z')).toBe('2026-07-22 10:00:00');
+		expect(isoToPipedriveTime('nonsense')).toBe('1970-01-01 00:00:00');
+	});
+
+	describe('verifyConnection', () => {
+		it('returns the current-user details', async () => {
+			getCurrentUserMock.mockResolvedValueOnce({
+				data: { id: 7, name: 'Ada', company_name: 'Acme', company_domain: 'acme' }
+			});
+			const res = await plugin.verifyConnection({ apiToken: 'pd-x' }, {});
+			expect(res.valid).toBe(true);
+			expect(res.details).toMatchObject({ userId: '7', userName: 'Ada', companyDomain: 'acme' });
+			expect(clientFactoryMock).toHaveBeenCalledWith('pd-x');
+		});
+
+		it('degrades loudly (never silently) when the token is missing', async () => {
+			const res = await plugin.verifyConnection({}, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/apiToken/);
+			expect(clientFactoryMock).not.toHaveBeenCalled();
+		});
+
+		it('surfaces the Pipedrive error payload when the probe fails', async () => {
+			getCurrentUserMock.mockRejectedValueOnce({ response: { data: { error: 'invalid api token' } } });
+			const res = await plugin.verifyConnection({ apiToken: 'pd-x' }, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/invalid api token/);
+		});
+	});
+
+	describe('send', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('adds a note bound to the resolved deal', async () => {
+			addNoteMock.mockResolvedValueOnce({ data: { id: 99 } });
+			const res = await plugin.send(
+				{
+					text: 'call summary',
+					messageRef: 'ref-1',
+					attribution: { userId: 'u1' },
+					target: { recordId: '501' }
+				},
+				options
+			);
+			expect(addNoteMock).toHaveBeenCalledWith({ content: 'call summary', deal_id: 501 });
+			expect(res.providerMessageId).toBe('99');
+			expect(res.provider).toBe('pipedrive-connector');
+		});
+
+		it('binds the note to the requested entity type', async () => {
+			addNoteMock.mockResolvedValueOnce({ data: { id: 100 } });
+			await plugin.send(
+				{
+					text: 'note',
+					messageRef: 'ref-2',
+					attribution: { userId: 'u1' },
+					target: { recordId: '7', recordType: 'organizations' }
+				},
+				options
+			);
+			expect(addNoteMock).toHaveBeenCalledWith({ content: 'note', org_id: 7 });
+		});
+
+		it('falls back to the configured default deal id', async () => {
+			addNoteMock.mockResolvedValueOnce({ data: { id: 101 } });
+			await plugin.send(
+				{ text: 'note', messageRef: 'ref-3', attribution: { userId: 'u1' } },
+				{ ...options, settings: { ...SETTINGS, defaultDealId: '12' } }
+			);
+			expect(addNoteMock).toHaveBeenCalledWith({ content: 'note', deal_id: 12 });
+		});
+
+		it('is idempotent on messageRef — a retry never double-posts', async () => {
+			addNoteMock.mockResolvedValue({ data: { id: 1 } });
+			const payload = {
+				text: 'once only',
+				messageRef: 'ref-dup',
+				attribution: { userId: 'u1' },
+				target: { recordId: '5' }
+			};
+			const first = await plugin.send(payload, options);
+			const second = await plugin.send(payload, options);
+			expect(addNoteMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws a clear error when no record id can be resolved', async () => {
+			await expect(
+				plugin.send({ text: 'x', messageRef: 'r', attribution: { userId: 'u1' } }, options)
+			).rejects.toThrow(/record id is required/);
+			expect(addNoteMock).not.toHaveBeenCalled();
+		});
+
+		it('throws when the API token is missing instead of silently no-oping', async () => {
+			await expect(
+				plugin.send(
+					{ text: 'x', messageRef: 'r', attribution: { userId: 'u1' }, target: { recordId: '1' } },
+					{ connectorId: 'c' }
+				)
+			).rejects.toThrow(/API token is required/);
+		});
+	});
+
+	describe('createRecord', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('creates the record for the requested collection', async () => {
+			addRecordMock.mockResolvedValueOnce({ data: { id: 321 } });
+			const res = await plugin.createRecord(
+				{ collection: 'persons', fields: { name: 'Ada' }, idempotencyKey: 'k-1' },
+				options
+			);
+			expect(addRecordMock).toHaveBeenCalledWith('persons', { name: 'Ada' });
+			expect(res).toEqual({ provider: 'pipedrive-connector', recordId: '321' });
+		});
+
+		it('rejects an unsupported collection loudly', async () => {
+			await expect(
+				plugin.createRecord({ collection: 'leads', fields: {}, idempotencyKey: 'k' }, options)
+			).rejects.toThrow(/unsupported collection 'leads'/);
+			expect(addRecordMock).not.toHaveBeenCalled();
+		});
+
+		it('is idempotent on idempotencyKey', async () => {
+			addRecordMock.mockResolvedValue({ data: { id: 1 } });
+			const input = { collection: 'deals', fields: { title: 'x' }, idempotencyKey: 'dup' };
+			const first = await plugin.createRecord(input, options);
+			const second = await plugin.createRecord(input, options);
+			expect(addRecordMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws when Pipedrive returns no record id', async () => {
+			addRecordMock.mockResolvedValueOnce({ data: {} });
+			await expect(
+				plugin.createRecord({ collection: 'deals', fields: {}, idempotencyKey: 'k' }, options)
+			).rejects.toThrow(/no record id/);
+		});
+	});
+
+	describe('pullEvents', () => {
+		it('throws EventSourceNotConfiguredError when the token is missing', async () => {
+			await expect(plugin.pullEvents({ since: new Date(0).toISOString(), settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
+			expect(getRecentsMock).not.toHaveBeenCalled();
+		});
+
+		it('first pull with backfill off uses a now-anchored window (no history)', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			getRecentsMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({ since: new Date(0).toISOString(), settings: SETTINGS });
+			expect(getRecentsMock.mock.calls[0][0]).toMatchObject({
+				since_timestamp: '2026-07-25 12:00:00',
+				items: 'deal'
+			});
+		});
+
+		it('first pull with backfillDays widens the window, clamped to 90 days', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			getRecentsMock.mockResolvedValue(emptyPage());
+			await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(getRecentsMock.mock.calls[0][0].since_timestamp).toBe('2026-06-25 12:00:00');
+
+			await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 500 }
+			});
+			expect(getRecentsMock.mock.calls[1][0].since_timestamp).toBe('2026-04-26 12:00:00');
+		});
+
+		it('a non-first pull keeps the platform watermark as the window', async () => {
+			getRecentsMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(getRecentsMock.mock.calls[0][0].since_timestamp).toBe('2026-07-20 00:00:00');
+		});
+
+		it('normalizes recents into typed envelopes with subject, deep link and capped fields', async () => {
+			getRecentsMock.mockResolvedValueOnce({
+				data: [
+					{
+						item: 'deal',
+						id: 501,
+						data: {
+							id: 501,
+							title: 'Q3 renewal',
+							status: 'open',
+							value: 12000,
+							currency: 'USD',
+							address: 'a'.repeat(PIPEDRIVE_EVENT_TEXT_MAX_CHARS + 10),
+							add_time: '2026-07-21 10:00:00',
+							update_time: '2026-07-22 10:00:00',
+							owner_id: { id: 3, name: 'Ada' }
+						}
+					}
+				],
+				additional_data: { pagination: { more_items_in_collection: false } }
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, companyDomain: 'acme' }
+			});
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.source).toBe('pipedrive-connector');
+			expect(env.kind).toBe('pipedrive.deal');
+			expect(env.sourceEventId).toBe('deals:501:2026-07-22T10:00:00.000Z');
+			expect(env.occurredAt).toBe('2026-07-22T10:00:00.000Z');
+			expect(env.subject).toEqual({ type: 'crm-record', externalId: '501', title: 'Q3 renewal' });
+			expect(env.sourceUrl).toBe('https://acme.pipedrive.com/deal/501');
+			expect(env.payload.changeType).toBe('created');
+			const fields = env.payload.fields as Record<string, unknown>;
+			expect(fields.value).toBe(12000);
+			// Nested expansions (owner_id object) and non-whitelisted fields are dropped.
+			expect(fields.owner_id).toBeUndefined();
+			expect(fields.address).toBeUndefined();
+			// The API token must never leak into the envelope.
+			expect(JSON.stringify(res.events)).not.toContain(SETTINGS.apiToken);
+		});
+
+		it('omits the deep link when no companyDomain is configured', async () => {
+			getRecentsMock.mockResolvedValueOnce({
+				data: [{ item: 'deal', id: 1, data: { id: 1, update_time: '2026-07-22 10:00:00' } }],
+				additional_data: { pagination: { more_items_in_collection: false } }
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events[0].sourceUrl).toBeUndefined();
+		});
+
+		it('pages within an entity type and keeps the SAME window across pages', async () => {
+			getRecentsMock.mockResolvedValueOnce({
+				data: [],
+				additional_data: { pagination: { more_items_in_collection: true, next_start: 50 } }
+			});
+			const first = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed).toMatchObject({ t: 'deals', n: 50, s: '2026-07-20T00:00:00.000Z' });
+
+			getRecentsMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-24T00:00:00.000Z', // a moved watermark must NOT shift the running sweep
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			expect(getRecentsMock.mock.calls[1][0]).toMatchObject({
+				start: 50,
+				since_timestamp: '2026-07-20 00:00:00'
+			});
+		});
+
+		it('advances deals → persons → organizations → done across the sweep', async () => {
+			getRecentsMock.mockResolvedValue(emptyPage());
+			const afterDeals = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(JSON.parse(afterDeals.nextCursor as string).t).toBe('persons');
+
+			const afterPersons = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterDeals.nextCursor,
+				settings: SETTINGS
+			});
+			expect(JSON.parse(afterPersons.nextCursor as string).t).toBe('organizations');
+			expect(getRecentsMock.mock.calls[1][0].items).toBe('person');
+
+			const afterOrgs = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterPersons.nextCursor,
+				settings: SETTINGS
+			});
+			expect(afterOrgs.nextCursor).toBeUndefined();
+		});
+
+		it('bounds backfill sweeps to the per-phase page budget', async () => {
+			getRecentsMock.mockResolvedValueOnce({
+				data: [],
+				additional_data: { pagination: { more_items_in_collection: true, next_start: 900 } }
+			});
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				cursor: JSON.stringify({
+					t: 'deals',
+					n: 850,
+					s: '2026-05-01T00:00:00.000Z',
+					f: 1,
+					b: PIPEDRIVE_BACKFILL_MAX_PAGES - 1
+				}),
+				settings: { ...SETTINGS, backfillDays: 90 }
+			});
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed.t).toBe('persons');
+			expect(parsed.n).toBeUndefined();
+			expect(parsed.b).toBe(0);
+		});
+
+		it('restarts at the first type when the cursor names a type dropped from settings', async () => {
+			getRecentsMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: JSON.stringify({ t: 'organizations', n: 10, s: '2026-07-20T00:00:00.000Z' }),
+				settings: { ...SETTINGS, entityTypes: 'deals' }
+			});
+			expect(getRecentsMock.mock.calls[0][0].items).toBe('deal');
+			expect(getRecentsMock.mock.calls[0][0].start).toBeUndefined();
+		});
+
+		it('treats a malformed cursor as a fresh sweep instead of crashing', async () => {
+			getRecentsMock.mockResolvedValueOnce(emptyPage());
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: 'not-json{{{',
+				settings: SETTINGS
+			});
+			expect(getRecentsMock).toHaveBeenCalledTimes(1);
+			expect(res.events).toEqual([]);
+		});
+
+		it('skips a recents entry with no resolvable id', async () => {
+			getRecentsMock.mockResolvedValueOnce({
+				data: [{ item: 'deal', data: { title: 'orphan' } }],
+				additional_data: { pagination: { more_items_in_collection: false } }
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toEqual([]);
+		});
+	});
+});

--- a/packages/plugins/pipedrive-connector/src/pipedrive-connector-plugin.ts
+++ b/packages/plugins/pipedrive-connector/src/pipedrive-connector-plugin.ts
@@ -1,0 +1,693 @@
+import { randomUUID } from 'node:crypto';
+// The official SDK exposes both Pipedrive API generations behind their
+// own subpaths, and the surfaces this connector needs are split across
+// them: `/recents`, notes and the current-user probe only exist in v1,
+// while record creation moved to v2. Import both rather than hand-roll
+// the missing calls.
+import { Configuration as ConfigurationV1, NotesApi, RecentsApi, UsersApi } from 'pipedrive/v1';
+import { Configuration as ConfigurationV2, DealsApi, OrganizationsApi, PersonsApi } from 'pipedrive/v2';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ConnectorRecordInput,
+	ConnectorRecordResult,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	PluginSettings,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); a CRM field value never
+ * needs more than this to be useful in Memory/Activities.
+ */
+export const PIPEDRIVE_EVENT_TEXT_MAX_CHARS = 4000;
+
+/** Records requested per `/recents` page. */
+export const PIPEDRIVE_PULL_PAGE_SIZE = 50;
+
+/**
+ * Historical backfill bound: at most this many pages per phase (per
+ * entity type) during the opt-in first-pull backfill, so a large
+ * account can never turn activation into an unbounded crawl.
+ */
+export const PIPEDRIVE_BACKFILL_MAX_PAGES = 10;
+
+/** Entity types this connector understands, in sweep order. */
+export const PIPEDRIVE_ENTITY_TYPES = ['deals', 'persons', 'organizations'] as const;
+export type PipedriveEntityType = (typeof PIPEDRIVE_ENTITY_TYPES)[number];
+
+/** Per-entity ingest / deep-link / note-association metadata. */
+interface PipedriveEntityMeta {
+	/** Envelope `kind` (source-namespaced, singular). */
+	readonly kind: string;
+	/** Value the `/recents` `items` filter expects. */
+	readonly recentsItem: string;
+	/** Path segment in a Pipedrive web deep link. */
+	readonly urlSegment: string;
+	/** Field carrying the human title on the record. */
+	readonly titleField: string;
+	/** Field the note payload uses to attach to this entity. */
+	readonly noteField: string;
+	/** Non-custom fields copied into the envelope payload. */
+	readonly payloadFields: readonly string[];
+}
+
+export const PIPEDRIVE_ENTITY_META: Readonly<Record<PipedriveEntityType, PipedriveEntityMeta>> = {
+	deals: {
+		kind: 'pipedrive.deal',
+		recentsItem: 'deal',
+		urlSegment: 'deal',
+		titleField: 'title',
+		noteField: 'deal_id',
+		payloadFields: ['title', 'status', 'stage_id', 'pipeline_id', 'value', 'currency', 'add_time', 'update_time']
+	},
+	persons: {
+		kind: 'pipedrive.person',
+		recentsItem: 'person',
+		urlSegment: 'person',
+		titleField: 'name',
+		noteField: 'person_id',
+		payloadFields: ['name', 'org_id', 'owner_id', 'add_time', 'update_time']
+	},
+	organizations: {
+		kind: 'pipedrive.organization',
+		recentsItem: 'organization',
+		urlSegment: 'organization',
+		titleField: 'name',
+		noteField: 'org_id',
+		payloadFields: ['name', 'address', 'owner_id', 'people_count', 'add_time', 'update_time']
+	}
+};
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+function truncateText(text: string): string {
+	return text.length > PIPEDRIVE_EVENT_TEXT_MAX_CHARS ? text.slice(0, PIPEDRIVE_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/**
+ * Which entity types to sweep. Unknown entries are dropped; an empty or
+ * absent setting means "all three", matching the manifest default.
+ */
+export function resolveEntityTypes(settings: PluginSettings | undefined): PipedriveEntityType[] {
+	const raw = settings?.entityTypes;
+	if (typeof raw !== 'string' || raw.trim().length === 0) return [...PIPEDRIVE_ENTITY_TYPES];
+	const requested = raw
+		.split(/[\s,]+/)
+		.map((t) => t.trim().toLowerCase())
+		.filter((t): t is PipedriveEntityType => (PIPEDRIVE_ENTITY_TYPES as readonly string[]).includes(t));
+	return requested.length > 0
+		? [...PIPEDRIVE_ENTITY_TYPES].filter((t) => requested.includes(t))
+		: [...PIPEDRIVE_ENTITY_TYPES];
+}
+
+/**
+ * Pipedrive timestamps are `YYYY-MM-DD HH:MM:SS` in UTC without a zone
+ * marker, which `Date.parse` would read as LOCAL time. Normalize to a
+ * real ISO instant (epoch on garbage, so an envelope never carries NaN).
+ */
+export function pipedriveTimeToIso(value: unknown): string {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === 'string' && value.trim().length > 0) {
+		const raw = value.trim();
+		const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(raw) ? `${raw.replace(' ', 'T')}Z` : raw;
+		const ms = Date.parse(normalized);
+		if (Number.isFinite(ms)) return new Date(ms).toISOString();
+	}
+	return new Date(0).toISOString();
+}
+
+/** ISO instant → the `YYYY-MM-DD HH:MM:SS` UTC form `/recents` expects. */
+export function isoToPipedriveTime(iso: string): string {
+	const ms = Date.parse(iso);
+	const date = new Date(Number.isFinite(ms) ? ms : 0);
+	return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+/** Extract a readable message from a `pipedrive` SDK error. */
+function pipedriveErrorMessage(err: unknown): string {
+	const e = err as {
+		message?: string;
+		response?: { data?: { error?: string; error_info?: string }; status?: number };
+	};
+	return (
+		e.response?.data?.error ??
+		e.message ??
+		(typeof e.response?.status === 'number' ? `HTTP ${e.response.status}` : 'unknown error')
+	);
+}
+
+/**
+ * Opaque pull cursor. `t` is the entity type the sweep is on, `n` the
+ * `/recents` `next_start` offset, `s` the effective since-watermark the
+ * sweep was started with (later pages of the same sweep keep the SAME
+ * window), `f` flags a first-pull backfill sweep and `b` counts pages
+ * used in the current phase (backfill page bound). Malformed input
+ * restarts the sweep — safe, the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ */
+interface PipedrivePullCursor {
+	t: PipedriveEntityType;
+	n?: number;
+	s: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): PipedrivePullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as PipedrivePullCursor;
+		if (
+			parsed &&
+			typeof parsed.s === 'string' &&
+			(PIPEDRIVE_ENTITY_TYPES as readonly string[]).includes(parsed.t)
+		) {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** One `/recents` entry: the item type plus the record itself. */
+interface PipedriveRecentItem {
+	item?: string;
+	id?: number | string;
+	data?: Record<string, unknown>;
+}
+
+interface PipedriveRecentsResponse {
+	data?: PipedriveRecentItem[] | null;
+	additional_data?: {
+		pagination?: { start?: number; limit?: number; more_items_in_collection?: boolean; next_start?: number };
+	};
+}
+
+interface PipedriveIdResponse {
+	data?: { id?: number | string } | null;
+}
+
+interface PipedriveUserResponse {
+	data?: { id?: number | string; name?: string; company_name?: string; company_domain?: string } | null;
+}
+
+/** The subset of the Pipedrive SDK surface this plugin calls. */
+interface PipedriveClientLike {
+	getCurrentUser(): Promise<PipedriveUserResponse>;
+	getRecents(params: Record<string, unknown>): Promise<PipedriveRecentsResponse>;
+	addNote(payload: Record<string, unknown>): Promise<PipedriveIdResponse>;
+	addRecord(entityType: PipedriveEntityType, fields: Record<string, unknown>): Promise<PipedriveIdResponse>;
+}
+
+function resolveApiToken(config: ChannelTargetConfig, options: ConnectorCallOptions): string | undefined {
+	const candidates = [config.apiToken, options.settings?.apiToken];
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	return undefined;
+}
+
+/**
+ * First usable id among the candidates, in order. Record ids arrive as
+ * strings from `targetConfig` but as numbers from the API, so both are
+ * accepted and normalized to a string.
+ */
+function firstString(candidates: unknown[]): string | undefined {
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.trim().length > 0) return c.trim();
+		if (typeof c === 'number' && Number.isFinite(c)) return String(c);
+	}
+	return undefined;
+}
+
+/** Narrow an arbitrary string to a known entity type. */
+export function asEntityType(value: unknown): PipedriveEntityType | undefined {
+	if (typeof value !== 'string') return undefined;
+	const candidate = value.trim().toLowerCase();
+	return (PIPEDRIVE_ENTITY_TYPES as readonly string[]).includes(candidate)
+		? (candidate as PipedriveEntityType)
+		: undefined;
+}
+
+/**
+ * Resolve which record an outbound note attaches to. A per-send
+ * `recordId`/`recordType` overrides the connection default; the
+ * resolved plugin `settings` `defaultDealId` is the final fallback.
+ */
+export function resolveNoteTarget(
+	config: ChannelTargetConfig,
+	options: ConnectorCallOptions
+): { entityType: PipedriveEntityType; recordId: string } {
+	const explicitId = firstString([config.recordId, config.dealId]);
+	if (explicitId) {
+		const entityType = asEntityType(config.recordType) ?? 'deals';
+		return { entityType, recordId: explicitId };
+	}
+	const defaultDealId = firstString([config.defaultDealId, options.settings?.defaultDealId]);
+	if (defaultDealId) {
+		return { entityType: 'deals', recordId: defaultDealId };
+	}
+	throw new Error(
+		'pipedrive-connector: a record id is required for an outbound note ' +
+			'(targetConfig.recordId or settings.defaultDealId)'
+	);
+}
+
+/**
+ * Pipedrive CRM connector — first-party native connector.
+ *
+ * Outbound: `send` appends a note to a deal / person / organization and
+ * `createRecord` writes a new record of any of those types, both through
+ * the official `pipedrive` Node SDK (API-token auth; the SDK pins the
+ * API host, so there is no SSRF surface).
+ *
+ * Event source: `pullEvents` sweeps each configured entity type in turn
+ * through `/recents` — Pipedrive's own "everything that changed since
+ * this timestamp" endpoint — normalized into `IngestedEventEnvelope`s
+ * (`pipedrive.deal` / `.person` / `.organization`) for the platform's
+ * event-ingest spine. When a `companyDomain` is configured every
+ * envelope carries a record deep link as `sourceUrl`. The opt-in
+ * historical backfill (`backfillDays`, default 0 = off, max 90) widens
+ * the FIRST pull's window only, with a per-phase page bound so
+ * activation never becomes an unbounded crawl. Re-delivery across
+ * overlapping windows is fine — the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ *
+ * Unconfigured is always LOUD: `verifyConnection` reports the missing
+ * token, `send`/`createRecord` throw, and `pullEvents` throws
+ * `EventSourceNotConfiguredError`. Nothing silently no-ops.
+ */
+export class PipedriveConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'pipedrive-connector';
+	readonly name = 'Pipedrive Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_PIPEDRIVE,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'pipedrive';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'outbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: true,
+			outboundRecord: true,
+			inbound: false,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['apiToken'],
+		properties: {
+			apiToken: {
+				type: 'string',
+				title: 'Pipedrive API token',
+				'x-secret': true,
+				'x-envVar': 'PIPEDRIVE_API_TOKEN'
+			},
+			entityTypes: {
+				type: 'string',
+				title: 'Entity types to ingest (comma-separated; deals, persons, organizations when empty)',
+				default: 'deals,persons,organizations'
+			},
+			companyDomain: {
+				type: 'string',
+				title: 'Pipedrive company domain (e.g. `acme` for acme.pipedrive.com) — enables deep links'
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			},
+			defaultDealId: {
+				type: 'string',
+				title: 'Default deal id outbound notes are attached to'
+			}
+		}
+	};
+
+	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+	private readonly recordIdempotencyCache = new Map<string, ConnectorRecordResult>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; a client is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.idempotencyCache.clear();
+		this.recordIdempotencyCache.clear();
+	}
+
+	/**
+	 * Testable seam — specs stub this; production adapts the official
+	 * SDK's per-resource API classes onto the narrow surface above.
+	 */
+	protected createClient(apiToken: string): PipedriveClientLike {
+		const v1 = new ConfigurationV1({ apiKey: apiToken });
+		const v2 = new ConfigurationV2({ apiKey: apiToken });
+		const users = new UsersApi(v1);
+		const recents = new RecentsApi(v1);
+		const notes = new NotesApi(v1);
+		const deals = new DealsApi(v2);
+		const persons = new PersonsApi(v2);
+		const organizations = new OrganizationsApi(v2);
+		return {
+			getCurrentUser: () => users.getCurrentUser() as unknown as Promise<PipedriveUserResponse>,
+			getRecents: (params) =>
+				recents.getRecents(
+					params as unknown as Parameters<RecentsApi['getRecents']>[0]
+				) as unknown as Promise<PipedriveRecentsResponse>,
+			// The generated SDK wraps every request body in a property
+			// named after its schema — `addNote({ AddNoteRequest: {…} })`.
+			addNote: (payload) =>
+				notes.addNote({
+					AddNoteRequest: payload as unknown as NonNullable<
+						Parameters<NotesApi['addNote']>[0]
+					>['AddNoteRequest']
+				}) as unknown as Promise<PipedriveIdResponse>,
+			addRecord: (entityType, fields) => {
+				if (entityType === 'persons') {
+					return persons.addPerson({
+						AddPersonRequest: fields as unknown as NonNullable<
+							Parameters<PersonsApi['addPerson']>[0]
+						>['AddPersonRequest']
+					}) as unknown as Promise<PipedriveIdResponse>;
+				}
+				if (entityType === 'organizations') {
+					return organizations.addOrganization({
+						AddOrganizationRequest: fields as unknown as NonNullable<
+							Parameters<OrganizationsApi['addOrganization']>[0]
+						>['AddOrganizationRequest']
+					}) as unknown as Promise<PipedriveIdResponse>;
+				}
+				return deals.addDeal({
+					AddDealRequest: fields as unknown as NonNullable<
+						Parameters<DealsApi['addDeal']>[0]
+					>['AddDealRequest']
+				}) as unknown as Promise<PipedriveIdResponse>;
+			}
+		};
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const apiToken = resolveApiToken(config, options);
+		if (!apiToken) {
+			return { valid: false, message: 'apiToken is required' };
+		}
+		try {
+			const me = await this.createClient(apiToken).getCurrentUser();
+			const user = me?.data ?? undefined;
+			return {
+				valid: true,
+				details: {
+					...(user?.id !== undefined ? { userId: String(user.id) } : {}),
+					...(user?.name ? { userName: user.name } : {}),
+					...(user?.company_name ? { companyName: user.company_name } : {}),
+					...(user?.company_domain ? { companyDomain: user.company_domain } : {})
+				}
+			};
+		} catch (err) {
+			return { valid: false, message: `Pipedrive getCurrentUser failed: ${pipedriveErrorMessage(err)}` };
+		}
+	}
+
+	/** Outbound leg — append a note to a deal / person / organization. */
+	async send(payload: ChannelSendInput, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const config = payload.target ?? options.target ?? {};
+		const apiToken = resolveApiToken(config, options);
+		if (!apiToken) {
+			throw new Error(
+				'pipedrive-connector: an API token is required (targetConfig.apiToken or settings.apiToken)'
+			);
+		}
+		const { entityType, recordId } = resolveNoteTarget(config, options);
+		const noteField = PIPEDRIVE_ENTITY_META[entityType].noteField;
+
+		// Idempotency: scope the key to connectorId + record + messageRef with a
+		// NUL separator so components can't collide across tenants (mirrors the
+		// slack-connector hardening — this plugin is a module-level singleton).
+		const cacheKey = `${options.connectorId ?? ''}\0${entityType}\0${recordId}\0${payload.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let noteId: string | undefined;
+		try {
+			const numericId = Number(recordId);
+			const res = await this.createClient(apiToken).addNote({
+				content: payload.text,
+				[noteField]: Number.isFinite(numericId) ? numericId : recordId
+			});
+			const id = res?.data?.id;
+			noteId = id === undefined || id === null ? undefined : String(id);
+		} catch (err) {
+			throw new Error(`Pipedrive addNote failed: ${pipedriveErrorMessage(err)}`);
+		}
+
+		const result: ChannelSendResult = {
+			provider: this.id,
+			providerMessageId: noteId ?? `pipedrive-${payload.messageRef}`,
+			deliveredAt: new Date()
+		};
+		this.idempotencyCache.set(cacheKey, result);
+		if (this.idempotencyCache.size > 500) {
+			const firstKey = this.idempotencyCache.keys().next().value;
+			if (firstKey) this.idempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	/** Outbound record leg — create a deal / person / organization. */
+	async createRecord(record: ConnectorRecordInput, options: ConnectorCallOptions): Promise<ConnectorRecordResult> {
+		const config = options.target ?? {};
+		const apiToken = resolveApiToken(config, options);
+		if (!apiToken) {
+			throw new Error(
+				'pipedrive-connector: an API token is required (targetConfig.apiToken or settings.apiToken)'
+			);
+		}
+		const entityType = asEntityType(record.collection);
+		if (!entityType) {
+			throw new Error(
+				`pipedrive-connector: unsupported collection '${record.collection}' — ` +
+					`use one of ${PIPEDRIVE_ENTITY_TYPES.join(', ')}`
+			);
+		}
+
+		const cacheKey = `${options.connectorId ?? ''}\0${entityType}\0${record.idempotencyKey}`;
+		const cached = this.recordIdempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let recordId: string | undefined;
+		try {
+			const res = await this.createClient(apiToken).addRecord(entityType, { ...record.fields });
+			const id = res?.data?.id;
+			recordId = id === undefined || id === null ? undefined : String(id);
+		} catch (err) {
+			throw new Error(`Pipedrive ${entityType} create failed: ${pipedriveErrorMessage(err)}`);
+		}
+		if (!recordId) {
+			throw new Error(`Pipedrive ${entityType} create returned no record id`);
+		}
+
+		const result: ConnectorRecordResult = { provider: this.id, recordId };
+		this.recordIdempotencyCache.set(cacheKey, result);
+		if (this.recordIdempotencyCache.size > 500) {
+			const firstKey = this.recordIdempotencyCache.keys().next().value;
+			if (firstKey) this.recordIdempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one `/recents` page of the current entity-type phase since the
+	 * effective watermark, normalized to envelopes. The returned cursor
+	 * resumes the same phase (`next_start` offset) or advances to the
+	 * next configured entity type; no cursor means the sweep is done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const apiToken = input.settings?.apiToken;
+		if (typeof apiToken !== 'string' || apiToken.length === 0) {
+			throw new EventSourceNotConfiguredError(
+				'pipedrive-connector: settings.apiToken is required to pull events'
+			);
+		}
+
+		const entityTypes = resolveEntityTypes(input.settings);
+		const cursor = parsePullCursor(input.cursor);
+		let entityType: PipedriveEntityType;
+		let start: number | undefined;
+		let since: string;
+		let backfill: boolean;
+		let pagesUsed: number;
+
+		if (cursor) {
+			entityType = cursor.t;
+			start = cursor.n;
+			since = cursor.s;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			if (firstPull) {
+				const anchor = backfillDays > 0 ? Date.now() - backfillDays * 86400_000 : Date.now();
+				since = new Date(anchor).toISOString();
+				backfill = backfillDays > 0;
+			} else {
+				since = new Date(sinceMs).toISOString();
+				backfill = false;
+			}
+			entityType = entityTypes[0];
+			start = undefined;
+			pagesUsed = 0;
+		}
+
+		// A type dropped from settings mid-sweep restarts at the first one.
+		let typeIndex = entityTypes.indexOf(entityType);
+		if (typeIndex === -1) {
+			typeIndex = 0;
+			entityType = entityTypes[0];
+			start = undefined;
+			pagesUsed = 0;
+		}
+
+		const meta = PIPEDRIVE_ENTITY_META[entityType];
+		const companyDomain =
+			typeof input.settings?.companyDomain === 'string' ? input.settings.companyDomain.trim() : undefined;
+		const client = this.createClient(apiToken);
+
+		const page = await client.getRecents({
+			since_timestamp: isoToPipedriveTime(since),
+			items: meta.recentsItem,
+			limit: PIPEDRIVE_PULL_PAGE_SIZE,
+			...(typeof start === 'number' ? { start } : {})
+		});
+
+		const events: IngestedEventEnvelope[] = [];
+		for (const item of page.data ?? []) {
+			const envelope = this.normalizeRecent(item, entityType, since, companyDomain);
+			if (envelope) events.push(envelope);
+		}
+
+		const pagination = page.additional_data?.pagination;
+		const nextStart =
+			pagination?.more_items_in_collection === true && typeof pagination.next_start === 'number'
+				? pagination.next_start
+				: undefined;
+
+		pagesUsed += 1;
+		const pageBudgetExhausted = backfill && pagesUsed >= PIPEDRIVE_BACKFILL_MAX_PAGES;
+
+		let next: PipedrivePullCursor | undefined;
+		if (nextStart !== undefined && !pageBudgetExhausted) {
+			next = { t: entityType, n: nextStart, s: since, ...(backfill ? { f: 1 as const } : {}), b: pagesUsed };
+		} else if (typeIndex + 1 < entityTypes.length) {
+			// Advance to the next entity type (page counter resets per phase).
+			next = { t: entityTypes[typeIndex + 1], s: since, ...(backfill ? { f: 1 as const } : {}), b: 0 };
+		}
+
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	private normalizeRecent(
+		item: PipedriveRecentItem,
+		entityType: PipedriveEntityType,
+		since: string,
+		companyDomain: string | undefined
+	): IngestedEventEnvelope | null {
+		const meta = PIPEDRIVE_ENTITY_META[entityType];
+		const data = item.data ?? {};
+		const rawId = item.id ?? data.id;
+		if (rawId === undefined || rawId === null || rawId === '') return null;
+		const recordId = String(rawId);
+
+		const updatedAt = pipedriveTimeToIso(data.update_time ?? data.add_time);
+		const createdAt = pipedriveTimeToIso(data.add_time);
+		const changeType = Date.parse(createdAt) >= Date.parse(since) ? 'created' : 'updated';
+		const rawTitle = data[meta.titleField];
+		const title = typeof rawTitle === 'string' && rawTitle.trim().length > 0 ? rawTitle.trim() : undefined;
+		const sourceUrl = companyDomain
+			? `https://${encodeURIComponent(companyDomain)}.pipedrive.com/${meta.urlSegment}/${encodeURIComponent(recordId)}`
+			: undefined;
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${entityType}:${recordId}:${updatedAt}`,
+			kind: meta.kind,
+			occurredAt: updatedAt,
+			subject: {
+				type: 'crm-record',
+				externalId: recordId,
+				...(title ? { title } : {})
+			},
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				entityType,
+				recordId,
+				changeType,
+				createdAt,
+				updatedAt,
+				fields: this.sanitizeFields(data, meta)
+			}
+		};
+	}
+
+	/**
+	 * Payload fields are limited to the per-entity whitelist and each
+	 * string value is capped, so a record with a huge free-text field can
+	 * never blow the envelope byte budget (and custom fields, which can
+	 * hold anything, never ride along).
+	 */
+	private sanitizeFields(data: Record<string, unknown>, meta: PipedriveEntityMeta): Record<string, unknown> {
+		const out: Record<string, unknown> = {};
+		for (const key of meta.payloadFields) {
+			const value = data[key];
+			if (value === undefined || value === null) continue;
+			if (typeof value === 'string') {
+				out[key] = truncateText(value);
+			} else if (typeof value === 'number' || typeof value === 'boolean') {
+				out[key] = value;
+			}
+			// Objects (nested owner/org expansions) are intentionally dropped.
+		}
+		return out;
+	}
+}
+
+export const pipedriveConnectorPlugin = new PipedriveConnectorPlugin();

--- a/packages/plugins/pipedrive-connector/tsconfig.json
+++ b/packages/plugins/pipedrive-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/pipedrive-connector/tsup.config.ts
+++ b/packages/plugins/pipedrive-connector/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/pipedrive-connector/vitest.config.ts
+++ b/packages/plugins/pipedrive-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1524,6 +1524,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/bluesky-connector:
+    dependencies:
+      '@atproto/api':
+        specifier: ^0.20.34
+        version: 0.20.34
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/brave:
     devDependencies:
       '@ever-works/plugin':
@@ -2088,6 +2113,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/hubspot-connector:
+    dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@hubspot/api-client':
+        specifier: ^14.0.1
+        version: 14.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/jina:
     devDependencies:
       '@ever-works/plugin':
@@ -2513,6 +2563,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/mastodon-connector:
+    dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      masto:
+        specifier: ^7.12.0
+        version: 7.12.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/memory-pipeline-modifier:
     devDependencies:
       '@ever-works/plugin':
@@ -2843,6 +2918,31 @@ importers:
       typeorm:
         specifier: 0.3.29
         version: 0.3.29(better-sqlite3@12.6.2)(ioredis@5.10.1)(mysql2@3.17.1)(pg@8.18.0)(sql.js@1.14.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(typescript@5.9.3))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/pipedrive-connector:
+    dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      pipedrive:
+        specifier: ^33.5.0
+        version: 33.5.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3861,6 +3961,34 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@atproto/api@0.20.34':
+    resolution: {integrity: sha512-nKfCLkH2Al58YupLGtoVIucZ5XjtN9sU5oOTI70lp8J4nxl52C/Tk7AktcWe+Nx7st3I0fUgf+C5cHePgvwT0w==}
+    engines: {node: '>=22'}
+
+  '@atproto/common-web@0.5.6':
+    resolution: {integrity: sha512-5Y4MIK9dpkJPiKiE6u7iEHitxj+g3aAU2GfGL686JlKE2zDKD4y18BJb+uVek6nXQKb5XOdNVvw+7BHarpn8Fw==}
+    engines: {node: '>=22'}
+
+  '@atproto/lex-data@0.1.5':
+    resolution: {integrity: sha512-TEM6GHuYpNm4O90LjNgbYq1Gmcr875S+BHrDxkg4PB5w/nlsz4HlbkGQG/WP/xbIV5O8TF5nNHDpCZ5ezTRrFA==}
+    engines: {node: '>=22'}
+
+  '@atproto/lex-json@0.1.4':
+    resolution: {integrity: sha512-ENR2cWkVrES+UL6TovbCRdX9BJOyHHJUS8jYx3Lxp3j4vEphjn/u+DW7bWloST2O8ID2OuVlt6+28ftNEEjmQQ==}
+    engines: {node: '>=22'}
+
+  '@atproto/lexicon@0.7.7':
+    resolution: {integrity: sha512-92VH2oEsJdrIVNy7WY8rGn99ANNVglyUffoN7GJc0mxKi+fXN5iVlJ2cOyTfYABhr2ldSiptZWXEPEdBaIR9/A==}
+    engines: {node: '>=22'}
+
+  '@atproto/syntax@0.7.2':
+    resolution: {integrity: sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==}
+    engines: {node: '>=22'}
+
+  '@atproto/xrpc@0.8.6':
+    resolution: {integrity: sha512-yVfKrlwZBBm44Ft9jDvHcTCwQ1ElqSlzXHWhT/KcqE+u24EAhWVFosfABfGbUByB/PmN8eLJ06FsWo5pUQcMNQ==}
+    engines: {node: '>=22'}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -6297,6 +6425,10 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.12.25'
+
+  '@hubspot/api-client@14.0.1':
+    resolution: {integrity: sha512-+2/9e3DguqVXB/htjQ5yxWkLD4fGdS1MNsOVYlc05a4TAGx0PGt+EgvW8o5P9GwQsMIGHCCiR6CJpNYNQtbiqw==}
+    engines: {node: '>=22.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -12400,6 +12532,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  await-lock@3.0.0:
+    resolution: {integrity: sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
@@ -12958,6 +13093,9 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -14410,6 +14548,9 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -14679,6 +14820,9 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events-to-async@2.0.2:
+    resolution: {integrity: sha512-WzI6m/SU+F38t2tejHh6IQuQkNZ0dMOmSEmODJb9czaeMYtQ5FVZ+b6DOHr3hC6hNKNnn9CwDUN8mJiAkWSI9Q==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -16267,6 +16411,9 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
+
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
@@ -17214,6 +17361,9 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
 
+  masto@7.12.0:
+    resolution: {integrity: sha512-hSqRfaqVhtaRB3+lSJ4YusqBZ/tj4/gtzS0PXZgrg2JLiDFLmsBdmuyVVF2c+QlKSMEKo7grVh3dN8TX1TECVw==}
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -17776,6 +17926,9 @@ packages:
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
+
+  multiformats@13.4.2:
+    resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -18635,6 +18788,9 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pipedrive@33.5.0:
+    resolution: {integrity: sha512-X8zWVagv9GE28x7xl+y2vucSTTByEAqFVYz2e/LT8W4pLyaeDSjawqn8neKwkyJpvq0cqAybRkge4tdCTEfISg==}
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -21260,6 +21416,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -21619,6 +21779,9 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -22656,6 +22819,52 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@atproto/api@0.20.34':
+    dependencies:
+      '@atproto/common-web': 0.5.6
+      '@atproto/lexicon': 0.7.7
+      '@atproto/syntax': 0.7.2
+      '@atproto/xrpc': 0.8.6
+      await-lock: 3.0.0
+      multiformats: 13.4.2
+      tlds: 1.261.0
+      zod: 3.25.76
+
+  '@atproto/common-web@0.5.6':
+    dependencies:
+      '@atproto/lex-data': 0.1.5
+      '@atproto/lex-json': 0.1.4
+      '@atproto/syntax': 0.7.2
+      zod: 3.25.76
+
+  '@atproto/lex-data@0.1.5':
+    dependencies:
+      multiformats: 13.4.2
+      tslib: 2.8.1
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.1.4':
+    dependencies:
+      '@atproto/lex-data': 0.1.5
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.7.7':
+    dependencies:
+      '@atproto/common-web': 0.5.6
+      '@atproto/syntax': 0.7.2
+      multiformats: 13.4.2
+      zod: 3.25.76
+
+  '@atproto/syntax@0.7.2':
+    dependencies:
+      iso-datestring-validator: 2.2.2
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.8.6':
+    dependencies:
+      '@atproto/lexicon': 0.7.7
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -26163,6 +26372,14 @@ snapshots:
   '@hono/node-server@2.0.1(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
+
+  '@hubspot/api-client@14.0.1':
+    dependencies:
+      '@types/node': 22.19.11
+      bottleneck: 2.19.5
+      es6-promise: 4.2.8
+      form-data: 4.0.6
+      lodash.merge: 4.6.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -33422,6 +33639,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  await-lock@3.0.0: {}
+
   aws-ssl-profiles@1.1.2: {}
 
   axe-core@4.11.2: {}
@@ -34091,6 +34310,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
 
@@ -35767,6 +35988,8 @@ snapshots:
   es6-error@4.1.1:
     optional: true
 
+  es6-promise@4.2.8: {}
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -36178,6 +36401,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
+
+  events-to-async@2.0.2: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -38058,6 +38283,8 @@ snapshots:
 
   isexe@4.0.0: {}
 
+  iso-datestring-validator@2.2.2: {}
+
   isobject@3.0.1: {}
 
   isomorphic-git@1.37.1:
@@ -39221,6 +39448,17 @@ snapshots:
   marked@16.4.2: {}
 
   marked@7.0.4: {}
+
+  masto@7.12.0:
+    dependencies:
+      change-case: 5.4.4
+      events-to-async: 2.0.2
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      ts-custom-error: 3.3.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   matcher@3.0.0:
     dependencies:
@@ -40545,6 +40783,8 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
+  multiformats@13.4.2: {}
+
   mustache@4.2.0: {}
 
   mute-stream@0.0.8: {}
@@ -41511,6 +41751,14 @@ snapshots:
   picomatch@4.0.5: {}
 
   pify@4.0.1: {}
+
+  pipedrive@33.5.0:
+    dependencies:
+      axios: 1.18.1
+      qs: 6.15.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   pirates@4.0.7: {}
 
@@ -44743,8 +44991,7 @@ snapshots:
       markdown-it-task-lists: 2.1.1
       prosemirror-markdown: 1.13.4
 
-  tlds@1.261.0:
-    optional: true
+  tlds@1.261.0: {}
 
   tldts-core@7.0.24: {}
 
@@ -44905,6 +45152,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-custom-error@3.3.1: {}
 
   ts-dedent@2.2.0: {}
 
@@ -45247,6 +45496,8 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-segmenter@0.14.5: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
Four native connectors on the existing connector + event-source contract, closing the CRM and social gaps in the native-connector set.

**Vendor SDKs, not hand-written fetch** — `@hubspot/api-client`, `pipedrive`, `@atproto/api`, `masto`.

## What each does

| connector | outbound | event-source leg |
|---|---|---|
| **HubSpot** | write records + notes | record changes → ingest spine |
| **Pipedrive** | write records + notes | record changes → ingest spine |
| **Bluesky** | publish a post | mentions/replies + own timeline |
| **Mastodon** | publish a post | mentions/replies + own timeline |

A deal moving stage becomes an event the platform can act on, rather than something a user has to notice.

## Who calls this in production

No new plumbing — and that's the point. All four declare `connector` + `connector-<vendor>` + `event-source`, and `EventSourcePullService` selects by **capability, not by name**:

```ts
const registered = this.registry.getByCapability(PLUGIN_CAPABILITIES.EVENT_SOURCE);
```
(`packages/agent/src/ingest/event-source-pull.service.ts:147`, also `:319` for backfill)

So these are pulled by the same production path already driving Slack, Linear, Notion, Jira, Zoom, Discord, Google Workspace and Microsoft 365. The four new `CONNECTOR_<VENDOR>` constants exist for targeted resolution, exactly as the eight existing connectors declare theirs.

## Gates (all green, run locally on the merged tree)

| gate | result |
|---|---|
| `pnpm build --filter=ever-works-api` | 15/15 |
| connector package builds | 6/6 |
| `packages/agent` jest | 449 suites, 8250 tests |
| `apps/api` jest | 234 suites, 3836 tests |
| `packages/plugin` vitest | 303 |
| connector vitest | 109 (hubspot 28, pipedrive 32, bluesky 24, mastodon 25) |
| prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native connectors for HubSpot, Pipedrive, Bluesky, and Mastodon.
  * Support sending messages, creating CRM records, threaded replies, and idempotent retries.
  * Added event polling with normalization, pagination, optional historical backfill, and source links.
  * Expanded available connector capabilities for CRM and social platforms.

* **Documentation**
  * Added setup, configuration, behavior, and troubleshooting guidance for each connector.

* **Tests**
  * Added comprehensive coverage for authentication, validation, sending, polling, backfill, pagination, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->