### PR TITLE
chore(cascade): browser-automation tsc fix to production

### DIFF
--- a/packages/plugins/browser-automation/src/browser-automation.plugin.ts
+++ b/packages/plugins/browser-automation/src/browser-automation.plugin.ts
@@ -293,15 +293,22 @@ export class BrowserAutomationPlugin implements IPlugin, IBrowserAutomationPlugi
 
 	async act(handle: BrowserSessionHandle, steps: readonly BrowserActStep[]): Promise<BrowserActResult> {
 		const session = this.requireSession(handle);
-		if (!Array.isArray(steps) || steps.length === 0) {
+		// Re-bound rather than narrowed in place: `Array.isArray()` on a
+		// `readonly T[]` widens the guarded branch to `any[]`, which would
+		// make `step.kind` `any` and silently defeat the exhaustiveness
+		// check at the bottom of the switch below. The runtime guard still
+		// earns its keep (callers reach this across a plugin boundary and
+		// are not all typed), it just must not be the thing that types it.
+		const actSteps: readonly BrowserActStep[] = Array.isArray(steps) ? steps : [];
+		if (actSteps.length === 0) {
 			return { performed: 0, url: session.page.url(), blockedRequests: this.drainBlocked(session) };
 		}
-		if (steps.length > MAX_ACT_STEPS) {
-			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${steps.length}).`);
+		if (actSteps.length > MAX_ACT_STEPS) {
+			throw new RangeError(`act() accepts at most ${MAX_ACT_STEPS} steps (received ${actSteps.length}).`);
 		}
 
 		let performed = 0;
-		for (const step of steps) {
+		for (const step of actSteps) {
 			const timeout = clampTimeout(step.timeoutMs, session.policy.timeoutMs);
 
 			if (step.kind === 'wait' && !step.selector) {


### PR DESCRIPTION
Carries #1927 to `main`, fixing the **Desktop App Build** failure introduced by #1926.

`Array.isArray()` narrows a `readonly T[]` to `any[]`, so the guard in `act()` left `step.kind` as `any` and the `const unknownKind: never = step.kind` exhaustiveness check stopped compiling. Re-bound instead of narrowed in place; the runtime guard is retained.

**Not a production-API concern** — `Build and Publish Docker Images Prod` and `Release Prod` do not build `packages/plugins/*`, so the `e658c2fb` API deploy was never blocked by this. It broke the full-platform build that Desktop App Build runs.

Verified with `pnpm build` across the whole monorepo (**114/114**), which is the gate that would have caught it on #1918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)