### PR TITLE
fix(browser-automation): restore the act() exhaustiveness check

### DIFF
--- a/packages/plugins/browser-automation/src/browser-automation.plugin.ts
+++ b/packages/plugins/browser-automation/src/browser-automation.plugin.ts
@@ -293,15 +293,22 @@ export class BrowserAutomationPlugin implements IPlugin, IBrowserAutomationPlugi
 
 	async act(handle: BrowserSessionHandle, steps: readonly BrowserActStep[]): Promise<BrowserActResult> {
 		const session = this.requireSession(handle);
-		if (!Array.isArray(steps) || steps.length === 0) {
+		// Re-bound rather than narrowed in place: `Array.isArray()` on a
+		// `readonly T[]` widens the guarded branch to `any[]`, which would
+		// make `step.kind` `any` and silently defeat the exhaustiveness
+		// check at the bottom of the switch below. The runtime guard still
+		// earns its keep (callers reach this across a plugin boundary and
+		// are not all typed), it just must not be the thing that types it.
+		const actSteps: readonly BrowserActStep[] = Array.isArray(steps) ? steps : [];
+		if (actSteps.length === 0) {
 			return { performed: 0, url: session.page.url(), blockedRequests: this.drainBlocked(session) };
 		}
-		if (steps.length > MAX_ACT_STEPS) {
-			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${steps.length}).`);
+		if (actSteps.length > MAX_ACT_STEPS) {
+			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${actSteps.length}).`);
 		}
 
 		let performed = 0;
-		for (const step of steps) {
+		for (const step of actSteps) {
 			const timeout = clampTimeout(step.timeoutMs, session.policy.timeoutMs);
 
 			if (step.kind === 'wait' && !step.selector) {


### PR DESCRIPTION
`packages/plugins/browser-automation` fails `tsc --noEmit` on CI — caught by **Desktop App Build** on `main` after #1926:

```
browser-automation.plugin.ts(343,12): error TS2322:
Type 'any' is not assignable to type 'never'.
```

## Cause

`Array.isArray()` narrows a `readonly T[]` to **`any[]`**, not to `T[]`. So

```ts
if (!Array.isArray(steps) || steps.length === 0) { … }
```

left `steps` as `any[]` for the rest of the method, `step.kind` became `any`, and the exhaustiveness guard at the bottom of the switch —

```ts
const unknownKind: never = step.kind;
```

— stopped compiling. Which is the guard *telling the truth*: it could no longer prove the switch was exhaustive.

## Fix

Re-bind rather than narrow in place:

```ts
const actSteps: readonly BrowserActStep[] = Array.isArray(steps) ? steps : [];
```

The runtime guard still earns its keep — callers reach `act()` across a plugin boundary and are not all typed — it just must not be the thing that *types* the value.

## Why CI caught this and I didn't

`pnpm build --filter=ever-works-api` does **not** reach `packages/plugins/*`, and the gate I ran on #1918 was the plugin's vitest suite (132 tests, passing then and now). The plugin's `build` script is `tsc --noEmit && tsup` — and that was never run. My mistake, and the reason the regression reached `main`.

Verified here with the gate that would have caught it:

| gate | result |
|---|---|
| `pnpm build` (full monorepo) | **114/114 tasks** |
| `packages/plugins/browser-automation` build (`tsc --noEmit && tsup`) | clean |
| `packages/plugins/browser-automation` vitest | 132 |
| prettier | clean |

## Blast radius

API-only. `Build and Publish Docker Images Prod` and `Release Prod` do not build this plugin, so the production API deploy of `e658c2fb` is unaffected — the failure is confined to the full-platform build used by **Desktop App Build**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser automation handling for invalid or empty action-step inputs.
  * Added safeguards to prevent oversized action sequences from being processed.
  * Ensured action execution consistently uses validated step data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->