### PR TITLE
fix: unbreak develop's test gate (gate-suite mocks + facades barrel pin)

### DIFF
--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -261,6 +261,12 @@ describe('FacadesModule + barrel re-exports', () => {
                     // Merge-policy matrix (Wave 3, D4). `AgentMergeActor` is
                     // type-only and correctly absent from this runtime list.
                     'MergePolicyRefusedError',
+                    // Voice dictation (#1940) — `POST /api/transcription` maps
+                    // this to a 503 so the client hides the mic instead of
+                    // offering a control that can only fail. It crosses the
+                    // package boundary into apps/api, so it must be barrel
+                    // -exported, and therefore pinned here.
+                    'TranscriptionNotConfiguredError',
                 ].sort(),
             );
         });

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -124,6 +124,22 @@ vi.mock('@ever-works/agent/agents', () => ({
     AgentRunService: AgentRunServiceToken,
     RunDispatchGateService: RunDispatchGateServiceToken,
     AgentEscalationService: AgentEscalationServiceToken,
+    // `recordLoopSample` calls this on EVERY gate grade, not only when the
+    // run-loop detector is switched on, so its absence from this factory
+    // threw inside the gate try-block and every gate case came back
+    // `gate-execution-failed`. Real signature is
+    // `(failures) => string` (agents/loop-detector.ts); a stable digest of
+    // the failing ids is enough for these tests and keeps the fingerprint
+    // meaningful — an empty string would make consecutive distinct
+    // failures look identical to the detector.
+    fingerprintFailures: (
+        failures: ReadonlyArray<{ id?: unknown; outcome?: unknown } | null | undefined>,
+    ): string =>
+        (failures ?? [])
+            .filter(Boolean)
+            .map((failure) => String((failure as { id?: unknown }).id ?? ''))
+            .sort()
+            .join('|'),
 }));
 
 // Judgment layer G2 - the worker reads the L0 pre-check operator switch
@@ -138,6 +154,14 @@ vi.mock('@ever-works/agent/config', () => ({
             // default OFF so every pre-judge case in this suite keeps its
             // byte-identical shape.
             isGateJudgeEnabled: () => judgeSwitch.on,
+            // Run-loop detector (same wave as `fingerprintFailures`). The
+            // worker calls these while grading a gate; without them the
+            // mocked `config.agents` returned undefined and the call threw.
+            // Default OFF, matching every other switch here, so existing
+            // cases keep their byte-identical pre-detector path.
+            isRunLoopDetectorEnabled: () => false,
+            getRunLoopRepeatThreshold: () => 3,
+            getRunLoopMaxRetries: () => 2,
         },
     },
 }));


### PR DESCRIPTION
Two independent reasons `develop`'s `run test on all packages` step is red. Both fixed here.

## 1. `agent-task-execute` gate suite — 24 of 44 red

**This looked like a product bug.** Every quality-gate case returned `gate-execution-failed` — "the gate crashed, no PR opened" — and I flagged it as possibly-live-in-production while cascading #1940. It is **not** a product bug. The gates are fine.

Two mock factories had drifted behind the code:

- **`@ever-works/agent/agents` did not export `fingerprintFailures`.** `recordLoopSample` calls it on *every* gate grade, not only when the run-loop detector is on ([`agent-task-execute.task.ts:597`](packages/tasks/src/tasks/trigger/agent-task-execute.task.ts#L597)). Accessing a missing export on a mocked module throws — inside the gate `try`. That `catch` marks the run failed and returns `gate-execution-failed`.
- **`config.agents` was missing** `isRunLoopDetectorEnabled`, `getRunLoopRepeatThreshold`, `getRunLoopMaxRetries`.

Both arrived with the run-loop detector; the factories were never extended.

The `catch` that hid this is *correct* — "a gate that did not run must not pass anything". It faithfully converted a missing test-mock export into a plausible product failure, which is why it read as real for so long. The assertions (`expected "vi.fn()" to be called 1 times, but got 0`) only ever showed the symptom.

Found by temporarily logging the caught error's stack inside that `catch`:

```
Error: [vitest] No "fingerprintFailures" export is defined on the
"@ever-works/agent/agents" mock.
  at recordLoopSample (agent-task-execute.task.ts:597:34)
```

## 2. Facades barrel pin — 1 red, and this one is mine

#1940 added `TranscriptionNotConfiguredError` to the facades barrel (apps/api needs it to map a missing transcription provider to a 503) without updating the runtime-symbol pin that exists to make barrel additions deliberate. The guard failed — which is the guard working.

I ran the full agent suite *before* adding that export and never re-ran it after. Building and running the new transcription specs was not enough: a barrel addition is exactly what that pin watches.

Test-only impact — the export is additive and harmless at runtime, which is why it reached develop and production without breaking anything.

## No test weakened

No assertion changed in part 1; the mocks now simply describe what the code imports. `fingerprintFailures` is stubbed as a stable digest of the failing check ids rather than a constant — an empty string would make consecutive *distinct* failures look identical to the detector it feeds.

Part 2 adds the one symbol that is genuinely exported, with a comment on why it crosses the package boundary.

## Gates

- `agent-task-execute.task.spec.ts` — **44/44** (was 24 failed / 20 passed)
- `packages/tasks` — 28 files / 461 tests
- `packages/agent` — **458 suites / 8385 tests**
- `pnpm format:check` — clean

Together with the format repair already on develop, this should leave `develop`'s CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for iterative task execution and gate grading.
  * Added deterministic failure fingerprinting to stabilize gate-grade failure handling.
  * Included run-loop detector configuration in test scenarios for more reliable execution paths.
  * Extended a barrel-export regression test to ensure a transcription-related error remains exported consistently across the package boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->