### PR TITLE
feat(agents): workflow graph edges, typed HITL questions and sub-agent delegation

### DIFF
--- a/apps/web/src/components/ai/canvas/CanvasArtifactView.unit.spec.tsx
+++ b/apps/web/src/components/ai/canvas/CanvasArtifactView.unit.spec.tsx
@@ -161,4 +161,127 @@ describe('CanvasArtifactView', () => {
             expect(screen.getByText((c) => c.includes(text))).toBeTruthy();
         });
     });
+
+    // Judgment layer G8s — typed human-in-the-loop payloads rendered by the
+    // canvas registry. Props are the contract's `HitlQuestion`/`HitlAnswer`,
+    // so these double as a round-trip check through `ComponentArtifact`.
+    describe('HITL renderers', () => {
+        const hitl = (
+            component: 'hitl_question' | 'hitl_answer',
+            props: Record<string, unknown>,
+        ): ComponentArtifact => ({
+            id: '1',
+            kind: 'component',
+            title: 'Needs you',
+            component,
+            props,
+        });
+
+        it('renders a confirm question with both labels', () => {
+            render(
+                <CanvasArtifactView
+                    artifact={hitl('hitl_question', {
+                        id: 'q1',
+                        kind: 'confirm',
+                        prompt: 'Force-push the branch?',
+                        confirmLabel: 'Force-push',
+                        cancelLabel: 'Leave it',
+                    })}
+                />,
+            );
+            expect(screen.getByText('Force-push the branch?')).toBeTruthy();
+            expect(screen.getByText('Force-push')).toBeTruthy();
+            expect(screen.getByText('Leave it')).toBeTruthy();
+        });
+
+        it('renders every option of a choice question, with descriptions', () => {
+            render(
+                <CanvasArtifactView
+                    artifact={hitl('hitl_question', {
+                        id: 'q2',
+                        kind: 'choice',
+                        prompt: 'Which fix?',
+                        context: 'Both are green.',
+                        options: [
+                            { id: 'revert', label: 'Revert the commit', tone: 'warning' },
+                            { id: 'patch', label: 'Patch forward', description: 'Smaller diff' },
+                        ],
+                    })}
+                />,
+            );
+            expect(screen.getByText('Both are green.')).toBeTruthy();
+            expect(screen.getByText('Revert the commit')).toBeTruthy();
+            expect(screen.getByText('Patch forward')).toBeTruthy();
+            expect(screen.getByText('Smaller diff')).toBeTruthy();
+        });
+
+        it('renders an approval question with its action and risks', () => {
+            render(
+                <CanvasArtifactView
+                    artifact={hitl('hitl_question', {
+                        id: 'q3',
+                        kind: 'approval',
+                        prompt: 'May I merge?',
+                        action: 'Merge PR #42 into develop',
+                        risks: ['Touches billing'],
+                    })}
+                />,
+            );
+            expect(screen.getByText('Merge PR #42 into develop')).toBeTruthy();
+            expect(screen.getByText('Touches billing')).toBeTruthy();
+        });
+
+        it('renders a text question placeholder', () => {
+            render(
+                <CanvasArtifactView
+                    artifact={hitl('hitl_question', {
+                        id: 'q4',
+                        kind: 'text',
+                        prompt: 'Release note?',
+                        placeholder: 'One line please',
+                    })}
+                />,
+            );
+            expect(screen.getByText('One line please')).toBeTruthy();
+        });
+
+        it('degrades visibly on a malformed question payload instead of crashing', () => {
+            render(<CanvasArtifactView artifact={hitl('hitl_question', { kind: 'nope' })} />);
+            expect(screen.getByText('Unreadable question payload')).toBeTruthy();
+        });
+
+        it('renders an approval answer with its note', () => {
+            render(
+                <CanvasArtifactView
+                    artifact={hitl('hitl_answer', {
+                        questionId: 'q3',
+                        kind: 'approval',
+                        decision: 'approved',
+                        note: 'Reviewed the diff.',
+                    })}
+                />,
+            );
+            expect(screen.getByText('Approved')).toBeTruthy();
+            expect(screen.getByText('Reviewed the diff.')).toBeTruthy();
+            expect(screen.getByText((c) => c.includes('Answer to q3'))).toBeTruthy();
+        });
+
+        it('renders a multi_choice answer as its selected ids', () => {
+            render(
+                <CanvasArtifactView
+                    artifact={hitl('hitl_answer', {
+                        questionId: 'q5',
+                        kind: 'multi_choice',
+                        optionIds: ['unit', 'lint'],
+                    })}
+                />,
+            );
+            expect(screen.getByText('unit, lint')).toBeTruthy();
+        });
+
+        it('degrades visibly on a malformed answer payload', () => {
+            render(<CanvasArtifactView artifact={hitl('hitl_answer', { kind: 'confirm' })} />);
+            expect(screen.getByText('Unreadable answer payload')).toBeTruthy();
+        });
+    });
 });

--- a/apps/web/src/components/ai/canvas/components.tsx
+++ b/apps/web/src/components/ai/canvas/components.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { describeHitlQuestion, parseHitlAnswer, parseHitlQuestion } from '@ever-works/contracts';
+import type { HitlChoiceOption, HitlQuestion } from '@ever-works/contracts';
 import { cn } from '@/lib/utils/cn';
 import { ChatMarkdown } from '../ChatMarkdown';
 import type { CanvasComponentKey } from './types';
@@ -610,6 +612,189 @@ function Calendar({ props }: { props: Record<string, unknown> }) {
     );
 }
 
+/**
+ * props: a `HitlQuestion` (judgment layer G8s).
+ *
+ * The agent parks on a typed question instead of a free-text "please
+ * advise" line; this renders the question as the control a human would
+ * expect to see. Read-only by design in this increment — answering
+ * happens on the escalation surface that owns the write path — but the
+ * SHAPE is the contract's, so an answer widget can drop straight in.
+ *
+ * Parsed with the contract's own `parseHitlQuestion`, so an unknown or
+ * malformed payload shows a visible "unreadable" state rather than
+ * throwing inside the canvas.
+ */
+function HitlQuestionView({ props }: { props: Record<string, unknown> }) {
+    const question = parseHitlQuestion(props);
+    if (!question) return <Empty label="Unreadable question payload" />;
+    return (
+        <div className="space-y-3">
+            <div>
+                <p className="text-xs font-medium text-text dark:text-text-dark">
+                    {question.prompt}
+                </p>
+                {question.context ? (
+                    <p className="mt-1 whitespace-pre-wrap text-[11px] text-text-muted dark:text-text-muted-dark">
+                        {question.context}
+                    </p>
+                ) : null}
+            </div>
+            <HitlQuestionBody question={question} />
+            <p className="text-[10px] text-text-muted/70 dark:text-text-muted-dark/70">
+                {describeHitlQuestion(question)}
+            </p>
+        </div>
+    );
+}
+
+const HITL_TONE_CLASS: Record<string, string> = {
+    success: 'border-success/40 bg-success/5',
+    warning: 'border-warning/40 bg-warning/5',
+    danger: 'border-danger/40 bg-danger/5',
+};
+
+function HitlOptionList({
+    options,
+    multi,
+}: {
+    options: readonly HitlChoiceOption[];
+    multi: boolean;
+}) {
+    return (
+        <ul className="space-y-1.5">
+            {options.map((option) => (
+                <li
+                    key={option.id}
+                    className={cn(
+                        'flex items-start gap-2 rounded-lg border px-3 py-2',
+                        'border-border dark:border-border-dark',
+                        option.tone ? HITL_TONE_CLASS[option.tone] : undefined,
+                    )}
+                >
+                    <span
+                        aria-hidden
+                        className={cn(
+                            'mt-0.5 h-3 w-3 shrink-0 border border-border dark:border-border-dark',
+                            multi ? 'rounded-[3px]' : 'rounded-full',
+                        )}
+                    />
+                    <span className="min-w-0">
+                        <span className="block text-[11px] font-medium text-text dark:text-text-dark">
+                            {option.label}
+                        </span>
+                        {option.description ? (
+                            <span className="block text-[10px] text-text-muted dark:text-text-muted-dark">
+                                {option.description}
+                            </span>
+                        ) : null}
+                    </span>
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+function HitlQuestionBody({ question }: { question: HitlQuestion }) {
+    switch (question.kind) {
+        case 'confirm':
+            return (
+                <div className="flex gap-2">
+                    <span className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text dark:border-border-dark dark:text-text-dark">
+                        {question.confirmLabel ?? 'Yes'}
+                    </span>
+                    <span className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-muted dark:border-border-dark dark:text-text-muted-dark">
+                        {question.cancelLabel ?? 'No'}
+                    </span>
+                </div>
+            );
+        case 'choice':
+            return <HitlOptionList options={question.options} multi={false} />;
+        case 'multi_choice':
+            return <HitlOptionList options={question.options} multi />;
+        case 'text':
+            return (
+                <div className="rounded-lg border border-dashed border-border px-3 py-2 text-[11px] text-text-muted dark:border-border-dark dark:text-text-muted-dark">
+                    {question.placeholder ?? 'Free-text answer'}
+                </div>
+            );
+        case 'approval':
+            return (
+                <div className="space-y-2">
+                    <div className="rounded-lg border border-warning/40 bg-warning/5 px-3 py-2">
+                        <p className="text-[11px] font-medium text-text dark:text-text-dark">
+                            {question.action}
+                        </p>
+                        {question.risks?.length ? (
+                            <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                                {question.risks.map((risk, i) => (
+                                    <li
+                                        key={i}
+                                        className="text-[10px] text-text-muted dark:text-text-muted-dark"
+                                    >
+                                        {risk}
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : null}
+                    </div>
+                    {question.preview ? (
+                        <pre className="max-h-56 overflow-auto rounded-lg bg-surface-secondary p-3 text-[10px] leading-relaxed text-text dark:bg-white/[0.04] dark:text-text-dark">
+                            {question.preview}
+                        </pre>
+                    ) : null}
+                </div>
+            );
+        default:
+            return <Empty label="Unsupported question kind" />;
+    }
+}
+
+/** props: a `HitlAnswer` (judgment layer G8s) — what the human decided. */
+function HitlAnswerView({ props }: { props: Record<string, unknown> }) {
+    const answer = parseHitlAnswer(props);
+    if (!answer) return <Empty label="Unreadable answer payload" />;
+    const summary = (() => {
+        switch (answer.kind) {
+            case 'confirm':
+                return answer.confirmed ? 'Confirmed' : 'Declined';
+            case 'choice':
+                return answer.optionId;
+            case 'multi_choice':
+                return answer.optionIds.length ? answer.optionIds.join(', ') : 'Nothing selected';
+            case 'text':
+                return answer.text || '(empty)';
+            case 'approval':
+                return answer.decision === 'approved' ? 'Approved' : 'Rejected';
+            default:
+                return '—';
+        }
+    })();
+    const tone =
+        (answer.kind === 'confirm' && !answer.confirmed) ||
+        (answer.kind === 'approval' && answer.decision === 'rejected')
+            ? 'border-danger/40 bg-danger/5'
+            : 'border-success/40 bg-success/5';
+    return (
+        <div className="space-y-2">
+            <div className={cn('rounded-lg border px-3 py-2', tone)}>
+                <p className="whitespace-pre-wrap text-xs text-text dark:text-text-dark">
+                    {summary}
+                </p>
+            </div>
+            {answer.kind === 'approval' && answer.note ? (
+                <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
+                    {answer.note}
+                </p>
+            ) : null}
+            <p className="text-[10px] text-text-muted/70 dark:text-text-muted-dark/70">
+                Answer to {answer.questionId}
+                {answer.answeredAt ? ` · ${answer.answeredAt}` : ''}
+            </p>
+        </div>
+    );
+}
+
 function Empty({ label }: { label: string }) {
     return (
         <div className="flex h-24 items-center justify-center text-xs text-text-muted dark:text-text-muted-dark">
@@ -641,6 +826,8 @@ const REGISTRY: Record<
     heatmap: Heatmap,
     rating: Rating,
     calendar: Calendar,
+    hitl_question: HitlQuestionView,
+    hitl_answer: HitlAnswerView,
 };
 
 export function renderCanvasComponent(

--- a/apps/web/src/components/ai/canvas/types.ts
+++ b/apps/web/src/components/ai/canvas/types.ts
@@ -99,6 +99,12 @@ export const CANVAS_COMPONENT_KEYS = [
     'heatmap',
     'rating',
     'calendar',
+    // Judgment layer G8s — typed human-in-the-loop payloads. Props are a
+    // `HitlQuestion` / `HitlAnswer` from `@ever-works/contracts`; the
+    // renderers parse them defensively (`parseHitlQuestion`) so a
+    // malformed payload degrades to a visible error, never a crash.
+    'hitl_question',
+    'hitl_answer',
 ] as const;
 export type CanvasComponentKey = (typeof CANVAS_COMPONENT_KEYS)[number];
 

--- a/apps/web/src/lib/ai/tools/canvas.tools.ts
+++ b/apps/web/src/lib/ai/tools/canvas.tools.ts
@@ -151,7 +151,13 @@ export const showComponent = tool({
         '"json": props { data } (pretty JSON); "code": props { code, language? } (code block); ' +
         '"heatmap": props { rows: [{ label, values: number[] }], columns? } (intensity grid); ' +
         '"rating": props { value, max?, label? } (star rating); ' +
-        '"calendar": props { days: [{ date, value }] } (contribution-graph day grid). ' +
+        '"calendar": props { days: [{ date, value }] } (contribution-graph day grid); ' +
+        '"hitl_question": props are a typed human-in-the-loop question — ' +
+        '{ id, kind: "confirm" | "choice" | "multi_choice" | "text" | "approval", prompt, context?, ' +
+        'and the per-kind fields: options: [{ id, label, description?, tone? }] for choice/multi_choice, ' +
+        'action + risks? + preview? for approval } (renders the question a human must answer); ' +
+        '"hitl_answer": props are the matching answer — ' +
+        '{ questionId, kind, and one of confirmed | optionId | optionIds | text | decision (+ note?) }. ' +
         'After calling, give a one-line summary in chat.',
     inputSchema: z.object({
         title: z.string(),

--- a/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
@@ -1,0 +1,214 @@
+import {
+    composeRunAdmission,
+    creditsAdmission,
+    orgConcurrencyAdmission,
+    workConcurrencyAdmission,
+    DEFAULT_RUN_ADMISSION_CHAIN,
+    QUEUED_REASON_CONCURRENCY,
+    QUEUED_REASON_INSUFFICIENT_CREDITS,
+    RUN_ADMISSION_ADMITTED,
+    type RunAdmissionContext,
+    type RunAdmissionMiddleware,
+} from '../run-admission-chain';
+
+/**
+ * Judgment layer G15 — the pre-run path as a composed middleware chain.
+ *
+ * These tests pin the CHAIN mechanics (order, short-circuiting,
+ * next()-once, extensibility) plus each middleware in isolation. The
+ * "behaviour is unchanged" half is proven end-to-end by the existing
+ * `run-dispatch-gate.service.spec.ts` admit() suite, which still passes
+ * against the refactored gate untouched.
+ */
+describe('run admission chain', () => {
+    const makeContext = (over: Partial<RunAdmissionContext> = {}): RunAdmissionContext => ({
+        input: { userId: 'user-1', workId: 'work-1', organizationId: null },
+        counters: {
+            countInFlightForWork: jest.fn().mockResolvedValue(0),
+            countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+            countInFlightForUser: jest.fn().mockResolvedValue(0),
+        },
+        logger: { log: jest.fn(), warn: jest.fn() },
+        resolveWorkLimit: () => 10,
+        resolveOrgLimit: () => 25,
+        isCreditsEnforcementEnabled: () => false,
+        ...over,
+    });
+
+    describe('composeRunAdmission', () => {
+        it('admits when every middleware calls next()', async () => {
+            const order: string[] = [];
+            const step =
+                (name: string): RunAdmissionMiddleware =>
+                async (_ctx, next) => {
+                    order.push(name);
+                    return next();
+                };
+            const run = composeRunAdmission([step('a'), step('b'), step('c')]);
+            await expect(run(makeContext())).resolves.toEqual(RUN_ADMISSION_ADMITTED);
+            expect(order).toEqual(['a', 'b', 'c']);
+        });
+
+        it('short-circuits at the first middleware that returns a verdict', async () => {
+            const later = jest.fn();
+            const run = composeRunAdmission([
+                async () => ({ admitted: false, queuedReason: 'stop-here' }),
+                async (_ctx, next) => {
+                    later();
+                    return next();
+                },
+            ]);
+            await expect(run(makeContext())).resolves.toEqual({
+                admitted: false,
+                queuedReason: 'stop-here',
+            });
+            expect(later).not.toHaveBeenCalled();
+        });
+
+        it('admits an empty chain', async () => {
+            await expect(composeRunAdmission([])(makeContext())).resolves.toEqual(
+                RUN_ADMISSION_ADMITTED,
+            );
+        });
+
+        it('refuses a middleware that calls next() twice — double-counting is a real bug', async () => {
+            const run = composeRunAdmission([
+                async (_ctx, next) => {
+                    await next();
+                    return next();
+                },
+            ]);
+            await expect(run(makeContext())).rejects.toThrow(/more than once/);
+        });
+
+        it('composes a NEW policy without touching any existing middleware', async () => {
+            const maintenanceWindow: RunAdmissionMiddleware = async () => ({
+                admitted: false,
+                queuedReason: 'maintenance',
+            });
+            const run = composeRunAdmission([maintenanceWindow, ...DEFAULT_RUN_ADMISSION_CHAIN]);
+            const context = makeContext();
+            await expect(run(context)).resolves.toEqual({
+                admitted: false,
+                queuedReason: 'maintenance',
+            });
+            expect(context.counters.countInFlightForWork).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('workConcurrencyAdmission', () => {
+        it('admits under the limit', async () => {
+            const context = makeContext();
+            (context.counters.countInFlightForWork as jest.Mock).mockResolvedValue(9);
+            const run = composeRunAdmission([workConcurrencyAdmission]);
+            await expect(run(context)).resolves.toEqual(RUN_ADMISSION_ADMITTED);
+        });
+
+        it('parks at/over the limit with the concurrency reason', async () => {
+            const context = makeContext();
+            (context.counters.countInFlightForWork as jest.Mock).mockResolvedValue(10);
+            const run = composeRunAdmission([workConcurrencyAdmission]);
+            await expect(run(context)).resolves.toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+        });
+
+        it('skips the count entirely for a Work-less run or a disabled valve', async () => {
+            const noWork = makeContext({ input: { userId: 'user-1', workId: null } });
+            await composeRunAdmission([workConcurrencyAdmission])(noWork);
+            expect(noWork.counters.countInFlightForWork).not.toHaveBeenCalled();
+
+            const disabled = makeContext({ resolveWorkLimit: () => 0 });
+            await composeRunAdmission([workConcurrencyAdmission])(disabled);
+            expect(disabled.counters.countInFlightForWork).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('orgConcurrencyAdmission', () => {
+        it('counts per-org when an organizationId is present, per-user otherwise', async () => {
+            const withOrg = makeContext({
+                input: { userId: 'user-1', workId: null, organizationId: 'org-1' },
+            });
+            await composeRunAdmission([orgConcurrencyAdmission])(withOrg);
+            expect(withOrg.counters.countInFlightForOrganization).toHaveBeenCalledWith('org-1');
+            expect(withOrg.counters.countInFlightForUser).not.toHaveBeenCalled();
+
+            const withoutOrg = makeContext({ input: { userId: 'user-1', workId: null } });
+            await composeRunAdmission([orgConcurrencyAdmission])(withoutOrg);
+            expect(withoutOrg.counters.countInFlightForUser).toHaveBeenCalledWith('user-1');
+        });
+
+        it('parks over the valve', async () => {
+            const context = makeContext();
+            (context.counters.countInFlightForUser as jest.Mock).mockResolvedValue(25);
+            await expect(composeRunAdmission([orgConcurrencyAdmission])(context)).resolves.toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+        });
+    });
+
+    describe('creditsAdmission', () => {
+        it('is dark unless the kill-switch is on', async () => {
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(true) };
+            const context = makeContext({ creditsPrecheck: precheck });
+            await expect(composeRunAdmission([creditsAdmission])(context)).resolves.toEqual(
+                RUN_ADMISSION_ADMITTED,
+            );
+            expect(precheck.shouldQueueForCredits).not.toHaveBeenCalled();
+        });
+
+        it('parks a broke user when enabled', async () => {
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(true) };
+            const context = makeContext({
+                creditsPrecheck: precheck,
+                isCreditsEnforcementEnabled: () => true,
+            });
+            await expect(composeRunAdmission([creditsAdmission])(context)).resolves.toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_INSUFFICIENT_CREDITS,
+            });
+        });
+
+        it('fails OPEN when the precheck throws', async () => {
+            const precheck = {
+                shouldQueueForCredits: jest.fn().mockRejectedValue(new Error('billing down')),
+            };
+            const context = makeContext({
+                creditsPrecheck: precheck,
+                isCreditsEnforcementEnabled: () => true,
+            });
+            await expect(composeRunAdmission([creditsAdmission])(context)).resolves.toEqual(
+                RUN_ADMISSION_ADMITTED,
+            );
+            expect(context.logger.warn).toHaveBeenCalled();
+        });
+    });
+
+    describe('DEFAULT_RUN_ADMISSION_CHAIN', () => {
+        it('is the shipped order: Work valve, org/user valve, credits', () => {
+            expect(DEFAULT_RUN_ADMISSION_CHAIN).toEqual([
+                workConcurrencyAdmission,
+                orgConcurrencyAdmission,
+                creditsAdmission,
+            ]);
+        });
+
+        it('lets the concurrency valve win over the credits precheck', async () => {
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(true) };
+            const context = makeContext({
+                creditsPrecheck: precheck,
+                isCreditsEnforcementEnabled: () => true,
+            });
+            (context.counters.countInFlightForWork as jest.Mock).mockResolvedValue(10);
+            await expect(
+                composeRunAdmission(DEFAULT_RUN_ADMISSION_CHAIN)(context),
+            ).resolves.toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+            expect(precheck.shouldQueueForCredits).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/agent/src/agents/__tests__/sub-agent-delegation.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/sub-agent-delegation.service.spec.ts
@@ -1,0 +1,169 @@
+import type { SubAgentDelegationRequest, SubAgentScope } from '@ever-works/contracts';
+import { SubAgentDelegationService } from '../sub-agent-delegation.service';
+import type { SubAgentDelegationRunner } from '../sub-agent-delegation.port';
+
+/**
+ * Judgment layer G9 — delegation contract at the service seam.
+ *
+ * The pure rules (scope algebra, depth/fan-out caps) are pinned in the
+ * contracts spec; this file pins the SERVICE behaviour: the runner only
+ * ever sees a validated + narrowed request, an unbound runner is a typed
+ * refusal, and a runner that throws or returns garbage still produces a
+ * result a parent can branch on.
+ */
+describe('SubAgentDelegationService', () => {
+    const parentScope: SubAgentScope = {
+        allowedTools: ['read_file', 'write_file'],
+        allowedPaths: ['packages/agent'],
+        workId: 'work-1',
+        organizationId: 'org-1',
+        networkAccess: false,
+    };
+
+    const request = (over: Partial<SubAgentDelegationRequest> = {}): SubAgentDelegationRequest => ({
+        delegationId: 'del-1',
+        parentAgentId: 'agent-1',
+        parentRunId: 'run-1',
+        depth: 0,
+        objective: 'Summarize the failing test output',
+        scope: { allowedTools: ['read_file', 'deploy'] },
+        ...over,
+    });
+
+    const runner = (
+        impl?: SubAgentDelegationRunner['run'],
+    ): SubAgentDelegationRunner & { run: jest.Mock } => ({
+        run: jest.fn(
+            impl ??
+                (async (req: SubAgentDelegationRequest) => ({
+                    delegationId: req.delegationId,
+                    status: 'completed' as const,
+                    summary: 'done',
+                    output: { answer: 42 },
+                })),
+        ),
+    });
+
+    it('hands the runner the NARROWED request, never the one it was given', async () => {
+        const child = runner();
+        const result = await new SubAgentDelegationService(child).delegate(request(), {
+            parentScope,
+        });
+        expect(result).toMatchObject({
+            delegationId: 'del-1',
+            status: 'completed',
+            output: { answer: 42 },
+        });
+        const passed = child.run.mock.calls[0][0] as SubAgentDelegationRequest;
+        // `deploy` was asked for and is NOT in the parent scope — it is gone.
+        expect(passed.scope.allowedTools).toEqual(['read_file']);
+        expect(passed.scope.workId).toBe('work-1');
+        expect(passed.scope.networkAccess).toBe(false);
+    });
+
+    it('refuses with no-runner (and never throws) when nothing is bound', async () => {
+        const result = await new SubAgentDelegationService().delegate(request(), { parentScope });
+        expect(result).toMatchObject({
+            delegationId: 'del-1',
+            status: 'refused',
+            refusalCode: 'no-runner',
+            output: null,
+        });
+    });
+
+    it('refuses past the depth ceiling WITHOUT touching the runner', async () => {
+        const child = runner();
+        const result = await new SubAgentDelegationService(child).delegate(request({ depth: 3 }), {
+            parentScope,
+        });
+        expect(result).toMatchObject({ status: 'refused', refusalCode: 'depth-exceeded' });
+        expect(child.run).not.toHaveBeenCalled();
+    });
+
+    it('refuses past the sibling fan-out cap WITHOUT touching the runner', async () => {
+        const child = runner();
+        const result = await new SubAgentDelegationService(child).delegate(request(), {
+            parentScope,
+            siblingCount: 5,
+        });
+        expect(result).toMatchObject({ status: 'refused', refusalCode: 'fanout-exceeded' });
+        expect(child.run).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the narrowed scope grants nothing', async () => {
+        const child = runner();
+        const result = await new SubAgentDelegationService(child).delegate(
+            request({ scope: { allowedTools: ['deploy'] } }),
+            { parentScope },
+        );
+        expect(result).toMatchObject({ status: 'refused', refusalCode: 'scope-empty' });
+        expect(child.run).not.toHaveBeenCalled();
+    });
+
+    it('turns a thrown runner into a typed failed result', async () => {
+        const child = runner(async () => {
+            throw new Error('child run crashed');
+        });
+        const result = await new SubAgentDelegationService(child).delegate(request(), {
+            parentScope,
+        });
+        expect(result).toEqual({
+            delegationId: 'del-1',
+            status: 'failed',
+            summary: 'child run crashed',
+            output: null,
+        });
+    });
+
+    it('normalizes an unknown status and a missing summary', async () => {
+        const child = runner(async () => ({ status: 'weird', output: undefined }) as never);
+        const result = await new SubAgentDelegationService(child).delegate(request(), {
+            parentScope,
+        });
+        expect(result).toMatchObject({
+            status: 'failed',
+            summary: 'delegation failed',
+            output: null,
+        });
+    });
+
+    it('re-stamps the delegationId so a runner cannot break correlation', async () => {
+        const child = runner(async () => ({
+            delegationId: 'somebody-elses-id',
+            status: 'completed' as const,
+            summary: 'done',
+            output: {},
+        }));
+        const result = await new SubAgentDelegationService(child).delegate(request(), {
+            parentScope,
+        });
+        expect(result.delegationId).toBe('del-1');
+    });
+
+    it('carries an escalated result through untouched', async () => {
+        const child = runner(async () => ({
+            delegationId: 'del-1',
+            status: 'escalated' as const,
+            summary: 'needs a human',
+            escalationReasonCode: 'awaiting-input' as const,
+            output: null,
+        }));
+        const result = await new SubAgentDelegationService(child).delegate(request(), {
+            parentScope,
+        });
+        expect(result).toMatchObject({
+            status: 'escalated',
+            escalationReasonCode: 'awaiting-input',
+        });
+    });
+
+    it('preflights without dispatching', async () => {
+        const child = runner();
+        const service = new SubAgentDelegationService(child);
+        expect(service.preflight(request({ depth: 9 }), { parentScope })).toMatchObject({
+            ok: false,
+            refusalCode: 'depth-exceeded',
+        });
+        expect(child.run).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/agents/__tests__/workflow-graph-executor.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/workflow-graph-executor.service.spec.ts
@@ -1,0 +1,448 @@
+import type { WorkflowGraph, WorkflowNode } from '@ever-works/contracts';
+import { WorkflowGraphExecutorService } from '../workflow-graph-executor.service';
+import type {
+    WorkflowDecisionPort,
+    WorkflowNodeRunResult,
+    WorkflowNodeRunner,
+} from '../workflow-graph.ports';
+
+/**
+ * Judgment layer G5 — the four edge kinds + input_mapping.
+ *
+ * One test per edge kind proves the traversal RULE, not just that the
+ * executor walks: on_failure only fires on a failure it catches,
+ * conditional picks by predicate in declaration order, llm_decide asks
+ * once and honours the returned token (and degrades to the declared
+ * fallback arm when the decider is unavailable), and input_mapping
+ * actually shapes the next node's inputs.
+ */
+describe('WorkflowGraphExecutorService', () => {
+    /** Runner whose per-node behaviour is scripted by id. */
+    const scriptedRunner = (
+        script: Record<string, WorkflowNodeRunResult>,
+    ): WorkflowNodeRunner & {
+        calls: Array<{ nodeId: string; inputs: Record<string, unknown> }>;
+    } => {
+        const calls: Array<{ nodeId: string; inputs: Record<string, unknown> }> = [];
+        return {
+            calls,
+            run: jest.fn(async (node: WorkflowNode, inputs: Record<string, unknown>) => {
+                calls.push({ nodeId: node.id, inputs });
+                return script[node.id] ?? { ok: true, output: { from: node.id } };
+            }),
+        };
+    };
+
+    const node = (id: string) => ({ id, kind: 'noop' });
+
+    describe('sequential edges', () => {
+        it('walks the happy path and completes with the last output', async () => {
+            const graph: WorkflowGraph = {
+                id: 'g',
+                entryNodeId: 'a',
+                nodes: [node('a'), node('b')],
+                edges: [{ id: 'e1', kind: 'sequential', from: 'a', to: 'b' }],
+            };
+            const runner = scriptedRunner({
+                a: { ok: true, output: { value: 1 } },
+                b: { ok: true, output: { value: 2 } },
+            });
+            const result = await new WorkflowGraphExecutorService(runner).execute(graph);
+            expect(result.status).toBe('completed');
+            expect(result.visited).toEqual(['a', 'b']);
+            expect(result.traversedEdges).toEqual(['e1']);
+            expect(result.output).toEqual({ value: 2 });
+        });
+
+        it('passes the source output straight through when the edge has no mapping', async () => {
+            const graph: WorkflowGraph = {
+                id: 'g',
+                entryNodeId: 'a',
+                nodes: [node('a'), node('b')],
+                edges: [{ id: 'e1', kind: 'sequential', from: 'a', to: 'b' }],
+            };
+            const runner = scriptedRunner({ a: { ok: true, output: { value: 7 } } });
+            await new WorkflowGraphExecutorService(runner).execute(graph);
+            expect(runner.calls[1]).toEqual({ nodeId: 'b', inputs: { input: { value: 7 } } });
+        });
+
+        it('refuses an invalid graph before running anything', async () => {
+            const graph: WorkflowGraph = {
+                id: 'g',
+                entryNodeId: 'ghost',
+                nodes: [node('a')],
+                edges: [],
+            };
+            const runner = scriptedRunner({});
+            const result = await new WorkflowGraphExecutorService(runner).execute(graph);
+            expect(result.status).toBe('failed');
+            expect(result.failureCode).toBe('graph-invalid');
+            expect(runner.run).not.toHaveBeenCalled();
+        });
+
+        it('stops with max-steps-exceeded instead of looping forever', async () => {
+            const graph: WorkflowGraph = {
+                id: 'g',
+                entryNodeId: 'a',
+                nodes: [node('a')],
+                edges: [{ id: 'loop', kind: 'sequential', from: 'a', to: 'a' }],
+                maxSteps: 4,
+            };
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({})).execute(
+                graph,
+            );
+            expect(result.status).toBe('failed');
+            expect(result.failureCode).toBe('max-steps-exceeded');
+            expect(result.visited).toHaveLength(4);
+        });
+
+        it('blocks (not fails) when no node runner is bound', async () => {
+            const graph: WorkflowGraph = {
+                id: 'g',
+                entryNodeId: 'a',
+                nodes: [node('a')],
+                edges: [],
+            };
+            const result = await new WorkflowGraphExecutorService().execute(graph);
+            expect(result).toMatchObject({ status: 'blocked', failureCode: 'no-node-runner' });
+        });
+    });
+
+    describe('on_failure edges', () => {
+        const graph = (over: Partial<WorkflowGraph> = {}): WorkflowGraph => ({
+            id: 'g',
+            entryNodeId: 'a',
+            nodes: [node('a'), node('recover'), node('next')],
+            edges: [
+                { id: 'e-ok', kind: 'sequential', from: 'a', to: 'next' },
+                { id: 'e-fail', kind: 'on_failure', from: 'a', to: 'recover' },
+            ],
+            ...over,
+        });
+
+        it('is NOT taken when the node succeeds', async () => {
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({})).execute(
+                graph(),
+            );
+            expect(result.visited).toEqual(['a', 'next']);
+            expect(result.traversedEdges).toEqual(['e-ok']);
+        });
+
+        it('is taken when the node fails, and the run then completes normally', async () => {
+            const runner = scriptedRunner({ a: { ok: false, failureCode: 'lint-red' } });
+            const result = await new WorkflowGraphExecutorService(runner).execute(graph());
+            expect(result.status).toBe('completed');
+            expect(result.visited).toEqual(['a', 'recover']);
+            expect(result.traversedEdges).toEqual(['e-fail']);
+        });
+
+        it('only catches the failure codes it declares', async () => {
+            const narrowed = graph({
+                edges: [
+                    {
+                        id: 'e-fail',
+                        kind: 'on_failure',
+                        from: 'a',
+                        to: 'recover',
+                        catch: ['lint-red'],
+                    },
+                ],
+            });
+            const runner = scriptedRunner({ a: { ok: false, failureCode: 'build-red' } });
+            const result = await new WorkflowGraphExecutorService(runner).execute(narrowed);
+            expect(result.status).toBe('failed');
+            expect(result.failureCode).toBe('node-failed');
+            expect(result.failedNodeId).toBe('a');
+            expect(result.visited).toEqual(['a']);
+        });
+
+        it('turns a THROWN node into a catchable failure rather than losing the trace', async () => {
+            // Only `a` throws. A runner that threw for every node would make
+            // the recovery node throw too, which tests nothing about the
+            // on_failure edge — the point here is that a THROW is caught and
+            // routed exactly like a returned failure.
+            const runner: WorkflowNodeRunner = {
+                run: jest.fn(async (node: WorkflowNode) => {
+                    if (node.id === 'a') throw new Error('runner exploded');
+                    return { ok: true, output: { from: node.id } };
+                }),
+            };
+            const result = await new WorkflowGraphExecutorService(runner).execute(graph());
+            expect(result.status).toBe('completed');
+            expect(result.visited).toEqual(['a', 'recover']);
+            expect(result.nodes[0]).toMatchObject({ ok: false, failureCode: 'node-threw' });
+        });
+    });
+
+    describe('conditional edges', () => {
+        const graph: WorkflowGraph = {
+            id: 'g',
+            entryNodeId: 'a',
+            nodes: [node('a'), node('big'), node('small'), node('fallback')],
+            edges: [
+                {
+                    id: 'e-big',
+                    kind: 'conditional',
+                    from: 'a',
+                    to: 'big',
+                    when: { path: 'nodes.a.output.count', operator: 'gte', value: 10 },
+                },
+                {
+                    id: 'e-small',
+                    kind: 'conditional',
+                    from: 'a',
+                    to: 'small',
+                    when: { path: 'nodes.a.output.count', operator: 'gt', value: 0 },
+                },
+                { id: 'e-seq', kind: 'sequential', from: 'a', to: 'fallback' },
+            ],
+        };
+
+        it('takes the first predicate that holds, in declaration order', async () => {
+            const big = await new WorkflowGraphExecutorService(
+                scriptedRunner({ a: { ok: true, output: { count: 42 } } }),
+            ).execute(graph);
+            expect(big.visited).toEqual(['a', 'big']);
+
+            const small = await new WorkflowGraphExecutorService(
+                scriptedRunner({ a: { ok: true, output: { count: 3 } } }),
+            ).execute(graph);
+            expect(small.visited).toEqual(['a', 'small']);
+        });
+
+        it('falls through to the sequential edge when no predicate holds', async () => {
+            const result = await new WorkflowGraphExecutorService(
+                scriptedRunner({ a: { ok: true, output: { count: 0 } } }),
+            ).execute(graph);
+            expect(result.visited).toEqual(['a', 'fallback']);
+            expect(result.traversedEdges).toEqual(['e-seq']);
+        });
+    });
+
+    describe('llm_decide edges', () => {
+        const graph = (over: Partial<WorkflowGraph> = {}): WorkflowGraph => ({
+            id: 'g',
+            entryNodeId: 'a',
+            nodes: [node('a'), node('ship'), node('revise')],
+            edges: [
+                {
+                    id: 'e-ship',
+                    kind: 'llm_decide',
+                    from: 'a',
+                    to: 'ship',
+                    choice: 'ship',
+                    choiceDescription: 'The draft is good enough',
+                },
+                {
+                    id: 'e-revise',
+                    kind: 'llm_decide',
+                    from: 'a',
+                    to: 'revise',
+                    choice: 'revise',
+                    fallback: true,
+                },
+            ],
+            ...over,
+        });
+
+        const decider = (choice: string): WorkflowDecisionPort => ({
+            decide: jest.fn(async () => ({ choice, rationale: 'because' })),
+        });
+
+        it('asks the decider ONCE with every arm and takes the chosen one', async () => {
+            const port = decider('ship');
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({}), port).execute(
+                graph(),
+            );
+            expect(port.decide).toHaveBeenCalledTimes(1);
+            expect(port.decide).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    nodeId: 'a',
+                    choices: [
+                        {
+                            choice: 'ship',
+                            targetNodeId: 'ship',
+                            description: 'The draft is good enough',
+                        },
+                        { choice: 'revise', targetNodeId: 'revise' },
+                    ],
+                }),
+            );
+            expect(result.visited).toEqual(['a', 'ship']);
+            expect(result.decisions).toEqual([
+                { nodeId: 'a', choice: 'ship', rationale: 'because' },
+            ]);
+        });
+
+        it('takes the declared fallback arm — marked degraded — when no decider is bound', async () => {
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({})).execute(
+                graph(),
+            );
+            expect(result.visited).toEqual(['a', 'revise']);
+            expect(result.decisions).toEqual([{ nodeId: 'a', choice: 'revise', degraded: true }]);
+        });
+
+        it('degrades the same way when the decider throws', async () => {
+            const port: WorkflowDecisionPort = {
+                decide: jest.fn(async () => {
+                    throw new Error('provider down');
+                }),
+            };
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({}), port).execute(
+                graph(),
+            );
+            expect(result.visited).toEqual(['a', 'revise']);
+            expect(result.decisions[0]).toMatchObject({ degraded: true });
+        });
+
+        it('BLOCKS loudly when the decider is unavailable and no fallback arm is declared', async () => {
+            const noFallback = graph({
+                edges: [
+                    { id: 'e-ship', kind: 'llm_decide', from: 'a', to: 'ship', choice: 'ship' },
+                    {
+                        id: 'e-revise',
+                        kind: 'llm_decide',
+                        from: 'a',
+                        to: 'revise',
+                        choice: 'revise',
+                    },
+                ],
+            });
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({})).execute(
+                noFallback,
+            );
+            expect(result).toMatchObject({
+                status: 'blocked',
+                failureCode: 'llm-decide-unavailable',
+            });
+            expect(result.visited).toEqual(['a']);
+        });
+
+        it('fails on an unknown choice when there is no fallback to fall back to', async () => {
+            const noFallback = graph({
+                edges: [
+                    { id: 'e-ship', kind: 'llm_decide', from: 'a', to: 'ship', choice: 'ship' },
+                    {
+                        id: 'e-revise',
+                        kind: 'llm_decide',
+                        from: 'a',
+                        to: 'revise',
+                        choice: 'revise',
+                    },
+                ],
+            });
+            const result = await new WorkflowGraphExecutorService(
+                scriptedRunner({}),
+                decider('teleport'),
+            ).execute(noFallback);
+            expect(result).toMatchObject({
+                status: 'failed',
+                failureCode: 'llm-decide-unknown-choice',
+            });
+        });
+
+        it('is only consulted after conditional edges have had their chance', async () => {
+            const withConditional = graph({
+                edges: [
+                    {
+                        id: 'e-cond',
+                        kind: 'conditional',
+                        from: 'a',
+                        to: 'ship',
+                        when: { path: 'nodes.a.ok', operator: 'truthy' },
+                    },
+                    {
+                        id: 'e-revise',
+                        kind: 'llm_decide',
+                        from: 'a',
+                        to: 'revise',
+                        choice: 'revise',
+                    },
+                ],
+            });
+            const port = decider('revise');
+            const result = await new WorkflowGraphExecutorService(scriptedRunner({}), port).execute(
+                withConditional,
+            );
+            expect(result.visited).toEqual(['a', 'ship']);
+            expect(port.decide).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('input_mapping', () => {
+        const graph = (mapping: WorkflowGraph['edges'][number]['inputMapping']): WorkflowGraph => ({
+            id: 'g',
+            entryNodeId: 'a',
+            nodes: [node('a'), node('b')],
+            edges: [{ id: 'e1', kind: 'sequential', from: 'a', to: 'b', inputMapping: mapping }],
+        });
+
+        it('builds the destination inputs from scope paths and literals', async () => {
+            const runner = scriptedRunner({ a: { ok: true, output: { items: [1, 2, 3] } } });
+            await new WorkflowGraphExecutorService(runner).execute(
+                graph([
+                    { to: 'items', from: 'nodes.a.output.items' },
+                    { to: 'seed', from: 'input.seed' },
+                    { to: 'mode', fallback: 'strict' },
+                ]),
+                { input: { seed: 9 } },
+            );
+            expect(runner.calls[1].inputs).toEqual({ items: [1, 2, 3], seed: 9, mode: 'strict' });
+        });
+
+        it('reads ambient run context too', async () => {
+            const runner = scriptedRunner({});
+            await new WorkflowGraphExecutorService(runner).execute(
+                graph([{ to: 'work', from: 'context.workId' }]),
+                { context: { workId: 'work-1' } },
+            );
+            expect(runner.calls[1].inputs).toEqual({ work: 'work-1' });
+        });
+
+        it('fails the run when a REQUIRED binding cannot be resolved', async () => {
+            const runner = scriptedRunner({});
+            const result = await new WorkflowGraphExecutorService(runner).execute(
+                graph([{ to: 'must', from: 'nodes.a.output.missing', required: true }]),
+            );
+            expect(result).toMatchObject({
+                status: 'failed',
+                failureCode: 'input-mapping-unresolved',
+                failedNodeId: 'a',
+            });
+            // The destination node never ran with a silently missing input.
+            expect(runner.calls.map((call) => call.nodeId)).toEqual(['a']);
+        });
+
+        it('omits an OPTIONAL binding that cannot be resolved', async () => {
+            const runner = scriptedRunner({});
+            const result = await new WorkflowGraphExecutorService(runner).execute(
+                graph([{ to: 'maybe', from: 'nodes.a.output.missing' }]),
+            );
+            expect(result.status).toBe('completed');
+            expect(runner.calls[1].inputs).toEqual({});
+        });
+
+        it('applies on an on_failure edge as well, so a recovery node gets the failure code', async () => {
+            const runner = scriptedRunner({ a: { ok: false, failureCode: 'lint-red' } });
+            const recoveryGraph: WorkflowGraph = {
+                id: 'g',
+                entryNodeId: 'a',
+                nodes: [node('a'), node('b')],
+                edges: [
+                    {
+                        id: 'e1',
+                        kind: 'on_failure',
+                        from: 'a',
+                        to: 'b',
+                        inputMapping: [
+                            { to: 'reason', from: 'nodes.a.failureCode', required: true },
+                        ],
+                    },
+                ],
+            };
+            const result = await new WorkflowGraphExecutorService(runner).execute(recoveryGraph);
+            expect(result.status).toBe('completed');
+            expect(runner.calls[1].inputs).toEqual({ reason: 'lint-red' });
+        });
+    });
+});

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -37,6 +37,10 @@ import { TerminalSessionLauncher } from './terminal-session-launcher.service';
 import { AgentToolService } from './agent-tool.service';
 import { AgentEscalationService } from './agent-escalation.service';
 import { EscalationConfidenceService } from './escalation-confidence';
+import { WorkflowGraphExecutorService } from './workflow-graph-executor.service';
+import { WorkflowAiDecisionAdapter } from './workflow-ai-decision.adapter';
+import { WORKFLOW_DECISION_PORT } from './workflow-graph.ports';
+import { SubAgentDelegationService } from './sub-agent-delegation.service';
 import { VisionContextService } from '../services/vision-context.service';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { SkillsModule } from '../skills/skills.module';
@@ -154,6 +158,19 @@ import { FacadesModule } from '../facades/facades.module';
         // table otherwise). FacadesModule is already imported above, so
         // the AiFacadeService it consumes resolves in production.
         EscalationConfidenceService,
+        // Judgment layer G5 - workflow graph execution. The node runner
+        // (WORKFLOW_NODE_RUNNER) stays @Optional() and is bound by the
+        // host that owns node semantics; the decider is bound HERE to the
+        // AI-facade adapter so every llm_decide call goes through the
+        // facade/plugin seam (FacadesModule is already imported above).
+        WorkflowAiDecisionAdapter,
+        { provide: WORKFLOW_DECISION_PORT, useExisting: WorkflowAiDecisionAdapter },
+        WorkflowGraphExecutorService,
+        // Judgment layer G9 - scoped sub-agent delegation. The runner it
+        // dispatches through (SUB_AGENT_DELEGATION_RUNNER) is @Optional()
+        // and bound by the api-side @Global() module, exactly like
+        // RunDispatchGateService's dispatcher.
+        SubAgentDelegationService,
     ],
     exports: [
         AgentRepository,
@@ -179,6 +196,10 @@ import { FacadesModule } from '../facades/facades.module';
         AgentToolService,
         AgentEscalationService,
         EscalationConfidenceService,
+        WorkflowGraphExecutorService,
+        WorkflowAiDecisionAdapter,
+        WORKFLOW_DECISION_PORT,
+        SubAgentDelegationService,
     ],
 })
 export class AgentsModule {}

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -11,7 +11,34 @@ export * from './agent-schedule-dispatcher.service';
 export * from './agent-export.service';
 export * from './prompt-assembler.service';
 export * from './agent-run.service';
+// Judgment layer G15 — the pre-run path as a composable middleware chain.
+// Named exports (not `export *`) so the two QUEUED_REASON_* constants have
+// exactly ONE path out of this barrel: `run-dispatch-gate.service`, which
+// re-exports them for every pre-existing importer.
+export {
+    composeRunAdmission,
+    creditsAdmission,
+    orgConcurrencyAdmission,
+    workConcurrencyAdmission,
+    DEFAULT_RUN_ADMISSION_CHAIN,
+    RUN_ADMISSION_ADMITTED,
+    type RunAdmissionContext,
+    type RunAdmissionCounters,
+    type RunAdmissionInput,
+    type RunAdmissionLogger,
+    type RunAdmissionMiddleware,
+    type RunAdmissionNext,
+    type RunAdmissionVerdict,
+} from './run-admission-chain';
 export * from './run-dispatch-gate.service';
+// Judgment layer G5 — workflow graph edges (on_failure / conditional /
+// llm_decide) + input mapping, and the AI-facade-backed decider.
+export * from './workflow-graph.ports';
+export * from './workflow-graph-executor.service';
+export * from './workflow-ai-decision.adapter';
+// Judgment layer G9 — scoped sub-agent delegation with a typed result.
+export * from './sub-agent-delegation.port';
+export * from './sub-agent-delegation.service';
 export * from './run-steering.service';
 export * from './run-credits-precheck';
 export * from './terminal-session-dispatcher';

--- a/packages/agent/src/agents/run-admission-chain.ts
+++ b/packages/agent/src/agents/run-admission-chain.ts
@@ -1,0 +1,173 @@
+import type { RunCreditsPrecheck } from './run-credits-precheck';
+
+/**
+ * Pre-run admission chain (judgment layer G15).
+ *
+ * The pre-run path used to be ONE imperative method: count the Work's
+ * in-flight runs, then the org's, then maybe consult credits — three
+ * unrelated policies welded into a single `if`-ladder that could not be
+ * reordered, reused, unit-tested in isolation, or extended without
+ * editing the method every time.
+ *
+ * This file makes each policy a MIDDLEWARE: `(ctx, next) => Promise<result>`.
+ * A middleware either short-circuits with a verdict or calls `next()`.
+ * {@link composeRunAdmission} folds a list into one callable, so the
+ * order is data (`DEFAULT_RUN_ADMISSION_CHAIN`) rather than control flow.
+ *
+ * This is a STRUCTURAL change only. `DEFAULT_RUN_ADMISSION_CHAIN`
+ * reproduces the previous behaviour exactly, token for token and log
+ * line for log line: Work valve first, then org/user valve, then the
+ * (kill-switched, fail-open) credits precheck.
+ */
+
+/** Stamped when the gate parks a run for concurrency. Re-exported by the gate service. */
+export const QUEUED_REASON_CONCURRENCY = 'concurrency-limit' as const;
+
+/** Stamped when the soft credits precheck parks a run. Re-exported by the gate service. */
+export const QUEUED_REASON_INSUFFICIENT_CREDITS = 'insufficient-credits' as const;
+
+export interface RunAdmissionInput {
+    userId: string;
+    workId?: string | null;
+    organizationId?: string | null;
+}
+
+export interface RunAdmissionVerdict {
+    admitted: boolean;
+    /** Set only when `admitted === false`. */
+    queuedReason?: string;
+}
+
+/** The narrow slice of `AgentRunRepository` the chain actually counts with. */
+export interface RunAdmissionCounters {
+    countInFlightForWork(workId: string): Promise<number>;
+    countInFlightForOrganization(organizationId: string): Promise<number>;
+    countInFlightForUser(userId: string): Promise<number>;
+}
+
+/** Just enough of a Nest `Logger` to keep the chain framework-free. */
+export interface RunAdmissionLogger {
+    log(message: string): void;
+    warn(message: string): void;
+}
+
+/**
+ * Everything a middleware may read. Limits arrive as THUNKS, not
+ * numbers, so the documented per-Work override column can slot in
+ * behind `resolveWorkLimit` without touching a single middleware.
+ */
+export interface RunAdmissionContext {
+    readonly input: RunAdmissionInput;
+    readonly counters: RunAdmissionCounters;
+    readonly logger: RunAdmissionLogger;
+    readonly resolveWorkLimit: () => number;
+    readonly resolveOrgLimit: () => number;
+    readonly isCreditsEnforcementEnabled: () => boolean;
+    readonly creditsPrecheck?: RunCreditsPrecheck;
+}
+
+export type RunAdmissionNext = () => Promise<RunAdmissionVerdict>;
+
+export type RunAdmissionMiddleware = (
+    context: RunAdmissionContext,
+    next: RunAdmissionNext,
+) => Promise<RunAdmissionVerdict>;
+
+/** The verdict a chain that never short-circuits ends on. */
+export const RUN_ADMISSION_ADMITTED: RunAdmissionVerdict = { admitted: true };
+
+/**
+ * Fold middlewares into one callable. Runs left to right; the first one
+ * that returns without calling `next()` decides. A middleware that
+ * calls `next()` twice is a bug and is refused loudly — silently
+ * double-running the tail would double-count in-flight runs.
+ */
+export function composeRunAdmission(
+    chain: readonly RunAdmissionMiddleware[],
+): (context: RunAdmissionContext) => Promise<RunAdmissionVerdict> {
+    return async (context: RunAdmissionContext) => {
+        let lastCalled = -1;
+        const dispatch = async (index: number): Promise<RunAdmissionVerdict> => {
+            if (index <= lastCalled) {
+                throw new Error('run admission middleware called next() more than once');
+            }
+            lastCalled = index;
+            const middleware = chain[index];
+            if (!middleware) return RUN_ADMISSION_ADMITTED;
+            return middleware(context, () => dispatch(index + 1));
+        };
+        return dispatch(0);
+    };
+}
+
+/**
+ * Per-Work concurrency valve. A limit of `<= 0` disables it entirely —
+ * and, importantly, skips the count query, which is what the "valve of
+ * 0 never touches the repository" contract depends on.
+ */
+export const workConcurrencyAdmission: RunAdmissionMiddleware = async (context, next) => {
+    const { input, counters, logger } = context;
+    const limit = context.resolveWorkLimit();
+    if (!input.workId || limit <= 0) return next();
+    const inFlight = await counters.countInFlightForWork(input.workId);
+    if (inFlight < limit) return next();
+    logger.log(
+        `Dispatch gate: Work ${input.workId} at ${inFlight}/${limit} in-flight runs — queueing.`,
+    );
+    return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
+};
+
+/**
+ * Per-org valve, falling back to per-user when the run has no org. Same
+ * `<= 0` disables semantics as the Work valve.
+ */
+export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, next) => {
+    const { input, counters, logger } = context;
+    const limit = context.resolveOrgLimit();
+    if (limit <= 0) return next();
+    const inFlight = input.organizationId
+        ? await counters.countInFlightForOrganization(input.organizationId)
+        : await counters.countInFlightForUser(input.userId);
+    if (inFlight < limit) return next();
+    logger.log(
+        `Dispatch gate: ${
+            input.organizationId ? `org ${input.organizationId}` : `user ${input.userId}`
+        } at ${inFlight}/${limit} in-flight runs — queueing.`,
+    );
+    return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
+};
+
+/**
+ * Soft credits enforcement (ship-dark). Runs ONLY when the kill-switch
+ * is on AND the precheck token is bound. Fail-open on any error: a
+ * broken billing check must never stop work.
+ */
+export const creditsAdmission: RunAdmissionMiddleware = async (context, next) => {
+    const { input, logger, creditsPrecheck } = context;
+    if (!creditsPrecheck || !context.isCreditsEnforcementEnabled()) return next();
+    try {
+        if (await creditsPrecheck.shouldQueueForCredits(input.userId)) {
+            logger.log(
+                `Dispatch gate: user ${input.userId} is credit-limited with an ` +
+                    `exhausted balance — queueing.`,
+            );
+            return { admitted: false, queuedReason: QUEUED_REASON_INSUFFICIENT_CREDITS };
+        }
+    } catch (err) {
+        logger.warn(
+            `Dispatch gate: credits precheck failed for user ${input.userId} (fail-open): ${err}`,
+        );
+    }
+    return next();
+};
+
+/**
+ * The shipped order. Concurrency wins over credits by construction —
+ * a saturated Work parks with `concurrency-limit` and never spends a
+ * billing query, which is exactly what the pre-refactor ladder did.
+ */
+export const DEFAULT_RUN_ADMISSION_CHAIN: readonly RunAdmissionMiddleware[] = [
+    workConcurrencyAdmission,
+    orgConcurrencyAdmission,
+    creditsAdmission,
+];

--- a/packages/agent/src/agents/run-dispatch-gate.service.ts
+++ b/packages/agent/src/agents/run-dispatch-gate.service.ts
@@ -9,13 +9,24 @@ import {
     type AgentTaskExecuteDispatcher,
 } from '../tasks-domain/task-dispatcher';
 import { RUN_CREDITS_PRECHECK, type RunCreditsPrecheck } from './run-credits-precheck';
+import {
+    composeRunAdmission,
+    DEFAULT_RUN_ADMISSION_CHAIN,
+    QUEUED_REASON_CONCURRENCY,
+    QUEUED_REASON_INSUFFICIENT_CREDITS,
+    type RunAdmissionMiddleware,
+} from './run-admission-chain';
 
 /**
  * Stable machine token stamped into `agent_runs.queuedReason` when the
  * gate parks a run instead of dispatching it. The drain looks rows up by
  * this exact literal — one shared constant, never three drifting copies.
+ *
+ * Judgment layer G15 — the literal now LIVES in `run-admission-chain.ts`
+ * (the middlewares stamp it) and is re-exported here so every existing
+ * importer of `run-dispatch-gate.service` keeps working unchanged.
  */
-export const QUEUED_REASON_CONCURRENCY = 'concurrency-limit' as const;
+export { QUEUED_REASON_CONCURRENCY };
 
 /**
  * Pricing Wave 9 M2 — stamped when the soft credits precheck parks a run
@@ -26,7 +37,7 @@ export const QUEUED_REASON_CONCURRENCY = 'concurrency-limit' as const;
  * documented Wave 9 follow-up; until then the run stays visibly queued
  * with this reason in the Sessions view.
  */
-export const QUEUED_REASON_INSUFFICIENT_CREDITS = 'insufficient-credits' as const;
+export { QUEUED_REASON_INSUFFICIENT_CREDITS };
 
 export interface RunDispatchAdmitInput {
     userId: string;
@@ -116,10 +127,37 @@ export function runAdmissionLockScope(input: RunDispatchAdmitInput): string {
  *     the row is bookkeeping for work in flight, not a new admission;
  *   - `TerminalSessionLauncher` — attaches a shell to an ALREADY-admitted
  *     live run; it enqueues no AgentRun.
+ *
+ * Judgment layer G15 — the pre-run decision itself is no longer an
+ * imperative ladder inside `evaluate()`. It is a COMPOSED chain of
+ * admission middlewares (`run-admission-chain.ts`): Work valve, then
+ * org/user valve, then the ship-dark credits precheck. Behaviour is
+ * byte-identical to the ladder it replaced; what changed is that a new
+ * pre-run policy is now a new middleware in a list instead of another
+ * branch in a growing method.
  */
 @Injectable()
 export class RunDispatchGateService {
     private readonly logger = new Logger(RunDispatchGateService.name);
+
+    /**
+     * The composed pre-run chain. A field, not a ctor param: the
+     * middleware list is code-level policy, not an injectable, so the
+     * gate's constructor arity (which unit specs construct positionally)
+     * stays exactly as it was. Subclasses / tests that need a different
+     * order call {@link withAdmissionChain}.
+     */
+    private admissionChain = composeRunAdmission(DEFAULT_RUN_ADMISSION_CHAIN);
+
+    /**
+     * Swap the pre-run chain. Exists so a test — or a future install
+     * that adds, say, a maintenance-window middleware — can compose a
+     * different order without reaching into `evaluate()`.
+     */
+    withAdmissionChain(chain: readonly RunAdmissionMiddleware[]): this {
+        this.admissionChain = composeRunAdmission(chain);
+        return this;
+    }
 
     constructor(
         private readonly runs: AgentRunRepository,
@@ -200,61 +238,22 @@ export class RunDispatchGateService {
             : run();
     }
 
+    /**
+     * Run the composed pre-run chain. Every policy — the Work valve, the
+     * org/user valve, the ship-dark credits precheck — is a middleware
+     * in `DEFAULT_RUN_ADMISSION_CHAIN`; this method only supplies the
+     * context they read (counters, limit thunks, logger, precheck).
+     */
     private async evaluate(input: RunDispatchAdmitInput): Promise<RunDispatchAdmitResult> {
-        const workLimit = this.resolveWorkLimit();
-        if (input.workId && workLimit > 0) {
-            const inFlight = await this.runs.countInFlightForWork(input.workId);
-            if (inFlight >= workLimit) {
-                this.logger.log(
-                    `Dispatch gate: Work ${input.workId} at ${inFlight}/${workLimit} in-flight runs — queueing.`,
-                );
-                return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
-            }
-        }
-
-        const orgLimit = this.resolveOrgLimit();
-        if (orgLimit > 0) {
-            const inFlight = input.organizationId
-                ? await this.runs.countInFlightForOrganization(input.organizationId)
-                : await this.runs.countInFlightForUser(input.userId);
-            if (inFlight >= orgLimit) {
-                this.logger.log(
-                    `Dispatch gate: ${
-                        input.organizationId
-                            ? `org ${input.organizationId}`
-                            : `user ${input.userId}`
-                    } at ${inFlight}/${orgLimit} in-flight runs — queueing.`,
-                );
-                return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
-            }
-        }
-
-        // Pricing Wave 9 M2 — soft credits enforcement (ship-dark). Runs
-        // ONLY when the CREDITS_ENFORCEMENT kill-switch is on AND the
-        // precheck token is bound. Fail-open on any error: a broken
-        // billing check must never stop work (same posture as a broken
-        // concurrency valve).
-        if (this.creditsPrecheck && config.billing.credits.isEnforcementEnabled()) {
-            try {
-                if (await this.creditsPrecheck.shouldQueueForCredits(input.userId)) {
-                    this.logger.log(
-                        `Dispatch gate: user ${input.userId} is credit-limited with an ` +
-                            `exhausted balance — queueing.`,
-                    );
-                    return {
-                        admitted: false,
-                        queuedReason: QUEUED_REASON_INSUFFICIENT_CREDITS,
-                    };
-                }
-            } catch (err) {
-                this.logger.warn(
-                    `Dispatch gate: credits precheck failed for user ${input.userId} ` +
-                        `(fail-open): ${err}`,
-                );
-            }
-        }
-
-        return { admitted: true };
+        return this.admissionChain({
+            input,
+            counters: this.runs,
+            logger: this.logger,
+            resolveWorkLimit: () => this.resolveWorkLimit(),
+            resolveOrgLimit: () => this.resolveOrgLimit(),
+            isCreditsEnforcementEnabled: () => config.billing.credits.isEnforcementEnabled(),
+            ...(this.creditsPrecheck ? { creditsPrecheck: this.creditsPrecheck } : {}),
+        });
     }
 
     /**

--- a/packages/agent/src/agents/sub-agent-delegation.port.ts
+++ b/packages/agent/src/agents/sub-agent-delegation.port.ts
@@ -1,0 +1,23 @@
+import type { SubAgentDelegationRequest, SubAgentDelegationResult } from '@ever-works/contracts';
+
+/**
+ * The seam that turns a VALIDATED delegation request into an actual
+ * child run (judgment layer G9).
+ *
+ * A PORT, not a class: the thing that can actually start an agent run
+ * lives behind the job runtime, and `SubAgentDelegationService` must
+ * stay runtime-free so it can be unit-tested and reused from the
+ * worker. Bound by the api-side @Global() module with the same
+ * `@Optional()` posture as every other dispatch seam here — unbound,
+ * a delegation is REFUSED with `no-runner` rather than silently
+ * dropped.
+ *
+ * Contract for implementors: the request handed here has ALREADY been
+ * validated and narrowed (`validateSubAgentDelegationRequest`), so the
+ * scope on it is the effective scope. Never re-widen it.
+ */
+export interface SubAgentDelegationRunner {
+    run(request: SubAgentDelegationRequest): Promise<SubAgentDelegationResult>;
+}
+
+export const SUB_AGENT_DELEGATION_RUNNER = 'SUB_AGENT_DELEGATION_RUNNER' as const;

--- a/packages/agent/src/agents/sub-agent-delegation.service.ts
+++ b/packages/agent/src/agents/sub-agent-delegation.service.ts
@@ -1,0 +1,139 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    refuseSubAgentDelegation,
+    validateSubAgentDelegationRequest,
+    SUB_AGENT_DELEGATION_STATUSES,
+    SUB_AGENT_MAX_SUMMARY_CHARS,
+    type SubAgentDelegationLimits,
+    type SubAgentDelegationRequest,
+    type SubAgentDelegationResult,
+} from '@ever-works/contracts';
+import {
+    SUB_AGENT_DELEGATION_RUNNER,
+    type SubAgentDelegationRunner,
+} from './sub-agent-delegation.port';
+
+/**
+ * Sub-agent delegation (judgment layer G9) — the one place a parent
+ * agent's "do this smaller thing for me" becomes a bounded child run
+ * with a typed answer.
+ *
+ * The service is deliberately thin, because the interesting parts are
+ * the CONTRACT rules and they live in `@ever-works/contracts` as pure
+ * functions:
+ *
+ *   1. validate + narrow  — depth cap, sibling fan-out cap, scope
+ *                           intersection against the parent, budget
+ *                           ceiling. Failing any of these is a REFUSAL
+ *                           (typed code, nothing ran), not an error.
+ *   2. dispatch           — hand the EFFECTIVE request (narrowed scope)
+ *                           to the bound runner.
+ *   3. normalize          — whatever the runner returns is coerced back
+ *                           into the closed result shape, so a parent
+ *                           can always branch on
+ *                           `completed | failed | refused | escalated`.
+ *
+ * Never throws for a delegation's own reasons: a thrown runner becomes
+ * `status: 'failed'` with the message as the summary, because a parent
+ * that loses the delegation record loses the only trace of what it
+ * asked for.
+ */
+@Injectable()
+export class SubAgentDelegationService {
+    private readonly logger = new Logger(SubAgentDelegationService.name);
+
+    constructor(
+        // Bound by the api-side @Global() module; absent in unit tests and
+        // installs without a job runtime. @Optional() + appended LAST per
+        // the positional-spec arity rule.
+        @Optional()
+        @Inject(SUB_AGENT_DELEGATION_RUNNER)
+        private readonly runner?: SubAgentDelegationRunner,
+    ) {}
+
+    /**
+     * Validate a request WITHOUT running it. Exposed so a caller (or a
+     * chat tool) can preflight a delegation and show the refusal reason
+     * before spending anything.
+     */
+    preflight(request: SubAgentDelegationRequest, limits: SubAgentDelegationLimits = {}) {
+        return validateSubAgentDelegationRequest(request, limits);
+    }
+
+    async delegate(
+        request: SubAgentDelegationRequest,
+        limits: SubAgentDelegationLimits = {},
+    ): Promise<SubAgentDelegationResult> {
+        const delegationId = request?.delegationId ?? 'unknown';
+        const validation = validateSubAgentDelegationRequest(request, limits);
+        // `=== false` rather than `!validation.ok`: this package compiles
+        // with `strictNullChecks: false`, under which negated-discriminant
+        // narrowing silently picks the WRONG union member. An explicit
+        // literal comparison narrows correctly in both modes.
+        if (validation.ok === false) {
+            this.logger.log(
+                `Delegation ${delegationId} refused (${validation.refusalCode}): ${validation.message}`,
+            );
+            return refuseSubAgentDelegation(
+                delegationId,
+                validation.refusalCode,
+                validation.message,
+            );
+        }
+
+        if (!this.runner) {
+            const message = 'no sub-agent delegation runner is bound in this process';
+            this.logger.warn(`Delegation ${delegationId} refused: ${message}`);
+            return refuseSubAgentDelegation(delegationId, 'no-runner', message);
+        }
+
+        const effective = validation.request;
+        try {
+            const result = await this.runner.run(effective);
+            return this.normalize(delegationId, result);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            this.logger.warn(`Delegation ${delegationId} runner threw: ${message}`);
+            return {
+                delegationId,
+                status: 'failed',
+                summary: message.slice(0, SUB_AGENT_MAX_SUMMARY_CHARS),
+                output: null,
+            };
+        }
+    }
+
+    /**
+     * Coerce a runner's answer into the closed result shape. A runner
+     * that returns garbage (missing status, wrong delegationId) is a bug
+     * in the runner, not a reason to hand the parent an untyped blob.
+     */
+    private normalize(
+        delegationId: string,
+        result: SubAgentDelegationResult,
+    ): SubAgentDelegationResult {
+        if (!result || typeof result !== 'object') {
+            return {
+                delegationId,
+                status: 'failed',
+                summary: 'the delegation runner returned nothing',
+                output: null,
+            };
+        }
+        const status = SUB_AGENT_DELEGATION_STATUSES.includes(result.status)
+            ? result.status
+            : 'failed';
+        const summary =
+            typeof result.summary === 'string' && result.summary.trim().length > 0
+                ? result.summary.slice(0, SUB_AGENT_MAX_SUMMARY_CHARS)
+                : `delegation ${status}`;
+        return {
+            ...result,
+            // The id is the correlation key — the runner never gets to change it.
+            delegationId,
+            status,
+            summary,
+            output: result.output ?? null,
+        };
+    }
+}

--- a/packages/agent/src/agents/workflow-ai-decision.adapter.ts
+++ b/packages/agent/src/agents/workflow-ai-decision.adapter.ts
@@ -1,0 +1,105 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+import { AiFacadeService } from '../facades/ai.facade';
+import type {
+    WorkflowDecision,
+    WorkflowDecisionPort,
+    WorkflowDecisionRequest,
+} from './workflow-graph.ports';
+
+/** What the model must return. Kept tiny so any provider can honour it. */
+const decisionSchema = z.object({
+    choice: z.string(),
+    rationale: z.string().optional(),
+});
+
+/** Cap on the serialized node output handed to the model (prompt-size guard). */
+export const WORKFLOW_DECISION_MAX_OUTPUT_CHARS = 4000;
+
+function summarizeOutput(output: unknown): string {
+    if (output === undefined || output === null) return '(no output)';
+    let text: string;
+    try {
+        text = typeof output === 'string' ? output : JSON.stringify(output);
+    } catch {
+        return '(unserializable output)';
+    }
+    if (!text) return '(no output)';
+    return text.length > WORKFLOW_DECISION_MAX_OUTPUT_CHARS
+        ? `${text.slice(0, WORKFLOW_DECISION_MAX_OUTPUT_CHARS)}…(truncated)`
+        : text;
+}
+
+/**
+ * The production binding for `WORKFLOW_DECISION_PORT` (judgment layer G5).
+ *
+ * Turns the executor's `llm_decide` question into ONE `askJson` call on
+ * the AI facade — never a raw provider SDK, so budget enforcement,
+ * per-run cost attribution, provider override and the plugin seam all
+ * apply exactly as they do for every other model call in the platform.
+ *
+ * The model is asked to return a `choice` token, not free prose, and the
+ * executor still verifies the returned token against the graph's arms —
+ * this adapter is a translator, not a trust boundary.
+ */
+@Injectable()
+export class WorkflowAiDecisionAdapter implements WorkflowDecisionPort {
+    private readonly logger = new Logger(WorkflowAiDecisionAdapter.name);
+
+    constructor(private readonly ai: AiFacadeService) {}
+
+    async decide(request: WorkflowDecisionRequest): Promise<WorkflowDecision> {
+        const userId =
+            typeof request.context.userId === 'string' ? request.context.userId : undefined;
+        if (!userId) {
+            // The facade is user-scoped (settings, budget, attribution). No
+            // user ⇒ no legitimate call; fail LOUDLY so the executor can take
+            // its declared fallback arm instead of a silent default branch.
+            throw new Error('workflow llm_decide needs a userId in the run context');
+        }
+
+        const options = [
+            'You are choosing the next step of a workflow.',
+            `Step just completed: "${request.nodeId}".`,
+            `Its output: ${summarizeOutput(request.nodeOutput)}`,
+            '',
+            'Choose EXACTLY ONE of these options and reply with its token:',
+            ...request.choices.map(
+                (choice) =>
+                    `- ${choice.choice}${choice.description ? `: ${choice.description}` : ''}`,
+            ),
+            '',
+            'Answer as JSON: { "choice": "<one of the tokens above>", "rationale": "<one short line>" }',
+        ].join('\n');
+
+        const facadeOptions: {
+            userId: string;
+            workId?: string;
+            agentId?: string;
+            taskId?: string;
+            runId?: string;
+        } = { userId };
+        if (typeof request.context.workId === 'string')
+            facadeOptions.workId = request.context.workId;
+        if (typeof request.context.agentId === 'string')
+            facadeOptions.agentId = request.context.agentId;
+        if (typeof request.context.taskId === 'string')
+            facadeOptions.taskId = request.context.taskId;
+        if (typeof request.context.runId === 'string') facadeOptions.runId = request.context.runId;
+
+        const response = await this.ai.askJson(
+            options,
+            decisionSchema,
+            { temperature: 0 },
+            facadeOptions,
+        );
+
+        const choice = response.result.choice?.trim();
+        this.logger.log(
+            `Workflow ${request.graphId}: node "${request.nodeId}" decided "${choice}" (${response.model}).`,
+        );
+        const decision: { choice: string; rationale?: string } = { choice: choice ?? '' };
+        if (response.result.rationale) decision.rationale = response.result.rationale;
+        return decision;
+    }
+}

--- a/packages/agent/src/agents/workflow-graph-executor.service.ts
+++ b/packages/agent/src/agents/workflow-graph-executor.service.ts
@@ -1,0 +1,433 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    applyWorkflowInputMapping,
+    evaluateWorkflowCondition,
+    onFailureEdgeCatches,
+    outgoingWorkflowEdges,
+    validateWorkflowGraph,
+    WORKFLOW_DEFAULT_MAX_STEPS,
+    WORKFLOW_MAX_STEPS_CEILING,
+    type WorkflowEdge,
+    type WorkflowGraph,
+    type WorkflowLlmDecideEdge,
+    type WorkflowNode,
+} from '@ever-works/contracts';
+import {
+    WORKFLOW_DECISION_PORT,
+    WORKFLOW_NODE_RUNNER,
+    type WorkflowDecisionPort,
+    type WorkflowNodeRunner,
+} from './workflow-graph.ports';
+
+/**
+ * Terminal states of a graph run.
+ *
+ *   - `completed` — walked off the end of the graph with the last node green.
+ *   - `failed`    — a node failed and no `on_failure` edge caught it, or a
+ *                   structural/traversal rule stopped the run.
+ *   - `blocked`   — the run cannot continue for a reason that is not the
+ *                   graph's fault (no decider bound and no fallback arm,
+ *                   no node runner bound). Distinct from `failed` so a
+ *                   caller can retry rather than escalate.
+ */
+export type WorkflowRunStatus = 'completed' | 'failed' | 'blocked';
+
+/** Machine tokens for why a run stopped. Persisted in traces — never rename. */
+export type WorkflowRunFailureCode =
+    | 'graph-invalid'
+    | 'node-not-found'
+    | 'node-failed'
+    | 'no-node-runner'
+    | 'input-mapping-unresolved'
+    | 'llm-decide-unavailable'
+    | 'llm-decide-unknown-choice'
+    | 'max-steps-exceeded';
+
+export interface WorkflowNodeTrace {
+    readonly nodeId: string;
+    readonly viaEdgeId: string | null;
+    readonly ok: boolean;
+    readonly failureCode?: string;
+    readonly error?: string;
+}
+
+export interface WorkflowDecisionTrace {
+    readonly nodeId: string;
+    readonly choice: string;
+    readonly rationale?: string;
+    /** True when the decider was unavailable and the declared fallback arm was taken. */
+    readonly degraded?: boolean;
+}
+
+export interface WorkflowRunResult {
+    readonly status: WorkflowRunStatus;
+    readonly runId: string;
+    /** Node ids in execution order. */
+    readonly visited: readonly string[];
+    /** Edge ids in traversal order. */
+    readonly traversedEdges: readonly string[];
+    readonly nodes: readonly WorkflowNodeTrace[];
+    readonly decisions: readonly WorkflowDecisionTrace[];
+    /** Output of the last node that ran green. `undefined` when nothing succeeded. */
+    readonly output: unknown;
+    readonly nodeOutputs: Readonly<Record<string, unknown>>;
+    readonly failureCode?: WorkflowRunFailureCode;
+    readonly failedNodeId?: string;
+    readonly errors: readonly string[];
+}
+
+export interface WorkflowRunOptions {
+    /** Stable id for the run — echoed into node/decision context. */
+    readonly runId?: string;
+    /** Inputs handed to the entry node. */
+    readonly input?: Record<string, unknown>;
+    /** Ambient context passed through to the runner + decider (userId, workId …). */
+    readonly context?: Record<string, unknown>;
+}
+
+/** The scope every `conditional` path and `inputMapping` reads from. */
+interface WorkflowScope {
+    readonly input: Record<string, unknown>;
+    readonly context: Record<string, unknown>;
+    readonly nodes: Record<string, { output: unknown; ok: boolean; failureCode?: string }>;
+    /** The node that just ran — so mappings can say `last.output.x`. */
+    last: { nodeId: string; output: unknown; ok: boolean; failureCode?: string } | null;
+}
+
+let runCounter = 0;
+
+function nextRunId(): string {
+    runCounter += 1;
+    return `wf-${Date.now().toString(36)}-${runCounter.toString(36)}`;
+}
+
+/**
+ * Workflow-graph executor (judgment layer G5).
+ *
+ * Walks a {@link WorkflowGraph} one node at a time and picks the next
+ * edge with a FIXED precedence that is the whole point of the model:
+ *
+ *   node failed  → `on_failure` edges whose `catch` matches (declaration order)
+ *   node green   → `conditional` edges whose predicate holds (declaration order)
+ *                → `llm_decide` edges (one question, the matching arm wins)
+ *                → the single `sequential` edge
+ *                → nothing left ⇒ the run completed
+ *
+ * `inputMapping` is applied on EVERY traversal, so the destination node
+ * receives exactly the inputs the edge declared. An edge with no mapping
+ * passes the source node's output through as `{ input: <output> }`,
+ * which keeps the trivial two-node graph free of ceremony.
+ *
+ * Cycles are legal (a retry loop is a cycle); unbounded runs are not —
+ * `maxSteps` is clamped to {@link WORKFLOW_MAX_STEPS_CEILING}.
+ *
+ * The executor NEVER throws on a graph's account: every stop is a typed
+ * `WorkflowRunResult`. A throw from an injected runner or decider is
+ * caught and turned into the corresponding failure, because a workflow
+ * that dies mid-walk with a raw exception loses the trace, and the
+ * trace is the thing a human needs.
+ */
+@Injectable()
+export class WorkflowGraphExecutorService {
+    private readonly logger = new Logger(WorkflowGraphExecutorService.name);
+
+    constructor(
+        // Bound by the host that owns node semantics. Absent in unit tests
+        // and in installs that only validate graphs — a run then stops
+        // LOUDLY with `no-node-runner` rather than pretending to succeed.
+        @Optional()
+        @Inject(WORKFLOW_NODE_RUNNER)
+        private readonly runner?: WorkflowNodeRunner,
+        // Bound to the AI-facade adapter in production (`@Optional()` +
+        // appended LAST, per the positional-spec arity rule). Every model
+        // call therefore goes through the facade/plugin seam.
+        @Optional()
+        @Inject(WORKFLOW_DECISION_PORT)
+        private readonly decider?: WorkflowDecisionPort,
+    ) {}
+
+    async execute(
+        graph: WorkflowGraph,
+        options: WorkflowRunOptions = {},
+    ): Promise<WorkflowRunResult> {
+        const runId = options.runId ?? nextRunId();
+        const visited: string[] = [];
+        const traversedEdges: string[] = [];
+        const nodes: WorkflowNodeTrace[] = [];
+        const decisions: WorkflowDecisionTrace[] = [];
+        const errors: string[] = [];
+
+        const validation = validateWorkflowGraph(graph);
+        if (!validation.valid) {
+            return {
+                status: 'failed',
+                runId,
+                visited,
+                traversedEdges,
+                nodes,
+                decisions,
+                output: undefined,
+                nodeOutputs: {},
+                failureCode: 'graph-invalid',
+                errors: validation.errors,
+            };
+        }
+
+        const scope: WorkflowScope = {
+            input: options.input ?? {},
+            context: options.context ?? {},
+            nodes: {},
+            last: null,
+        };
+
+        const finish = (
+            status: WorkflowRunStatus,
+            failureCode?: WorkflowRunFailureCode,
+            failedNodeId?: string,
+        ): WorkflowRunResult => {
+            const nodeOutputs: Record<string, unknown> = {};
+            for (const [nodeId, state] of Object.entries(scope.nodes))
+                nodeOutputs[nodeId] = state.output;
+            const result: WorkflowRunResult = {
+                status,
+                runId,
+                visited,
+                traversedEdges,
+                nodes,
+                decisions,
+                output: scope.last?.ok ? scope.last.output : undefined,
+                nodeOutputs,
+                errors,
+                ...(failureCode ? { failureCode } : {}),
+                ...(failedNodeId ? { failedNodeId } : {}),
+            };
+            return result;
+        };
+
+        if (!this.runner) {
+            errors.push('no WORKFLOW_NODE_RUNNER is bound — nothing can execute a node');
+            return finish('blocked', 'no-node-runner');
+        }
+
+        const byId = new Map<string, WorkflowNode>();
+        for (const node of graph.nodes) byId.set(node.id, node);
+
+        const maxSteps = Math.min(
+            graph.maxSteps && graph.maxSteps > 0 ? graph.maxSteps : WORKFLOW_DEFAULT_MAX_STEPS,
+            WORKFLOW_MAX_STEPS_CEILING,
+        );
+
+        let currentNodeId: string | null = graph.entryNodeId;
+        let viaEdgeId: string | null = null;
+        let inputs: Record<string, unknown> = { ...scope.input };
+
+        for (let stepIndex = 0; currentNodeId !== null; stepIndex += 1) {
+            if (stepIndex >= maxSteps) {
+                errors.push(`run exceeded maxSteps (${maxSteps}) — the graph is looping`);
+                return finish('failed', 'max-steps-exceeded', currentNodeId);
+            }
+
+            const node = byId.get(currentNodeId);
+            if (!node) {
+                errors.push(`node "${currentNodeId}" is not in the graph`);
+                return finish('failed', 'node-not-found', currentNodeId);
+            }
+
+            const runResult = await this.runNode(node, inputs, {
+                graphId: graph.id,
+                runId,
+                viaEdgeId,
+                stepIndex,
+                context: scope.context,
+            });
+
+            visited.push(node.id);
+            nodes.push({
+                nodeId: node.id,
+                viaEdgeId,
+                ok: runResult.ok,
+                ...(runResult.failureCode ? { failureCode: runResult.failureCode } : {}),
+                ...(runResult.error ? { error: runResult.error } : {}),
+            });
+            const state = {
+                output: runResult.output,
+                ok: runResult.ok,
+                ...(runResult.failureCode ? { failureCode: runResult.failureCode } : {}),
+            };
+            scope.nodes[node.id] = state;
+            scope.last = { nodeId: node.id, ...state };
+
+            const selection = await this.selectNextEdge(
+                graph,
+                node,
+                runResult.ok,
+                scope,
+                runId,
+                decisions,
+            );
+            if (selection.kind === 'stop') {
+                if (selection.failureCode) {
+                    if (selection.error) errors.push(selection.error);
+                    return finish(selection.status, selection.failureCode, node.id);
+                }
+                return finish(selection.status);
+            }
+
+            const edge = selection.edge;
+            const mapped = applyWorkflowInputMapping(edge.inputMapping, scope);
+            // `=== false` for the same reason as in the delegation service:
+            // `strictNullChecks: false` breaks negated-discriminant narrowing.
+            if (mapped.ok === false) {
+                errors.push(
+                    `edge "${edge.id}" could not resolve required input(s): ${mapped.missing.join(', ')}`,
+                );
+                return finish('failed', 'input-mapping-unresolved', node.id);
+            }
+
+            traversedEdges.push(edge.id);
+            // No mapping ⇒ pass the source output straight through, so the
+            // simple case needs no `inputMapping` boilerplate.
+            inputs =
+                edge.inputMapping && edge.inputMapping.length > 0
+                    ? mapped.inputs
+                    : { input: runResult.output };
+            viaEdgeId = edge.id;
+            currentNodeId = edge.to;
+        }
+
+        return finish('completed');
+    }
+
+    private async runNode(
+        node: WorkflowNode,
+        inputs: Record<string, unknown>,
+        context: Parameters<WorkflowNodeRunner['run']>[2],
+    ): Promise<{ ok: boolean; output?: unknown; failureCode?: string; error?: string }> {
+        try {
+            return await this.runner!.run(node, inputs, context);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            this.logger.warn(`Workflow ${context.graphId}: node "${node.id}" threw: ${message}`);
+            // A thrown runner is just another failure — `on_failure` edges
+            // get their chance instead of the whole run dying untraced.
+            return { ok: false, failureCode: 'node-threw', error: message };
+        }
+    }
+
+    private async selectNextEdge(
+        graph: WorkflowGraph,
+        node: WorkflowNode,
+        ok: boolean,
+        scope: WorkflowScope,
+        runId: string,
+        decisions: WorkflowDecisionTrace[],
+    ): Promise<
+        | { kind: 'edge'; edge: WorkflowEdge }
+        | {
+              kind: 'stop';
+              status: WorkflowRunStatus;
+              failureCode?: WorkflowRunFailureCode;
+              error?: string;
+          }
+    > {
+        if (!ok) {
+            const failureCode = scope.last?.failureCode;
+            for (const edge of outgoingWorkflowEdges(graph, node.id, 'on_failure')) {
+                if (onFailureEdgeCatches(edge, failureCode)) return { kind: 'edge', edge };
+            }
+            return {
+                kind: 'stop',
+                status: 'failed',
+                failureCode: 'node-failed',
+                error: `node "${node.id}" failed (${failureCode ?? 'no code'}) and no on_failure edge caught it`,
+            };
+        }
+
+        for (const edge of outgoingWorkflowEdges(graph, node.id, 'conditional')) {
+            if (evaluateWorkflowCondition(edge.when, scope)) return { kind: 'edge', edge };
+        }
+
+        const decideEdges = outgoingWorkflowEdges(graph, node.id, 'llm_decide');
+        if (decideEdges.length > 0) {
+            return this.decideNextEdge(graph, node, decideEdges, scope, runId, decisions);
+        }
+
+        const sequential = outgoingWorkflowEdges(graph, node.id, 'sequential');
+        if (sequential.length > 0) return { kind: 'edge', edge: sequential[0] };
+
+        return { kind: 'stop', status: 'completed' };
+    }
+
+    private async decideNextEdge(
+        graph: WorkflowGraph,
+        node: WorkflowNode,
+        decideEdges: readonly WorkflowLlmDecideEdge[],
+        scope: WorkflowScope,
+        runId: string,
+        decisions: WorkflowDecisionTrace[],
+    ): Promise<
+        | { kind: 'edge'; edge: WorkflowEdge }
+        | {
+              kind: 'stop';
+              status: WorkflowRunStatus;
+              failureCode?: WorkflowRunFailureCode;
+              error?: string;
+          }
+    > {
+        const fallback = decideEdges.find((edge) => edge.fallback);
+        const degrade = (reason: string) => {
+            if (!fallback) {
+                return {
+                    kind: 'stop' as const,
+                    status: 'blocked' as const,
+                    failureCode: 'llm-decide-unavailable' as const,
+                    error: `${reason} and node "${node.id}" declares no fallback arm`,
+                };
+            }
+            this.logger.warn(
+                `Workflow ${graph.id}: ${reason} — taking the declared fallback arm "${fallback.choice}".`,
+            );
+            decisions.push({ nodeId: node.id, choice: fallback.choice, degraded: true });
+            return { kind: 'edge' as const, edge: fallback as WorkflowEdge };
+        };
+
+        if (!this.decider) return degrade('no WORKFLOW_DECISION_PORT is bound');
+
+        let decision;
+        try {
+            decision = await this.decider.decide({
+                graphId: graph.id,
+                runId,
+                nodeId: node.id,
+                nodeOutput: scope.last?.output,
+                choices: decideEdges.map((edge) => ({
+                    choice: edge.choice,
+                    targetNodeId: edge.to,
+                    ...(edge.choiceDescription ? { description: edge.choiceDescription } : {}),
+                })),
+                context: scope.context,
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return degrade(`the decision port threw (${message})`);
+        }
+
+        const chosen = decideEdges.find((edge) => edge.choice === decision.choice);
+        if (!chosen) {
+            if (fallback)
+                return degrade(`the decider returned unknown choice "${decision.choice}"`);
+            return {
+                kind: 'stop',
+                status: 'failed',
+                failureCode: 'llm-decide-unknown-choice',
+                error: `the decider returned "${decision.choice}", which is not an arm of node "${node.id}"`,
+            };
+        }
+        decisions.push({
+            nodeId: node.id,
+            choice: chosen.choice,
+            ...(decision.rationale ? { rationale: decision.rationale } : {}),
+        });
+        return { kind: 'edge', edge: chosen as WorkflowEdge };
+    }
+}

--- a/packages/agent/src/agents/workflow-graph.ports.ts
+++ b/packages/agent/src/agents/workflow-graph.ports.ts
@@ -1,0 +1,83 @@
+import type { WorkflowNode } from '@ever-works/contracts';
+
+/**
+ * Ports the workflow-graph executor runs against (judgment layer G5).
+ *
+ * The executor owns EDGE semantics — on_failure / conditional /
+ * llm_decide / input_mapping — and nothing else. What a node actually
+ * DOES, and who answers an `llm_decide` question, are both seams:
+ *
+ *   - `WORKFLOW_NODE_RUNNER` is bound by whatever host is executing the
+ *     graph (a pipeline, an agent run, a test double).
+ *   - `WORKFLOW_DECISION_PORT` is bound to the AI-facade adapter in
+ *     production, so every model call still goes through the facade /
+ *     plugin seam and never a raw provider SDK.
+ *
+ * Both are `@Optional()` at the injection site: a graph made only of
+ * sequential / conditional / on_failure edges runs with no decider
+ * bound, and a host that never registered a runner gets a LOUD,
+ * typed failure instead of a silent no-op.
+ */
+
+/** Everything a node runner is told about the hop that reached it. */
+export interface WorkflowNodeRunContext {
+    readonly graphId: string;
+    readonly runId: string;
+    /** Edge that led here; `null` for the entry node. */
+    readonly viaEdgeId: string | null;
+    /** How many nodes have already executed in this run. */
+    readonly stepIndex: number;
+    /** Caller-supplied ambient context (userId, workId, agentId …). */
+    readonly context: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkflowNodeRunResult {
+    readonly ok: boolean;
+    readonly output?: unknown;
+    /**
+     * Stable machine token for a failure, matched by an `on_failure`
+     * edge's `catch` list. Free-form by design — a node kind owns its
+     * own failure vocabulary.
+     */
+    readonly failureCode?: string;
+    readonly error?: string;
+}
+
+export interface WorkflowNodeRunner {
+    run(
+        node: WorkflowNode,
+        inputs: Record<string, unknown>,
+        context: WorkflowNodeRunContext,
+    ): Promise<WorkflowNodeRunResult>;
+}
+
+export const WORKFLOW_NODE_RUNNER = 'WORKFLOW_NODE_RUNNER' as const;
+
+/** One arm offered to the decider. */
+export interface WorkflowDecisionChoice {
+    readonly choice: string;
+    readonly description?: string;
+    readonly targetNodeId: string;
+}
+
+export interface WorkflowDecisionRequest {
+    readonly graphId: string;
+    readonly runId: string;
+    readonly nodeId: string;
+    /** The node's own output — what the decision should be based on. */
+    readonly nodeOutput: unknown;
+    readonly choices: readonly WorkflowDecisionChoice[];
+    readonly context: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkflowDecision {
+    /** Must be one of the offered `choice` tokens. */
+    readonly choice: string;
+    readonly rationale?: string;
+}
+
+export interface WorkflowDecisionPort {
+    decide(request: WorkflowDecisionRequest): Promise<WorkflowDecision>;
+}
+
+export const WORKFLOW_DECISION_PORT = 'WORKFLOW_DECISION_PORT' as const;

--- a/packages/contracts/src/delegation/__tests__/sub-agent-delegation.spec.ts
+++ b/packages/contracts/src/delegation/__tests__/sub-agent-delegation.spec.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import {
+	isSubAgentDelegationSuccessful,
+	isSubAgentScopeSubset,
+	narrowSubAgentScope,
+	refuseSubAgentDelegation,
+	validateSubAgentDelegationRequest,
+	SUB_AGENT_DELEGATION_REFUSAL_CODES,
+	SUB_AGENT_DELEGATION_STATUSES,
+	SUB_AGENT_MAX_DELEGATION_DEPTH,
+	SUB_AGENT_MAX_OBJECTIVE_CHARS,
+	SUB_AGENT_MAX_SIBLING_DELEGATIONS,
+	type SubAgentDelegationRequest,
+	type SubAgentScope
+} from '../sub-agent-delegation.types.js';
+
+const parentScope: SubAgentScope = {
+	allowedTools: ['read_file', 'write_file', 'run_tests'],
+	allowedPaths: ['apps/api', 'packages/agent'],
+	workId: 'work-1',
+	organizationId: 'org-1',
+	networkAccess: true
+};
+
+const request = (over: Partial<SubAgentDelegationRequest> = {}): SubAgentDelegationRequest => ({
+	delegationId: 'del-1',
+	parentAgentId: 'agent-1',
+	parentRunId: 'run-1',
+	depth: 0,
+	objective: 'Fix the failing lint rule in packages/agent',
+	scope: { allowedTools: ['read_file', 'write_file'] },
+	...over
+});
+
+describe('delegation vocabularies', () => {
+	it('pins the closed status set', () => {
+		expect([...SUB_AGENT_DELEGATION_STATUSES].sort()).toEqual(['completed', 'escalated', 'failed', 'refused']);
+	});
+
+	it('pins the refusal codes', () => {
+		expect([...SUB_AGENT_DELEGATION_REFUSAL_CODES].sort()).toEqual([
+			'budget-exceeded',
+			'depth-exceeded',
+			'fanout-exceeded',
+			'invalid-request',
+			'no-runner',
+			'scope-empty',
+			'scope-not-subset'
+		]);
+	});
+});
+
+describe('narrowSubAgentScope', () => {
+	it('intersects the tool allowlist — a child can never gain a tool', () => {
+		const narrowed = narrowSubAgentScope(parentScope, {
+			allowedTools: ['write_file', 'deploy', 'delete_repo']
+		});
+		expect(narrowed.allowedTools).toEqual(['write_file']);
+	});
+
+	it('inherits the parent list when the child asks for the wildcard', () => {
+		expect(narrowSubAgentScope(parentScope, { allowedTools: ['*'] }).allowedTools).toEqual(
+			parentScope.allowedTools
+		);
+	});
+
+	it('keeps only paths under a parent prefix', () => {
+		const narrowed = narrowSubAgentScope(parentScope, {
+			allowedTools: ['read_file'],
+			allowedPaths: ['apps/api/src', 'apps/web', 'packages/agent']
+		});
+		expect(narrowed.allowedPaths).toEqual(['apps/api/src', 'packages/agent']);
+	});
+
+	it('pins workId/organizationId from the parent — a child cannot hop scope', () => {
+		const narrowed = narrowSubAgentScope(parentScope, {
+			allowedTools: ['read_file'],
+			workId: 'work-999',
+			organizationId: 'org-999'
+		});
+		expect(narrowed.workId).toBe('work-1');
+		expect(narrowed.organizationId).toBe('org-1');
+	});
+
+	it('can only turn networkAccess OFF', () => {
+		expect(
+			narrowSubAgentScope(parentScope, { allowedTools: ['read_file'], networkAccess: false }).networkAccess
+		).toBe(false);
+		expect(
+			narrowSubAgentScope(
+				{ allowedTools: ['*'], networkAccess: false },
+				{ allowedTools: ['read_file'], networkAccess: true }
+			).networkAccess
+		).toBe(false);
+	});
+});
+
+describe('isSubAgentScopeSubset', () => {
+	it('accepts a narrowed scope and rejects a widened one', () => {
+		expect(isSubAgentScopeSubset({ allowedTools: ['read_file'] }, parentScope)).toBe(false);
+		expect(
+			isSubAgentScopeSubset(
+				{ allowedTools: ['read_file'], workId: 'work-1', organizationId: 'org-1' },
+				parentScope
+			)
+		).toBe(true);
+		expect(
+			isSubAgentScopeSubset({ allowedTools: ['*'], workId: 'work-1', organizationId: 'org-1' }, parentScope)
+		).toBe(false);
+		expect(
+			isSubAgentScopeSubset(
+				{
+					allowedTools: ['read_file'],
+					allowedPaths: ['apps/web'],
+					workId: 'work-1',
+					organizationId: 'org-1'
+				},
+				parentScope
+			)
+		).toBe(false);
+	});
+});
+
+describe('validateSubAgentDelegationRequest', () => {
+	it('accepts a well-formed request and returns the NARROWED scope', () => {
+		const result = validateSubAgentDelegationRequest(request(), { parentScope });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.request.scope.allowedTools).toEqual(['read_file', 'write_file']);
+		expect(result.request.scope.workId).toBe('work-1');
+	});
+
+	it('refuses at the depth ceiling', () => {
+		const result = validateSubAgentDelegationRequest(request({ depth: SUB_AGENT_MAX_DELEGATION_DEPTH }), {
+			parentScope
+		});
+		expect(result).toMatchObject({ ok: false, refusalCode: 'depth-exceeded' });
+	});
+
+	it('refuses past the sibling fan-out cap', () => {
+		const result = validateSubAgentDelegationRequest(request(), {
+			parentScope,
+			siblingCount: SUB_AGENT_MAX_SIBLING_DELEGATIONS
+		});
+		expect(result).toMatchObject({ ok: false, refusalCode: 'fanout-exceeded' });
+	});
+
+	it('refuses when narrowing leaves the child with no tools at all', () => {
+		const result = validateSubAgentDelegationRequest(request({ scope: { allowedTools: ['deploy'] } }), {
+			parentScope
+		});
+		expect(result).toMatchObject({ ok: false, refusalCode: 'scope-empty' });
+	});
+
+	it('refuses a budget above what the parent has left', () => {
+		const result = validateSubAgentDelegationRequest(request({ budget: { maxCostCents: 500 } }), {
+			parentScope,
+			remainingCostCents: 100
+		});
+		expect(result).toMatchObject({ ok: false, refusalCode: 'budget-exceeded' });
+	});
+
+	it.each([
+		['no delegationId', { delegationId: '' }],
+		['no parentAgentId', { parentAgentId: '' }],
+		['blank objective', { objective: '   ' }],
+		['negative depth', { depth: -1 }],
+		['over-long objective', { objective: 'x'.repeat(SUB_AGENT_MAX_OBJECTIVE_CHARS + 1) }]
+	] as const)('refuses %s as invalid-request', (_label, over) => {
+		const result = validateSubAgentDelegationRequest(request(over as never), { parentScope });
+		expect(result).toMatchObject({ ok: false, refusalCode: 'invalid-request' });
+	});
+
+	it('validates without a parent scope (top-level delegation) and leaves the scope alone', () => {
+		const result = validateSubAgentDelegationRequest(request());
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.request.scope).toEqual({ allowedTools: ['read_file', 'write_file'] });
+	});
+});
+
+describe('result helpers', () => {
+	it('builds a canonical refusal', () => {
+		expect(refuseSubAgentDelegation('del-9', 'no-runner', 'nothing bound')).toEqual({
+			delegationId: 'del-9',
+			status: 'refused',
+			refusalCode: 'no-runner',
+			summary: 'nothing bound',
+			output: null
+		});
+	});
+
+	it('only treats "completed" as consumable', () => {
+		for (const status of SUB_AGENT_DELEGATION_STATUSES) {
+			expect(
+				isSubAgentDelegationSuccessful({
+					delegationId: 'd',
+					status,
+					summary: 's',
+					output: null
+				})
+			).toBe(status === 'completed');
+		}
+	});
+});

--- a/packages/contracts/src/delegation/index.ts
+++ b/packages/contracts/src/delegation/index.ts
@@ -1,0 +1,1 @@
+export * from './sub-agent-delegation.types.js';

--- a/packages/contracts/src/delegation/sub-agent-delegation.types.ts
+++ b/packages/contracts/src/delegation/sub-agent-delegation.types.ts
@@ -1,0 +1,357 @@
+/**
+ * Sub-agent delegation contract (judgment layer G9).
+ *
+ * Before this file an agent could PROPOSE a `spawn_agent` action into
+ * the approval queue, but there was no contract for the delegation
+ * itself: no way to say what the child may touch, no bound on how deep
+ * the fan-out goes, and no typed result to hand back. "Spawn something"
+ * with a free-form payload is not a delegation, it is a wish.
+ *
+ * The contract has three parts:
+ *
+ *   1. A REQUEST that states the objective, the inputs, the scope the
+ *      child runs under, and the budget it may spend.
+ *   2. A SCOPE algebra: a child's scope is always the INTERSECTION of
+ *      what it asked for and what its parent already had
+ *      ({@link narrowSubAgentScope}). Privilege can only ever shrink
+ *      going down the tree — that is the whole safety property.
+ *   3. A typed RESULT with a closed status set, so a caller can branch
+ *      on `completed | failed | refused | escalated` instead of
+ *      sniffing an untyped blob. A refusal always carries a machine
+ *      code, and an escalation reuses the G3
+ *      `AgentEscalationReasonCode` vocabulary rather than inventing a
+ *      parallel one.
+ *
+ * Zero-dependency value types + pure helpers. The service that turns a
+ * validated request into an actual child run lives in
+ * `@ever-works/agent/agents`; nothing here talks to a runtime.
+ */
+
+import type { AgentEscalationReasonCode } from '../agents/escalation.types.js';
+
+/** How a delegation ended. Persisted tokens — never rename, only add. */
+export type SubAgentDelegationStatus = 'completed' | 'failed' | 'refused' | 'escalated';
+
+export const SUB_AGENT_DELEGATION_STATUSES: readonly SubAgentDelegationStatus[] = [
+	'completed',
+	'failed',
+	'refused',
+	'escalated'
+];
+
+/**
+ * Why a delegation was refused BEFORE anything ran. Distinct from
+ * `failed` on purpose: a refusal is the contract saying no, a failure
+ * is the child trying and not managing it.
+ */
+export type SubAgentDelegationRefusalCode =
+	| 'invalid-request'
+	| 'depth-exceeded'
+	| 'fanout-exceeded'
+	| 'scope-not-subset'
+	| 'scope-empty'
+	| 'budget-exceeded'
+	| 'no-runner';
+
+export const SUB_AGENT_DELEGATION_REFUSAL_CODES: readonly SubAgentDelegationRefusalCode[] = [
+	'invalid-request',
+	'depth-exceeded',
+	'fanout-exceeded',
+	'scope-not-subset',
+	'scope-empty',
+	'budget-exceeded',
+	'no-runner'
+];
+
+/** Default fan-out bounds. Operator knobs, not product limits. */
+export const SUB_AGENT_MAX_DELEGATION_DEPTH = 3;
+export const SUB_AGENT_MAX_SIBLING_DELEGATIONS = 5;
+export const SUB_AGENT_MAX_OBJECTIVE_CHARS = 2000;
+export const SUB_AGENT_MAX_SUMMARY_CHARS = 1000;
+
+/**
+ * What a delegated run is allowed to touch.
+ *
+ * `allowedTools` is an explicit allowlist of tool ids. The single-entry
+ * wildcard `['*']` means "everything the parent had" and exists so a
+ * top-level scope can be expressed without enumerating the whole tool
+ * catalog; it is the ONLY wildcard, and intersecting anything with it
+ * yields the other side.
+ */
+export interface SubAgentScope {
+	readonly allowedTools: readonly string[];
+	/** Repo-relative path prefixes the child may read/write. Absent ⇒ inherit the parent's. */
+	readonly allowedPaths?: readonly string[];
+	readonly workId?: string | null;
+	readonly organizationId?: string | null;
+	/** Outbound network. A child may never turn this ON when the parent had it off. */
+	readonly networkAccess?: boolean;
+}
+
+/** Ceilings for one delegated run. Every field is optional; absent ⇒ inherit the parent's. */
+export interface SubAgentBudget {
+	readonly maxCostCents?: number;
+	readonly maxTokens?: number;
+	readonly maxDurationMs?: number;
+}
+
+export interface SubAgentDelegationRequest {
+	/** Caller-minted id. Echoed on the result so a caller can correlate. */
+	readonly delegationId: string;
+	readonly parentAgentId: string;
+	readonly parentRunId?: string | null;
+	readonly parentTaskId?: string | null;
+	/** 0 for a delegation issued by a top-level run; +1 per level below. */
+	readonly depth: number;
+	/** What the child must accomplish, in prose. */
+	readonly objective: string;
+	/** Checkable statements the child's output must satisfy. */
+	readonly successCriteria?: readonly string[];
+	/** Structured inputs handed to the child (already-gathered context). */
+	readonly inputs?: Readonly<Record<string, unknown>>;
+	readonly scope: SubAgentScope;
+	readonly budget?: SubAgentBudget;
+	/** Pin the child to a specific Agent row; omit to let the host pick. */
+	readonly childAgentId?: string | null;
+	/** Hint for the shape the child should return (a JSON-schema-ish description). */
+	readonly resultSchemaHint?: string;
+}
+
+export interface SubAgentDelegationUsage {
+	readonly costCents?: number;
+	readonly tokens?: number;
+	readonly durationMs?: number;
+}
+
+export interface SubAgentDelegationArtifact {
+	/** Short machine-ish label: `patch`, `report`, `pr-url`. */
+	readonly label: string;
+	/** Where the artifact lives (path, url, id). Never inline secrets. */
+	readonly ref: string;
+	readonly mediaType?: string;
+}
+
+export interface SubAgentDelegationResult {
+	readonly delegationId: string;
+	readonly status: SubAgentDelegationStatus;
+	/** One line a human (or the parent) can read without opening anything. */
+	readonly summary: string;
+	/** The child's structured output. `null` on refusal. */
+	readonly output: unknown;
+	/** Set iff `status === 'refused'`. */
+	readonly refusalCode?: SubAgentDelegationRefusalCode;
+	/** Set iff `status === 'escalated'` — reuses the G3 vocabulary. */
+	readonly escalationReasonCode?: AgentEscalationReasonCode;
+	readonly childRunId?: string | null;
+	readonly childAgentId?: string | null;
+	readonly usage?: SubAgentDelegationUsage;
+	readonly artifacts?: readonly SubAgentDelegationArtifact[];
+}
+
+const TOOL_WILDCARD = '*';
+
+function hasWildcard(tools: readonly string[] | undefined): boolean {
+	return Array.isArray(tools) && tools.includes(TOOL_WILDCARD);
+}
+
+function intersectAllowlist(
+	parent: readonly string[] | undefined,
+	requested: readonly string[] | undefined
+): readonly string[] {
+	// Absent on the child ⇒ inherit the parent's list verbatim.
+	if (requested === undefined) return parent === undefined ? [] : [...parent];
+	if (hasWildcard(requested)) return parent === undefined ? [TOOL_WILDCARD] : [...parent];
+	if (parent === undefined || hasWildcard(parent)) return [...requested];
+	const allowed = new Set(parent);
+	return requested.filter((entry) => allowed.has(entry));
+}
+
+/** Is `path` the same as, or nested under, one of `prefixes`? */
+function isUnderAnyPrefix(path: string, prefixes: readonly string[]): boolean {
+	return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
+/**
+ * Compute the scope a child ACTUALLY runs under: the intersection of
+ * what it asked for and what the parent had. Never widens — an entry
+ * the parent lacks is dropped, and `networkAccess` can only go from
+ * true to false.
+ */
+export function narrowSubAgentScope(parent: SubAgentScope, requested: SubAgentScope): SubAgentScope {
+	const allowedTools = intersectAllowlist(parent.allowedTools, requested.allowedTools);
+	const parentPaths = parent.allowedPaths;
+	const allowedPaths =
+		requested.allowedPaths === undefined
+			? parentPaths
+			: parentPaths === undefined
+				? [...requested.allowedPaths]
+				: requested.allowedPaths.filter((path) => isUnderAnyPrefix(path, parentPaths));
+	const narrowed: {
+		allowedTools: readonly string[];
+		allowedPaths?: readonly string[];
+		workId?: string | null;
+		organizationId?: string | null;
+		networkAccess?: boolean;
+	} = { allowedTools };
+	if (allowedPaths !== undefined) narrowed.allowedPaths = allowedPaths;
+	// Scope keys are pinned by the parent — a child may not hop Works or orgs.
+	if (parent.workId !== undefined) narrowed.workId = parent.workId;
+	if (parent.organizationId !== undefined) narrowed.organizationId = parent.organizationId;
+	if (parent.networkAccess !== undefined || requested.networkAccess !== undefined) {
+		narrowed.networkAccess = Boolean(parent.networkAccess) && Boolean(requested.networkAccess);
+	}
+	return narrowed;
+}
+
+/** Is `child` no wider than `parent` in every dimension? */
+export function isSubAgentScopeSubset(child: SubAgentScope, parent: SubAgentScope): boolean {
+	if (!hasWildcard(parent.allowedTools)) {
+		if (hasWildcard(child.allowedTools)) return false;
+		const allowed = new Set(parent.allowedTools ?? []);
+		if ((child.allowedTools ?? []).some((tool) => !allowed.has(tool))) return false;
+	}
+	const parentPaths = parent.allowedPaths;
+	if (parentPaths !== undefined) {
+		const childPaths = child.allowedPaths ?? [];
+		if (childPaths.some((path) => !isUnderAnyPrefix(path, parentPaths))) return false;
+	}
+	if (child.networkAccess && !parent.networkAccess) return false;
+	if (parent.workId !== undefined && parent.workId !== null && child.workId !== parent.workId) return false;
+	if (
+		parent.organizationId !== undefined &&
+		parent.organizationId !== null &&
+		child.organizationId !== parent.organizationId
+	) {
+		return false;
+	}
+	return true;
+}
+
+/** Budget ceilings enforced against the parent's remaining allowance. */
+export interface SubAgentDelegationLimits {
+	readonly maxDepth?: number;
+	readonly maxSiblings?: number;
+	/** How many delegations the parent has already issued in this run. */
+	readonly siblingCount?: number;
+	/** The scope the PARENT holds; the request's scope is narrowed against it. */
+	readonly parentScope?: SubAgentScope;
+	/** What the parent has left to spend, if it is metered. */
+	readonly remainingCostCents?: number;
+}
+
+export type SubAgentDelegationValidation =
+	| { readonly ok: true; readonly request: SubAgentDelegationRequest }
+	| {
+			readonly ok: false;
+			readonly refusalCode: SubAgentDelegationRefusalCode;
+			readonly message: string;
+	  };
+
+/**
+ * Validate a delegation request and return the EFFECTIVE request — the
+ * one with the narrowed scope already applied. Callers must run the
+ * returned request, never the one they were handed: that is what makes
+ * "privilege only shrinks" mechanical instead of a convention.
+ */
+export function validateSubAgentDelegationRequest(
+	request: SubAgentDelegationRequest,
+	limits: SubAgentDelegationLimits = {}
+): SubAgentDelegationValidation {
+	if (!request || typeof request !== 'object') {
+		return { ok: false, refusalCode: 'invalid-request', message: 'request is not an object' };
+	}
+	if (!request.delegationId) {
+		return { ok: false, refusalCode: 'invalid-request', message: 'delegationId is required' };
+	}
+	if (!request.parentAgentId) {
+		return { ok: false, refusalCode: 'invalid-request', message: 'parentAgentId is required' };
+	}
+	const objective = typeof request.objective === 'string' ? request.objective.trim() : '';
+	if (objective.length === 0) {
+		return { ok: false, refusalCode: 'invalid-request', message: 'objective is required' };
+	}
+	if (objective.length > SUB_AGENT_MAX_OBJECTIVE_CHARS) {
+		return {
+			ok: false,
+			refusalCode: 'invalid-request',
+			message: `objective exceeds ${SUB_AGENT_MAX_OBJECTIVE_CHARS} characters`
+		};
+	}
+	if (!Number.isInteger(request.depth) || request.depth < 0) {
+		return { ok: false, refusalCode: 'invalid-request', message: 'depth must be a non-negative integer' };
+	}
+	if (!request.scope || !Array.isArray(request.scope.allowedTools)) {
+		return { ok: false, refusalCode: 'invalid-request', message: 'scope.allowedTools is required' };
+	}
+
+	const maxDepth = limits.maxDepth ?? SUB_AGENT_MAX_DELEGATION_DEPTH;
+	if (request.depth >= maxDepth) {
+		return {
+			ok: false,
+			refusalCode: 'depth-exceeded',
+			message: `delegation depth ${request.depth} reaches the limit of ${maxDepth}`
+		};
+	}
+
+	const maxSiblings = limits.maxSiblings ?? SUB_AGENT_MAX_SIBLING_DELEGATIONS;
+	if ((limits.siblingCount ?? 0) >= maxSiblings) {
+		return {
+			ok: false,
+			refusalCode: 'fanout-exceeded',
+			message: `parent already issued ${limits.siblingCount} delegations (limit ${maxSiblings})`
+		};
+	}
+
+	let effectiveScope = request.scope;
+	if (limits.parentScope) {
+		effectiveScope = narrowSubAgentScope(limits.parentScope, request.scope);
+		if (!isSubAgentScopeSubset(effectiveScope, limits.parentScope)) {
+			return {
+				ok: false,
+				refusalCode: 'scope-not-subset',
+				message: 'requested scope is not a subset of the parent scope'
+			};
+		}
+	}
+	if (effectiveScope.allowedTools.length === 0) {
+		return {
+			ok: false,
+			refusalCode: 'scope-empty',
+			message: 'narrowed scope grants no tools — the child could not do anything'
+		};
+	}
+
+	if (
+		limits.remainingCostCents !== undefined &&
+		request.budget?.maxCostCents !== undefined &&
+		request.budget.maxCostCents > limits.remainingCostCents
+	) {
+		return {
+			ok: false,
+			refusalCode: 'budget-exceeded',
+			message: `requested ${request.budget.maxCostCents}c exceeds the parent's remaining ${limits.remainingCostCents}c`
+		};
+	}
+
+	return { ok: true, request: { ...request, objective, scope: effectiveScope } };
+}
+
+/** Build the canonical refusal result for a request that never ran. */
+export function refuseSubAgentDelegation(
+	delegationId: string,
+	refusalCode: SubAgentDelegationRefusalCode,
+	message: string
+): SubAgentDelegationResult {
+	return {
+		delegationId,
+		status: 'refused',
+		refusalCode,
+		summary: message.slice(0, SUB_AGENT_MAX_SUMMARY_CHARS),
+		output: null
+	};
+}
+
+/** True when the parent may consume `result.output` as a real answer. */
+export function isSubAgentDelegationSuccessful(result: SubAgentDelegationResult): boolean {
+	return result.status === 'completed';
+}

--- a/packages/contracts/src/hitl/__tests__/hitl-question.spec.ts
+++ b/packages/contracts/src/hitl/__tests__/hitl-question.spec.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import {
+	describeHitlQuestion,
+	parseHitlAnswer,
+	parseHitlQuestion,
+	serializeHitlAnswer,
+	serializeHitlQuestion,
+	validateHitlAnswer,
+	HITL_QUESTION_KINDS,
+	HITL_MAX_PROMPT_CHARS,
+	HITL_MAX_TEXT_ANSWER_CHARS,
+	type HitlAnswer,
+	type HitlQuestion
+} from '../hitl-question.types.js';
+
+const questions: Record<string, HitlQuestion> = {
+	confirm: {
+		id: 'q-confirm',
+		kind: 'confirm',
+		prompt: 'Force-push the rebased branch?',
+		confirmLabel: 'Force-push',
+		cancelLabel: 'Leave it',
+		defaultValue: false
+	},
+	choice: {
+		id: 'q-choice',
+		kind: 'choice',
+		prompt: 'Which fix should I apply?',
+		context: 'Both make the suite green.',
+		options: [
+			{ id: 'revert', label: 'Revert the commit', tone: 'warning' },
+			{ id: 'patch', label: 'Patch forward', description: 'Smaller diff' }
+		],
+		defaultOptionId: 'patch'
+	},
+	multi_choice: {
+		id: 'q-multi',
+		kind: 'multi_choice',
+		prompt: 'Which suites should I rerun?',
+		options: [
+			{ id: 'unit', label: 'Unit' },
+			{ id: 'e2e', label: 'E2E' },
+			{ id: 'lint', label: 'Lint' }
+		],
+		minSelected: 1,
+		maxSelected: 2
+	},
+	text: {
+		id: 'q-text',
+		kind: 'text',
+		prompt: 'What should the release note say?',
+		placeholder: 'One line',
+		multiline: true,
+		maxLength: 120
+	},
+	approval: {
+		id: 'q-approval',
+		kind: 'approval',
+		prompt: 'May I merge this?',
+		action: 'Merge PR #42 into develop',
+		risks: ['Touches billing', 'No reviewer'],
+		preview: 'diff --git a/x b/x'
+	}
+};
+
+describe('HITL question round-trip', () => {
+	it('covers exactly the five shipped kinds', () => {
+		expect([...HITL_QUESTION_KINDS].sort()).toEqual(['approval', 'choice', 'confirm', 'multi_choice', 'text']);
+		expect(Object.keys(questions).sort()).toEqual([...HITL_QUESTION_KINDS].sort());
+	});
+
+	it.each(Object.entries(questions))('%s survives serialize → parse unchanged', (_kind, question) => {
+		const parsed = parseHitlQuestion(serializeHitlQuestion(question));
+		expect(parsed).toEqual(question);
+	});
+
+	it.each(Object.entries(questions))('%s parses from an already-decoded object too', (_kind, question) => {
+		expect(parseHitlQuestion(JSON.parse(serializeHitlQuestion(question)))).toEqual(question);
+	});
+
+	it('drops unknown extra keys instead of rejecting the payload (forward compatible)', () => {
+		const parsed = parseHitlQuestion({ ...questions.confirm, futureField: 'ignored' });
+		expect(parsed).toEqual(questions.confirm);
+	});
+
+	it('returns null for anything it cannot read', () => {
+		expect(parseHitlQuestion('not json')).toBeNull();
+		expect(parseHitlQuestion(null)).toBeNull();
+		expect(parseHitlQuestion([])).toBeNull();
+		expect(parseHitlQuestion({ kind: 'nope', id: 'x', prompt: 'y' })).toBeNull();
+		expect(parseHitlQuestion({ kind: 'confirm', prompt: 'no id' })).toBeNull();
+		expect(parseHitlQuestion({ kind: 'confirm', id: 'x', prompt: '   ' })).toBeNull();
+		expect(parseHitlQuestion({ kind: 'choice', id: 'x', prompt: 'y', options: [] })).toBeNull();
+		expect(parseHitlQuestion({ kind: 'approval', id: 'x', prompt: 'y' })).toBeNull();
+	});
+
+	it('refuses duplicate option ids — an ambiguous answer is worse than no question', () => {
+		expect(
+			parseHitlQuestion({
+				kind: 'choice',
+				id: 'x',
+				prompt: 'y',
+				options: [
+					{ id: 'a', label: 'A' },
+					{ id: 'a', label: 'A again' }
+				]
+			})
+		).toBeNull();
+	});
+
+	it('caps an over-long prompt instead of rejecting it', () => {
+		const parsed = parseHitlQuestion({
+			kind: 'confirm',
+			id: 'x',
+			prompt: 'p'.repeat(HITL_MAX_PROMPT_CHARS + 500)
+		});
+		expect(parsed?.prompt.length).toBe(HITL_MAX_PROMPT_CHARS);
+	});
+
+	it('drops a defaultOptionId that is not one of the options', () => {
+		const parsed = parseHitlQuestion({ ...questions.choice, defaultOptionId: 'ghost' });
+		expect(parsed).toBeTruthy();
+		expect((parsed as { defaultOptionId?: string }).defaultOptionId).toBeUndefined();
+	});
+
+	it('renders a one-line description for every kind', () => {
+		for (const question of Object.values(questions)) {
+			expect(describeHitlQuestion(question)).toContain(question.prompt);
+		}
+	});
+});
+
+const answers: Record<string, HitlAnswer> = {
+	confirm: { questionId: 'q-confirm', kind: 'confirm', confirmed: true },
+	choice: { questionId: 'q-choice', kind: 'choice', optionId: 'patch' },
+	multi_choice: { questionId: 'q-multi', kind: 'multi_choice', optionIds: ['unit', 'lint'] },
+	text: { questionId: 'q-text', kind: 'text', text: 'Fixes the billing rounding bug.' },
+	approval: {
+		questionId: 'q-approval',
+		kind: 'approval',
+		decision: 'approved',
+		note: 'Reviewed the diff.'
+	}
+};
+
+describe('HITL answer round-trip', () => {
+	it.each(Object.entries(answers))('%s survives serialize → parse unchanged', (_kind, answer) => {
+		expect(parseHitlAnswer(serializeHitlAnswer(answer))).toEqual(answer);
+	});
+
+	it('returns null for a malformed answer', () => {
+		expect(parseHitlAnswer('{')).toBeNull();
+		expect(parseHitlAnswer({ kind: 'confirm' })).toBeNull();
+		expect(parseHitlAnswer({ kind: 'confirm', questionId: 'q', confirmed: 'yes' })).toBeNull();
+		expect(parseHitlAnswer({ kind: 'choice', questionId: 'q', optionId: '' })).toBeNull();
+		expect(parseHitlAnswer({ kind: 'multi_choice', questionId: 'q', optionIds: ['a', 3] })).toBeNull();
+		expect(parseHitlAnswer({ kind: 'approval', questionId: 'q', decision: 'maybe' })).toBeNull();
+	});
+
+	it('caps an over-long text answer', () => {
+		const parsed = parseHitlAnswer({
+			kind: 'text',
+			questionId: 'q-text',
+			text: 't'.repeat(HITL_MAX_TEXT_ANSWER_CHARS + 100)
+		});
+		expect((parsed as { text: string }).text.length).toBe(HITL_MAX_TEXT_ANSWER_CHARS);
+	});
+});
+
+describe('validateHitlAnswer', () => {
+	it.each(Object.keys(questions))('accepts the matching %s answer', (kind) => {
+		expect(validateHitlAnswer(questions[kind], answers[kind])).toEqual({ valid: true });
+	});
+
+	it('rejects an answer for a different question', () => {
+		const result = validateHitlAnswer(questions.confirm, {
+			...answers.confirm,
+			questionId: 'somebody-else'
+		});
+		expect(result.valid).toBe(false);
+	});
+
+	it('rejects a kind mismatch', () => {
+		const result = validateHitlAnswer(questions.confirm, answers.choice);
+		expect(result.valid).toBe(false);
+	});
+
+	it('rejects an option that was never offered', () => {
+		const result = validateHitlAnswer(questions.choice, {
+			questionId: 'q-choice',
+			kind: 'choice',
+			optionId: 'ghost'
+		});
+		expect(result).toEqual({ valid: false, error: '"ghost" is not one of the offered options' });
+	});
+
+	it('enforces min/max selection and rejects duplicates on multi_choice', () => {
+		expect(
+			validateHitlAnswer(questions.multi_choice, {
+				questionId: 'q-multi',
+				kind: 'multi_choice',
+				optionIds: []
+			}).valid
+		).toBe(false);
+		expect(
+			validateHitlAnswer(questions.multi_choice, {
+				questionId: 'q-multi',
+				kind: 'multi_choice',
+				optionIds: ['unit', 'e2e', 'lint']
+			}).valid
+		).toBe(false);
+		expect(
+			validateHitlAnswer(questions.multi_choice, {
+				questionId: 'q-multi',
+				kind: 'multi_choice',
+				optionIds: ['unit', 'unit']
+			}).valid
+		).toBe(false);
+	});
+
+	it('enforces the text question maxLength', () => {
+		const result = validateHitlAnswer(questions.text, {
+			questionId: 'q-text',
+			kind: 'text',
+			text: 'x'.repeat(200)
+		});
+		expect(result.valid).toBe(false);
+	});
+});

--- a/packages/contracts/src/hitl/hitl-question.types.ts
+++ b/packages/contracts/src/hitl/hitl-question.types.ts
@@ -1,0 +1,471 @@
+/**
+ * Human-in-the-loop question payloads (judgment layer G8s).
+ *
+ * G3 shipped the escalation RECORD — "the agent gave up, here is a
+ * one-line summary and a free-text `decisionNeeded`". That is enough to
+ * notify a human and nothing more: a free-text question cannot be
+ * rendered as a control, cannot be validated, and cannot be answered
+ * machine-readably. This file adds the typed half.
+ *
+ * A HITL question is a discriminated union over five shapes, each with a
+ * matching answer shape:
+ *
+ *   confirm       → { confirmed: boolean }
+ *   choice        → { optionId: string }
+ *   multi_choice  → { optionIds: string[] }
+ *   text          → { text: string }
+ *   approval      → { decision: 'approved' | 'rejected', note? }
+ *
+ * Everything round-trips through JSON: {@link serializeHitlQuestion} /
+ * {@link parseHitlQuestion} are the persistence + wire boundary, and
+ * {@link validateHitlAnswer} is the one place an answer is checked
+ * against the question that asked for it. Parsers are TOLERANT on
+ * unknown extra keys (forward compatibility) and STRICT on the fields
+ * they read — an unparseable payload is `null`, never a half-built
+ * object.
+ *
+ * Zero-dependency value types: the renderers live in the web app's
+ * canvas registry, the writers are the agent runtime, and the readers
+ * are the Task-detail surfaces.
+ */
+
+export type HitlQuestionKind = 'confirm' | 'choice' | 'multi_choice' | 'text' | 'approval';
+
+export const HITL_QUESTION_KINDS: readonly HitlQuestionKind[] = [
+	'confirm',
+	'choice',
+	'multi_choice',
+	'text',
+	'approval'
+];
+
+/** Hard caps applied by the parser (DoS + prompt-log guard). */
+export const HITL_MAX_PROMPT_CHARS = 1000;
+export const HITL_MAX_CONTEXT_CHARS = 4000;
+export const HITL_MAX_OPTIONS = 25;
+export const HITL_MAX_OPTION_LABEL_CHARS = 200;
+export const HITL_MAX_TEXT_ANSWER_CHARS = 4000;
+export const HITL_MAX_NOTE_CHARS = 1000;
+
+/** One selectable option for `choice` / `multi_choice`. */
+export interface HitlChoiceOption {
+	/** Stable machine token returned in the answer. */
+	readonly id: string;
+	readonly label: string;
+	readonly description?: string;
+	/** Renderers may highlight a risky option (e.g. the destructive branch). */
+	readonly tone?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+interface HitlQuestionBase {
+	readonly id: string;
+	/** What the human is being asked, in one line. Plain text — never markup. */
+	readonly prompt: string;
+	/** Optional longer background (what was tried, what is at stake). */
+	readonly context?: string;
+	/** Escalation this question belongs to, when it came from one (G3). */
+	readonly escalationId?: string | null;
+	readonly runId?: string | null;
+	readonly taskId?: string | null;
+}
+
+export interface HitlConfirmQuestion extends HitlQuestionBase {
+	readonly kind: 'confirm';
+	readonly confirmLabel?: string;
+	readonly cancelLabel?: string;
+	readonly defaultValue?: boolean;
+}
+
+export interface HitlChoiceQuestion extends HitlQuestionBase {
+	readonly kind: 'choice';
+	readonly options: readonly HitlChoiceOption[];
+	readonly defaultOptionId?: string;
+}
+
+export interface HitlMultiChoiceQuestion extends HitlQuestionBase {
+	readonly kind: 'multi_choice';
+	readonly options: readonly HitlChoiceOption[];
+	readonly minSelected?: number;
+	readonly maxSelected?: number;
+}
+
+export interface HitlTextQuestion extends HitlQuestionBase {
+	readonly kind: 'text';
+	readonly placeholder?: string;
+	readonly multiline?: boolean;
+	readonly maxLength?: number;
+}
+
+/**
+ * The "may I do this?" gate. Distinct from `confirm` because it carries
+ * WHAT is about to happen and WHY it is risky — the renderer shows the
+ * action + risks, and the answer records a decision plus an optional
+ * note that becomes the escalation's resolution note.
+ */
+export interface HitlApprovalQuestion extends HitlQuestionBase {
+	readonly kind: 'approval';
+	/** One line describing the action awaiting approval. */
+	readonly action: string;
+	readonly risks?: readonly string[];
+	/** Optional preview (diff, message body) — plain text, rendered verbatim. */
+	readonly preview?: string;
+}
+
+export type HitlQuestion =
+	| HitlConfirmQuestion
+	| HitlChoiceQuestion
+	| HitlMultiChoiceQuestion
+	| HitlTextQuestion
+	| HitlApprovalQuestion;
+
+interface HitlAnswerBase {
+	readonly questionId: string;
+	readonly answeredByUserId?: string | null;
+	/** ISO-8601. Left to the writer so this stays a pure value type. */
+	readonly answeredAt?: string | null;
+}
+
+export interface HitlConfirmAnswer extends HitlAnswerBase {
+	readonly kind: 'confirm';
+	readonly confirmed: boolean;
+}
+
+export interface HitlChoiceAnswer extends HitlAnswerBase {
+	readonly kind: 'choice';
+	readonly optionId: string;
+}
+
+export interface HitlMultiChoiceAnswer extends HitlAnswerBase {
+	readonly kind: 'multi_choice';
+	readonly optionIds: readonly string[];
+}
+
+export interface HitlTextAnswer extends HitlAnswerBase {
+	readonly kind: 'text';
+	readonly text: string;
+}
+
+export interface HitlApprovalAnswer extends HitlAnswerBase {
+	readonly kind: 'approval';
+	readonly decision: 'approved' | 'rejected';
+	readonly note?: string;
+}
+
+export type HitlAnswer =
+	| HitlConfirmAnswer
+	| HitlChoiceAnswer
+	| HitlMultiChoiceAnswer
+	| HitlTextAnswer
+	| HitlApprovalAnswer;
+
+export function isHitlQuestionKind(value: unknown): value is HitlQuestionKind {
+	return typeof value === 'string' && (HITL_QUESTION_KINDS as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cappedString(value: unknown, max: number): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return undefined;
+	return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+function nullableId(value: unknown): string | null | undefined {
+	if (value === null) return null;
+	if (typeof value !== 'string') return undefined;
+	return value.length > 0 ? value : undefined;
+}
+
+function parseOptions(value: unknown): readonly HitlChoiceOption[] | null {
+	if (!Array.isArray(value) || value.length === 0) return null;
+	const options: HitlChoiceOption[] = [];
+	const seen = new Set<string>();
+	for (const raw of value.slice(0, HITL_MAX_OPTIONS)) {
+		if (!isRecord(raw)) return null;
+		const id = typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : null;
+		const label = cappedString(raw.label, HITL_MAX_OPTION_LABEL_CHARS);
+		if (!id || !label) return null;
+		// A duplicate option id makes the answer ambiguous — refuse the
+		// whole payload rather than silently picking one of them.
+		if (seen.has(id)) return null;
+		seen.add(id);
+		const option: {
+			id: string;
+			label: string;
+			description?: string;
+			tone?: HitlChoiceOption['tone'];
+		} = { id, label };
+		const description = cappedString(raw.description, HITL_MAX_OPTION_LABEL_CHARS);
+		if (description) option.description = description;
+		if (raw.tone === 'default' || raw.tone === 'success' || raw.tone === 'warning' || raw.tone === 'danger') {
+			option.tone = raw.tone;
+		}
+		options.push(option);
+	}
+	return options.length > 0 ? options : null;
+}
+
+function parseBase(raw: Record<string, unknown>): HitlQuestionBase | null {
+	const id = typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : null;
+	const prompt = cappedString(raw.prompt, HITL_MAX_PROMPT_CHARS);
+	if (!id || !prompt) return null;
+	const base: {
+		id: string;
+		prompt: string;
+		context?: string;
+		escalationId?: string | null;
+		runId?: string | null;
+		taskId?: string | null;
+	} = { id, prompt };
+	const context = cappedString(raw.context, HITL_MAX_CONTEXT_CHARS);
+	if (context) base.context = context;
+	const escalationId = nullableId(raw.escalationId);
+	if (escalationId !== undefined) base.escalationId = escalationId;
+	const runId = nullableId(raw.runId);
+	if (runId !== undefined) base.runId = runId;
+	const taskId = nullableId(raw.taskId);
+	if (taskId !== undefined) base.taskId = taskId;
+	return base;
+}
+
+/**
+ * Parse an untrusted payload into a `HitlQuestion`, or `null`.
+ *
+ * Accepts either a JSON string or an already-parsed object so the same
+ * function guards a DB column, a tool argument, and a wire body.
+ */
+export function parseHitlQuestion(input: unknown): HitlQuestion | null {
+	let raw: unknown = input;
+	if (typeof raw === 'string') {
+		try {
+			raw = JSON.parse(raw);
+		} catch {
+			return null;
+		}
+	}
+	if (!isRecord(raw)) return null;
+	const kind = raw.kind;
+	if (!isHitlQuestionKind(kind)) return null;
+	const base = parseBase(raw);
+	if (!base) return null;
+
+	switch (kind) {
+		case 'confirm': {
+			const confirmLabel = cappedString(raw.confirmLabel, HITL_MAX_OPTION_LABEL_CHARS);
+			const cancelLabel = cappedString(raw.cancelLabel, HITL_MAX_OPTION_LABEL_CHARS);
+			const question: HitlConfirmQuestion = {
+				...base,
+				kind: 'confirm',
+				...(confirmLabel ? { confirmLabel } : {}),
+				...(cancelLabel ? { cancelLabel } : {}),
+				...(typeof raw.defaultValue === 'boolean' ? { defaultValue: raw.defaultValue } : {})
+			};
+			return question;
+		}
+		case 'choice': {
+			const options = parseOptions(raw.options);
+			if (!options) return null;
+			const defaultOptionId =
+				typeof raw.defaultOptionId === 'string' && options.some((option) => option.id === raw.defaultOptionId)
+					? raw.defaultOptionId
+					: undefined;
+			const question: HitlChoiceQuestion = {
+				...base,
+				kind: 'choice',
+				options,
+				...(defaultOptionId ? { defaultOptionId } : {})
+			};
+			return question;
+		}
+		case 'multi_choice': {
+			const options = parseOptions(raw.options);
+			if (!options) return null;
+			const minSelected =
+				typeof raw.minSelected === 'number' && Number.isInteger(raw.minSelected) && raw.minSelected >= 0
+					? raw.minSelected
+					: undefined;
+			const maxSelected =
+				typeof raw.maxSelected === 'number' && Number.isInteger(raw.maxSelected) && raw.maxSelected > 0
+					? raw.maxSelected
+					: undefined;
+			const question: HitlMultiChoiceQuestion = {
+				...base,
+				kind: 'multi_choice',
+				options,
+				...(minSelected !== undefined ? { minSelected } : {}),
+				...(maxSelected !== undefined ? { maxSelected } : {})
+			};
+			return question;
+		}
+		case 'text': {
+			const maxLength =
+				typeof raw.maxLength === 'number' && Number.isInteger(raw.maxLength) && raw.maxLength > 0
+					? Math.min(raw.maxLength, HITL_MAX_TEXT_ANSWER_CHARS)
+					: undefined;
+			const placeholder = cappedString(raw.placeholder, HITL_MAX_OPTION_LABEL_CHARS);
+			const question: HitlTextQuestion = {
+				...base,
+				kind: 'text',
+				...(placeholder ? { placeholder } : {}),
+				...(typeof raw.multiline === 'boolean' ? { multiline: raw.multiline } : {}),
+				...(maxLength !== undefined ? { maxLength } : {})
+			};
+			return question;
+		}
+		case 'approval': {
+			const action = cappedString(raw.action, HITL_MAX_PROMPT_CHARS);
+			if (!action) return null;
+			const risks = Array.isArray(raw.risks)
+				? raw.risks
+						.map((risk) => cappedString(risk, HITL_MAX_OPTION_LABEL_CHARS))
+						.filter((risk): risk is string => Boolean(risk))
+						.slice(0, HITL_MAX_OPTIONS)
+				: [];
+			const preview = cappedString(raw.preview, HITL_MAX_CONTEXT_CHARS);
+			const question: HitlApprovalQuestion = {
+				...base,
+				kind: 'approval',
+				action,
+				...(risks.length > 0 ? { risks } : {}),
+				...(preview ? { preview } : {})
+			};
+			return question;
+		}
+		default:
+			return null;
+	}
+}
+
+/** JSON form of a question — the persistence + wire representation. */
+export function serializeHitlQuestion(question: HitlQuestion): string {
+	return JSON.stringify(question);
+}
+
+/** Parse an untrusted payload into a `HitlAnswer`, or `null`. */
+export function parseHitlAnswer(input: unknown): HitlAnswer | null {
+	let raw: unknown = input;
+	if (typeof raw === 'string') {
+		try {
+			raw = JSON.parse(raw);
+		} catch {
+			return null;
+		}
+	}
+	if (!isRecord(raw)) return null;
+	const kind = raw.kind;
+	if (!isHitlQuestionKind(kind)) return null;
+	const questionId = typeof raw.questionId === 'string' && raw.questionId.length > 0 ? raw.questionId : null;
+	if (!questionId) return null;
+
+	const base: { questionId: string; answeredByUserId?: string | null; answeredAt?: string | null } = {
+		questionId
+	};
+	const answeredByUserId = nullableId(raw.answeredByUserId);
+	if (answeredByUserId !== undefined) base.answeredByUserId = answeredByUserId;
+	const answeredAt = nullableId(raw.answeredAt);
+	if (answeredAt !== undefined) base.answeredAt = answeredAt;
+
+	switch (raw.kind) {
+		case 'confirm':
+			if (typeof raw.confirmed !== 'boolean') return null;
+			return { ...base, kind: 'confirm', confirmed: raw.confirmed };
+		case 'choice':
+			if (typeof raw.optionId !== 'string' || raw.optionId.length === 0) return null;
+			return { ...base, kind: 'choice', optionId: raw.optionId };
+		case 'multi_choice': {
+			if (!Array.isArray(raw.optionIds)) return null;
+			const optionIds = raw.optionIds.filter((id): id is string => typeof id === 'string' && id.length > 0);
+			if (optionIds.length !== raw.optionIds.length) return null;
+			return { ...base, kind: 'multi_choice', optionIds };
+		}
+		case 'text': {
+			if (typeof raw.text !== 'string') return null;
+			const text = raw.text.slice(0, HITL_MAX_TEXT_ANSWER_CHARS);
+			return { ...base, kind: 'text', text };
+		}
+		case 'approval': {
+			if (raw.decision !== 'approved' && raw.decision !== 'rejected') return null;
+			const note = cappedString(raw.note, HITL_MAX_NOTE_CHARS);
+			return { ...base, kind: 'approval', decision: raw.decision, ...(note ? { note } : {}) };
+		}
+		default:
+			return null;
+	}
+}
+
+export function serializeHitlAnswer(answer: HitlAnswer): string {
+	return JSON.stringify(answer);
+}
+
+export type HitlAnswerValidation = { readonly valid: true } | { readonly valid: false; readonly error: string };
+
+/**
+ * Check an answer against the question that asked for it. This is the
+ * ONE place the pairing rules live — the renderer, the API edge and the
+ * agent runtime all call it rather than re-deriving them.
+ */
+export function validateHitlAnswer(question: HitlQuestion, answer: HitlAnswer): HitlAnswerValidation {
+	if (answer.questionId !== question.id) {
+		return { valid: false, error: `answer is for question "${answer.questionId}", not "${question.id}"` };
+	}
+	if (answer.kind !== question.kind) {
+		return { valid: false, error: `answer kind "${answer.kind}" does not match question kind "${question.kind}"` };
+	}
+	switch (question.kind) {
+		case 'choice': {
+			const chosen = (answer as HitlChoiceAnswer).optionId;
+			if (!question.options.some((option) => option.id === chosen)) {
+				return { valid: false, error: `"${chosen}" is not one of the offered options` };
+			}
+			return { valid: true };
+		}
+		case 'multi_choice': {
+			const chosen = (answer as HitlMultiChoiceAnswer).optionIds;
+			const unique = new Set(chosen);
+			if (unique.size !== chosen.length) return { valid: false, error: 'duplicate option selected' };
+			for (const id of chosen) {
+				if (!question.options.some((option) => option.id === id)) {
+					return { valid: false, error: `"${id}" is not one of the offered options` };
+				}
+			}
+			if (question.minSelected !== undefined && chosen.length < question.minSelected) {
+				return { valid: false, error: `at least ${question.minSelected} option(s) required` };
+			}
+			if (question.maxSelected !== undefined && chosen.length > question.maxSelected) {
+				return { valid: false, error: `at most ${question.maxSelected} option(s) allowed` };
+			}
+			return { valid: true };
+		}
+		case 'text': {
+			const text = (answer as HitlTextAnswer).text;
+			const max = question.maxLength ?? HITL_MAX_TEXT_ANSWER_CHARS;
+			if (text.length > max) return { valid: false, error: `answer exceeds ${max} characters` };
+			return { valid: true };
+		}
+		default:
+			return { valid: true };
+	}
+}
+
+/** One-line rendering for logs, notifications and digest lines. */
+export function describeHitlQuestion(question: HitlQuestion): string {
+	switch (question.kind) {
+		case 'confirm':
+			return `${question.prompt} (yes/no)`;
+		case 'choice':
+			return `${question.prompt} (${question.options.map((option) => option.label).join(' / ')})`;
+		case 'multi_choice':
+			return `${question.prompt} (pick any: ${question.options.map((option) => option.label).join(', ')})`;
+		case 'text':
+			return `${question.prompt} (free text)`;
+		case 'approval':
+			return `${question.prompt} — approve: ${question.action}`;
+		default:
+			// Unreachable while the union and this switch stay in lockstep;
+			// a new kind added without a case lands here instead of throwing.
+			return (question as HitlQuestionBase).prompt;
+	}
+}

--- a/packages/contracts/src/hitl/index.ts
+++ b/packages/contracts/src/hitl/index.ts
@@ -1,0 +1,1 @@
+export * from './hitl-question.types.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -11,3 +11,8 @@ export * from './skills/index.js';
 export * from './agents/index.js';
 export * from './fleet/index.js';
 export * from './digest/index.js';
+// Judgment layer G5 / G8s / G9 — workflow graph edges + input mapping,
+// typed human-in-the-loop question payloads, sub-agent delegation.
+export * from './workflow/index.js';
+export * from './hitl/index.js';
+export * from './delegation/index.js';

--- a/packages/contracts/src/workflow/__tests__/workflow-graph.spec.ts
+++ b/packages/contracts/src/workflow/__tests__/workflow-graph.spec.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import {
+	applyWorkflowInputMapping,
+	evaluateWorkflowCondition,
+	onFailureEdgeCatches,
+	outgoingWorkflowEdges,
+	resolveWorkflowPath,
+	validateWorkflowGraph,
+	WORKFLOW_EDGE_KINDS,
+	isWorkflowEdgeKind,
+	type WorkflowGraph
+} from '../workflow-graph.types.js';
+
+const scope = {
+	input: { seed: 3 },
+	nodes: {
+		research: { ok: true, output: { count: 5, items: ['a', 'b'], label: 'done' } },
+		draft: { ok: false, output: null, failureCode: 'lint-red' }
+	}
+};
+
+describe('WORKFLOW_EDGE_KINDS', () => {
+	it('carries exactly the four edge kinds the executor implements', () => {
+		expect([...WORKFLOW_EDGE_KINDS].sort()).toEqual(['conditional', 'llm_decide', 'on_failure', 'sequential']);
+	});
+
+	it('narrows unknown tokens', () => {
+		expect(isWorkflowEdgeKind('on_failure')).toBe(true);
+		expect(isWorkflowEdgeKind('maybe')).toBe(false);
+		expect(isWorkflowEdgeKind(undefined)).toBe(false);
+	});
+});
+
+describe('resolveWorkflowPath', () => {
+	it('walks nested objects and array indices', () => {
+		expect(resolveWorkflowPath(scope, 'nodes.research.output.count')).toBe(5);
+		expect(resolveWorkflowPath(scope, 'nodes.research.output.items.1')).toBe('b');
+	});
+
+	it('returns undefined for anything unreachable', () => {
+		expect(resolveWorkflowPath(scope, 'nodes.missing.output')).toBeUndefined();
+		expect(resolveWorkflowPath(scope, 'nodes.research.output.items.9')).toBeUndefined();
+		expect(resolveWorkflowPath(scope, '')).toBeUndefined();
+		expect(resolveWorkflowPath(scope, 'nodes..output')).toBeUndefined();
+	});
+
+	it('refuses to walk the prototype chain', () => {
+		expect(resolveWorkflowPath(scope, '__proto__.polluted')).toBeUndefined();
+		expect(resolveWorkflowPath(scope, 'nodes.constructor.name')).toBeUndefined();
+		expect(resolveWorkflowPath({ a: 1 }, 'toString')).toBeUndefined();
+	});
+});
+
+describe('evaluateWorkflowCondition', () => {
+	it.each([
+		['eq', 'nodes.research.output.count', 5, true],
+		['eq', 'nodes.research.output.count', 4, false],
+		['neq', 'nodes.research.output.count', 4, true],
+		['gt', 'nodes.research.output.count', 4, true],
+		['gte', 'nodes.research.output.count', 5, true],
+		['lt', 'nodes.research.output.count', 6, true],
+		['lte', 'nodes.research.output.count', 5, true],
+		['contains', 'nodes.research.output.items', 'a', true],
+		['contains', 'nodes.research.output.items', 'z', false],
+		['in', 'nodes.research.output.label', ['done', 'pending'], true]
+	] as const)('%s over %s', (operator, path, value, expected) => {
+		expect(evaluateWorkflowCondition({ path, operator, value }, scope)).toBe(expected);
+	});
+
+	it('handles the value-free operators', () => {
+		expect(evaluateWorkflowCondition({ path: 'nodes.research', operator: 'exists' }, scope)).toBe(true);
+		expect(evaluateWorkflowCondition({ path: 'nodes.nope', operator: 'not_exists' }, scope)).toBe(true);
+		expect(evaluateWorkflowCondition({ path: 'nodes.research.ok', operator: 'truthy' }, scope)).toBe(true);
+		expect(evaluateWorkflowCondition({ path: 'nodes.draft.ok', operator: 'falsy' }, scope)).toBe(true);
+	});
+
+	it('is false rather than throwing for uncomparable pairs and unknown operators', () => {
+		expect(
+			evaluateWorkflowCondition({ path: 'nodes.research.output.label', operator: 'gt', value: 2 }, scope)
+		).toBe(false);
+		expect(
+			evaluateWorkflowCondition({ path: 'nodes.research', operator: 'nonsense' as never, value: 1 }, scope)
+		).toBe(false);
+	});
+});
+
+describe('applyWorkflowInputMapping', () => {
+	it('is a no-op for an absent or empty mapping', () => {
+		expect(applyWorkflowInputMapping(undefined, scope)).toEqual({ ok: true, inputs: {} });
+		expect(applyWorkflowInputMapping([], scope)).toEqual({ ok: true, inputs: {} });
+	});
+
+	it('binds scope paths onto destination input keys', () => {
+		const result = applyWorkflowInputMapping(
+			[
+				{ to: 'count', from: 'nodes.research.output.count' },
+				{ to: 'seed', from: 'input.seed' }
+			],
+			scope
+		);
+		expect(result).toEqual({ ok: true, inputs: { count: 5, seed: 3 } });
+	});
+
+	it('falls back to the literal when the path misses', () => {
+		const result = applyWorkflowInputMapping([{ to: 'count', from: 'nodes.nope.count', fallback: 0 }], scope);
+		expect(result).toEqual({ ok: true, inputs: { count: 0 } });
+	});
+
+	it('omits an optional unresolvable binding but FAILS a required one', () => {
+		expect(applyWorkflowInputMapping([{ to: 'x', from: 'nodes.nope.x' }], scope)).toEqual({
+			ok: true,
+			inputs: {}
+		});
+		expect(applyWorkflowInputMapping([{ to: 'x', from: 'nodes.nope.x', required: true }], scope)).toEqual({
+			ok: false,
+			missing: ['x']
+		});
+	});
+
+	it('never writes a prototype-polluting destination key', () => {
+		const result = applyWorkflowInputMapping([{ to: '__proto__', fallback: { polluted: true } }], scope);
+		expect(result).toEqual({ ok: true, inputs: {} });
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+	});
+});
+
+const graph = (over: Partial<WorkflowGraph> = {}): WorkflowGraph => ({
+	id: 'g1',
+	entryNodeId: 'a',
+	nodes: [
+		{ id: 'a', kind: 'noop' },
+		{ id: 'b', kind: 'noop' },
+		{ id: 'c', kind: 'noop' }
+	],
+	edges: [{ id: 'e1', kind: 'sequential', from: 'a', to: 'b' }],
+	...over
+});
+
+describe('validateWorkflowGraph', () => {
+	it('accepts a well-formed graph', () => {
+		expect(validateWorkflowGraph(graph())).toEqual({ valid: true, errors: [] });
+	});
+
+	it('rejects an entry node that is not in the graph', () => {
+		const result = validateWorkflowGraph(graph({ entryNodeId: 'zzz' }));
+		expect(result.valid).toBe(false);
+		expect(result.errors.join(' ')).toContain('entryNodeId "zzz"');
+	});
+
+	it('rejects dangling edge endpoints and duplicate ids', () => {
+		const result = validateWorkflowGraph(
+			graph({
+				nodes: [
+					{ id: 'a', kind: 'noop' },
+					{ id: 'a', kind: 'noop' }
+				],
+				edges: [{ id: 'e1', kind: 'sequential', from: 'a', to: 'ghost' }]
+			})
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.join(' ')).toContain('duplicate node id "a"');
+		expect(result.errors.join(' ')).toContain('unknown node "ghost"');
+	});
+
+	it('rejects two sequential edges out of one node — branching needs an explicit kind', () => {
+		const result = validateWorkflowGraph(
+			graph({
+				edges: [
+					{ id: 'e1', kind: 'sequential', from: 'a', to: 'b' },
+					{ id: 'e2', kind: 'sequential', from: 'a', to: 'c' }
+				]
+			})
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.join(' ')).toContain('more than one sequential edge');
+	});
+
+	it('rejects colliding llm_decide choices and a second fallback arm', () => {
+		const result = validateWorkflowGraph(
+			graph({
+				edges: [
+					{ id: 'e1', kind: 'llm_decide', from: 'a', to: 'b', choice: 'x', fallback: true },
+					{ id: 'e2', kind: 'llm_decide', from: 'a', to: 'c', choice: 'x', fallback: true }
+				]
+			})
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.join(' ')).toContain('two llm_decide edges with choice "x"');
+		expect(result.errors.join(' ')).toContain('more than one llm_decide fallback arm');
+	});
+
+	it('rejects a conditional edge with an unknown operator and a mapping with no source', () => {
+		const result = validateWorkflowGraph(
+			graph({
+				edges: [
+					{
+						id: 'e1',
+						kind: 'conditional',
+						from: 'a',
+						to: 'b',
+						when: { path: 'x', operator: 'wat' as never },
+						inputMapping: [{ to: 'y' }]
+					}
+				]
+			})
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.join(' ')).toContain('unknown operator');
+		expect(result.errors.join(' ')).toContain('neither "from" nor "fallback"');
+	});
+});
+
+describe('outgoingWorkflowEdges + onFailureEdgeCatches', () => {
+	it('filters by source node and kind, preserving declaration order', () => {
+		const g = graph({
+			edges: [
+				{ id: 'e1', kind: 'conditional', from: 'a', to: 'b', when: { path: 'x', operator: 'truthy' } },
+				{ id: 'e2', kind: 'sequential', from: 'a', to: 'c' },
+				{ id: 'e3', kind: 'sequential', from: 'b', to: 'c' }
+			]
+		});
+		expect(outgoingWorkflowEdges(g, 'a').map((edge) => edge.id)).toEqual(['e1', 'e2']);
+		expect(outgoingWorkflowEdges(g, 'a', 'sequential').map((edge) => edge.id)).toEqual(['e2']);
+	});
+
+	it('treats an absent catch list as the catch-all and an empty one as catching nothing', () => {
+		const base = { id: 'e', kind: 'on_failure', from: 'a', to: 'b' } as const;
+		expect(onFailureEdgeCatches({ ...base }, 'lint-red')).toBe(true);
+		expect(onFailureEdgeCatches({ ...base }, undefined)).toBe(true);
+		expect(onFailureEdgeCatches({ ...base, catch: [] }, 'lint-red')).toBe(false);
+		expect(onFailureEdgeCatches({ ...base, catch: ['lint-red'] }, 'lint-red')).toBe(true);
+		expect(onFailureEdgeCatches({ ...base, catch: ['lint-red'] }, 'other')).toBe(false);
+	});
+});

--- a/packages/contracts/src/workflow/index.ts
+++ b/packages/contracts/src/workflow/index.ts
@@ -1,0 +1,1 @@
+export * from './workflow-graph.types.js';

--- a/packages/contracts/src/workflow/workflow-graph.types.ts
+++ b/packages/contracts/src/workflow/workflow-graph.types.ts
@@ -1,0 +1,432 @@
+/**
+ * Workflow graph model (judgment layer G5).
+ *
+ * The graph is the declarative half of "run these steps in this order,
+ * and pick the next step from what happened". Before this file the only
+ * ordering primitive was an implicit `sequential` hop, so a workflow
+ * could not say "on failure go here", "only go here when X", "let the
+ * model pick", or "feed THAT output into THIS input".
+ *
+ * Four edge kinds, one input-mapping primitive:
+ *
+ *   - `sequential`  — the plain happy-path hop (what already existed).
+ *   - `on_failure`  — taken only when the source node failed; optionally
+ *                     narrowed to specific failure codes.
+ *   - `conditional` — taken when a declarative predicate over the run
+ *                     scope holds. Never an eval'd expression: a
+ *                     `{ path, operator, value }` triple, so a graph
+ *                     authored by a model can be persisted and replayed
+ *                     without executing attacker-authored code.
+ *   - `llm_decide`  — the escape hatch: all `llm_decide` edges leaving a
+ *                     node form ONE multiple-choice question; the model
+ *                     answers with a stable `choice` token and the
+ *                     matching edge wins.
+ *
+ * `inputMapping` hangs off EVERY edge kind: it is how the destination
+ * node's inputs are built from the run scope, so nodes stay reusable
+ * instead of hard-coding their predecessors' output shapes.
+ *
+ * Zero-dependency value types + pure helpers only — the executor lives
+ * in `@ever-works/agent/agents` and the persistence (when a graph
+ * becomes a stored entity) is a follow-up. Everything here is plain
+ * JSON so a graph round-trips through a column, a tool call, or a wire
+ * payload untouched.
+ */
+
+/** Every edge kind the executor understands. Persisted tokens — never rename. */
+export type WorkflowEdgeKind = 'sequential' | 'on_failure' | 'conditional' | 'llm_decide';
+
+/** Canonical list — one source of truth for validators, pins and `@IsIn`. */
+export const WORKFLOW_EDGE_KINDS: readonly WorkflowEdgeKind[] = [
+	'sequential',
+	'on_failure',
+	'conditional',
+	'llm_decide'
+];
+
+export function isWorkflowEdgeKind(value: unknown): value is WorkflowEdgeKind {
+	return typeof value === 'string' && (WORKFLOW_EDGE_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Comparison vocabulary for a `conditional` edge. Deliberately small and
+ * total — a richer expression language would need a parser, and a parser
+ * over model-authored text is exactly the thing this design avoids.
+ */
+export type WorkflowConditionOperator =
+	| 'eq'
+	| 'neq'
+	| 'gt'
+	| 'gte'
+	| 'lt'
+	| 'lte'
+	| 'exists'
+	| 'not_exists'
+	| 'truthy'
+	| 'falsy'
+	| 'contains'
+	| 'in';
+
+export const WORKFLOW_CONDITION_OPERATORS: readonly WorkflowConditionOperator[] = [
+	'eq',
+	'neq',
+	'gt',
+	'gte',
+	'lt',
+	'lte',
+	'exists',
+	'not_exists',
+	'truthy',
+	'falsy',
+	'contains',
+	'in'
+];
+
+/**
+ * One predicate over the run scope.
+ *
+ * `path` is a dot-path (`nodes.research.output.count`). Numeric segments
+ * index arrays (`nodes.research.output.items.0.id`).
+ */
+export interface WorkflowCondition {
+	readonly path: string;
+	readonly operator: WorkflowConditionOperator;
+	/** Right-hand side. Unused by `exists` / `not_exists` / `truthy` / `falsy`. */
+	readonly value?: unknown;
+}
+
+/**
+ * One destination-input binding. `from` reads the run scope; `fallback`
+ * is used when the path resolves to `undefined`. A `required` entry that
+ * resolves to nothing is a HARD stop — the executor refuses to run the
+ * destination node with a silently missing input.
+ */
+export interface WorkflowInputMappingEntry {
+	/** Key set on the destination node's input object. */
+	readonly to: string;
+	/** Dot-path into the run scope. Omit to use `fallback` as a literal. */
+	readonly from?: string;
+	/** Literal used when `from` is absent or resolves to `undefined`. */
+	readonly fallback?: unknown;
+	/** When true, an unresolvable binding fails the run instead of omitting the key. */
+	readonly required?: boolean;
+}
+
+export type WorkflowInputMapping = readonly WorkflowInputMappingEntry[];
+
+interface WorkflowEdgeBase {
+	readonly id: string;
+	readonly from: string;
+	readonly to: string;
+	/** How the destination node's inputs are built. Omit to pass the source output through. */
+	readonly inputMapping?: WorkflowInputMapping;
+	/** Human label for graph views + traces. */
+	readonly label?: string;
+}
+
+/** The plain happy-path hop. At most one per source node (validated). */
+export interface WorkflowSequentialEdge extends WorkflowEdgeBase {
+	readonly kind: 'sequential';
+}
+
+/**
+ * Taken only when the source node FAILED. `catch` narrows it to specific
+ * failure codes; omit to catch every failure from that node.
+ */
+export interface WorkflowOnFailureEdge extends WorkflowEdgeBase {
+	readonly kind: 'on_failure';
+	readonly catch?: readonly string[];
+}
+
+/** Taken when `when` holds against the run scope. First match wins, in declaration order. */
+export interface WorkflowConditionalEdge extends WorkflowEdgeBase {
+	readonly kind: 'conditional';
+	readonly when: WorkflowCondition;
+}
+
+/**
+ * One arm of a model-decided branch. All `llm_decide` edges leaving a
+ * node are offered together as the choice set; the edge whose `choice`
+ * the decider returns wins.
+ *
+ * `fallback` marks the arm taken when the decider is unbound or errors —
+ * at most one per source node. Without a fallback arm a decider outage
+ * fails the run LOUDLY rather than silently picking a branch.
+ */
+export interface WorkflowLlmDecideEdge extends WorkflowEdgeBase {
+	readonly kind: 'llm_decide';
+	/** Stable token the decider returns. Unique per source node (validated). */
+	readonly choice: string;
+	/** What this arm means — handed to the decider as the choice description. */
+	readonly choiceDescription?: string;
+	readonly fallback?: boolean;
+}
+
+export type WorkflowEdge =
+	| WorkflowSequentialEdge
+	| WorkflowOnFailureEdge
+	| WorkflowConditionalEdge
+	| WorkflowLlmDecideEdge;
+
+/**
+ * One unit of work. `kind` is an opaque key the host's node runner
+ * resolves (a pipeline step, an agent run, a tool call) — the graph
+ * model deliberately knows nothing about what a node DOES.
+ */
+export interface WorkflowNode {
+	readonly id: string;
+	readonly kind: string;
+	readonly name?: string;
+	readonly config?: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkflowGraph {
+	readonly id: string;
+	readonly name?: string;
+	readonly entryNodeId: string;
+	readonly nodes: readonly WorkflowNode[];
+	readonly edges: readonly WorkflowEdge[];
+	/** Loop guard — max node executions. Defaults to {@link WORKFLOW_DEFAULT_MAX_STEPS}. */
+	readonly maxSteps?: number;
+}
+
+/** Default loop guard. A cyclic graph is legal; an unbounded one is not. */
+export const WORKFLOW_DEFAULT_MAX_STEPS = 50;
+
+/** Hard ceiling the executor clamps `maxSteps` to, whatever a graph asks for. */
+export const WORKFLOW_MAX_STEPS_CEILING = 500;
+
+/** Keys a dot-path may never traverse — prototype-pollution guard. */
+const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Read a dot-path out of the run scope. Returns `undefined` for anything
+ * unreachable — including a path that tries to walk the prototype chain,
+ * which is refused outright rather than resolved.
+ */
+export function resolveWorkflowPath(scope: unknown, path: string): unknown {
+	if (typeof path !== 'string' || path.length === 0) return undefined;
+	let current: unknown = scope;
+	for (const segment of path.split('.')) {
+		if (segment.length === 0) return undefined;
+		if (FORBIDDEN_PATH_SEGMENTS.has(segment)) return undefined;
+		if (current === null || current === undefined) return undefined;
+		if (Array.isArray(current)) {
+			const index = Number(segment);
+			if (!Number.isInteger(index) || index < 0 || index >= current.length) return undefined;
+			current = current[index];
+			continue;
+		}
+		if (typeof current !== 'object') return undefined;
+		if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+		current = (current as Record<string, unknown>)[segment];
+	}
+	return current;
+}
+
+function looseContains(haystack: unknown, needle: unknown): boolean {
+	if (Array.isArray(haystack)) return haystack.some((entry) => entry === needle);
+	if (typeof haystack === 'string') return haystack.includes(String(needle));
+	return false;
+}
+
+function numericCompare(left: unknown, right: unknown, compare: (a: number, b: number) => boolean): boolean {
+	const a = typeof left === 'number' ? left : Number(left);
+	const b = typeof right === 'number' ? right : Number(right);
+	if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+	return compare(a, b);
+}
+
+/**
+ * Evaluate one `conditional` predicate. Total by construction: an
+ * unknown operator, an unreachable path or a non-comparable pair is
+ * `false`, never a throw — a broken predicate must not crash a run, it
+ * must simply not take the edge.
+ */
+export function evaluateWorkflowCondition(condition: WorkflowCondition, scope: unknown): boolean {
+	const actual = resolveWorkflowPath(scope, condition.path);
+	switch (condition.operator) {
+		case 'exists':
+			return actual !== undefined && actual !== null;
+		case 'not_exists':
+			return actual === undefined || actual === null;
+		case 'truthy':
+			return Boolean(actual);
+		case 'falsy':
+			return !actual;
+		case 'eq':
+			return actual === condition.value;
+		case 'neq':
+			return actual !== condition.value;
+		case 'gt':
+			return numericCompare(actual, condition.value, (a, b) => a > b);
+		case 'gte':
+			return numericCompare(actual, condition.value, (a, b) => a >= b);
+		case 'lt':
+			return numericCompare(actual, condition.value, (a, b) => a < b);
+		case 'lte':
+			return numericCompare(actual, condition.value, (a, b) => a <= b);
+		case 'contains':
+			return looseContains(actual, condition.value);
+		case 'in':
+			return looseContains(condition.value, actual);
+		default:
+			return false;
+	}
+}
+
+/** Outcome of applying an edge's `inputMapping` to the run scope. */
+export type WorkflowInputMappingResult =
+	| { readonly ok: true; readonly inputs: Record<string, unknown> }
+	| { readonly ok: false; readonly missing: readonly string[] };
+
+/**
+ * Build the destination node's inputs from the run scope.
+ *
+ * Absent mapping ⇒ `{ ok: true, inputs: {} }`; the executor treats an
+ * unmapped edge as "pass the source output through" so the common case
+ * needs no ceremony.
+ */
+export function applyWorkflowInputMapping(
+	mapping: WorkflowInputMapping | undefined,
+	scope: unknown
+): WorkflowInputMappingResult {
+	if (!mapping || mapping.length === 0) return { ok: true, inputs: {} };
+	const inputs: Record<string, unknown> = {};
+	const missing: string[] = [];
+	for (const entry of mapping) {
+		if (!entry || typeof entry.to !== 'string' || entry.to.length === 0) continue;
+		if (FORBIDDEN_PATH_SEGMENTS.has(entry.to)) continue;
+		const resolved = entry.from === undefined ? undefined : resolveWorkflowPath(scope, entry.from);
+		const value = resolved === undefined ? entry.fallback : resolved;
+		if (value === undefined) {
+			if (entry.required) missing.push(entry.to);
+			continue;
+		}
+		inputs[entry.to] = value;
+	}
+	return missing.length > 0 ? { ok: false, missing } : { ok: true, inputs };
+}
+
+export interface WorkflowGraphValidation {
+	readonly valid: boolean;
+	readonly errors: readonly string[];
+}
+
+/**
+ * Structural validation. Catches the mistakes that would otherwise be
+ * discovered mid-run: dangling references, duplicate ids, an entry node
+ * that does not exist, two happy paths out of one node, and colliding
+ * or over-supplied `llm_decide` arms.
+ */
+export function validateWorkflowGraph(graph: WorkflowGraph): WorkflowGraphValidation {
+	const errors: string[] = [];
+	if (!graph || typeof graph !== 'object') return { valid: false, errors: ['graph is not an object'] };
+
+	const nodeIds = new Set<string>();
+	for (const node of graph.nodes ?? []) {
+		if (!node?.id) {
+			errors.push('node without an id');
+			continue;
+		}
+		if (nodeIds.has(node.id)) errors.push(`duplicate node id "${node.id}"`);
+		nodeIds.add(node.id);
+	}
+
+	if (!graph.entryNodeId) errors.push('graph has no entryNodeId');
+	else if (!nodeIds.has(graph.entryNodeId)) {
+		errors.push(`entryNodeId "${graph.entryNodeId}" is not a node in the graph`);
+	}
+
+	const edgeIds = new Set<string>();
+	const sequentialBySource = new Map<string, number>();
+	const choicesBySource = new Map<string, Set<string>>();
+	const fallbacksBySource = new Map<string, number>();
+
+	for (const edge of graph.edges ?? []) {
+		if (!edge?.id) {
+			errors.push('edge without an id');
+			continue;
+		}
+		if (edgeIds.has(edge.id)) errors.push(`duplicate edge id "${edge.id}"`);
+		edgeIds.add(edge.id);
+		if (!isWorkflowEdgeKind(edge.kind)) {
+			errors.push(`edge "${edge.id}" has unknown kind "${String((edge as { kind?: unknown }).kind)}"`);
+			continue;
+		}
+		if (!nodeIds.has(edge.from)) errors.push(`edge "${edge.id}" leaves unknown node "${edge.from}"`);
+		if (!nodeIds.has(edge.to)) errors.push(`edge "${edge.id}" points at unknown node "${edge.to}"`);
+
+		if (edge.kind === 'sequential') {
+			const count = (sequentialBySource.get(edge.from) ?? 0) + 1;
+			sequentialBySource.set(edge.from, count);
+			if (count === 2) {
+				errors.push(
+					`node "${edge.from}" has more than one sequential edge — use conditional or llm_decide to branch`
+				);
+			}
+		}
+
+		if (edge.kind === 'conditional') {
+			if (!edge.when?.path) errors.push(`conditional edge "${edge.id}" has no when.path`);
+			else if (!WORKFLOW_CONDITION_OPERATORS.includes(edge.when.operator)) {
+				errors.push(`conditional edge "${edge.id}" has unknown operator "${String(edge.when.operator)}"`);
+			}
+		}
+
+		if (edge.kind === 'llm_decide') {
+			if (!edge.choice) errors.push(`llm_decide edge "${edge.id}" has no choice token`);
+			else {
+				const choices = choicesBySource.get(edge.from) ?? new Set<string>();
+				if (choices.has(edge.choice)) {
+					errors.push(`node "${edge.from}" has two llm_decide edges with choice "${edge.choice}"`);
+				}
+				choices.add(edge.choice);
+				choicesBySource.set(edge.from, choices);
+			}
+			if (edge.fallback) {
+				const count = (fallbacksBySource.get(edge.from) ?? 0) + 1;
+				fallbacksBySource.set(edge.from, count);
+				if (count === 2) {
+					errors.push(`node "${edge.from}" has more than one llm_decide fallback arm`);
+				}
+			}
+		}
+
+		for (const binding of edge.inputMapping ?? []) {
+			if (!binding?.to) errors.push(`edge "${edge.id}" has an input mapping without a "to" key`);
+			else if (binding.from === undefined && binding.fallback === undefined) {
+				errors.push(`edge "${edge.id}" mapping "${binding.to}" has neither "from" nor "fallback"`);
+			}
+		}
+	}
+
+	if (graph.maxSteps !== undefined && (!Number.isInteger(graph.maxSteps) || graph.maxSteps <= 0)) {
+		errors.push('maxSteps must be a positive integer when set');
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+/** Every edge leaving `nodeId`, in declaration order, optionally narrowed by kind. */
+export function outgoingWorkflowEdges<TKind extends WorkflowEdgeKind>(
+	graph: WorkflowGraph,
+	nodeId: string,
+	kind?: TKind
+): readonly Extract<WorkflowEdge, { kind: TKind }>[] {
+	return (graph.edges ?? []).filter(
+		(edge): edge is Extract<WorkflowEdge, { kind: TKind }> =>
+			edge.from === nodeId && (kind === undefined || edge.kind === kind)
+	);
+}
+
+/**
+ * Does this `on_failure` edge catch that failure code? An edge without
+ * `catch` is the catch-all; an empty `catch` array catches nothing (the
+ * author asked for a narrowing and supplied none).
+ */
+export function onFailureEdgeCatches(edge: WorkflowOnFailureEdge, failureCode?: string): boolean {
+	if (edge.catch === undefined) return true;
+	if (failureCode === undefined) return false;
+	return edge.catch.includes(failureCode);
+}


### PR DESCRIPTION
Audit items **G5 / G8s / G9 / G15**. Four related pieces — **two are live end to end, two are engines whose host port is not yet bound.** Which is which is stated explicitly rather than implied.

## ✅ Live — G8s, typed human-in-the-loop questions

A question was free-form text, so *"approve?"* and *"pick one of these three"* rendered the same, and the answer came back as prose nobody could branch on.

Adds typed question/answer contracts (approval, confirm, choice, multi-choice, text) with parse / serialize / validate — **consumed by the web canvas renderers** (`components.tsx:629` uses `parseHitlQuestion`, plus `describeHitlQuestion` / `parseHitlAnswer`) and declared as canvas tool props. Renderers parse defensively, so a malformed question degrades to a readable card instead of throwing in the chat surface.

## ✅ Live — G15, run admission as a composed chain

The pre-run decision was an imperative ladder inside `RunDispatchGateService.evaluate()`. It's now a composed list of admission middlewares (**Work valve → org/user valve → ship-dark credits precheck**), wired at `run-dispatch-gate.service.ts` via `composeRunAdmission(DEFAULT_RUN_ADMISSION_CHAIN)`.

Behaviour is byte-identical. What changed is that the next pre-run policy is a new middleware rather than another branch in a growing method.

## ⚙️ Engine — G5, workflow graph edges

Four edge kinds (`sequential`, `on_failure`, `conditional`, `llm_decide`) plus input mapping, with a validator, a traversal executor, and a decision port bound to the AI facade. One test per edge kind proves the traversal **rule**: `on_failure` only fires for the codes it declares; `conditional` picks by predicate in declaration order; `llm_decide` asks once and degrades to the declared fallback arm when the decider is unreachable.

**`WORKFLOW_NODE_RUNNER` is `@Optional()` and not bound in this PR.** With no runner the executor returns `{ status: 'blocked', failureCode: 'no-node-runner' }` — a designed and tested state, not a crash. It runs when a host that owns node semantics binds the port.

## ⚙️ Engine — G9, scoped sub-agent delegation

Validation, scope narrowing (*privilege only ever shrinks* — the caller must run the **returned** request, which is what makes that mechanical rather than a convention), depth and sibling caps, budget.

Same posture: `SUB_AGENT_DELEGATION_RUNNER` is unbound, so `delegate()` refuses with `no-runner`.

## Two real defects fixed while merging

1. **`strictNullChecks: false` inverts negated discriminant narrowing.** In `packages/agent`, `if (!v.ok)` narrowed to the `ok: true` member, so both refusal branches referenced fields that don't exist there. I compiled all three forms against the package's own tsconfig — only `v.ok === false` narrows correctly (`if (v.ok)` + `else` fails too). Fixed at both sites, with the reason recorded inline so it doesn't get "tidied" back.
2. **The `on_failure` spec's runner threw for every node**, so the recovery node threw too and the run could never reach the `completed` the test asserted. Fixed the **fixture** (only `a` throws) — the assertions are the point of the test and are unchanged.

## Gates (all green, run locally on the merged tree)

| gate | result |
|---|---|
| `pnpm build --filter=ever-works-api` | 15/15 |
| `packages/agent` jest | 457 suites, 8379 tests |
| `apps/api` jest | 235 suites, 3850 tests |
| `packages/contracts` vitest | 11 files, 307 tests |
| `apps/web` tsc | clean |
| `apps/web` canvas vitest | 26 |
| prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for interactive human-review questions and answers in the canvas, including confirmations, choices, text responses, and approvals.
  * Added workflow graph execution with sequential, conditional, failure-handling, and AI-assisted decision paths.
  * Added input mapping, execution tracing, and graceful fallback behavior for workflow issues.
  * Added safer sub-agent delegation with scoped permissions, budget checks, and structured refusal results.
* **Bug Fixes**
  * Improved resilience when HITL data, workflow decisions, or delegated task responses are incomplete or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->