### PR TITLE
fix(kb): stop injecting unreviewed `proposed` documents into Work context

### DIFF
--- a/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
@@ -479,10 +479,9 @@ export class WorkKnowledgeDocumentRepository {
             .andWhere('doc.workId IS NULL')
             .andWhere('doc.kbDocumentClass IN (:...inheritableClasses)', { inheritableClasses })
             .andWhere('doc.status = :status', { status: 'active' as KbDocumentStatus })
-            .andWhere(
-                '(doc.reviewState IS NULL OR doc.reviewState != :proposed)',
-                { proposed: KbReviewState.PROPOSED },
-            )
+            .andWhere('(doc.reviewState IS NULL OR doc.reviewState != :proposed)', {
+                proposed: KbReviewState.PROPOSED,
+            })
             .orderBy('doc.path', 'ASC')
             .getMany();
     }

--- a/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
@@ -461,15 +461,30 @@ export class WorkKnowledgeDocumentRepository {
             return [];
         }
 
-        return this.repository.find({
-            where: {
-                organizationId,
-                workId: IsNull(),
-                kbDocumentClass: In(inheritableClasses),
-                status: 'active' as KbDocumentStatus,
-            },
-            order: { path: 'ASC' },
-        });
+        // Defense in depth for the review gate.
+        //
+        // `KnowledgeBaseService.resolveInheritableDocuments` already
+        // withholds `proposed` documents, but this is the query that feeds
+        // it: excluding them here means an unreviewed machine merge is
+        // never even fetched, and any future caller of this method
+        // inherits the guarantee instead of having to remember it.
+        //
+        // Written as an explicit NULL branch rather than `Not('proposed')`.
+        // In SQL, `review_state != 'proposed'` evaluates to NULL — not
+        // true — for a NULL column, so the simple form would silently drop
+        // every document predating the review gate, which is all of them.
+        return this.repository
+            .createQueryBuilder('doc')
+            .where('doc.organizationId = :organizationId', { organizationId })
+            .andWhere('doc.workId IS NULL')
+            .andWhere('doc.kbDocumentClass IN (:...inheritableClasses)', { inheritableClasses })
+            .andWhere('doc.status = :status', { status: 'active' as KbDocumentStatus })
+            .andWhere(
+                '(doc.reviewState IS NULL OR doc.reviewState != :proposed)',
+                { proposed: KbReviewState.PROPOSED },
+            )
+            .orderBy('doc.path', 'ASC')
+            .getMany();
     }
 
     async listWorkOverridesForClasses(

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -1288,6 +1288,81 @@ describe('KnowledgeBaseService', () => {
     });
 
     describe('resolveInheritableDocuments', () => {
+        it('never injects a `proposed` org document into a Work context', async () => {
+            // Memory consolidation (`apply: true`) synthesizes LLM-merged org
+            // documents and lands them as `reviewState: 'proposed'`, on the
+            // documented promise that they are "excluded from context
+            // injection until a human accepts them in the review queue".
+            //
+            // Nothing enforced that. `listInheritableForOrg` filters on
+            // organizationId / workId IS NULL / class / status='active' and
+            // never looks at reviewState, so an unreviewed machine-merged
+            // document was resolved into every Work's context exactly as if
+            // an operator had approved it — the "an unreviewed merge can
+            // never teach other agents" guarantee inverted.
+            const accepted = buildDocument({
+                id: 'org-accepted',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'legal/terms.md',
+                title: 'Accepted terms',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+                reviewState: 'accepted' as never,
+            });
+            const proposed = buildDocument({
+                id: 'org-proposed',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'legal/synthesis-abc.md',
+                title: 'Synthesis: Terms',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+                reviewState: 'proposed' as never,
+            });
+
+            docRepo.listInheritableForOrg.mockResolvedValue([accepted, proposed]);
+            docRepo.listWorkOverridesForClasses.mockResolvedValue([]);
+
+            const result = await service.resolveInheritableDocuments(WORK_ID, ORG_ID, [
+                'legal' as KbDocumentClass,
+            ]);
+
+            const paths = result.map((d) => d.path);
+            expect(paths).toContain('legal/terms.md');
+            expect(paths).not.toContain('legal/synthesis-abc.md');
+        });
+
+        it('also withholds a `proposed` Work-level override', async () => {
+            // Same rule on the other leg: a Work override is merged over the
+            // org doc by path, so an unreviewed override would otherwise
+            // SHADOW an accepted org document rather than merely appear.
+            const orgTerms = buildDocument({
+                id: 'org-terms',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'legal/terms.md',
+                title: 'Accepted org terms',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+                reviewState: 'accepted' as never,
+            });
+            const proposedOverride = buildDocument({
+                id: 'work-terms',
+                workId: WORK_ID,
+                path: 'legal/terms.md',
+                title: 'Unreviewed work override',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+                reviewState: 'proposed' as never,
+            });
+
+            docRepo.listInheritableForOrg.mockResolvedValue([orgTerms]);
+            docRepo.listWorkOverridesForClasses.mockResolvedValue([proposedOverride]);
+
+            const result = await service.resolveInheritableDocuments(WORK_ID, ORG_ID, [
+                'legal' as KbDocumentClass,
+            ]);
+
+            expect(result.map((d) => d.title)).toEqual(['Accepted org terms']);
+        });
+
         it('merges org docs with Work overrides by path', async () => {
             const orgPrivacy = buildDocument({
                 id: 'org-privacy',

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -2358,12 +2358,36 @@ export class KnowledgeBaseService {
             targetClasses,
         );
 
+        // Withhold anything still awaiting review.
+        //
+        // Memory consolidation lands LLM-synthesized org documents as
+        // `reviewState: 'proposed'` on the documented promise that they are
+        // "excluded from context injection until a human accepts them".
+        // Nothing enforced that: `listInheritableForOrg` filters on
+        // organizationId / workId IS NULL / class / status='active' and
+        // never looks at reviewState, so an unreviewed machine-merged
+        // document was resolved into every Work's context exactly as if an
+        // operator had approved it — inverting the guarantee that "an
+        // unreviewed merge can never teach other agents".
+        //
+        // Applied to BOTH legs, and before the merge. A proposed Work
+        // override would otherwise not merely appear but SHADOW the
+        // accepted org document at the same path.
+        //
+        // Only an explicit 'proposed' is withheld: `reviewState` is null on
+        // every document predating the review gate, and the repository's own
+        // accepted-filter already treats NULL as accepted.
+        const awaitingReview = (d: WorkKnowledgeDocument): boolean =>
+            (d.reviewState as string | null | undefined) === 'proposed';
+
         // Build a map keyed by path with Work overriding org.
         const byPath = new Map<string, WorkKnowledgeDocument>();
         for (const d of orgDocs) {
+            if (awaitingReview(d)) continue;
             byPath.set(d.path, d);
         }
         for (const d of workOverrides) {
+            if (awaitingReview(d)) continue;
             byPath.set(d.path, d);
         }
 


### PR DESCRIPTION
## The defect

Memory consolidation (`apply: true`) synthesizes LLM-merged organization documents and lands them as `reviewState: 'proposed'`, on a promise written in three separate places:

> "Synthesized documents land as `reviewState: 'proposed'` (**excluded from context injection** until a human accepts them in the review queue)"

> "an unreviewed merge can **never teach other agents**"

**Nothing enforced it.**

`resolveInheritableDocuments` returns whatever `listInheritableForOrg` gives it, and that query filters on `organizationId` / `workId IS NULL` / `class` / `status='active'` — it never looks at `reviewState`. Synthesis documents are created with the default `status: 'active'` and an inheritable class (consolidation deliberately skips every other class), so they matched every predicate.

Result: **machine-merged text no human approved was resolved into every Work's context, exactly as if an operator had signed off on it.** That is the inverse of the stated guarantee, and it is the KB-poisoning shape this codebase guards against elsewhere.

## Verification, not inference

I got a "production bug" call wrong earlier in this session, so this one is proven rather than argued. Both tests were written **first** and confirmed failing against the previous code:

```
× never injects a `proposed` org document into a Work context
× also withholds a `proposed` Work-level override
```

The full chain was read end to end before writing them: consolidation → `createOrgDocument` (defaults `status: 'active'`) → inheritable class only → `listInheritableForOrg` predicate list.

## The fix

Filter on **both legs, before the path merge**. The Work-override leg matters as much as the org leg — overrides win by path, so an unreviewed override would not merely appear, it would **shadow** the accepted org document beneath it.

Only an explicit `'proposed'` is withheld. `reviewState` is `null` on every document predating the review gate, and the repository's own accepted-filter already treats `NULL` as accepted, so legacy content is untouched.

## Follow-ups (deliberately not here)

1. The same predicate belongs in `listInheritableForOrg` so those rows are never fetched at all. Service-level was chosen for this fix because it covers both legs in one place and is unit-testable without a database.
2. **The review queue still has no UI.** These documents are waiting for a human to accept them and there is nowhere to do it. Building that is my next change — this PR makes the gate real; that one makes it operable.

## Gates

- `packages/agent` — **458 suites / 8387 tests** (2 new)
- `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented proposed knowledge-base documents from appearing in Work contexts.
  * Ensured proposed organization-level documents and Work-level overrides are withheld, including when they would otherwise replace accepted documents by path.
  * Added coverage to verify that only eligible, reviewed documents are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->