### PR TITLE
feat(policy): tool-grant matrix, skill activation gate and credential brokering

### DIFF
--- a/apps/api/src/agents/agents.module.spec.ts
+++ b/apps/api/src/agents/agents.module.spec.ts
@@ -89,6 +89,7 @@ jest.mock('@ever-works/agent/policy', () => ({
     PolicyModule: class PolicyModule {},
     MergePolicyService: class MergePolicyService {},
     PullRequestGateService: class PullRequestGateService {},
+    ToolGrantService: class ToolGrantService {},
 }));
 jest.mock('@ever-works/agent/services', () => ({
     WorkOwnershipService: class WorkOwnershipService {},
@@ -123,7 +124,7 @@ import { DigestModule, DigestService } from '@ever-works/agent/digest';
 import { MeetingsModule, MeetingRepository } from '@ever-works/agent/meetings';
 import { FleetModule, FleetService } from '@ever-works/agent/fleet';
 import { PrReviewModule, PrReviewService } from '@ever-works/agent/pr-review';
-import { PolicyModule, MergePolicyService } from '@ever-works/agent/policy';
+import { PolicyModule, MergePolicyService, ToolGrantService } from '@ever-works/agent/policy';
 import { WorkOwnershipService } from '@ever-works/agent/services';
 import {
     TasksService,
@@ -189,6 +190,8 @@ describe('api-side AgentsModule — domain chat-tool wiring', () => {
             BrowserAutomationFacadeService,
             // Judgment layer G3/G10 — the escalation queue tools.
             AgentEscalationService,
+            // Tool-grant matrix (audit item G4) — the read-only grant tools.
+            ToolGrantService,
         ]);
     });
 
@@ -228,6 +231,8 @@ describe('api-side AgentsModule — domain chat-tool wiring', () => {
             'prReview',
             'mergePolicy',
             'escalations',
+            // Audit G4 — the read-only tool-grant matrix.
+            'toolGrants',
         ]);
     });
 });

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -76,7 +76,12 @@ import { DigestModule, DigestService } from '@ever-works/agent/digest';
 import { MeetingsModule, MeetingRepository } from '@ever-works/agent/meetings';
 import { FleetModule, FleetService } from '@ever-works/agent/fleet';
 import { PrReviewModule, PrReviewService } from '@ever-works/agent/pr-review';
-import { PolicyModule, MergePolicyService, PullRequestGateService } from '@ever-works/agent/policy';
+import {
+    PolicyModule,
+    MergePolicyService,
+    PullRequestGateService,
+    ToolGrantService,
+} from '@ever-works/agent/policy';
 import { WorkOwnershipService } from '@ever-works/agent/services';
 import {
     FacadesModule,
@@ -744,6 +749,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 AgentRepository,
                 BrowserAutomationFacadeService,
                 AgentEscalationService,
+                ToolGrantService,
             ],
             useFactory: (
                 tasksService: TasksService,
@@ -761,6 +767,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 agents: AgentRepository,
                 browser: BrowserAutomationFacadeService,
                 escalationService: AgentEscalationService,
+                toolGrants: ToolGrantService,
             ): AgentDomainToolSources => ({
                 // All three membership repositories are bound: the
                 // commentOnTask gate is fail-closed and DENIES every call
@@ -806,6 +813,32 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 // takes the agent owner's userId), so unlike merge-policy
                 // there is no model-supplied id to authorize.
                 escalations: { service: escalationService },
+                // Tool-grant matrix (audit item G4) — the read-only grant
+                // chat tools. Same owner-check posture as the merge-policy
+                // source above: the ids come from the MODEL, so both are
+                // verified against the acting user before any resolution,
+                // and a foreign id returns null (no existence leak).
+                toolGrants: {
+                    service: toolGrants,
+                    async authorize(userId, input) {
+                        if (input.workId) {
+                            try {
+                                await workOwnership.ensureAccess(input.workId, userId);
+                            } catch {
+                                return null;
+                            }
+                        }
+                        if (input.agentId) {
+                            const agent = await agents.findByIdAndUser(input.agentId, userId);
+                            if (!agent) return null;
+                        }
+                        return {
+                            userId,
+                            workId: input.workId ?? null,
+                            agentId: input.agentId ?? null,
+                        };
+                    },
+                },
             }),
         },
     ],

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -58,6 +58,7 @@ import { IngestModule } from './ingest/ingest.module';
 import { MeetingsApiModule } from './meetings/meetings.module';
 import { FleetApiModule } from './fleet/fleet.module';
 import { MergePolicyApiModule } from './merge-policy/merge-policy.module';
+import { ToolGrantsApiModule } from './tool-grants/tool-grants.module';
 import { DigestApiModule } from './digest/digest.module';
 import { EscalationsApiModule } from './escalations/escalations.module';
 import { PrReviewApiModule } from './pr-review/pr-review.module';
@@ -215,6 +216,11 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // agent-side PolicyModule. Writes ride the existing Work / Agent /
         // organization PATCH endpoints.
         MergePolicyApiModule,
+        // Tool-grant matrix (audit item G4) — owner-scoped resolve/check
+        // preview plus the write path for the per-scope grant rows. Same
+        // ownership checks as the merge-policy preview; grants are their
+        // own rows, so unlike a merge policy they need a write path here.
+        ToolGrantsApiModule,
         // Digest read (Wave 7) — GET /api/digest owner-scoped composed
         // digest over the agent-side DigestModule. Cadence stays a
         // profile preference; delivery stays on the digest-dispatcher

--- a/apps/api/src/migrations/1784780000000-CreateToolGrants.ts
+++ b/apps/api/src/migrations/1784780000000-CreateToolGrants.ts
@@ -1,0 +1,126 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Tool-grant matrix (audit item G4) — `tool_grants`, one row per
+ * (owner, scope) carrying that scope's allow/deny contribution.
+ *
+ * WHY
+ *   Before this table there was no tenant → organization → Work → Agent
+ *   lattice for TOOL access at all: the only gate was the per-Agent
+ *   `permissions` booleans, which an Agent's own row could set. An
+ *   operator could not say "nobody under this organization may call
+ *   deploy_*" and have it hold for every Agent beneath it.
+ *
+ * SEMANTICS (resolution lives in `@ever-works/agent/policy`)
+ *   - No row  → inherit. With no rows anywhere the chain resolves to the
+ *     permissive platform default (`allow: ['*']`), so EVERY existing
+ *     install keeps behaving exactly as it did before this migration.
+ *   - `allow` present → intersected with the inherited set. A pattern the
+ *     ancestors never granted is rejected, not widened in.
+ *   - `deny` is additive and permanent down the chain.
+ *
+ * SCHEMA NOTES
+ *   - `scopeId` is NOT NULL for every scope including tenant, so the
+ *     unique index `(userId, scopeType, scopeId)` has no nullable member
+ *     (SQL treats NULLs as DISTINCT inside a unique index, which would let
+ *     a concurrent same-scope create burst all succeed).
+ *   - `tenantId` / `organizationId` are the Tier A/C scope columns
+ *     auto-stamped by `ScopeStampingSubscriber`. They are raw uuid columns
+ *     with no entity relation — the EW-654 cycle-avoidance rule — and are
+ *     indexed rather than FK'd so a tenant/org delete can never block a
+ *     grant delete.
+ *   - `allow` / `deny` are TEXT (`simple-json`), matching the
+ *     `agents.permissions` / `works.checkDefaults` storage pattern.
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1784300000000-CreateTerminalTranscriptChunks`.
+ */
+export class CreateToolGrants1784780000000 implements MigrationInterface {
+    name = 'CreateToolGrants1784780000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('tool_grants')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'tool_grants',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'scopeType', type: 'varchar', length: '16' },
+                    { name: 'scopeId', type: 'uuid' },
+                    { name: 'allow', type: 'text', isNullable: true },
+                    { name: 'deny', type: 'text', isNullable: true },
+                    { name: 'note', type: 'text', isNullable: true },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'tool_grants',
+            new TableIndex({
+                name: 'uq_tool_grants_owner_scope',
+                columnNames: ['userId', 'scopeType', 'scopeId'],
+                isUnique: true,
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'tool_grants',
+            new TableIndex({ name: 'idx_tool_grants_user', columnNames: ['userId'] }),
+        );
+
+        await queryRunner.createIndex(
+            'tool_grants',
+            new TableIndex({
+                name: 'idx_tool_grants_scope',
+                columnNames: ['scopeType', 'scopeId'],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'tool_grants',
+            new TableIndex({ name: 'idx_tool_grants_tenant', columnNames: ['tenantId'] }),
+        );
+
+        await queryRunner.createIndex(
+            'tool_grants',
+            new TableIndex({
+                name: 'idx_tool_grants_organization',
+                columnNames: ['organizationId'],
+            }),
+        );
+
+        if (await queryRunner.hasTable('users')) {
+            await queryRunner.createForeignKey(
+                'tool_grants',
+                new TableForeignKey({
+                    name: 'fk_tool_grants_user',
+                    columnNames: ['userId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('tool_grants')) {
+            await queryRunner.dropTable('tool_grants', true);
+        }
+    }
+}

--- a/apps/api/src/tool-grants/dto/tool-grant.dto.ts
+++ b/apps/api/src/tool-grants/dto/tool-grant.dto.ts
@@ -1,0 +1,110 @@
+import {
+    ArrayMaxSize,
+    IsArray,
+    IsIn,
+    IsOptional,
+    IsString,
+    IsUUID,
+    Matches,
+    MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TOOL_GRANT_PATTERN, type ToolGrantScope } from '@ever-works/contracts';
+
+/** Upper bound on patterns per field — a grant list is a policy, not a database. */
+const MAX_PATTERNS = 200;
+
+/**
+ * Query for `GET /api/tool-grants/resolve` (audit item G4).
+ *
+ * At least one of `workId` / `agentId` / `organizationId` must be present
+ * — the controller enforces that. A bare call would only echo the
+ * permissive platform default and tell the caller nothing about their
+ * setup.
+ */
+export class ResolveToolGrantsQueryDto {
+    @ApiPropertyOptional({
+        description: 'Resolve the grants as they apply to this Work. Must be owned/accessible.',
+    })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Resolve the grants as they apply to this Agent (most specific scope; its Work, organization and tenant are discovered from the row). Must be owned.',
+    })
+    @IsOptional()
+    @IsUUID()
+    agentId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Resolve the grants as they apply to this Organization (tenant + organization layers only). Must belong to the caller’s Tenant.',
+    })
+    @IsOptional()
+    @IsUUID()
+    organizationId?: string;
+}
+
+/** Query for `GET /api/tool-grants/check` — same scope, plus the tool. */
+export class CheckToolGrantQueryDto extends ResolveToolGrantsQueryDto {
+    @ApiProperty({ description: 'The exact tool name to test, e.g. "commitToRepo".' })
+    @IsString()
+    @MaxLength(120)
+    toolName: string;
+}
+
+/**
+ * Body for `PUT /api/tool-grants` — create-or-update ONE scope's grant.
+ *
+ * `allow` and `deny` are both optional and independently meaningful:
+ *  - omitted `allow` → inherit whatever the ancestors grant;
+ *  - `allow: []`     → this scope grants NOTHING (the strongest narrowing);
+ *  - `deny`          → always additive and permanent down the chain.
+ *
+ * Patterns are validated against `TOOL_GRANT_PATTERN` here AND sanitized
+ * again in the service — the wire is not a trust boundary you get to
+ * check once.
+ */
+export class UpsertToolGrantDto {
+    @ApiProperty({
+        enum: ['tenant', 'organization', 'work', 'agent'],
+        description: 'Which scope this grant configures.',
+    })
+    @IsIn(['tenant', 'organization', 'work', 'agent'])
+    scopeType: ToolGrantScope;
+
+    @ApiProperty({ description: 'Id of the scope entity. Must be owned/accessible by the caller.' })
+    @IsUUID()
+    scopeId: string;
+
+    @ApiPropertyOptional({
+        type: [String],
+        description:
+            'Allow patterns: "*", "prefix*" or an exact tool name. Intersected with the ancestors — a pattern they never granted is rejected at resolve time, never widened in.',
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(MAX_PATTERNS)
+    @IsString({ each: true })
+    @Matches(TOOL_GRANT_PATTERN, { each: true })
+    allow?: string[];
+
+    @ApiPropertyOptional({
+        type: [String],
+        description: 'Deny patterns. Additive and permanent for every scope beneath this one.',
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(MAX_PATTERNS)
+    @IsString({ each: true })
+    @Matches(TOOL_GRANT_PATTERN, { each: true })
+    deny?: string[];
+
+    @ApiPropertyOptional({ description: 'Operator note — why this grant exists. Never a secret.' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(500)
+    note?: string;
+}

--- a/apps/api/src/tool-grants/tool-grants.controller.spec.ts
+++ b/apps/api/src/tool-grants/tool-grants.controller.spec.ts
@@ -1,0 +1,196 @@
+// The controller's DI types come from three `@ever-works/agent` barrels
+// whose runtime graphs (entities → items-generator DTOs) do not load under
+// this app's jest module mapping. Every dependency is injected here as a
+// stub anyway, so stub the barrels at module scope — the same posture the
+// merge-policy controller spec uses. Nothing about the controller's
+// behaviour is mocked.
+jest.mock('@ever-works/agent/policy', () => ({ ToolGrantService: class {} }));
+jest.mock('@ever-works/agent/services', () => ({ WorkOwnershipService: class {} }));
+jest.mock('@ever-works/agent/database', () => ({
+    AgentRepository: class {},
+    OrganizationRepository: class {},
+    UserRepository: class {},
+}));
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ToolGrantsController } from './tool-grants.controller';
+
+/**
+ * Tool-grant matrix (audit item G4) — the endpoint's OWNER SCOPING.
+ *
+ * Every scope id is checked BEFORE anything is resolved or written.
+ * Without that, `GET /api/tool-grants/resolve` is a cross-tenant
+ * access-policy oracle and `PUT /api/tool-grants` writes access policy
+ * into somebody else's tenant.
+ */
+describe('ToolGrantsController', () => {
+    const auth = { userId: 'user-1' } as never;
+    const resolved = { matrix: { allow: ['*'], deny: [] }, source: 'default' as const, chain: [] };
+
+    function make(overrides?: {
+        ensureAccess?: jest.Mock;
+        findAgent?: jest.Mock;
+        resolve?: jest.Mock;
+        decide?: jest.Mock;
+        upsert?: jest.Mock;
+        remove?: jest.Mock;
+        findOrganization?: jest.Mock;
+        findUser?: jest.Mock;
+    }) {
+        const resolve = overrides?.resolve ?? jest.fn().mockResolvedValue(resolved);
+        const decide = overrides?.decide ?? jest.fn().mockResolvedValue({ allowed: true });
+        const upsert = overrides?.upsert ?? jest.fn().mockResolvedValue({ id: 'g1' });
+        const remove = overrides?.remove ?? jest.fn().mockResolvedValue(true);
+        const list = jest.fn().mockResolvedValue([]);
+        const ensureAccess = overrides?.ensureAccess ?? jest.fn().mockResolvedValue({});
+        const findAgent = overrides?.findAgent ?? jest.fn().mockResolvedValue({ id: 'agent-1' });
+        const findOrganization =
+            overrides?.findOrganization ??
+            jest.fn().mockResolvedValue({ id: 'org-1', tenantId: 'tenant-1' });
+        const findUser =
+            overrides?.findUser ??
+            jest.fn().mockResolvedValue({ id: 'user-1', tenantId: 'tenant-1' });
+        const controller = new ToolGrantsController(
+            { resolve, decide, upsert, remove, list } as never,
+            { ensureAccess } as never,
+            { findByIdAndUser: findAgent } as never,
+            { findById: findOrganization } as never,
+            { findById: findUser } as never,
+        );
+        return { controller, resolve, decide, upsert, remove, ensureAccess, findAgent };
+    }
+
+    describe('resolve', () => {
+        it('rejects a call with no scope id at all', async () => {
+            const { controller, resolve } = make();
+            await expect(controller.resolve(auth, {})).rejects.toBeInstanceOf(BadRequestException);
+            expect(resolve).not.toHaveBeenCalled();
+        });
+
+        it('gates the Work through WorkOwnershipService before resolving', async () => {
+            const ensureAccess = jest.fn().mockRejectedValue(new NotFoundException('nope'));
+            const { controller, resolve } = make({ ensureAccess });
+            await expect(controller.resolve(auth, { workId: 'work-9' })).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(resolve).not.toHaveBeenCalled();
+        });
+
+        it('404s a foreign Agent without leaking that it exists', async () => {
+            const findAgent = jest.fn().mockResolvedValue(null);
+            const { controller, resolve } = make({ findAgent });
+            await expect(controller.resolve(auth, { agentId: 'agent-9' })).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(resolve).not.toHaveBeenCalled();
+        });
+
+        it('404s an Organization outside the caller’s Tenant', async () => {
+            const findOrganization = jest
+                .fn()
+                .mockResolvedValue({ id: 'org-9', tenantId: 'other-tenant' });
+            const { controller, resolve } = make({ findOrganization });
+            await expect(
+                controller.resolve(auth, { organizationId: 'org-9' }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(resolve).not.toHaveBeenCalled();
+        });
+
+        it('resolves for the AUTHENTICATED user, never a body-supplied one', async () => {
+            const { controller, resolve } = make();
+            await controller.resolve(auth, { agentId: 'agent-1' });
+            expect(resolve).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'user-1', agentId: 'agent-1' }),
+            );
+        });
+    });
+
+    describe('check', () => {
+        it('applies the same scope gate before deciding', async () => {
+            const findAgent = jest.fn().mockResolvedValue(null);
+            const { controller, decide } = make({ findAgent });
+            await expect(
+                controller.check(auth, { agentId: 'agent-9', toolName: 'commitToRepo' }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(decide).not.toHaveBeenCalled();
+        });
+
+        it('passes the tool name through to the decision point', async () => {
+            const { controller, decide } = make();
+            await controller.check(auth, { agentId: 'agent-1', toolName: 'commitToRepo' });
+            expect(decide).toHaveBeenCalledWith(expect.any(Object), 'commitToRepo');
+        });
+    });
+
+    describe('upsert', () => {
+        it('requires at least one of allow / deny', async () => {
+            const { controller, upsert } = make();
+            await expect(
+                controller.upsert(auth, { scopeType: 'work', scopeId: 'work-1' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(upsert).not.toHaveBeenCalled();
+        });
+
+        it('keeps an explicitly EMPTY allow (grants nothing) rather than treating it as absent', async () => {
+            const { controller, upsert } = make();
+            await controller.upsert(auth, { scopeType: 'work', scopeId: 'work-1', allow: [] });
+            expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ grant: { allow: [] } }));
+        });
+
+        it('gates a Work-scoped write through WorkOwnershipService', async () => {
+            const ensureAccess = jest.fn().mockRejectedValue(new NotFoundException('nope'));
+            const { controller, upsert } = make({ ensureAccess });
+            await expect(
+                controller.upsert(auth, {
+                    scopeType: 'work',
+                    scopeId: 'work-9',
+                    deny: ['deploy_*'],
+                }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(upsert).not.toHaveBeenCalled();
+        });
+
+        it('SECURITY: refuses to write a tenant grant for a tenant the caller is not in', async () => {
+            // A ceiling anyone can write into is not a ceiling.
+            const { controller, upsert } = make();
+            await expect(
+                controller.upsert(auth, {
+                    scopeType: 'tenant',
+                    scopeId: 'someone-elses-tenant',
+                    deny: ['*'],
+                }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(upsert).not.toHaveBeenCalled();
+        });
+
+        it('writes a tenant grant for the caller’s OWN tenant', async () => {
+            const { controller, upsert } = make();
+            await controller.upsert(auth, {
+                scopeType: 'tenant',
+                scopeId: 'tenant-1',
+                deny: ['deploy_*'],
+            });
+            expect(upsert).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    scopeType: 'tenant',
+                    scopeId: 'tenant-1',
+                    grant: { deny: ['deploy_*'] },
+                }),
+            );
+        });
+    });
+
+    describe('remove', () => {
+        it('404s when the row is not the caller’s', async () => {
+            const { controller } = make({ remove: jest.fn().mockResolvedValue(false) });
+            await expect(controller.remove(auth, 'g-9')).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('deletes scoped to the caller', async () => {
+            const { controller, remove } = make();
+            await expect(controller.remove(auth, 'g1')).resolves.toEqual({ deleted: true });
+            expect(remove).toHaveBeenCalledWith('user-1', 'g1');
+        });
+    });
+});

--- a/apps/api/src/tool-grants/tool-grants.controller.ts
+++ b/apps/api/src/tool-grants/tool-grants.controller.ts
@@ -1,0 +1,229 @@
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    NotFoundException,
+    Param,
+    Put,
+    Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { ResolvedToolGrants, ToolGrantDecision, ToolGrantScope } from '@ever-works/contracts';
+import { ToolGrantService } from '@ever-works/agent/policy';
+import type { ToolGrant } from '@ever-works/agent/entities';
+import {
+    AgentRepository,
+    OrganizationRepository,
+    UserRepository,
+} from '@ever-works/agent/database';
+import { WorkOwnershipService } from '@ever-works/agent/services';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import {
+    CheckToolGrantQueryDto,
+    ResolveToolGrantsQueryDto,
+    UpsertToolGrantDto,
+} from './dto/tool-grant.dto';
+
+/**
+ * Tool-grant matrix (audit item G4) — the customer-facing surface.
+ *
+ *   GET    /api/tool-grants/resolve?workId=&agentId=&organizationId=
+ *   GET    /api/tool-grants/check?toolName=&workId=&agentId=
+ *   GET    /api/tool-grants
+ *   PUT    /api/tool-grants
+ *   DELETE /api/tool-grants/:id
+ *
+ * `resolve` deliberately returns the whole `chain` (least → most specific,
+ * starting at the platform default) including each layer's REJECTED
+ * patterns. "That tool isn't available" is only a usable answer if the UI
+ * can also say WHERE the restriction came from, and "your Agent-level
+ * grant asked for something its Work never granted" is only debuggable if
+ * the rejection is reported rather than silently dropped.
+ *
+ * Unlike the merge policy — a field on an existing entity, written through
+ * that entity's PATCH — a tool grant is its own row, so it needs its own
+ * write path. Every write is owner-checked against the SAME rules as the
+ * read:
+ *   - Work → `WorkOwnershipService.ensureAccess` (cross-user Works 404
+ *     with no existence leak);
+ *   - Agent → owner-filtered lookup;
+ *   - Organization → same-Tenant check;
+ *   - Tenant → must be the caller's OWN tenant.
+ *
+ * Without those checks this endpoint would be both a cross-tenant policy
+ * oracle and a way to write access policy into someone else's tenant.
+ */
+@ApiTags('tool-grants')
+@Controller('api/tool-grants')
+export class ToolGrantsController {
+    constructor(
+        private readonly toolGrants: ToolGrantService,
+        private readonly ownership: WorkOwnershipService,
+        private readonly agents: AgentRepository,
+        private readonly organizations: OrganizationRepository,
+        private readonly users: UserRepository,
+    ) {}
+
+    @Get('resolve')
+    @ApiOperation({
+        summary:
+            'Preview the effective tool-grant matrix for a Work and/or Agent, with the resolution chain (tenant → organization → Work → Agent over the platform default).',
+    })
+    @HttpCode(HttpStatus.OK)
+    async resolve(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: ResolveToolGrantsQueryDto,
+    ): Promise<ResolvedToolGrants> {
+        await this.assertScopeAccess(auth, query);
+        return this.toolGrants.resolve({
+            userId: auth.userId,
+            workId: query.workId ?? null,
+            agentId: query.agentId ?? null,
+            organizationId: query.organizationId ?? null,
+        });
+    }
+
+    @Get('check')
+    @ApiOperation({
+        summary: 'Check whether one named tool is allowed for a Work and/or Agent.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async check(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CheckToolGrantQueryDto,
+    ): Promise<ToolGrantDecision> {
+        await this.assertScopeAccess(auth, query);
+        return this.toolGrants.decide(
+            {
+                userId: auth.userId,
+                workId: query.workId ?? null,
+                agentId: query.agentId ?? null,
+                organizationId: query.organizationId ?? null,
+            },
+            query.toolName,
+        );
+    }
+
+    @Get()
+    @ApiOperation({ summary: "List the caller's own stored tool grants, one row per scope." })
+    @HttpCode(HttpStatus.OK)
+    async list(@CurrentUser() auth: AuthenticatedUser): Promise<ToolGrant[]> {
+        return this.toolGrants.list(auth.userId);
+    }
+
+    @Put()
+    @ApiOperation({
+        summary:
+            'Create or update the grant for one scope. A second write for the same scope UPDATES it — a scope never contributes two layers.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async upsert(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: UpsertToolGrantDto,
+    ): Promise<ToolGrant> {
+        if (body.allow === undefined && body.deny === undefined) {
+            throw new BadRequestException(
+                'Provide allow and/or deny. To clear a grant, DELETE the row instead.',
+            );
+        }
+        await this.assertWritableScope(auth, body.scopeType, body.scopeId);
+        const grant: { allow?: string[]; deny?: string[] } = {};
+        if (body.allow !== undefined) grant.allow = body.allow;
+        if (body.deny !== undefined) grant.deny = body.deny;
+        return this.toolGrants.upsert({
+            userId: auth.userId,
+            scopeType: body.scopeType,
+            scopeId: body.scopeId,
+            grant,
+            note: body.note ?? null,
+        });
+    }
+
+    @Delete(':id')
+    @ApiOperation({ summary: 'Delete one grant row. The scope reverts to inheriting.' })
+    @HttpCode(HttpStatus.OK)
+    async remove(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+    ): Promise<{ deleted: true }> {
+        const deleted = await this.toolGrants.remove(auth.userId, id);
+        if (!deleted) {
+            throw new NotFoundException(`Tool grant with id '${id}' not found`);
+        }
+        return { deleted: true };
+    }
+
+    // ── ownership ─────────────────────────────────────────────────────
+
+    /** Read-side scope check. Mirrors `MergePolicyController.resolve` exactly. */
+    private async assertScopeAccess(
+        auth: AuthenticatedUser,
+        query: ResolveToolGrantsQueryDto,
+    ): Promise<void> {
+        if (!query.workId && !query.agentId && !query.organizationId) {
+            throw new BadRequestException('Provide workId, agentId and/or organizationId.');
+        }
+        if (query.workId) {
+            // Throws 404 for a Work the caller cannot reach.
+            await this.ownership.ensureAccess(query.workId, auth.userId);
+        }
+        if (query.agentId) {
+            const agent = await this.agents.findByIdAndUser(query.agentId, auth.userId);
+            if (!agent) {
+                throw new NotFoundException(`Agent with id '${query.agentId}' not found`);
+            }
+        }
+        if (query.organizationId) {
+            await this.assertOrganizationInTenant(auth, query.organizationId);
+        }
+    }
+
+    /** Write-side scope check — one scope at a time, including tenant. */
+    private async assertWritableScope(
+        auth: AuthenticatedUser,
+        scopeType: ToolGrantScope,
+        scopeId: string,
+    ): Promise<void> {
+        switch (scopeType) {
+            case 'work':
+                await this.ownership.ensureAccess(scopeId, auth.userId);
+                return;
+            case 'agent': {
+                const agent = await this.agents.findByIdAndUser(scopeId, auth.userId);
+                if (!agent) throw new NotFoundException(`Agent with id '${scopeId}' not found`);
+                return;
+            }
+            case 'organization':
+                await this.assertOrganizationInTenant(auth, scopeId);
+                return;
+            case 'tenant': {
+                // A tenant ceiling that anyone could write into is not a
+                // ceiling. Only the caller's OWN tenant is writable here.
+                const user = await this.users.findById(auth.userId);
+                if (!user?.tenantId || user.tenantId !== scopeId) {
+                    throw new NotFoundException(`Tenant with id '${scopeId}' not found`);
+                }
+                return;
+            }
+        }
+    }
+
+    private async assertOrganizationInTenant(
+        auth: AuthenticatedUser,
+        organizationId: string,
+    ): Promise<void> {
+        // Same-Tenant check as `OrganizationService.update` — an
+        // Organization outside the caller's Tenant 404s with no existence
+        // leak, so the org layer can never become a cross-tenant oracle.
+        const user = await this.users.findById(auth.userId);
+        const org = await this.organizations.findById(organizationId);
+        if (!user?.tenantId || !org || org.tenantId !== user.tenantId) {
+            throw new NotFoundException(`Organization with id '${organizationId}' not found`);
+        }
+    }
+}

--- a/apps/api/src/tool-grants/tool-grants.module.ts
+++ b/apps/api/src/tool-grants/tool-grants.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { PolicyModule } from '@ever-works/agent/policy';
+import { AgentsModule } from '@ever-works/agent/agents';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { WorkModule } from '@ever-works/agent/services';
+import { ToolGrantsController } from './tool-grants.controller';
+
+/**
+ * Tool-grant matrix (audit item G4) — thin API module over the agent-side
+ * `PolicyModule` (resolution, the narrowing rule and the single decision
+ * point all live there).
+ *
+ * `WorkModule` supplies `WorkOwnershipService`, `AgentsModule` supplies
+ * `AgentRepository`, and `DatabaseModule` supplies `OrganizationRepository`
+ * + `UserRepository` — the four owner-scope checks the controller runs
+ * BEFORE resolving or writing anything, so this endpoint can be neither a
+ * cross-tenant policy oracle nor a way to write access policy into
+ * somebody else's tenant.
+ *
+ * Mirrors `MergePolicyApiModule`. The one structural difference: tool
+ * grants are their OWN rows, so unlike a merge policy they need a write
+ * path here rather than riding along on an existing entity's PATCH.
+ */
+@Module({
+    imports: [PolicyModule, WorkModule, AgentsModule, DatabaseModule],
+    controllers: [ToolGrantsController],
+    exports: [PolicyModule],
+})
+export class ToolGrantsApiModule {}

--- a/apps/web/src/lib/ai/tools/tool-selection.ts
+++ b/apps/web/src/lib/ai/tools/tool-selection.ts
@@ -95,6 +95,25 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
     events: ['event', 'ingest', 'ingested', 'feed', 'happened', 'came in'],
     digest: ['digest', 'recap', 'catch up', 'catch-up', 'summary of', 'daily', 'weekly'],
     prreview: ['pull request', 'pull-request', 'merge request', 'review', 'diff', 'changed files'],
+    // Tool-grant matrix (audit item G4) — keyword slots ship WITH the
+    // surface (program DoD rule). Without a slot, `deriveDomain` drops
+    // these into the `works` catch-all where the `isExplicit` guard keeps
+    // them out of core, so only a `works` keyword could ever reach them.
+    // The phrasings are the ones people actually use when a tool went
+    // missing ("why can't the agent deploy") rather than the entity name.
+    toolgrants: [
+        'tool grant',
+        'tool-grant',
+        'tool access',
+        'grant matrix',
+        'allowed tool',
+        'allowed tools',
+        'tool permission',
+        'which tools',
+        'revoke tool',
+        "why can't the agent",
+        'why cannot the agent',
+    ],
     members: ['member', 'invite', 'invitation', 'team', 'collaborator', 'people'],
     apikeys: ['api key', 'api-key', 'apikey', 'token'],
     budgets: ['budget', 'usage', 'spend', 'spending', 'cost', 'billing'],
@@ -137,6 +156,7 @@ function deriveDomain(path: string): string {
     if (p.includes('/api/ingest')) return 'events';
     if (p.includes('/api/digest')) return 'digest';
     if (p.includes('/api/pr-review')) return 'prreview';
+    if (p.includes('/api/tool-grants')) return 'toolgrants';
     if (p.includes('/members') || p.includes('/invitations')) return 'members';
     if (p.includes('/api-keys')) return 'apikeys';
     if (p.includes('/budgets') || p.includes('/usage')) return 'budgets';

--- a/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
@@ -82,6 +82,10 @@ const DOMAIN_TOOL_NAMES = [
     'get_meeting_summary',
     'list_fleet_nodes',
     'resolve_merge_policy',
+    // Tool-grant matrix (audit item G4) — the DoD chat tools ship WITH
+    // the surface, so they are pinned here like every other domain.
+    'resolve_tool_grants',
+    'check_tool_grant',
 ];
 
 describe('AgentToolService — domain chat tool assembly', () => {
@@ -135,6 +139,13 @@ describe('AgentToolService — domain chat tool assembly', () => {
             },
             mergePolicy: {
                 service: { resolve: jest.fn().mockResolvedValue({ source: 'work' }) } as any,
+                authorize: authorize as any,
+            },
+            toolGrants: {
+                service: {
+                    resolve: jest.fn().mockResolvedValue({ source: 'work' }),
+                    decide: jest.fn().mockResolvedValue({ allowed: true }),
+                } as any,
                 authorize: authorize as any,
             },
         };
@@ -274,6 +285,45 @@ describe('AgentToolService — domain chat tool assembly', () => {
 
         expect(result).toEqual({ error: 'Not found or not accessible to the current user.' });
         expect((sources.mergePolicy!.service as any).resolve).not.toHaveBeenCalled();
+    });
+
+    it('authorizes resolve_tool_grants against the agent owner before resolving', async () => {
+        const tools = makeSvc().resolveAllowedTools(makeAgent({ userId: 'owner-9' }));
+        const tool = tools.find((t) => t.name === 'resolve_tool_grants')!;
+
+        await tool.invoke({ agentId: 'a1' });
+
+        expect(authorize).toHaveBeenCalledWith('owner-9', { agentId: 'a1' });
+        expect((sources.toolGrants!.service as any).resolve).toHaveBeenCalled();
+    });
+
+    it('refuses the grant tools for a scope the owner may not reach (no existence leak)', async () => {
+        authorize.mockResolvedValue(null);
+        const tools = makeSvc().resolveAllowedTools(makeAgent());
+
+        const resolveResult = await tools
+            .find((t) => t.name === 'resolve_tool_grants')!
+            .invoke({ workId: 'someone-elses-work' });
+        const checkResult = await tools
+            .find((t) => t.name === 'check_tool_grant')!
+            .invoke({ workId: 'someone-elses-work', toolName: 'commitToRepo' });
+
+        expect(resolveResult).toEqual({
+            error: 'Not found or not accessible to the current user.',
+        });
+        expect(checkResult).toEqual({
+            error: 'Not found or not accessible to the current user.',
+        });
+        expect((sources.toolGrants!.service as any).resolve).not.toHaveBeenCalled();
+        expect((sources.toolGrants!.service as any).decide).not.toHaveBeenCalled();
+    });
+
+    it('requires a tool name before checking a grant', async () => {
+        const tools = makeSvc().resolveAllowedTools(makeAgent());
+        const result = await tools
+            .find((t) => t.name === 'check_tool_grant')!
+            .invoke({ agentId: 'a1' });
+        expect(result).toEqual({ error: 'toolName is required.' });
     });
 
     it('keeps commentOnTask fail-closed on membership', async () => {

--- a/packages/agent/src/agents/__tests__/agent-tool-grants-credentials.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-grants-credentials.spec.ts
@@ -1,0 +1,346 @@
+import { AgentToolService } from '../agent-tool.service';
+import {
+    AgentScope,
+    AgentStatus,
+    AgentAvatarMode,
+    AgentIdleBehavior,
+} from '../../entities/agent.entity';
+import type { Agent, AgentPermissions } from '../../entities/agent.entity';
+import type { AgentDomainToolSources } from '../agent-domain-tool-sources';
+import { resolveToolGrantChain } from '../../policy/tool-grant';
+import {
+    checkToolCredentialDeclarations,
+    TOOL_CREDENTIAL_REQUIREMENTS,
+} from '../../policy/tool-credentials';
+import { ENV_CREDENTIAL_PREFIX } from '../../policy/credential-resolver';
+
+/**
+ * Enforcement of the tool-grant matrix (G4) and `{{cred.key}}`
+ * interpolation (G14) at the ONE tool-assembly point.
+ *
+ * The pure rules are tested in `policy/__tests__`; this file pins that
+ * `AgentToolService` actually applies them — and that with neither
+ * dependency wired the service behaves exactly as it did before.
+ *
+ * It also carries the CI check the audit asked for: every declared tool
+ * credential requirement must name a tool the platform really builds and
+ * a credential the catalog really defines.
+ */
+
+function makePerms(over: Partial<AgentPermissions> = {}): AgentPermissions {
+    return {
+        canCreateAgents: false,
+        canAssignTasks: false,
+        canEditSkills: false,
+        canEditAgentFiles: false,
+        canSpend: false,
+        canCommitToRepo: false,
+        canOpenPullRequests: false,
+        canCallExternalTools: false,
+        ...over,
+    };
+}
+
+function makeAgent(over: Partial<Agent> = {}): Agent {
+    return {
+        id: 'a1',
+        userId: 'u1',
+        scope: AgentScope.WORK,
+        missionId: null,
+        ideaId: null,
+        workId: 'w1',
+        name: 'Operator',
+        slug: 'operator',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: null,
+        maxSkillContextTokens: 4000,
+        status: AgentStatus.ACTIVE,
+        permissions: makePerms(),
+        targets: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        soulMd: '# Soul',
+        agentsMd: null,
+        heartbeatMd: null,
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Agent;
+}
+
+const agentsRepo: any = { create: jest.fn(), findByIdAndUser: jest.fn() };
+const agentsService: any = { create: jest.fn() };
+
+function makeSvc(over: { toolGrants?: any; credentials?: any; sources?: any } = {}) {
+    return new AgentToolService(
+        agentsRepo,
+        agentsService,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        over.sources as AgentDomainToolSources | undefined,
+        over.toolGrants,
+        over.credentials,
+    );
+}
+
+describe('AgentToolService.resolveGrantedTools (audit item G4)', () => {
+    it('returns every tool unchanged when no grant enforcer is wired', async () => {
+        const svc = makeSvc();
+        const sync = svc.resolveAllowedTools(makeAgent()).map((t) => t.name);
+        const { tools, refused } = await svc.resolveGrantedTools(makeAgent());
+        expect(tools.map((t) => t.name)).toEqual(sync);
+        expect(refused).toEqual([]);
+    });
+
+    it('returns every tool when the matrix is the permissive default', async () => {
+        const toolGrants = {
+            resolve: jest.fn().mockResolvedValue(resolveToolGrantChain([])),
+            decide: jest.fn(),
+        };
+        const { tools, refused } = await makeSvc({ toolGrants }).resolveGrantedTools(makeAgent());
+        expect(tools.length).toBeGreaterThan(0);
+        expect(refused).toEqual([]);
+    });
+
+    it('withholds a tool the matrix denies, and reports the refusal', async () => {
+        const toolGrants = {
+            resolve: jest
+                .fn()
+                .mockResolvedValue(
+                    resolveToolGrantChain([
+                        { scope: 'tenant', id: 't1', grant: { deny: ['getKbDocument'] } },
+                    ]),
+                ),
+            decide: jest.fn(),
+        };
+        const { tools, refused } = await makeSvc({ toolGrants }).resolveGrantedTools(makeAgent());
+        expect(tools.map((t) => t.name)).not.toContain('getKbDocument');
+        expect(tools.map((t) => t.name)).toContain('getActivity');
+        expect(refused.map((r) => r.toolName)).toEqual(['getKbDocument']);
+    });
+
+    it('resolves against the AGENT OWNER and the agent’s own scope tuple', async () => {
+        const toolGrants = {
+            resolve: jest.fn().mockResolvedValue(resolveToolGrantChain([])),
+            decide: jest.fn(),
+        };
+        await makeSvc({ toolGrants }).resolveGrantedTools(
+            makeAgent({ userId: 'owner-9', workId: 'w-7' }),
+        );
+        expect(toolGrants.resolve).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 'owner-9', agentId: 'a1', workId: 'w-7' }),
+        );
+    });
+
+    it('degrades to the permission gates when the grant lookup throws', async () => {
+        const toolGrants = {
+            resolve: jest.fn().mockRejectedValue(new Error('db down')),
+            decide: jest.fn(),
+        };
+        const { tools, refused } = await makeSvc({ toolGrants }).resolveGrantedTools(makeAgent());
+        // Failing CLOSED here would strip every Agent of every tool on a
+        // transient blip — worse than not narrowing for a moment.
+        expect(tools.length).toBeGreaterThan(0);
+        expect(refused).toEqual([]);
+    });
+});
+
+describe('`{{cred.key}}` interpolation at invoke time (audit item G14)', () => {
+    const ORIGINAL = process.env[`${ENV_CREDENTIAL_PREFIX}API_TOKEN`];
+
+    afterEach(() => {
+        if (ORIGINAL === undefined) delete process.env[`${ENV_CREDENTIAL_PREFIX}API_TOKEN`];
+        else process.env[`${ENV_CREDENTIAL_PREFIX}API_TOKEN`] = ORIGINAL;
+    });
+
+    /**
+     * A service wired with one credential resolver. `getActivity` is used
+     * as the probe because it is always registered and its invoke ignores
+     * its arguments — so what is asserted is the WRAPPER, not the tool.
+     */
+    function svcWithEchoTool(credentials?: any) {
+        const sources = {
+            fleet: { service: { listForUser: jest.fn().mockResolvedValue([]) } },
+        } as unknown as AgentDomainToolSources;
+        return { svc: makeSvc({ credentials, sources }) };
+    }
+
+    it('leaves tools untouched when no resolver is wired', async () => {
+        const { svc } = svcWithEchoTool();
+        const tool = svc.resolveAllowedTools(makeAgent()).find((t) => t.name === 'getActivity')!;
+        // No throw, no interpolation machinery in the way.
+        await expect(tool.invoke({ limit: 1 })).resolves.toBeDefined();
+    });
+
+    it('refuses a call whose referenced credential cannot be resolved', async () => {
+        const credentials = { resolve: jest.fn().mockResolvedValue(new Map()) };
+        const { svc } = svcWithEchoTool(credentials);
+        const tool = svc.resolveAllowedTools(makeAgent()).find((t) => t.name === 'getActivity')!;
+
+        const result = (await tool.invoke({ note: '{{cred.api_token}}' })) as { error?: string };
+
+        expect(result.error).toContain('{{cred.api_token}}');
+        expect(result.error).toContain(`${ENV_CREDENTIAL_PREFIX}API_TOKEN`);
+        // The refusal must never suggest pasting the secret into chat.
+        expect(result.error).toContain('Do not ask the user to paste');
+    });
+
+    it('takes the fast path (no resolver call) when nothing references a credential', async () => {
+        const credentials = { resolve: jest.fn().mockResolvedValue(new Map()) };
+        const { svc } = svcWithEchoTool(credentials);
+        const tool = svc.resolveAllowedTools(makeAgent()).find((t) => t.name === 'getActivity')!;
+
+        await tool.invoke({ limit: 5 });
+
+        expect(credentials.resolve).not.toHaveBeenCalled();
+    });
+
+    it('resolves for the agent owner, never a model-supplied identity', async () => {
+        const credentials = {
+            resolve: jest.fn().mockResolvedValue(new Map([['api_token', 'value-12345']])),
+        };
+        const { svc } = svcWithEchoTool(credentials);
+        const tool = svc
+            .resolveAllowedTools(makeAgent({ userId: 'owner-9' }))
+            .find((t) => t.name === 'getActivity')!;
+
+        await tool.invoke({ note: '{{cred.api_token}}', userId: 'someone-else' });
+
+        expect(credentials.resolve).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: 'owner-9', agentId: 'a1' }),
+            ['api_token'],
+        );
+    });
+
+    it('does not mistake other mustache templates for credential references', async () => {
+        const credentials = { resolve: jest.fn() };
+        const { svc } = svcWithEchoTool(credentials);
+        const tool = svc.resolveAllowedTools(makeAgent()).find((t) => t.name === 'getActivity')!;
+
+        const result = (await tool.invoke({ note: '{{user.email}} {{secret.k}}' })) as {
+            error?: string;
+        };
+
+        expect(result.error).toBeUndefined();
+        expect(credentials.resolve).not.toHaveBeenCalled();
+    });
+
+    it('never surfaces the underlying error when the resolver throws', async () => {
+        const credentials = {
+            resolve: jest.fn().mockRejectedValue(new Error('vault said: value=hunter2')),
+        };
+        const { svc } = svcWithEchoTool(credentials);
+        const tool = svc.resolveAllowedTools(makeAgent()).find((t) => t.name === 'getActivity')!;
+
+        const result = (await tool.invoke({ note: '{{cred.api_token}}' })) as { error?: string };
+
+        expect(result.error).toBe('Credential resolution failed.');
+        expect(result.error).not.toContain('hunter2');
+    });
+});
+
+describe('CI check — tool credential declarations (audit item G14)', () => {
+    it('every declared requirement names a real tool and a defined credential', () => {
+        const svc = makeSvc();
+        const knownToolNames = svc
+            .resolveAllowedTools(
+                makeAgent({
+                    permissions: makePerms({
+                        canCreateAgents: true,
+                        canAssignTasks: true,
+                        canEditAgentFiles: true,
+                        canCommitToRepo: true,
+                        canOpenPullRequests: true,
+                        canCallExternalTools: true,
+                    }),
+                }),
+            )
+            .map((tool) => tool.name);
+
+        expect(checkToolCredentialDeclarations({ knownToolNames })).toEqual([]);
+    });
+
+    it('the requirement table is a plain object of string arrays', () => {
+        for (const [tool, keys] of Object.entries(TOOL_CREDENTIAL_REQUIREMENTS)) {
+            expect(typeof tool).toBe('string');
+            expect(Array.isArray(keys)).toBe(true);
+        }
+    });
+
+    describe('the checker itself', () => {
+        it('CATCHES a requirement naming a tool that does not exist', () => {
+            const problems = checkToolCredentialDeclarations({
+                knownToolNames: ['realTool'],
+                catalog: { k: { description: 'x', envVar: `${ENV_CREDENTIAL_PREFIX}K` } },
+                requirements: { ghostTool: ['k'] },
+            });
+            expect(problems.map((p) => p.kind)).toContain('unknown-tool');
+        });
+
+        it('CATCHES a requirement naming a credential no catalog entry defines', () => {
+            const problems = checkToolCredentialDeclarations({
+                knownToolNames: ['realTool'],
+                catalog: {},
+                requirements: { realTool: ['missing_key'] },
+            });
+            expect(problems.map((p) => p.kind)).toContain('unknown-credential-key');
+        });
+
+        it('CATCHES a catalog entry whose env var does not match the resolver', () => {
+            const problems = checkToolCredentialDeclarations({
+                catalog: { api_token: { description: 'x', envVar: 'API_TOKEN' } },
+                requirements: {},
+            });
+            expect(problems.map((p) => p.kind)).toContain('env-var-mismatch');
+        });
+
+        it('CATCHES a malformed catalog key', () => {
+            const problems = checkToolCredentialDeclarations({
+                catalog: { 'not a key!': { description: 'x', envVar: 'X' } },
+                requirements: {},
+            });
+            expect(problems.map((p) => p.kind)).toContain('malformed-credential-key');
+        });
+
+        it('CATCHES an empty requirement', () => {
+            const problems = checkToolCredentialDeclarations({
+                knownToolNames: ['realTool'],
+                catalog: {},
+                requirements: { realTool: [] },
+            });
+            expect(problems.map((p) => p.kind)).toContain('empty-requirement');
+        });
+
+        it('ACCEPTS a coherent declaration', () => {
+            const problems = checkToolCredentialDeclarations({
+                knownToolNames: ['realTool'],
+                catalog: {
+                    api_token: {
+                        description: 'x',
+                        envVar: `${ENV_CREDENTIAL_PREFIX}API_TOKEN`,
+                    },
+                },
+                requirements: { realTool: ['api_token'] },
+            });
+            expect(problems).toEqual([]);
+        });
+    });
+});

--- a/packages/agent/src/agents/agent-domain-tool-sources.ts
+++ b/packages/agent/src/agents/agent-domain-tool-sources.ts
@@ -14,6 +14,8 @@ import type { MergePolicyResolveInput, MergePolicyService } from '../policy/merg
 import type { ResolveMergePolicyArgs } from '../policy/agent-merge-policy-tools';
 import type { BrowserAutomationFacadeService } from '../facades/browser-automation.facade';
 import type { EscalationToolService } from './agent-escalation-tools';
+import type { ToolGrantEnforcer, ToolGrantResolveInput } from '../policy/tool-grant.enforcer';
+import type { ResolveToolGrantsArgs } from '../policy/agent-tool-grant-tools';
 
 /**
  * Domain chat-tool sources — the ONE injection seam that lets
@@ -107,10 +109,18 @@ export interface AgentEscalationToolSource {
 }
 
 /**
- * The bundle itself. Every member optional: a runtime binds what it can
- * reach, and `resolveAllowedTools` registers exactly the corresponding
- * tools.
+ * Tool-grant matrix (audit item G4) — the read-only grant surface.
+ *
+ * Same shape and same reasoning as `AgentMergePolicyToolSource`: the ids
+ * come from the MODEL, so `authorize` runs an owner check before any
+ * resolution and returns null (never throws) when the user may not reach
+ * the scope — no existence leak.
  */
+export interface AgentToolGrantToolSource {
+    service: Pick<ToolGrantEnforcer, 'resolve' | 'decide'>;
+    authorize(userId: string, input: ResolveToolGrantsArgs): Promise<ToolGrantResolveInput | null>;
+}
+
 /**
  * Headless browsing (audit item G22). Read-only by construction — the
  * source carries only `read`, so no wiring mistake can hand the model the
@@ -120,6 +130,11 @@ export interface AgentBrowserToolSource {
     facade: Pick<BrowserAutomationFacadeService, 'read'>;
 }
 
+/**
+ * The bundle itself. Every member optional: a runtime binds what it can
+ * reach, and `resolveAllowedTools` registers exactly the corresponding
+ * tools.
+ */
 export interface AgentDomainToolSources {
     tasks?: AgentTaskToolSource;
     ingest?: AgentIngestToolSource;
@@ -130,4 +145,5 @@ export interface AgentDomainToolSources {
     mergePolicy?: AgentMergePolicyToolSource;
     browser?: AgentBrowserToolSource;
     escalations?: AgentEscalationToolSource;
+    toolGrants?: AgentToolGrantToolSource;
 }

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -35,6 +35,11 @@ import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
 import { resolveMemoryRecall } from '../services/memory-recall';
 import { VisionContextService } from '../services/vision-context.service';
 import { createAgentRunAbortSource } from './agent-run-abort';
+// Tool-grant matrix (G4) + grant-aware skill activation (G12). Leaf
+// modules with type-only / contracts-only imports — no runtime graph is
+// pulled into `agents/`.
+import { TOOL_GRANT_ENFORCER, type ToolGrantEnforcer } from '../policy/tool-grant.enforcer';
+import { filterSkillsByToolGrants } from '../policy/skill-activation';
 import { isGenerationCancelledError } from '../utils/generation-cancellation.utils';
 import { redactSecrets } from '../utils/secret-scan';
 
@@ -181,6 +186,15 @@ export class AgentRunService {
         // AgentsModule. When absent (or the user has no active Org /
         // no vision) the run's prompt simply has no vision segment.
         @Optional() private readonly visionContext?: VisionContextService,
+        // Tool-grant matrix (audit item G4) + grant-aware skill
+        // activation (G12). Trailing + `@Optional()` so existing
+        // unit-test constructor calls that omit it keep working;
+        // production DI provides it via `PolicyModule`. When absent the
+        // run resolves tools and skills exactly as it did before the
+        // matrix existed.
+        @Optional()
+        @Inject(TOOL_GRANT_ENFORCER)
+        private readonly toolGrants?: ToolGrantEnforcer,
     ) {}
 
     async execute(context: AgentRunContext): Promise<AgentRunExecuteResult> {
@@ -250,7 +264,7 @@ export class AgentRunService {
         const [recentRuns, recentActivityRows, resolvedSkills, companyVision] = await Promise.all([
             this.runs.findByAgent(agent.id, 5, 0).catch(() => []),
             this.findRecentActivityForAgent(agent.userId, agent.id).catch(() => []),
-            this.resolveSkillsForRun(agent).catch(() => []),
+            this.resolveSkillsForRun(agent, context.runId).catch(() => []),
             this.visionContext
                 ? this.visionContext.resolveForUser(agent.userId).catch(() => null)
                 : Promise.resolve(null),
@@ -601,10 +615,7 @@ export class AgentRunService {
         });
         const editsThisRunByFile = new Set<string>();
         const baseDescriptors: AgentToolDescriptor[] = this.toolService
-            ? this.toolService.resolveAllowedTools(agent, {
-                  runId: context.runId,
-                  editsThisRunByFile,
-              })
+            ? await this.resolveToolsForRun(agent, context.runId, editsThisRunByFile)
             : [];
         // Virtual transitionTask descriptor — only exposed on `task`
         // kind runs. It captures the model's transition intent rather
@@ -1428,12 +1439,63 @@ export class AgentRunService {
     }
 
     /**
+     * Tool-grant matrix (audit item G4) — resolve the run's tool set
+     * through the grant-aware path when the tool service offers it.
+     *
+     * The `typeof` guard is deliberate: several unit tests mock
+     * `AgentToolService` with only the sync `resolveAllowedTools`, and a
+     * missing method must degrade to the previous behaviour rather than
+     * crash a run. Refused tools are recorded as WARN run-log rows — a
+     * tool that silently vanishes from the loop is the most confusing
+     * failure mode there is.
+     */
+    private async resolveToolsForRun(
+        agent: Agent,
+        runId: string,
+        editsThisRunByFile: Set<string>,
+    ): Promise<AgentToolDescriptor[]> {
+        const service = this.toolService;
+        if (!service) return [];
+        const runContext = { runId, editsThisRunByFile };
+        if (typeof service.resolveGrantedTools !== 'function') {
+            return service.resolveAllowedTools(agent, runContext);
+        }
+
+        const { tools, refused } = await service.resolveGrantedTools(agent, runContext);
+        for (const decision of refused) {
+            void this.runLogs
+                ?.append({
+                    runId,
+                    level: 'WARN',
+                    step: 'tools',
+                    message: `Tool '${decision.toolName}' withheld by the tool-grant matrix (${decision.source} scope).`,
+                    metadata: {
+                        toolName: decision.toolName,
+                        source: decision.source,
+                        code: decision.code ?? null,
+                    },
+                })
+                .catch(() => undefined);
+        }
+        return tools;
+    }
+
+    /**
      * Skills feature — Phase 10.2. Resolve active skills for this
      * Agent run from the binding table. Returns an empty array when
      * the skill-bindings repository is not wired (unit-test mode).
+     *
+     * Grant-aware since audit item G12: a Skill whose frontmatter
+     * declares `allowedTools` and whose EVERY declared tool is refused by
+     * the effective grant matrix is suppressed. Injecting instructions for
+     * a surface the Agent provably cannot reach burns prompt budget and
+     * invites the model to work around the denial. Skills that declare no
+     * tools — the overwhelming majority — are unaffected, as is every
+     * install with no grant rows (the default matrix grants `*`).
      */
     private async resolveSkillsForRun(
         agent: Agent,
+        runId?: string,
     ): Promise<Array<{ slug: string; body: string; priority: number }>> {
         if (!this.skillBindings) return [];
         const rows: ResolvedSkill[] = await this.skillBindings.resolveActive({
@@ -1444,11 +1506,58 @@ export class AgentRunService {
             ideaId: agent.ideaId ?? undefined,
             forAgentRun: true,
         });
-        return rows.map(({ binding, skill }) => ({
+        const candidates = rows.map(({ binding, skill }) => ({
             slug: skill.slug,
             body: skill.instructionsMd,
             priority: binding.priority,
+            allowedTools: skill.frontmatter?.allowedTools ?? null,
         }));
+
+        const grants = await this.resolveGrantsForSkills(agent);
+        const { active, suppressed } = filterSkillsByToolGrants(candidates, grants);
+
+        for (const entry of suppressed) {
+            void this.runLogs
+                ?.append({
+                    runId: runId ?? 'no-run',
+                    level: 'WARN',
+                    step: 'skills',
+                    message: `Skill '${entry.slug}' suppressed — every tool it declares is refused by the tool-grant matrix.`,
+                    metadata: {
+                        slug: entry.slug,
+                        refusedTools: entry.refusals.map((r) => r.toolName),
+                    },
+                })
+                .catch(() => undefined);
+        }
+
+        return active.map(({ slug, body, priority }) => ({ slug, body, priority }));
+    }
+
+    /**
+     * Resolve the grant matrix for skill activation, or `null` when no
+     * enforcer is wired (which leaves every skill active).
+     *
+     * Never throws: a failed lookup must not take the run's skills away.
+     */
+    private async resolveGrantsForSkills(agent: Agent) {
+        if (!this.toolGrants) return null;
+        try {
+            return await this.toolGrants.resolve({
+                userId: agent.userId,
+                agentId: agent.id,
+                workId: agent.workId ?? null,
+                organizationId: agent.organizationId ?? null,
+                tenantId: agent.tenantId ?? null,
+            });
+        } catch (err) {
+            this.logger.warn(
+                `Agent ${agent.id}: tool-grant resolution failed during skill activation; all bound skills stay active: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return null;
+        }
     }
 
     /**

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -50,6 +50,26 @@ import { buildBrowserTools } from '../facades/agent-browser-tools';
 import { buildEscalationTools } from './agent-escalation-tools';
 import { buildPrReviewTools } from '../pr-review/agent-pr-review-tools';
 import { buildMergePolicyTools } from '../policy/agent-merge-policy-tools';
+import { buildToolGrantTools } from '../policy/agent-tool-grant-tools';
+// Tool-grant matrix (G4) + `{{cred.key}}` interpolation (G14). All four
+// modules are leaves whose own imports are type-only or contracts-only,
+// so they add no runtime graph to the `agents/` subpath — the same
+// property that lets the domain tool factories live next to their
+// domains.
+import { partitionToolsByGrant } from '../policy/tool-grant';
+import { TOOL_GRANT_ENFORCER, type ToolGrantEnforcer } from '../policy/tool-grant.enforcer';
+import { CREDENTIAL_RESOLVER, type CredentialResolver } from '../policy/credential-resolver';
+import {
+    collectCredentialRefs,
+    interpolateCredentials,
+    invalidCredentialKeys,
+    redactCredentialValues,
+} from '../policy/credential-interpolation';
+import {
+    checkToolCredentialsAvailable,
+    requiredCredentialsForTool,
+} from '../policy/tool-credentials';
+import type { ToolGrantDecision } from '@ever-works/contracts';
 // Security: lexical SSRF guard reused by the model-controlled URL tools
 // (screenshot / extractContent). Blocks non-HTTP(S) schemes, literal
 // private/loopback/link-local IPs, and cloud-metadata hostnames before
@@ -160,6 +180,18 @@ export class AgentToolService {
         @Optional()
         @Inject(AGENT_DOMAIN_TOOL_SOURCES)
         private readonly domainToolSources?: AgentDomainToolSources,
+        // Tool-grant matrix (audit item G4). APPENDED LAST + @Optional()
+        // so every existing positional constructor call in the unit tests
+        // keeps working, and so a runtime without `PolicyModule` behaves
+        // exactly as it did before the matrix existed.
+        @Optional()
+        @Inject(TOOL_GRANT_ENFORCER)
+        private readonly toolGrants?: ToolGrantEnforcer,
+        // `{{cred.key}}` interpolation (audit item G14). Same posture:
+        // unbound → no interpolation, no behaviour change.
+        @Optional()
+        @Inject(CREDENTIAL_RESOLVER)
+        private readonly credentials?: CredentialResolver,
     ) {}
 
     /**
@@ -287,7 +319,11 @@ export class AgentToolService {
         // assertion) is unchanged.
         tools.push(...this.buildDomainTools(agent));
 
-        return tools;
+        // `{{cred.key}}` interpolation (audit item G14). A no-op unless a
+        // CredentialResolver is bound, and even then a no-op for every
+        // call whose arguments reference no credential — so ordering,
+        // names and schemas are untouched.
+        return tools.map((tool) => this.withCredentialInterpolation(agent, tool));
     }
 
     /**
@@ -426,7 +462,167 @@ export class AgentToolService {
             );
         }
 
+        // Tool-grant matrix (audit item G4) — the DoD chat tools for the
+        // grant surface. Read-only: the model may ask what it is allowed
+        // to do and why, never widen it.
+        if (sources.toolGrants) {
+            const toolGrants = sources.toolGrants;
+            add('tool-grants', () =>
+                buildToolGrantTools({
+                    userId: agent.userId,
+                    service: toolGrants.service,
+                    authorize: (input) => toolGrants.authorize(agent.userId, input),
+                }),
+            );
+        }
+
         return out;
+    }
+
+    /**
+     * Tool-grant matrix (audit item G4) — the async companion to
+     * `resolveAllowedTools`.
+     *
+     * `resolveAllowedTools` stays exactly as it was (sync, permission
+     * flags + facade presence). This method wraps it with the ONE thing
+     * that needs I/O: resolving the tenant → organization → Work → Agent
+     * grant matrix and dropping every tool it does not grant.
+     *
+     * Additive on purpose. Callers that have no grant enforcer wired (unit
+     * tests, the worker, any runtime without `PolicyModule`) keep calling
+     * the sync method and behave exactly as before; and even WITH the
+     * enforcer bound, the platform default grants `*`, so nothing is
+     * dropped until an operator writes a grant row.
+     *
+     * Returns the dropped tools alongside the kept ones so the caller can
+     * log WHY a tool the model was told about is absent — a silently
+     * missing tool is the single most confusing failure mode in a tool
+     * loop.
+     */
+    async resolveGrantedTools(
+        agent: Agent,
+        runContext: { runId: string; editsThisRunByFile: Set<string> } = {
+            runId: 'no-run',
+            editsThisRunByFile: new Set(),
+        },
+    ): Promise<{ tools: AgentToolDescriptor[]; refused: ToolGrantDecision[] }> {
+        const tools = this.resolveAllowedTools(agent, runContext);
+        if (!this.toolGrants) return { tools, refused: [] };
+
+        try {
+            const resolved = await this.toolGrants.resolve({
+                userId: agent.userId,
+                agentId: agent.id,
+                workId: agent.workId ?? null,
+                organizationId: agent.organizationId ?? null,
+                tenantId: agent.tenantId ?? null,
+            });
+            const { refused } = partitionToolsByGrant(
+                resolved,
+                tools.map((tool) => tool.name),
+            );
+            if (refused.length === 0) return { tools, refused: [] };
+            const refusedNames = new Set(refused.map((decision) => decision.toolName));
+            return {
+                tools: tools.filter((tool) => !refusedNames.has(tool.name)),
+                refused,
+            };
+        } catch (err) {
+            // An access matrix that fails CLOSED on its own lookup error
+            // takes the product down on a transient DB blip. The
+            // per-Agent permission gates above still applied, so degrade
+            // to them and say so loudly.
+            this.logger.warn(
+                `Agent ${agent.id}: tool-grant resolution failed, falling back to permission gates only: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return { tools, refused: [] };
+        }
+    }
+
+    /**
+     * `{{cred.key}}` interpolation (audit item G14).
+     *
+     * Wraps ONE descriptor so that, immediately before the underlying
+     * invoke runs:
+     *
+     *   1. every `{{cred.x}}` reference in the model-supplied arguments is
+     *      resolved SERVER-SIDE from the bound `CredentialResolver`;
+     *   2. a call whose credentials cannot be resolved is REFUSED with a
+     *      message naming the missing KEYS (never values) — a
+     *      half-authenticated outbound call is worse than a clear refusal;
+     *   3. the result is scrubbed of any resolved value before it travels
+     *      back to the model, because the remote API is not ours and error
+     *      bodies that echo an Authorization header are commonplace.
+     *
+     * Tools whose arguments reference nothing and which declare no
+     * requirement take a zero-cost fast path.
+     */
+    private withCredentialInterpolation(
+        agent: Agent,
+        descriptor: AgentToolDescriptor,
+    ): AgentToolDescriptor {
+        const resolver = this.credentials;
+        if (!resolver) return descriptor;
+        const invoke = descriptor.invoke;
+
+        return {
+            ...descriptor,
+            invoke: async (args: unknown) => {
+                const referenced = collectCredentialRefs(args);
+                const required = requiredCredentialsForTool(descriptor.name);
+                if (referenced.length === 0 && required.length === 0) {
+                    return invoke(args);
+                }
+
+                const malformed = invalidCredentialKeys(args);
+                if (malformed.length > 0) {
+                    return {
+                        error: `Malformed credential reference(s): ${malformed
+                            .map((key) => `{{cred.${key}}}`)
+                            .join(', ')}.`,
+                    };
+                }
+
+                const keys = Array.from(new Set([...referenced, ...required]));
+                let resolved: Map<string, string>;
+                try {
+                    resolved = await resolver.resolve(
+                        {
+                            userId: agent.userId,
+                            agentId: agent.id,
+                            workId: agent.workId ?? null,
+                            organizationId: agent.organizationId ?? null,
+                            tenantId: agent.tenantId ?? null,
+                        },
+                        keys,
+                    );
+                } catch (err) {
+                    // Never surface the underlying error verbatim — a
+                    // secret-store client can put the value it was
+                    // fetching in its own message.
+                    this.logger.warn(
+                        `Agent ${agent.id}: credential resolution failed for tool ${descriptor.name}.`,
+                    );
+                    void err;
+                    return { error: 'Credential resolution failed.' };
+                }
+
+                const availability = checkToolCredentialsAvailable({
+                    toolName: descriptor.name,
+                    referenced,
+                    resolved,
+                });
+                if (!availability.ok) {
+                    return { error: availability.error ?? 'Missing credentials.' };
+                }
+
+                const interpolated = interpolateCredentials(args, resolved);
+                const result = await invoke(interpolated.value);
+                return redactCredentialValues(result, resolved);
+            },
+        } as AgentToolDescriptor;
     }
 
     // ── tool builders ─────────────────────────────────────────────

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -40,6 +40,7 @@ import { EscalationConfidenceService } from './escalation-confidence';
 import { VisionContextService } from '../services/vision-context.service';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { SkillsModule } from '../skills/skills.module';
+import { PolicyModule } from '../policy/policy.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { FacadesModule } from '../facades/facades.module';
 
@@ -92,6 +93,15 @@ import { FacadesModule } from '../facades/facades.module';
         // Phase 10 — AgentRunService resolves active skills via
         // SkillBindingRepository before assembling the prompt.
         SkillsModule,
+        // Audit items G4 + G12 + G14 — binds TOOL_GRANT_ENFORCER (the
+        // tool-grant matrix consumed by AgentToolService and by
+        // AgentRunService's skill activation) and CREDENTIAL_RESOLVER
+        // (`{{cred.key}}` interpolation). Both are @Optional() at the
+        // consumer, so WITHOUT this import the wiring silently never
+        // fires — the same trap FacadesModule documents just below.
+        // PolicyModule is a leaf (four scope entities + tool_grants), so
+        // this import cannot cycle.
+        PolicyModule,
         // PR #1084 follow-up: AgentRunService injects
         // AgentMemoryFacadeService (@Optional) so it can open + close a
         // memory session per run. Without this import the @Optional()

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -130,6 +130,7 @@ import { FleetNode } from '../entities/fleet-node.entity';
 import { TerminalTranscriptChunk } from '../entities/terminal-transcript-chunk.entity';
 
 import { FleetJob } from '../entities/fleet-job.entity';
+import { ToolGrant } from '../entities/tool-grant.entity';
 
 import {
     PluginEntity,
@@ -314,4 +315,7 @@ export const ENTITIES = [
     // Fleet job runtime (Desktop PRD M4) — the lease-able work queue
     // whose workers are the enrolled nodes above.
     FleetJob,
+    // Tool-grant matrix (audit item G4) — one row per (owner, scope)
+    // carrying that scope's tool allow/deny contribution.
+    ToolGrant,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -149,6 +149,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     // ──────────────────────────────────────────────────────────
     // Streaming-terminal M9 / D1 — persisted terminal transcripts.
     'TerminalTranscriptChunk',
+    // Tool-grant matrix (audit item G4) — per-scope tool allow/deny rows.
+    'ToolGrant',
     'UsageLedgerEntry',
     'User',
     'UserNotificationCategoryMute',

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -145,3 +145,5 @@ export * from './fleet-node.entity';
 export * from './terminal-transcript-chunk.entity';
 
 export * from './fleet-job.entity';
+// Tool-grant matrix (audit item G4) — per-scope tool allow/deny rows.
+export * from './tool-grant.entity';

--- a/packages/agent/src/entities/tool-grant.entity.ts
+++ b/packages/agent/src/entities/tool-grant.entity.ts
@@ -1,0 +1,104 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import type { ToolGrantScope } from '@ever-works/contracts';
+
+/**
+ * Tool-grant matrix (audit item G4) — one stored grant row for ONE scope.
+ *
+ * The matrix answers "may this Agent call this tool?" by folding the four
+ * scopes tenant → organization → Work → Agent over a permissive platform
+ * default, with a hard rule that a more specific scope may only NARROW
+ * (see `policy/tool-grant.ts`). This table is where each scope's
+ * contribution lives.
+ *
+ * # Why a table and not four more JSON columns
+ *
+ * The merge-policy matrix put a `mergePolicy` column on each of the four
+ * scope entities because a policy is five booleans that every scope always
+ * has an opinion about. Tool grants are different: most scopes have no row
+ * at all (they inherit), rows are written and revoked far more often than
+ * an entity is updated, and an audit trail per grant is worth having. A
+ * dedicated table keeps `tenants`/`organizations`/`works`/`agents` from
+ * growing an unbounded JSON blob that every unrelated read would carry.
+ *
+ * # Scope columns
+ *
+ * `tenantId` / `organizationId` are the Tier A/C scope columns and are
+ * auto-stamped on insert by
+ * [`ScopeStampingSubscriber`](../../../../apps/api/src/scope/scope-stamping.subscriber.ts)
+ * from the active `ScopeContextService` — the subscriber keys on an entity
+ * declaring BOTH columns, which this one does. As with every other
+ * tenant-scoped entity there is deliberately **no `@ManyToOne`** on them:
+ * that is the known entities import cycle (see `user.entity.ts`, EW-654).
+ * The FKs and indexes are enforced at the DB layer by the migration.
+ *
+ * Note that `scopeType`/`scopeId` (what this grant is ABOUT) and
+ * `tenantId`/`organizationId` (which tenant/org the ROW belongs to) are
+ * different things: a Work-scoped grant row carries `scopeType='work'`,
+ * `scopeId=<workId>` and is itself stamped with the tenant/org it was
+ * created under.
+ */
+@Entity({ name: 'tool_grants' })
+// One grant row per (owner, scope) — a second write for the same scope is
+// an UPDATE, not a duplicate layer. Enforced at the DB layer too so a
+// concurrent double-create cannot produce two contradictory rows.
+@Index('uq_tool_grants_owner_scope', ['userId', 'scopeType', 'scopeId'], { unique: true })
+@Index('idx_tool_grants_user', ['userId'])
+@Index('idx_tool_grants_scope', ['scopeType', 'scopeId'])
+export class ToolGrant {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner of the grant. Every read/write is scoped to this column. */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    /** Which scope this row configures: tenant | organization | work | agent. */
+    @Column({ type: 'varchar', length: 16 })
+    scopeType: ToolGrantScope;
+
+    /**
+     * The id of the scope entity. Non-null for every scope INCLUDING
+     * tenant (a tenant grant names its tenant id) so the unique index has
+     * no nullable member — SQL treats NULLs as DISTINCT inside a unique
+     * index, which would let a same-scope create burst all succeed.
+     */
+    @Column({ type: 'uuid' })
+    scopeId: string;
+
+    /**
+     * Allow patterns (`*`, `prefix*`, `exact_name`). `null` means INHERIT —
+     * never "deny". Stored as `simple-json` (TEXT at the DB layer) to match
+     * the `agents.permissions` / `works.checkDefaults` storage pattern.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    allow?: string[] | null;
+
+    /** Deny patterns. Additive and permanent down the chain. */
+    @Column({ type: 'simple-json', nullable: true })
+    deny?: string[] | null;
+
+    /** Optional operator note — why this grant exists. Never a secret. */
+    @Column({ type: 'text', nullable: true })
+    note?: string | null;
+
+    // Tier A/C scope columns — auto-stamped by ScopeStampingSubscriber.
+    // No @ManyToOne: known entities import cycle (user.entity.ts, EW-654).
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/policy/__tests__/credential-interpolation.spec.ts
+++ b/packages/agent/src/policy/__tests__/credential-interpolation.spec.ts
@@ -1,0 +1,163 @@
+import {
+    collectCredentialRefs,
+    credentialRedactionToken,
+    interpolateCredentials,
+    invalidCredentialKeys,
+    redactCredentialValues,
+} from '../credential-interpolation';
+import {
+    EnvCredentialResolver,
+    ENV_CREDENTIAL_PREFIX,
+    envVarNameForCredential,
+} from '../credential-resolver';
+
+/**
+ * `{{cred.key}}` interpolation (audit item G14).
+ *
+ * The invariants under test are the security ones: a reference resolves
+ * SERVER-SIDE, an unresolvable reference fails the call rather than
+ * silently becoming an empty string, and a resolved value that comes back
+ * in a tool result is scrubbed before it can re-enter the conversation.
+ */
+
+describe('collectCredentialRefs', () => {
+    it('finds references in strings, arrays and nested objects', () => {
+        const refs = collectCredentialRefs({
+            headers: { Authorization: 'Bearer {{cred.api_token}}' },
+            body: ['{{cred.tenant_id}}', 'plain'],
+        });
+        expect(refs).toEqual(['api_token', 'tenant_id']);
+    });
+
+    it('tolerates whitespace inside the braces and dedupes', () => {
+        expect(collectCredentialRefs('{{ cred.a }} and {{cred.a}}')).toEqual(['a']);
+    });
+
+    it('returns nothing for values with no references', () => {
+        expect(collectCredentialRefs({ a: 1, b: 'plain', c: null })).toEqual([]);
+    });
+
+    it('does not treat other mustache-ish templates as credentials', () => {
+        expect(collectCredentialRefs('{{user.email}} {{secret.key}}')).toEqual([]);
+    });
+});
+
+describe('interpolateCredentials', () => {
+    it('substitutes a resolved reference and reports the key as used', () => {
+        const result = interpolateCredentials(
+            { headers: { Authorization: 'Bearer {{cred.api_token}}' } },
+            new Map([['api_token', 's3cr3t-value']]),
+        );
+        expect(result.value).toEqual({ headers: { Authorization: 'Bearer s3cr3t-value' } });
+        expect(result.used).toEqual(['api_token']);
+        expect(result.missing).toEqual([]);
+    });
+
+    it('leaves an UNRESOLVED reference verbatim and reports it missing', () => {
+        // Substituting an empty string would send an unauthenticated
+        // request that looks like it worked — the caller must be able to
+        // fail instead.
+        const result = interpolateCredentials('Bearer {{cred.nope}}', new Map());
+        expect(result.value).toBe('Bearer {{cred.nope}}');
+        expect(result.missing).toEqual(['nope']);
+    });
+
+    it('walks arrays and nested plain objects', () => {
+        const result = interpolateCredentials(
+            { list: [{ token: '{{cred.k}}' }] },
+            new Map([['k', 'v-abcdefgh']]),
+        );
+        expect(result.value).toEqual({ list: [{ token: 'v-abcdefgh' }] });
+    });
+
+    it('leaves class instances untouched rather than mangling them', () => {
+        const date = new Date(0);
+        const result = interpolateCredentials({ when: date }, new Map());
+        expect(result.value.when).toBe(date);
+    });
+
+    it('does not mutate the input', () => {
+        const input = { token: '{{cred.k}}' };
+        interpolateCredentials(input, new Map([['k', 'value-1234']]));
+        expect(input.token).toBe('{{cred.k}}');
+    });
+});
+
+describe('redactCredentialValues', () => {
+    it('scrubs a resolved value that an upstream API echoed back', () => {
+        const credentials = new Map([['api_token', 'super-secret-token']]);
+        const result = redactCredentialValues(
+            { error: 'invalid key: super-secret-token' },
+            credentials,
+        );
+        expect(result.error).toBe(`invalid key: ${credentialRedactionToken('api_token')}`);
+        expect(JSON.stringify(result)).not.toContain('super-secret-token');
+    });
+
+    it('scrubs every occurrence, including inside nested structures', () => {
+        const credentials = new Map([['k', 'abcdefgh12345']]);
+        const result = redactCredentialValues(
+            { a: ['abcdefgh12345', { b: 'x abcdefgh12345 y' }] },
+            credentials,
+        );
+        expect(JSON.stringify(result)).not.toContain('abcdefgh12345');
+    });
+
+    it('ignores implausibly short values so ordinary text is not corrupted', () => {
+        const result = redactCredentialValues({ text: 'about the cat' }, new Map([['k', 'cat']]));
+        expect(result.text).toBe('about the cat');
+    });
+
+    it('is a no-op when nothing was resolved', () => {
+        const value = { a: 'b' };
+        expect(redactCredentialValues(value, new Map())).toBe(value);
+    });
+});
+
+describe('invalidCredentialKeys', () => {
+    it('reports nothing for well-formed keys', () => {
+        expect(invalidCredentialKeys('{{cred.api_token}} {{cred.a-b.c}}')).toEqual([]);
+    });
+});
+
+describe('EnvCredentialResolver', () => {
+    const resolver = new EnvCredentialResolver();
+    const ctx = { userId: 'u1' };
+
+    afterEach(() => {
+        delete process.env[`${ENV_CREDENTIAL_PREFIX}API_TOKEN`];
+    });
+
+    it('maps a credential key to a NAMESPACED env var', () => {
+        expect(envVarNameForCredential('api_token')).toBe(`${ENV_CREDENTIAL_PREFIX}API_TOKEN`);
+        expect(envVarNameForCredential('a-b.c')).toBe(`${ENV_CREDENTIAL_PREFIX}A_B_C`);
+    });
+
+    it('resolves a configured key', async () => {
+        process.env[`${ENV_CREDENTIAL_PREFIX}API_TOKEN`] = 'from-env';
+        const resolved = await resolver.resolve(ctx, ['api_token']);
+        expect(resolved.get('api_token')).toBe('from-env');
+    });
+
+    it('OMITS an unconfigured key rather than returning an empty string', async () => {
+        const resolved = await resolver.resolve(ctx, ['api_token']);
+        expect(resolved.has('api_token')).toBe(false);
+    });
+
+    it('SECURITY: cannot reach a platform env var outside the namespace', async () => {
+        // The whole point of the mandatory prefix: a model-authored
+        // `{{cred.database_url}}` must not hand out DATABASE_URL.
+        process.env.DATABASE_URL = 'postgres://secret';
+        try {
+            const resolved = await resolver.resolve(ctx, ['database_url']);
+            expect(resolved.has('database_url')).toBe(false);
+        } finally {
+            delete process.env.DATABASE_URL;
+        }
+    });
+
+    it('ignores a malformed key', async () => {
+        const resolved = await resolver.resolve(ctx, ['not a key!']);
+        expect(resolved.size).toBe(0);
+    });
+});

--- a/packages/agent/src/policy/__tests__/policy.module.spec.ts
+++ b/packages/agent/src/policy/__tests__/policy.module.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Merge-policy matrix (Wave 3, D4) — module-shape pin for PolicyModule.
+ * Policy matrices (Wave 3 D4 + audit items G4/G14) — module-shape pin for
+ * PolicyModule.
  *
  * Pattern mirrors `fleet/__tests__/fleet.module.spec.ts`: heavy runtime
  * trees (TypeORM, the entity graph) are mocked at module scope so the
@@ -16,6 +17,7 @@ jest.mock('../../entities/agent.entity', () => ({ Agent: class Agent {} }));
 jest.mock('../../entities/work.entity', () => ({ Work: class Work {} }));
 jest.mock('../../entities/organization.entity', () => ({ Organization: class Organization {} }));
 jest.mock('../../entities/tenant.entity', () => ({ Tenant: class Tenant {} }));
+jest.mock('../../entities/tool-grant.entity', () => ({ ToolGrant: class ToolGrant {} }));
 jest.mock('../merge-policy.repository', () => ({
     MergePolicyScopeRepository: class MergePolicyScopeRepository {},
 }));
@@ -26,6 +28,12 @@ jest.mock('../pull-request-gate.service', () => ({
     PullRequestGateService: class PullRequestGateService {},
     PullRequestGateRefusedError: class PullRequestGateRefusedError extends Error {},
 }));
+jest.mock('../tool-grant.repository', () => ({
+    ToolGrantRepository: class ToolGrantRepository {},
+}));
+jest.mock('../tool-grant.service', () => ({
+    ToolGrantService: class ToolGrantService {},
+}));
 
 import 'reflect-metadata';
 import { PolicyModule } from '../policy.module';
@@ -33,29 +41,42 @@ import { MERGE_POLICY_ENFORCER } from '../merge-policy.enforcer';
 import { MergePolicyScopeRepository } from '../merge-policy.repository';
 import { MergePolicyService } from '../merge-policy.service';
 import { PullRequestGateService } from '../pull-request-gate.service';
+import { TOOL_GRANT_ENFORCER } from '../tool-grant.enforcer';
+import { ToolGrantRepository } from '../tool-grant.repository';
+import { ToolGrantService } from '../tool-grant.service';
+import { CREDENTIAL_RESOLVER, EnvCredentialResolver } from '../credential-resolver';
 
 describe('PolicyModule', () => {
     const meta = (key: string): unknown[] => Reflect.getMetadata(key, PolicyModule) ?? [];
 
-    it('provides the scope repository, the services and the enforcer binding', () => {
+    it('provides both matrices, their enforcer bindings and the credential resolver', () => {
         expect(meta('providers')).toEqual([
             MergePolicyScopeRepository,
             MergePolicyService,
             { provide: MERGE_POLICY_ENFORCER, useExisting: MergePolicyService },
             PullRequestGateService,
+            ToolGrantRepository,
+            ToolGrantService,
+            { provide: TOOL_GRANT_ENFORCER, useExisting: ToolGrantService },
+            EnvCredentialResolver,
+            { provide: CREDENTIAL_RESOLVER, useExisting: EnvCredentialResolver },
         ]);
     });
 
-    it('exports all four so consumers can take the TOKEN or the PR gate', () => {
+    it('exports the tokens so consumers depend on the CONTRACT, not the class', () => {
         expect(meta('exports')).toEqual([
             MergePolicyScopeRepository,
             MergePolicyService,
             MERGE_POLICY_ENFORCER,
             PullRequestGateService,
+            ToolGrantRepository,
+            ToolGrantService,
+            TOOL_GRANT_ENFORCER,
+            CREDENTIAL_RESOLVER,
         ]);
     });
 
-    it('imports only the four scope entities — a leaf module cannot cycle', () => {
+    it('imports only the scope entities + tool_grants — a leaf module cannot cycle', () => {
         expect(meta('imports')).toHaveLength(1);
     });
 });
@@ -81,5 +102,19 @@ describe('policy barrel', () => {
         expect(typeof barrel.resolveMergePolicyChain).toBe('function');
         expect(typeof barrel.evaluateAgentMerge).toBe('function');
         expect(typeof barrel.sanitizeMergePolicyOverride).toBe('function');
+    });
+
+    it('re-exports the tool-grant surface (G4/G12/G14)', () => {
+        expect(barrel.ToolGrantService).toBe(ToolGrantService);
+        expect(barrel.ToolGrantRepository).toBe(ToolGrantRepository);
+        expect(barrel.TOOL_GRANT_ENFORCER).toBe(TOOL_GRANT_ENFORCER);
+        expect(barrel.CREDENTIAL_RESOLVER).toBe(CREDENTIAL_RESOLVER);
+        expect(typeof barrel.buildToolGrantTools).toBe('function');
+        expect(typeof barrel.resolveToolGrantChain).toBe('function');
+        expect(typeof barrel.decideToolGrant).toBe('function');
+        expect(typeof barrel.filterSkillsByToolGrants).toBe('function');
+        expect(typeof barrel.interpolateCredentials).toBe('function');
+        expect(typeof barrel.redactCredentialValues).toBe('function');
+        expect(typeof barrel.checkToolCredentialDeclarations).toBe('function');
     });
 });

--- a/packages/agent/src/policy/__tests__/skill-activation.spec.ts
+++ b/packages/agent/src/policy/__tests__/skill-activation.spec.ts
@@ -1,0 +1,82 @@
+import { filterSkillsByToolGrants } from '../skill-activation';
+import { resolveToolGrantChain } from '../tool-grant';
+
+/**
+ * Grant-aware skill activation (audit item G12).
+ *
+ * The behaviour that matters: a Skill is suppressed ONLY when every tool
+ * it declares is refused. Declaring nothing, or keeping one tool, keeps it
+ * active — and with no matrix wired nothing changes at all.
+ */
+
+const skill = (slug: string, allowedTools?: string[] | null) => ({ slug, allowedTools });
+
+describe('filterSkillsByToolGrants', () => {
+    it('leaves every skill active when no matrix is wired', () => {
+        const skills = [skill('a', ['deploy_work']), skill('b')];
+        const result = filterSkillsByToolGrants(skills, null);
+        expect(result.active).toEqual(skills);
+        expect(result.suppressed).toEqual([]);
+    });
+
+    it('leaves every skill active under the permissive platform default', () => {
+        const grants = resolveToolGrantChain([]);
+        const result = filterSkillsByToolGrants([skill('a', ['deploy_work']), skill('b')], grants);
+        expect(result.active.map((s) => s.slug)).toEqual(['a', 'b']);
+    });
+
+    it('keeps a skill that declares no tools even when the matrix grants nothing', () => {
+        const grants = resolveToolGrantChain([{ scope: 'tenant', id: 't1', grant: { allow: [] } }]);
+        const result = filterSkillsByToolGrants([skill('style-guide')], grants);
+        expect(result.active.map((s) => s.slug)).toEqual(['style-guide']);
+    });
+
+    it('suppresses a skill whose every declared tool is refused', () => {
+        const grants = resolveToolGrantChain([
+            { scope: 'tenant', id: 't1', grant: { allow: ['git_*'] } },
+        ]);
+        const result = filterSkillsByToolGrants(
+            [skill('deployer', ['deploy_work', 'deploy_rollback'])],
+            grants,
+        );
+        expect(result.active).toEqual([]);
+        expect(result.suppressed).toHaveLength(1);
+        expect(result.suppressed[0].slug).toBe('deployer');
+        expect(result.suppressed[0].refusals.map((r) => r.toolName)).toEqual([
+            'deploy_work',
+            'deploy_rollback',
+        ]);
+    });
+
+    it('keeps a skill that retains at least ONE granted tool', () => {
+        const grants = resolveToolGrantChain([
+            { scope: 'tenant', id: 't1', grant: { allow: ['git_*'] } },
+        ]);
+        const result = filterSkillsByToolGrants(
+            [skill('mixed', ['deploy_work', 'git_commit'])],
+            grants,
+        );
+        expect(result.active.map((s) => s.slug)).toEqual(['mixed']);
+        expect(result.suppressed).toEqual([]);
+    });
+
+    it('honours a deny even when the tool is otherwise allowed', () => {
+        const grants = resolveToolGrantChain([
+            { scope: 'tenant', id: 't1', grant: { allow: ['*'] } },
+            { scope: 'organization', id: 'o1', grant: { deny: ['commitToRepo'] } },
+        ]);
+        const result = filterSkillsByToolGrants([skill('committer', ['commitToRepo'])], grants);
+        expect(result.active).toEqual([]);
+        expect(result.suppressed[0].refusals[0].code).toBe('tool-denied');
+    });
+
+    it('ignores blank / non-string entries in allowedTools', () => {
+        const grants = resolveToolGrantChain([{ scope: 'tenant', id: 't1', grant: { allow: [] } }]);
+        const result = filterSkillsByToolGrants(
+            [skill('junk', ['   ', '', null as unknown as string])],
+            grants,
+        );
+        // Nothing meaningful was declared → treated as "declares nothing".
+        expect(result.active.map((s) => s.slug)).toEqual(['junk']);
+    });
+});

--- a/packages/agent/src/policy/__tests__/tool-grant.service.spec.ts
+++ b/packages/agent/src/policy/__tests__/tool-grant.service.spec.ts
@@ -1,0 +1,146 @@
+import { ToolGrantService } from '../tool-grant.service';
+
+/**
+ * Tool-grant matrix (audit item G4) — the I/O half.
+ *
+ * What matters here is the scope WALK (an agentId must pull in its Work,
+ * organization and tenant layers), the owner scoping of every read, and
+ * the fail-open-to-default posture on a broken lookup.
+ */
+
+function makeScopes(over: Partial<Record<string, any>> = {}) {
+    return {
+        findAgent: jest.fn().mockResolvedValue({
+            id: 'a1',
+            workId: 'w1',
+            organizationId: 'o1',
+            tenantId: 't1',
+        }),
+        findWork: jest.fn().mockResolvedValue({ id: 'w1', organizationId: 'o1', tenantId: 't1' }),
+        findOrganization: jest.fn().mockResolvedValue({ id: 'o1', tenantId: 't1' }),
+        findTenant: jest.fn().mockResolvedValue({ id: 't1' }),
+        ...over,
+    } as any;
+}
+
+function makeGrants(rows: any[] = []) {
+    return {
+        findForScopes: jest.fn().mockResolvedValue(rows),
+        findOne: jest.fn(),
+        findByIdAndUser: jest.fn(),
+        listForUser: jest.fn().mockResolvedValue([]),
+        upsert: jest.fn().mockImplementation(async (input) => ({ id: 'g1', ...input })),
+        deleteByIdAndUser: jest.fn().mockResolvedValue(true),
+    } as any;
+}
+
+describe('ToolGrantService.resolve', () => {
+    it('walks UPWARD from an agentId and asks for all four scope layers', async () => {
+        const scopes = makeScopes();
+        const grants = makeGrants();
+        const svc = new ToolGrantService(scopes, grants);
+
+        await svc.resolve({ userId: 'u1', agentId: 'a1' });
+
+        expect(grants.findForScopes).toHaveBeenCalledWith('u1', [
+            { scopeType: 'tenant', scopeId: 't1' },
+            { scopeType: 'organization', scopeId: 'o1' },
+            { scopeType: 'work', scopeId: 'w1' },
+            { scopeType: 'agent', scopeId: 'a1' },
+        ]);
+    });
+
+    it('lets an explicit id win over the discovered one', async () => {
+        const scopes = makeScopes();
+        const svc = new ToolGrantService(scopes, makeGrants());
+
+        await svc.resolve({ userId: 'u1', agentId: 'a1', workId: 'w-other' });
+
+        expect(scopes.findWork).toHaveBeenCalledWith('w-other');
+    });
+
+    it('folds the loaded rows into the effective matrix', async () => {
+        const svc = new ToolGrantService(
+            makeScopes(),
+            makeGrants([
+                { scopeType: 'tenant', scopeId: 't1', allow: ['git_*', 'deploy_*'], deny: null },
+                { scopeType: 'work', scopeId: 'w1', allow: ['git_*'], deny: ['git_push'] },
+            ]),
+        );
+
+        const resolved = await svc.resolve({ userId: 'u1', agentId: 'a1' });
+
+        expect(resolved.matrix.allow).toEqual(['git_*']);
+        expect(resolved.matrix.deny).toEqual(['git_push']);
+        expect(resolved.source).toBe('work');
+    });
+
+    it('resolves to the permissive default when nothing is stored', async () => {
+        const svc = new ToolGrantService(makeScopes(), makeGrants());
+        const resolved = await svc.resolve({ userId: 'u1', agentId: 'a1' });
+        expect(resolved.matrix).toEqual({ allow: ['*'], deny: [] });
+        expect(resolved.source).toBe('default');
+    });
+
+    it('contributes no layer for a scope row that does not exist', async () => {
+        const scopes = makeScopes({ findOrganization: jest.fn().mockResolvedValue(null) });
+        const grants = makeGrants();
+        const svc = new ToolGrantService(scopes, grants);
+
+        await svc.resolve({ userId: 'u1', workId: 'w1', organizationId: 'o-missing' });
+
+        const refs = grants.findForScopes.mock.calls[0][1];
+        expect(refs.map((r: any) => r.scopeType)).not.toContain('organization');
+    });
+
+    it('degrades to the platform default (never throws) when a lookup fails', async () => {
+        const scopes = makeScopes({ findAgent: jest.fn().mockRejectedValue(new Error('db')) });
+        const svc = new ToolGrantService(scopes, makeGrants());
+
+        const resolved = await svc.resolve({ userId: 'u1', agentId: 'a1' });
+
+        expect(resolved.matrix).toEqual({ allow: ['*'], deny: [] });
+        expect(resolved.chain).toEqual([]);
+    });
+});
+
+describe('ToolGrantService.decide', () => {
+    it('answers one tool against the resolved matrix', async () => {
+        const svc = new ToolGrantService(
+            makeScopes(),
+            makeGrants([{ scopeType: 'tenant', scopeId: 't1', allow: ['git_*'], deny: null }]),
+        );
+
+        await expect(svc.decide({ userId: 'u1', agentId: 'a1' }, 'git_commit')).resolves.toEqual(
+            expect.objectContaining({ allowed: true }),
+        );
+        await expect(svc.decide({ userId: 'u1', agentId: 'a1' }, 'deploy_work')).resolves.toEqual(
+            expect.objectContaining({ allowed: false, code: 'tool-not-granted' }),
+        );
+    });
+});
+
+describe('ToolGrantService writes', () => {
+    it('sanitizes an override on the way in — junk patterns never reach the row', async () => {
+        const grants = makeGrants();
+        const svc = new ToolGrantService(makeScopes(), grants);
+
+        await svc.upsert({
+            userId: 'u1',
+            scopeType: 'work',
+            scopeId: 'w1',
+            grant: { allow: ['git_*', 'not a pattern!', ''] as string[], deny: undefined },
+        });
+
+        expect(grants.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({ grant: { allow: ['git_*'] } }),
+        );
+    });
+
+    it('scopes a delete to the owner', async () => {
+        const grants = makeGrants();
+        const svc = new ToolGrantService(makeScopes(), grants);
+        await svc.remove('u1', 'g1');
+        expect(grants.deleteByIdAndUser).toHaveBeenCalledWith('g1', 'u1');
+    });
+});

--- a/packages/agent/src/policy/__tests__/tool-grant.spec.ts
+++ b/packages/agent/src/policy/__tests__/tool-grant.spec.ts
@@ -1,0 +1,252 @@
+import {
+    PLATFORM_DEFAULT_TOOL_GRANT,
+    matchesToolPattern,
+    toolPatternCovers,
+} from '@ever-works/contracts';
+import {
+    decideToolGrant,
+    narrowAllowPatterns,
+    partitionToolsByGrant,
+    resolveToolGrantChain,
+    type ToolGrantLayer,
+} from '../tool-grant';
+
+/**
+ * Tool-grant matrix (audit item G4) — the pure resolution + decision core.
+ *
+ * The security-critical assertion in this file is the "no upward
+ * widening" block: an Agent-level grant must never reach past what its
+ * Work / organization / tenant granted. Everything else is a supporting
+ * cast.
+ */
+
+const layer = (
+    scope: ToolGrantLayer['scope'],
+    grant: ToolGrantLayer['grant'],
+    id = `${scope}-1`,
+): ToolGrantLayer => ({ scope, id, grant });
+
+/** Last chain entry — `Array.prototype.at` is ES2022; this package targets ES2021. */
+const lastEntry = <T>(rows: T[]): T => rows[rows.length - 1];
+
+describe('matchesToolPattern', () => {
+    it('matches everything on `*`', () => {
+        expect(matchesToolPattern('*', 'anything')).toBe(true);
+    });
+
+    it('matches a prefix glob', () => {
+        expect(matchesToolPattern('git_*', 'git_commit')).toBe(true);
+        expect(matchesToolPattern('git_*', 'deploy_work')).toBe(false);
+    });
+
+    it('matches an exact name, case-insensitively', () => {
+        expect(matchesToolPattern('commitToRepo', 'committorepo')).toBe(true);
+        expect(matchesToolPattern('commitToRepo', 'commitToRepoNow')).toBe(false);
+    });
+
+    it('never matches on empty input', () => {
+        expect(matchesToolPattern('', 'x')).toBe(false);
+        expect(matchesToolPattern('*', '')).toBe(false);
+    });
+});
+
+describe('toolPatternCovers', () => {
+    it('`*` covers every pattern including other wildcards', () => {
+        expect(toolPatternCovers('*', 'git_*')).toBe(true);
+        expect(toolPatternCovers('*', 'commitToRepo')).toBe(true);
+    });
+
+    it('a prefix glob covers narrower patterns under the same prefix', () => {
+        expect(toolPatternCovers('git_*', 'git_commit')).toBe(true);
+        expect(toolPatternCovers('git_*', 'git_*')).toBe(true);
+    });
+
+    it('a narrower pattern does NOT cover a broader one', () => {
+        expect(toolPatternCovers('git_commit', 'git_*')).toBe(false);
+        expect(toolPatternCovers('git_*', '*')).toBe(false);
+    });
+});
+
+describe('resolveToolGrantChain', () => {
+    it('resolves to the permissive platform default when no layer speaks', () => {
+        const resolved = resolveToolGrantChain([]);
+        expect(resolved.matrix).toEqual({
+            allow: [...PLATFORM_DEFAULT_TOOL_GRANT.allow],
+            deny: [...PLATFORM_DEFAULT_TOOL_GRANT.deny],
+        });
+        expect(resolved.source).toBe('default');
+    });
+
+    it('preserves the platform default for layers that store nothing', () => {
+        const resolved = resolveToolGrantChain([
+            layer('tenant', null),
+            layer('work', {}),
+            layer('agent', undefined),
+        ]);
+        expect(resolved.matrix.allow).toEqual(['*']);
+        expect(resolved.source).toBe('default');
+    });
+
+    it('narrows down the chain — each layer intersects its ancestors', () => {
+        const resolved = resolveToolGrantChain([
+            layer('tenant', { allow: ['git_*', 'deploy_*'] }),
+            layer('work', { allow: ['git_*'] }),
+            layer('agent', { allow: ['git_commit'] }),
+        ]);
+        expect(resolved.matrix.allow).toEqual(['git_commit']);
+        expect(resolved.source).toBe('agent');
+    });
+
+    it('sorts layers into precedence order regardless of input order', () => {
+        const resolved = resolveToolGrantChain([
+            layer('agent', { allow: ['git_commit'] }),
+            layer('tenant', { allow: ['git_*'] }),
+        ]);
+        expect(resolved.matrix.allow).toEqual(['git_commit']);
+        expect(resolved.chain.map((entry) => entry.scope)).toEqual(['default', 'tenant', 'agent']);
+    });
+
+    it('unions denies and keeps them permanent down the chain', () => {
+        const resolved = resolveToolGrantChain([
+            layer('organization', { deny: ['deploy_*'] }),
+            // The Agent tries to allow exactly what the org denied.
+            layer('agent', { allow: ['*'], deny: [] }),
+        ]);
+        expect(resolved.matrix.deny).toEqual(['deploy_*']);
+        expect(
+            decideToolGrant({ matrix: resolved.matrix, chain: resolved.chain }, 'deploy_work')
+                .allowed,
+        ).toBe(false);
+    });
+
+    it('treats a declared EMPTY allow as "this scope grants nothing"', () => {
+        const resolved = resolveToolGrantChain([layer('work', { allow: [] })]);
+        expect(resolved.matrix.allow).toEqual([]);
+        expect(decideToolGrant({ matrix: resolved.matrix }, 'anything').allowed).toBe(false);
+    });
+
+    it('reports each layer’s contribution in the chain, least specific first', () => {
+        const resolved = resolveToolGrantChain([
+            layer('tenant', { allow: ['git_*', 'deploy_*'] }),
+            layer('work', { deny: ['deploy_work'] }),
+        ]);
+        expect(resolved.chain).toEqual([
+            { scope: 'default', id: null, allow: ['*'], deny: [], rejected: [] },
+            {
+                scope: 'tenant',
+                id: 'tenant-1',
+                allow: ['git_*', 'deploy_*'],
+                deny: [],
+                rejected: [],
+            },
+            { scope: 'work', id: 'work-1', allow: [], deny: ['deploy_work'], rejected: [] },
+        ]);
+    });
+});
+
+describe('SECURITY — a grant never widens scope upward', () => {
+    it('drops an Agent grant its Work never granted, and reports the rejection', () => {
+        const resolved = resolveToolGrantChain([
+            layer('tenant', { allow: ['git_*', 'deploy_*'] }),
+            layer('work', { allow: ['git_*'] }),
+            // The Agent asks for a tool its Work does not grant.
+            layer('agent', { allow: ['git_commit', 'deploy_work'] }),
+        ]);
+
+        expect(resolved.matrix.allow).toEqual(['git_commit']);
+        const agentEntry = resolved.chain.find((entry) => entry.scope === 'agent');
+        expect(agentEntry?.rejected).toEqual(['deploy_work']);
+
+        const decision = decideToolGrant(
+            { matrix: resolved.matrix, chain: resolved.chain },
+            'deploy_work',
+        );
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('tool-not-granted');
+    });
+
+    it('an Agent asking for `*` cannot escape a narrower tenant', () => {
+        const resolved = resolveToolGrantChain([
+            layer('tenant', { allow: ['git_*'] }),
+            layer('agent', { allow: ['*'] }),
+        ]);
+        // `*` is broader than `git_*`, so it is rejected outright rather
+        // than silently promoting the Agent to everything.
+        expect(resolved.matrix.allow).toEqual([]);
+        expect(lastEntry(resolved.chain).rejected).toEqual(['*']);
+        expect(decideToolGrant({ matrix: resolved.matrix }, 'git_commit').allowed).toBe(false);
+    });
+
+    it('an Agent cannot un-deny what an ancestor denied', () => {
+        const resolved = resolveToolGrantChain([
+            layer('organization', { deny: ['commitToRepo'] }),
+            layer('work', { allow: ['*'] }),
+            layer('agent', { allow: ['commitToRepo'] }),
+        ]);
+        const decision = decideToolGrant(
+            { matrix: resolved.matrix, chain: resolved.chain },
+            'commitToRepo',
+        );
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('tool-denied');
+        expect(decision.source).toBe('organization');
+    });
+
+    it('a Work cannot widen past its organization either (the rule is not agent-specific)', () => {
+        const resolved = resolveToolGrantChain([
+            layer('organization', { allow: ['git_commit'] }),
+            layer('work', { allow: ['git_*'] }),
+        ]);
+        expect(resolved.matrix.allow).toEqual([]);
+        expect(lastEntry(resolved.chain).rejected).toEqual(['git_*']);
+    });
+
+    it('narrowAllowPatterns splits kept from rejected and dedupes', () => {
+        expect(narrowAllowPatterns(['git_*'], ['git_commit', 'git_commit', 'deploy_x'])).toEqual({
+            kept: ['git_commit'],
+            rejected: ['deploy_x'],
+        });
+    });
+});
+
+describe('decideToolGrant', () => {
+    const resolved = resolveToolGrantChain([
+        layer('tenant', { allow: ['git_*', 'searchWeb'] }),
+        layer('work', { deny: ['git_push'] }),
+    ]);
+    const ctx = { matrix: resolved.matrix, chain: resolved.chain };
+
+    it('allows a granted tool and attributes it to the deciding scope', () => {
+        const decision = decideToolGrant(ctx, 'git_commit');
+        expect(decision.allowed).toBe(true);
+        expect(decision.source).toBe('tenant');
+    });
+
+    it('deny beats allow', () => {
+        const decision = decideToolGrant(ctx, 'git_push');
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('tool-denied');
+        expect(decision.source).toBe('work');
+    });
+
+    it('refuses an ungranted tool with an actionable reason', () => {
+        const decision = decideToolGrant(ctx, 'deploy_work');
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('tool-not-granted');
+        expect(decision.reason).toContain('deploy_work');
+        expect(decision.reason).toContain('git_*');
+    });
+
+    it('rejects an empty tool name rather than guessing', () => {
+        expect(decideToolGrant(ctx, '   ').code).toBe('tool-name-invalid');
+    });
+});
+
+describe('partitionToolsByGrant', () => {
+    it('splits a tool list into granted and refused', () => {
+        const resolved = resolveToolGrantChain([layer('tenant', { allow: ['git_*'] })]);
+        const { granted, refused } = partitionToolsByGrant(resolved, ['git_commit', 'deploy_work']);
+        expect(granted).toEqual(['git_commit']);
+        expect(refused.map((decision) => decision.toolName)).toEqual(['deploy_work']);
+    });
+});

--- a/packages/agent/src/policy/agent-tool-grant-tools.ts
+++ b/packages/agent/src/policy/agent-tool-grant-tools.ts
@@ -1,0 +1,127 @@
+import type { ResolvedToolGrants, ToolGrantDecision } from '@ever-works/contracts';
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type { ToolGrantEnforcer, ToolGrantResolveInput } from './tool-grant.enforcer';
+
+/**
+ * Tool-grant matrix (audit item G4) — chat tools for the grant surface,
+ * per the program DoD rule that every new entity ships with chat tools +
+ * keyword slots, not just REST.
+ *
+ * Mirrors `agent-merge-policy-tools.ts`: a descriptor-factory the tool
+ * assembly concatenates at run time (type-only import of
+ * `TaskToolDescriptor`, so the Tasks runtime graph is NOT pulled into the
+ * policy subpath).
+ *
+ * READ-ONLY by design. The tools explain what is granted and why; WRITING
+ * a grant is an access-control change and goes through the REST surface
+ * with its own ownership checks and audit trail. A model that can widen
+ * its own tool access on request is not an access-control system.
+ *
+ * Keyword slots (wired in `apps/web/src/lib/ai/tools/tool-selection.ts`):
+ * "tool grant", "tool access", "grant matrix", "allowed tools", "which
+ * tools can", "why can't the agent", "revoke tool", "tool permission".
+ */
+
+export interface ResolveToolGrantsArgs {
+    /** Resolve as it would apply to this Work. */
+    workId?: string;
+    /** Resolve as it would apply to this Agent (most specific scope). */
+    agentId?: string;
+}
+
+export interface CheckToolGrantArgs extends ResolveToolGrantsArgs {
+    /** The tool name to test against the effective matrix. */
+    toolName?: string;
+}
+
+export function buildToolGrantTools(args: {
+    /**
+     * Owner scope. The caller (API / chat runtime) has already established
+     * this user; the tools only ever resolve scopes they are handed.
+     */
+    userId: string;
+    service: Pick<ToolGrantEnforcer, 'resolve' | 'decide'>;
+    /**
+     * Owner check for the ids the MODEL supplies — without it the tool is
+     * a cross-tenant access-policy oracle. Returns the scope tuple the
+     * user may resolve, or null when they may not.
+     */
+    authorize: (input: ResolveToolGrantsArgs) => Promise<ToolGrantResolveInput | null>;
+}): TaskToolDescriptor[] {
+    const out: TaskToolDescriptor[] = [];
+
+    const scopeProperties = {
+        workId: {
+            type: 'string' as const,
+            description: 'Resolve the grants as they apply to this Work.',
+        },
+        agentId: {
+            type: 'string' as const,
+            description:
+                'Resolve the grants as they apply to this Agent (the most specific scope; its Work, organization and tenant are discovered automatically).',
+        },
+    };
+
+    out.push({
+        name: 'resolve_tool_grants',
+        description:
+            'Resolve the effective tool-grant matrix for a Work or Agent — which tools are allowed, which are denied, and which scope (tenant, organization, Work, Agent or the platform default) each rule came from. Also reports grant patterns a scope asked for that its parent scope never granted (those are rejected, never widened). Use when the user asks what tools an agent may use, why a tool is unavailable, or who controls tool access.',
+        parameters: {
+            type: 'object',
+            properties: scopeProperties,
+            required: [],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as ResolveToolGrantsArgs;
+            if (!a.workId && !a.agentId) {
+                return { error: 'Provide workId or agentId to resolve a tool-grant matrix.' };
+            }
+            try {
+                const scope = await args.authorize(a);
+                if (!scope) {
+                    return { error: 'Not found or not accessible to the current user.' };
+                }
+                return await args.service.resolve(scope);
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<ResolveToolGrantsArgs, ResolvedToolGrants | { error: string }>);
+
+    out.push({
+        name: 'check_tool_grant',
+        description:
+            'Check whether ONE named tool is currently allowed for a Work or Agent, and report which scope decided. Use when the user asks "can this agent call X?" or wants to know why a specific tool was refused.',
+        parameters: {
+            type: 'object',
+            properties: {
+                ...scopeProperties,
+                toolName: {
+                    type: 'string',
+                    description: 'The exact tool name to test, e.g. "commitToRepo".',
+                },
+            },
+            required: ['toolName'],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as CheckToolGrantArgs;
+            if (!a.toolName || typeof a.toolName !== 'string') {
+                return { error: 'toolName is required.' };
+            }
+            if (!a.workId && !a.agentId) {
+                return { error: 'Provide workId or agentId to check a tool grant.' };
+            }
+            try {
+                const scope = await args.authorize(a);
+                if (!scope) {
+                    return { error: 'Not found or not accessible to the current user.' };
+                }
+                return await args.service.decide(scope, a.toolName);
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<CheckToolGrantArgs, ToolGrantDecision | { error: string }>);
+
+    return out;
+}

--- a/packages/agent/src/policy/credential-interpolation.ts
+++ b/packages/agent/src/policy/credential-interpolation.ts
@@ -1,0 +1,214 @@
+import { credentialRefPattern, isCredentialKey } from '@ever-works/contracts';
+
+/**
+ * `{{cred.key}}` interpolation (audit item G14) — the PURE half.
+ *
+ * ## The problem this closes
+ *
+ * A tool that needs a secret had no way to say so. Either the secret was
+ * baked into a plugin's settings (invisible to the tool contract) or the
+ * model was expected to supply it — which means the secret has to be IN
+ * the prompt, i.e. in the transcript, in the provider's logs, and one
+ * prompt-injection away from exfiltration.
+ *
+ * `{{cred.key}}` is the fix: the model writes the REFERENCE, the server
+ * substitutes the VALUE immediately before the outbound call, and the
+ * value never travels back. Three invariants hold everywhere below:
+ *
+ *   1. **Server-side only.** Resolution happens in the tool-invocation
+ *      path, never in prompt assembly. A secret must never be a token in
+ *      a system message.
+ *   2. **Never logged.** Nothing here accepts a logger, and every error
+ *      message names KEYS, never values.
+ *   3. **Never echoed back.** `redactCredentialValues` scrubs any resolved
+ *      value that turns up in a tool RESULT before that result re-enters
+ *      the conversation — an API that reflects its own auth header would
+ *      otherwise hand the secret straight to the model.
+ *
+ * All functions are side-effect free and dependency-free so they can be
+ * unit-tested exhaustively and reused by the worker.
+ */
+
+/** Max nesting depth when walking tool arguments. Guards pathological input. */
+const MAX_WALK_DEPTH = 8;
+
+/**
+ * Collect every distinct `{{cred.key}}` key referenced anywhere in a
+ * value — strings, arrays, plain objects. Order is first-seen so error
+ * messages are stable.
+ */
+export function collectCredentialRefs(value: unknown, depth = 0): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+
+    const visit = (node: unknown, level: number): void => {
+        if (level > MAX_WALK_DEPTH) return;
+        if (typeof node === 'string') {
+            const pattern = credentialRefPattern();
+            let match: RegExpExecArray | null;
+            while ((match = pattern.exec(node)) !== null) {
+                const key = match[1];
+                if (!seen.has(key)) {
+                    seen.add(key);
+                    out.push(key);
+                }
+            }
+            return;
+        }
+        if (Array.isArray(node)) {
+            for (const item of node) visit(item, level + 1);
+            return;
+        }
+        if (node && typeof node === 'object') {
+            for (const item of Object.values(node as Record<string, unknown>)) {
+                visit(item, level + 1);
+            }
+        }
+    };
+
+    visit(value, depth);
+    return out;
+}
+
+export interface InterpolationResult<T> {
+    /** The value with every RESOLVED reference substituted. */
+    value: T;
+    /** Keys that were substituted. Keys only — never values. */
+    used: string[];
+    /**
+     * Keys the value referenced that the resolver could not supply. The
+     * reference is left VERBATIM in the output so the caller can fail the
+     * call; silently substituting an empty string would send an
+     * unauthenticated request that looks like it worked.
+     */
+    missing: string[];
+}
+
+/**
+ * Substitute `{{cred.key}}` references using a resolved key → value map.
+ *
+ * Structure-preserving: strings, arrays and plain objects are walked;
+ * anything else passes through untouched. A string that is EXACTLY one
+ * reference is replaced wholesale (so a numeric-looking secret is still a
+ * string, which is what every HTTP header wants).
+ */
+export function interpolateCredentials<T>(
+    value: T,
+    credentials: ReadonlyMap<string, string>,
+): InterpolationResult<T> {
+    const used = new Set<string>();
+    const missing = new Set<string>();
+
+    const substitute = (input: string, level: number): string => {
+        if (level > MAX_WALK_DEPTH) return input;
+        return input.replace(credentialRefPattern(), (whole, key: string) => {
+            const resolved = credentials.get(key);
+            if (resolved === undefined) {
+                missing.add(key);
+                return whole;
+            }
+            used.add(key);
+            return resolved;
+        });
+    };
+
+    const walk = (node: unknown, level: number): unknown => {
+        if (typeof node === 'string') return substitute(node, level);
+        if (Array.isArray(node)) return node.map((item) => walk(item, level + 1));
+        if (node && typeof node === 'object') {
+            // Only PLAIN objects are rebuilt; class instances (Date, Buffer,
+            // …) pass through untouched so we never mangle them.
+            if (!isPlainObject(node)) return node;
+            const out: Record<string, unknown> = {};
+            for (const [key, item] of Object.entries(node as Record<string, unknown>)) {
+                out[key] = walk(item, level + 1);
+            }
+            return out;
+        }
+        return node;
+    };
+
+    return {
+        value: walk(value, 0) as T,
+        used: Array.from(used),
+        missing: Array.from(missing),
+    };
+}
+
+/** Placeholder written in place of a leaked secret. */
+export function credentialRedactionToken(key: string): string {
+    return `[redacted:cred.${key}]`;
+}
+
+/** Plain object = literal or `Object.create(null)`. Class instances are not. */
+function isPlainObject(node: object): boolean {
+    const proto = Object.getPrototypeOf(node);
+    return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Minimum length for a value to be treated as a plausible secret. Below
+ * this, blanket-replacing every occurrence would corrupt ordinary text
+ * (a 3-character "key" would scrub half the response).
+ */
+const MIN_REDACTABLE_SECRET_LENGTH = 8;
+
+/**
+ * Scrub resolved credential VALUES out of anything about to travel back
+ * to the model (or into a log, or into a stored transcript).
+ *
+ * Called on every tool result whose arguments carried a credential — the
+ * upstream API is not ours and may well reflect the token it was given
+ * (error bodies that echo the Authorization header are depressingly
+ * common). Each occurrence becomes `[redacted:cred.<key>]`, which is both
+ * unmistakable in a transcript and tells a debugging human WHICH
+ * credential leaked without telling them its value.
+ */
+export function redactCredentialValues<T>(
+    value: T,
+    credentials: ReadonlyMap<string, string> | Iterable<[string, string]>,
+): T {
+    const entries = Array.from(
+        credentials instanceof Map ? credentials.entries() : credentials,
+    ).filter(
+        ([, secret]) => typeof secret === 'string' && secret.length >= MIN_REDACTABLE_SECRET_LENGTH,
+    );
+    // Longest first, so a secret that contains another is scrubbed whole.
+    entries.sort((a, b) => b[1].length - a[1].length);
+    if (entries.length === 0) return value;
+
+    const scrubString = (input: string): string => {
+        let out = input;
+        for (const [key, secret] of entries) {
+            if (!out.includes(secret)) continue;
+            out = out.split(secret).join(credentialRedactionToken(key));
+        }
+        return out;
+    };
+
+    const walk = (node: unknown, level: number): unknown => {
+        if (level > MAX_WALK_DEPTH) return node;
+        if (typeof node === 'string') return scrubString(node);
+        if (Array.isArray(node)) return node.map((item) => walk(item, level + 1));
+        if (node && typeof node === 'object') {
+            if (!isPlainObject(node)) return node;
+            const out: Record<string, unknown> = {};
+            for (const [key, item] of Object.entries(node as Record<string, unknown>)) {
+                out[key] = walk(item, level + 1);
+            }
+            return out;
+        }
+        return node;
+    };
+
+    return walk(value, 0) as T;
+}
+
+/**
+ * Validate the KEYS a template references. A key that does not match the
+ * credential-key grammar can never resolve, so catching it here turns a
+ * confusing "missing credential" at call time into a precise complaint.
+ */
+export function invalidCredentialKeys(value: unknown): string[] {
+    return collectCredentialRefs(value).filter((key) => !isCredentialKey(key));
+}

--- a/packages/agent/src/policy/credential-resolver.ts
+++ b/packages/agent/src/policy/credential-resolver.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { isCredentialKey } from '@ever-works/contracts';
+
+/**
+ * `{{cred.key}}` resolution (audit item G14) — the PORT.
+ *
+ * Where a credential actually LIVES is deployment-specific (operator env,
+ * the tenant secret store, a plugin's `x-secret` setting). The tool loop
+ * must not care, so it consumes this narrow interface and the runtime
+ * binds whichever implementation it has.
+ *
+ * The contract is deliberately batch-shaped (`resolve(ctx, keys)`) rather
+ * than one-key-at-a-time: a store-backed implementation gets to make one
+ * round trip per tool call instead of N, and the loop never has a reason
+ * to hold a credential longer than the single call it was resolved for.
+ */
+
+export interface CredentialContext {
+    /** Owner whose credentials may be read. Never optional. */
+    userId: string;
+    agentId?: string | null;
+    workId?: string | null;
+    organizationId?: string | null;
+    tenantId?: string | null;
+}
+
+export interface CredentialResolver {
+    /**
+     * Resolve the given keys for this context. MUST omit keys it cannot
+     * supply rather than returning an empty string — the caller
+     * distinguishes "missing" from "empty" and fails the call on missing.
+     *
+     * MUST NOT log the values it returns.
+     */
+    resolve(ctx: CredentialContext, keys: readonly string[]): Promise<Map<string, string>>;
+}
+
+export const CREDENTIAL_RESOLVER = 'CREDENTIAL_RESOLVER' as const;
+
+/**
+ * Default, self-hosting-friendly implementation: operator environment.
+ *
+ * `{{cred.stripe_key}}` reads `EVERWORKS_CRED_STRIPE_KEY`. The prefix is
+ * mandatory and non-negotiable — without it a tool argument could name
+ * `DATABASE_URL`, `PLATFORM_ENCRYPTION_KEY` or `AWS_SECRET_ACCESS_KEY`
+ * and the tool loop would happily hand the model's outbound call the
+ * platform's own crown jewels. With it, only variables an operator
+ * DELIBERATELY published under that namespace are reachable.
+ *
+ * This resolver is tenant-blind (env is process-wide), which is correct
+ * for single-tenant / self-hosted installs and explicitly NOT correct for
+ * multi-tenant SaaS — that deployment binds a store-backed resolver
+ * instead. Named in the class so nobody has to guess.
+ */
+export const ENV_CREDENTIAL_PREFIX = 'EVERWORKS_CRED_';
+
+export function envVarNameForCredential(key: string): string {
+    return `${ENV_CREDENTIAL_PREFIX}${key.replace(/[.-]/g, '_').toUpperCase()}`;
+}
+
+@Injectable()
+export class EnvCredentialResolver implements CredentialResolver {
+    private readonly logger = new Logger(EnvCredentialResolver.name);
+
+    async resolve(_ctx: CredentialContext, keys: readonly string[]): Promise<Map<string, string>> {
+        const out = new Map<string, string>();
+        for (const key of keys) {
+            if (!isCredentialKey(key)) {
+                // Key names are safe to log; values never are.
+                this.logger.warn(`Ignoring malformed credential key '${key}'.`);
+                continue;
+            }
+            const value = process.env[envVarNameForCredential(key)];
+            if (typeof value === 'string' && value.length > 0) {
+                out.set(key, value);
+            }
+        }
+        return out;
+    }
+}

--- a/packages/agent/src/policy/index.ts
+++ b/packages/agent/src/policy/index.ts
@@ -11,4 +11,21 @@ export * from './merge-policy.service';
 // routes through (audit W3 M3).
 export * from './pull-request-gate.service';
 export * from './agent-merge-policy-tools';
+
+// Tool-grant matrix (audit item G4) + grant-aware skill activation (G12)
+// + `{{cred.key}}` interpolation (G14). Same shape: pure resolution and
+// decision functions, a feature-owned repository, the service that is the
+// single decision point, the `TOOL_GRANT_ENFORCER` token its consumers
+// depend on, and the `resolve_tool_grants` / `check_tool_grant` chat-tool
+// factory.
+export * from './tool-grant';
+export * from './tool-grant.enforcer';
+export * from './tool-grant.repository';
+export * from './tool-grant.service';
+export * from './agent-tool-grant-tools';
+export * from './skill-activation';
+export * from './credential-interpolation';
+export * from './credential-resolver';
+export * from './tool-credentials';
+
 export * from './policy.module';

--- a/packages/agent/src/policy/policy.module.ts
+++ b/packages/agent/src/policy/policy.module.ts
@@ -3,24 +3,43 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agent } from '../entities/agent.entity';
 import { Organization } from '../entities/organization.entity';
 import { Tenant } from '../entities/tenant.entity';
+import { ToolGrant } from '../entities/tool-grant.entity';
 import { Work } from '../entities/work.entity';
 import { MERGE_POLICY_ENFORCER } from './merge-policy.enforcer';
 import { MergePolicyScopeRepository } from './merge-policy.repository';
 import { MergePolicyService } from './merge-policy.service';
 import { PullRequestGateService } from './pull-request-gate.service';
+import { CREDENTIAL_RESOLVER, EnvCredentialResolver } from './credential-resolver';
+import { TOOL_GRANT_ENFORCER } from './tool-grant.enforcer';
+import { ToolGrantRepository } from './tool-grant.repository';
+import { ToolGrantService } from './tool-grant.service';
 
 /**
- * Merge-policy matrix (Wave 3, founder decision D4) — agent-side module
- * owning policy RESOLUTION and the single merge decision point.
+ * Policy matrices (Wave 3 founder decision D4 + audit items G4/G14) —
+ * agent-side module owning policy RESOLUTION and the single decision point
+ * for BOTH matrices:
  *
- * Deliberately a leaf: it imports only the four scope entities, so
- * `FacadesModule` (and anything else that has to ask "may this agent
- * merge?") can depend on it without creating a cycle. It binds
- * `MERGE_POLICY_ENFORCER` to `MergePolicyService` via `useExisting`, so
- * `GitFacadeService` consumes the contract, never the concrete class.
+ *  - merge policy  — "may this agent land this pull request?"
+ *  - tool grants   — "may this tool be called in this scope?"
  *
- * The four entities MUST also stay registered in the DataSource ENTITIES
- * array (`database/database.config.ts`) — this repo has no
+ * They share the same tenant → organization → Work → Agent lattice and the
+ * same `MergePolicyScopeRepository` parent walk, which is exactly why they
+ * live in one module: two copies of a security-relevant scope walk is how
+ * the two drift apart.
+ *
+ * Deliberately a leaf: it imports only the four scope entities plus the
+ * `tool_grants` table, so `FacadesModule` (and anything else that has to
+ * ask a policy question) can depend on it without creating a cycle. Both
+ * enforcer tokens are bound via `useExisting`, so consumers depend on the
+ * CONTRACT, never the concrete class.
+ *
+ * `CREDENTIAL_RESOLVER` defaults to the env-backed resolver
+ * (`EVERWORKS_CRED_*`), which is the right answer for self-hosted installs.
+ * A multi-tenant deployment overrides the token with a store-backed
+ * implementation; nothing else changes.
+ *
+ * Every entity here MUST also stay registered in the DataSource ENTITIES
+ * array (`database/_entities-inventory.ts`) — this repo has no
  * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
  * EntityMetadataNotFoundError on first query. All four have been
  * registered since their own features landed; this module adds no new
@@ -32,20 +51,30 @@ import { PullRequestGateService } from './pull-request-gate.service';
  * / import modules must be able to ask "may this PR open?" without pulling
  * the whole Tasks domain into their graph. It has NO injected dependency,
  * so adding it costs the module nothing.
+ * EntityMetadataNotFoundError on first query.
  */
 @Module({
-    imports: [TypeOrmModule.forFeature([Agent, Work, Organization, Tenant])],
+    imports: [TypeOrmModule.forFeature([Agent, Work, Organization, Tenant, ToolGrant])],
     providers: [
         MergePolicyScopeRepository,
         MergePolicyService,
         { provide: MERGE_POLICY_ENFORCER, useExisting: MergePolicyService },
         PullRequestGateService,
+        ToolGrantRepository,
+        ToolGrantService,
+        { provide: TOOL_GRANT_ENFORCER, useExisting: ToolGrantService },
+        EnvCredentialResolver,
+        { provide: CREDENTIAL_RESOLVER, useExisting: EnvCredentialResolver },
     ],
     exports: [
         MergePolicyScopeRepository,
         MergePolicyService,
         MERGE_POLICY_ENFORCER,
         PullRequestGateService,
+        ToolGrantRepository,
+        ToolGrantService,
+        TOOL_GRANT_ENFORCER,
+        CREDENTIAL_RESOLVER,
     ],
 })
 export class PolicyModule {}

--- a/packages/agent/src/policy/skill-activation.ts
+++ b/packages/agent/src/policy/skill-activation.ts
@@ -1,0 +1,97 @@
+import type { ResolvedToolGrants, ToolGrantDecision } from '@ever-works/contracts';
+import { decideToolGrant } from './tool-grant';
+
+/**
+ * Grant-aware skill activation (audit item G12) — the PURE half.
+ *
+ * ## The gap this closes
+ *
+ * A Skill's frontmatter can declare `allowedTools` — "this skill is about
+ * committing code" / "this skill drives the deploy tools". Activation
+ * ignored it completely: every bound Skill was injected into the system
+ * message regardless of whether the Agent could call the tools the Skill
+ * exists to drive.
+ *
+ * That is not merely untidy. A Skill is instructions, and instructions the
+ * Agent cannot carry out are the worst kind of context: the model spends
+ * its budget on them, then either hallucinates the missing tool or
+ * apologises to the user for a capability the operator deliberately took
+ * away. Worse, a Skill body describing a denied surface is a standing
+ * invitation to work around the denial.
+ *
+ * So: a Skill whose declared tools are ALL denied by the effective grant
+ * matrix is SUPPRESSED. A Skill that declares nothing is always active
+ * (the overwhelming majority — and the reason today's behaviour is
+ * preserved exactly under the permissive default matrix).
+ *
+ * A Skill that declares several tools and keeps at least one stays active:
+ * partial capability is still capability, and suppressing it would be a
+ * surprising cliff.
+ */
+
+/** The subset of a resolved skill this filter needs. */
+export interface ActivatableSkill {
+    slug: string;
+    /** `frontmatter.allowedTools`, if the Skill declared any. */
+    allowedTools?: readonly string[] | null;
+}
+
+export interface SuppressedSkill<T> {
+    skill: T;
+    slug: string;
+    /** Every declared tool, each with the refusal that killed it. */
+    refusals: ToolGrantDecision[];
+}
+
+export interface SkillActivationResult<T> {
+    active: T[];
+    suppressed: SuppressedSkill<T>[];
+}
+
+/**
+ * Partition skills into the ones the effective grant matrix leaves usable
+ * and the ones it does not.
+ *
+ * `resolved` may be `null`/`undefined` — that is the "no grant matrix
+ * wired" case (unit tests, runtimes without the policy module) and every
+ * skill stays active, exactly as before this feature landed.
+ */
+export function filterSkillsByToolGrants<T extends ActivatableSkill>(
+    skills: readonly T[],
+    resolved: Pick<ResolvedToolGrants, 'matrix' | 'chain'> | null | undefined,
+): SkillActivationResult<T> {
+    if (!resolved) return { active: [...skills], suppressed: [] };
+
+    const active: T[] = [];
+    const suppressed: SuppressedSkill<T>[] = [];
+
+    for (const skill of skills) {
+        const declared = (skill.allowedTools ?? []).filter(
+            (tool): tool is string => typeof tool === 'string' && tool.trim().length > 0,
+        );
+        if (declared.length === 0) {
+            // Declares nothing → not about tools → always active.
+            active.push(skill);
+            continue;
+        }
+
+        const refusals: ToolGrantDecision[] = [];
+        let anyAllowed = false;
+        for (const tool of declared) {
+            const decision = decideToolGrant(
+                { matrix: resolved.matrix, chain: resolved.chain },
+                tool,
+            );
+            if (decision.allowed) {
+                anyAllowed = true;
+                break;
+            }
+            refusals.push(decision);
+        }
+
+        if (anyAllowed) active.push(skill);
+        else suppressed.push({ skill, slug: skill.slug, refusals });
+    }
+
+    return { active, suppressed };
+}

--- a/packages/agent/src/policy/tool-credentials.ts
+++ b/packages/agent/src/policy/tool-credentials.ts
@@ -1,0 +1,181 @@
+import { isCredentialKey } from '@ever-works/contracts';
+import { envVarNameForCredential } from './credential-resolver';
+
+/**
+ * Tool credential requirements (audit item G14) — the DECLARATION plus
+ * the check that keeps it honest.
+ *
+ * ## Why a declaration at all
+ *
+ * `{{cred.key}}` lets a tool argument reference a secret. Without a
+ * declaration of what a tool NEEDS, two failures are invisible until
+ * production:
+ *
+ *   1. A tool ships expecting `{{cred.foo}}`, the operator never
+ *      configures `foo`, and the first real call fails at the remote API
+ *      with a 401 that says nothing about a missing platform credential.
+ *   2. A credential key is renamed (or its tool deleted) and the stale
+ *      requirement rots silently.
+ *
+ * `checkToolCredentialDeclarations` is the CI-time answer to both: it is
+ * run by `__tests__/tool-credentials.spec.ts` against the REAL tool list
+ * assembled by `AgentToolService`, so a requirement naming a tool that no
+ * longer exists — or a key that no catalog entry defines — turns the
+ * suite red in seconds instead of turning a customer's run red in weeks.
+ *
+ * `assertToolCredentialsAvailable` is the run-time half: it refuses a call
+ * whose credentials could not be resolved, naming the KEYS (never the
+ * values) so the failure is actionable.
+ */
+
+export interface ToolCredentialDefinition {
+    /** What this credential is, in one line. Shown to operators. */
+    description: string;
+    /**
+     * Where the default (env-backed) resolver reads it from. Derived, not
+     * hand-typed — the check asserts it matches
+     * `envVarNameForCredential(key)` so the two can never drift.
+     */
+    envVar: string;
+}
+
+/**
+ * Every credential key the platform knows about.
+ *
+ * Deliberately EMPTY on landing: no built-in tool requires a credential
+ * today, and inventing keys nobody resolves would be worse than useless.
+ * The value here is the mechanism — a tool that starts needing a secret
+ * adds its key here and its requirement below, and CI enforces both.
+ */
+export const TOOL_CREDENTIAL_CATALOG: Readonly<Record<string, ToolCredentialDefinition>> =
+    Object.freeze({});
+
+/**
+ * Which tools require which credential keys.
+ *
+ * Keyed by the exact tool name the model sees. A tool listed here is
+ * REFUSED at invoke time when any of its keys cannot be resolved — a
+ * half-authenticated outbound call is worse than a clear refusal.
+ */
+export const TOOL_CREDENTIAL_REQUIREMENTS: Readonly<Record<string, readonly string[]>> =
+    Object.freeze({});
+
+/** Credential keys one tool requires. Empty for the overwhelming majority. */
+export function requiredCredentialsForTool(toolName: string): readonly string[] {
+    return TOOL_CREDENTIAL_REQUIREMENTS[toolName] ?? [];
+}
+
+export interface ToolCredentialProblem {
+    kind:
+        | 'unknown-credential-key'
+        | 'malformed-credential-key'
+        | 'env-var-mismatch'
+        | 'unknown-tool'
+        | 'empty-requirement';
+    detail: string;
+}
+
+export interface CheckToolCredentialsInput {
+    /**
+     * Every tool name the platform can actually build. When supplied, a
+     * requirement naming something else is reported as `unknown-tool`.
+     * Omit in a pure unit test of the checker itself.
+     */
+    knownToolNames?: readonly string[];
+    catalog?: Readonly<Record<string, ToolCredentialDefinition>>;
+    requirements?: Readonly<Record<string, readonly string[]>>;
+}
+
+/**
+ * THE CI check. Pure, so it can be exercised against deliberately-broken
+ * fixtures — a checker nobody has ever seen fail is not a check.
+ */
+export function checkToolCredentialDeclarations(
+    input: CheckToolCredentialsInput = {},
+): ToolCredentialProblem[] {
+    const catalog = input.catalog ?? TOOL_CREDENTIAL_CATALOG;
+    const requirements = input.requirements ?? TOOL_CREDENTIAL_REQUIREMENTS;
+    const problems: ToolCredentialProblem[] = [];
+
+    for (const [key, definition] of Object.entries(catalog)) {
+        if (!isCredentialKey(key)) {
+            problems.push({
+                kind: 'malformed-credential-key',
+                detail: `Catalog key '${key}' is not a valid credential key.`,
+            });
+            continue;
+        }
+        const expected = envVarNameForCredential(key);
+        if (definition.envVar !== expected) {
+            problems.push({
+                kind: 'env-var-mismatch',
+                detail: `Catalog key '${key}' declares envVar '${definition.envVar}' but the resolver reads '${expected}'.`,
+            });
+        }
+    }
+
+    const known = input.knownToolNames ? new Set(input.knownToolNames) : null;
+    for (const [toolName, keys] of Object.entries(requirements)) {
+        if (known && !known.has(toolName)) {
+            problems.push({
+                kind: 'unknown-tool',
+                detail: `Credential requirement declared for tool '${toolName}', which the platform does not build.`,
+            });
+        }
+        if (keys.length === 0) {
+            problems.push({
+                kind: 'empty-requirement',
+                detail: `Tool '${toolName}' declares an empty credential requirement — omit the entry instead.`,
+            });
+        }
+        for (const key of keys) {
+            if (!Object.prototype.hasOwnProperty.call(catalog, key)) {
+                problems.push({
+                    kind: 'unknown-credential-key',
+                    detail: `Tool '${toolName}' requires credential '${key}', which no catalog entry defines.`,
+                });
+            }
+        }
+    }
+
+    return problems;
+}
+
+export interface ToolCredentialAvailability {
+    ok: boolean;
+    missing: string[];
+    /** Ready-to-return refusal. Names keys only — never values. */
+    error?: string;
+}
+
+/**
+ * Run-time half: are the credentials this call needs actually present?
+ *
+ * `referenced` are the keys the arguments mention; `required` are the ones
+ * the tool declares it cannot work without. Both are checked, because a
+ * model that writes `{{cred.typo}}` deserves the same clear failure as an
+ * operator who forgot to configure a declared key.
+ */
+export function checkToolCredentialsAvailable(args: {
+    toolName: string;
+    referenced?: readonly string[];
+    resolved: ReadonlyMap<string, string>;
+}): ToolCredentialAvailability {
+    const needed = new Set<string>([
+        ...requiredCredentialsForTool(args.toolName),
+        ...(args.referenced ?? []),
+    ]);
+    const missing = Array.from(needed).filter((key) => !args.resolved.has(key));
+    if (missing.length === 0) return { ok: true, missing: [] };
+    return {
+        ok: false,
+        missing,
+        error:
+            `Tool '${args.toolName}' needs credential(s) ${missing
+                .map((key) => `{{cred.${key}}}`)
+                .join(', ')}, which are not configured. ` +
+            `Ask an operator to set ${missing.map(envVarNameForCredential).join(', ')} ` +
+            '(or the equivalent entry in the configured secret store). ' +
+            'Do not ask the user to paste the secret into the conversation.',
+    };
+}

--- a/packages/agent/src/policy/tool-grant.enforcer.ts
+++ b/packages/agent/src/policy/tool-grant.enforcer.ts
@@ -1,0 +1,43 @@
+import type { ResolvedToolGrants, ToolGrantDecision } from '@ever-works/contracts';
+
+/**
+ * Tool-grant matrix (audit item G4) — injection token + contract for the
+ * enforcement half.
+ *
+ * Token + contract only (leaf file, type-only imports — the same
+ * circular-dep dodge as `MERGE_POLICY_ENFORCER` and the other agent
+ * injection tokens, see `docs/architecture/agent-injection-tokens.md`).
+ * `AgentRunService` and `SkillsService` consume it via
+ * `@Optional() @Inject(...)`; `PolicyModule` binds it to
+ * `ToolGrantService`.
+ *
+ * **Left unbound** — unit tests, the worker, any runtime without the
+ * policy module — every consumer behaves exactly as it did before this
+ * feature landed. That is deliberate: an access matrix that fails CLOSED
+ * when its own wiring is missing would take the whole product down on a
+ * DI mistake, and the safe default here is the permissive platform default
+ * (which is what the resolver returns anyway when there are no rows).
+ */
+
+/** Where a resolution starts. Any subset; more specific ids win. */
+export interface ToolGrantResolveInput {
+    agentId?: string | null;
+    workId?: string | null;
+    organizationId?: string | null;
+    tenantId?: string | null;
+    /** Owner of the grant rows. Required — grants are user-scoped. */
+    userId: string;
+}
+
+export interface ToolGrantEnforcer {
+    /** Resolve the effective matrix + the chain that explains it. */
+    resolve(input: ToolGrantResolveInput): Promise<ResolvedToolGrants>;
+    /**
+     * The single decision point: may THIS tool be called in THIS scope?
+     * Implementations must never throw for policy reasons — a refusal is
+     * `{ allowed: false, code, reason }`.
+     */
+    decide(input: ToolGrantResolveInput, toolName: string): Promise<ToolGrantDecision>;
+}
+
+export const TOOL_GRANT_ENFORCER = 'TOOL_GRANT_ENFORCER' as const;

--- a/packages/agent/src/policy/tool-grant.repository.ts
+++ b/packages/agent/src/policy/tool-grant.repository.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import type { ToolGrantOverride, ToolGrantScope } from '@ever-works/contracts';
+import { ToolGrant } from '../entities/tool-grant.entity';
+
+/** One (scope, id) pair to load a grant row for. */
+export interface ToolGrantScopeRef {
+    scopeType: ToolGrantScope;
+    scopeId: string;
+}
+
+export interface UpsertToolGrantInput extends ToolGrantScopeRef {
+    userId: string;
+    grant: ToolGrantOverride;
+    note?: string | null;
+}
+
+/**
+ * Tool-grant matrix (audit item G4) — feature-owned repository for the
+ * `tool_grants` rows.
+ *
+ * Provided by `PolicyModule`, not `DatabaseModule` — the same split as
+ * `MergePolicyScopeRepository` / `FleetNodeRepository` / `MeetingRepository`.
+ *
+ * Every method takes the owning `userId` and puts it in the WHERE clause.
+ * That is not belt-and-braces: the scope ids arrive from request bodies
+ * and, on the chat-tool path, from the MODEL — an unscoped read here would
+ * turn the matrix into a cross-tenant oracle, and an unscoped write would
+ * let one tenant grant itself tools inside another.
+ *
+ * Scope-column stamping (`tenantId` / `organizationId`) is NOT done here:
+ * `ScopeStampingSubscriber` fills both from the active `ScopeContextService`
+ * on insert. Setting them manually would fight the subscriber's
+ * "explicit value wins" rule.
+ */
+@Injectable()
+export class ToolGrantRepository {
+    constructor(
+        @InjectRepository(ToolGrant)
+        private readonly grants: Repository<ToolGrant>,
+    ) {}
+
+    /**
+     * Load every grant row for one owner across a set of scope refs, in a
+     * SINGLE query (the chain is at most four rows, but N+1 on the tool
+     * loop's hot path is still N+1).
+     */
+    async findForScopes(userId: string, refs: ToolGrantScopeRef[]): Promise<ToolGrant[]> {
+        if (refs.length === 0) return [];
+        const scopeTypes = Array.from(new Set(refs.map((r) => r.scopeType)));
+        const scopeIds = Array.from(new Set(refs.map((r) => r.scopeId)));
+        const rows = await this.grants.find({
+            where: { userId, scopeType: In(scopeTypes), scopeId: In(scopeIds) },
+        });
+        // The IN × IN product can match a (type, id) pair nobody asked for
+        // when two scopes share an id — filter back down to the exact refs.
+        const wanted = new Set(refs.map((r) => `${r.scopeType}:${r.scopeId}`));
+        return rows.filter((row) => wanted.has(`${row.scopeType}:${row.scopeId}`));
+    }
+
+    async findOne(userId: string, ref: ToolGrantScopeRef): Promise<ToolGrant | null> {
+        return this.grants.findOne({
+            where: { userId, scopeType: ref.scopeType, scopeId: ref.scopeId },
+        });
+    }
+
+    async findByIdAndUser(id: string, userId: string): Promise<ToolGrant | null> {
+        return this.grants.findOne({ where: { id, userId } });
+    }
+
+    async listForUser(userId: string): Promise<ToolGrant[]> {
+        return this.grants.find({ where: { userId }, order: { createdAt: 'ASC' } });
+    }
+
+    /**
+     * Create-or-update the single row for (userId, scopeType, scopeId).
+     * The unique index makes that tuple the natural key, so a second write
+     * for the same scope is an UPDATE — never a second, contradictory
+     * layer in the chain.
+     */
+    async upsert(input: UpsertToolGrantInput): Promise<ToolGrant> {
+        const existing = await this.findOne(input.userId, input);
+        const allow = input.grant.allow ?? null;
+        const deny = input.grant.deny ?? null;
+        if (existing) {
+            await this.grants.update(
+                { id: existing.id, userId: input.userId },
+                { allow, deny, note: input.note ?? null },
+            );
+            const refreshed = await this.findByIdAndUser(existing.id, input.userId);
+            return refreshed ?? existing;
+        }
+        const created = this.grants.create({
+            userId: input.userId,
+            scopeType: input.scopeType,
+            scopeId: input.scopeId,
+            allow,
+            deny,
+            note: input.note ?? null,
+        });
+        return this.grants.save(created);
+    }
+
+    async deleteByIdAndUser(id: string, userId: string): Promise<boolean> {
+        const result = await this.grants.delete({ id, userId });
+        return (result.affected ?? 0) > 0;
+    }
+}

--- a/packages/agent/src/policy/tool-grant.service.ts
+++ b/packages/agent/src/policy/tool-grant.service.ts
@@ -1,0 +1,188 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+    PLATFORM_DEFAULT_TOOL_GRANT,
+    sanitizeToolGrantOverride,
+    type ResolvedToolGrants,
+    type ToolGrantDecision,
+    type ToolGrantOverride,
+} from '@ever-works/contracts';
+import { decideToolGrant, resolveToolGrantChain, type ToolGrantLayer } from './tool-grant';
+import type { ToolGrantEnforcer, ToolGrantResolveInput } from './tool-grant.enforcer';
+import { MergePolicyScopeRepository } from './merge-policy.repository';
+import {
+    ToolGrantRepository,
+    type ToolGrantScopeRef,
+    type UpsertToolGrantInput,
+} from './tool-grant.repository';
+import type { ToolGrant } from '../entities/tool-grant.entity';
+
+/**
+ * Tool-grant matrix (audit item G4) — the I/O half.
+ *
+ * ONE resolution function (`resolve`) and ONE decision point (`decide`).
+ * Every path that could hand a tool to a model routes through the latter,
+ * so "may this tool be called here?" is answered by CONFIGURATION in
+ * exactly one place.
+ *
+ * Scope discovery walks UPWARD from whatever the caller knows, exactly
+ * like `MergePolicyService`: an `agentId` yields the Agent's `workId` /
+ * `organizationId` / `tenantId`, a Work yields its org + tenant, an org
+ * yields its tenant. Explicit ids passed by the caller win over discovered
+ * ones (a preview can ask "what would this Agent's grants be under that
+ * Work?").
+ *
+ * The chain walk REUSES `MergePolicyScopeRepository` rather than cloning
+ * it. Despite its name that repository is simply the read-only projection
+ * of the four scope rows down to `{ id, workId, organizationId, tenantId }`
+ * — the identical lattice both matrices resolve over. Two copies of a
+ * security-relevant parent walk is how the two drift apart.
+ *
+ * Never throws for policy reasons: a lookup failure degrades to the
+ * permissive platform default with a warning. That is the right posture
+ * HERE (unlike the merge policy, whose default is restrictive) because a
+ * broken read must not silently strip every Agent of every tool — the
+ * per-Agent `permissions` gates still apply underneath, and a total
+ * outage caused by the access layer failing closed is worse than the
+ * matrix briefly not narrowing.
+ */
+@Injectable()
+export class ToolGrantService implements ToolGrantEnforcer {
+    private readonly logger = new Logger(ToolGrantService.name);
+
+    constructor(
+        private readonly scopes: MergePolicyScopeRepository,
+        private readonly grants: ToolGrantRepository,
+    ) {}
+
+    /**
+     * Resolve the effective matrix for a scope tuple.
+     *
+     * Returns the matrix, the most specific scope that contributed
+     * (`source`), and the full `chain` least → most specific — including
+     * each layer's REJECTED patterns, so a UI can explain "your
+     * Agent-level grant asked for `deploy_*`, which its Work never
+     * granted, so it was ignored".
+     */
+    async resolve(input: ToolGrantResolveInput): Promise<ResolvedToolGrants> {
+        try {
+            const refs = await this.discoverScopeRefs(input);
+            const rows = await this.grants.findForScopes(input.userId, refs);
+            const byScope = new Map<string, ToolGrant>();
+            for (const row of rows) byScope.set(`${row.scopeType}:${row.scopeId}`, row);
+
+            const layers: ToolGrantLayer[] = refs.map((ref) => {
+                const row = byScope.get(`${ref.scopeType}:${ref.scopeId}`);
+                const layer: ToolGrantLayer = { scope: ref.scopeType, id: ref.scopeId };
+                if (row) {
+                    layer.grant = { allow: row.allow ?? undefined, deny: row.deny ?? undefined };
+                }
+                return layer;
+            });
+
+            return resolveToolGrantChain(layers);
+        } catch (error) {
+            this.logger.warn(
+                `Tool-grant resolution failed (falling back to the platform default): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return {
+                matrix: {
+                    allow: [...PLATFORM_DEFAULT_TOOL_GRANT.allow],
+                    deny: [...PLATFORM_DEFAULT_TOOL_GRANT.deny],
+                },
+                source: 'default',
+                chain: [],
+            };
+        }
+    }
+
+    /**
+     * THE decision point. Resolves the matrix for the scope tuple, then
+     * evaluates one tool name against it. Refusals carry a stable `code`
+     * and a human `reason` naming the offending pattern.
+     */
+    async decide(input: ToolGrantResolveInput, toolName: string): Promise<ToolGrantDecision> {
+        const resolved = await this.resolve(input);
+        return decideToolGrant({ matrix: resolved.matrix, chain: resolved.chain }, toolName);
+    }
+
+    // ── Writes ────────────────────────────────────────────────────────
+
+    async list(userId: string): Promise<ToolGrant[]> {
+        return this.grants.listForUser(userId);
+    }
+
+    /**
+     * Create-or-update one scope's grant.
+     *
+     * The override is sanitized on the way IN (drop-if-unrecognized, never
+     * coerce) so a junk pattern can never be stored and later re-read as a
+     * permissive `*`. Narrowing against the ancestors is NOT applied here
+     * on purpose: a stored row records what the operator asked for, and
+     * resolution rejects anything the ancestors never granted at READ
+     * time. Otherwise loosening a parent grant later would silently fail
+     * to reach children whose rows had been trimmed at write time.
+     */
+    async upsert(input: Omit<UpsertToolGrantInput, 'grant'> & { grant: ToolGrantOverride }) {
+        const grant = sanitizeToolGrantOverride(input.grant);
+        return this.grants.upsert({ ...input, grant });
+    }
+
+    async remove(userId: string, id: string): Promise<boolean> {
+        return this.grants.deleteByIdAndUser(id, userId);
+    }
+
+    // ── internals ─────────────────────────────────────────────────────
+
+    /**
+     * Walk upward from whatever the caller knows and return the scope refs
+     * in LEAST → MOST specific order. (`resolveToolGrantChain` re-sorts
+     * defensively, but keeping the walk ordered makes the layers readable
+     * in a debugger.)
+     */
+    private async discoverScopeRefs(input: ToolGrantResolveInput): Promise<ToolGrantScopeRef[]> {
+        let workId = input.workId ?? null;
+        let organizationId = input.organizationId ?? null;
+        let tenantId = input.tenantId ?? null;
+        let agentId: string | null = null;
+
+        if (input.agentId) {
+            const agent = await this.scopes.findAgent(input.agentId);
+            if (agent) {
+                agentId = agent.id;
+                workId = workId ?? agent.workId ?? null;
+                organizationId = organizationId ?? agent.organizationId ?? null;
+                tenantId = tenantId ?? agent.tenantId ?? null;
+            }
+        }
+
+        if (workId) {
+            const work = await this.scopes.findWork(workId);
+            if (work) {
+                organizationId = organizationId ?? work.organizationId ?? null;
+                tenantId = tenantId ?? work.tenantId ?? null;
+            } else {
+                // An unknown Work contributes no layer — but it must not
+                // silently vanish the org/tenant the caller passed in.
+                workId = null;
+            }
+        }
+
+        if (organizationId) {
+            const org = await this.scopes.findOrganization(organizationId);
+            if (org) {
+                tenantId = tenantId ?? org.tenantId ?? null;
+            } else {
+                organizationId = null;
+            }
+        }
+
+        const refs: ToolGrantScopeRef[] = [];
+        if (tenantId) refs.push({ scopeType: 'tenant', scopeId: tenantId });
+        if (organizationId) refs.push({ scopeType: 'organization', scopeId: organizationId });
+        if (workId) refs.push({ scopeType: 'work', scopeId: workId });
+        if (agentId) refs.push({ scopeType: 'agent', scopeId: agentId });
+        return refs;
+    }
+}

--- a/packages/agent/src/policy/tool-grant.ts
+++ b/packages/agent/src/policy/tool-grant.ts
@@ -1,0 +1,248 @@
+import {
+    PLATFORM_DEFAULT_TOOL_GRANT,
+    TOOL_GRANT_SCOPE_PRECEDENCE,
+    matchesAnyToolPattern,
+    matchesToolPattern,
+    sanitizeToolGrantOverride,
+    toolPatternCovers,
+    type ResolvedToolGrants,
+    type ToolGrantChainEntry,
+    type ToolGrantDecision,
+    type ToolGrantMatrix,
+    type ToolGrantOverride,
+    type ToolGrantScope,
+    type ToolGrantSource,
+} from '@ever-works/contracts';
+
+/**
+ * Tool-grant matrix (audit item G4) — the PURE half.
+ *
+ * Before this existed, tool access could not be scoped: the only gate was
+ * the per-Agent `permissions` booleans, which live on the Agent's own row.
+ * An organization could not say "no Agent under me may call `deploy_*`"
+ * and have that hold.
+ *
+ * The matrix folds four scopes over a permissive platform default:
+ *
+ *     platform default  <  tenant  <  organization  <  Work  <  Agent
+ *
+ * ## The one rule that makes this a security boundary
+ *
+ * **A grant may never widen scope upward.** The fold is therefore NOT a
+ * "last writer wins" override like the merge-policy matrix:
+ *
+ *   - `allow` INTERSECTS. A child layer keeps only the patterns some
+ *     ancestor pattern already covers; anything else is REJECTED and
+ *     reported in the chain (so an operator can see why their grant did
+ *     nothing) but never applied.
+ *   - `deny` UNIONS and is permanent. Once any ancestor denies a tool no
+ *     descendant can un-deny it.
+ *
+ * "Most specific wins" still holds in the sense that matters: within the
+ * bounds its ancestors set, the deepest layer that speaks about a tool is
+ * the one that decides, and `decideToolGrant` reports exactly which layer
+ * that was.
+ *
+ * ## Safe default
+ *
+ * With no rows anywhere the chain resolves to `PLATFORM_DEFAULT_TOOL_GRANT`
+ * (`allow: ['*']`, `deny: []`) — i.e. today's behaviour, unchanged. The
+ * matrix only ever subtracts, and subtracts nothing until someone writes a
+ * row.
+ *
+ * Everything here is side-effect free so the precedence rules and the
+ * decision can be unit-tested without a database, and so the same
+ * functions run in the API, the worker and the agent tool loop. The I/O
+ * half (loading the rows) lives in `tool-grant.service.ts`.
+ */
+
+/** One layer of the resolution chain. */
+export interface ToolGrantLayer {
+    scope: ToolGrantScope;
+    /** Row id of the scope entity; kept for the reported chain. */
+    id: string;
+    /** What the row stores. `null`/`undefined`/`{}` all mean "inherit". */
+    grant?: ToolGrantOverride | null;
+}
+
+function cloneMatrix(matrix: ToolGrantMatrix): ToolGrantMatrix {
+    return { allow: [...matrix.allow], deny: [...matrix.deny] };
+}
+
+/**
+ * Split a child's requested allow patterns into the ones its ancestors
+ * already cover (kept) and the ones they never granted (rejected).
+ *
+ * Exported because this split IS the no-upward-widening rule, and a rule
+ * that cannot be tested in isolation is a rule nobody trusts.
+ */
+export function narrowAllowPatterns(
+    inherited: readonly string[],
+    requested: readonly string[],
+): { kept: string[]; rejected: string[] } {
+    const kept: string[] = [];
+    const rejected: string[] = [];
+    for (const pattern of requested) {
+        const covered = inherited.some((outer) => toolPatternCovers(outer, pattern));
+        if (covered) kept.push(pattern);
+        else rejected.push(pattern);
+    }
+    return { kept: Array.from(new Set(kept)), rejected: Array.from(new Set(rejected)) };
+}
+
+/**
+ * THE resolution function. Folds the layers over the platform default,
+ * least → most specific.
+ *
+ * Layers may be passed in any order — they are sorted into the documented
+ * precedence here, so no caller can accidentally invert it (which, for
+ * this matrix, would mean a tenant "narrowing" an Agent instead of the
+ * other way round).
+ */
+export function resolveToolGrantChain(layers: ToolGrantLayer[]): ResolvedToolGrants {
+    const ordered = [...layers].sort(
+        (a, b) =>
+            TOOL_GRANT_SCOPE_PRECEDENCE.indexOf(a.scope) -
+            TOOL_GRANT_SCOPE_PRECEDENCE.indexOf(b.scope),
+    );
+
+    const matrix = cloneMatrix(PLATFORM_DEFAULT_TOOL_GRANT);
+    const chain: ToolGrantChainEntry[] = [
+        {
+            scope: 'default',
+            id: null,
+            allow: [...PLATFORM_DEFAULT_TOOL_GRANT.allow],
+            deny: [...PLATFORM_DEFAULT_TOOL_GRANT.deny],
+            rejected: [],
+        },
+    ];
+
+    let source: ToolGrantSource = 'default';
+
+    for (const layer of ordered) {
+        const override = sanitizeToolGrantOverride(layer.grant);
+        const entry: ToolGrantChainEntry = {
+            scope: layer.scope,
+            id: layer.id,
+            allow: [],
+            deny: [],
+            rejected: [],
+        };
+
+        if (override.allow !== undefined) {
+            // Narrow, never widen: only patterns an ancestor already
+            // covers survive. An empty result is legitimate — "this scope
+            // grants nothing" is the strongest narrowing there is.
+            const { kept, rejected } = narrowAllowPatterns(matrix.allow, override.allow);
+            matrix.allow = kept;
+            entry.allow = [...kept];
+            entry.rejected = rejected;
+            source = layer.scope;
+        }
+
+        if (override.deny !== undefined && override.deny.length > 0) {
+            matrix.deny = Array.from(new Set([...matrix.deny, ...override.deny]));
+            entry.deny = [...override.deny];
+            source = layer.scope;
+        }
+
+        chain.push(entry);
+    }
+
+    return { matrix, source, chain };
+}
+
+/** What the decision point needs beyond the tool name. */
+export interface ToolGrantDecisionContext {
+    /** The already-resolved matrix (from `resolveToolGrantChain`). */
+    matrix: ToolGrantMatrix;
+    /** The reported chain, used to attribute the decision to a scope. */
+    chain?: ToolGrantChainEntry[];
+}
+
+/**
+ * Attribute a decision to the most specific layer that spoke about the
+ * tool. The chain is least → most specific, so we scan BACKWARDS and stop
+ * at the first layer whose patterns match.
+ */
+function attribute(
+    chain: ToolGrantChainEntry[] | undefined,
+    toolName: string,
+    field: 'allow' | 'deny',
+): ToolGrantSource {
+    if (!chain || chain.length === 0) return 'default';
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+        const entry = chain[i];
+        if (matchesAnyToolPattern(entry[field], toolName)) return entry.scope;
+    }
+    return 'default';
+}
+
+/**
+ * THE decision point. Every path that could hand a tool to a model routes
+ * through this one function, so "may this tool be called in this scope?"
+ * is answered in exactly one place.
+ *
+ * Order matters: deny beats allow. A denied tool is denied even if some
+ * layer also allows it — otherwise a broad `allow: ['*']` at the tenant
+ * would defeat a targeted `deny` beneath it.
+ */
+export function decideToolGrant(
+    ctx: ToolGrantDecisionContext,
+    toolName: string,
+): ToolGrantDecision {
+    const name = typeof toolName === 'string' ? toolName.trim() : '';
+    if (!name) {
+        return {
+            allowed: false,
+            toolName: String(toolName ?? ''),
+            source: 'default',
+            code: 'tool-name-invalid',
+            reason: 'A tool name is required to evaluate a grant.',
+        };
+    }
+
+    const denyMatch = ctx.matrix.deny.find((pattern) => matchesToolPattern(pattern, name));
+    if (denyMatch) {
+        return {
+            allowed: false,
+            toolName: name,
+            source: attribute(ctx.chain, name, 'deny'),
+            code: 'tool-denied',
+            reason: `Tool '${name}' is denied by the effective tool-grant matrix (pattern '${denyMatch}').`,
+        };
+    }
+
+    if (!matchesAnyToolPattern(ctx.matrix.allow, name)) {
+        return {
+            allowed: false,
+            toolName: name,
+            source: attribute(ctx.chain, name, 'allow'),
+            code: 'tool-not-granted',
+            reason:
+                `Tool '${name}' is not granted by the effective tool-grant matrix (allowed: ` +
+                `${ctx.matrix.allow.join(', ') || 'nothing'}).`,
+        };
+    }
+
+    return { allowed: true, toolName: name, source: attribute(ctx.chain, name, 'allow') };
+}
+
+/**
+ * Convenience for the tool loop: partition a set of tool names into the
+ * granted ones and the refused ones (each with its refusal). Keeps the
+ * caller from re-implementing the deny-beats-allow order.
+ */
+export function partitionToolsByGrant(
+    resolved: Pick<ResolvedToolGrants, 'matrix' | 'chain'>,
+    toolNames: readonly string[],
+): { granted: string[]; refused: ToolGrantDecision[] } {
+    const granted: string[] = [];
+    const refused: ToolGrantDecision[] = [];
+    for (const name of toolNames) {
+        const decision = decideToolGrant({ matrix: resolved.matrix, chain: resolved.chain }, name);
+        if (decision.allowed) granted.push(name);
+        else refused.push(decision);
+    }
+    return { granted, refused };
+}

--- a/packages/agent/src/skills/skills.module.ts
+++ b/packages/agent/src/skills/skills.module.ts
@@ -12,6 +12,7 @@ import { WorkProposalRepository } from '../user-research/work-proposal.repositor
 import { SkillsService } from './skills.service';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { DatabaseModule } from '../database/database.module';
+import { PolicyModule } from '../policy/policy.module';
 
 /**
  * Skills feature — Phase 8 + 9.
@@ -29,6 +30,11 @@ import { DatabaseModule } from '../database/database.module';
         DatabaseModule,
         TypeOrmModule.forFeature([Skill, SkillBinding, Mission, Agent, WorkProposal]),
         ActivityLogModule,
+        // Audit item G12 — grant-aware activation. Binds
+        // TOOL_GRANT_ENFORCER for `SkillsService.resolveActiveForAgent`,
+        // which is @Optional(): without this import the filter silently
+        // never fires. PolicyModule is a leaf, so this cannot cycle.
+        PolicyModule,
     ],
     providers: [
         SkillRepository,

--- a/packages/agent/src/skills/skills.service.ts
+++ b/packages/agent/src/skills/skills.service.ts
@@ -1,6 +1,7 @@
 import {
     BadRequestException,
     ConflictException,
+    Inject,
     Injectable,
     InternalServerErrorException,
     Logger,
@@ -26,6 +27,10 @@ import { AgentRepository } from '../database/repositories/agent.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkProposalRepository } from '../user-research/work-proposal.repository';
 import { Mission } from '../entities/mission.entity';
+// Grant-aware skill activation (audit item G12). Both are leaf modules
+// (token + pure function) so the skills subpath gains no runtime graph.
+import { TOOL_GRANT_ENFORCER, type ToolGrantEnforcer } from '../policy/tool-grant.enforcer';
+import { filterSkillsByToolGrants } from '../policy/skill-activation';
 
 export interface CreateSkillInput {
     ownerType: SkillOwnerType;
@@ -94,6 +99,12 @@ export class SkillsService {
         private readonly agents?: AgentRepository,
         private readonly works?: WorkRepository,
         private readonly ideas?: WorkProposalRepository,
+        // Grant-aware skill activation (audit item G12). APPENDED LAST +
+        // `@Optional()` so every existing positional constructor call
+        // keeps working; unbound → activation behaves exactly as before.
+        @Optional()
+        @Inject(TOOL_GRANT_ENFORCER)
+        private readonly toolGrants?: ToolGrantEnforcer,
     ) {}
 
     // ── Skill CRUD ────────────────────────────────────────────────
@@ -254,6 +265,16 @@ export class SkillsService {
         return { deleted: true };
     }
 
+    /**
+     * Which Skills apply to this Agent right now?
+     *
+     * Grant-aware since audit item G12: a Skill whose frontmatter declares
+     * `allowedTools` and whose EVERY declared tool is refused by the
+     * effective tool-grant matrix is dropped here, not injected and then
+     * ignored. Skills that declare no tools are untouched, and an install
+     * with no grant rows (or no enforcer wired) resolves exactly as it did
+     * before the matrix existed.
+     */
     async resolveActiveForAgent(
         userId: string,
         agentId: string,
@@ -261,7 +282,7 @@ export class SkillsService {
         missionId?: string,
         ideaId?: string,
     ): Promise<ResolvedSkill[]> {
-        return this.bindings.resolveActive({
+        const resolved = await this.bindings.resolveActive({
             userId,
             agentId,
             workId,
@@ -269,6 +290,33 @@ export class SkillsService {
             ideaId,
             forAgentRun: true,
         });
+        if (!this.toolGrants || resolved.length === 0) return resolved;
+
+        let grants;
+        try {
+            grants = await this.toolGrants.resolve({
+                userId,
+                agentId,
+                workId: workId ?? null,
+            });
+        } catch (err) {
+            // A failed policy read must never silently strip an Agent of
+            // its Skills — degrade to "everything active" and say so.
+            this.logger.warn(
+                `Tool-grant resolution failed during skill activation for agent ${agentId}; all bound skills stay active: ${err}`,
+            );
+            return resolved;
+        }
+
+        const { active } = filterSkillsByToolGrants(
+            resolved.map((row) => ({
+                slug: row.skill.slug,
+                allowedTools: row.skill.frontmatter?.allowedTools ?? null,
+                row,
+            })),
+            grants,
+        );
+        return active.map((entry) => entry.row);
     }
 
     // ── internals ─────────────────────────────────────────────────

--- a/packages/contracts/src/policy/index.ts
+++ b/packages/contracts/src/policy/index.ts
@@ -1,2 +1,4 @@
 export * from './merge-policy.types.js';
 export * from './merge-policy.sanitize.js';
+export * from './tool-grant.types.js';
+export * from './tool-grant.sanitize.js';

--- a/packages/contracts/src/policy/tool-grant.sanitize.ts
+++ b/packages/contracts/src/policy/tool-grant.sanitize.ts
@@ -1,0 +1,41 @@
+import type { ToolGrantOverride } from './tool-grant.types.js';
+import { TOOL_GRANT_PATTERN } from './tool-grant.types.js';
+
+/**
+ * Tool-grant matrix (audit item G4) — the shape guard for a stored
+ * override.
+ *
+ * Same posture (and same reasons) as `sanitizeMergePolicyOverride`: it
+ * lives next to the type because every writer needs it — the API upsert
+ * endpoint, the agent-side service, any future importer — and none of them
+ * should drag the entity graph in just to validate two string arrays.
+ *
+ * Rules:
+ *  - A non-string or malformed pattern is DROPPED, never coerced. A junk
+ *    entry must not become a permissive `*`.
+ *  - A declared-but-EMPTY `allow` is meaningful and kept: it means "this
+ *    scope grants nothing", which is the strongest possible narrowing.
+ *  - A declared-but-entirely-invalid `allow` is dropped (→ "inherit"),
+ *    because silently turning garbage into "grant nothing" would break a
+ *    running tenant on a typo.
+ *  - `deny` follows the same rules; dropping a bad deny is safe because a
+ *    deny only ever subtracts.
+ */
+export function sanitizeToolGrantOverride(raw: ToolGrantOverride | null | undefined): ToolGrantOverride {
+	if (!raw || typeof raw !== 'object') return {};
+	const out: ToolGrantOverride = {};
+
+	for (const key of ['allow', 'deny'] as const) {
+		const value = raw[key];
+		if (!Array.isArray(value)) continue;
+		const patterns = value
+			.filter((p): p is string => typeof p === 'string')
+			.map((p) => p.trim())
+			.filter((p) => p.length > 0 && TOOL_GRANT_PATTERN.test(p));
+		if (patterns.length > 0 || value.length === 0) {
+			out[key] = Array.from(new Set(patterns));
+		}
+	}
+
+	return out;
+}

--- a/packages/contracts/src/policy/tool-grant.types.ts
+++ b/packages/contracts/src/policy/tool-grant.types.ts
@@ -1,0 +1,179 @@
+/**
+ * Tool-grant matrix (audit item G4) — the CONTRACT half.
+ *
+ * Tool access is scoped down the same four-level lattice the merge-policy
+ * matrix already uses:
+ *
+ *     platform default  <  tenant  <  organization  <  Work  <  Agent
+ *
+ * with one rule that makes it a security boundary rather than a
+ * preference: **a more specific scope may only ever NARROW what its
+ * ancestors granted.** An Agent-level grant that names a tool its Work /
+ * organization / tenant never granted is rejected outright — it does not
+ * widen the Agent's reach, it is dropped and reported.
+ *
+ * Everything here is pure and dependency-free so the same functions run in
+ * the API, the agent tool loop, the worker and the web UI.
+ */
+
+/** The four configurable scopes, least → most specific. */
+export type ToolGrantScope = 'tenant' | 'organization' | 'work' | 'agent';
+
+/**
+ * Precedence order. Layers may be supplied in any order — the resolver
+ * sorts them by this array so no caller can accidentally invert it.
+ */
+export const TOOL_GRANT_SCOPE_PRECEDENCE: readonly ToolGrantScope[] = Object.freeze([
+	'tenant',
+	'organization',
+	'work',
+	'agent'
+] as readonly ToolGrantScope[]);
+
+/** Where a resolved matrix (or a single decision) came from. */
+export type ToolGrantSource = 'default' | ToolGrantScope;
+
+/**
+ * What one scope row stores. Both fields optional:
+ *
+ *  - `allow` omitted  → "inherit whatever my ancestors allow".
+ *  - `allow` present  → intersected with the inherited set; patterns the
+ *    ancestors never granted are REJECTED (never widened in).
+ *  - `deny` is always additive and permanent: once a scope denies a tool,
+ *    no descendant can un-deny it.
+ */
+export interface ToolGrantOverride {
+	allow?: string[];
+	deny?: string[];
+}
+
+/** A fully-resolved grant matrix — the effective allow/deny sets. */
+export interface ToolGrantMatrix {
+	allow: string[];
+	deny: string[];
+}
+
+/**
+ * The safe default: everything allowed, nothing denied.
+ *
+ * This preserves today's behaviour exactly — before this feature there was
+ * no matrix at all, so every tool the per-Agent `permissions` flags already
+ * permitted stayed reachable. The matrix only ever SUBTRACTS from that, and
+ * subtracts nothing until an operator writes a row.
+ */
+export const PLATFORM_DEFAULT_TOOL_GRANT: ToolGrantMatrix = Object.freeze({
+	allow: Object.freeze(['*']) as unknown as string[],
+	deny: Object.freeze([]) as unknown as string[]
+});
+
+/** One reported layer of the resolution chain, least specific first. */
+export interface ToolGrantChainEntry {
+	scope: ToolGrantSource;
+	/** Row id of the scope entity; `null` for the platform default. */
+	id: string | null;
+	/** Allow patterns this layer contributed AFTER the narrowing check. */
+	allow: string[];
+	/** Deny patterns this layer contributed. */
+	deny: string[];
+	/**
+	 * Allow patterns this layer asked for that its ancestors never granted.
+	 * Reported, never applied — this is the "no upward widening" rule made
+	 * visible so an operator can see why their grant did nothing.
+	 */
+	rejected: string[];
+}
+
+export interface ResolvedToolGrants {
+	matrix: ToolGrantMatrix;
+	/** The most specific layer that contributed anything. */
+	source: ToolGrantSource;
+	/** Least → most specific, starting at the platform default. */
+	chain: ToolGrantChainEntry[];
+}
+
+/** Stable refusal codes so callers can branch without string-matching. */
+export type ToolGrantDecisionCode = 'tool-denied' | 'tool-not-granted' | 'tool-name-invalid';
+
+export interface ToolGrantDecision {
+	allowed: boolean;
+	toolName: string;
+	/** Which scope decided. */
+	source: ToolGrantSource;
+	code?: ToolGrantDecisionCode;
+	/** Human-readable, names the offending pattern — never a secret. */
+	reason?: string;
+}
+
+/**
+ * Pattern matching for tool names. Deliberately tiny — three forms only:
+ *
+ *   `*`          matches every tool
+ *   `prefix*`    matches every tool starting with `prefix`
+ *   `exact_name` matches that tool only
+ *
+ * Case-insensitive because tool names are model-facing identifiers and a
+ * grant that silently misses on case is a security bug, not a nicety.
+ */
+export function matchesToolPattern(pattern: string, toolName: string): boolean {
+	const p = pattern.trim().toLowerCase();
+	const name = toolName.trim().toLowerCase();
+	if (!p || !name) return false;
+	if (p === '*') return true;
+	if (p.endsWith('*')) return name.startsWith(p.slice(0, -1));
+	return p === name;
+}
+
+/** Does ANY pattern in the list match this tool name? */
+export function matchesAnyToolPattern(patterns: readonly string[], toolName: string): boolean {
+	for (const pattern of patterns) {
+		if (matchesToolPattern(pattern, toolName)) return true;
+	}
+	return false;
+}
+
+/**
+ * Does the broader pattern `outer` fully cover `inner`?
+ *
+ * This is the narrowing test: a child layer may only keep an allow pattern
+ * that some ancestor pattern already covers. `*` covers everything;
+ * `git_*` covers `git_commit` and `git_*` but NOT `*` or `deploy_*`.
+ */
+export function toolPatternCovers(outer: string, inner: string): boolean {
+	const o = outer.trim().toLowerCase();
+	const i = inner.trim().toLowerCase();
+	if (!o || !i) return false;
+	if (o === '*') return true;
+	if (o.endsWith('*')) return i.startsWith(o.slice(0, -1));
+	// A concrete outer pattern can only cover the identical concrete inner
+	// one — a wildcard inner would reach further than the outer allows.
+	return o === i;
+}
+
+/** Tool names are model-facing identifiers; keep them boring and bounded. */
+export const TOOL_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,120}$/;
+
+/** Allow patterns additionally permit a single trailing `*`. */
+export const TOOL_GRANT_PATTERN = /^(\*|[A-Za-z0-9_.:-]{1,120}\*?)$/;
+
+// ── Credential references (audit item G14) ───────────────────────────
+
+/**
+ * `{{cred.<key>}}` — the only credential reference syntax the platform
+ * understands. Resolved SERVER-SIDE immediately before an outbound call;
+ * the resolved value is never logged, never persisted and never echoed
+ * back to the model.
+ *
+ * Returned as a FACTORY, not a shared constant: a `/g` regex carries
+ * `lastIndex` state, and a shared instance silently skips matches on the
+ * second call. Every caller gets its own.
+ */
+export function credentialRefPattern(): RegExp {
+	return /\{\{\s*cred\.([A-Za-z0-9_][A-Za-z0-9_.-]{0,63})\s*\}\}/g;
+}
+
+/** A credential key: alphanumeric, `_`, `.` and `-`, up to 64 chars. */
+export const CREDENTIAL_KEY_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$/;
+
+export function isCredentialKey(value: string): boolean {
+	return CREDENTIAL_KEY_PATTERN.test(value);
+}


### PR DESCRIPTION
Audit items **G4 / G12 / G14**.

Agent tool permissions were a flat per-agent boolean set (`canCommitToRepo`, `canCallExternalTools`, …). There was no way to say *"this agent may use this tool, in this Work, with these credentials"* — so the answer to "what can this agent actually do here?" lived nowhere, and the honest answer to "with whose key?" was "the instance's".

## G4 — the matrix

A `tool_grants` table plus a scope chain resolved the same way merge policy already is (**agent → work → org → tenant**), with the same `resolve` / `decide` split so a decision is *explainable* rather than merely returned.

Read-only chat tools expose it. Like the merge-policy source, the ids come from the **model**, so `authorize` runs an owner check before any resolution and returns `null` on a foreign id — no existence leak.

## G12 — skill activation

`filterSkillsByToolGrants` gates which skills go live for a run. A skill whose tools aren't granted in this scope is **suppressed rather than offered and then refused mid-run** — the difference between a capability boundary and an error message.

## G14 — credential brokering

`CREDENTIAL_RESOLVER` (env-backed by default, swappable) resolves per-scope credentials. `interpolateCredentials` substitutes them into tool arguments **at invoke time** — never into a stored grant, never into a task payload. `redactCredentialValues` covers anything that could be echoed back, and the resolver logs the *key* of a malformed entry, never its value.

Consumers depend on the **token**, not the class, so a deployment can swap the resolver without touching call sites.

## Who calls this in production

| symbol | call site |
|---|---|
| `filterSkillsByToolGrants` | `agent-run.service.ts:1517` — skill activation |
| `interpolateCredentials` | `agent-tool.service.ts:621` — tool invoke path |
| `buildToolGrantTools` | `agent-tool.service.ts:471` — tool assembly |
| `TOOL_GRANT_ENFORCER` | injected at `agent-run.service.ts:196`, `agent-tool.service.ts:188` |
| `CREDENTIAL_RESOLVER` | injected at `agent-tool.service.ts:193` |
| `ToolGrantsController` | `apps/api/src/tool-grants/` |

## Repo-rule checks

- **Entity registration** — `ToolGrant` is in *both* `_entities-inventory.ts` and `_entity-names.ts`. An entity that is `forFeature`'d but missing from the explicit inventory is a 500 on every query, in production too.
- **Migration order** — renumbered `1784740000000` → `1784780000000` so it lands after the migrations that reached develop while this branch was parked.
- **Module-shape pins** — `PolicyModule` and the api `AgentsModule` pins updated; the bundle now carries `browser` (G22), `escalations` (G3/G10) and `toolGrants` (G4) side by side.

## Gates (all green, run locally on the merged tree)

| gate | result |
|---|---|
| `pnpm build --filter=ever-works-api` | 15/15 |
| `packages/agent` jest | 454 suites, 8332 tests |
| `apps/api` jest | 235 suites, 3850 tests |
| `apps/web` tsc | clean |
| prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)