### PR TITLE
fix(ai): stop silently dropping multimodal message content

### DIFF
--- a/packages/plugin/src/ai/__tests__/ai-operations.messages.spec.ts
+++ b/packages/plugin/src/ai/__tests__/ai-operations.messages.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import { AiOperations } from '../ai-operations';
+import type { ChatMessage } from '../../contracts/capabilities/ai-provider.interface';
+
+/**
+ * `toLangChainMessages` is the boundary where our `ChatMessage` union meets
+ * LangChain. It used to read:
+ *
+ *     const content = typeof msg.content === 'string' ? msg.content : '';
+ *
+ * so ANY array-shaped content — the multimodal form the contract has always
+ * declared — became an empty string. No throw, no warning: the request went
+ * out, the model answered, and the answer was about nothing. That failure is
+ * invisible to every other kind of test, which is why it survived; these
+ * pin it directly.
+ *
+ * The method is private, so the tests reach it the way the class's own
+ * callers effectively do — via a typed cast — rather than by widening the
+ * public API just to be testable.
+ */
+
+type MessageConverter = {
+	toLangChainMessages(messages: readonly ChatMessage[]): unknown[];
+};
+
+const convert = (messages: readonly ChatMessage[]) =>
+	(Object.create(AiOperations.prototype) as MessageConverter).toLangChainMessages(messages);
+
+describe('AiOperations.toLangChainMessages', () => {
+	it('passes a plain string through unchanged', () => {
+		const [msg] = convert([{ role: 'user', content: 'hello' }]) as HumanMessage[];
+		expect(msg).toBeInstanceOf(HumanMessage);
+		expect(msg.content).toBe('hello');
+	});
+
+	it('does NOT drop multimodal content — the regression this file exists for', () => {
+		const [msg] = convert([
+			{
+				role: 'user',
+				content: [
+					{ type: 'text', text: 'what is in this image?' },
+					{ type: 'image_url', image_url: { url: 'https://example.com/a.png' } }
+				]
+			}
+		]) as HumanMessage[];
+
+		expect(Array.isArray(msg.content)).toBe(true);
+		const parts = msg.content as Array<Record<string, unknown>>;
+		expect(parts).toHaveLength(2);
+		expect(parts[0]).toMatchObject({ type: 'text', text: 'what is in this image?' });
+		expect(parts[1]).toMatchObject({
+			type: 'image_url',
+			image_url: { url: 'https://example.com/a.png' }
+		});
+	});
+
+	it('preserves the image detail hint when one is supplied', () => {
+		const [msg] = convert([
+			{
+				role: 'user',
+				content: [{ type: 'image_url', image_url: { url: 'u', detail: 'high' } }]
+			}
+		]) as HumanMessage[];
+		const parts = msg.content as Array<Record<string, unknown>>;
+		expect(parts[0]).toMatchObject({ image_url: { url: 'u', detail: 'high' } });
+	});
+
+	it('collapses an all-text array back to a plain string', () => {
+		// No reason to hand a provider a parts array for what is just text.
+		const [msg] = convert([
+			{
+				role: 'user',
+				content: [
+					{ type: 'text', text: 'line one' },
+					{ type: 'text', text: 'line two' }
+				]
+			}
+		]) as HumanMessage[];
+		expect(msg.content).toBe('line one\nline two');
+	});
+
+	it('flattens to TEXT for system messages rather than dropping them', () => {
+		// Providers reject structured parts in a system message, so the
+		// words have to survive as a string — previously they became ''.
+		const [msg] = convert([
+			{
+				role: 'system',
+				content: [
+					{ type: 'text', text: 'be terse' },
+					{ type: 'image_url', image_url: { url: 'https://example.com/a.png' } }
+				]
+			}
+		]) as SystemMessage[];
+		expect(msg).toBeInstanceOf(SystemMessage);
+		expect(msg.content).toBe('be terse\n[image]');
+	});
+
+	it('flattens to TEXT for tool messages and keeps the tool_call_id', () => {
+		const [msg] = convert([
+			{
+				role: 'tool',
+				toolCallId: 'call_42',
+				content: [{ type: 'text', text: '{"ok":true}' }]
+			}
+		]) as ToolMessage[];
+		expect(msg).toBeInstanceOf(ToolMessage);
+		expect(msg.content).toBe('{"ok":true}');
+		expect(msg.tool_call_id).toBe('call_42');
+	});
+
+	it('still carries assistant tool calls across', () => {
+		const [msg] = convert([
+			{
+				role: 'assistant',
+				content: '',
+				toolCalls: [
+					{
+						id: 'call_1',
+						type: 'function',
+						function: { name: 'doThing', arguments: '{"a":1}' }
+					}
+				]
+			}
+		]) as AIMessage[];
+		expect(msg).toBeInstanceOf(AIMessage);
+		expect(msg.tool_calls?.[0]).toMatchObject({
+			id: 'call_1',
+			name: 'doThing',
+			args: { a: 1 }
+		});
+	});
+
+	it('treats an empty array as empty string rather than throwing', () => {
+		const [msg] = convert([{ role: 'user', content: [] }]) as HumanMessage[];
+		expect(msg.content).toBe('');
+	});
+});

--- a/packages/plugin/src/ai/ai-operations.ts
+++ b/packages/plugin/src/ai/ai-operations.ts
@@ -13,7 +13,8 @@ import {
 	AIMessage,
 	ToolMessage,
 	type AIMessageChunk,
-	type BaseMessage
+	type BaseMessage,
+	type MessageContentComplex
 } from '@langchain/core/messages';
 import type {
 	ChatCompletionOptions,
@@ -531,12 +532,85 @@ export class AiOperations {
 		return undefined;
 	}
 
+	/**
+	 * Flatten message content to a plain string, keeping the TEXT.
+	 *
+	 * Used for roles where a provider will not accept structured parts
+	 * (system, tool). The point is that the words still arrive — the old
+	 * behaviour returned `''` for anything non-string, which meant a
+	 * caller's prompt could vanish in full with no error raised.
+	 */
+	private flattenContentToText(content: ChatMessage['content']): string {
+		if (typeof content === 'string') return content;
+		if (!Array.isArray(content)) return '';
+		return content
+			.map((part) => {
+				if (typeof part === 'string') return part;
+				if (part && part.type === 'text') return part.text;
+				// An image in a system/tool message has no text form; name it
+				// rather than dropping it to nothing, so the model is not
+				// silently handed a shorter prompt than the caller wrote.
+				if (part && part.type === 'image_url') return '[image]';
+				return '';
+			})
+			.filter((chunk) => chunk.length > 0)
+			.join('\n');
+	}
+
+	/**
+	 * Convert our content union into what LangChain accepts.
+	 *
+	 * `ChatMessageContent` and LangChain's complex-content parts describe
+	 * the same two shapes (`text`, `image_url`), so multimodal input is a
+	 * pass-through — but it was NOT passed through: `toLangChainMessages`
+	 * used to collapse any non-string content to `''`. A caller sending
+	 * `[{type:'text'...},{type:'image_url'...}]` got an empty user message
+	 * and no warning, which is the worst version of this bug: the request
+	 * succeeds, the model answers, and the answer is about nothing.
+	 *
+	 * An all-text array is joined back into a plain string — no reason to
+	 * hand a provider a one-element parts array for what is just text.
+	 */
+	private toLangChainContent(content: ChatMessage['content']): string | MessageContentComplex[] {
+		if (typeof content === 'string') return content;
+		if (!Array.isArray(content) || content.length === 0) return '';
+
+		const parts: MessageContentComplex[] = [];
+		let sawNonText = false;
+		for (const part of content) {
+			if (typeof part === 'string') {
+				parts.push({ type: 'text', text: part });
+				continue;
+			}
+			if (part?.type === 'text') {
+				parts.push({ type: 'text', text: part.text });
+				continue;
+			}
+			if (part?.type === 'image_url') {
+				sawNonText = true;
+				parts.push({
+					type: 'image_url',
+					image_url: part.image_url.detail
+						? { url: part.image_url.url, detail: part.image_url.detail }
+						: { url: part.image_url.url }
+				});
+			}
+		}
+		if (!sawNonText) {
+			return parts.map((p) => ('text' in p ? (p.text as string) : '')).join('\n');
+		}
+		return parts;
+	}
+
 	private toLangChainMessages(messages: readonly ChatMessage[]): BaseMessage[] {
 		return messages.map((msg) => {
-			const content = typeof msg.content === 'string' ? msg.content : '';
+			// system / tool must stay a string — providers reject structured
+			// parts there — so flatten rather than drop.
+			const textOnly = this.flattenContentToText(msg.content);
+			const content = this.toLangChainContent(msg.content);
 			switch (msg.role) {
 				case 'system':
-					return new SystemMessage(content);
+					return new SystemMessage(textOnly);
 				case 'assistant': {
 					const aiMsg = new AIMessage({ content });
 					if (msg.toolCalls?.length) {
@@ -551,12 +625,16 @@ export class AiOperations {
 				}
 				case 'tool':
 					return new ToolMessage({
-						content,
+						content: textOnly,
 						tool_call_id: msg.toolCallId ?? ''
 					});
 				case 'user':
 				default:
-					return new HumanMessage(content);
+					// Object form, not the string overload: the positional
+					// ctor only accepts a string, so passing complex parts
+					// through it would not compile — and silently stringifying
+					// them is exactly the bug this method now fixes.
+					return new HumanMessage({ content });
 			}
 		});
 	}


### PR DESCRIPTION
`AiOperations.toLangChainMessages` read:

```ts
const content = typeof msg.content === 'string' ? msg.content : '';
```

`ChatMessage.content` is typed `string | readonly ChatMessageContent[]`, and `ChatMessageContent` has included an `image_url` variant since the contract was written. So any caller sending the array form — **the only form that can carry an image** — had its entire message replaced with an empty string on the way to LangChain.

This is the worst shape a bug can take: **no throw, no warning, no log.** The request succeeds, the provider bills for it, the model answers, and the answer is about nothing. A caller could not distinguish *"the model ignored my image"* from *"the model never received anything"*.

## The fix

Converted rather than discarded. Our two part shapes (`text`, `image_url`) map 1:1 onto LangChain's complex-content parts, so this is a pass-through, not a translation layer:

- **user / assistant** keep structured parts, including the `detail` hint;
- an **all-text array collapses back to a plain string** — no reason to hand a provider a one-element parts array for plain text;
- **system / tool flatten to text** (providers reject structured parts in those roles) — but they *flatten*, they do not vanish. An image in a system message becomes `[image]`, so the prompt the caller wrote is never silently shorter than the prompt the model sees.

`HumanMessage` now uses the object form; the positional overload accepts only a string, which is the API detail that made stringifying look like the path of least resistance originally.

## The test actually catches it

A passing test proves nothing here, so I checked the other direction: reverting `toLangChainContent` to the old expression **fails 3 of the 8 new tests**, and restoring it turns them green. The spec pins the regression, not just the current behaviour.

## Still open, for whoever wires chat attachments next

`supportsVision` remains **write-only metadata** — plugins set it, the facade defaults it, nothing reads it. Nothing here gates on model capability, so sending an image to a text-only model will now reach the provider instead of being silently blanked. That is strictly better (a real error beats a phantom success) but it is not the same as a capability gate.

## Gates

| gate | result |
|---|---|
| **`pnpm build` (full monorepo)** | **114/114** |
| `packages/plugin` vitest | 26 files, 311 tests (8 new) |
| `packages/agent` jest | 457 suites, 8379 tests |
| `apps/web` tsc | clean |
| prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)