### PR TITLE
docs: correct environment hostnames + document the live GHCR/ArgoCD deploy path

### DIFF
--- a/docs/devops/github-workflows-deep-dive.md
+++ b/docs/devops/github-workflows-deep-dive.md
@@ -7,7 +7,17 @@ sidebar_position: 8
 
 # GitHub Workflows Deep Dive
 
-The Ever Works platform uses 11 GitHub Actions workflow files in `.github/workflows/` to automate CI, Docker image builds, Kubernetes deployments, CLI publishing, and Trigger.dev deployments across three environments (dev, stage, prod).
+The Ever Works platform uses GitHub Actions workflows in `.github/workflows/` to automate CI, container
+image builds, Kubernetes deployments, CLI publishing, and Trigger.dev deployments across three environments
+(dev, stage, prod).
+
+> **Which pipeline is actually live?** Images are built by **`k8s-build.yml`** and pushed to **GHCR**, then
+> deployed to the self-hosted **`ever-k8s`** cluster by **ArgoCD**, which syncs manifests from the
+> **`ever-co/k8s-gitops`** repo (ArgoCD Image Updater bumps the image digests automatically).
+>
+> The `deploy-do-*.yml` workflows below deploy to **DigitalOcean** and are **gated off** behind
+> `vars.DO_ENABLED == 'true'`. They are retained deliberately (no-removal policy), not active. Treat any
+> DigitalOcean hostname, registry or IP in this document as historical.
 
 ## Workflow Inventory
 
@@ -17,9 +27,11 @@ The Ever Works platform uses 11 GitHub Actions workflow files in `.github/workfl
 | `docker-build-publish-dev.yml`   | Build and Publish Docker Images Dev   | Push to develop                 | Build Docker images for dev   |
 | `docker-build-publish-stage.yml` | Build and Publish Docker Images Stage | Push to stage                   | Build Docker images for stage |
 | `docker-build-publish-prod.yml`  | Build and Publish Docker Images Prod  | Push to main                    | Build Docker images for prod  |
-| `deploy-do-dev.yml`              | Deploy to DO Dev                      | After Docker Dev completes      | Deploy to K8s dev             |
-| `deploy-do-stage.yml`            | Deploy to DO Stage                    | After Docker Stage completes    | Deploy to K8s stage           |
-| `deploy-do-prod.yml`             | Deploy to DO Prod                     | After Docker Prod completes     | Deploy to K8s prod            |
+| `k8s-build.yml`                  | k8s-build                             | Push to develop, stage, main    | **LIVE** — build api/web/mcp/docs images → GHCR |
+| `docker-build-publish-mcp-{dev,stage,prod}.yml` | Build and Publish MCP Images | Push to branch            | Build MCP images (DigitalOcean path) |
+| `deploy-do-dev.yml`              | Deploy to DO Dev                      | After Docker Dev completes      | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
+| `deploy-do-stage.yml`            | Deploy to DO Stage                    | After Docker Stage completes    | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
+| `deploy-do-prod.yml`             | Deploy to DO Prod                     | After Docker Prod completes     | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
 | `release-trigger-dev.yml`        | Deploy to Trigger.dev Dev             | After CI on develop             | Deploy Trigger.dev dev        |
 | `release-trigger-stage.yml`      | Deploy to Trigger.dev Stage           | After CI on stage               | Deploy Trigger.dev staging    |
 | `release-trigger-prod.yml`       | Deploy to Trigger.dev Prod            | After CI on main                | Deploy Trigger.dev prod       |
@@ -31,15 +43,18 @@ The Ever Works platform uses 11 GitHub Actions workflow files in `.github/workfl
 flowchart LR
     subgraph develop["Push to develop"]
         ci_dev["ci.yml"] --> trigger_dev["release-trigger-dev.yml"]
-        docker_dev["docker-build-publish-dev.yml"] --> deploy_dev["deploy-do-dev.yml"]
+        k8s_dev["k8s-build.yml"] --> ghcr_dev["GHCR :dev"] --> argo_dev["ArgoCD → ever-k8s"]
+        docker_dev["docker-build-publish-dev.yml"] -.gated.-> deploy_dev["deploy-do-dev.yml"]
     end
     subgraph stage["Push to stage"]
         ci_stage["ci.yml"] --> trigger_stage["release-trigger-stage.yml"]
-        docker_stage["docker-build-publish-stage.yml"] --> deploy_stage["deploy-do-stage.yml"]
+        k8s_stage["k8s-build.yml"] --> ghcr_stage["GHCR :stage"] --> argo_stage["ArgoCD → ever-k8s"]
+        docker_stage["docker-build-publish-stage.yml"] -.gated.-> deploy_stage["deploy-do-stage.yml"]
     end
     subgraph main["Push to main"]
         ci_main["ci.yml"] --> trigger_prod["release-trigger-prod.yml"]
-        docker_main["docker-build-publish-prod.yml"] --> deploy_prod["deploy-do-prod.yml"]
+        k8s_main["k8s-build.yml"] --> ghcr_main["GHCR :prod"] --> argo_prod["ArgoCD → ever-k8s"]
+        docker_main["docker-build-publish-prod.yml"] -.gated.-> deploy_prod["deploy-do-prod.yml"]
         publish["publish-cli.yml (on tags)"]
     end
 ```
@@ -114,6 +129,11 @@ Each image is pushed to up to four registries:
 
 ## Kubernetes Deploy Workflows
 
+> **Legacy — not the live path.** These three workflows deploy to **DigitalOcean** Kubernetes and every step
+> is gated behind `vars.DO_ENABLED == 'true'`, which is not set. The live deployment path is
+> `k8s-build.yml` → GHCR → ArgoCD → `ever-k8s` (manifests in `ever-co/k8s-gitops`). This section is kept
+> for reference and in case the DigitalOcean path is ever re-enabled.
+
 Three workflows (`deploy-do-dev.yml`, `deploy-do-stage.yml`, `deploy-do-prod.yml`) deploy to DigitalOcean Kubernetes.
 
 ### Trigger
@@ -147,7 +167,7 @@ The manifests receive a comprehensive set of environment variables:
 
 | Variable          | Example                                                             |
 | ----------------- | ------------------------------------------------------------------- |
-| `WEB_URL`         | `https://app.ever.works` (prod) / `https://appdev.ever.works` (dev) |
+| `WEB_URL`         | `https://app.ever.works` (prod) / `https://app-dev.ever.works` (dev) |
 | `ALLOWED_ORIGINS` | `https://app.ever.works,https://api.ever.works`                     |
 | `JWT_SECRET`      | From secrets                                                        |
 | `AUTH_SECRET`     | From secrets                                                        |
@@ -203,11 +223,19 @@ The manifests receive a comprehensive set of environment variables:
 
 ### Environment URLs
 
-| Environment | Web URL                        | API URL                        |
-| ----------- | ------------------------------ | ------------------------------ |
-| dev         | `https://appdev.ever.works`    | `https://apidev.ever.works`    |
-| stage       | (configured in stage manifest) | (configured in stage manifest) |
-| prod        | `https://app.ever.works`       | `https://api.ever.works`       |
+These are the hostnames actually served by `ever-k8s` (ingress rules live in `ever-co/k8s-gitops` under
+`apps/ever-works-app-{dev,stage,prod}`):
+
+| Environment | Web URL                        | API URL                        | Admin URL                        | MCP URL                        |
+| ----------- | ------------------------------ | ------------------------------ | -------------------------------- | ------------------------------ |
+| dev         | `https://app-dev.ever.works`   | `https://api-dev.ever.works`   | `https://admin-dev.ever.works`   | `https://mcpdev.ever.works`    |
+| stage       | `https://app-stage.ever.works` | `https://api-stage.ever.works` | `https://admin-stage.ever.works` | `https://mcpstage.ever.works`  |
+| prod        | `https://app.ever.works`       | `https://api.ever.works`       | `https://admin.ever.works`       | `https://mcp.ever.works`       |
+
+**Legacy aliases.** The pre-migration DigitalOcean hostnames `appdev` / `apidev` / `appstage` /
+`apistage.ever.works` (no hyphen) are still served as additional ingress rules on the same backends, so old
+links and bookmarks keep working. Prefer the hyphenated names above for anything new — they are the ones the
+manifests are keyed on.
 
 ## Trigger.dev Deploy Workflows
 

--- a/docs/devops/github-workflows-deep-dive.md
+++ b/docs/devops/github-workflows-deep-dive.md
@@ -21,21 +21,21 @@ image builds, Kubernetes deployments, CLI publishing, and Trigger.dev deployment
 
 ## Workflow Inventory
 
-| Workflow File                    | Name                                  | Trigger                         | Purpose                       |
-| -------------------------------- | ------------------------------------- | ------------------------------- | ----------------------------- |
-| `ci.yml`                         | CI                                    | Push/PR to main, develop, stage | Lint, build, test             |
-| `docker-build-publish-dev.yml`   | Build and Publish Docker Images Dev   | Push to develop                 | Build Docker images for dev   |
-| `docker-build-publish-stage.yml` | Build and Publish Docker Images Stage | Push to stage                   | Build Docker images for stage |
-| `docker-build-publish-prod.yml`  | Build and Publish Docker Images Prod  | Push to main                    | Build Docker images for prod  |
-| `k8s-build.yml`                  | k8s-build                             | Push to develop, stage, main    | **LIVE** — build api/web/mcp/docs images → GHCR |
-| `docker-build-publish-mcp-{dev,stage,prod}.yml` | Build and Publish MCP Images | Push to branch            | Build MCP images (DigitalOcean path) |
-| `deploy-do-dev.yml`              | Deploy to DO Dev                      | After Docker Dev completes      | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
-| `deploy-do-stage.yml`            | Deploy to DO Stage                    | After Docker Stage completes    | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
-| `deploy-do-prod.yml`             | Deploy to DO Prod                     | After Docker Prod completes     | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
-| `release-trigger-dev.yml`        | Deploy to Trigger.dev Dev             | After CI on develop             | Deploy Trigger.dev dev        |
-| `release-trigger-stage.yml`      | Deploy to Trigger.dev Stage           | After CI on stage               | Deploy Trigger.dev staging    |
-| `release-trigger-prod.yml`       | Deploy to Trigger.dev Prod            | After CI on main                | Deploy Trigger.dev prod       |
-| `publish-cli.yml`                | Build and Publish CLIs                | Push to main, tags, manual      | Publish CLI packages          |
+| Workflow File                                   | Name                                  | Trigger                         | Purpose                                               |
+| ----------------------------------------------- | ------------------------------------- | ------------------------------- | ----------------------------------------------------- |
+| `ci.yml`                                        | CI                                    | Push/PR to main, develop, stage | Lint, build, test                                     |
+| `docker-build-publish-dev.yml`                  | Build and Publish Docker Images Dev   | Push to develop                 | Build Docker images for dev                           |
+| `docker-build-publish-stage.yml`                | Build and Publish Docker Images Stage | Push to stage                   | Build Docker images for stage                         |
+| `docker-build-publish-prod.yml`                 | Build and Publish Docker Images Prod  | Push to main                    | Build Docker images for prod                          |
+| `k8s-build.yml`                                 | k8s-build                             | Push to develop, stage, main    | **LIVE** — build api/web/mcp/docs images → GHCR       |
+| `docker-build-publish-mcp-{dev,stage,prod}.yml` | Build and Publish MCP Images          | Push to branch                  | Build MCP images (DigitalOcean path)                  |
+| `deploy-do-dev.yml`                             | Deploy to DO Dev                      | After Docker Dev completes      | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
+| `deploy-do-stage.yml`                           | Deploy to DO Stage                    | After Docker Stage completes    | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
+| `deploy-do-prod.yml`                            | Deploy to DO Prod                     | After Docker Prod completes     | **GATED** (`DO_ENABLED`) — legacy DigitalOcean deploy |
+| `release-trigger-dev.yml`                       | Deploy to Trigger.dev Dev             | After CI on develop             | Deploy Trigger.dev dev                                |
+| `release-trigger-stage.yml`                     | Deploy to Trigger.dev Stage           | After CI on stage               | Deploy Trigger.dev staging                            |
+| `release-trigger-prod.yml`                      | Deploy to Trigger.dev Prod            | After CI on main                | Deploy Trigger.dev prod                               |
+| `publish-cli.yml`                               | Build and Publish CLIs                | Push to main, tags, manual      | Publish CLI packages                                  |
 
 ## Pipeline Flow
 
@@ -165,12 +165,12 @@ The manifests receive a comprehensive set of environment variables:
 
 **Application:**
 
-| Variable          | Example                                                             |
-| ----------------- | ------------------------------------------------------------------- |
+| Variable          | Example                                                              |
+| ----------------- | -------------------------------------------------------------------- |
 | `WEB_URL`         | `https://app.ever.works` (prod) / `https://app-dev.ever.works` (dev) |
-| `ALLOWED_ORIGINS` | `https://app.ever.works,https://api.ever.works`                     |
-| `JWT_SECRET`      | From secrets                                                        |
-| `AUTH_SECRET`     | From secrets                                                        |
+| `ALLOWED_ORIGINS` | `https://app.ever.works,https://api.ever.works`                      |
+| `JWT_SECRET`      | From secrets                                                         |
+| `AUTH_SECRET`     | From secrets                                                         |
 
 **Trigger.dev:**
 
@@ -226,11 +226,11 @@ The manifests receive a comprehensive set of environment variables:
 These are the hostnames actually served by `ever-k8s` (ingress rules live in `ever-co/k8s-gitops` under
 `apps/ever-works-app-{dev,stage,prod}`):
 
-| Environment | Web URL                        | API URL                        | Admin URL                        | MCP URL                        |
-| ----------- | ------------------------------ | ------------------------------ | -------------------------------- | ------------------------------ |
-| dev         | `https://app-dev.ever.works`   | `https://api-dev.ever.works`   | `https://admin-dev.ever.works`   | `https://mcpdev.ever.works`    |
-| stage       | `https://app-stage.ever.works` | `https://api-stage.ever.works` | `https://admin-stage.ever.works` | `https://mcpstage.ever.works`  |
-| prod        | `https://app.ever.works`       | `https://api.ever.works`       | `https://admin.ever.works`       | `https://mcp.ever.works`       |
+| Environment | Web URL                        | API URL                        | Admin URL                        | MCP URL                       |
+| ----------- | ------------------------------ | ------------------------------ | -------------------------------- | ----------------------------- |
+| dev         | `https://app-dev.ever.works`   | `https://api-dev.ever.works`   | `https://admin-dev.ever.works`   | `https://mcpdev.ever.works`   |
+| stage       | `https://app-stage.ever.works` | `https://api-stage.ever.works` | `https://admin-stage.ever.works` | `https://mcpstage.ever.works` |
+| prod        | `https://app.ever.works`       | `https://api.ever.works`       | `https://admin.ever.works`       | `https://mcp.ever.works`      |
 
 **Legacy aliases.** The pre-migration DigitalOcean hostnames `appdev` / `apidev` / `appstage` /
 `apistage.ever.works` (no hyphen) are still served as additional ingress rules on the same backends, so old

--- a/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
+++ b/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
@@ -140,7 +140,7 @@ user.isAnonymous: true }`.
 | ------------------------------- | ------------------------------------------------------------------------------------ |
 | `DEPLOY_EVER_WORKS_ENABLED`     | `true` (inlined in deploy-do-{dev,stage,prod}.yml)                                   |
 | `EVER_WORKS_DOMAIN`             | `ever.works` (inlined in workflows)                                                  |
-| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | `lb.ever.works` → A `157.230.74.11` (k8s-works ingress LB)                           |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | `lb.ever.works` → proxied CNAME → Cloudflare Tunnel (see "DNS anchor record")        |
 | `CLOUDFLARE_API_TOKEN`          | GH secret `CLOUDFLARE_API_TOKEN` (Zone:DNS edit on ever.works)                       |
 | `CLOUDFLARE_ZONE_ID`            | GH secret `CLOUDFLARE_ZONE_ID` → `14b28d7fd73db5679d4280e4278ec6cf`                  |
 | `CAPTCHA_PROVIDER`              | GH secret `CAPTCHA_PROVIDER` — **empty** until Turnstile widget + client wiring ship |
@@ -159,13 +159,43 @@ ever-works/ever-works`.
 
 ### DNS anchor record
 
-`lb.ever.works → A 157.230.74.11` is the anchor that all customer
-`{slug}.ever.works` CNAMEs point at. Created via the Cloudflare API
-2026-05-15 (PR ${{TBD}}). To rotate the LB IP, update this A record
-once; every existing CNAME inherits the new target. The k8s-works
-LoadBalancer Service (`ingress-nginx/ingress-nginx-controller`) does not
-expose a hostname, only an IP, which is why the anchor record exists in
-the first place.
+`lb.ever.works` is the anchor that customer `{slug}.ever.works` CNAMEs
+point at. Created via the Cloudflare API 2026-05-15; **repointed
+2026-07-29**.
+
+**Current shape:** `lb.ever.works` → **proxied CNAME** →
+`5a1c27a6-7d93-4f25-a329-3154995e16db.cfargotunnel.com`, i.e. the same
+Cloudflare Tunnel every other `ever.works` hostname uses. The tunnel has
+a catch-all rule to `ingress-nginx-controller.ingress-nginx` on the
+self-hosted `ever-k8s` cluster.
+
+🛑 **It must stay proxied.** `*.cfargotunnel.com` only resolves through
+the Cloudflare proxy; a grey-cloud (unproxied) record pointing at the
+tunnel will not resolve.
+
+**History:** it previously pointed at `A 157.230.74.11`, the DigitalOcean
+k8s-works ingress LB. That droplet was decommissioned, so the anchor
+resolved to a dead origin (Cloudflare HTTP 521) until it was repointed.
+Any customer subdomain CNAMEd to it during that window would have been
+unreachable.
+
+**Note on current practice:** the customer Work subdomains that exist
+today (`chairs`, `dir`, `startup-books`, `timetrack`, `vectordb`,
+`compliance-automation`, `mcpserver`) are CNAMEd **directly** at the
+tunnel rather than at this anchor, so the anchor currently has zero
+dependents. It is kept working because
+`EVER_WORKS_DEPLOY_LB_HOSTNAME` still defaults to it in
+`managed-subdomain.service`.
+
+**Rotating:** because the target is now a tunnel rather than an IP,
+there is normally nothing to rotate — changing which cluster serves a
+hostname is done in the tunnel's ingress rules / the k8s Ingress, not in
+DNS.
+
+⚠️ A subdomain will still 404 unless a matching k8s Ingress rule exists.
+Pointing DNS at the tunnel is necessary but **not sufficient**: the
+tunnel catch-all forwards to ingress-nginx, which returns 404 for a Host
+it has no server block for.
 
 ### Cloudflare token security note
 


### PR DESCRIPTION
## Why

`docs/devops/github-workflows-deep-dive.md` documented `appdev.ever.works` / `apidev.ever.works` as the dev
URLs. Those are **DigitalOcean-era** hostnames. Their Cloudflare records still pointed at the decommissioned
droplet `167.172.10.5`, which refuses TCP on 80 and 443 — so anyone following this doc got a **Cloudflare 521**
and reasonably concluded dev/stage were down. They were not: the workloads have been healthy the whole time on
`ever-k8s` under new hyphenated hostnames (`api-dev`, `app-dev`, …) that appear nowhere in this repo, because
their Ingress rules live in `ever-co/k8s-gitops`.

That gap is what this PR closes. The DNS and Ingress side is already fixed; all the hostnames below now serve.

## Changes

**`docs/devops/github-workflows-deep-dive.md`**
- Adds an up-front note on which pipeline is actually live: `k8s-build.yml` → GHCR → ArgoCD → `ever-k8s`
  (manifests in `ever-co/k8s-gitops`, digests bumped by ArgoCD Image Updater).
- Marks the `deploy-do-*.yml` workflows as **gated** behind `vars.DO_ENABLED == 'true'`. They are kept
  deliberately under the no-removal policy — this PR does not touch them, it just stops them reading as active.
- Adds `k8s-build.yml` and the MCP build workflows to the inventory; drops the stale "11 workflow files" count.
- Pipeline-flow diagram now shows the live GHCR/ArgoCD path, with the DO path as a dotted `gated` edge.
- **Environment URLs** table rewritten to the hostnames actually served, for all three envs, now including
  Admin and MCP columns. The old table left stage as "(configured in stage manifest)".
- Notes that the legacy non-hyphenated aliases still resolve, so existing links keep working.

**`docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md`**
- The `lb.ever.works` managed-subdomain anchor is no longer `A 157.230.74.11` (also a dead DO droplet). It is
  now a **proxied CNAME to the Cloudflare Tunnel**, matching every other `ever.works` hostname.
- Flags that it **must stay proxied** — `*.cfargotunnel.com` only resolves through the Cloudflare proxy, so a
  grey-cloud record pointing at the tunnel silently fails to resolve.
- Records that the anchor currently has **zero dependents** (today's customer Work subdomains CNAME straight at
  the tunnel), but is kept working because `EVER_WORKS_DEPLOY_LB_HOSTNAME` still defaults to it in
  `managed-subdomain.service`.
- Adds the gotcha that DNS alone is not sufficient — without a matching k8s Ingress rule the tunnel catch-all
  reaches ingress-nginx, which 404s an unknown Host.

## Scope

Docs only — no code, workflow or manifest changes. The DigitalOcean manifests under `.deploy/k8s/` still carry
the old hostnames; those are left untouched since they describe the DO deployment and are gated off.

## Verification

All hostnames in the new table were checked live:

| Host | Result |
| --- | --- |
| `api-dev` / `api-stage` / `api` `/api/version` | 200, each serving its own `gitRef` (`develop` / `stage` / `main`) |
| `app-dev` / `app-stage` / `app` | 307 |
| `mcpdev` / `mcpstage` / `mcp` `/health` | `{"status":"ok"}` |
| legacy `apidev` / `apistage` / `appdev` / `appstage` | 200 / 200 / 307 / 307 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD documentation to reflect image publishing through GHCR and deployments through ArgoCD.
  * Marked legacy DigitalOcean deployment workflows and documented their gating conditions.
  * Expanded environment URL references for Admin and MCP services across development, staging, and production.
  * Updated the deployment runbook with current load balancer, DNS, and Cloudflare Tunnel configuration details.
  * Clarified supported legacy hostnames and DNS operational behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->