### PR TITLE
chore(cascade): browser-automation tsc fix to stage

### DIFF
--- a/packages/plugins/browser-automation/src/browser-automation.plugin.ts
+++ b/packages/plugins/browser-automation/src/browser-automation.plugin.ts
@@ -293,15 +293,22 @@ export class BrowserAutomationPlugin implements IPlugin, IBrowserAutomationPlugi
 
 	async act(handle: BrowserSessionHandle, steps: readonly BrowserActStep[]): Promise<BrowserActResult> {
 		const session = this.requireSession(handle);
-		if (!Array.isArray(steps) || steps.length === 0) {
+		// Re-bound rather than narrowed in place: `Array.isArray()` on a
+		// `readonly T[]` widens the guarded branch to `any[]`, which would
+		// make `step.kind` `any` and silently defeat the exhaustiveness
+		// check at the bottom of the switch below. The runtime guard still
+		// earns its keep (callers reach this across a plugin boundary and
+		// are not all typed), it just must not be the thing that types it.
+		const actSteps: readonly BrowserActStep[] = Array.isArray(steps) ? steps : [];
+		if (actSteps.length === 0) {
 			return { performed: 0, url: session.page.url(), blockedRequests: this.drainBlocked(session) };
 		}
-		if (steps.length > MAX_ACT_STEPS) {
-			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${steps.length}).`);
+		if (actSteps.length > MAX_ACT_STEPS) {
+			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${actSteps.length}).`);
 		}
 
 		let performed = 0;
-		for (const step of steps) {
+		for (const step of actSteps) {
 			const timeout = clampTimeout(step.timeoutMs, session.policy.timeoutMs);
 
 			if (step.kind === 'wait' && !step.selector) {


### PR DESCRIPTION
Carries #1927 to `stage`.

`packages/plugins/browser-automation` failed `tsc --noEmit` — `Array.isArray()` narrows a `readonly T[]` to `any[]`, which defeated the `never` exhaustiveness guard in `act()`. Caught by **Desktop App Build** on `main` after #1926; API deploy path (Docker / Release Prod) was unaffected.

Verified with `pnpm build` across the full monorepo — **114/114 tasks** — which is the gate that should have run on #1918 and didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)