### PR TITLE
ci: skip the 118-package build+test on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,16 +125,58 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Formatting is checked on EVERY run, including docs-only PRs: prettier
+      # covers *.md, and a hand-wrapped markdown table is exactly the kind of
+      # thing it catches (PR #1949). It needs only the install above.
       - name: Check formatting
         run: pnpm format:check
 
+      # Decide whether the expensive half of this job is needed.
+      #
+      # `lint-and-test` is the ONLY required status check on main/develop/stage,
+      # so this job must always RUN and report a conclusion — a workflow-level
+      # `paths-ignore` would leave the check permanently "expected" and block
+      # every docs PR forever. Hence a per-step gate rather than a trigger
+      # filter.
+      #
+      # Fails SAFE: every unexpected condition (push build, absent base sha,
+      # unfetchable base, empty or failed diff) resolves to `code=true`, so the
+      # full build+test runs. The only way to skip it is a positive
+      # determination that the PR touches nothing but `docs/` and `*.md`.
+      #
+      # Note the pattern deliberately anchors `^docs/` rather than matching
+      # `docs/` anywhere: `apps/docs` is a real Next.js app whose .tsx must
+      # still be built and tested.
+      - name: Decide whether the heavy build/test steps are needed
+        id: scope
+        run: |
+          decide() { echo "code=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+          [ "${{ github.event_name }}" = "pull_request" ] || decide true
+          BASE="${{ github.event.pull_request.base.sha }}"
+          [ -n "$BASE" ] || decide true
+          git fetch --no-tags --depth=1 origin "$BASE" >/dev/null 2>&1 || true
+          git cat-file -e "$BASE^{commit}" 2>/dev/null || decide true
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null) || decide true
+          [ -n "$CHANGED" ] || decide true
+          echo "Changed files:"; printf '  %s\n' $CHANGED
+          if printf '%s\n' "$CHANGED" | grep -qvE '^docs/|\.md$'; then
+            echo "-> non-docs changes present; running the full build + test."
+            decide true
+          else
+            echo "-> docs-only change; skipping build + test (formatting was still checked)."
+            decide false
+          fi
+
       - name: Build all packages
+        if: steps.scope.outputs.code == 'true'
         run: pnpm build --filter=!./apps/docs
 
       - name: run test on all packages
+        if: steps.scope.outputs.code == 'true'
         run: pnpm test
 
       - name: Build Internal CLI
+        if: steps.scope.outputs.code == 'true'
         working-directory: apps/internal-cli
         run: pnpm build:cli
         env:
@@ -142,6 +184,7 @@ jobs:
           WEB_URL: ${{ secrets.WEB_URL }}
 
       - name: Build External CLI
+        if: steps.scope.outputs.code == 'true'
         working-directory: apps/cli
         run: pnpm build:cli
         env:
@@ -149,6 +192,7 @@ jobs:
           WEB_URL: ${{ secrets.WEB_URL }}
 
       - name: Test Internal CLI
+        if: steps.scope.outputs.code == 'true'
         working-directory: apps/internal-cli
         # NODE_ENV=test signals this is a test-context bootstrap (the CLI uses
         # in-memory sqlite here, not a real database). C-07 PR-B made
@@ -162,6 +206,7 @@ jobs:
         run: pnpm test:cli
 
       - name: Test External CLI
+        if: steps.scope.outputs.code == 'true'
         working-directory: apps/cli
         # See note above on the Internal CLI step â€” same C-07 PR-B implication.
         env:


### PR DESCRIPTION
## Why

`lint-and-test (22.x)` is the **only** required status check on `main`/`develop`/`stage`, and it runs the entire monorepo: install → `format:check` → build all packages → `pnpm test` across 118 packages → build + test both CLIs. A two-file **markdown-only** change (#1949) took ~50 minutes to report.

That cost has a second-order effect that already bit us. Because the check is slow and expensive, a red result gets ignored — and on 2026-07-29 three separate PRs were sitting red on a failure **none of them caused**: #1939 had been cut from `eb285ea`, a `develop` state where `lint-and-test` was already failing, and had drifted 25 commits behind. Its 24 failures were all in `packages/tasks`, a directory it does not touch. Nobody had traced it, because "lint-and-test is red" had stopped carrying information.

## What

Gate the expensive steps on whether the PR actually touches code:

| Step | Before | After |
| --- | --- | --- |
| `Check formatting` | always | **always** (unchanged) |
| Build all packages | always | only when non-docs files changed |
| `pnpm test` (118 pkgs) | always | only when non-docs files changed |
| Build/Test Internal + External CLI | always | only when non-docs files changed |

**`Check formatting` deliberately still runs on every PR.** Prettier covers `*.md`, and a hand-wrapped markdown table is exactly what it catches — that was the real failure in #1949. Docs PRs keep that coverage; they just skip the build and test matrix.

## Why a per-step gate and not `paths-ignore`

This is the important detail. A workflow-level `paths-ignore` would mean the workflow never runs for a docs PR, so the **required check never reports a conclusion** — GitHub leaves it as "Expected" and the PR is blocked *forever*. Gating individual steps keeps the job running and reporting, so the required check is satisfied either way.

## Fails safe

The detection resolves to `code=true` (run everything) on **every** uncertain path: non-`pull_request` events, an absent `base.sha`, a base commit that can't be fetched, and an empty or failed diff. The only way to skip the heavy steps is a positive determination that the changed-file list contains nothing but `docs/` and `*.md`.

Two deliberate choices in the matcher:
- `^docs/` is **anchored**, so `apps/docs` — a real Next.js app — is treated as code and still gets built and tested.
- No third-party action. This repo pins action SHAs (`pnpm/action-setup@0ebf471…`) and sets an explicit least-privilege `permissions:` block, so adding something like `dorny/paths-filter` would widen the supply-chain surface for what plain `git` already does.

## Verification

- `js-yaml` parses the result; no tabs, LF-only.
- Parsed structure checked: all 5 jobs intact, `lint-and-test` has 12 steps, the 6 intended ones carry the `if:` and `Check formatting` does not.
- **This PR changes a `.yml`, not docs — so its own CI run exercises the full path and must go green before merge.** That is the real test.

## Not included

I also considered enabling `strict` branch protection ("require branches to be up to date"), which would have prevented the stale-base confusion outright. Left out on purpose: it would immediately block every open PR until rebased, and on a repo this active it means near-constant rebasing. Worth a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now runs formatting checks on every change.
  * Documentation-only changes skip lengthy build and test steps, making validation faster.
  * Code changes continue to receive full package and CLI build and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->