### PR TITLE
Feat/prompt composer claude style

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -31,6 +31,7 @@ import {
     type ComposerAttachment,
 } from '@/components/common/PromptComposer';
 import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
+import { seedFromExample, usePromptSeed } from '@/components/common/composer/use-prompt-seed';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import type { ProviderWithConnection } from './page';
@@ -105,6 +106,8 @@ const PLACEHOLDERS_BY_KIND: Record<InitialWorkKind, ReadonlyArray<string>> = {
     ],
 };
 
+const PROMPT_INPUT_ID = 'new-work-prompt';
+
 interface NewWorkClientProps {
     user: AuthUser;
     providers: ProviderWithConnection[];
@@ -161,6 +164,11 @@ export default function NewWorkClient({
     const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
+    const seedPrompt = usePromptSeed({
+        value: prompt,
+        onChange: setPrompt,
+        inputId: PROMPT_INPUT_ID,
+    });
 
     const WORK_KIND_INTENT_LABEL: Record<InitialWorkKind, string> = {
         website: 'website',
@@ -269,7 +277,7 @@ export default function NewWorkClient({
                 />
 
                 <PromptComposer
-                    inputId="new-work-prompt"
+                    inputId={PROMPT_INPUT_ID}
                     value={prompt}
                     onChange={setPrompt}
                     onSubmit={submitPrompt}
@@ -296,6 +304,11 @@ export default function NewWorkClient({
                                         return;
                                     }
                                     setSelectedKind(next);
+                                    // Picking a kind writes that kind's
+                                    // example into the input — the chip
+                                    // hands over a real prompt to edit,
+                                    // not just a hint.
+                                    seedPrompt(seedFromExample(PLACEHOLDERS_BY_KIND[next][0]));
                                 }}
                                 ariaLabel={t('promptLabel')}
                                 testIdPrefix="new-work-kind"

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.unit.spec.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.unit.spec.tsx
@@ -101,6 +101,20 @@ describe('NewWorkClient chip seeding', () => {
         expect(getTextarea(container).value).toBe(BLOG_SEED);
     });
 
+    it('stops replacing a seed once the user has edited it', () => {
+        // Editing the seed makes it the user's own words — the next chip pick
+        // has to leave it alone even though we put the first draft there.
+        const { container } = render(<NewWorkClient {...BASE_PROPS} />);
+        clickChip(container, 'directory');
+
+        const edited = `${DIRECTORY_SEED}, self-hosted only`;
+        fireEvent.change(getTextarea(container), { target: { value: edited } });
+
+        clickChip(container, 'blog');
+
+        expect(getTextarea(container).value).toBe(edited);
+    });
+
     it('never overwrites text the user typed', () => {
         const { container } = render(<NewWorkClient {...BASE_PROPS} />);
         fireEvent.change(getTextarea(container), {

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.unit.spec.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.unit.spec.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    Link: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/hooks/use-start-from-prompt', () => ({
+    useStartFromPrompt: () => vi.fn(),
+}));
+
+// The entry view (creationMode === null) never renders these, but they are
+// module-scope imports that drag in the API/data layer. Stub them so the spec
+// stays scoped to the composer.
+vi.mock('@/components/works/WorkAICreator', () => ({
+    WorkAICreator: () => null,
+}));
+vi.mock('@/components/works/WorkImportForm', () => ({
+    WorkImportForm: () => null,
+}));
+vi.mock('./git-provider-selector', () => ({
+    GitProviderSelector: () => null,
+}));
+vi.mock('./deploy-provider-selector', () => ({
+    DeployProviderSelector: () => null,
+}));
+
+import NewWorkClient from './new-work-client';
+
+type NewWorkClientProps = React.ComponentProps<typeof NewWorkClient>;
+
+const BASE_PROPS: NewWorkClientProps = {
+    user: { id: 'u-1', email: 'u@example.dev' } as NewWorkClientProps['user'],
+    providers: [],
+    defaultProviderId: null,
+    deployProviders: [],
+    defaultDeployProviderId: null,
+    websiteTemplates: [],
+};
+
+function getTextarea(container: HTMLElement): HTMLTextAreaElement {
+    const el = container.querySelector('textarea[data-testid="new-work-prompt"]');
+    if (!el) throw new Error('prompt textarea not found');
+    return el as HTMLTextAreaElement;
+}
+
+/**
+ * Same `usePromptSeed` contract `NewPageClient` asserts, on the `/works/new`
+ * entry view: a chip pick writes that kind's first placeholder example into
+ * the box as submittable text, replaces a seed we put there ourselves, and
+ * never touches words the user wrote.
+ */
+describe('NewWorkClient chip seeding', () => {
+    const DIRECTORY_SEED =
+        'Directory of AI coding assistants with reviews, pricing tiers, and editor compatibility';
+    const BLOG_SEED =
+        'Personal blog about indie game development with postmortems and tooling tags';
+
+    function clickChip(container: HTMLElement, value: string) {
+        // `testIdPrefix="new-work-kind"` on this surface's PromptChipsRow.
+        const chip = container.querySelector(`button[data-testid="new-work-kind-${value}"]`);
+        if (!chip) throw new Error(`chip ${value} not found`);
+        fireEvent.click(chip);
+    }
+
+    it('writes the picked chip’s example into the input', () => {
+        const { container } = render(<NewWorkClient {...BASE_PROPS} />);
+        expect(getTextarea(container).value).toBe('');
+
+        clickChip(container, 'directory');
+
+        // The `e.g. "…"` wrapper is stripped — what lands in the box is a
+        // prompt the user can send as-is.
+        expect(getTextarea(container).value).toBe(DIRECTORY_SEED);
+    });
+
+    it('replaces its own seed when the user switches chips', () => {
+        const { container } = render(<NewWorkClient {...BASE_PROPS} />);
+        clickChip(container, 'directory');
+        clickChip(container, 'blog');
+        expect(getTextarea(container).value).toBe(BLOG_SEED);
+    });
+
+    it('never overwrites text the user typed', () => {
+        const { container } = render(<NewWorkClient {...BASE_PROPS} />);
+        fireEvent.change(getTextarea(container), {
+            target: { value: 'My own brief, in my own words' },
+        });
+
+        clickChip(container, 'directory');
+
+        expect(getTextarea(container).value).toBe('My own brief, in my own words');
+    });
+
+    it('never overwrites an `initialPrompt` handed over from the URL', () => {
+        // `?prompt=` prefill is the user's own words carried across a
+        // navigation — a chip pick must leave it alone.
+        const { container } = render(
+            <NewWorkClient {...BASE_PROPS} initialPrompt="Prompt carried over from /new" />,
+        );
+
+        clickChip(container, 'directory');
+
+        expect(getTextarea(container).value).toBe('Prompt carried over from /new');
+    });
+
+    it('does not seed from an inert “Soon” chip (store / company are not clickable)', () => {
+        const { container } = render(<NewWorkClient {...BASE_PROPS} disabledKinds={['store']} />);
+
+        for (const value of ['store', 'company']) {
+            // Rendered as the inert span, so there is no click handler that
+            // could seed — and no chip whose example the seed could come from.
+            expect(
+                container.querySelector(`button[data-testid="new-work-kind-${value}"]`),
+            ).toBeNull();
+            const soon = container.querySelector(`span[data-testid="new-work-kind-${value}"]`);
+            expect(soon).not.toBeNull();
+            expect(soon?.getAttribute('aria-disabled')).toBe('true');
+        }
+        expect(getTextarea(container).value).toBe('');
+    });
+});

--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -182,13 +182,13 @@ export function PromptChipsRow<TValue extends string = string>({
                 <>
                     <div
                         aria-hidden="true"
-                        className="pointer-events-none absolute left-0 top-0 bottom-0 z-10 w-12 bg-gradient-to-r from-background to-transparent dark:from-black"
+                        className="pointer-events-none absolute left-0 top-0 bottom-0 z-10 w-12 bg-gradient-to-r from-background to-transparent dark:from-surface-dark"
                     />
                     <button
                         type="button"
                         onClick={() => panBy(-STEP)}
                         aria-label="Show previous chips"
-                        className="absolute left-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
+                        className="absolute left-0 top-1/2 z-20 grid size-8 -translate-y-1/2 place-items-center rounded-full border border-border/60 bg-background/90 text-text-secondary shadow-md transition-colors hover:bg-foreground/5 hover:text-text dark:border-white/10 dark:bg-surface-dark/90 dark:text-text-secondary-dark dark:hover:bg-white/6 dark:hover:text-text-dark"
                         data-testid={testIdPrefix ? `${testIdPrefix}-scroll-left` : undefined}
                     >
                         <ChevronLeft className="size-4" aria-hidden="true" />
@@ -227,7 +227,7 @@ export function PromptChipsRow<TValue extends string = string>({
                                     aria-disabled="true"
                                     aria-selected="false"
                                     title="Coming soon"
-                                    className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-sm border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
+                                    className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-xs border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
                                     data-testid={
                                         testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
                                     }
@@ -265,10 +265,10 @@ export function PromptChipsRow<TValue extends string = string>({
                                     testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
                                 }
                                 className={cn(
-                                    'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                    'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-xs transition-colors',
                                     selected
-                                        ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
-                                        : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
+                                        ? 'border-text bg-text text-white shadow-sm dark:border-white dark:bg-white dark:text-black'
+                                        : 'border-border/60 bg-transparent text-text-secondary hover:border-border hover:bg-foreground/3 hover:text-text dark:border-white/10 dark:text-text-secondary-dark dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-text-dark',
                                 )}
                             >
                                 <Icon className="size-3.5" aria-hidden="true" />
@@ -283,13 +283,13 @@ export function PromptChipsRow<TValue extends string = string>({
                 <>
                     <div
                         aria-hidden="true"
-                        className="pointer-events-none absolute right-0 top-0 bottom-0 z-10 w-12 bg-gradient-to-l from-background to-transparent dark:from-black"
+                        className="pointer-events-none absolute right-0 top-0 bottom-0 z-10 w-12 bg-gradient-to-l from-background to-transparent dark:from-surface-dark"
                     />
                     <button
                         type="button"
                         onClick={() => panBy(STEP)}
                         aria-label="Show next chips"
-                        className="absolute right-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
+                        className="absolute right-0 top-1/2 z-20 grid size-8 -translate-y-1/2 place-items-center rounded-full border border-border/60 bg-background/90 text-text-secondary shadow-md transition-colors hover:bg-foreground/5 hover:text-text dark:border-white/10 dark:bg-surface-dark/90 dark:text-text-secondary-dark dark:hover:bg-white/6 dark:hover:text-text-dark"
                         data-testid={testIdPrefix ? `${testIdPrefix}-scroll-right` : undefined}
                     >
                         <ChevronRight className="size-4" aria-hidden="true" />

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -227,12 +227,19 @@ interface DirectoryEntryLike {
 const MAX_DROPPED_FOLDER_FILES = 200;
 
 /**
- * Ceiling (px) the auto-growing textarea stops at before it scrolls
- * internally. Matches the height of the fixed three-row box the composer
- * used before it grew with its content: three lines of `text-base` at
- * `leading-relaxed` (3 × 26px) plus the `pt-4` / `pb-3` padding (28px).
+ * Vertical geometry of the textarea, used to turn a `rows` count into the
+ * pixel ceiling the auto-growing box stops at: one line of `text-base` at
+ * `leading-relaxed`, plus the `pt-4` / `pb-3` padding.
  */
-const MAX_TEXTAREA_HEIGHT = 106;
+const TEXTAREA_LINE_HEIGHT = 26;
+const TEXTAREA_VERTICAL_PADDING = 28;
+
+/**
+ * Floor for the ceiling (px) the auto-growing textarea stops at before it
+ * scrolls internally. Matches the height of the fixed three-row box the
+ * composer used before it grew with its content.
+ */
+const MAX_TEXTAREA_HEIGHT = 3 * TEXTAREA_LINE_HEIGHT + TEXTAREA_VERTICAL_PADDING;
 
 /**
  * Geometry for the (+) popover. It renders in a portal at the document root
@@ -346,11 +353,15 @@ export interface PromptComposerProps {
     minLength?: number;
     /** Hard cap enforced by the textarea. Defaults to 5000. */
     maxLength?: number;
-    /** Starting height of the textarea, in rows. Defaults to 3. */
+    /**
+     * Starting height of the textarea, in rows. Defaults to 3. Also sets the
+     * auto-grow ceiling unless `maxHeight` pins it explicitly.
+     */
     rows?: number;
     /**
      * Ceiling (px) the auto-growing textarea stops at before it scrolls
-     * internally. Defaults to the old fixed three-row height.
+     * internally. Defaults to whichever is taller: `rows`, or the old fixed
+     * three-row height.
      */
     maxHeight?: number;
     submitting?: boolean;
@@ -404,7 +415,7 @@ export function PromptComposer({
     minLength = 10,
     maxLength = 5000,
     rows = 3,
-    maxHeight = MAX_TEXTAREA_HEIGHT,
+    maxHeight,
     submitting = false,
     placeholderExamples,
     placeholder,
@@ -710,16 +721,23 @@ export function PromptComposer({
     /* Text input                                                       */
     /* ---------------------------------------------------------------- */
 
-    // Grow with the content up to `maxHeight`, then scroll internally, so a
+    // Without an explicit `maxHeight` the ceiling tracks `rows`, so a surface
+    // that asked for a taller box keeps it instead of being clamped back to
+    // the three-row default.
+    const heightCeiling =
+        maxHeight ??
+        Math.max(MAX_TEXTAREA_HEIGHT, rows * TEXTAREA_LINE_HEIGHT + TEXTAREA_VERTICAL_PADDING);
+
+    // Grow with the content up to the ceiling, then scroll internally, so a
     // short brief gets a compact box and a long one never pushes the card
-    // past the height the old fixed-row layout settled on.
+    // past the height the fixed-row layout settled on.
     const autoGrow = useCallback(() => {
         const el = textareaRef.current;
         if (!el) return;
         el.style.height = 'auto';
-        el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
-        el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
-    }, [maxHeight]);
+        el.style.height = `${Math.min(el.scrollHeight, heightCeiling)}px`;
+        el.style.overflowY = el.scrollHeight > heightCeiling ? 'auto' : 'hidden';
+    }, [heightCeiling]);
 
     useLayoutEffect(() => {
         autoGrow();

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -1,35 +1,70 @@
 'use client';
 
-import { ArrowRight, File as FileIcon, Folder, Github, Loader2, Mic, Plus, X } from 'lucide-react';
+import {
+    ArrowUp,
+    File as FileIcon,
+    Folder,
+    Github,
+    Image as ImageIcon,
+    Loader2,
+    Mic,
+    Paperclip,
+    Plus,
+} from 'lucide-react';
 import {
     useCallback,
     useEffect,
+    useLayoutEffect,
+    useMemo,
     useRef,
     useState,
+    type ClipboardEvent,
+    type DragEvent,
     type KeyboardEvent,
     type ReactNode,
 } from 'react';
 import { cn } from '@/lib/utils/cn';
 import { uploadFile, UploadError } from '@/lib/api/uploads';
+import { AttachmentStrip } from './composer/AttachmentStrip';
+import { AttachmentPreview } from './composer/AttachmentPreview';
+import { VoiceBar } from './composer/VoiceBar';
+import { useDictation } from './composer/use-dictation';
+import {
+    buildAttachmentRefs,
+    formatBytes,
+    isImageFile,
+    isPreviewableAttachment,
+    MAX_UPLOAD_BYTES,
+    type ComposerAttachment,
+    type ComposerAttachmentRef,
+    type ComposerFileAttachment,
+} from './composer/attachments';
 
 /**
- * Shared prompt composer used by `/missions`, `/ideas`, `/new`, and
- * `/works/new`. Modeled on the website's `LandingPromptForm` (see
- * `Ever Works/Code/website/packages/web/components/global/
- * LandingPromptForm.tsx`) so the dashboard's prompt surfaces read
- * the same way visitors first met the product:
+ * Shared prompt composer used by `/missions`, `/ideas`, `/new`, `/agents`
+ * and `/works/new`. Modeled on the website's `LandingPromptForm` so the
+ * dashboard's prompt surfaces read the same way visitors first met the
+ * product, and on the ergonomics people now expect from a chat composer:
  *
- *   - Rounded card on the page's natural dark background (no nested
- *     `bg-card` wrapper).
+ *   - Rounded card on the page's natural background, growing with the text
+ *     up to `maxHeight` instead of a fixed `rows` box.
  *   - Typewriter placeholder cycling through example briefs.
- *   - Bottom toolbar (single row): `+` attachment popover, mic
- *     dictation, character counter, arrow submit.
- *   - Optional attachment chip strip (file / folder / GitHub repo)
- *     rendered INSIDE the card, above the toolbar.
- *   - Optional `chipsBelow` slot for generation-type chip strips
- *     (rendered OUTSIDE / BELOW the card on the page) so the chip
- *     row visually mirrors the website.
- *   - Enter submits; Shift+Enter inserts a newline.
+ *   - Images attach as thumbnails, documents as cards with type + size +
+ *     progress, and a picked folder as one expandable card. Images and text
+ *     documents open full size in `AttachmentPreview`.
+ *   - Files can arrive three ways — the `+` menu, drag-and-drop onto the
+ *     card, or pasting a screenshot straight into the textarea.
+ *   - Dictation swaps the toolbar for a recording bar with a live mic
+ *     meter, elapsed time, and discard / keep actions (`VoiceBar`).
+ *   - Optional `chipsBelow` slot for generation-type chip strips (rendered
+ *     OUTSIDE / BELOW the card) so the chip row mirrors the website.
+ *   - Enter submits; Shift+Enter inserts a newline; Cmd/Ctrl+Enter submits
+ *     from anywhere in the text.
+ *
+ * Palette: design-system tokens only — neutral surfaces, `button-primary`
+ * for the send/confirm affordance, and `danger` / `warning` for state. The
+ * brand accent is deliberately absent: this is chrome around the user's own
+ * words, not a call to action competing with them.
  */
 const TYPE_MS = 35;
 const ERASE_MS = 18;
@@ -42,6 +77,12 @@ const HOLD_ERASED_MS = 350;
 // validation; this is just to keep obvious garbage out of the picker.
 const GITHUB_REPO_RE =
     /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[/?#].*)?$/i;
+
+let idSeq = 0;
+function nextLocalId(prefix: string): string {
+    idSeq += 1;
+    return `${prefix}-${Date.now().toString(36)}-${idSeq}`;
+}
 
 function useTypewriterPlaceholder(
     focused: boolean,
@@ -103,150 +144,151 @@ function useTypewriterPlaceholder(
     return shown || examples[0] || fallback || '';
 }
 
-// Web Speech API isn't in TS's default DOM lib. Use a narrow ambient
-// type just for the bits we touch; browsers expose it on
-// `window.SpeechRecognition` (standard) or `window.webkitSpeechRecognition`
-// (Chrome / Safari).
-interface SpeechResult {
-    readonly isFinal: boolean;
-    readonly [index: number]: { readonly transcript: string };
-}
-interface SpeechResultList {
-    readonly length: number;
-    readonly [index: number]: SpeechResult;
-}
-interface SpeechEvent {
-    readonly resultIndex: number;
-    readonly results: SpeechResultList;
-}
-interface SpeechRecognizer {
-    continuous: boolean;
-    interimResults: boolean;
-    lang: string;
-    onresult: ((event: SpeechEvent) => void) | null;
-    onend: (() => void) | null;
-    onerror: (() => void) | null;
-    start(): void;
-    stop(): void;
-}
-type SpeechRecognizerCtor = new () => SpeechRecognizer;
+/**
+ * Rows in the (+) popover, in order. Data rather than four near-identical
+ * JSX blocks — the hints are what make the menu self-explanatory (a bare
+ * "Upload a file" doesn't tell you a PDF is welcome). `github` is dropped
+ * unless the surface opted into repo imports.
+ */
+const ATTACH_MENU_ITEMS = [
+    {
+        id: 'image',
+        label: 'Add photos',
+        hint: 'Or paste a screenshot',
+        icon: ImageIcon,
+    },
+    {
+        id: 'file',
+        label: 'Upload files',
+        hint: 'PDF, docs, data, code',
+        icon: FileIcon,
+    },
+    {
+        id: 'folder',
+        label: 'Upload a folder',
+        hint: 'Everything inside it',
+        icon: Folder,
+    },
+    {
+        id: 'github',
+        label: 'Import GitHub repo',
+        hint: 'Public repository URL',
+        icon: Github,
+    },
+] as const;
 
-declare global {
-    interface Window {
-        SpeechRecognition?: SpeechRecognizerCtor;
-        webkitSpeechRecognition?: SpeechRecognizerCtor;
-    }
+type AttachMenuItemId = (typeof ATTACH_MENU_ITEMS)[number]['id'];
+
+/** Drag-and-drop and paste both hand us a DataTransfer-shaped object. */
+function filesFrom(data: DataTransfer | null): File[] {
+    if (!data) return [];
+    if (data.files && data.files.length > 0) return Array.from(data.files);
+    return Array.from(data.items ?? [])
+        .filter((item) => item.kind === 'file')
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => Boolean(file));
 }
 
 /**
- * Hook: Web Speech API wrapper. Gracefully no-ops in browsers without
- * SpeechRecognition.
+ * A file on its way in, with the path it had inside a picked folder. The
+ * browser's `File` carries `webkitRelativePath` only for `<input
+ * webkitdirectory>` picks — a *dropped* folder gives us the path through the
+ * entry API instead, and `webkitRelativePath` is read-only, so the path
+ * travels alongside the file rather than on it.
  */
-function useSpeechRecognition(onResult: (text: string) => void) {
-    const recognitionRef = useRef<SpeechRecognizer | null>(null);
-    const [listening, setListening] = useState(false);
-    const [supported, setSupported] = useState(false);
-
-    // Park the latest callback in a ref so the recognizer can dispatch
-    // through it without re-subscribing every render. See the website's
-    // LandingPromptForm — re-subscribing would tear down continuous
-    // dictation after the first phrase.
-    const onResultRef = useRef(onResult);
-    useEffect(() => {
-        onResultRef.current = onResult;
-    }, [onResult]);
-
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-        const Ctor = window.SpeechRecognition || window.webkitSpeechRecognition;
-        if (!Ctor) {
-            // `supported` defaults to false at mount — nothing to do here.
-            // We deliberately avoid calling setSupported(false) in the effect
-            // body to satisfy react-hooks/set-state-in-effect.
-            return;
-        }
-        const rec = new Ctor();
-        rec.continuous = true;
-        rec.interimResults = false;
-        rec.lang = typeof navigator !== 'undefined' ? navigator.language || 'en-US' : 'en-US';
-        rec.onresult = (event) => {
-            let transcript = '';
-            for (let i = event.resultIndex; i < event.results.length; i++) {
-                if (event.results[i].isFinal) transcript += event.results[i][0].transcript;
-            }
-            if (transcript) onResultRef.current(transcript.trim());
-        };
-        rec.onend = () => setListening(false);
-        rec.onerror = () => setListening(false);
-        recognitionRef.current = rec;
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot capability detection at mount; can't be derived during render (needs window.SpeechRecognition).
-        setSupported(true);
-        return () => {
-            try {
-                rec.stop();
-            } catch {
-                /* noop */
-            }
-        };
-    }, []);
-
-    const start = useCallback(() => {
-        if (!recognitionRef.current) return;
-        try {
-            recognitionRef.current.start();
-            setListening(true);
-        } catch {
-            /* already started */
-        }
-    }, []);
-    const stop = useCallback(() => {
-        try {
-            recognitionRef.current?.stop();
-        } catch {
-            /* noop */
-        }
-        setListening(false);
-    }, []);
-
-    return { supported, listening, start, stop };
+interface PickedFile {
+    readonly file: File;
+    readonly path?: string;
 }
 
-// Attachment shapes — discriminated union mirrors the website's
-// LandingPromptForm. Each `file` / `folder-file` entry tracks its own
-// upload state (progress / uploadId / url / error) so the chip strip
-// can render distinct uploading / ready / error variants.
-type ComposerAttachment =
-    | {
-          readonly kind: 'file' | 'folder-file';
-          readonly localId: string;
-          readonly file: File;
-          readonly displayName: string;
-          /** 0–100 percent — XHR-driven during upload. */
-          progress: number;
-          uploading: boolean;
-          /**
-           * Server-side upload id (sha256 of bytes) once the upload
-           * completes. Callers persist this — it's the canonical
-           * reference for `POST /api/me/missions/:id/attachments` etc.
-           */
-          uploadId?: string;
-          /**
-           * API-routed serve URL (`/api/uploads/<userId>/<filename>`)
-           * once the upload completes. Forwarded into the chat prompt
-           * so the chat AI can reference the file by URL.
-           */
-          url?: string;
-          /** Server-declared MIME (echoed from backend response). */
-          mimeType?: string;
-          /** Human-readable failure message; chip flips to red. */
-          error?: string;
-      }
-    | {
-          readonly kind: 'github-repo';
-          readonly localId: string;
-          readonly url: string;
-          readonly displayName: string;
-      };
+/**
+ * The slice of the (non-standard, but universally implemented) drag-and-drop
+ * entry API we need to walk a dropped folder. Not in TS's DOM lib.
+ */
+interface DirectoryEntryLike {
+    readonly isFile: boolean;
+    readonly isDirectory: boolean;
+    readonly name: string;
+    file?: (onFile: (file: File) => void, onError?: (error: unknown) => void) => void;
+    createReader?: () => {
+        readEntries: (
+            onEntries: (entries: DirectoryEntryLike[]) => void,
+            onError?: (error: unknown) => void,
+        ) => void;
+    };
+}
+
+/**
+ * Ceiling on files taken from a single dropped folder. Someone who drags a
+ * project directory would otherwise queue thousands of uploads (and every
+ * `node_modules` inside it) from one gesture.
+ */
+const MAX_DROPPED_FOLDER_FILES = 200;
+
+/**
+ * `webkitGetAsEntry()` must be called synchronously inside the drop handler —
+ * the item list is emptied as soon as the event finishes. The returned entry
+ * objects stay valid afterwards, so the async walk below is safe.
+ */
+function entriesFrom(data: DataTransfer | null): DirectoryEntryLike[] {
+    const entries: DirectoryEntryLike[] = [];
+    for (const item of Array.from(data?.items ?? [])) {
+        if (item.kind !== 'file') continue;
+        const getEntry = (
+            item as DataTransferItem & { webkitGetAsEntry?: () => DirectoryEntryLike | null }
+        ).webkitGetAsEntry;
+        const entry = typeof getEntry === 'function' ? getEntry.call(item) : null;
+        if (entry) entries.push(entry);
+    }
+    return entries;
+}
+
+function fileOfEntry(entry: DirectoryEntryLike): Promise<File | null> {
+    return new Promise((resolve) => {
+        if (!entry.file) {
+            resolve(null);
+            return;
+        }
+        entry.file(
+            (file) => resolve(file),
+            () => resolve(null),
+        );
+    });
+}
+
+/** Depth-first walk of a dropped directory into `{ file, path }` pairs. */
+async function walkEntry(
+    entry: DirectoryEntryLike,
+    prefix: string,
+    out: PickedFile[],
+    limit: number,
+): Promise<void> {
+    if (out.length >= limit) return;
+
+    if (entry.isFile) {
+        const file = await fileOfEntry(entry);
+        if (file) out.push({ file, path: prefix ? `${prefix}/${entry.name}` : entry.name });
+        return;
+    }
+    if (!entry.isDirectory || !entry.createReader) return;
+
+    const reader = entry.createReader();
+    const nested = prefix ? `${prefix}/${entry.name}` : entry.name;
+    // `readEntries` pages — it must be called until it returns an empty batch.
+    for (;;) {
+        const batch = await new Promise<DirectoryEntryLike[]>((resolve) => {
+            reader.readEntries(
+                (items) => resolve(items),
+                () => resolve([]),
+            );
+        });
+        if (batch.length === 0) break;
+        for (const child of batch) {
+            await walkEntry(child, nested, out, limit);
+            if (out.length >= limit) return;
+        }
+    }
+}
 
 export interface PromptComposerProps {
     value: string;
@@ -256,8 +298,13 @@ export interface PromptComposerProps {
     minLength?: number;
     /** Hard cap enforced by the textarea. Defaults to 5000. */
     maxLength?: number;
-    /** Number of rows in the textarea. Defaults to 3. */
+    /** Starting height of the textarea, in rows. Defaults to 3. */
     rows?: number;
+    /**
+     * Ceiling (px) the auto-growing textarea stops at before it scrolls
+     * internally. Defaults to 240.
+     */
+    maxHeight?: number;
     submitting?: boolean;
     /** Placeholder examples to cycle through. Falls back to the single `placeholder`. */
     placeholderExamples?: ReadonlyArray<string>;
@@ -290,7 +337,8 @@ export interface PromptComposerProps {
     showImportGithubRepo?: boolean;
     /**
      * Whether to render the (+) attachment button at all. Defaults to
-     * true; set false on surfaces that don't want attachments.
+     * true; set false on surfaces that don't want attachments. Also gates
+     * drag-and-drop and paste-to-attach.
      */
     attachmentsEnabled?: boolean;
     /**
@@ -308,6 +356,7 @@ export function PromptComposer({
     minLength = 10,
     maxLength = 5000,
     rows = 3,
+    maxHeight = 240,
     submitting = false,
     placeholderExamples,
     placeholder,
@@ -326,6 +375,7 @@ export function PromptComposer({
     const [focused, setFocused] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const imageInputRef = useRef<HTMLInputElement | null>(null);
     const folderInputRef = useRef<HTMLInputElement | null>(null);
     const attachButtonRef = useRef<HTMLButtonElement | null>(null);
     const attachMenuRef = useRef<HTMLDivElement | null>(null);
@@ -336,23 +386,99 @@ export function PromptComposer({
     const [githubFormOpen, setGithubFormOpen] = useState(false);
     const [githubUrl, setGithubUrl] = useState('');
     const [githubError, setGithubError] = useState<string | null>(null);
+    const [dragging, setDragging] = useState(false);
+    const [previewId, setPreviewId] = useState<string | null>(null);
+    // Transient explanation for something we did to the user's pick (e.g.
+    // truncating a very large dropped folder). Cleared on the next intake.
+    const [notice, setNotice] = useState<string | null>(null);
 
     const trimmed = value.trim();
     // The textarea's native `maxLength={maxLength}` caps the raw value
     // before we ever see it, so no `tooLong` guard is needed here —
     // trimming can only shorten the string, never grow it past the cap.
     const canSubmit = !disabled && !submitting && trimmed.length >= minLength;
+    const inputDisabled = disabled || submitting;
 
     const examples =
         placeholderExamples && placeholderExamples.length > 0 ? placeholderExamples : [];
     const typed = useTypewriterPlaceholder(focused || value.length > 0, examples, placeholder);
     const effectivePlaceholder = examples.length > 0 ? typed : placeholder || '';
 
-    const speech = useSpeechRecognition((text) =>
-        onChange(value ? `${value} ${text}`.slice(0, maxLength) : text.slice(0, maxLength)),
+    /* ---------------------------------------------------------------- */
+    /* Dictation                                                        */
+    /* ---------------------------------------------------------------- */
+
+    // Everything this dictation session appended, so "discard" can put the
+    // prompt back exactly as it was instead of clearing the whole field.
+    const dictatedRef = useRef('');
+
+    const appendDictated = useCallback(
+        (text: string) => {
+            const separator = value.length > 0 && !/\s$/.test(value) ? ' ' : '';
+            const next = `${value}${separator}${text}`.slice(0, maxLength);
+            // Slice off what actually landed — the cap may have truncated it.
+            dictatedRef.current += next.slice(value.length);
+            onChange(next);
+        },
+        [value, maxLength, onChange],
     );
 
-    // Surface attachment changes to consumers that wire this up.
+    const dictation = useDictation(appendDictated);
+
+    const startDictation = useCallback(() => {
+        dictatedRef.current = '';
+        dictation.start();
+    }, [dictation]);
+
+    const finishDictation = useCallback(() => {
+        dictation.stop();
+        dictatedRef.current = '';
+        textareaRef.current?.focus();
+    }, [dictation]);
+
+    const discardDictation = useCallback(() => {
+        dictation.stop();
+        const appended = dictatedRef.current;
+        dictatedRef.current = '';
+        // Only rewind when the tail is still verbatim ours; if the user
+        // edited mid-dictation we leave their text alone rather than
+        // guessing which part to cut.
+        if (appended && value.endsWith(appended)) {
+            onChange(value.slice(0, value.length - appended.length));
+        }
+        textareaRef.current?.focus();
+    }, [dictation, onChange, value]);
+
+    // A composer that goes disabled mid-sentence (submit in flight) must not
+    // leave the mic open behind it.
+    const { listening: dictating, stop: stopDictation } = dictation;
+    useEffect(() => {
+        if (inputDisabled && dictating) stopDictation();
+    }, [inputDisabled, dictating, stopDictation]);
+
+    // Starting dictation unmounts the mic button (the toolbar becomes the
+    // VoiceBar), which would drop keyboard focus to <body>. Park it on the
+    // textarea instead — the caret sits where the words are landing, and the
+    // bar's discard / keep buttons are the next tab stops.
+    useEffect(() => {
+        if (dictating) textareaRef.current?.focus();
+    }, [dictating]);
+
+    /* ---------------------------------------------------------------- */
+    /* Attachments                                                      */
+    /* ---------------------------------------------------------------- */
+
+    // Object URLs pin the underlying file in memory until revoked, so every
+    // one we mint is tracked and released on removal / unmount.
+    const objectUrlsRef = useRef<Set<string>>(new Set());
+    useEffect(
+        () => () => {
+            objectUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+            objectUrlsRef.current.clear();
+        },
+        [],
+    );
+
     const onAttachmentsChangeRef = useRef(onAttachmentsChange);
     useEffect(() => {
         onAttachmentsChangeRef.current = onAttachmentsChange;
@@ -361,25 +487,283 @@ export function PromptComposer({
         onAttachmentsChangeRef.current?.(attachments);
     }, [attachments]);
 
+    const patchFile = useCallback((localId: string, changes: Partial<ComposerFileAttachment>) => {
+        setAttachments((cur) =>
+            cur.map((a) =>
+                a.localId === localId && a.kind !== 'github-repo' ? { ...a, ...changes } : a,
+            ),
+        );
+    }, []);
+
+    const startUpload = useCallback(
+        (file: File, localId: string) => {
+            patchFile(localId, { uploading: true, progress: 0, error: undefined });
+            void uploadFile(file, {
+                onProgress: (percent) => patchFile(localId, { progress: percent }),
+            })
+                .then((res) => {
+                    patchFile(localId, {
+                        uploading: false,
+                        progress: 100,
+                        uploadId: res.id,
+                        url: res.url,
+                        mimeType: res.mimeType,
+                    });
+                })
+                .catch((err: unknown) => {
+                    const message =
+                        err instanceof UploadError
+                            ? err.message
+                            : err instanceof Error
+                              ? err.message
+                              : 'Upload failed';
+                    patchFile(localId, { uploading: false, progress: 0, error: message });
+                });
+        },
+        [patchFile],
+    );
+
+    const ingestFiles = useCallback(
+        (picked: ReadonlyArray<PickedFile>, kind: 'file' | 'folder-file') => {
+            if (picked.length === 0) return;
+
+            const next = picked.map(({ file, path }): ComposerFileAttachment => {
+                const relPath =
+                    path || (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+                const displayName = kind === 'folder-file' && relPath ? relPath : file.name;
+                // Fail oversized files here rather than pushing 30 MB up the
+                // wire just to have the API reject it.
+                const tooLarge = file.size > MAX_UPLOAD_BYTES;
+
+                let previewUrl: string | undefined;
+                if (isImageFile(file)) {
+                    try {
+                        previewUrl = URL.createObjectURL(file);
+                        objectUrlsRef.current.add(previewUrl);
+                    } catch {
+                        /* no preview — degrades to a file chip */
+                    }
+                }
+
+                return {
+                    kind,
+                    localId: nextLocalId(kind),
+                    file,
+                    displayName,
+                    progress: 0,
+                    uploading: !tooLarge,
+                    previewUrl,
+                    error: tooLarge
+                        ? `File is larger than ${formatBytes(MAX_UPLOAD_BYTES)}`
+                        : undefined,
+                };
+            });
+
+            setAttachments((cur) => [...cur, ...next]);
+
+            // One XHR per file, in parallel. Each settles independently;
+            // failures stay in `attachments` with an `error` so the user can
+            // retry or dismiss them.
+            for (const attachment of next) {
+                if (!attachment.error) startUpload(attachment.file, attachment.localId);
+            }
+        },
+        [startUpload],
+    );
+
+    const ingestPlainFiles = useCallback(
+        (files: ReadonlyArray<File>) => {
+            ingestFiles(
+                files.map((file) => ({ file })),
+                'file',
+            );
+        },
+        [ingestFiles],
+    );
+
+    /**
+     * Resolve a drop. A dropped *folder* arrives as a directory entry, not a
+     * file: taking `dataTransfer.files` at face value would attach a 0-byte
+     * stub named after the folder and then fail to upload it. So when any
+     * entry is a directory we walk the tree and ingest its contents as folder
+     * files, exactly like the folder picker does.
+     */
+    const ingestDrop = useCallback(
+        async (entries: ReadonlyArray<DirectoryEntryLike>, flat: ReadonlyArray<File>) => {
+            if (!entries.some((entry) => entry.isDirectory)) {
+                ingestPlainFiles(flat);
+                return;
+            }
+
+            const loose: PickedFile[] = [];
+            const nested: PickedFile[] = [];
+            for (const entry of entries) {
+                if (entry.isDirectory) {
+                    await walkEntry(entry, '', nested, MAX_DROPPED_FOLDER_FILES);
+                } else {
+                    const file = await fileOfEntry(entry);
+                    if (file) loose.push({ file });
+                }
+            }
+
+            if (loose.length > 0) ingestFiles(loose, 'file');
+            if (nested.length > 0) ingestFiles(nested, 'folder-file');
+            if (nested.length >= MAX_DROPPED_FOLDER_FILES) {
+                setNotice(`Attached the first ${MAX_DROPPED_FOLDER_FILES} files from that folder.`);
+            }
+        },
+        [ingestFiles, ingestPlainFiles],
+    );
+
+    const removeAttachment = useCallback(
+        (localId: string) => {
+            // Revoke outside the updater — state updaters must stay pure
+            // (StrictMode runs them twice in development).
+            const target = attachments.find((a) => a.localId === localId);
+            if (target && target.kind !== 'github-repo' && target.previewUrl) {
+                URL.revokeObjectURL(target.previewUrl);
+                objectUrlsRef.current.delete(target.previewUrl);
+            }
+            setAttachments((cur) => cur.filter((a) => a.localId !== localId));
+        },
+        [attachments],
+    );
+
+    const retryAttachment = useCallback(
+        (localId: string) => {
+            const target = attachments.find((a) => a.localId === localId);
+            if (!target || target.kind === 'github-repo') return;
+            if (target.file.size > MAX_UPLOAD_BYTES) return;
+            startUpload(target.file, localId);
+        },
+        [attachments, startUpload],
+    );
+
+    // Everything the overlay can render — images and readable text documents,
+    // including files inside a picked folder.
+    const previewable = useMemo(() => attachments.filter(isPreviewableAttachment), [attachments]);
+    const previewIndex = previewId ? previewable.findIndex((a) => a.localId === previewId) : -1;
+
+    // Announce upload progress for screen readers — the tiles and chips
+    // carry this visually, but only visually.
+    const status = useMemo(() => {
+        const files = attachments.filter((a) => a.kind !== 'github-repo');
+        const uploading = files.filter((a) => a.uploading).length;
+        const failed = files.filter((a) => a.error).length;
+        if (uploading > 0) return `Uploading ${uploading} file${uploading === 1 ? '' : 's'}`;
+        if (failed > 0) return `${failed} upload${failed === 1 ? '' : 's'} failed`;
+        if (files.length > 0)
+            return `${files.length} file${files.length === 1 ? '' : 's'} attached`;
+        return '';
+    }, [attachments]);
+
+    /* ---------------------------------------------------------------- */
+    /* Text input                                                       */
+    /* ---------------------------------------------------------------- */
+
+    // Grow with the content up to `maxHeight`, then scroll internally —
+    // a fixed 3-row box hid the tail of anything longer than a sentence.
+    const autoGrow = useCallback(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.style.height = 'auto';
+        el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+        el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    }, [maxHeight]);
+
+    useLayoutEffect(() => {
+        autoGrow();
+    }, [value, autoGrow]);
+
     function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            if (canSubmit) onSubmit();
+            return;
+        }
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             if (canSubmit) onSubmit();
         }
     }
 
+    function onPaste(e: ClipboardEvent<HTMLTextAreaElement>) {
+        if (!attachmentsEnabled || inputDisabled) return;
+        const data = e.clipboardData;
+        // A pasted screenshot carries files and no text/plain. Rich text
+        // copied from a page can carry both — that should paste as text.
+        if (Array.from(data?.types ?? []).includes('text/plain')) return;
+        const files = filesFrom(data);
+        if (files.length === 0) return;
+        e.preventDefault();
+        setNotice(null);
+        ingestPlainFiles(files);
+    }
+
+    /* ---------------------------------------------------------------- */
+    /* Drag and drop                                                    */
+    /* ---------------------------------------------------------------- */
+
+    // Dragging over a child fires dragleave on the parent, so count enters
+    // and exits instead of toggling on the first leave.
+    const dragDepthRef = useRef(0);
+    const dropEnabled = attachmentsEnabled && !inputDisabled;
+
+    function dragHasFiles(e: DragEvent<HTMLDivElement>) {
+        return Array.from(e.dataTransfer?.types ?? []).includes('Files');
+    }
+
+    function onDragEnter(e: DragEvent<HTMLDivElement>) {
+        if (!dropEnabled || !dragHasFiles(e)) return;
+        dragDepthRef.current += 1;
+        setDragging(true);
+    }
+    function onDragOver(e: DragEvent<HTMLDivElement>) {
+        if (!dropEnabled || !dragHasFiles(e)) return;
+        // Without preventDefault the browser navigates to the file on drop.
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+    }
+    function onDragLeave() {
+        if (!dropEnabled) return;
+        dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+        if (dragDepthRef.current === 0) setDragging(false);
+    }
+    function onDrop(e: DragEvent<HTMLDivElement>) {
+        if (!dropEnabled) return;
+        dragDepthRef.current = 0;
+        setDragging(false);
+        // Both reads have to happen before the handler yields: the entry list
+        // and `dataTransfer.files` are both cleared once the event completes.
+        const entries = entriesFrom(e.dataTransfer);
+        const files = filesFrom(e.dataTransfer);
+        // Neither means someone dragged *text* in — let the textarea handle
+        // that natively instead of swallowing the drop.
+        if (entries.length === 0 && files.length === 0) return;
+        e.preventDefault();
+        setNotice(null);
+        void ingestDrop(entries, files);
+    }
+
+    /* ---------------------------------------------------------------- */
+    /* Attach menu                                                      */
+    /* ---------------------------------------------------------------- */
+
+    const closeAttachMenu = useCallback((restoreFocus = false) => {
+        setGithubFormOpen(false);
+        setAttachMenuOpen(false);
+        if (restoreFocus) attachButtonRef.current?.focus();
+    }, []);
+
     // Escape closes the popover (and the github sub-form).
     useEffect(() => {
         if (!attachMenuOpen) return;
         const onKey = (e: globalThis.KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                setGithubFormOpen(false);
-                setAttachMenuOpen(false);
-            }
+            if (e.key === 'Escape') closeAttachMenu(true);
         };
         document.addEventListener('keydown', onKey);
         return () => document.removeEventListener('keydown', onKey);
-    }, [attachMenuOpen]);
+    }, [attachMenuOpen, closeAttachMenu]);
 
     // Document-level mousedown listener to close the popover on outside
     // click. The composer card uses backdrop-blur which creates a
@@ -393,114 +777,65 @@ export function PromptComposer({
             if (!target) return;
             if (attachMenuRef.current?.contains(target)) return;
             if (attachButtonRef.current?.contains(target)) return;
-            setGithubFormOpen(false);
-            setAttachMenuOpen(false);
+            closeAttachMenu();
         };
         document.addEventListener('mousedown', onDocMouseDown);
         return () => document.removeEventListener('mousedown', onDocMouseDown);
-    }, [attachMenuOpen]);
+    }, [attachMenuOpen, closeAttachMenu]);
 
     useEffect(() => {
         if (githubFormOpen) githubInputRef.current?.focus();
     }, [githubFormOpen]);
 
-    const ingestFiles = useCallback((picked: FileList, kind: 'file' | 'folder-file') => {
-        if (!picked || picked.length === 0) return;
-        const next = Array.from(picked).map(
-            (file): Extract<ComposerAttachment, { kind: 'file' | 'folder-file' }> => {
-                const relPath =
-                    (file as File & { webkitRelativePath?: string }).webkitRelativePath || '';
-                const displayName = kind === 'folder-file' && relPath ? relPath : file.name;
-                return {
-                    kind,
-                    localId: `${file.name}-${file.size}-${file.lastModified}-${Math.random()
-                        .toString(36)
-                        .slice(2, 6)}`,
-                    file,
-                    displayName,
-                    progress: 0,
-                    uploading: true,
-                };
-            },
-        );
-        setAttachments((cur) => [...cur, ...next]);
+    // Land focus on the first item so the menu is usable from the keyboard
+    // the moment it opens.
+    useEffect(() => {
+        if (!attachMenuOpen || githubFormOpen) return;
+        attachMenuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    }, [attachMenuOpen, githubFormOpen]);
 
-        // Fire one XHR upload per file in parallel. Each settles
-        // independently; failures stay in `attachments` with an `error`
-        // field so the user can see + retry / dismiss. The submit flow
-        // can choose to wait for in-flight uploads or filter to
-        // completed `uploadId`s — that's the caller's call.
-        for (const attachment of next) {
-            void uploadFile(attachment.file, {
-                onProgress: (percent) => {
-                    setAttachments((cur) =>
-                        cur.map((a) =>
-                            a.localId === attachment.localId &&
-                            (a.kind === 'file' || a.kind === 'folder-file')
-                                ? { ...a, progress: percent }
-                                : a,
-                        ),
-                    );
-                },
-            })
-                .then((res) => {
-                    setAttachments((cur) =>
-                        cur.map((a) =>
-                            a.localId === attachment.localId &&
-                            (a.kind === 'file' || a.kind === 'folder-file')
-                                ? {
-                                      ...a,
-                                      uploading: false,
-                                      progress: 100,
-                                      uploadId: res.id,
-                                      url: res.url,
-                                      mimeType: res.mimeType,
-                                  }
-                                : a,
-                        ),
-                    );
-                })
-                .catch((err: unknown) => {
-                    const message =
-                        err instanceof UploadError
-                            ? err.message
-                            : err instanceof Error
-                              ? err.message
-                              : 'Upload failed';
-                    setAttachments((cur) =>
-                        cur.map((a) =>
-                            a.localId === attachment.localId &&
-                            (a.kind === 'file' || a.kind === 'folder-file')
-                                ? { ...a, uploading: false, progress: 0, error: message }
-                                : a,
-                        ),
-                    );
-                });
-        }
-    }, []);
+    function onMenuKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+        const items = Array.from(
+            attachMenuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+        );
+        if (items.length === 0) return;
+        e.preventDefault();
+        const active = items.indexOf(document.activeElement as HTMLElement);
+        const delta = e.key === 'ArrowDown' ? 1 : -1;
+        items[(active + delta + items.length) % items.length].focus();
+    }
 
     function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
         const picked = e.target.files;
-        if (picked) ingestFiles(picked, 'file');
+        setNotice(null);
+        if (picked) ingestPlainFiles(Array.from(picked));
+        // Reset so picking the same file twice still fires a change.
         e.target.value = '';
     }
 
     function onPickFolder(e: React.ChangeEvent<HTMLInputElement>) {
         const picked = e.target.files;
-        if (picked) ingestFiles(picked, 'folder-file');
+        setNotice(null);
+        if (picked) {
+            ingestFiles(
+                Array.from(picked).map((file) => ({ file })),
+                'folder-file',
+            );
+        }
         e.target.value = '';
     }
 
-    function removeAttachment(localId: string) {
-        setAttachments((cur) => cur.filter((a) => a.localId !== localId));
+    function onClickImages() {
+        closeAttachMenu();
+        imageInputRef.current?.click();
     }
-
     function onClickFile() {
-        setAttachMenuOpen(false);
+        closeAttachMenu();
         fileInputRef.current?.click();
     }
     function onClickFolder() {
-        setAttachMenuOpen(false);
+        closeAttachMenu();
         folderInputRef.current?.click();
     }
     function onClickGithub() {
@@ -520,15 +855,16 @@ export function PromptComposer({
         const repoRaw = match[2].replace(/\.git$/i, '');
         const displayName = `${owner}/${repoRaw}`;
         const canonical = `https://github.com/${owner}/${repoRaw}`;
-        const entry: ComposerAttachment = {
-            kind: 'github-repo',
-            localId: `gh-${owner}-${repoRaw}-${Math.random().toString(36).slice(2, 6)}`,
-            url: canonical,
-            displayName,
-        };
-        setAttachments((cur) => [...cur, entry]);
-        setGithubFormOpen(false);
-        setAttachMenuOpen(false);
+        setAttachments((cur) => [
+            ...cur,
+            {
+                kind: 'github-repo',
+                localId: nextLocalId('gh'),
+                url: canonical,
+                displayName,
+            },
+        ]);
+        closeAttachMenu();
         setGithubUrl('');
         setGithubError(null);
     }
@@ -538,19 +874,54 @@ export function PromptComposer({
         setGithubError(null);
     }
 
-    const inputDisabled = disabled || submitting;
+    const attachMenuActions: Record<AttachMenuItemId, () => void> = {
+        image: onClickImages,
+        file: onClickFile,
+        folder: onClickFolder,
+        github: onClickGithub,
+    };
+
+    // Menu rows are padded buttons with their own rounding inside a padded
+    // popover, so hover reads as a contained pill rather than a full-bleed
+    // band — and at 13px the labels sit under the prompt text instead of
+    // competing with it.
+    const menuItemClass = cn(
+        'flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-[13px]',
+        'text-text transition-colors dark:text-text-dark',
+        'hover:bg-foreground/[0.06] focus:bg-foreground/[0.06] focus:outline-none',
+        'dark:hover:bg-white/[0.06] dark:focus:bg-white/[0.06]',
+    );
+    const menuIconClass =
+        'flex size-6 shrink-0 items-center justify-center rounded-md bg-foreground/[0.05] text-text-secondary dark:bg-white/[0.06] dark:text-text-secondary-dark';
+    const toolbarButtonClass = cn(
+        'rounded-lg p-2 transition-colors',
+        'text-text-muted dark:text-text-muted-dark',
+        'hover:bg-foreground/[0.06] hover:text-text dark:hover:bg-white/[0.06] dark:hover:text-text-dark',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40',
+        'disabled:cursor-not-allowed disabled:opacity-40',
+    );
 
     return (
         <div className={cn('w-full space-y-3', className)}>
             <div
+                onDragEnter={onDragEnter}
+                onDragOver={onDragOver}
+                onDragLeave={onDragLeave}
+                onDrop={onDrop}
+                data-dragging={dragging || undefined}
                 className={cn(
-                    'relative flex flex-col rounded-2xl overflow-hidden',
+                    'relative flex flex-col overflow-hidden rounded-2xl',
                     'border border-border/60 dark:border-white/10',
                     'bg-background dark:bg-zinc-900/50',
                     'shadow-sm',
                     'transition-[border-color,box-shadow,opacity] duration-200',
-                    'focus-within:border-border dark:focus-within:border-white/20',
-                    submitting && 'opacity-60 pointer-events-none',
+                    'focus-within:border-border-secondary focus-within:shadow-md',
+                    'focus-within:ring-2 focus-within:ring-foreground/6',
+                    'dark:focus-within:border-white/20',
+                    dictating && 'border-border-secondary dark:border-white/20',
+                    dragging &&
+                        'border-border-secondary ring-2 ring-foreground/10 dark:border-white/25',
+                    submitting && 'pointer-events-none opacity-60',
                 )}
             >
                 <textarea
@@ -559,6 +930,7 @@ export function PromptComposer({
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                     onKeyDown={onKeyDown}
+                    onPaste={onPaste}
                     onFocus={() => setFocused(true)}
                     onBlur={() => setFocused(false)}
                     placeholder={effectivePlaceholder}
@@ -567,434 +939,352 @@ export function PromptComposer({
                     disabled={inputDisabled}
                     aria-label={ariaLabel}
                     data-testid={testId}
-                    className="block w-full resize-none bg-transparent px-4 pt-4 pb-3 text-base leading-relaxed placeholder:text-text-muted/50 dark:placeholder:text-text-muted-dark/50 text-text dark:text-text-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/40 focus-visible:outline-offset-[-2px]"
+                    className="block w-full resize-none bg-transparent px-4 pb-3 pt-4 text-base leading-relaxed text-text placeholder:text-text-muted/50 focus:outline-none dark:text-text-dark dark:placeholder:text-text-muted-dark/50"
                 />
 
-                {attachments.length > 0 ? (
-                    <div
-                        className="flex flex-wrap gap-2 px-4 pb-2"
-                        aria-label="Attached files"
-                        data-testid={testId ? `${testId}-attachments` : undefined}
+                <AttachmentStrip
+                    attachments={attachments}
+                    onRemove={removeAttachment}
+                    onRetry={retryAttachment}
+                    onPreview={setPreviewId}
+                    testId={testId}
+                />
+
+                {notice ? (
+                    <p
+                        className="px-4 pb-2 text-[11px] text-text-muted dark:text-text-muted-dark"
+                        data-testid={testId ? `${testId}-notice` : undefined}
                     >
-                        {attachments.map((a) => {
-                            if (a.kind === 'github-repo') {
-                                return (
-                                    <div
-                                        key={a.localId}
-                                        className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 dark:border-white/10 bg-foreground/[0.04] dark:bg-white/[0.04] px-2.5 py-1 text-xs text-text dark:text-text-dark"
-                                        title={a.url}
-                                    >
-                                        <Github
-                                            className="size-3 text-text-muted dark:text-text-muted-dark"
-                                            aria-hidden="true"
-                                        />
-                                        <span className="max-w-[12rem] truncate" title={a.url}>
-                                            {a.displayName}
-                                        </span>
-                                        <button
-                                            type="button"
-                                            onClick={() => removeAttachment(a.localId)}
-                                            aria-label={`Remove ${a.displayName}`}
-                                            className="ml-0.5 rounded p-0.5 text-text-muted dark:text-text-muted-dark hover:bg-foreground/10 hover:text-text dark:hover:text-text-dark transition-colors"
-                                        >
-                                            <X className="size-3" aria-hidden="true" />
-                                        </button>
-                                    </div>
-                                );
-                            }
-                            // Three visual states:
-                            //   uploading: spinner + "% N"
-                            //   error: red ring + tooltip
-                            //   ready: default
-                            const variant = a.error
-                                ? 'border-red-500/30 bg-red-500/[0.06] text-red-700 dark:text-red-300'
-                                : a.uploading
-                                  ? 'border-border/50 dark:border-white/10 bg-foreground/[0.04] dark:bg-white/[0.04] text-text-muted dark:text-text-muted-dark opacity-75'
-                                  : 'border-border/50 dark:border-white/10 bg-foreground/[0.04] dark:bg-white/[0.04] text-text dark:text-text-dark';
-                            const stateTag = a.error
-                                ? 'error'
-                                : a.uploading
-                                  ? 'uploading'
-                                  : 'ready';
-                            return (
-                                <div
-                                    key={a.localId}
-                                    className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs ${variant}`}
-                                    title={a.error || a.displayName}
-                                    data-testid={
-                                        testId ? `${testId}-attachment-${stateTag}` : undefined
-                                    }
-                                >
-                                    {a.uploading ? (
-                                        <Loader2
-                                            className="size-3 animate-spin text-text-muted dark:text-text-muted-dark"
-                                            aria-hidden="true"
-                                        />
-                                    ) : a.kind === 'folder-file' ? (
-                                        <Folder
-                                            className="size-3 text-text-muted dark:text-text-muted-dark"
-                                            aria-hidden="true"
-                                        />
-                                    ) : (
-                                        <FileIcon
-                                            className="size-3 text-text-muted dark:text-text-muted-dark"
-                                            aria-hidden="true"
-                                        />
-                                    )}
-                                    <span className="max-w-[12rem] truncate" title={a.displayName}>
-                                        {a.displayName}
-                                    </span>
-                                    {a.uploading ? (
-                                        <span
-                                            className="text-[10px] tabular-nums text-text-muted dark:text-text-muted-dark"
-                                            aria-label={`Uploading ${a.progress} percent`}
-                                        >
-                                            {a.progress}%
-                                        </span>
-                                    ) : null}
-                                    {a.error ? (
-                                        <span className="text-[10px] font-medium uppercase tracking-wider">
-                                            failed
-                                        </span>
-                                    ) : null}
-                                    <button
-                                        type="button"
-                                        onClick={() => removeAttachment(a.localId)}
-                                        aria-label={`Remove ${a.displayName}`}
-                                        className="ml-0.5 rounded p-0.5 text-text-muted dark:text-text-muted-dark hover:bg-foreground/10 hover:text-text dark:hover:text-text-dark transition-colors"
-                                    >
-                                        <X className="size-3" aria-hidden="true" />
-                                    </button>
-                                </div>
-                            );
-                        })}
-                    </div>
+                        {notice}
+                    </p>
                 ) : null}
 
-                <div className="flex items-center gap-0.5 px-2 pb-2.5 pt-1.5 border-t border-border/[0.15] dark:border-white/[0.06]">
-                    {attachmentsEnabled ? (
-                        <>
-                            {/* Hidden file pickers driven by the popover menu. */}
-                            <input
-                                ref={fileInputRef}
-                                type="file"
-                                className="hidden"
-                                onChange={onPickFiles}
-                                data-testid={testId ? `${testId}-file-input` : undefined}
-                            />
-                            <input
-                                ref={folderInputRef}
-                                type="file"
-                                multiple
-                                className="hidden"
-                                onChange={onPickFolder}
-                                data-testid={testId ? `${testId}-folder-input` : undefined}
-                                // `webkitdirectory` lets the browser pick a folder
-                                // and surface every file in it. React 19 types
-                                // accept it as a string attribute; cast for older
-                                // types.
-                                {...({ webkitdirectory: '', directory: '' } as Record<
-                                    string,
-                                    string
-                                >)}
-                            />
+                {dictating && dictation.startedAt !== null ? (
+                    <VoiceBar
+                        startedAt={dictation.startedAt}
+                        canvasRef={dictation.canvasRef}
+                        waveformActive={dictation.waveformActive}
+                        onCancel={discardDictation}
+                        onDone={finishDictation}
+                        testId={testId}
+                    />
+                ) : (
+                    <div className="flex items-center gap-0.5 border-t border-border/[0.15] px-2 pb-2.5 pt-1.5 dark:border-white/[0.06]">
+                        {attachmentsEnabled ? (
+                            <>
+                                {/* Hidden pickers driven by the popover menu. */}
+                                <input
+                                    ref={imageInputRef}
+                                    type="file"
+                                    accept="image/*"
+                                    multiple
+                                    className="hidden"
+                                    onChange={onPickFiles}
+                                    data-testid={testId ? `${testId}-image-input` : undefined}
+                                />
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    multiple
+                                    className="hidden"
+                                    onChange={onPickFiles}
+                                    data-testid={testId ? `${testId}-file-input` : undefined}
+                                />
+                                <input
+                                    ref={folderInputRef}
+                                    type="file"
+                                    multiple
+                                    className="hidden"
+                                    onChange={onPickFolder}
+                                    data-testid={testId ? `${testId}-folder-input` : undefined}
+                                    // `webkitdirectory` lets the browser pick a folder
+                                    // and surface every file in it. React 19 types
+                                    // accept it as a string attribute; cast for older
+                                    // types.
+                                    {...({ webkitdirectory: '', directory: '' } as Record<
+                                        string,
+                                        string
+                                    >)}
+                                />
 
-                            <div className="relative">
-                                <button
-                                    ref={attachButtonRef}
-                                    type="button"
-                                    onClick={() => {
-                                        setGithubFormOpen(false);
-                                        setAttachMenuOpen((v) => !v);
-                                    }}
-                                    aria-label="Add attachment"
-                                    title={
-                                        showImportGithubRepo
-                                            ? 'Add attachment (file, folder, or GitHub repo)'
-                                            : 'Add attachment (file or folder)'
-                                    }
-                                    aria-haspopup="menu"
-                                    aria-expanded={attachMenuOpen}
-                                    disabled={inputDisabled}
-                                    className={cn(
-                                        'rounded-lg p-2 transition-colors',
-                                        'text-text-muted dark:text-text-muted-dark',
-                                        'hover:bg-foreground/[0.06] hover:text-text dark:hover:text-text-dark',
-                                        'disabled:opacity-40 disabled:cursor-not-allowed',
-                                        attachMenuOpen &&
-                                            'bg-foreground/[0.06] text-text dark:text-text-dark',
-                                    )}
-                                    data-testid={testId ? `${testId}-attach` : undefined}
-                                >
-                                    <Plus className="size-4" aria-hidden="true" />
-                                </button>
-
-                                {attachMenuOpen ? (
-                                    <div
-                                        ref={attachMenuRef}
-                                        role="menu"
-                                        aria-label="Attachment options"
-                                        data-testid={testId ? `${testId}-attach-menu` : undefined}
-                                        // Positioned ABOVE the (+) button so the
-                                        // menu stays visible without clipping —
-                                        // page content below the composer is
-                                        // typically dense.
-                                        className="absolute bottom-full left-0 z-50 mb-2 min-w-[15rem] rounded-xl border border-border/60 dark:border-white/10 bg-background dark:bg-zinc-900 shadow-xl ring-1 ring-black/[0.04] dark:ring-white/[0.04] overflow-hidden"
+                                <div className="relative">
+                                    <button
+                                        ref={attachButtonRef}
+                                        type="button"
+                                        onClick={() => {
+                                            setGithubFormOpen(false);
+                                            setAttachMenuOpen((v) => !v);
+                                        }}
+                                        aria-label="Add attachment"
+                                        title={
+                                            showImportGithubRepo
+                                                ? 'Add images, files, folders, or a GitHub repo'
+                                                : 'Add images, files, or folders'
+                                        }
+                                        aria-haspopup="menu"
+                                        aria-expanded={attachMenuOpen}
+                                        disabled={inputDisabled}
+                                        className={cn(
+                                            toolbarButtonClass,
+                                            attachMenuOpen &&
+                                                'bg-foreground/[0.06] text-text dark:text-text-dark',
+                                        )}
+                                        data-testid={testId ? `${testId}-attach` : undefined}
                                     >
-                                        {githubFormOpen ? (
-                                            <div className="flex flex-col gap-3 p-3">
-                                                <label
-                                                    htmlFor={
-                                                        testId
-                                                            ? `${testId}-attach-github-input`
-                                                            : undefined
-                                                    }
-                                                    className="text-[11px] font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark"
-                                                >
-                                                    GitHub repo URL
-                                                </label>
-                                                <input
-                                                    ref={githubInputRef}
-                                                    id={
-                                                        testId
-                                                            ? `${testId}-attach-github-input`
-                                                            : undefined
-                                                    }
-                                                    data-testid={
-                                                        testId
-                                                            ? `${testId}-attach-github-input`
-                                                            : undefined
-                                                    }
-                                                    type="url"
-                                                    value={githubUrl}
-                                                    onChange={(e) => {
-                                                        setGithubUrl(e.target.value);
-                                                        if (githubError) setGithubError(null);
-                                                    }}
-                                                    onKeyDown={(e) => {
-                                                        if (e.key === 'Enter') {
-                                                            e.preventDefault();
-                                                            onAddGithub();
-                                                        } else if (e.key === 'Escape') {
-                                                            e.preventDefault();
-                                                            onCancelGithub();
-                                                        }
-                                                    }}
-                                                    placeholder="https://github.com/owner/repo"
-                                                    className="w-full rounded-lg border border-border/60 dark:border-white/10 bg-foreground/[0.03] dark:bg-white/[0.03] px-3 py-1.5 text-xs text-text dark:text-text-dark placeholder:text-text-muted/50 dark:placeholder:text-text-muted-dark/50 focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-colors"
-                                                />
-                                                {githubError ? (
-                                                    <p
-                                                        role="alert"
-                                                        className="text-[11px] text-red-600 dark:text-red-400"
-                                                    >
-                                                        {githubError}
-                                                    </p>
-                                                ) : null}
-                                                <div className="flex items-center justify-end gap-2">
-                                                    <button
-                                                        type="button"
-                                                        onClick={onCancelGithub}
-                                                        className="rounded-lg px-3 py-1.5 text-xs text-text-muted dark:text-text-muted-dark hover:bg-foreground/[0.06] transition-colors"
-                                                    >
-                                                        Cancel
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={onAddGithub}
-                                                        data-testid={
+                                        <Plus
+                                            className={cn(
+                                                'size-4 transition-transform duration-200',
+                                                attachMenuOpen && 'rotate-45',
+                                            )}
+                                            aria-hidden="true"
+                                        />
+                                    </button>
+
+                                    {attachMenuOpen ? (
+                                        <div
+                                            ref={attachMenuRef}
+                                            role="menu"
+                                            aria-label="Attachment options"
+                                            onKeyDown={onMenuKeyDown}
+                                            data-testid={
+                                                testId ? `${testId}-attach-menu` : undefined
+                                            }
+                                            // Positioned ABOVE the (+) button so the
+                                            // menu stays visible without clipping —
+                                            // page content below the composer is
+                                            // typically dense.
+                                            className={cn(
+                                                'absolute bottom-full left-0 z-50 mb-2 w-60 overflow-hidden rounded-2xl',
+                                                'border border-border/60 bg-background shadow-lg shadow-black/5',
+                                                'dark:border-white/10 dark:bg-zinc-900 dark:shadow-black/40',
+                                                'animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150',
+                                            )}
+                                        >
+                                            {githubFormOpen ? (
+                                                <div className="flex flex-col gap-3 p-3">
+                                                    <label
+                                                        htmlFor={
                                                             testId
-                                                                ? `${testId}-attach-github-add`
+                                                                ? `${testId}-attach-github-input`
                                                                 : undefined
                                                         }
-                                                        className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-primary/90 transition-colors"
+                                                        className="text-[11px] font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark"
                                                     >
-                                                        Add
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        ) : (
-                                            <ul className="flex flex-col py-1.5">
-                                                <li>
-                                                    <button
-                                                        type="button"
-                                                        role="menuitem"
-                                                        onClick={onClickFile}
-                                                        data-testid={
+                                                        GitHub repo URL
+                                                    </label>
+                                                    <input
+                                                        ref={githubInputRef}
+                                                        id={
                                                             testId
-                                                                ? `${testId}-attach-file`
+                                                                ? `${testId}-attach-github-input`
                                                                 : undefined
                                                         }
-                                                        className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-text dark:text-text-dark hover:bg-foreground/[0.05] transition-colors"
-                                                    >
-                                                        <FileIcon
-                                                            className="size-4 text-text-muted dark:text-text-muted-dark"
-                                                            aria-hidden="true"
-                                                        />
-                                                        Upload a file
-                                                    </button>
-                                                </li>
-                                                <li>
-                                                    <button
-                                                        type="button"
-                                                        role="menuitem"
-                                                        onClick={onClickFolder}
                                                         data-testid={
                                                             testId
-                                                                ? `${testId}-attach-folder`
+                                                                ? `${testId}-attach-github-input`
                                                                 : undefined
                                                         }
-                                                        className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-text dark:text-text-dark hover:bg-foreground/[0.05] transition-colors"
-                                                    >
-                                                        <Folder
-                                                            className="size-4 text-text-muted dark:text-text-muted-dark"
-                                                            aria-hidden="true"
-                                                        />
-                                                        Upload a folder
-                                                    </button>
-                                                </li>
-                                                {showImportGithubRepo ? (
-                                                    <li>
+                                                        type="url"
+                                                        value={githubUrl}
+                                                        onChange={(e) => {
+                                                            setGithubUrl(e.target.value);
+                                                            if (githubError) setGithubError(null);
+                                                        }}
+                                                        onKeyDown={(e) => {
+                                                            if (e.key === 'Enter') {
+                                                                e.preventDefault();
+                                                                onAddGithub();
+                                                            } else if (e.key === 'Escape') {
+                                                                e.preventDefault();
+                                                                onCancelGithub();
+                                                            }
+                                                        }}
+                                                        placeholder="https://github.com/owner/repo"
+                                                        className="w-full rounded-lg border border-border/60 bg-foreground/[0.03] px-2.5 py-1.5 text-[13px] text-text transition-colors placeholder:text-text-muted/50 focus:border-border-secondary focus:outline-none focus:ring-1 focus:ring-foreground/10 dark:border-white/10 dark:bg-white/[0.03] dark:text-text-dark dark:placeholder:text-text-muted-dark/50 dark:focus:border-white/25"
+                                                    />
+                                                    {githubError ? (
+                                                        <p
+                                                            role="alert"
+                                                            className="text-[11px] text-danger"
+                                                        >
+                                                            {githubError}
+                                                        </p>
+                                                    ) : null}
+                                                    <div className="flex items-center justify-end gap-2">
                                                         <button
                                                             type="button"
-                                                            role="menuitem"
-                                                            onClick={onClickGithub}
+                                                            onClick={onCancelGithub}
+                                                            className="rounded-lg px-2.5 py-1.5 text-xs text-text-muted transition-colors hover:bg-foreground/[0.06] dark:text-text-muted-dark dark:hover:bg-white/[0.06]"
+                                                        >
+                                                            Cancel
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            onClick={onAddGithub}
                                                             data-testid={
                                                                 testId
-                                                                    ? `${testId}-attach-github`
+                                                                    ? `${testId}-attach-github-add`
                                                                     : undefined
                                                             }
-                                                            className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-text dark:text-text-dark hover:bg-foreground/[0.05] transition-colors"
+                                                            className="rounded-lg bg-button-primary px-2.5 py-1.5 text-xs font-medium text-button-primary-foreground transition-colors hover:bg-button-primary-hover dark:bg-button-primary-dark dark:text-button-primary-foreground-dark dark:hover:bg-button-primary-hover-dark"
                                                         >
-                                                            <Github
-                                                                className="size-4 text-text-muted dark:text-text-muted-dark"
-                                                                aria-hidden="true"
-                                                            />
-                                                            Import GitHub Repo
+                                                            Add
                                                         </button>
-                                                    </li>
-                                                ) : null}
-                                            </ul>
-                                        )}
-                                    </div>
-                                ) : null}
-                            </div>
-                        </>
-                    ) : null}
+                                                    </div>
+                                                </div>
+                                            ) : (
+                                                <ul className="flex flex-col gap-0.5 p-1.5">
+                                                    {ATTACH_MENU_ITEMS.map((item) => {
+                                                        if (
+                                                            item.id === 'github' &&
+                                                            !showImportGithubRepo
+                                                        )
+                                                            return null;
+                                                        const Icon = item.icon;
+                                                        return (
+                                                            <li key={item.id}>
+                                                                <button
+                                                                    type="button"
+                                                                    role="menuitem"
+                                                                    onClick={
+                                                                        attachMenuActions[item.id]
+                                                                    }
+                                                                    data-testid={
+                                                                        testId
+                                                                            ? `${testId}-attach-${item.id}`
+                                                                            : undefined
+                                                                    }
+                                                                    className={menuItemClass}
+                                                                >
+                                                                    <span
+                                                                        className={menuIconClass}
+                                                                        aria-hidden="true"
+                                                                    >
+                                                                        <Icon className="size-3.5" />
+                                                                    </span>
+                                                                    <span className="min-w-0 flex-1">
+                                                                        <span className="block truncate">
+                                                                            {item.label}
+                                                                        </span>
+                                                                        <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                                                                            {item.hint}
+                                                                        </span>
+                                                                    </span>
+                                                                </button>
+                                                            </li>
+                                                        );
+                                                    })}
+                                                </ul>
+                                            )}
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </>
+                        ) : null}
 
-                    {speech.supported ? (
-                        <button
-                            type="button"
-                            onClick={() => (speech.listening ? speech.stop() : speech.start())}
-                            aria-label={speech.listening ? 'Stop dictation' : 'Start dictation'}
-                            title={speech.listening ? 'Stop dictation' : 'Dictate your prompt'}
-                            aria-pressed={speech.listening}
-                            disabled={inputDisabled}
-                            className={cn(
-                                'rounded-lg p-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed',
-                                speech.listening
-                                    ? 'text-red-500 bg-red-500/10'
-                                    : 'text-text-muted dark:text-text-muted-dark hover:bg-foreground/[0.06] hover:text-text dark:hover:text-text-dark',
-                            )}
-                            data-testid={testId ? `${testId}-mic` : undefined}
-                        >
-                            <Mic className="size-4" aria-hidden="true" />
-                        </button>
-                    ) : null}
+                        {dictation.supported ? (
+                            <button
+                                type="button"
+                                onClick={startDictation}
+                                aria-label="Start dictation"
+                                title="Dictate your prompt"
+                                disabled={inputDisabled}
+                                className={toolbarButtonClass}
+                                data-testid={testId ? `${testId}-mic` : undefined}
+                            >
+                                <Mic className="size-4" aria-hidden="true" />
+                            </button>
+                        ) : null}
 
-                    <div className="ml-auto flex items-center gap-3">
-                        {showCounter ? (
-                            <span
+                        <div className="ml-auto flex items-center gap-3">
+                            {/* Counter stays out of the way until it's close to
+                                mattering, or the user is actively typing. */}
+                            {showCounter && (focused || trimmed.length > maxLength * 0.6) ? (
+                                <span
+                                    className={cn(
+                                        'text-[11px] tabular-nums transition-colors',
+                                        trimmed.length >= maxLength
+                                            ? 'text-danger'
+                                            : trimmed.length > maxLength * 0.9
+                                              ? 'text-warning'
+                                              : 'text-text-muted/60 dark:text-text-muted-dark/60',
+                                    )}
+                                >
+                                    {trimmed.length}/{maxLength}
+                                </span>
+                            ) : null}
+                            <button
+                                type="button"
+                                onClick={onSubmit}
+                                disabled={!canSubmit}
+                                title={submitTitle}
+                                aria-label={submitTitle || ariaLabel}
+                                data-testid={testId ? `${testId}-submit` : undefined}
                                 className={cn(
-                                    'text-[11px] tabular-nums transition-colors',
-                                    trimmed.length > maxLength * 0.9
-                                        ? 'text-amber-500 dark:text-amber-400'
-                                        : 'text-text-muted/60 dark:text-text-muted-dark/60',
+                                    'inline-flex items-center justify-center rounded-full p-2.5',
+                                    'transition-[transform,box-shadow,background-color,color] duration-150',
+                                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                                    canSubmit
+                                        ? cn(
+                                              'bg-button-primary text-button-primary-foreground shadow-sm',
+                                              'dark:bg-button-primary-dark dark:text-button-primary-foreground-dark',
+                                              'hover:bg-button-primary-hover hover:shadow-md',
+                                              'dark:hover:bg-button-primary-hover-dark active:scale-95',
+                                          )
+                                        : // Neutral rather than a faded solid: a
+                                          // ghosted action button reads as "broken",
+                                          // a quiet one reads as "not yet".
+                                          'cursor-not-allowed bg-foreground/[0.06] text-text-muted dark:bg-white/[0.06] dark:text-text-muted-dark',
                                 )}
                             >
-                                {trimmed.length}/{maxLength}
-                            </span>
-                        ) : null}
-                        <button
-                            type="button"
-                            onClick={onSubmit}
-                            disabled={!canSubmit}
-                            title={submitTitle}
-                            aria-label={submitTitle || ariaLabel}
-                            data-testid={testId ? `${testId}-submit` : undefined}
-                            className={cn(
-                                'inline-flex items-center justify-center rounded-full p-2.5',
-                                'bg-primary text-white',
-                                'shadow-sm hover:bg-primary/90 hover:shadow-md',
-                                'active:scale-95',
-                                'transition-[transform,box-shadow,background-color] duration-150',
-                                'disabled:cursor-not-allowed disabled:opacity-35',
-                            )}
-                        >
-                            {submitting ? (
-                                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                            ) : (
-                                <ArrowRight className="size-4" aria-hidden="true" />
-                            )}
-                        </button>
+                                {submitting ? (
+                                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                                ) : (
+                                    <ArrowUp className="size-4" aria-hidden="true" />
+                                )}
+                            </button>
+                        </div>
                     </div>
-                </div>
+                )}
+
+                {dragging ? (
+                    <div
+                        className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-background/85 backdrop-blur-sm dark:bg-zinc-900/85"
+                        data-testid={testId ? `${testId}-dropzone` : undefined}
+                    >
+                        <div className="flex flex-col items-center gap-2 rounded-xl border-2 border-dashed border-border-secondary px-8 py-5 dark:border-white/25">
+                            <Paperclip
+                                className="size-5 text-text-secondary dark:text-text-secondary-dark"
+                                aria-hidden="true"
+                            />
+                            <p className="text-sm font-medium text-text dark:text-text-dark">
+                                Drop files or a folder to attach
+                            </p>
+                        </div>
+                    </div>
+                ) : null}
             </div>
+
+            <span aria-live="polite" className="sr-only">
+                {[notice, status].filter(Boolean).join('. ')}
+            </span>
+
+            {previewIndex >= 0 ? (
+                <AttachmentPreview
+                    attachments={previewable}
+                    index={previewIndex}
+                    onIndexChange={(next) => setPreviewId(previewable[next]?.localId ?? null)}
+                    onClose={() => setPreviewId(null)}
+                    testId={testId}
+                />
+            ) : null}
 
             {chipsBelow ? <div>{chipsBelow}</div> : null}
         </div>
     );
 }
 
-// Re-export the attachment shape so consumers wiring up
-// `onAttachmentsChange` can type their state safely.
-export type { ComposerAttachment };
-
-/**
- * Helper for caller pages: turn the composer's full attachment list
- * into the lighter `{ name, url, mimeType?, kind }` shape that
- * `useStartFromPrompt` accepts. Uploads still in flight, uploads that
- * failed, and entries that don't yet have a server-side URL are
- * filtered out — only references the chat AI can actually act on are
- * forwarded.
- *
- * Returned tuple matches `StartFromPromptAttachmentRef` from
- * `use-start-from-prompt.tsx`; we don't import the type here to keep
- * this module free of upstream-hook dependencies, but consumers can
- * pass the return value straight into `startFromPrompt({ attachments })`.
- */
-export interface ComposerAttachmentRef {
-    readonly name: string;
-    readonly url: string;
-    readonly mimeType?: string;
-    readonly kind: 'upload' | 'github-repo';
-    /**
-     * SHA-256 upload id — present only for `kind: 'upload'` refs that
-     * have completed. Callers that wire the upload to a freshly-
-     * created entity (Mission/Idea/Agent) pass this to
-     * `addAttachment`. The chat-forwarder ignores this field.
-     */
-    readonly uploadId?: string;
-}
-
-export function buildAttachmentRefs(
-    attachments: ReadonlyArray<ComposerAttachment>,
-): ReadonlyArray<ComposerAttachmentRef> {
-    const refs: ComposerAttachmentRef[] = [];
-    for (const a of attachments) {
-        if (a.kind === 'github-repo') {
-            refs.push({ name: a.displayName, url: a.url, kind: 'github-repo' });
-            continue;
-        }
-        if (a.url && a.uploadId && !a.uploading && !a.error) {
-            refs.push({
-                name: a.displayName,
-                url: a.url,
-                mimeType: a.mimeType,
-                kind: 'upload',
-                uploadId: a.uploadId,
-            });
-        }
-    }
-    return refs;
-}
+// Re-export the attachment shapes + ref helper so existing consumers keep
+// importing them from this module.
+export { buildAttachmentRefs };
+export type { ComposerAttachment, ComposerAttachmentRef };

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -23,6 +23,7 @@ import {
     type KeyboardEvent,
     type ReactNode,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils/cn';
 import { uploadFile, UploadError } from '@/lib/api/uploads';
 import { AttachmentStrip } from './composer/AttachmentStrip';
@@ -226,6 +227,53 @@ interface DirectoryEntryLike {
 const MAX_DROPPED_FOLDER_FILES = 200;
 
 /**
+ * Ceiling (px) the auto-growing textarea stops at before it scrolls
+ * internally. Matches the height of the fixed three-row box the composer
+ * used before it grew with its content: three lines of `text-base` at
+ * `leading-relaxed` (3 × 26px) plus the `pt-4` / `pb-3` padding (28px).
+ */
+const MAX_TEXTAREA_HEIGHT = 106;
+
+/**
+ * Geometry for the (+) popover. It renders in a portal at the document root
+ * rather than next to the button, because the composer card clips its
+ * children (`overflow-hidden`, for the rounded corners) and the pages that
+ * embed the composer clip theirs — an absolutely positioned menu got sliced
+ * off at the card's edge.
+ *
+ * `MENU_WIDTH` mirrors the old `w-60` and `MENU_EST_HEIGHT` is roughly the
+ * tallest the menu gets (four rows); both only feed the flip / clamp
+ * decisions, so approximations are fine.
+ */
+const MENU_WIDTH = 240;
+const MENU_EST_HEIGHT = 260;
+const MENU_GAP = 8;
+const VIEWPORT_MARGIN = 8;
+
+interface MenuPosition {
+    readonly left: number;
+    /** Set when the menu opens downward. */
+    readonly top?: number;
+    /** Set when the menu opens upward (the preferred direction). */
+    readonly bottom?: number;
+}
+
+function measureMenuPosition(button: HTMLElement): MenuPosition {
+    const rect = button.getBoundingClientRect();
+    const left = Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(rect.left, window.innerWidth - MENU_WIDTH - VIEWPORT_MARGIN),
+    );
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    // Above is the default — content directly under a composer is usually
+    // dense — but flip when there genuinely isn't room up there.
+    const openAbove = spaceAbove >= MENU_EST_HEIGHT + MENU_GAP || spaceAbove >= spaceBelow;
+    if (openAbove) return { left, bottom: window.innerHeight - rect.top + MENU_GAP };
+    return { left, top: rect.bottom + MENU_GAP };
+}
+
+/**
  * `webkitGetAsEntry()` must be called synchronously inside the drop handler —
  * the item list is emptied as soon as the event finishes. The returned entry
  * objects stay valid afterwards, so the async walk below is safe.
@@ -302,7 +350,7 @@ export interface PromptComposerProps {
     rows?: number;
     /**
      * Ceiling (px) the auto-growing textarea stops at before it scrolls
-     * internally. Defaults to 240.
+     * internally. Defaults to the old fixed three-row height.
      */
     maxHeight?: number;
     submitting?: boolean;
@@ -356,7 +404,7 @@ export function PromptComposer({
     minLength = 10,
     maxLength = 5000,
     rows = 3,
-    maxHeight = 240,
+    maxHeight = MAX_TEXTAREA_HEIGHT,
     submitting = false,
     placeholderExamples,
     placeholder,
@@ -383,6 +431,7 @@ export function PromptComposer({
 
     const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
     const [attachMenuOpen, setAttachMenuOpen] = useState(false);
+    const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
     const [githubFormOpen, setGithubFormOpen] = useState(false);
     const [githubUrl, setGithubUrl] = useState('');
     const [githubError, setGithubError] = useState<string | null>(null);
@@ -661,8 +710,9 @@ export function PromptComposer({
     /* Text input                                                       */
     /* ---------------------------------------------------------------- */
 
-    // Grow with the content up to `maxHeight`, then scroll internally —
-    // a fixed 3-row box hid the tail of anything longer than a sentence.
+    // Grow with the content up to `maxHeight`, then scroll internally, so a
+    // short brief gets a compact box and a long one never pushes the card
+    // past the height the old fixed-row layout settled on.
     const autoGrow = useCallback(() => {
         const el = textareaRef.current;
         if (!el) return;
@@ -764,6 +814,34 @@ export function PromptComposer({
         document.addEventListener('keydown', onKey);
         return () => document.removeEventListener('keydown', onKey);
     }, [attachMenuOpen, closeAttachMenu]);
+
+    // The menu only ever opens from a click, so `document` is guaranteed by
+    // then; this guard is just for the server render of the closed state.
+    const canPortal = typeof document !== 'undefined';
+
+    const openAttachMenu = useCallback(() => {
+        setGithubFormOpen(false);
+        const button = attachButtonRef.current;
+        if (button) setMenuPosition(measureMenuPosition(button));
+        setAttachMenuOpen(true);
+    }, []);
+
+    // The portaled menu is anchored to a point in the viewport, so it has to
+    // follow the button when the page moves under it. Scroll is captured so
+    // nested scrollers count too; either event just re-measures.
+    useEffect(() => {
+        if (!attachMenuOpen) return;
+        const reposition = () => {
+            const button = attachButtonRef.current;
+            if (button) setMenuPosition(measureMenuPosition(button));
+        };
+        window.addEventListener('scroll', reposition, true);
+        window.addEventListener('resize', reposition);
+        return () => {
+            window.removeEventListener('scroll', reposition, true);
+            window.removeEventListener('resize', reposition);
+        };
+    }, [attachMenuOpen]);
 
     // Document-level mousedown listener to close the popover on outside
     // click. The composer card uses backdrop-blur which creates a
@@ -1007,13 +1085,13 @@ export function PromptComposer({
                                     >)}
                                 />
 
-                                <div className="relative">
+                                <div>
                                     <button
                                         ref={attachButtonRef}
                                         type="button"
                                         onClick={() => {
-                                            setGithubFormOpen(false);
-                                            setAttachMenuOpen((v) => !v);
+                                            if (attachMenuOpen) closeAttachMenu();
+                                            else openAttachMenu();
                                         }}
                                         aria-label="Add attachment"
                                         title={
@@ -1040,144 +1118,164 @@ export function PromptComposer({
                                         />
                                     </button>
 
-                                    {attachMenuOpen ? (
-                                        <div
-                                            ref={attachMenuRef}
-                                            role="menu"
-                                            aria-label="Attachment options"
-                                            onKeyDown={onMenuKeyDown}
-                                            data-testid={
-                                                testId ? `${testId}-attach-menu` : undefined
-                                            }
-                                            // Positioned ABOVE the (+) button so the
-                                            // menu stays visible without clipping —
-                                            // page content below the composer is
-                                            // typically dense.
-                                            className={cn(
-                                                'absolute bottom-full left-0 z-50 mb-2 w-60 overflow-hidden rounded-2xl',
-                                                'border border-border/60 bg-background shadow-lg shadow-black/5',
-                                                'dark:border-white/10 dark:bg-zinc-900 dark:shadow-black/40',
-                                                'animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150',
-                                            )}
-                                        >
-                                            {githubFormOpen ? (
-                                                <div className="flex flex-col gap-3 p-3">
-                                                    <label
-                                                        htmlFor={
-                                                            testId
-                                                                ? `${testId}-attach-github-input`
-                                                                : undefined
-                                                        }
-                                                        className="text-[11px] font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark"
-                                                    >
-                                                        GitHub repo URL
-                                                    </label>
-                                                    <input
-                                                        ref={githubInputRef}
-                                                        id={
-                                                            testId
-                                                                ? `${testId}-attach-github-input`
-                                                                : undefined
-                                                        }
-                                                        data-testid={
-                                                            testId
-                                                                ? `${testId}-attach-github-input`
-                                                                : undefined
-                                                        }
-                                                        type="url"
-                                                        value={githubUrl}
-                                                        onChange={(e) => {
-                                                            setGithubUrl(e.target.value);
-                                                            if (githubError) setGithubError(null);
-                                                        }}
-                                                        onKeyDown={(e) => {
-                                                            if (e.key === 'Enter') {
-                                                                e.preventDefault();
-                                                                onAddGithub();
-                                                            } else if (e.key === 'Escape') {
-                                                                e.preventDefault();
-                                                                onCancelGithub();
-                                                            }
-                                                        }}
-                                                        placeholder="https://github.com/owner/repo"
-                                                        className="w-full rounded-lg border border-border/60 bg-foreground/[0.03] px-2.5 py-1.5 text-[13px] text-text transition-colors placeholder:text-text-muted/50 focus:border-border-secondary focus:outline-none focus:ring-1 focus:ring-foreground/10 dark:border-white/10 dark:bg-white/[0.03] dark:text-text-dark dark:placeholder:text-text-muted-dark/50 dark:focus:border-white/25"
-                                                    />
-                                                    {githubError ? (
-                                                        <p
-                                                            role="alert"
-                                                            className="text-[11px] text-danger"
-                                                        >
-                                                            {githubError}
-                                                        </p>
-                                                    ) : null}
-                                                    <div className="flex items-center justify-end gap-2">
-                                                        <button
-                                                            type="button"
-                                                            onClick={onCancelGithub}
-                                                            className="rounded-lg px-2.5 py-1.5 text-xs text-text-muted transition-colors hover:bg-foreground/[0.06] dark:text-text-muted-dark dark:hover:bg-white/[0.06]"
-                                                        >
-                                                            Cancel
-                                                        </button>
-                                                        <button
-                                                            type="button"
-                                                            onClick={onAddGithub}
-                                                            data-testid={
-                                                                testId
-                                                                    ? `${testId}-attach-github-add`
-                                                                    : undefined
-                                                            }
-                                                            className="rounded-lg bg-button-primary px-2.5 py-1.5 text-xs font-medium text-button-primary-foreground transition-colors hover:bg-button-primary-hover dark:bg-button-primary-dark dark:text-button-primary-foreground-dark dark:hover:bg-button-primary-hover-dark"
-                                                        >
-                                                            Add
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            ) : (
-                                                <ul className="flex flex-col gap-0.5 p-1.5">
-                                                    {ATTACH_MENU_ITEMS.map((item) => {
-                                                        if (
-                                                            item.id === 'github' &&
-                                                            !showImportGithubRepo
-                                                        )
-                                                            return null;
-                                                        const Icon = item.icon;
-                                                        return (
-                                                            <li key={item.id}>
-                                                                <button
-                                                                    type="button"
-                                                                    role="menuitem"
-                                                                    onClick={
-                                                                        attachMenuActions[item.id]
-                                                                    }
-                                                                    data-testid={
-                                                                        testId
-                                                                            ? `${testId}-attach-${item.id}`
-                                                                            : undefined
-                                                                    }
-                                                                    className={menuItemClass}
-                                                                >
-                                                                    <span
-                                                                        className={menuIconClass}
-                                                                        aria-hidden="true"
-                                                                    >
-                                                                        <Icon className="size-3.5" />
-                                                                    </span>
-                                                                    <span className="min-w-0 flex-1">
-                                                                        <span className="block truncate">
-                                                                            {item.label}
-                                                                        </span>
-                                                                        <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
-                                                                            {item.hint}
-                                                                        </span>
-                                                                    </span>
-                                                                </button>
-                                                            </li>
-                                                        );
-                                                    })}
-                                                </ul>
-                                            )}
-                                        </div>
-                                    ) : null}
+                                    {attachMenuOpen && menuPosition && canPortal
+                                        ? createPortal(
+                                              <div
+                                                  ref={attachMenuRef}
+                                                  role="menu"
+                                                  aria-label="Attachment options"
+                                                  onKeyDown={onMenuKeyDown}
+                                                  data-testid={
+                                                      testId ? `${testId}-attach-menu` : undefined
+                                                  }
+                                                  // Fixed to coordinates measured off the (+)
+                                                  // button, in a portal at the document root:
+                                                  // both the composer card and the pages
+                                                  // around it clip their overflow, so an
+                                                  // absolutely positioned menu was cut off at
+                                                  // the card's edge.
+                                                  style={{
+                                                      position: 'fixed',
+                                                      left: menuPosition.left,
+                                                      top: menuPosition.top,
+                                                      bottom: menuPosition.bottom,
+                                                      width: MENU_WIDTH,
+                                                  }}
+                                                  className={cn(
+                                                      'z-70 overflow-hidden rounded-2xl',
+                                                      'border border-border/60 bg-background shadow-lg shadow-black/5',
+                                                      'dark:border-white/10 dark:bg-zinc-900 dark:shadow-black/40',
+                                                      'animate-in fade-in-0 zoom-in-95 duration-150',
+                                                      menuPosition.bottom !== undefined
+                                                          ? 'slide-in-from-bottom-1'
+                                                          : 'slide-in-from-top-1',
+                                                  )}
+                                              >
+                                                  {githubFormOpen ? (
+                                                      <div className="flex flex-col gap-3 p-3">
+                                                          <label
+                                                              htmlFor={
+                                                                  testId
+                                                                      ? `${testId}-attach-github-input`
+                                                                      : undefined
+                                                              }
+                                                              className="text-[11px] font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark"
+                                                          >
+                                                              GitHub repo URL
+                                                          </label>
+                                                          <input
+                                                              ref={githubInputRef}
+                                                              id={
+                                                                  testId
+                                                                      ? `${testId}-attach-github-input`
+                                                                      : undefined
+                                                              }
+                                                              data-testid={
+                                                                  testId
+                                                                      ? `${testId}-attach-github-input`
+                                                                      : undefined
+                                                              }
+                                                              type="url"
+                                                              value={githubUrl}
+                                                              onChange={(e) => {
+                                                                  setGithubUrl(e.target.value);
+                                                                  if (githubError)
+                                                                      setGithubError(null);
+                                                              }}
+                                                              onKeyDown={(e) => {
+                                                                  if (e.key === 'Enter') {
+                                                                      e.preventDefault();
+                                                                      onAddGithub();
+                                                                  } else if (e.key === 'Escape') {
+                                                                      e.preventDefault();
+                                                                      onCancelGithub();
+                                                                  }
+                                                              }}
+                                                              placeholder="https://github.com/owner/repo"
+                                                              className="w-full rounded-lg border border-border/60 bg-foreground/[0.03] px-2.5 py-1.5 text-[13px] text-text transition-colors placeholder:text-text-muted/50 focus:border-border-secondary focus:outline-none focus:ring-1 focus:ring-foreground/10 dark:border-white/10 dark:bg-white/[0.03] dark:text-text-dark dark:placeholder:text-text-muted-dark/50 dark:focus:border-white/25"
+                                                          />
+                                                          {githubError ? (
+                                                              <p
+                                                                  role="alert"
+                                                                  className="text-[11px] text-danger"
+                                                              >
+                                                                  {githubError}
+                                                              </p>
+                                                          ) : null}
+                                                          <div className="flex items-center justify-end gap-2">
+                                                              <button
+                                                                  type="button"
+                                                                  onClick={onCancelGithub}
+                                                                  className="rounded-lg px-2.5 py-1.5 text-xs text-text-muted transition-colors hover:bg-foreground/[0.06] dark:text-text-muted-dark dark:hover:bg-white/[0.06]"
+                                                              >
+                                                                  Cancel
+                                                              </button>
+                                                              <button
+                                                                  type="button"
+                                                                  onClick={onAddGithub}
+                                                                  data-testid={
+                                                                      testId
+                                                                          ? `${testId}-attach-github-add`
+                                                                          : undefined
+                                                                  }
+                                                                  className="rounded-lg bg-button-primary px-2.5 py-1.5 text-xs font-medium text-button-primary-foreground transition-colors hover:bg-button-primary-hover dark:bg-button-primary-dark dark:text-button-primary-foreground-dark dark:hover:bg-button-primary-hover-dark"
+                                                              >
+                                                                  Add
+                                                              </button>
+                                                          </div>
+                                                      </div>
+                                                  ) : (
+                                                      <ul className="flex flex-col gap-0.5 p-1.5">
+                                                          {ATTACH_MENU_ITEMS.map((item) => {
+                                                              if (
+                                                                  item.id === 'github' &&
+                                                                  !showImportGithubRepo
+                                                              )
+                                                                  return null;
+                                                              const Icon = item.icon;
+                                                              return (
+                                                                  <li key={item.id}>
+                                                                      <button
+                                                                          type="button"
+                                                                          role="menuitem"
+                                                                          onClick={
+                                                                              attachMenuActions[
+                                                                                  item.id
+                                                                              ]
+                                                                          }
+                                                                          data-testid={
+                                                                              testId
+                                                                                  ? `${testId}-attach-${item.id}`
+                                                                                  : undefined
+                                                                          }
+                                                                          className={menuItemClass}
+                                                                      >
+                                                                          <span
+                                                                              className={
+                                                                                  menuIconClass
+                                                                              }
+                                                                              aria-hidden="true"
+                                                                          >
+                                                                              <Icon className="size-3.5" />
+                                                                          </span>
+                                                                          <span className="min-w-0 flex-1">
+                                                                              <span className="block truncate">
+                                                                                  {item.label}
+                                                                              </span>
+                                                                              <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                                                                                  {item.hint}
+                                                                              </span>
+                                                                          </span>
+                                                                      </button>
+                                                                  </li>
+                                                              );
+                                                          })}
+                                                      </ul>
+                                                  )}
+                                              </div>,
+                                              document.body,
+                                          )
+                                        : null}
                                 </div>
                             </>
                         ) : null}

--- a/apps/web/src/components/common/PromptComposer.unit.spec.tsx
+++ b/apps/web/src/components/common/PromptComposer.unit.spec.tsx
@@ -1,10 +1,5 @@
-// Unit spec for the PromptComposer's attachment + dictation behaviour:
-// image thumbnails and the full-size preview overlay, paste / drop intake,
-// document cards, folder grouping, and the dictation bar's append / discard
-// semantics.
-//
-// The upload client is mocked — this spec is about what the composer renders
-// and hands back, not about the XHR in `lib/api/uploads`.
+// The upload client is mocked — this spec covers what the composer renders and
+// hands back, not the XHR in `lib/api/uploads`.
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -141,8 +136,7 @@ describe('PromptComposer attachments', () => {
         const card = await screen.findByTestId(`${TEST_ID}-attachment-ready`);
         expect(card).toHaveTextContent('brief.pdf');
         expect(card).toHaveTextContent(/PDF · \d+ B/);
-        // A PDF is not an image and cannot be rendered in-app, so no thumbnail
-        // and no preview affordance — a download instead.
+        // A PDF cannot be rendered in-app, so it offers a download instead.
         expect(screen.queryByLabelText('Preview brief.pdf')).toBeNull();
         expect(screen.getByLabelText('Download brief.pdf')).toBeInTheDocument();
         await waitFor(() => expect(screen.getByTestId('ref-count')).toHaveTextContent('1'));
@@ -223,10 +217,6 @@ describe('PromptComposer attachments', () => {
     });
 });
 
-/* -------------------------------------------------------------------- */
-/* Dictation                                                            */
-/* -------------------------------------------------------------------- */
-
 interface FakeSpeechEvent {
     resultIndex: number;
     results: { length: number; [index: number]: unknown };
@@ -274,8 +264,7 @@ describe('PromptComposer dictation', () => {
         // Send is replaced by keep/discard — recording is a mode, not a toggle.
         expect(screen.queryByTestId(`${TEST_ID}-submit`)).toBeNull();
         expect(screen.getByTestId(`${TEST_ID}-voice-done`)).toBeInTheDocument();
-        // No getUserMedia in jsdom, so the live meter degrades to static bars;
-        // the wordless bar keeps its status in an sr-only region.
+        // No getUserMedia in jsdom, so the live meter degrades to static bars.
         expect(screen.getByTestId(`${TEST_ID}-voice-static`)).toBeInTheDocument();
         expect(screen.getByText('Listening…')).toHaveClass('sr-only');
     });

--- a/apps/web/src/components/common/PromptComposer.unit.spec.tsx
+++ b/apps/web/src/components/common/PromptComposer.unit.spec.tsx
@@ -253,7 +253,12 @@ describe('PromptComposer dictation', () => {
         (window as unknown as { SpeechRecognition: unknown }).SpeechRecognition = FakeRecognition;
     });
     afterEach(() => {
-        delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
+        const w = window as unknown as {
+            SpeechRecognition?: unknown;
+            webkitSpeechRecognition?: unknown;
+        };
+        delete w.SpeechRecognition;
+        delete w.webkitSpeechRecognition;
     });
 
     it('swaps the toolbar for the dictation bar while listening', async () => {
@@ -279,6 +284,22 @@ describe('PromptComposer dictation', () => {
 
         fireEvent.click(screen.getByTestId(`${TEST_ID}-voice-cancel`));
         await waitFor(() => expect(textarea.value).toBe('Build me'));
+    });
+
+    it('falls back to webkitSpeechRecognition on browsers without the standard name', async () => {
+        const w = window as unknown as {
+            SpeechRecognition?: unknown;
+            webkitSpeechRecognition?: unknown;
+        };
+        delete w.SpeechRecognition;
+        w.webkitSpeechRecognition = FakeRecognition;
+
+        render(<Harness />);
+        fireEvent.click(await screen.findByTestId(`${TEST_ID}-mic`));
+
+        emit('a pricing page');
+        const textarea = screen.getByTestId(TEST_ID) as HTMLTextAreaElement;
+        await waitFor(() => expect(textarea.value).toBe('a pricing page'));
     });
 
     it('keeps the transcript when dictation is confirmed', async () => {

--- a/apps/web/src/components/common/PromptComposer.unit.spec.tsx
+++ b/apps/web/src/components/common/PromptComposer.unit.spec.tsx
@@ -1,0 +1,306 @@
+// Unit spec for the PromptComposer's attachment + dictation behaviour:
+// image thumbnails and the full-size preview overlay, paste / drop intake,
+// document cards, folder grouping, and the dictation bar's append / discard
+// semantics.
+//
+// The upload client is mocked — this spec is about what the composer renders
+// and hands back, not about the XHR in `lib/api/uploads`.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import { PromptComposer, buildAttachmentRefs, type ComposerAttachment } from './PromptComposer';
+
+vi.mock('@/lib/api/uploads', () => ({
+    uploadFile: vi.fn(() =>
+        Promise.resolve({
+            id: 'sha256-abc',
+            url: '/api/uploads/user-1/sha256-abc.png',
+            filename: 'sha256-abc.png',
+            size: 4,
+            mimeType: 'image/png',
+            hash: 'sha256-abc',
+        }),
+    ),
+    UploadError: class UploadError extends Error {},
+}));
+
+const TEST_ID = 'pc';
+
+function imageFile(name = 'shot.png') {
+    return new File(['png-'], name, { type: 'image/png' });
+}
+function textFile(name = 'notes.txt') {
+    return new File(['hello'], name, { type: 'text/plain' });
+}
+function pdfFile(name = 'brief.pdf') {
+    return new File(['%PDF-'], name, { type: 'application/pdf' });
+}
+/** A file as the folder picker hands it over: name plus a relative path. */
+function folderFile(relativePath: string) {
+    const file = new File(['x'], relativePath.split('/').pop() ?? relativePath, {
+        type: 'text/plain',
+    });
+    Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+    return file;
+}
+
+/** Controlled wrapper — the composer is a controlled input. */
+function Harness(props: { readonly initial?: string } = {}) {
+    const [value, setValue] = useState(props.initial ?? '');
+    const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
+    return (
+        <>
+            <PromptComposer
+                value={value}
+                onChange={setValue}
+                onSubmit={() => undefined}
+                ariaLabel="Describe your work"
+                testId={TEST_ID}
+                showImportGithubRepo
+                onAttachmentsChange={setAttachments}
+            />
+            <output data-testid="ref-count">{buildAttachmentRefs(attachments).length}</output>
+        </>
+    );
+}
+
+beforeEach(() => {
+    // jsdom implements neither of these.
+    URL.createObjectURL = vi.fn(() => 'blob:mock-preview');
+    URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('PromptComposer attachments', () => {
+    it('renders a picked image as a clickable thumbnail, not a filename chip', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-image-input`), {
+            target: { files: [imageFile()] },
+        });
+
+        const tile = await screen.findByLabelText('Preview shot.png');
+        const thumb = tile.querySelector('img');
+        expect(thumb).toBeTruthy();
+        expect(thumb).toHaveAttribute('src', 'blob:mock-preview');
+    });
+
+    it('opens the full-size lightbox when the thumbnail is clicked, and closes on Escape', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-image-input`), {
+            target: { files: [imageFile('diagram.png')] },
+        });
+        fireEvent.click(await screen.findByLabelText('Preview diagram.png'));
+
+        const lightbox = await screen.findByTestId(`${TEST_ID}-lightbox`);
+        expect(lightbox).toHaveAttribute('aria-modal', 'true');
+        expect(screen.getByTestId(`${TEST_ID}-lightbox-image`)).toHaveAttribute(
+            'alt',
+            'diagram.png',
+        );
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        await waitFor(() =>
+            expect(screen.queryByTestId(`${TEST_ID}-lightbox`)).not.toBeInTheDocument(),
+        );
+    });
+
+    it('steps through multiple images with the arrow keys', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-image-input`), {
+            target: { files: [imageFile('one.png'), imageFile('two.png')] },
+        });
+        fireEvent.click(await screen.findByLabelText('Preview one.png'));
+
+        expect(screen.getByTestId(`${TEST_ID}-lightbox-image`)).toHaveAttribute('alt', 'one.png');
+        fireEvent.keyDown(document, { key: 'ArrowRight' });
+        await waitFor(() =>
+            expect(screen.getByTestId(`${TEST_ID}-lightbox-image`)).toHaveAttribute(
+                'alt',
+                'two.png',
+            ),
+        );
+    });
+
+    it('renders a document as a typed card and exposes it as a ref once uploaded', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-file-input`), {
+            target: { files: [pdfFile()] },
+        });
+
+        // Ready only after the mocked upload resolves — an in-flight upload is
+        // never forwarded to callers.
+        const card = await screen.findByTestId(`${TEST_ID}-attachment-ready`);
+        expect(card).toHaveTextContent('brief.pdf');
+        expect(card).toHaveTextContent(/PDF · \d+ B/);
+        // A PDF is not an image and cannot be rendered in-app, so no thumbnail
+        // and no preview affordance — a download instead.
+        expect(screen.queryByLabelText('Preview brief.pdf')).toBeNull();
+        expect(screen.getByLabelText('Download brief.pdf')).toBeInTheDocument();
+        await waitFor(() => expect(screen.getByTestId('ref-count')).toHaveTextContent('1'));
+    });
+
+    it('previews a text document from the local file, without waiting on the upload', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-file-input`), {
+            target: { files: [textFile()] },
+        });
+        fireEvent.click(await screen.findByLabelText('Preview notes.txt'));
+
+        const pane = await screen.findByTestId(`${TEST_ID}-lightbox-text`);
+        await waitFor(() => expect(pane).toHaveTextContent('hello'));
+    });
+
+    it('collapses a picked folder into one expandable card', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-folder-input`), {
+            target: {
+                files: [folderFile('docs/intro.md'), folderFile('docs/guides/setup.md')],
+            },
+        });
+
+        const card = await screen.findByTestId(`${TEST_ID}-attachment-folder`);
+        expect(card).toHaveTextContent('docs');
+        // Collapsed: the individual paths are not on screen yet.
+        expect(screen.queryByText('guides/setup.md')).toBeNull();
+
+        fireEvent.click(screen.getByLabelText('Expand folder docs'));
+        expect(await screen.findByText('guides/setup.md')).toBeInTheDocument();
+        expect(screen.getByText('intro.md')).toBeInTheDocument();
+
+        // Removing the folder removes every file it contributed.
+        fireEvent.click(screen.getByLabelText('Remove folder docs'));
+        await waitFor(() =>
+            expect(screen.queryByTestId(`${TEST_ID}-attachment-folder`)).not.toBeInTheDocument(),
+        );
+    });
+
+    it('attaches a pasted screenshot', async () => {
+        render(<Harness />);
+
+        fireEvent.paste(screen.getByTestId(TEST_ID), {
+            clipboardData: { types: ['Files'], files: [imageFile('pasted.png')], items: [] },
+        });
+
+        expect(await screen.findByLabelText('Preview pasted.png')).toBeInTheDocument();
+    });
+
+    it('attaches dropped files and shows the drop hint while dragging', async () => {
+        render(<Harness />);
+        const card = screen.getByTestId(TEST_ID).parentElement as HTMLElement;
+
+        fireEvent.dragEnter(card, { dataTransfer: { types: ['Files'], items: [], files: [] } });
+        expect(await screen.findByTestId(`${TEST_ID}-dropzone`)).toBeInTheDocument();
+
+        fireEvent.drop(card, {
+            dataTransfer: { types: ['Files'], files: [imageFile('dropped.png')], items: [] },
+        });
+
+        expect(await screen.findByLabelText('Preview dropped.png')).toBeInTheDocument();
+        expect(screen.queryByTestId(`${TEST_ID}-dropzone`)).not.toBeInTheDocument();
+    });
+
+    it('removes an attachment and revokes its preview URL', async () => {
+        render(<Harness />);
+
+        fireEvent.change(screen.getByTestId(`${TEST_ID}-image-input`), {
+            target: { files: [imageFile('gone.png')] },
+        });
+        fireEvent.click(await screen.findByLabelText('Remove gone.png'));
+
+        await waitFor(() => expect(screen.queryByLabelText('Preview gone.png')).toBeNull());
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-preview');
+    });
+});
+
+/* -------------------------------------------------------------------- */
+/* Dictation                                                            */
+/* -------------------------------------------------------------------- */
+
+interface FakeSpeechEvent {
+    resultIndex: number;
+    results: { length: number; [index: number]: unknown };
+}
+
+class FakeRecognition {
+    static instances: FakeRecognition[] = [];
+    continuous = false;
+    interimResults = false;
+    lang = '';
+    onresult: ((event: FakeSpeechEvent) => void) | null = null;
+    onend: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor() {
+        FakeRecognition.instances.push(this);
+    }
+    start() {}
+    stop() {}
+}
+
+function emit(final: string) {
+    const rec = FakeRecognition.instances.at(-1);
+    act(() => {
+        rec?.onresult?.({
+            resultIndex: 0,
+            results: { length: 1, 0: { isFinal: true, 0: { transcript: final } } },
+        });
+    });
+}
+
+describe('PromptComposer dictation', () => {
+    beforeEach(() => {
+        FakeRecognition.instances = [];
+        (window as unknown as { SpeechRecognition: unknown }).SpeechRecognition = FakeRecognition;
+    });
+    afterEach(() => {
+        delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
+    });
+
+    it('swaps the toolbar for the dictation bar while listening', async () => {
+        render(<Harness />);
+        fireEvent.click(await screen.findByTestId(`${TEST_ID}-mic`));
+
+        expect(await screen.findByTestId(`${TEST_ID}-voice-bar`)).toBeInTheDocument();
+        // Send is replaced by keep/discard — recording is a mode, not a toggle.
+        expect(screen.queryByTestId(`${TEST_ID}-submit`)).toBeNull();
+        expect(screen.getByTestId(`${TEST_ID}-voice-done`)).toBeInTheDocument();
+        // No getUserMedia in jsdom, so the live meter degrades to static bars;
+        // the wordless bar keeps its status in an sr-only region.
+        expect(screen.getByTestId(`${TEST_ID}-voice-static`)).toBeInTheDocument();
+        expect(screen.getByText('Listening…')).toHaveClass('sr-only');
+    });
+
+    it('appends final transcripts and puts the prompt back on discard', async () => {
+        render(<Harness initial="Build me" />);
+        fireEvent.click(await screen.findByTestId(`${TEST_ID}-mic`));
+
+        emit('a directory of AI tools');
+        const textarea = screen.getByTestId(TEST_ID) as HTMLTextAreaElement;
+        await waitFor(() => expect(textarea.value).toBe('Build me a directory of AI tools'));
+
+        fireEvent.click(screen.getByTestId(`${TEST_ID}-voice-cancel`));
+        await waitFor(() => expect(textarea.value).toBe('Build me'));
+    });
+
+    it('keeps the transcript when dictation is confirmed', async () => {
+        render(<Harness />);
+        fireEvent.click(await screen.findByTestId(`${TEST_ID}-mic`));
+
+        emit('a landing page');
+        fireEvent.click(screen.getByTestId(`${TEST_ID}-voice-done`));
+
+        const textarea = screen.getByTestId(TEST_ID) as HTMLTextAreaElement;
+        await waitFor(() => expect(textarea.value).toBe('a landing page'));
+        expect(screen.queryByTestId(`${TEST_ID}-voice-bar`)).toBeNull();
+    });
+});

--- a/apps/web/src/components/common/composer/AttachmentPreview.tsx
+++ b/apps/web/src/components/common/composer/AttachmentPreview.tsx
@@ -14,34 +14,23 @@ import {
 
 /**
  * Full-size viewer for attachments the composer can render itself: images
- * (from their local object URL) and text / code / CSV documents (read
- * straight off the local `File`). Both paths are entirely local — nothing
- * here waits on the upload to finish.
+ * (from their local object URL) and text / code / CSV documents (read off the
+ * local `File`). PDFs and other binaries are intentionally absent — the
+ * uploads API serves attachments with a non-inline disposition and the app's
+ * CSP blocks `blob:` frames, so those cards offer a download instead.
  *
- * PDFs and other binaries are intentionally absent: the uploads API serves
- * attachments with a non-inline disposition and the app's CSP does not allow
- * `blob:` frames, so an embedded viewer would either be blocked or require
- * relaxing the policy. Those cards offer a download instead.
- *
- * Rendered through a portal onto `document.body` rather than inside the
- * composer card: the card is `overflow-hidden` and uses backdrop blur, which
- * establishes a containing block for `position: fixed` — an overlay mounted
- * inside it would be clipped to the card's rounded rectangle.
- *
- * Keyboard: Escape closes, ArrowLeft/ArrowRight step through the set. Focus
- * moves to the close button on open and returns to whatever was focused
- * before (the thumbnail) on close.
+ * Portalled onto `document.body`: the composer card is `overflow-hidden` and
+ * uses backdrop blur, which establishes a containing block for
+ * `position: fixed`, so an overlay mounted inside it would be clipped.
  */
 
 /** Placeholder so the hook below has a stable `File` to depend on. */
 const NO_FILE = typeof File === 'undefined' ? null : new File([], '');
 
 /**
- * Reads the head of a text file for display, flagging truncation.
- *
- * The resolved text is stored *with* the file it came from, so stepping from
- * one document to the next never shows the previous file's contents while the
- * new read is in flight.
+ * Reads the head of a text file for display. The resolved text is stored
+ * *with* the file it came from, so stepping from one document to the next
+ * never shows the previous file's contents while the new read is in flight.
  */
 function useTextPreview(file: File | null, enabled: boolean) {
     const [loaded, setLoaded] = useState<{
@@ -129,8 +118,8 @@ export function AttachmentPreview({
         return () => document.removeEventListener('keydown', onKey);
     }, [onClose, step]);
 
-    // Stop the page behind the overlay from scrolling, and hand focus to the
-    // dialog so Escape / arrows work without the user clicking first.
+    // Lock the page behind the overlay and hand focus to the dialog so Escape
+    // and the arrow keys work without the user clicking first.
     useEffect(() => {
         restoreFocusRef.current = document.activeElement;
         const previousOverflow = document.body.style.overflow;
@@ -154,8 +143,8 @@ export function AttachmentPreview({
             aria-label={`Attachment preview: ${current.displayName}`}
             data-testid={testId ? `${testId}-lightbox` : undefined}
             className="fixed inset-0 z-100 flex flex-col bg-black/80 backdrop-blur-sm"
-            // Only a click on the backdrop itself closes — clicks that
-            // started on the content or the chrome must not fall through.
+            // Only a click on the backdrop itself closes; clicks that started
+            // on the content or the chrome must not fall through.
             onMouseDown={(event) => {
                 if (event.target === event.currentTarget) onClose();
             }}
@@ -217,9 +206,8 @@ export function AttachmentPreview({
 
                 {isImage ? (
                     /* eslint-disable-next-line @next/next/no-img-element --
-                       the source is a local `blob:` object URL for a file the
-                       user just picked; next/image can neither optimize nor
-                       allowlist it. */
+                       local `blob:` object URL; nothing for next/image to
+                       optimize or allowlist. */
                     <img
                         key={current.localId}
                         src={current.previewUrl}

--- a/apps/web/src/components/common/composer/AttachmentPreview.tsx
+++ b/apps/web/src/components/common/composer/AttachmentPreview.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import {
+    fileTypeLabel,
+    formatBytes,
+    isTextLike,
+    TEXT_PREVIEW_BYTES,
+    type ComposerFileAttachment,
+} from './attachments';
+
+/**
+ * Full-size viewer for attachments the composer can render itself: images
+ * (from their local object URL) and text / code / CSV documents (read
+ * straight off the local `File`). Both paths are entirely local — nothing
+ * here waits on the upload to finish.
+ *
+ * PDFs and other binaries are intentionally absent: the uploads API serves
+ * attachments with a non-inline disposition and the app's CSP does not allow
+ * `blob:` frames, so an embedded viewer would either be blocked or require
+ * relaxing the policy. Those cards offer a download instead.
+ *
+ * Rendered through a portal onto `document.body` rather than inside the
+ * composer card: the card is `overflow-hidden` and uses backdrop blur, which
+ * establishes a containing block for `position: fixed` — an overlay mounted
+ * inside it would be clipped to the card's rounded rectangle.
+ *
+ * Keyboard: Escape closes, ArrowLeft/ArrowRight step through the set. Focus
+ * moves to the close button on open and returns to whatever was focused
+ * before (the thumbnail) on close.
+ */
+
+/** Placeholder so the hook below has a stable `File` to depend on. */
+const NO_FILE = typeof File === 'undefined' ? null : new File([], '');
+
+/**
+ * Reads the head of a text file for display, flagging truncation.
+ *
+ * The resolved text is stored *with* the file it came from, so stepping from
+ * one document to the next never shows the previous file's contents while the
+ * new read is in flight.
+ */
+function useTextPreview(file: File | null, enabled: boolean) {
+    const [loaded, setLoaded] = useState<{
+        readonly file: File | null;
+        readonly text: string;
+        readonly truncated: boolean;
+    }>({ file: null, text: '', truncated: false });
+
+    useEffect(() => {
+        if (!enabled || !file) return;
+        let cancelled = false;
+        const truncated = file.size > TEXT_PREVIEW_BYTES;
+        // Slice before reading: a 20 MB log would otherwise be decoded in
+        // full and handed to the DOM as one text node.
+        void file
+            .slice(0, TEXT_PREVIEW_BYTES)
+            .text()
+            .then((text) => {
+                if (!cancelled) setLoaded({ file, text, truncated });
+            })
+            .catch(() => {
+                if (!cancelled)
+                    setLoaded({ file, text: 'Could not read this file.', truncated: false });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [file, enabled]);
+
+    const ready = loaded.file === file;
+    return {
+        text: ready ? loaded.text : '',
+        truncated: ready && loaded.truncated,
+        loading: enabled && !ready,
+    };
+}
+
+export interface AttachmentPreviewProps {
+    readonly attachments: ReadonlyArray<ComposerFileAttachment>;
+    /** Index into `attachments`; callers keep this in sync with the clicked card. */
+    readonly index: number;
+    readonly onIndexChange: (next: number) => void;
+    readonly onClose: () => void;
+    readonly testId?: string;
+}
+
+export function AttachmentPreview({
+    attachments,
+    index,
+    onIndexChange,
+    onClose,
+    testId,
+}: AttachmentPreviewProps) {
+    const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+    const restoreFocusRef = useRef<Element | null>(null);
+
+    const current = attachments[index];
+    const count = attachments.length;
+    const isImage = Boolean(current?.previewUrl);
+    const asText = Boolean(current && !isImage && isTextLike(current.file, current.displayName));
+    const preview = useTextPreview(current?.file ?? NO_FILE, asText);
+
+    const step = useCallback(
+        (delta: number) => {
+            if (count < 2) return;
+            onIndexChange((index + delta + count) % count);
+        },
+        [count, index, onIndexChange],
+    );
+
+    useEffect(() => {
+        const onKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                onClose();
+            } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                step(1);
+            } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                step(-1);
+            }
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, [onClose, step]);
+
+    // Stop the page behind the overlay from scrolling, and hand focus to the
+    // dialog so Escape / arrows work without the user clicking first.
+    useEffect(() => {
+        restoreFocusRef.current = document.activeElement;
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        closeButtonRef.current?.focus();
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            const restore = restoreFocusRef.current;
+            if (restore instanceof HTMLElement) restore.focus();
+        };
+    }, []);
+
+    if (typeof document === 'undefined' || !current) return null;
+
+    const downloadHref = current.previewUrl ?? current.url;
+
+    return createPortal(
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Attachment preview: ${current.displayName}`}
+            data-testid={testId ? `${testId}-lightbox` : undefined}
+            className="fixed inset-0 z-100 flex flex-col bg-black/80 backdrop-blur-sm"
+            // Only a click on the backdrop itself closes — clicks that
+            // started on the content or the chrome must not fall through.
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) onClose();
+            }}
+        >
+            <div className="flex items-center gap-3 px-4 py-3 text-white">
+                <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium" title={current.displayName}>
+                        {current.displayName}
+                    </p>
+                    <p className="text-[11px] text-white/60">
+                        {fileTypeLabel(current.displayName, current.file.type)} ·{' '}
+                        {formatBytes(current.file.size)}
+                        {count > 1 ? ` · ${index + 1} of ${count}` : ''}
+                    </p>
+                </div>
+                {downloadHref ? (
+                    <a
+                        href={downloadHref}
+                        download={current.displayName}
+                        aria-label={`Download ${current.displayName}`}
+                        title="Download"
+                        className="rounded-lg p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                    >
+                        <Download className="size-4" aria-hidden="true" />
+                    </a>
+                ) : null}
+                <button
+                    ref={closeButtonRef}
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close attachment preview"
+                    title="Close (Esc)"
+                    className="rounded-lg p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                    data-testid={testId ? `${testId}-lightbox-close` : undefined}
+                >
+                    <X className="size-5" aria-hidden="true" />
+                </button>
+            </div>
+
+            <div
+                className="relative flex min-h-0 flex-1 items-center justify-center px-4 pb-6"
+                onMouseDown={(event) => {
+                    if (event.target === event.currentTarget) onClose();
+                }}
+            >
+                {count > 1 ? (
+                    <button
+                        type="button"
+                        onClick={() => step(-1)}
+                        aria-label="Previous attachment"
+                        className={cn(
+                            'absolute left-2 z-10 rounded-full p-2.5 sm:left-4',
+                            'bg-white/10 text-white backdrop-blur transition-colors hover:bg-white/20',
+                        )}
+                    >
+                        <ChevronLeft className="size-5" aria-hidden="true" />
+                    </button>
+                ) : null}
+
+                {isImage ? (
+                    /* eslint-disable-next-line @next/next/no-img-element --
+                       the source is a local `blob:` object URL for a file the
+                       user just picked; next/image can neither optimize nor
+                       allowlist it. */
+                    <img
+                        key={current.localId}
+                        src={current.previewUrl}
+                        alt={current.displayName}
+                        decoding="async"
+                        className="max-h-full max-w-full select-none rounded-lg object-contain shadow-2xl"
+                        data-testid={testId ? `${testId}-lightbox-image` : undefined}
+                    />
+                ) : (
+                    <div
+                        className="flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-xl bg-background shadow-2xl dark:bg-zinc-900"
+                        data-testid={testId ? `${testId}-lightbox-text` : undefined}
+                    >
+                        {preview.loading ? (
+                            <p className="p-4 text-sm text-text-muted dark:text-text-muted-dark">
+                                Reading file…
+                            </p>
+                        ) : (
+                            <pre className="min-h-0 flex-1 overflow-auto p-4 text-xs leading-relaxed text-text dark:text-text-dark">
+                                {preview.text}
+                            </pre>
+                        )}
+                        {preview.truncated ? (
+                            <p className="border-t border-border/60 px-4 py-2 text-[11px] text-text-muted dark:border-white/10 dark:text-text-muted-dark">
+                                Showing the first {formatBytes(TEXT_PREVIEW_BYTES)} of this file.
+                            </p>
+                        ) : null}
+                    </div>
+                )}
+
+                {count > 1 ? (
+                    <button
+                        type="button"
+                        onClick={() => step(1)}
+                        aria-label="Next attachment"
+                        className={cn(
+                            'absolute right-2 z-10 rounded-full p-2.5 sm:right-4',
+                            'bg-white/10 text-white backdrop-blur transition-colors hover:bg-white/20',
+                        )}
+                    >
+                        <ChevronRight className="size-5" aria-hidden="true" />
+                    </button>
+                ) : null}
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/apps/web/src/components/common/composer/AttachmentStrip.tsx
+++ b/apps/web/src/components/common/composer/AttachmentStrip.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import {
     AlertCircle,
-    ChevronRight,
     Download,
     File as FileIcon,
     FileArchive,
@@ -32,7 +31,6 @@ import {
     type ComposerAttachment,
     type ComposerFileAttachment,
     type ComposerFolderGroup,
-    type ComposerImageAttachment,
     type FileIconKind,
 } from './attachments';
 
@@ -40,17 +38,24 @@ import {
  * The strip of attached items rendered inside the composer card, above the
  * toolbar.
  *
- * Three shapes, matching what each thing actually is:
+ * **One tile shape for everything.** The image thumbnail is the shape the strip
+ * is built around — a square you can recognise at a glance, with its actions as
+ * badges on the corners — so a document, a picked folder and a GitHub repo take
+ * the same tile: same width, same height, same row, in the order they were
+ * added. What differs is only what sits inside the square and the caption under
+ * it:
  *
- *   - **Images** → thumbnail tiles. Showing a picked screenshot as a filename
- *     chip is what made the old composer feel unfinished: you could not tell
- *     *which* image you had attached, or look at it again.
- *   - **Documents** → a card with a type glyph, the name, and `PDF · 240 KB`.
- *     Text and code documents are clickable and open in the preview overlay;
- *     binaries offer a download once the upload resolves.
- *   - **Folders** → one card per picked folder (`webkitdirectory` hands us a
- *     flat file list), with an aggregate size and progress, expanding to the
- *     files inside. Forty separate chips for one folder pick is unreadable.
+ *   - **Images** → the thumbnail itself, so you can tell *which* screenshot you
+ *     attached. Clicking opens it full size.
+ *   - **Documents** → a type glyph. Text and code documents open in the preview
+ *     overlay; binaries offer a download badge once the upload resolves.
+ *   - **Folders** → a folder glyph with the file count (`webkitdirectory` hands
+ *     us a flat file list). Expanding one opens its file list *below* the row,
+ *     so the tiles themselves never change size. Forty separate tiles for one
+ *     folder pick is unreadable.
+ *
+ * The caption carries the name and `PDF · 240 KB` under every tile, since a
+ * glyph alone doesn't say which file it stands for.
  *
  * A failed upload stays on screen with its error and a retry rather than
  * disappearing; silently dropping it would let someone submit believing the
@@ -87,31 +92,43 @@ const KIND_TINTS: Record<FileIconKind, string> = {
     file: 'text-text-secondary dark:text-text-secondary-dark',
 };
 
-// `pr-9` reserves the lane the remove / retry actions are absolutely
-// positioned into, so a long filename truncates before it runs under them.
-const CARD_BASE =
-    'relative flex w-56 max-w-full items-center gap-2.5 overflow-hidden rounded-xl border py-2 pl-2.5 pr-9 text-left transition-colors';
-const CARD_QUIET =
-    'border-border/60 bg-foreground/[0.03] hover:bg-foreground/[0.06] dark:border-white/10 dark:bg-white/[0.04] dark:hover:bg-white/[0.07]';
-const CARD_ERROR = 'border-danger/40 bg-danger/[0.06]';
-const ICON_TILE =
-    'flex size-8 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.05] dark:bg-white/[0.06]';
+// The single footprint every attachment gets: a 4rem square plus its caption.
+// Fixed on both axes — a tile that grew with its label would break the row into
+// ragged bands.
+const ITEM = 'group relative w-16 shrink-0';
+const TILE_BASE =
+    'relative flex size-16 items-center justify-center overflow-hidden rounded-xl border transition-[transform,box-shadow,border-color] duration-150';
+const TILE_QUIET =
+    'border-border/60 bg-foreground/[0.03] dark:border-white/10 dark:bg-white/[0.04]';
+const TILE_ERROR = 'border-danger/50 bg-danger/[0.06]';
+// Only tiles that do something on click lift and take focus.
+const TILE_INTERACTIVE =
+    'hover:-translate-y-0.5 hover:shadow-md hover:border-border-secondary dark:hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40';
+const BADGE =
+    'absolute rounded-full border border-border/60 bg-background p-1 text-text-muted shadow-sm transition-colors hover:text-text dark:border-white/15 dark:bg-zinc-900 dark:text-text-muted-dark dark:hover:text-text-dark';
 const ROW_ACTION =
     'shrink-0 rounded-md p-1 text-text-muted transition-colors hover:bg-foreground/10 hover:text-text dark:text-text-muted-dark dark:hover:bg-white/10 dark:hover:text-text-dark';
+// Quiet until hover on pointer devices so the strip stays calm, but always
+// reachable by keyboard and on touch.
+const BADGE_REVEAL =
+    'opacity-0 group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100 max-sm:opacity-100';
 
 function stateTagOf(a: ComposerFileAttachment): string {
     if (a.error) return 'error';
     return a.uploading ? 'uploading' : 'ready';
 }
 
-/** Thin progress rule on a card's bottom edge — no extra row. */
-function ProgressRule({ percent }: { readonly percent: number }) {
+/** Name + `PDF · 240 KB` under a tile, clipped to the tile's width. */
+function Caption({ name, meta }: { readonly name: string; readonly meta: string }) {
     return (
-        <span
-            aria-hidden="true"
-            className="absolute bottom-0 left-0 h-0.5 bg-text-muted/70 transition-[width] duration-200 dark:bg-white/40"
-            style={{ width: `${percent}%` }}
-        />
+        <span className="mt-1 block w-16">
+            <span className="block truncate text-[11px] font-medium leading-tight text-text dark:text-text-dark">
+                {name}
+            </span>
+            <span className="block truncate text-[10px] leading-tight text-text-muted dark:text-text-muted-dark">
+                {meta}
+            </span>
+        </span>
     );
 }
 
@@ -159,105 +176,56 @@ function RetryButton({
     );
 }
 
-function ImageTile({
-    attachment,
-    onOpen,
-    onRemove,
-    onRetry,
-    testId,
-}: {
-    readonly attachment: ComposerImageAttachment;
-    readonly onOpen: () => void;
-    readonly onRemove: () => void;
-    readonly onRetry: () => void;
-    readonly testId?: string;
-}) {
+/** What fills the square: the picked image, or a typed glyph, plus its state. */
+function TileFace({ attachment }: { readonly attachment: ComposerFileAttachment }) {
     const { displayName, uploading, progress, error, file } = attachment;
+    const kind = fileIconKind(displayName, file.type);
+    const Icon = KIND_ICONS[kind];
+    const thumbnail = isImageAttachment(attachment) ? attachment.previewUrl : undefined;
+
     return (
-        <li className="group relative">
-            <button
-                type="button"
-                onClick={onOpen}
-                title={
-                    error
-                        ? `${displayName} — ${error}`
-                        : `${displayName} · ${formatBytes(file.size)}`
-                }
-                aria-label={`Preview ${displayName}`}
-                className={cn(
-                    'relative block size-16 overflow-hidden rounded-xl border',
-                    'transition-[transform,box-shadow,border-color] duration-150',
-                    'hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none',
-                    'focus-visible:ring-2 focus-visible:ring-text-muted/40',
-                    error
-                        ? 'border-danger/50'
-                        : 'border-border/60 hover:border-border-secondary dark:border-white/10 dark:hover:border-white/20',
-                )}
-                data-testid={testId ? `${testId}-attachment-${stateTagOf(attachment)}` : undefined}
-            >
-                {/* eslint-disable-next-line @next/next/no-img-element --
-                    local `blob:` object URL for a just-picked file; nothing
-                    for next/image to optimize or allowlist. */}
+        <>
+            {thumbnail ? (
+                /* eslint-disable-next-line @next/next/no-img-element --
+                   local `blob:` object URL for a just-picked file; nothing for
+                   next/image to optimize or allowlist. */
                 <img
-                    src={attachment.previewUrl}
+                    src={thumbnail}
                     alt=""
                     decoding="async"
-                    className={cn(
-                        'size-full object-cover',
-                        (uploading || error) && 'scale-100 blur-[1px]',
-                    )}
+                    className={cn('size-full object-cover', (uploading || error) && 'blur-[1px]')}
                 />
+            ) : (
+                <Icon className={cn('size-6', KIND_TINTS[kind])} aria-hidden="true" />
+            )}
 
-                {uploading ? (
-                    <span className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/45 text-white">
-                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                        <span
-                            className="text-[10px] font-medium tabular-nums"
-                            aria-label={`Uploading ${progress} percent`}
-                        >
-                            {progress}%
-                        </span>
+            {uploading ? (
+                <span className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/45 text-white">
+                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                    <span
+                        className="text-[10px] font-medium tabular-nums"
+                        aria-label={`Uploading ${progress} percent`}
+                    >
+                        {progress}%
                     </span>
-                ) : null}
-
-                {error ? (
-                    <span className="absolute inset-0 flex items-center justify-center bg-danger/25 text-danger">
-                        <AlertCircle className="size-4" aria-hidden="true" />
-                    </span>
-                ) : null}
-            </button>
-
-            {error ? (
-                <RetryButton
-                    label={`Retry upload of ${displayName}`}
-                    onClick={onRetry}
-                    className="absolute -bottom-1 -left-1 rounded-full border border-border/60 bg-background p-1 text-text-muted shadow-sm transition-colors hover:text-text dark:border-white/15 dark:bg-zinc-900 dark:text-text-muted-dark dark:hover:text-text-dark"
-                />
+                </span>
             ) : null}
 
-            <RemoveButton
-                label={`Remove ${displayName}`}
-                onClick={onRemove}
-                className={cn(
-                    'absolute -right-1.5 -top-1.5 rounded-full border p-1 shadow-sm transition-all',
-                    'border-border/60 bg-background text-text-muted dark:border-white/15 dark:bg-zinc-900 dark:text-text-muted-dark',
-                    'hover:text-text dark:hover:text-text-dark',
-                    // Always reachable by keyboard / touch, quiet until hover
-                    // on pointer devices so the strip stays calm.
-                    'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
-                    'group-focus-within:opacity-100 max-sm:opacity-100',
-                )}
-            />
-        </li>
+            {error ? (
+                <span className="absolute inset-0 flex items-center justify-center bg-danger/25 text-danger">
+                    <AlertCircle className="size-4" aria-hidden="true" />
+                </span>
+            ) : null}
+        </>
     );
 }
 
 /**
- * A document card: type glyph, name, and `PDF · 240 KB`. The card itself is
- * clickable when we can render the file ourselves (text / code / CSV);
- * otherwise it is inert and a download action appears once the upload lands.
+ * A tile for a single picked file — image or document alike. It is clickable
+ * when we can render the file ourselves (image / text / code / CSV); otherwise
+ * it is inert and a download badge appears once the upload lands.
  */
-function FileCard({
+function FileTile({
     attachment,
     onOpen,
     onRemove,
@@ -265,261 +233,270 @@ function FileCard({
     testId,
 }: {
     readonly attachment: ComposerFileAttachment;
-    /** Set when the file can be previewed in-app (text / code / CSV). */
+    /** Set when the file can be previewed in-app (image / text / code / CSV). */
     readonly onOpen?: () => void;
     readonly onRemove: () => void;
     readonly onRetry: () => void;
     readonly testId?: string;
 }) {
     const { displayName, uploading, progress, error, file } = attachment;
-    const kind = fileIconKind(displayName, file.type);
-    const Icon = KIND_ICONS[kind];
     const label = fileTypeLabel(displayName, file.type);
-
-    const body = (
-        <>
-            <span className={ICON_TILE}>
-                {uploading ? (
-                    <Loader2
-                        className="size-4 animate-spin text-text-muted dark:text-text-muted-dark"
-                        aria-hidden="true"
-                    />
-                ) : error ? (
-                    <AlertCircle className="size-4 text-danger" aria-hidden="true" />
-                ) : (
-                    <Icon className={cn('size-4', KIND_TINTS[kind])} aria-hidden="true" />
-                )}
-            </span>
-            <span className="min-w-0 flex-1">
-                <span className="block truncate text-[13px] font-medium text-text dark:text-text-dark">
-                    {displayName}
-                </span>
-                <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
-                    {error ? error : uploading ? `${progress}% · ${label}` : label}
-                    {error ? '' : ` · ${formatBytes(file.size)}`}
-                </span>
-            </span>
-        </>
-    );
-
-    // Widen the reserved action lane when there are two buttons in it.
-    const downloadable = !onOpen && !error && !uploading && Boolean(attachment.url);
-    const cardClass = cn(
-        CARD_BASE,
-        error ? CARD_ERROR : CARD_QUIET,
-        (error || downloadable) && 'pr-14',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40',
-    );
-    const testIdAttr = testId ? `${testId}-attachment-${stateTagOf(attachment)}` : undefined;
-    // Only offered once the upload resolves — before that there is no URL to
+    const meta = error
+        ? error
+        : uploading
+          ? `${progress}% · ${label}`
+          : `${label} · ${formatBytes(file.size)}`;
+    const tileClass = cn(TILE_BASE, error ? TILE_ERROR : TILE_QUIET, onOpen && TILE_INTERACTIVE);
+    // Offered only once the upload resolves — before that there is no URL to
     // point at.
-    const downloadHref = downloadable ? attachment.url : undefined;
+    const downloadHref = !onOpen && !error && !uploading ? attachment.url : undefined;
 
     return (
-        <li className="relative">
+        <li
+            className={ITEM}
+            data-testid={testId ? `${testId}-attachment-${stateTagOf(attachment)}` : undefined}
+        >
             {/* Element type is chosen from the file, never from upload state:
-                previewability doesn't change mid-flight, so the card never
+                previewability doesn't change mid-flight, so the tile never
                 remounts (and never loses focus) when an upload lands. */}
             {onOpen ? (
                 <button
                     type="button"
                     onClick={onOpen}
                     aria-label={`Preview ${displayName}`}
-                    title={`${displayName} — click to preview`}
-                    className={cardClass}
-                    data-testid={testIdAttr}
+                    title={
+                        error
+                            ? `${displayName} — ${error}`
+                            : `${displayName} · ${formatBytes(file.size)}`
+                    }
+                    className={tileClass}
                 >
-                    {body}
+                    <TileFace attachment={attachment} />
                 </button>
             ) : (
-                <div className={cardClass} title={error || displayName} data-testid={testIdAttr}>
-                    {body}
-                </div>
+                <span
+                    className={tileClass}
+                    title={error ? `${displayName} — ${error}` : displayName}
+                >
+                    <TileFace attachment={attachment} />
+                </span>
             )}
 
-            {/* Actions sit outside the card button so a click on them never
-                also opens the preview. */}
-            <span className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
-                {error ? (
-                    <RetryButton
-                        label={`Retry upload of ${displayName}`}
-                        onClick={onRetry}
-                        className={ROW_ACTION}
-                    />
-                ) : null}
-                {downloadHref ? (
-                    <a
-                        href={downloadHref}
-                        download={displayName}
-                        aria-label={`Download ${displayName}`}
-                        title="Download"
-                        className={ROW_ACTION}
-                    >
-                        <Download className="size-3" aria-hidden="true" />
-                    </a>
-                ) : null}
-                <RemoveButton
-                    label={`Remove ${displayName}`}
-                    onClick={onRemove}
-                    className={ROW_ACTION}
-                />
-            </span>
+            <Caption name={displayName} meta={meta} />
 
-            {uploading ? <ProgressRule percent={progress} /> : null}
+            {/* Badges sit outside the tile button so a click on one never also
+                opens the preview. */}
+            {error ? (
+                <RetryButton
+                    label={`Retry upload of ${displayName}`}
+                    onClick={onRetry}
+                    className={cn(BADGE, '-bottom-1 -left-1')}
+                />
+            ) : null}
+
+            {downloadHref ? (
+                <a
+                    href={downloadHref}
+                    download={displayName}
+                    aria-label={`Download ${displayName}`}
+                    title="Download"
+                    className={cn(BADGE, '-bottom-1 -right-1', BADGE_REVEAL)}
+                >
+                    <Download className="size-3" aria-hidden="true" />
+                </a>
+            ) : null}
+
+            <RemoveButton
+                label={`Remove ${displayName}`}
+                onClick={onRemove}
+                className={cn(BADGE, '-right-1.5 -top-1.5', BADGE_REVEAL)}
+            />
         </li>
     );
 }
 
-function FolderCard({
+function FolderTile({
+    group,
+    expanded,
+    onToggle,
+    onRemoveFolder,
+    testId,
+}: {
+    readonly group: ComposerFolderGroup;
+    readonly expanded: boolean;
+    readonly onToggle: () => void;
+    readonly onRemoveFolder: () => void;
+    readonly testId?: string;
+}) {
+    const { name, files, totalBytes, uploadingCount, failedCount, progress } = group;
+    const count = files.length;
+
+    const meta =
+        failedCount > 0
+            ? `${failedCount} of ${count} failed`
+            : uploadingCount > 0
+              ? `${progress}% · ${count} files`
+              : `${count} file${count === 1 ? '' : 's'} · ${formatBytes(totalBytes)}`;
+
+    return (
+        <li className={ITEM} data-testid={testId ? `${testId}-attachment-folder` : undefined}>
+            <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={expanded}
+                aria-label={`${expanded ? 'Collapse' : 'Expand'} folder ${name}`}
+                title={`${name} — click to ${expanded ? 'collapse' : 'expand'}`}
+                className={cn(
+                    TILE_BASE,
+                    failedCount > 0 ? TILE_ERROR : TILE_QUIET,
+                    TILE_INTERACTIVE,
+                    expanded && 'border-border-secondary dark:border-white/25',
+                )}
+            >
+                <Folder
+                    className="size-6 text-text-secondary dark:text-text-secondary-dark"
+                    aria-hidden="true"
+                />
+                {/* The count is what tells two folder tiles apart at a glance. */}
+                <span className="absolute bottom-1 right-1 rounded px-1 text-[10px] font-medium tabular-nums text-text-muted dark:text-text-muted-dark">
+                    {count}
+                </span>
+
+                {uploadingCount > 0 ? (
+                    <span className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/45 text-white">
+                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        <span className="text-[10px] font-medium tabular-nums">{progress}%</span>
+                    </span>
+                ) : failedCount > 0 ? (
+                    <span className="absolute inset-0 flex items-center justify-center bg-danger/25 text-danger">
+                        <AlertCircle className="size-4" aria-hidden="true" />
+                    </span>
+                ) : null}
+            </button>
+
+            <Caption name={name} meta={meta} />
+
+            <RemoveButton
+                label={`Remove folder ${name}`}
+                // Each file is its own attachment, so removing the folder
+                // removes them one by one; the functional state updates
+                // compose, so this settles as a single render.
+                onClick={onRemoveFolder}
+                className={cn(BADGE, '-right-1.5 -top-1.5', BADGE_REVEAL)}
+            />
+        </li>
+    );
+}
+
+function RepoTile({
+    attachment,
+    onRemove,
+}: {
+    readonly attachment: Extract<ComposerAttachment, { kind: 'github-repo' }>;
+    readonly onRemove: () => void;
+}) {
+    const { displayName, url } = attachment;
+    return (
+        <li className={ITEM}>
+            <span className={cn(TILE_BASE, TILE_QUIET)} title={url}>
+                <Github
+                    className="size-6 text-text-secondary dark:text-text-secondary-dark"
+                    aria-hidden="true"
+                />
+            </span>
+            <Caption name={displayName} meta="GitHub repo" />
+            <RemoveButton
+                label={`Remove ${displayName}`}
+                onClick={onRemove}
+                className={cn(BADGE, '-right-1.5 -top-1.5', BADGE_REVEAL)}
+            />
+        </li>
+    );
+}
+
+/**
+ * The contents of the one expanded folder, rendered under the tile row rather
+ * than inside the tile, so expanding never changes the size of a tile or
+ * reflows the row around it.
+ */
+function FolderFileList({
     group,
     onRemoveFile,
     onRetryFile,
     onOpenFile,
-    testId,
 }: {
     readonly group: ComposerFolderGroup;
     readonly onRemoveFile: (localId: string) => void;
     readonly onRetryFile: (localId: string) => void;
     readonly onOpenFile: (localId: string) => void;
-    readonly testId?: string;
 }) {
-    const [expanded, setExpanded] = useState(false);
-    const { name, files, totalBytes, uploadingCount, failedCount, progress } = group;
-    const count = files.length;
-
-    const summary =
-        failedCount > 0
-            ? `${failedCount} of ${count} failed`
-            : uploadingCount > 0
-              ? `Uploading ${count - uploadingCount + 1} of ${count}`
-              : `${count} file${count === 1 ? '' : 's'} · ${formatBytes(totalBytes)}`;
-
     return (
-        <li className="relative w-full">
-            <div
-                className={cn(CARD_BASE, 'w-full', failedCount > 0 ? CARD_ERROR : CARD_QUIET)}
-                data-testid={testId ? `${testId}-attachment-folder` : undefined}
-            >
-                <button
-                    type="button"
-                    onClick={() => setExpanded((v) => !v)}
-                    aria-expanded={expanded}
-                    aria-label={`${expanded ? 'Collapse' : 'Expand'} folder ${name}`}
-                    className="flex min-w-0 flex-1 items-center gap-2.5 text-left focus-visible:outline-none"
-                >
-                    <span className={ICON_TILE}>
-                        {uploadingCount > 0 ? (
-                            <Loader2
-                                className="size-4 animate-spin text-text-muted dark:text-text-muted-dark"
-                                aria-hidden="true"
-                            />
-                        ) : failedCount > 0 ? (
-                            <AlertCircle className="size-4 text-danger" aria-hidden="true" />
-                        ) : (
-                            <Folder
-                                className="size-4 text-text-secondary dark:text-text-secondary-dark"
-                                aria-hidden="true"
-                            />
-                        )}
-                    </span>
-                    <span className="min-w-0 flex-1">
-                        <span className="block truncate text-[13px] font-medium text-text dark:text-text-dark">
-                            {name}
-                        </span>
-                        <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
-                            {summary}
-                        </span>
-                    </span>
-                    <ChevronRight
-                        className={cn(
-                            'size-3.5 shrink-0 text-text-muted transition-transform duration-150 dark:text-text-muted-dark',
-                            expanded && 'rotate-90',
-                        )}
-                        aria-hidden="true"
-                    />
-                </button>
-
-                {/* Inside the card, not the <li> — the list item grows when
-                    the folder is expanded, so anchoring to it would drag the
-                    button down to the middle of the file list. */}
-                <span className="absolute right-1.5 top-1/2 -translate-y-1/2">
-                    <RemoveButton
-                        label={`Remove folder ${name}`}
-                        // Each file is its own attachment, so removing the
-                        // folder removes them one by one; the functional state
-                        // updates compose, so this settles as a single render.
-                        onClick={() => files.forEach((f) => onRemoveFile(f.localId))}
-                        className={ROW_ACTION}
-                    />
-                </span>
-
-                {uploadingCount > 0 ? <ProgressRule percent={progress} /> : null}
-            </div>
-
-            {expanded ? (
-                <ul className="mt-1 flex flex-col gap-px rounded-lg border border-border/40 bg-foreground/[0.02] p-1 dark:border-white/[0.07] dark:bg-white/[0.02]">
-                    {files.map((f) => {
-                        const relative = folderRelativePath(f.displayName);
-                        const previewable = isPreviewableAttachment(f);
-                        return (
-                            <li
-                                key={f.localId}
-                                className="flex items-center gap-2 rounded-md px-1.5 py-1"
-                            >
-                                {f.uploading ? (
-                                    <Loader2
-                                        className="size-3 shrink-0 animate-spin text-text-muted dark:text-text-muted-dark"
-                                        aria-hidden="true"
-                                    />
-                                ) : f.error ? (
-                                    <AlertCircle
-                                        className="size-3 shrink-0 text-danger"
-                                        aria-hidden="true"
-                                    />
-                                ) : (
-                                    <FileIcon
-                                        className="size-3 shrink-0 text-text-muted dark:text-text-muted-dark"
-                                        aria-hidden="true"
-                                    />
-                                )}
-                                {previewable ? (
-                                    <button
-                                        type="button"
-                                        onClick={() => onOpenFile(f.localId)}
-                                        className="min-w-0 flex-1 truncate text-left text-[11px] text-text underline-offset-2 hover:underline dark:text-text-dark"
-                                        title={`Preview ${relative}`}
-                                    >
-                                        {relative}
-                                    </button>
-                                ) : (
-                                    <span
-                                        className="min-w-0 flex-1 truncate text-[11px] text-text dark:text-text-dark"
-                                        title={relative}
-                                    >
-                                        {relative}
-                                    </span>
-                                )}
-                                <span className="shrink-0 text-[10px] tabular-nums text-text-muted/80 dark:text-text-muted-dark/80">
-                                    {formatBytes(f.file.size)}
+        <div className="rounded-lg border border-border/40 bg-foreground/[0.02] p-1 dark:border-white/[0.07] dark:bg-white/[0.02]">
+            <p className="px-1.5 py-1 text-[10px] font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
+                {group.name}
+            </p>
+            <ul className="flex flex-col gap-px" aria-label={`Files in ${group.name}`}>
+                {group.files.map((f) => {
+                    const relative = folderRelativePath(f.displayName);
+                    const previewable = isPreviewableAttachment(f);
+                    return (
+                        <li
+                            key={f.localId}
+                            className="flex items-center gap-2 rounded-md px-1.5 py-1"
+                        >
+                            {f.uploading ? (
+                                <Loader2
+                                    className="size-3 shrink-0 animate-spin text-text-muted dark:text-text-muted-dark"
+                                    aria-hidden="true"
+                                />
+                            ) : f.error ? (
+                                <AlertCircle
+                                    className="size-3 shrink-0 text-danger"
+                                    aria-hidden="true"
+                                />
+                            ) : (
+                                <FileIcon
+                                    className="size-3 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                    aria-hidden="true"
+                                />
+                            )}
+                            {previewable ? (
+                                <button
+                                    type="button"
+                                    onClick={() => onOpenFile(f.localId)}
+                                    className="min-w-0 flex-1 truncate text-left text-[11px] text-text underline-offset-2 hover:underline dark:text-text-dark"
+                                    title={`Preview ${relative}`}
+                                >
+                                    {relative}
+                                </button>
+                            ) : (
+                                <span
+                                    className="min-w-0 flex-1 truncate text-[11px] text-text dark:text-text-dark"
+                                    title={relative}
+                                >
+                                    {relative}
                                 </span>
-                                {f.error ? (
-                                    <RetryButton
-                                        label={`Retry upload of ${relative}`}
-                                        onClick={() => onRetryFile(f.localId)}
-                                        className={ROW_ACTION}
-                                    />
-                                ) : null}
-                                <RemoveButton
-                                    label={`Remove ${relative}`}
-                                    onClick={() => onRemoveFile(f.localId)}
+                            )}
+                            <span className="shrink-0 text-[10px] tabular-nums text-text-muted/80 dark:text-text-muted-dark/80">
+                                {formatBytes(f.file.size)}
+                            </span>
+                            {f.error ? (
+                                <RetryButton
+                                    label={`Retry upload of ${relative}`}
+                                    onClick={() => onRetryFile(f.localId)}
                                     className={ROW_ACTION}
                                 />
-                            </li>
-                        );
-                    })}
-                </ul>
-            ) : null}
-        </li>
+                            ) : null}
+                            <RemoveButton
+                                label={`Remove ${relative}`}
+                                onClick={() => onRemoveFile(f.localId)}
+                                className={ROW_ACTION}
+                            />
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
     );
 }
 
@@ -539,100 +516,63 @@ export function AttachmentStrip({
     onPreview,
     testId,
 }: AttachmentStripProps) {
+    // Which folder tile is open, by folder name. Held here rather than in the
+    // tile because the file list renders outside the row.
+    const [expandedFolder, setExpandedFolder] = useState<string | null>(null);
+
     if (attachments.length === 0) return null;
 
-    // Folder files always live inside their folder card, so the image and
-    // document rows only consider standalone picks.
-    const loose = attachments.filter((a) => a.kind === 'file');
-    const images = loose.filter(isImageAttachment);
-    const documents = loose.filter(
-        (a): a is ComposerFileAttachment => a.kind === 'file' && !isImageAttachment(a),
-    );
+    // Folder files always live inside their folder tile, so the loose tiles
+    // only cover standalone picks.
+    const loose = attachments.filter((a): a is ComposerFileAttachment => a.kind === 'file');
     const folders = groupFolderFiles(attachments);
-    const repos = attachments.filter((a) => a.kind === 'github-repo');
+    const repos = attachments.filter(
+        (a): a is Extract<ComposerAttachment, { kind: 'github-repo' }> => a.kind === 'github-repo',
+    );
+    const openFolder = folders.find((g) => g.name === expandedFolder);
 
     return (
         <div
-            className="flex flex-col gap-2 px-4 pb-2.5"
+            className="flex flex-col gap-2 px-4 pb-2.5 pt-1"
             data-testid={testId ? `${testId}-attachments` : undefined}
         >
-            {images.length > 0 ? (
-                <ul className="flex flex-wrap gap-2.5 pt-1" aria-label="Attached images">
-                    {images.map((a) => (
-                        <ImageTile
-                            key={a.localId}
-                            attachment={a}
-                            onOpen={() => onPreview(a.localId)}
-                            onRemove={() => onRemove(a.localId)}
-                            onRetry={() => onRetry(a.localId)}
-                            testId={testId}
-                        />
-                    ))}
-                </ul>
-            ) : null}
+            <ul className="flex flex-wrap items-start gap-3" aria-label="Attachments">
+                {loose.map((a) => (
+                    <FileTile
+                        key={a.localId}
+                        attachment={a}
+                        onOpen={isPreviewableAttachment(a) ? () => onPreview(a.localId) : undefined}
+                        onRemove={() => onRemove(a.localId)}
+                        onRetry={() => onRetry(a.localId)}
+                        testId={testId}
+                    />
+                ))}
 
-            {documents.length > 0 ? (
-                <ul className="flex flex-wrap gap-2" aria-label="Attached files">
-                    {documents.map((a) => (
-                        <FileCard
-                            key={a.localId}
-                            attachment={a}
-                            onOpen={
-                                isPreviewableAttachment(a) ? () => onPreview(a.localId) : undefined
-                            }
-                            onRemove={() => onRemove(a.localId)}
-                            onRetry={() => onRetry(a.localId)}
-                            testId={testId}
-                        />
-                    ))}
-                </ul>
-            ) : null}
+                {folders.map((group) => (
+                    <FolderTile
+                        key={group.name}
+                        group={group}
+                        expanded={group.name === expandedFolder}
+                        onToggle={() =>
+                            setExpandedFolder((cur) => (cur === group.name ? null : group.name))
+                        }
+                        onRemoveFolder={() => group.files.forEach((f) => onRemove(f.localId))}
+                        testId={testId}
+                    />
+                ))}
 
-            {folders.length > 0 ? (
-                <ul className="flex flex-col gap-1.5" aria-label="Attached folders">
-                    {folders.map((group) => (
-                        <FolderCard
-                            key={group.name}
-                            group={group}
-                            onRemoveFile={onRemove}
-                            onRetryFile={onRetry}
-                            onOpenFile={onPreview}
-                            testId={testId}
-                        />
-                    ))}
-                </ul>
-            ) : null}
+                {repos.map((a) => (
+                    <RepoTile key={a.localId} attachment={a} onRemove={() => onRemove(a.localId)} />
+                ))}
+            </ul>
 
-            {repos.length > 0 ? (
-                <ul className="flex flex-wrap gap-2" aria-label="Attached repositories">
-                    {repos.map((a) => (
-                        <li key={a.localId} className="relative">
-                            <div className={cn(CARD_BASE, CARD_QUIET)} title={a.url}>
-                                <span className={ICON_TILE}>
-                                    <Github
-                                        className="size-4 text-text-secondary dark:text-text-secondary-dark"
-                                        aria-hidden="true"
-                                    />
-                                </span>
-                                <span className="min-w-0 flex-1">
-                                    <span className="block truncate text-[13px] font-medium text-text dark:text-text-dark">
-                                        {a.displayName}
-                                    </span>
-                                    <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
-                                        GitHub repository
-                                    </span>
-                                </span>
-                            </div>
-                            <span className="absolute right-1.5 top-1/2 -translate-y-1/2">
-                                <RemoveButton
-                                    label={`Remove ${a.displayName}`}
-                                    onClick={() => onRemove(a.localId)}
-                                    className={ROW_ACTION}
-                                />
-                            </span>
-                        </li>
-                    ))}
-                </ul>
+            {openFolder ? (
+                <FolderFileList
+                    group={openFolder}
+                    onRemoveFile={onRemove}
+                    onRetryFile={onRetry}
+                    onOpenFile={onPreview}
+                />
             ) : null}
         </div>
     );

--- a/apps/web/src/components/common/composer/AttachmentStrip.tsx
+++ b/apps/web/src/components/common/composer/AttachmentStrip.tsx
@@ -1,0 +1,639 @@
+'use client';
+
+import { useState } from 'react';
+import {
+    AlertCircle,
+    ChevronRight,
+    Download,
+    File as FileIcon,
+    FileArchive,
+    FileAudio,
+    FileCode,
+    FileSpreadsheet,
+    FileText,
+    FileVideo,
+    Folder,
+    Github,
+    Image as ImageIcon,
+    Loader2,
+    RotateCcw,
+    X,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import {
+    fileIconKind,
+    fileTypeLabel,
+    formatBytes,
+    groupFolderFiles,
+    folderRelativePath,
+    isImageAttachment,
+    isPreviewableAttachment,
+    type ComposerAttachment,
+    type ComposerFileAttachment,
+    type ComposerFolderGroup,
+    type ComposerImageAttachment,
+    type FileIconKind,
+} from './attachments';
+
+/**
+ * The strip of attached items rendered inside the composer card, above the
+ * toolbar.
+ *
+ * Three shapes, matching what each thing actually is:
+ *
+ *   - **Images** → thumbnail tiles. Showing a picked screenshot as a filename
+ *     chip is what made the old composer feel unfinished: you could not tell
+ *     *which* image you had attached, or look at it again.
+ *   - **Documents** → a card with a type glyph, the name, and `PDF · 240 KB`.
+ *     Text and code documents are clickable and open in the preview overlay;
+ *     binaries offer a download once the upload resolves.
+ *   - **Folders** → one card per picked folder (`webkitdirectory` hands us a
+ *     flat file list), with an aggregate size and progress, expanding to the
+ *     files inside. Forty separate chips for one folder pick is unreadable.
+ *
+ * A failed upload stays on screen with its error and a retry rather than
+ * disappearing; silently dropping it would let someone submit believing the
+ * file went along.
+ *
+ * Colours come from the design-system tokens only (`text`, `text-muted`,
+ * `border`, `danger`, `warning`, `success`, `info`) — no brand/primary accent,
+ * so the strip stays quiet next to the prompt it belongs to.
+ */
+
+const KIND_ICONS: Record<FileIconKind, LucideIcon> = {
+    image: ImageIcon,
+    pdf: FileText,
+    text: FileText,
+    sheet: FileSpreadsheet,
+    code: FileCode,
+    archive: FileArchive,
+    audio: FileAudio,
+    video: FileVideo,
+    file: FileIcon,
+};
+
+// One muted hue per family so a stack of documents is scannable. All four are
+// design-system status tokens rather than the brand colour.
+const KIND_TINTS: Record<FileIconKind, string> = {
+    image: 'text-info',
+    pdf: 'text-danger',
+    text: 'text-text-secondary dark:text-text-secondary-dark',
+    sheet: 'text-success',
+    code: 'text-info',
+    archive: 'text-warning',
+    audio: 'text-info',
+    video: 'text-info',
+    file: 'text-text-secondary dark:text-text-secondary-dark',
+};
+
+// `pr-9` reserves the lane the remove / retry actions are absolutely
+// positioned into, so a long filename truncates before it runs under them.
+const CARD_BASE =
+    'relative flex w-56 max-w-full items-center gap-2.5 overflow-hidden rounded-xl border py-2 pl-2.5 pr-9 text-left transition-colors';
+const CARD_QUIET =
+    'border-border/60 bg-foreground/[0.03] hover:bg-foreground/[0.06] dark:border-white/10 dark:bg-white/[0.04] dark:hover:bg-white/[0.07]';
+const CARD_ERROR = 'border-danger/40 bg-danger/[0.06]';
+const ICON_TILE =
+    'flex size-8 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.05] dark:bg-white/[0.06]';
+const ROW_ACTION =
+    'shrink-0 rounded-md p-1 text-text-muted transition-colors hover:bg-foreground/10 hover:text-text dark:text-text-muted-dark dark:hover:bg-white/10 dark:hover:text-text-dark';
+
+function stateTagOf(a: ComposerFileAttachment): string {
+    if (a.error) return 'error';
+    return a.uploading ? 'uploading' : 'ready';
+}
+
+/** Thin progress rule on a card's bottom edge — no extra row. */
+function ProgressRule({ percent }: { readonly percent: number }) {
+    return (
+        <span
+            aria-hidden="true"
+            className="absolute bottom-0 left-0 h-0.5 bg-text-muted/70 transition-[width] duration-200 dark:bg-white/40"
+            style={{ width: `${percent}%` }}
+        />
+    );
+}
+
+function RemoveButton({
+    label,
+    onClick,
+    className,
+}: {
+    readonly label: string;
+    readonly onClick: () => void;
+    readonly className?: string;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={label}
+            title={label}
+            className={className}
+        >
+            <X className="size-3" aria-hidden="true" />
+        </button>
+    );
+}
+
+function RetryButton({
+    label,
+    onClick,
+    className,
+}: {
+    readonly label: string;
+    readonly onClick: () => void;
+    readonly className?: string;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={label}
+            title="Retry upload"
+            className={className}
+        >
+            <RotateCcw className="size-3" aria-hidden="true" />
+        </button>
+    );
+}
+
+function ImageTile({
+    attachment,
+    onOpen,
+    onRemove,
+    onRetry,
+    testId,
+}: {
+    readonly attachment: ComposerImageAttachment;
+    readonly onOpen: () => void;
+    readonly onRemove: () => void;
+    readonly onRetry: () => void;
+    readonly testId?: string;
+}) {
+    const { displayName, uploading, progress, error, file } = attachment;
+    return (
+        <li className="group relative">
+            <button
+                type="button"
+                onClick={onOpen}
+                title={
+                    error
+                        ? `${displayName} — ${error}`
+                        : `${displayName} · ${formatBytes(file.size)}`
+                }
+                aria-label={`Preview ${displayName}`}
+                className={cn(
+                    'relative block size-16 overflow-hidden rounded-xl border',
+                    'transition-[transform,box-shadow,border-color] duration-150',
+                    'hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none',
+                    'focus-visible:ring-2 focus-visible:ring-text-muted/40',
+                    error
+                        ? 'border-danger/50'
+                        : 'border-border/60 hover:border-border-secondary dark:border-white/10 dark:hover:border-white/20',
+                )}
+                data-testid={testId ? `${testId}-attachment-${stateTagOf(attachment)}` : undefined}
+            >
+                {/* eslint-disable-next-line @next/next/no-img-element --
+                    local `blob:` object URL for a just-picked file; nothing
+                    for next/image to optimize or allowlist. */}
+                <img
+                    src={attachment.previewUrl}
+                    alt=""
+                    decoding="async"
+                    className={cn(
+                        'size-full object-cover',
+                        (uploading || error) && 'scale-100 blur-[1px]',
+                    )}
+                />
+
+                {uploading ? (
+                    <span className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/45 text-white">
+                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        <span
+                            className="text-[10px] font-medium tabular-nums"
+                            aria-label={`Uploading ${progress} percent`}
+                        >
+                            {progress}%
+                        </span>
+                    </span>
+                ) : null}
+
+                {error ? (
+                    <span className="absolute inset-0 flex items-center justify-center bg-danger/25 text-danger">
+                        <AlertCircle className="size-4" aria-hidden="true" />
+                    </span>
+                ) : null}
+            </button>
+
+            {error ? (
+                <RetryButton
+                    label={`Retry upload of ${displayName}`}
+                    onClick={onRetry}
+                    className="absolute -bottom-1 -left-1 rounded-full border border-border/60 bg-background p-1 text-text-muted shadow-sm transition-colors hover:text-text dark:border-white/15 dark:bg-zinc-900 dark:text-text-muted-dark dark:hover:text-text-dark"
+                />
+            ) : null}
+
+            <RemoveButton
+                label={`Remove ${displayName}`}
+                onClick={onRemove}
+                className={cn(
+                    'absolute -right-1.5 -top-1.5 rounded-full border p-1 shadow-sm transition-all',
+                    'border-border/60 bg-background text-text-muted dark:border-white/15 dark:bg-zinc-900 dark:text-text-muted-dark',
+                    'hover:text-text dark:hover:text-text-dark',
+                    // Always reachable by keyboard / touch, quiet until hover
+                    // on pointer devices so the strip stays calm.
+                    'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                    'group-focus-within:opacity-100 max-sm:opacity-100',
+                )}
+            />
+        </li>
+    );
+}
+
+/**
+ * A document card: type glyph, name, and `PDF · 240 KB`. The card itself is
+ * clickable when we can render the file ourselves (text / code / CSV);
+ * otherwise it is inert and a download action appears once the upload lands.
+ */
+function FileCard({
+    attachment,
+    onOpen,
+    onRemove,
+    onRetry,
+    testId,
+}: {
+    readonly attachment: ComposerFileAttachment;
+    /** Set when the file can be previewed in-app (text / code / CSV). */
+    readonly onOpen?: () => void;
+    readonly onRemove: () => void;
+    readonly onRetry: () => void;
+    readonly testId?: string;
+}) {
+    const { displayName, uploading, progress, error, file } = attachment;
+    const kind = fileIconKind(displayName, file.type);
+    const Icon = KIND_ICONS[kind];
+    const label = fileTypeLabel(displayName, file.type);
+
+    const body = (
+        <>
+            <span className={ICON_TILE}>
+                {uploading ? (
+                    <Loader2
+                        className="size-4 animate-spin text-text-muted dark:text-text-muted-dark"
+                        aria-hidden="true"
+                    />
+                ) : error ? (
+                    <AlertCircle className="size-4 text-danger" aria-hidden="true" />
+                ) : (
+                    <Icon className={cn('size-4', KIND_TINTS[kind])} aria-hidden="true" />
+                )}
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block truncate text-[13px] font-medium text-text dark:text-text-dark">
+                    {displayName}
+                </span>
+                <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                    {error ? error : uploading ? `${progress}% · ${label}` : label}
+                    {error ? '' : ` · ${formatBytes(file.size)}`}
+                </span>
+            </span>
+        </>
+    );
+
+    // Widen the reserved action lane when there are two buttons in it.
+    const downloadable = !onOpen && !error && !uploading && Boolean(attachment.url);
+    const cardClass = cn(
+        CARD_BASE,
+        error ? CARD_ERROR : CARD_QUIET,
+        (error || downloadable) && 'pr-14',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40',
+    );
+    const testIdAttr = testId ? `${testId}-attachment-${stateTagOf(attachment)}` : undefined;
+    // Only offered once the upload resolves — before that there is no URL to
+    // point at.
+    const downloadHref = downloadable ? attachment.url : undefined;
+
+    return (
+        <li className="relative">
+            {/* Element type is chosen from the file, never from upload state:
+                previewability doesn't change mid-flight, so the card never
+                remounts (and never loses focus) when an upload lands. */}
+            {onOpen ? (
+                <button
+                    type="button"
+                    onClick={onOpen}
+                    aria-label={`Preview ${displayName}`}
+                    title={`${displayName} — click to preview`}
+                    className={cardClass}
+                    data-testid={testIdAttr}
+                >
+                    {body}
+                </button>
+            ) : (
+                <div className={cardClass} title={error || displayName} data-testid={testIdAttr}>
+                    {body}
+                </div>
+            )}
+
+            {/* Actions sit outside the card button so a click on them never
+                also opens the preview. */}
+            <span className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+                {error ? (
+                    <RetryButton
+                        label={`Retry upload of ${displayName}`}
+                        onClick={onRetry}
+                        className={ROW_ACTION}
+                    />
+                ) : null}
+                {downloadHref ? (
+                    <a
+                        href={downloadHref}
+                        download={displayName}
+                        aria-label={`Download ${displayName}`}
+                        title="Download"
+                        className={ROW_ACTION}
+                    >
+                        <Download className="size-3" aria-hidden="true" />
+                    </a>
+                ) : null}
+                <RemoveButton
+                    label={`Remove ${displayName}`}
+                    onClick={onRemove}
+                    className={ROW_ACTION}
+                />
+            </span>
+
+            {uploading ? <ProgressRule percent={progress} /> : null}
+        </li>
+    );
+}
+
+function FolderCard({
+    group,
+    onRemoveFile,
+    onRetryFile,
+    onOpenFile,
+    testId,
+}: {
+    readonly group: ComposerFolderGroup;
+    readonly onRemoveFile: (localId: string) => void;
+    readonly onRetryFile: (localId: string) => void;
+    readonly onOpenFile: (localId: string) => void;
+    readonly testId?: string;
+}) {
+    const [expanded, setExpanded] = useState(false);
+    const { name, files, totalBytes, uploadingCount, failedCount, progress } = group;
+    const count = files.length;
+
+    const summary =
+        failedCount > 0
+            ? `${failedCount} of ${count} failed`
+            : uploadingCount > 0
+              ? `Uploading ${count - uploadingCount + 1} of ${count}`
+              : `${count} file${count === 1 ? '' : 's'} · ${formatBytes(totalBytes)}`;
+
+    return (
+        <li className="relative w-full">
+            <div
+                className={cn(CARD_BASE, 'w-full', failedCount > 0 ? CARD_ERROR : CARD_QUIET)}
+                data-testid={testId ? `${testId}-attachment-folder` : undefined}
+            >
+                <button
+                    type="button"
+                    onClick={() => setExpanded((v) => !v)}
+                    aria-expanded={expanded}
+                    aria-label={`${expanded ? 'Collapse' : 'Expand'} folder ${name}`}
+                    className="flex min-w-0 flex-1 items-center gap-2.5 text-left focus-visible:outline-none"
+                >
+                    <span className={ICON_TILE}>
+                        {uploadingCount > 0 ? (
+                            <Loader2
+                                className="size-4 animate-spin text-text-muted dark:text-text-muted-dark"
+                                aria-hidden="true"
+                            />
+                        ) : failedCount > 0 ? (
+                            <AlertCircle className="size-4 text-danger" aria-hidden="true" />
+                        ) : (
+                            <Folder
+                                className="size-4 text-text-secondary dark:text-text-secondary-dark"
+                                aria-hidden="true"
+                            />
+                        )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[13px] font-medium text-text dark:text-text-dark">
+                            {name}
+                        </span>
+                        <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                            {summary}
+                        </span>
+                    </span>
+                    <ChevronRight
+                        className={cn(
+                            'size-3.5 shrink-0 text-text-muted transition-transform duration-150 dark:text-text-muted-dark',
+                            expanded && 'rotate-90',
+                        )}
+                        aria-hidden="true"
+                    />
+                </button>
+
+                {/* Inside the card, not the <li> — the list item grows when
+                    the folder is expanded, so anchoring to it would drag the
+                    button down to the middle of the file list. */}
+                <span className="absolute right-1.5 top-1/2 -translate-y-1/2">
+                    <RemoveButton
+                        label={`Remove folder ${name}`}
+                        // Each file is its own attachment, so removing the
+                        // folder removes them one by one; the functional state
+                        // updates compose, so this settles as a single render.
+                        onClick={() => files.forEach((f) => onRemoveFile(f.localId))}
+                        className={ROW_ACTION}
+                    />
+                </span>
+
+                {uploadingCount > 0 ? <ProgressRule percent={progress} /> : null}
+            </div>
+
+            {expanded ? (
+                <ul className="mt-1 flex flex-col gap-px rounded-lg border border-border/40 bg-foreground/[0.02] p-1 dark:border-white/[0.07] dark:bg-white/[0.02]">
+                    {files.map((f) => {
+                        const relative = folderRelativePath(f.displayName);
+                        const previewable = isPreviewableAttachment(f);
+                        return (
+                            <li
+                                key={f.localId}
+                                className="flex items-center gap-2 rounded-md px-1.5 py-1"
+                            >
+                                {f.uploading ? (
+                                    <Loader2
+                                        className="size-3 shrink-0 animate-spin text-text-muted dark:text-text-muted-dark"
+                                        aria-hidden="true"
+                                    />
+                                ) : f.error ? (
+                                    <AlertCircle
+                                        className="size-3 shrink-0 text-danger"
+                                        aria-hidden="true"
+                                    />
+                                ) : (
+                                    <FileIcon
+                                        className="size-3 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                        aria-hidden="true"
+                                    />
+                                )}
+                                {previewable ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onOpenFile(f.localId)}
+                                        className="min-w-0 flex-1 truncate text-left text-[11px] text-text underline-offset-2 hover:underline dark:text-text-dark"
+                                        title={`Preview ${relative}`}
+                                    >
+                                        {relative}
+                                    </button>
+                                ) : (
+                                    <span
+                                        className="min-w-0 flex-1 truncate text-[11px] text-text dark:text-text-dark"
+                                        title={relative}
+                                    >
+                                        {relative}
+                                    </span>
+                                )}
+                                <span className="shrink-0 text-[10px] tabular-nums text-text-muted/80 dark:text-text-muted-dark/80">
+                                    {formatBytes(f.file.size)}
+                                </span>
+                                {f.error ? (
+                                    <RetryButton
+                                        label={`Retry upload of ${relative}`}
+                                        onClick={() => onRetryFile(f.localId)}
+                                        className={ROW_ACTION}
+                                    />
+                                ) : null}
+                                <RemoveButton
+                                    label={`Remove ${relative}`}
+                                    onClick={() => onRemoveFile(f.localId)}
+                                    className={ROW_ACTION}
+                                />
+                            </li>
+                        );
+                    })}
+                </ul>
+            ) : null}
+        </li>
+    );
+}
+
+export interface AttachmentStripProps {
+    readonly attachments: ReadonlyArray<ComposerAttachment>;
+    readonly onRemove: (localId: string) => void;
+    readonly onRetry: (localId: string) => void;
+    /** Open the preview overlay on an image or readable text document. */
+    readonly onPreview: (localId: string) => void;
+    readonly testId?: string;
+}
+
+export function AttachmentStrip({
+    attachments,
+    onRemove,
+    onRetry,
+    onPreview,
+    testId,
+}: AttachmentStripProps) {
+    if (attachments.length === 0) return null;
+
+    // Folder files always live inside their folder card, so the image and
+    // document rows only consider standalone picks.
+    const loose = attachments.filter((a) => a.kind === 'file');
+    const images = loose.filter(isImageAttachment);
+    const documents = loose.filter(
+        (a): a is ComposerFileAttachment => a.kind === 'file' && !isImageAttachment(a),
+    );
+    const folders = groupFolderFiles(attachments);
+    const repos = attachments.filter((a) => a.kind === 'github-repo');
+
+    return (
+        <div
+            className="flex flex-col gap-2 px-4 pb-2.5"
+            data-testid={testId ? `${testId}-attachments` : undefined}
+        >
+            {images.length > 0 ? (
+                <ul className="flex flex-wrap gap-2.5 pt-1" aria-label="Attached images">
+                    {images.map((a) => (
+                        <ImageTile
+                            key={a.localId}
+                            attachment={a}
+                            onOpen={() => onPreview(a.localId)}
+                            onRemove={() => onRemove(a.localId)}
+                            onRetry={() => onRetry(a.localId)}
+                            testId={testId}
+                        />
+                    ))}
+                </ul>
+            ) : null}
+
+            {documents.length > 0 ? (
+                <ul className="flex flex-wrap gap-2" aria-label="Attached files">
+                    {documents.map((a) => (
+                        <FileCard
+                            key={a.localId}
+                            attachment={a}
+                            onOpen={
+                                isPreviewableAttachment(a) ? () => onPreview(a.localId) : undefined
+                            }
+                            onRemove={() => onRemove(a.localId)}
+                            onRetry={() => onRetry(a.localId)}
+                            testId={testId}
+                        />
+                    ))}
+                </ul>
+            ) : null}
+
+            {folders.length > 0 ? (
+                <ul className="flex flex-col gap-1.5" aria-label="Attached folders">
+                    {folders.map((group) => (
+                        <FolderCard
+                            key={group.name}
+                            group={group}
+                            onRemoveFile={onRemove}
+                            onRetryFile={onRetry}
+                            onOpenFile={onPreview}
+                            testId={testId}
+                        />
+                    ))}
+                </ul>
+            ) : null}
+
+            {repos.length > 0 ? (
+                <ul className="flex flex-wrap gap-2" aria-label="Attached repositories">
+                    {repos.map((a) => (
+                        <li key={a.localId} className="relative">
+                            <div className={cn(CARD_BASE, CARD_QUIET)} title={a.url}>
+                                <span className={ICON_TILE}>
+                                    <Github
+                                        className="size-4 text-text-secondary dark:text-text-secondary-dark"
+                                        aria-hidden="true"
+                                    />
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                    <span className="block truncate text-[13px] font-medium text-text dark:text-text-dark">
+                                        {a.displayName}
+                                    </span>
+                                    <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                                        GitHub repository
+                                    </span>
+                                </span>
+                            </div>
+                            <span className="absolute right-1.5 top-1/2 -translate-y-1/2">
+                                <RemoveButton
+                                    label={`Remove ${a.displayName}`}
+                                    onClick={() => onRemove(a.localId)}
+                                    className={ROW_ACTION}
+                                />
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/web/src/components/common/composer/AttachmentStrip.tsx
+++ b/apps/web/src/components/common/composer/AttachmentStrip.tsx
@@ -36,34 +36,12 @@ import {
 
 /**
  * The strip of attached items rendered inside the composer card, above the
- * toolbar.
- *
- * **One tile shape for everything.** The image thumbnail is the shape the strip
- * is built around — a square you can recognise at a glance, with its actions as
- * badges on the corners — so a document, a picked folder and a GitHub repo take
- * the same tile: same width, same height, same row, in the order they were
- * added. What differs is only what sits inside the square and the caption under
- * it:
- *
- *   - **Images** → the thumbnail itself, so you can tell *which* screenshot you
- *     attached. Clicking opens it full size.
- *   - **Documents** → a type glyph. Text and code documents open in the preview
- *     overlay; binaries offer a download badge once the upload resolves.
- *   - **Folders** → a folder glyph with the file count (`webkitdirectory` hands
- *     us a flat file list). Expanding one opens its file list *below* the row,
- *     so the tiles themselves never change size. Forty separate tiles for one
- *     folder pick is unreadable.
- *
- * The caption carries the name and `PDF · 240 KB` under every tile, since a
- * glyph alone doesn't say which file it stands for.
+ * toolbar. Images, documents, folders and repos all take the same tile shape;
+ * only the tile's face and caption differ.
  *
  * A failed upload stays on screen with its error and a retry rather than
- * disappearing; silently dropping it would let someone submit believing the
+ * disappearing — silently dropping it would let someone submit believing the
  * file went along.
- *
- * Colours come from the design-system tokens only (`text`, `text-muted`,
- * `border`, `danger`, `warning`, `success`, `info`) — no brand/primary accent,
- * so the strip stays quiet next to the prompt it belongs to.
  */
 
 const KIND_ICONS: Record<FileIconKind, LucideIcon> = {
@@ -78,8 +56,7 @@ const KIND_ICONS: Record<FileIconKind, LucideIcon> = {
     file: FileIcon,
 };
 
-// One muted hue per family so a stack of documents is scannable. All four are
-// design-system status tokens rather than the brand colour.
+// One muted hue per family so a stack of documents is scannable.
 const KIND_TINTS: Record<FileIconKind, string> = {
     image: 'text-info',
     pdf: 'text-danger',
@@ -92,16 +69,14 @@ const KIND_TINTS: Record<FileIconKind, string> = {
     file: 'text-text-secondary dark:text-text-secondary-dark',
 };
 
-// The single footprint every attachment gets: a 4rem square plus its caption.
-// Fixed on both axes — a tile that grew with its label would break the row into
-// ragged bands.
+// Fixed on both axes — a tile that grew with its label would break the row
+// into ragged bands.
 const ITEM = 'group relative w-16 shrink-0';
 const TILE_BASE =
     'relative flex size-16 items-center justify-center overflow-hidden rounded-xl border transition-[transform,box-shadow,border-color] duration-150';
 const TILE_QUIET =
     'border-border/60 bg-foreground/[0.03] dark:border-white/10 dark:bg-white/[0.04]';
 const TILE_ERROR = 'border-danger/50 bg-danger/[0.06]';
-// Only tiles that do something on click lift and take focus.
 const TILE_INTERACTIVE =
     'hover:-translate-y-0.5 hover:shadow-md hover:border-border-secondary dark:hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-muted/40';
 const BADGE =
@@ -118,7 +93,6 @@ function stateTagOf(a: ComposerFileAttachment): string {
     return a.uploading ? 'uploading' : 'ready';
 }
 
-/** Name + `PDF · 240 KB` under a tile, clipped to the tile's width. */
 function Caption({ name, meta }: { readonly name: string; readonly meta: string }) {
     return (
         <span className="mt-1 block w-16">
@@ -176,7 +150,6 @@ function RetryButton({
     );
 }
 
-/** What fills the square: the picked image, or a typed glyph, plus its state. */
 function TileFace({ attachment }: { readonly attachment: ComposerFileAttachment }) {
     const { displayName, uploading, progress, error, file } = attachment;
     const kind = fileIconKind(displayName, file.type);
@@ -220,11 +193,6 @@ function TileFace({ attachment }: { readonly attachment: ComposerFileAttachment 
     );
 }
 
-/**
- * A tile for a single picked file — image or document alike. It is clickable
- * when we can render the file ourselves (image / text / code / CSV); otherwise
- * it is inert and a download badge appears once the upload lands.
- */
 function FileTile({
     attachment,
     onOpen,
@@ -247,8 +215,7 @@ function FileTile({
           ? `${progress}% · ${label}`
           : `${label} · ${formatBytes(file.size)}`;
     const tileClass = cn(TILE_BASE, error ? TILE_ERROR : TILE_QUIET, onOpen && TILE_INTERACTIVE);
-    // Offered only once the upload resolves — before that there is no URL to
-    // point at.
+    // Only once the upload resolves — before that there is no URL to point at.
     const downloadHref = !onOpen && !error && !uploading ? attachment.url : undefined;
 
     return (
@@ -256,9 +223,8 @@ function FileTile({
             className={ITEM}
             data-testid={testId ? `${testId}-attachment-${stateTagOf(attachment)}` : undefined}
         >
-            {/* Element type is chosen from the file, never from upload state:
-                previewability doesn't change mid-flight, so the tile never
-                remounts (and never loses focus) when an upload lands. */}
+            {/* Element type comes from the file, never from upload state, so the
+                tile never remounts (or loses focus) when an upload lands. */}
             {onOpen ? (
                 <button
                     type="button"
@@ -284,8 +250,7 @@ function FileTile({
 
             <Caption name={displayName} meta={meta} />
 
-            {/* Badges sit outside the tile button so a click on one never also
-                opens the preview. */}
+            {/* Outside the tile button so a badge click never also opens the preview. */}
             {error ? (
                 <RetryButton
                     label={`Retry upload of ${displayName}`}
@@ -357,7 +322,6 @@ function FolderTile({
                     className="size-6 text-text-secondary dark:text-text-secondary-dark"
                     aria-hidden="true"
                 />
-                {/* The count is what tells two folder tiles apart at a glance. */}
                 <span className="absolute bottom-1 right-1 rounded px-1 text-[10px] font-medium tabular-nums text-text-muted dark:text-text-muted-dark">
                     {count}
                 </span>
@@ -378,9 +342,6 @@ function FolderTile({
 
             <RemoveButton
                 label={`Remove folder ${name}`}
-                // Each file is its own attachment, so removing the folder
-                // removes them one by one; the functional state updates
-                // compose, so this settles as a single render.
                 onClick={onRemoveFolder}
                 className={cn(BADGE, '-right-1.5 -top-1.5', BADGE_REVEAL)}
             />
@@ -415,9 +376,8 @@ function RepoTile({
 }
 
 /**
- * The contents of the one expanded folder, rendered under the tile row rather
- * than inside the tile, so expanding never changes the size of a tile or
- * reflows the row around it.
+ * Rendered under the tile row rather than inside the tile, so expanding a
+ * folder never resizes a tile or reflows the row around it.
  */
 function FolderFileList({
     group,
@@ -516,14 +476,11 @@ export function AttachmentStrip({
     onPreview,
     testId,
 }: AttachmentStripProps) {
-    // Which folder tile is open, by folder name. Held here rather than in the
-    // tile because the file list renders outside the row.
+    // Held here rather than in the tile because the file list renders outside the row.
     const [expandedFolder, setExpandedFolder] = useState<string | null>(null);
 
     if (attachments.length === 0) return null;
 
-    // Folder files always live inside their folder tile, so the loose tiles
-    // only cover standalone picks.
     const loose = attachments.filter((a): a is ComposerFileAttachment => a.kind === 'file');
     const folders = groupFolderFiles(attachments);
     const repos = attachments.filter(

--- a/apps/web/src/components/common/composer/VoiceBar.tsx
+++ b/apps/web/src/components/common/composer/VoiceBar.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Check, Mic, X } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * The composer's toolbar while dictation is running. Replaces the normal
+ * row (attach / mic / counter / send) rather than sitting next to it, so
+ * recording is a distinct mode instead of one more toggled button.
+ *
+ * Layout: mic → live meter → elapsed → discard / keep. Deliberately wordless
+ * next to the meter: the transcript is already landing in the textarea an
+ * inch above, so echoing it here (or captioning the meter "Listening…") was
+ * duplicate noise. The moving bars are the status.
+ *
+ * Colours are design-system neutrals — a red-tinted bar read as an error
+ * state rather than "we're recording".
+ *
+ * Owns its own ticker so the elapsed clock doesn't re-render the composer
+ * (and the textarea) twice a second.
+ */
+
+function formatElapsed(ms: number): string {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function ElapsedClock({ startedAt }: { readonly startedAt: number }) {
+    // Seeded from mount (which coincides with dictation starting) so there's
+    // no setState-in-effect just to show 0:00 on the first frame.
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 500);
+        return () => clearInterval(id);
+    }, [startedAt]);
+    return (
+        <span className="text-[11px] tabular-nums text-text-muted dark:text-text-muted-dark">
+            {formatElapsed(now - startedAt)}
+        </span>
+    );
+}
+
+/**
+ * Stand-in for the canvas meter when the mic level is unavailable — denied
+ * permission, no Web Audio, or `prefers-reduced-motion`. Still communicates
+ * "live" without claiming to show real levels.
+ */
+function StaticBars({ testId }: { readonly testId?: string }) {
+    return (
+        <span
+            className="flex h-6 shrink-0 items-center gap-[3px]"
+            aria-hidden="true"
+            data-testid={testId ? `${testId}-voice-static` : undefined}
+        >
+            {[0, 1, 2, 3, 4].map((i) => (
+                <span
+                    key={i}
+                    className="w-[2.5px] rounded-full bg-text-muted/60 motion-safe:animate-pulse dark:bg-text-muted-dark/70"
+                    style={{ height: `${[8, 14, 20, 12, 7][i]}px`, animationDelay: `${i * 120}ms` }}
+                />
+            ))}
+        </span>
+    );
+}
+
+export interface VoiceBarProps {
+    readonly startedAt: number;
+    readonly canvasRef: React.RefObject<HTMLCanvasElement | null>;
+    /** True when the mic meter is live; false falls back to static bars. */
+    readonly waveformActive: boolean;
+    /** Stop dictating and drop whatever this session appended. */
+    readonly onCancel: () => void;
+    /** Stop dictating and keep the transcript. */
+    readonly onDone: () => void;
+    readonly testId?: string;
+}
+
+export function VoiceBar({
+    startedAt,
+    canvasRef,
+    waveformActive,
+    onCancel,
+    onDone,
+    testId,
+}: VoiceBarProps) {
+    return (
+        <div
+            className={cn(
+                'flex items-center gap-2.5 px-2 pb-2.5 pt-1.5',
+                'border-t border-border/[0.15] bg-foreground/[0.02] dark:border-white/[0.06] dark:bg-white/[0.02]',
+            )}
+            data-testid={testId ? `${testId}-voice-bar` : undefined}
+        >
+            <span
+                className="relative ml-1 flex size-4 shrink-0 items-center justify-center"
+                aria-hidden="true"
+            >
+                <span className="absolute inline-flex size-3.5 animate-ping rounded-full bg-text-muted/30 motion-reduce:animate-none dark:bg-text-muted-dark/40" />
+                <Mic className="relative size-3.5 text-text dark:text-text-dark" />
+            </span>
+
+            {waveformActive ? (
+                <canvas
+                    ref={canvasRef}
+                    // The bar colour is read back off this element via
+                    // getComputedStyle — see paint() in use-mic-waveform.
+                    className="h-6 w-24 shrink-0 text-text-secondary dark:text-text-secondary-dark sm:w-40"
+                    aria-hidden="true"
+                    data-testid={testId ? `${testId}-voice-waveform` : undefined}
+                />
+            ) : (
+                <StaticBars testId={testId} />
+            )}
+
+            {/* The meter carries this visually; screen readers get it in words. */}
+            <span className="sr-only" aria-live="polite">
+                Listening…
+            </span>
+
+            <span className="ml-auto flex items-center gap-2">
+                <ElapsedClock startedAt={startedAt} />
+
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    aria-label="Discard dictation"
+                    title="Discard dictation"
+                    className="rounded-lg p-2 text-text-muted transition-colors hover:bg-foreground/[0.06] hover:text-text dark:text-text-muted-dark dark:hover:bg-white/[0.06] dark:hover:text-text-dark"
+                    data-testid={testId ? `${testId}-voice-cancel` : undefined}
+                >
+                    <X className="size-4" aria-hidden="true" />
+                </button>
+                <button
+                    type="button"
+                    onClick={onDone}
+                    aria-label="Stop dictation and keep text"
+                    title="Stop dictation and keep text"
+                    className={cn(
+                        'inline-flex items-center justify-center rounded-full p-2.5',
+                        'bg-button-primary text-button-primary-foreground shadow-sm',
+                        'dark:bg-button-primary-dark dark:text-button-primary-foreground-dark',
+                        'transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark',
+                        'active:scale-95',
+                    )}
+                    data-testid={testId ? `${testId}-voice-done` : undefined}
+                >
+                    <Check className="size-4" aria-hidden="true" />
+                </button>
+            </span>
+        </div>
+    );
+}

--- a/apps/web/src/components/common/composer/VoiceBar.tsx
+++ b/apps/web/src/components/common/composer/VoiceBar.tsx
@@ -5,20 +5,12 @@ import { Check, Mic, X } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 
 /**
- * The composer's toolbar while dictation is running. Replaces the normal
- * row (attach / mic / counter / send) rather than sitting next to it, so
- * recording is a distinct mode instead of one more toggled button.
+ * The composer's toolbar while dictation is running. Replaces the normal row
+ * (attach / mic / counter / send) rather than sitting next to it, so recording
+ * is a distinct mode instead of one more toggled button.
  *
- * Layout: mic → live meter → elapsed → discard / keep. Deliberately wordless
- * next to the meter: the transcript is already landing in the textarea an
- * inch above, so echoing it here (or captioning the meter "Listening…") was
- * duplicate noise. The moving bars are the status.
- *
- * Colours are design-system neutrals — a red-tinted bar read as an error
- * state rather than "we're recording".
- *
- * Owns its own ticker so the elapsed clock doesn't re-render the composer
- * (and the textarea) twice a second.
+ * Owns its own ticker so the elapsed clock doesn't re-render the composer (and
+ * the textarea) twice a second.
  */
 
 function formatElapsed(ms: number): string {
@@ -29,7 +21,7 @@ function formatElapsed(ms: number): string {
 }
 
 function ElapsedClock({ startedAt }: { readonly startedAt: number }) {
-    // Seeded from mount (which coincides with dictation starting) so there's
+    // Seeded from mount (which coincides with dictation starting) so there is
     // no setState-in-effect just to show 0:00 on the first frame.
     const [now, setNow] = useState(() => Date.now());
     useEffect(() => {
@@ -45,8 +37,7 @@ function ElapsedClock({ startedAt }: { readonly startedAt: number }) {
 
 /**
  * Stand-in for the canvas meter when the mic level is unavailable — denied
- * permission, no Web Audio, or `prefers-reduced-motion`. Still communicates
- * "live" without claiming to show real levels.
+ * permission, no Web Audio, or `prefers-reduced-motion`.
  */
 function StaticBars({ testId }: { readonly testId?: string }) {
     return (
@@ -105,7 +96,7 @@ export function VoiceBar({
             {waveformActive ? (
                 <canvas
                     ref={canvasRef}
-                    // The bar colour is read back off this element via
+                    // The bar colour is read off this element via
                     // getComputedStyle — see paint() in use-mic-waveform.
                     className="h-6 w-24 shrink-0 text-text-secondary dark:text-text-secondary-dark sm:w-40"
                     aria-hidden="true"

--- a/apps/web/src/components/common/composer/attachments.ts
+++ b/apps/web/src/components/common/composer/attachments.ts
@@ -2,17 +2,9 @@
  * Attachment shapes shared by the PromptComposer and its sub-components.
  *
  * Lives in its own module so `AttachmentStrip` / `AttachmentPreview` can type
- * their props without importing back from `PromptComposer.tsx` (which
- * imports them — a cycle). `PromptComposer` re-exports the public names so
- * existing consumers keep importing from
- * `@/components/common/PromptComposer`.
+ * their props without importing back from `PromptComposer.tsx` (a cycle).
  */
 
-/**
- * A picked file (or a file inside a picked folder). Each entry owns its
- * upload state so the strip can render distinct uploading / ready / error
- * variants.
- */
 export interface ComposerFileAttachment {
     readonly kind: 'file' | 'folder-file';
     readonly localId: string;
@@ -21,27 +13,16 @@ export interface ComposerFileAttachment {
     /** 0–100 percent — XHR-driven during upload. */
     progress: number;
     uploading: boolean;
-    /**
-     * Server-side upload id (sha256 of bytes) once the upload completes.
-     * Callers persist this — it's the canonical reference for
-     * `POST /api/me/missions/:id/attachments` etc.
-     */
+    /** Server-side upload id (sha256 of bytes); the canonical reference callers persist. */
     uploadId?: string;
-    /**
-     * API-routed serve URL (`/api/uploads/<userId>/<filename>`) once the
-     * upload completes. Forwarded into the chat prompt so the chat AI can
-     * reference the file by URL.
-     */
+    /** API-routed serve URL (`/api/uploads/<userId>/<filename>`) once uploaded. */
     url?: string;
-    /** Server-declared MIME (echoed from backend response). */
     mimeType?: string;
-    /** Human-readable failure message; the chip/tile flips to red. */
     error?: string;
     /**
-     * `URL.createObjectURL(file)` for images only. Set at pick time so the
-     * thumbnail renders instantly instead of waiting for the upload to
-     * resolve into a server URL. The composer revokes it on removal and on
-     * unmount — an un-revoked object URL pins the whole file in memory.
+     * `URL.createObjectURL(file)` for images only, set at pick time so the
+     * thumbnail renders without waiting on the upload. Revoked on removal and
+     * on unmount — an un-revoked object URL pins the whole file in memory.
      */
     previewUrl?: string;
 }
@@ -55,13 +36,9 @@ export interface ComposerGithubAttachment {
 
 export type ComposerAttachment = ComposerFileAttachment | ComposerGithubAttachment;
 
-/** A file attachment we have a local preview for — i.e. renderable as a tile. */
 export type ComposerImageAttachment = ComposerFileAttachment & { previewUrl: string };
 
-/**
- * Matches the uploads API's own default cap so the user is told before we
- * push 30 MB up the wire only to have it rejected.
- */
+/** Matches the uploads API's own default cap, so we reject before the wire. */
 export const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
 
 export function isImageFile(file: File): boolean {
@@ -69,17 +46,12 @@ export function isImageFile(file: File): boolean {
 }
 
 /**
- * Narrow to the entries the image strip / lightbox can render. Guards on
- * `previewUrl` rather than the MIME type so an image we could not create an
- * object URL for still degrades to a normal file chip.
+ * Guards on `previewUrl` rather than the MIME type so an image we could not
+ * create an object URL for still degrades to a normal file chip.
  */
 export function isImageAttachment(a: ComposerAttachment): a is ComposerImageAttachment {
     return a.kind !== 'github-repo' && typeof a.previewUrl === 'string';
 }
-
-/* -------------------------------------------------------------------- */
-/* File typing — what a document card shows and whether it can preview  */
-/* -------------------------------------------------------------------- */
 
 /** Which glyph a document card shows. Mapped to a lucide icon by the strip. */
 export type FileIconKind =
@@ -134,11 +106,10 @@ const TEXT_EXTENSIONS =
 export const TEXT_PREVIEW_BYTES = 128 * 1024;
 
 /**
- * Whether we can render this file's contents ourselves, from the local `File`
- * — no server round trip. Text and code we read and show in a `<pre>`; PDFs
- * and binaries we deliberately do not, because the uploads API serves
- * attachments with a non-inline disposition (and the app's CSP blocks
- * `blob:` frames), so there is nothing honest to embed.
+ * Whether we can render this file's contents ourselves from the local `File`.
+ * PDFs and binaries deliberately return false: the uploads API serves
+ * attachments with a non-inline disposition and the app's CSP blocks `blob:`
+ * frames, so there is nothing honest to embed.
  */
 export function isTextLike(file: File, displayName: string): boolean {
     if (file.type.startsWith('text/')) return true;
@@ -152,15 +123,9 @@ export function isPreviewableAttachment(a: ComposerAttachment): a is ComposerFil
     return typeof a.previewUrl === 'string' || isTextLike(a.file, a.displayName);
 }
 
-/* -------------------------------------------------------------------- */
-/* Folders                                                              */
-/* -------------------------------------------------------------------- */
-
 /**
- * A picked folder, reassembled from the flat `FileList` the browser hands
- * back for `webkitdirectory`. Dropping 40 individual chips on the user for
- * one folder pick is unreadable — the strip shows one card per folder that
- * expands to the files inside.
+ * A picked folder, reassembled from the flat `FileList` the browser hands back
+ * for `webkitdirectory` — one card per folder instead of 40 loose chips.
  */
 export interface ComposerFolderGroup {
     readonly name: string;
@@ -233,29 +198,20 @@ export function formatBytes(bytes: number): string {
     return `${value >= 10 || exponent === 0 ? Math.round(value) : value.toFixed(1)} ${units[exponent]}`;
 }
 
-/**
- * The lighter `{ name, url, mimeType?, kind }` shape that
- * `useStartFromPrompt` accepts.
- */
+/** The lighter attachment shape that `useStartFromPrompt` accepts. */
 export interface ComposerAttachmentRef {
     readonly name: string;
     readonly url: string;
     readonly mimeType?: string;
     readonly kind: 'upload' | 'github-repo';
-    /**
-     * SHA-256 upload id — present only for `kind: 'upload'` refs that have
-     * completed. Callers that wire the upload to a freshly-created entity
-     * (Mission/Idea/Agent) pass this to `addAttachment`. The chat-forwarder
-     * ignores this field.
-     */
+    /** SHA-256 upload id — present only for completed `kind: 'upload'` refs. */
     readonly uploadId?: string;
 }
 
 /**
- * Turn the composer's full attachment list into refs callers can act on.
  * Uploads still in flight, uploads that failed, and entries without a
- * server-side URL are filtered out — only references the chat AI can
- * actually resolve are forwarded.
+ * server-side URL are filtered out — only references the chat AI can actually
+ * resolve are forwarded.
  */
 export function buildAttachmentRefs(
     attachments: ReadonlyArray<ComposerAttachment>,

--- a/apps/web/src/components/common/composer/attachments.ts
+++ b/apps/web/src/components/common/composer/attachments.ts
@@ -1,0 +1,280 @@
+/**
+ * Attachment shapes shared by the PromptComposer and its sub-components.
+ *
+ * Lives in its own module so `AttachmentStrip` / `AttachmentPreview` can type
+ * their props without importing back from `PromptComposer.tsx` (which
+ * imports them — a cycle). `PromptComposer` re-exports the public names so
+ * existing consumers keep importing from
+ * `@/components/common/PromptComposer`.
+ */
+
+/**
+ * A picked file (or a file inside a picked folder). Each entry owns its
+ * upload state so the strip can render distinct uploading / ready / error
+ * variants.
+ */
+export interface ComposerFileAttachment {
+    readonly kind: 'file' | 'folder-file';
+    readonly localId: string;
+    readonly file: File;
+    readonly displayName: string;
+    /** 0–100 percent — XHR-driven during upload. */
+    progress: number;
+    uploading: boolean;
+    /**
+     * Server-side upload id (sha256 of bytes) once the upload completes.
+     * Callers persist this — it's the canonical reference for
+     * `POST /api/me/missions/:id/attachments` etc.
+     */
+    uploadId?: string;
+    /**
+     * API-routed serve URL (`/api/uploads/<userId>/<filename>`) once the
+     * upload completes. Forwarded into the chat prompt so the chat AI can
+     * reference the file by URL.
+     */
+    url?: string;
+    /** Server-declared MIME (echoed from backend response). */
+    mimeType?: string;
+    /** Human-readable failure message; the chip/tile flips to red. */
+    error?: string;
+    /**
+     * `URL.createObjectURL(file)` for images only. Set at pick time so the
+     * thumbnail renders instantly instead of waiting for the upload to
+     * resolve into a server URL. The composer revokes it on removal and on
+     * unmount — an un-revoked object URL pins the whole file in memory.
+     */
+    previewUrl?: string;
+}
+
+export interface ComposerGithubAttachment {
+    readonly kind: 'github-repo';
+    readonly localId: string;
+    readonly url: string;
+    readonly displayName: string;
+}
+
+export type ComposerAttachment = ComposerFileAttachment | ComposerGithubAttachment;
+
+/** A file attachment we have a local preview for — i.e. renderable as a tile. */
+export type ComposerImageAttachment = ComposerFileAttachment & { previewUrl: string };
+
+/**
+ * Matches the uploads API's own default cap so the user is told before we
+ * push 30 MB up the wire only to have it rejected.
+ */
+export const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+
+export function isImageFile(file: File): boolean {
+    return file.type.startsWith('image/');
+}
+
+/**
+ * Narrow to the entries the image strip / lightbox can render. Guards on
+ * `previewUrl` rather than the MIME type so an image we could not create an
+ * object URL for still degrades to a normal file chip.
+ */
+export function isImageAttachment(a: ComposerAttachment): a is ComposerImageAttachment {
+    return a.kind !== 'github-repo' && typeof a.previewUrl === 'string';
+}
+
+/* -------------------------------------------------------------------- */
+/* File typing — what a document card shows and whether it can preview  */
+/* -------------------------------------------------------------------- */
+
+/** Which glyph a document card shows. Mapped to a lucide icon by the strip. */
+export type FileIconKind =
+    | 'image'
+    | 'pdf'
+    | 'text'
+    | 'sheet'
+    | 'code'
+    | 'archive'
+    | 'audio'
+    | 'video'
+    | 'file';
+
+// Extension first, MIME as the fallback: browsers routinely hand us
+// `application/octet-stream` (or ``) for .md, .csv and most code files, so
+// trusting `file.type` alone would flatten every document to a generic icon.
+const EXTENSION_KINDS: ReadonlyArray<readonly [RegExp, FileIconKind]> = [
+    [/\.pdf$/i, 'pdf'],
+    [/\.(docx?|odt|rtf|txt|md|markdown|pages)$/i, 'text'],
+    [/\.(csv|tsv|xlsx?|ods|numbers)$/i, 'sheet'],
+    [/\.(zip|tar|gz|tgz|bz2|rar|7z)$/i, 'archive'],
+    [
+        /\.(json|ya?ml|toml|xml|html?|css|scss|less|tsx?|jsx?|mjs|cjs|py|rb|go|rs|java|kt|swift|c|h|cpp|cs|php|sh|bash|zsh|sql|ini|conf|env|log)$/i,
+        'code',
+    ],
+];
+
+export function fileIconKind(name: string, mimeType: string): FileIconKind {
+    if (mimeType.startsWith('image/')) return 'image';
+    if (mimeType.startsWith('audio/')) return 'audio';
+    if (mimeType.startsWith('video/')) return 'video';
+    if (mimeType === 'application/pdf') return 'pdf';
+    for (const [pattern, kind] of EXTENSION_KINDS) {
+        if (pattern.test(name)) return kind;
+    }
+    if (mimeType.startsWith('text/')) return 'text';
+    return 'file';
+}
+
+/** Short type badge for a card's second line — `PDF`, `DOCX`, `PNG`. */
+export function fileTypeLabel(name: string, mimeType: string): string {
+    const extension = /\.([a-z0-9]{1,8})$/i.exec(name)?.[1];
+    if (extension) return extension.toUpperCase();
+    const subtype = mimeType.split('/')[1];
+    return subtype ? subtype.split(/[+.;]/)[0].toUpperCase() : 'FILE';
+}
+
+const TEXT_EXTENSIONS =
+    /\.(txt|md|markdown|csv|tsv|json|ya?ml|toml|xml|html?|css|scss|less|tsx?|jsx?|mjs|cjs|py|rb|go|rs|java|kt|swift|c|h|cpp|cs|php|sh|bash|zsh|sql|ini|conf|env|log)$/i;
+
+/** How much of a text file we read for the preview pane. */
+export const TEXT_PREVIEW_BYTES = 128 * 1024;
+
+/**
+ * Whether we can render this file's contents ourselves, from the local `File`
+ * — no server round trip. Text and code we read and show in a `<pre>`; PDFs
+ * and binaries we deliberately do not, because the uploads API serves
+ * attachments with a non-inline disposition (and the app's CSP blocks
+ * `blob:` frames), so there is nothing honest to embed.
+ */
+export function isTextLike(file: File, displayName: string): boolean {
+    if (file.type.startsWith('text/')) return true;
+    if (file.type === 'application/json') return true;
+    return TEXT_EXTENSIONS.test(displayName);
+}
+
+/** Entries the preview overlay can open: images plus readable text files. */
+export function isPreviewableAttachment(a: ComposerAttachment): a is ComposerFileAttachment {
+    if (a.kind === 'github-repo') return false;
+    return typeof a.previewUrl === 'string' || isTextLike(a.file, a.displayName);
+}
+
+/* -------------------------------------------------------------------- */
+/* Folders                                                              */
+/* -------------------------------------------------------------------- */
+
+/**
+ * A picked folder, reassembled from the flat `FileList` the browser hands
+ * back for `webkitdirectory`. Dropping 40 individual chips on the user for
+ * one folder pick is unreadable — the strip shows one card per folder that
+ * expands to the files inside.
+ */
+export interface ComposerFolderGroup {
+    readonly name: string;
+    readonly files: ReadonlyArray<ComposerFileAttachment>;
+    readonly totalBytes: number;
+    readonly uploadingCount: number;
+    readonly failedCount: number;
+    /** Size-weighted aggregate upload progress, 0–100. */
+    readonly progress: number;
+}
+
+/** Top-level folder segment of a `webkitRelativePath`-derived display name. */
+export function folderNameOf(displayName: string): string {
+    const slash = displayName.indexOf('/');
+    return slash > 0 ? displayName.slice(0, slash) : 'Folder';
+}
+
+/** Path of a file relative to its folder card, for the expanded list. */
+export function folderRelativePath(displayName: string): string {
+    const slash = displayName.indexOf('/');
+    return slash > 0 ? displayName.slice(slash + 1) : displayName;
+}
+
+export function groupFolderFiles(
+    attachments: ReadonlyArray<ComposerAttachment>,
+): ReadonlyArray<ComposerFolderGroup> {
+    const buckets = new Map<string, ComposerFileAttachment[]>();
+    for (const a of attachments) {
+        if (a.kind !== 'folder-file') continue;
+        const name = folderNameOf(a.displayName);
+        const bucket = buckets.get(name);
+        if (bucket) bucket.push(a);
+        else buckets.set(name, [a]);
+    }
+
+    const groups: ComposerFolderGroup[] = [];
+    for (const [name, files] of buckets) {
+        let totalBytes = 0;
+        let totalWeight = 0;
+        let weightedProgress = 0;
+        let uploadingCount = 0;
+        let failedCount = 0;
+        for (const f of files) {
+            totalBytes += f.file.size;
+            // Weight by size so a folder's bar tracks bytes transferred, not
+            // file count; floor at 1 so zero-byte files still count as one.
+            const weight = Math.max(1, f.file.size);
+            totalWeight += weight;
+            weightedProgress += weight * (f.error ? 0 : f.uploading ? f.progress : 100);
+            if (f.uploading) uploadingCount += 1;
+            if (f.error) failedCount += 1;
+        }
+        groups.push({
+            name,
+            files,
+            totalBytes,
+            uploadingCount,
+            failedCount,
+            progress: Math.round(weightedProgress / totalWeight),
+        });
+    }
+    return groups;
+}
+
+export function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+    const value = bytes / 1024 ** exponent;
+    return `${value >= 10 || exponent === 0 ? Math.round(value) : value.toFixed(1)} ${units[exponent]}`;
+}
+
+/**
+ * The lighter `{ name, url, mimeType?, kind }` shape that
+ * `useStartFromPrompt` accepts.
+ */
+export interface ComposerAttachmentRef {
+    readonly name: string;
+    readonly url: string;
+    readonly mimeType?: string;
+    readonly kind: 'upload' | 'github-repo';
+    /**
+     * SHA-256 upload id — present only for `kind: 'upload'` refs that have
+     * completed. Callers that wire the upload to a freshly-created entity
+     * (Mission/Idea/Agent) pass this to `addAttachment`. The chat-forwarder
+     * ignores this field.
+     */
+    readonly uploadId?: string;
+}
+
+/**
+ * Turn the composer's full attachment list into refs callers can act on.
+ * Uploads still in flight, uploads that failed, and entries without a
+ * server-side URL are filtered out — only references the chat AI can
+ * actually resolve are forwarded.
+ */
+export function buildAttachmentRefs(
+    attachments: ReadonlyArray<ComposerAttachment>,
+): ReadonlyArray<ComposerAttachmentRef> {
+    const refs: ComposerAttachmentRef[] = [];
+    for (const a of attachments) {
+        if (a.kind === 'github-repo') {
+            refs.push({ name: a.displayName, url: a.url, kind: 'github-repo' });
+            continue;
+        }
+        if (a.url && a.uploadId && !a.uploading && !a.error) {
+            refs.push({
+                name: a.displayName,
+                url: a.url,
+                mimeType: a.mimeType,
+                kind: 'upload',
+                uploadId: a.uploadId,
+            });
+        }
+    }
+    return refs;
+}

--- a/apps/web/src/components/common/composer/use-dictation.ts
+++ b/apps/web/src/components/common/composer/use-dictation.ts
@@ -1,0 +1,171 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMicWaveform } from './use-mic-waveform';
+
+/**
+ * Web Speech API dictation for the composer, paired with a live mic meter.
+ *
+ * Only *final* results are appended, so a phrase the recognizer revises
+ * mid-sentence never leaves half-words in the user's prompt. Interim results
+ * are still requested (they make the recognizer commit finals sooner) but are
+ * deliberately not surfaced: they would either duplicate the text already
+ * landing in the textarea or re-render the composer on every syllable.
+ *
+ * The waveform (see `useMicWaveform`) is the recording indicator — it
+ * confirms the mic is actually hearing something, unlike a dot that looks
+ * identical whether the input is live or muted.
+ *
+ * Gracefully no-ops in browsers without SpeechRecognition (`supported`
+ * stays false and the mic button is not rendered).
+ */
+
+// Web Speech API isn't in TS's default DOM lib. Use a narrow ambient type
+// just for the bits we touch; browsers expose it on
+// `window.SpeechRecognition` (standard) or `window.webkitSpeechRecognition`
+// (Chrome / Safari).
+interface SpeechResult {
+    readonly isFinal: boolean;
+    readonly [index: number]: { readonly transcript: string };
+}
+interface SpeechResultList {
+    readonly length: number;
+    readonly [index: number]: SpeechResult;
+}
+interface SpeechEvent {
+    readonly resultIndex: number;
+    readonly results: SpeechResultList;
+}
+interface SpeechRecognizer {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    onresult: ((event: SpeechEvent) => void) | null;
+    onend: (() => void) | null;
+    onerror: (() => void) | null;
+    start(): void;
+    stop(): void;
+}
+type SpeechRecognizerCtor = new () => SpeechRecognizer;
+
+declare global {
+    interface Window {
+        SpeechRecognition?: SpeechRecognizerCtor;
+        webkitSpeechRecognition?: SpeechRecognizerCtor;
+    }
+}
+
+export interface Dictation {
+    /** Whether this browser can dictate at all. */
+    readonly supported: boolean;
+    readonly listening: boolean;
+    /** `Date.now()` at the moment dictation started — drives the elapsed timer. */
+    readonly startedAt: number | null;
+    /** True when the mic meter is live; false when it degraded gracefully. */
+    readonly waveformActive: boolean;
+    readonly canvasRef: React.RefObject<HTMLCanvasElement | null>;
+    start: () => void;
+    stop: () => void;
+}
+
+export function useDictation(onFinalText: (text: string) => void): Dictation {
+    const recognitionRef = useRef<SpeechRecognizer | null>(null);
+    const [listening, setListening] = useState(false);
+    const [supported, setSupported] = useState(false);
+    const [startedAt, setStartedAt] = useState<number | null>(null);
+    const waveform = useMicWaveform();
+
+    // Park the latest callback in a ref so the recognizer can dispatch
+    // through it without re-subscribing every render — re-subscribing would
+    // tear down continuous dictation after the first phrase.
+    const onFinalTextRef = useRef(onFinalText);
+    useEffect(() => {
+        onFinalTextRef.current = onFinalText;
+    }, [onFinalText]);
+
+    // Same reason: `onend` / `onerror` fire from outside React and must be
+    // able to shut the meter down without the effect depending on it.
+    const waveformStopRef = useRef(waveform.stop);
+    useEffect(() => {
+        waveformStopRef.current = waveform.stop;
+    }, [waveform.stop]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const Ctor = window.SpeechRecognition || window.webkitSpeechRecognition;
+        if (!Ctor) {
+            // `supported` defaults to false at mount — nothing to do here.
+            // We deliberately avoid calling setSupported(false) in the effect
+            // body to satisfy react-hooks/set-state-in-effect.
+            return;
+        }
+        const rec = new Ctor();
+        rec.continuous = true;
+        rec.interimResults = true;
+        rec.lang = typeof navigator !== 'undefined' ? navigator.language || 'en-US' : 'en-US';
+        rec.onresult = (event) => {
+            let finalText = '';
+            for (let i = event.resultIndex; i < event.results.length; i++) {
+                const result = event.results[i];
+                if (result.isFinal) finalText += result[0].transcript;
+            }
+            if (finalText.trim()) onFinalTextRef.current(finalText.trim());
+        };
+        const endSession = () => {
+            setListening(false);
+            setStartedAt(null);
+            waveformStopRef.current();
+        };
+        rec.onend = endSession;
+        rec.onerror = endSession;
+        recognitionRef.current = rec;
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot capability detection at mount; can't be derived during render (needs window.SpeechRecognition).
+        setSupported(true);
+        return () => {
+            try {
+                rec.stop();
+            } catch {
+                /* noop */
+            }
+        };
+    }, []);
+
+    const start = useCallback(() => {
+        if (!recognitionRef.current) return;
+        try {
+            // Recognition first: on some browsers an already-open
+            // getUserMedia stream makes SpeechRecognition.start() throw, so
+            // the meter is the thing we're willing to lose, not the words.
+            recognitionRef.current.start();
+        } catch {
+            return; /* already started */
+        }
+        setListening(true);
+        setStartedAt(Date.now());
+        void waveform.start();
+    }, [waveform]);
+
+    const stop = useCallback(() => {
+        try {
+            recognitionRef.current?.stop();
+        } catch {
+            /* noop */
+        }
+        setListening(false);
+        setStartedAt(null);
+        waveform.stop();
+    }, [waveform]);
+
+    return useMemo(
+        () => ({
+            supported,
+            listening,
+            startedAt,
+            waveformActive: waveform.active,
+            canvasRef: waveform.canvasRef,
+            start,
+            stop,
+        }),
+        [supported, listening, startedAt, waveform.active, waveform.canvasRef, start, stop],
+    );
+}

--- a/apps/web/src/components/common/composer/use-dictation.ts
+++ b/apps/web/src/components/common/composer/use-dictation.ts
@@ -8,22 +8,16 @@ import { useMicWaveform } from './use-mic-waveform';
  *
  * Only *final* results are appended, so a phrase the recognizer revises
  * mid-sentence never leaves half-words in the user's prompt. Interim results
- * are still requested (they make the recognizer commit finals sooner) but are
- * deliberately not surfaced: they would either duplicate the text already
- * landing in the textarea or re-render the composer on every syllable.
+ * are still requested — they make the recognizer commit finals sooner — but
+ * are not surfaced.
  *
- * The waveform (see `useMicWaveform`) is the recording indicator — it
- * confirms the mic is actually hearing something, unlike a dot that looks
- * identical whether the input is live or muted.
- *
- * Gracefully no-ops in browsers without SpeechRecognition (`supported`
- * stays false and the mic button is not rendered).
+ * No-ops in browsers without SpeechRecognition: `supported` stays false and
+ * the mic button is not rendered.
  */
 
-// Web Speech API isn't in TS's default DOM lib. Use a narrow ambient type
-// just for the bits we touch; browsers expose it on
-// `window.SpeechRecognition` (standard) or `window.webkitSpeechRecognition`
-// (Chrome / Safari).
+// Web Speech API isn't in TS's default DOM lib, so declare just the bits we
+// touch. Browsers expose it as `SpeechRecognition` (standard) or
+// `webkitSpeechRecognition` (Chrome / Safari).
 interface SpeechResult {
     readonly isFinal: boolean;
     readonly [index: number]: { readonly transcript: string };
@@ -61,7 +55,7 @@ export interface Dictation {
     readonly listening: boolean;
     /** `Date.now()` at the moment dictation started — drives the elapsed timer. */
     readonly startedAt: number | null;
-    /** True when the mic meter is live; false when it degraded gracefully. */
+    /** True when the mic meter is live; false when it degraded to static bars. */
     readonly waveformActive: boolean;
     readonly canvasRef: React.RefObject<HTMLCanvasElement | null>;
     start: () => void;
@@ -75,16 +69,16 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
     const [startedAt, setStartedAt] = useState<number | null>(null);
     const waveform = useMicWaveform();
 
-    // Park the latest callback in a ref so the recognizer can dispatch
-    // through it without re-subscribing every render — re-subscribing would
-    // tear down continuous dictation after the first phrase.
+    // Park the latest callback in a ref so the recognizer can dispatch through
+    // it without re-subscribing every render — re-subscribing would tear down
+    // continuous dictation after the first phrase.
     const onFinalTextRef = useRef(onFinalText);
     useEffect(() => {
         onFinalTextRef.current = onFinalText;
     }, [onFinalText]);
 
-    // Same reason: `onend` / `onerror` fire from outside React and must be
-    // able to shut the meter down without the effect depending on it.
+    // Same reason: `onend` / `onerror` fire from outside React and must shut
+    // the meter down without the effect depending on it.
     const waveformStopRef = useRef(waveform.stop);
     useEffect(() => {
         waveformStopRef.current = waveform.stop;
@@ -93,12 +87,9 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
     useEffect(() => {
         if (typeof window === 'undefined') return;
         const Ctor = window.SpeechRecognition || window.webkitSpeechRecognition;
-        if (!Ctor) {
-            // `supported` defaults to false at mount — nothing to do here.
-            // We deliberately avoid calling setSupported(false) in the effect
-            // body to satisfy react-hooks/set-state-in-effect.
-            return;
-        }
+        // `supported` already defaults to false; setting it here would trip
+        // react-hooks/set-state-in-effect for no gain.
+        if (!Ctor) return;
         const rec = new Ctor();
         rec.continuous = true;
         rec.interimResults = true;
@@ -133,9 +124,9 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
     const start = useCallback(() => {
         if (!recognitionRef.current) return;
         try {
-            // Recognition first: on some browsers an already-open
-            // getUserMedia stream makes SpeechRecognition.start() throw, so
-            // the meter is the thing we're willing to lose, not the words.
+            // Recognition first: on some browsers an already-open getUserMedia
+            // stream makes SpeechRecognition.start() throw, and the meter is
+            // the thing we're willing to lose, not the words.
             recognitionRef.current.start();
         } catch {
             return; /* already started */

--- a/apps/web/src/components/common/composer/use-dictation.ts
+++ b/apps/web/src/components/common/composer/use-dictation.ts
@@ -64,6 +64,7 @@ export interface Dictation {
 
 export function useDictation(onFinalText: (text: string) => void): Dictation {
     const recognitionRef = useRef<SpeechRecognizer | null>(null);
+    const sessionActiveRef = useRef(false);
     const [listening, setListening] = useState(false);
     const [supported, setSupported] = useState(false);
     const [startedAt, setStartedAt] = useState<number | null>(null);
@@ -95,6 +96,7 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
         rec.interimResults = true;
         rec.lang = typeof navigator !== 'undefined' ? navigator.language || 'en-US' : 'en-US';
         rec.onresult = (event) => {
+            if (!sessionActiveRef.current) return;
             let finalText = '';
             for (let i = event.resultIndex; i < event.results.length; i++) {
                 const result = event.results[i];
@@ -103,6 +105,7 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
             if (finalText.trim()) onFinalTextRef.current(finalText.trim());
         };
         const endSession = () => {
+            sessionActiveRef.current = false;
             setListening(false);
             setStartedAt(null);
             waveformStopRef.current();
@@ -113,6 +116,7 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
         // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot capability detection at mount; can't be derived during render (needs window.SpeechRecognition).
         setSupported(true);
         return () => {
+            sessionActiveRef.current = false;
             try {
                 rec.stop();
             } catch {
@@ -131,12 +135,14 @@ export function useDictation(onFinalText: (text: string) => void): Dictation {
         } catch {
             return; /* already started */
         }
+        sessionActiveRef.current = true;
         setListening(true);
         setStartedAt(Date.now());
         void waveform.start();
     }, [waveform]);
 
     const stop = useCallback(() => {
+        sessionActiveRef.current = false;
         try {
             recognitionRef.current?.stop();
         } catch {

--- a/apps/web/src/components/common/composer/use-mic-waveform.ts
+++ b/apps/web/src/components/common/composer/use-mic-waveform.ts
@@ -5,15 +5,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Live microphone level meter for the composer's dictation bar.
  *
- * The Web Speech API tells us *what* was said but exposes no audio level, so
- * a dictation UI built on it alone can only offer a static "listening" dot —
- * the user gets no confirmation their mic is actually picking anything up.
- * This hook opens a second, silent `getUserMedia` stream purely to read
- * amplitude off an `AnalyserNode` and paints it as a scrolling bar meter.
+ * The Web Speech API exposes no audio level, so this hook opens a second,
+ * silent `getUserMedia` stream purely to read amplitude off an `AnalyserNode`
+ * and paint it as a scrolling bar meter.
  *
- * Everything runs on refs + `requestAnimationFrame` into a `<canvas>`: React
- * never re-renders while recording, which matters because this repaints
- * continuously for as long as the user talks.
+ * Everything runs on refs + `requestAnimationFrame` into a `<canvas>`, so
+ * React never re-renders while recording.
  *
  * The analyser is deliberately NOT connected to `ctx.destination` — routing
  * the mic to the speakers would feed back.
@@ -35,15 +32,14 @@ export interface MicWaveform {
     /** True while a mic stream is open and the meter is painting. */
     readonly active: boolean;
     /**
-     * Opens the mic and starts painting. Resolves `false` when the mic is
-     * unavailable, permission is denied, or the browser lacks Web Audio —
-     * callers fall back to a non-audio "listening" indicator.
+     * Resolves `false` when the mic is unavailable, permission is denied, or
+     * the browser lacks Web Audio — callers fall back to a static indicator.
      */
     start: () => Promise<boolean>;
     stop: () => void;
 }
 
-/** RMS amplitude of the current audio frame, normalized to a 0–1 bar height. */
+/** RMS amplitude of the current frame, normalized to a 0–1 bar height. */
 function readLevel(analyser: AnalyserNode, data: Uint8Array<ArrayBuffer>): number {
     analyser.getByteTimeDomainData(data);
     let sumSquares = 0;
@@ -76,9 +72,9 @@ function paint(canvas: HTMLCanvasElement, levels: ReadonlyArray<number>): void {
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, cssWidth, cssHeight);
 
-    // Inherit the colour from CSS so the meter follows the light/dark design
-    // token set on the element instead of hard-coding a hex here.
-    // (`currentColor` is not a valid canvas fill, hence a literal neutral.)
+    // Inherit the colour from CSS so the meter follows the light/dark token on
+    // the element. (`currentColor` is not a valid canvas fill, hence the
+    // literal neutral fallback.)
     ctx.fillStyle = window.getComputedStyle(canvas).color || '#71717a';
 
     const step = BAR_WIDTH + BAR_GAP;
@@ -166,9 +162,8 @@ export function useMicWaveform(): MicWaveform {
             levelsRef.current = [];
             lastSampleRef.current = 0;
 
-            // The loop lives here (a hoisted declaration so it can schedule
-            // itself) and touches only refs, so it never needs re-creating
-            // and React never re-renders while the meter runs.
+            // Hoisted so it can schedule itself; touches only refs, so React
+            // never re-renders while the meter runs.
             function frame() {
                 rafRef.current = requestAnimationFrame(frame);
 
@@ -200,7 +195,6 @@ export function useMicWaveform(): MicWaveform {
     // Never leave a mic stream open behind an unmounted composer.
     useEffect(() => stop, [stop]);
 
-    // Stable identity so the consuming hook's start/stop stay stable too —
-    // they end up in effect dependency arrays.
+    // Stable identity: the consuming hook puts start/stop in dependency arrays.
     return useMemo(() => ({ canvasRef, active, start, stop }), [active, start, stop]);
 }

--- a/apps/web/src/components/common/composer/use-mic-waveform.ts
+++ b/apps/web/src/components/common/composer/use-mic-waveform.ts
@@ -27,14 +27,8 @@ const LEVEL_GAIN = 4;
 const MIN_LEVEL = 0.05;
 
 export interface MicWaveform {
-    /** Attach to the `<canvas>` that should show the meter. */
     readonly canvasRef: React.RefObject<HTMLCanvasElement | null>;
-    /** True while a mic stream is open and the meter is painting. */
     readonly active: boolean;
-    /**
-     * Resolves `false` when the mic is unavailable, permission is denied, or
-     * the browser lacks Web Audio — callers fall back to a static indicator.
-     */
     start: () => Promise<boolean>;
     stop: () => void;
 }
@@ -58,9 +52,6 @@ function paint(canvas: HTMLCanvasElement, levels: ReadonlyArray<number>): void {
     const cssWidth = canvas.clientWidth;
     const cssHeight = canvas.clientHeight;
     if (cssWidth === 0 || cssHeight === 0) return;
-
-    // Re-back the bitmap only when the CSS box or DPR actually changed;
-    // assigning width/height clears the canvas on every write.
     const dpr = window.devicePixelRatio || 1;
     const targetWidth = Math.round(cssWidth * dpr);
     const targetHeight = Math.round(cssHeight * dpr);
@@ -71,15 +62,10 @@ function paint(canvas: HTMLCanvasElement, levels: ReadonlyArray<number>): void {
 
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, cssWidth, cssHeight);
-
-    // Inherit the colour from CSS so the meter follows the light/dark token on
-    // the element. (`currentColor` is not a valid canvas fill, hence the
-    // literal neutral fallback.)
     ctx.fillStyle = window.getComputedStyle(canvas).color || '#71717a';
 
     const step = BAR_WIDTH + BAR_GAP;
     const visible = Math.max(6, Math.floor((cssWidth + BAR_GAP) / step));
-    // Newest sample sits at the right edge, so the meter scrolls leftwards.
     const window_ = levels.slice(-visible);
     const offset = visible - window_.length;
 
@@ -88,7 +74,6 @@ function paint(canvas: HTMLCanvasElement, levels: ReadonlyArray<number>): void {
         const height = Math.max(2, level * (cssHeight - 2));
         const x = (offset + i) * step;
         const y = (cssHeight - height) / 2;
-        // Fade the tail so the history reads as motion even in a still frame.
         ctx.globalAlpha = 0.3 + 0.7 * ((offset + i + 1) / visible);
         if (typeof ctx.roundRect === 'function') {
             ctx.beginPath();
@@ -107,20 +92,19 @@ export function useMicWaveform(): MicWaveform {
     const streamRef = useRef<MediaStream | null>(null);
     const audioCtxRef = useRef<AudioContext | null>(null);
     const analyserRef = useRef<AnalyserNode | null>(null);
-    // Explicit `<ArrayBuffer>` — `getByteTimeDomainData` rejects the
-    // `ArrayBufferLike` default (it could be a SharedArrayBuffer).
     const dataRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
     const rafRef = useRef<number | null>(null);
     const lastSampleRef = useRef(0);
+    /** Bumped by every `start`/`stop`; lets a resolving `start` know it is stale. */
+    const sessionRef = useRef(0);
     const [active, setActive] = useState(false);
 
     const stop = useCallback(() => {
+        sessionRef.current++;
         if (rafRef.current !== null) {
             cancelAnimationFrame(rafRef.current);
             rafRef.current = null;
         }
-        // Releasing the tracks is what turns the browser's recording
-        // indicator off — closing the AudioContext alone does not.
         streamRef.current?.getTracks().forEach((track) => track.stop());
         streamRef.current = null;
         analyserRef.current = null;
@@ -137,19 +121,24 @@ export function useMicWaveform(): MicWaveform {
 
     const start = useCallback(async () => {
         if (typeof window === 'undefined') return false;
-        // A continuously animating meter is exactly what "reduce motion"
-        // asks us not to draw; the caller shows a static indicator instead.
         if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return false;
         if (!navigator.mediaDevices?.getUserMedia || !window.AudioContext) return false;
 
+        const session = ++sessionRef.current;
+
         try {
             const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            // The permission prompt can outlive the request: bail out if the caller
+            // stopped dictation, or started it again, while we were waiting.
+            if (sessionRef.current !== session) {
+                stream.getTracks().forEach((track) => track.stop());
+                return false;
+            }
             streamRef.current = stream;
 
             const audioCtx = new window.AudioContext();
             audioCtxRef.current = audioCtx;
             void audioCtx.resume().catch(() => {
-                /* autoplay policy — the meter just stays flat */
             });
 
             const analyser = audioCtx.createAnalyser();
@@ -161,9 +150,6 @@ export function useMicWaveform(): MicWaveform {
 
             levelsRef.current = [];
             lastSampleRef.current = 0;
-
-            // Hoisted so it can schedule itself; touches only refs, so React
-            // never re-renders while the meter runs.
             function frame() {
                 rafRef.current = requestAnimationFrame(frame);
 
@@ -186,15 +172,11 @@ export function useMicWaveform(): MicWaveform {
             rafRef.current = requestAnimationFrame(frame);
             return true;
         } catch {
-            // Permission denied / no input device / mic already claimed.
-            stop();
+            if (sessionRef.current === session) stop();
             return false;
         }
     }, [stop]);
 
-    // Never leave a mic stream open behind an unmounted composer.
     useEffect(() => stop, [stop]);
-
-    // Stable identity: the consuming hook puts start/stop in dependency arrays.
     return useMemo(() => ({ canvasRef, active, start, stop }), [active, start, stop]);
 }

--- a/apps/web/src/components/common/composer/use-mic-waveform.ts
+++ b/apps/web/src/components/common/composer/use-mic-waveform.ts
@@ -1,0 +1,206 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Live microphone level meter for the composer's dictation bar.
+ *
+ * The Web Speech API tells us *what* was said but exposes no audio level, so
+ * a dictation UI built on it alone can only offer a static "listening" dot —
+ * the user gets no confirmation their mic is actually picking anything up.
+ * This hook opens a second, silent `getUserMedia` stream purely to read
+ * amplitude off an `AnalyserNode` and paints it as a scrolling bar meter.
+ *
+ * Everything runs on refs + `requestAnimationFrame` into a `<canvas>`: React
+ * never re-renders while recording, which matters because this repaints
+ * continuously for as long as the user talks.
+ *
+ * The analyser is deliberately NOT connected to `ctx.destination` — routing
+ * the mic to the speakers would feed back.
+ */
+
+/** Widest history we keep; the visible count is derived from canvas width. */
+const MAX_SAMPLES = 96;
+/** ~18 samples/sec — fast enough to track syllables, cheap to paint. */
+const SAMPLE_INTERVAL_MS = 55;
+const BAR_WIDTH = 2.5;
+const BAR_GAP = 2;
+/** Speech RMS lands around 0.02–0.2; scale so normal talking fills the bar. */
+const LEVEL_GAIN = 4;
+const MIN_LEVEL = 0.05;
+
+export interface MicWaveform {
+    /** Attach to the `<canvas>` that should show the meter. */
+    readonly canvasRef: React.RefObject<HTMLCanvasElement | null>;
+    /** True while a mic stream is open and the meter is painting. */
+    readonly active: boolean;
+    /**
+     * Opens the mic and starts painting. Resolves `false` when the mic is
+     * unavailable, permission is denied, or the browser lacks Web Audio —
+     * callers fall back to a non-audio "listening" indicator.
+     */
+    start: () => Promise<boolean>;
+    stop: () => void;
+}
+
+/** RMS amplitude of the current audio frame, normalized to a 0–1 bar height. */
+function readLevel(analyser: AnalyserNode, data: Uint8Array<ArrayBuffer>): number {
+    analyser.getByteTimeDomainData(data);
+    let sumSquares = 0;
+    for (let i = 0; i < data.length; i++) {
+        const deviation = (data[i] - 128) / 128;
+        sumSquares += deviation * deviation;
+    }
+    const rms = Math.sqrt(sumSquares / data.length);
+    return Math.min(1, Math.max(MIN_LEVEL, rms * LEVEL_GAIN));
+}
+
+function paint(canvas: HTMLCanvasElement, levels: ReadonlyArray<number>): void {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const cssWidth = canvas.clientWidth;
+    const cssHeight = canvas.clientHeight;
+    if (cssWidth === 0 || cssHeight === 0) return;
+
+    // Re-back the bitmap only when the CSS box or DPR actually changed;
+    // assigning width/height clears the canvas on every write.
+    const dpr = window.devicePixelRatio || 1;
+    const targetWidth = Math.round(cssWidth * dpr);
+    const targetHeight = Math.round(cssHeight * dpr);
+    if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+    }
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+    // Inherit the colour from CSS so the meter follows the light/dark design
+    // token set on the element instead of hard-coding a hex here.
+    // (`currentColor` is not a valid canvas fill, hence a literal neutral.)
+    ctx.fillStyle = window.getComputedStyle(canvas).color || '#71717a';
+
+    const step = BAR_WIDTH + BAR_GAP;
+    const visible = Math.max(6, Math.floor((cssWidth + BAR_GAP) / step));
+    // Newest sample sits at the right edge, so the meter scrolls leftwards.
+    const window_ = levels.slice(-visible);
+    const offset = visible - window_.length;
+
+    for (let i = 0; i < window_.length; i++) {
+        const level = window_[i];
+        const height = Math.max(2, level * (cssHeight - 2));
+        const x = (offset + i) * step;
+        const y = (cssHeight - height) / 2;
+        // Fade the tail so the history reads as motion even in a still frame.
+        ctx.globalAlpha = 0.3 + 0.7 * ((offset + i + 1) / visible);
+        if (typeof ctx.roundRect === 'function') {
+            ctx.beginPath();
+            ctx.roundRect(x, y, BAR_WIDTH, height, BAR_WIDTH / 2);
+            ctx.fill();
+        } else {
+            ctx.fillRect(x, y, BAR_WIDTH, height);
+        }
+    }
+    ctx.globalAlpha = 1;
+}
+
+export function useMicWaveform(): MicWaveform {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const levelsRef = useRef<number[]>([]);
+    const streamRef = useRef<MediaStream | null>(null);
+    const audioCtxRef = useRef<AudioContext | null>(null);
+    const analyserRef = useRef<AnalyserNode | null>(null);
+    // Explicit `<ArrayBuffer>` — `getByteTimeDomainData` rejects the
+    // `ArrayBufferLike` default (it could be a SharedArrayBuffer).
+    const dataRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
+    const rafRef = useRef<number | null>(null);
+    const lastSampleRef = useRef(0);
+    const [active, setActive] = useState(false);
+
+    const stop = useCallback(() => {
+        if (rafRef.current !== null) {
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        }
+        // Releasing the tracks is what turns the browser's recording
+        // indicator off — closing the AudioContext alone does not.
+        streamRef.current?.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+        analyserRef.current = null;
+        dataRef.current = null;
+        if (audioCtxRef.current) {
+            void audioCtxRef.current.close().catch(() => {
+                /* already closed */
+            });
+            audioCtxRef.current = null;
+        }
+        levelsRef.current = [];
+        setActive(false);
+    }, []);
+
+    const start = useCallback(async () => {
+        if (typeof window === 'undefined') return false;
+        // A continuously animating meter is exactly what "reduce motion"
+        // asks us not to draw; the caller shows a static indicator instead.
+        if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return false;
+        if (!navigator.mediaDevices?.getUserMedia || !window.AudioContext) return false;
+
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            streamRef.current = stream;
+
+            const audioCtx = new window.AudioContext();
+            audioCtxRef.current = audioCtx;
+            void audioCtx.resume().catch(() => {
+                /* autoplay policy — the meter just stays flat */
+            });
+
+            const analyser = audioCtx.createAnalyser();
+            analyser.fftSize = 1024;
+            analyser.smoothingTimeConstant = 0.7;
+            audioCtx.createMediaStreamSource(stream).connect(analyser);
+            analyserRef.current = analyser;
+            dataRef.current = new Uint8Array(analyser.fftSize);
+
+            levelsRef.current = [];
+            lastSampleRef.current = 0;
+
+            // The loop lives here (a hoisted declaration so it can schedule
+            // itself) and touches only refs, so it never needs re-creating
+            // and React never re-renders while the meter runs.
+            function frame() {
+                rafRef.current = requestAnimationFrame(frame);
+
+                const canvas = canvasRef.current;
+                const liveAnalyser = analyserRef.current;
+                const data = dataRef.current;
+                if (!canvas || !liveAnalyser || !data) return;
+
+                const now = performance.now();
+                if (now - lastSampleRef.current < SAMPLE_INTERVAL_MS) return;
+                lastSampleRef.current = now;
+
+                const levels = levelsRef.current;
+                levels.push(readLevel(liveAnalyser, data));
+                if (levels.length > MAX_SAMPLES) levels.shift();
+                paint(canvas, levels);
+            }
+
+            setActive(true);
+            rafRef.current = requestAnimationFrame(frame);
+            return true;
+        } catch {
+            // Permission denied / no input device / mic already claimed.
+            stop();
+            return false;
+        }
+    }, [stop]);
+
+    // Never leave a mic stream open behind an unmounted composer.
+    useEffect(() => stop, [stop]);
+
+    // Stable identity so the consuming hook's start/stop stay stable too —
+    // they end up in effect dependency arrays.
+    return useMemo(() => ({ canvasRef, active, start, stop }), [active, start, stop]);
+}

--- a/apps/web/src/components/common/composer/use-mic-waveform.ts
+++ b/apps/web/src/components/common/composer/use-mic-waveform.ts
@@ -138,8 +138,7 @@ export function useMicWaveform(): MicWaveform {
 
             const audioCtx = new window.AudioContext();
             audioCtxRef.current = audioCtx;
-            void audioCtx.resume().catch(() => {
-            });
+            void audioCtx.resume().catch(() => {});
 
             const analyser = audioCtx.createAnalyser();
             analyser.fftSize = 1024;

--- a/apps/web/src/components/common/composer/use-prompt-seed.ts
+++ b/apps/web/src/components/common/composer/use-prompt-seed.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+
+/**
+ * Seeding the composer from a chip pick.
+ *
+ * Picking "Directory" used to change only the placeholder — the box stayed
+ * empty and the user still had to invent the first sentence. Instead the chip
+ * now writes its example straight into the input, so the pick produces a real
+ * prompt the user can edit or send as-is.
+ *
+ * The one rule: never destroy words the user actually wrote. A seed lands in
+ * an empty box, or replaces a seed we put there ourselves when the user picks
+ * a different chip. The moment the text is theirs, chips go back to only
+ * switching the kind.
+ */
+
+/**
+ * Turns a typewriter placeholder example (`e.g. "Directory of …"`) into
+ * submittable prompt text. The placeholder lists are already each surface's
+ * source of truth for "what a good prompt for this kind looks like", so
+ * seeding from them keeps the example and the seed from drifting apart.
+ */
+export function seedFromExample(example: string): string {
+    return example
+        .replace(/^\s*e\.g\.\s*/i, '')
+        .replace(/^"|"$/g, '')
+        .trim();
+}
+
+export interface PromptSeedOptions {
+    /** Current composer value (the surface owns the state). */
+    readonly value: string;
+    readonly onChange: (next: string) => void;
+    /**
+     * `inputId` of the composer's textarea. When set, focus returns to the
+     * input with the caret at the end so the user can keep typing where the
+     * seeded sentence left off.
+     */
+    readonly inputId?: string;
+}
+
+/**
+ * Returns `seed(text)`. Call it from a chip's click handler; it no-ops when
+ * the box holds the user's own writing.
+ */
+export function usePromptSeed({ value, onChange, inputId }: PromptSeedOptions) {
+    // The exact string we last seeded. Anything else in the box came from the
+    // user (typed, pasted, or dictated) and is off limits.
+    const seededRef = useRef<string | null>(null);
+
+    return useCallback(
+        (seed: string) => {
+            const userWrote = value.trim().length > 0 && value !== seededRef.current;
+            if (userWrote) return;
+
+            seededRef.current = seed;
+            onChange(seed);
+
+            if (!inputId || typeof document === 'undefined') return;
+            // After the value has actually rendered — `setSelectionRange` on
+            // the pre-update value would put the caret in the wrong place.
+            requestAnimationFrame(() => {
+                const el = document.getElementById(inputId);
+                if (!(el instanceof HTMLTextAreaElement)) return;
+                el.focus();
+                el.setSelectionRange(el.value.length, el.value.length);
+            });
+        },
+        [value, onChange, inputId],
+    );
+}

--- a/apps/web/src/components/common/composer/use-prompt-seed.ts
+++ b/apps/web/src/components/common/composer/use-prompt-seed.ts
@@ -3,24 +3,19 @@
 import { useCallback, useRef } from 'react';
 
 /**
- * Seeding the composer from a chip pick.
- *
- * Picking "Directory" used to change only the placeholder — the box stayed
- * empty and the user still had to invent the first sentence. Instead the chip
- * now writes its example straight into the input, so the pick produces a real
- * prompt the user can edit or send as-is.
+ * Seeding the composer from a chip pick: the chip writes its example straight
+ * into the input so the pick produces a real prompt the user can edit or send
+ * as-is.
  *
  * The one rule: never destroy words the user actually wrote. A seed lands in
  * an empty box, or replaces a seed we put there ourselves when the user picks
- * a different chip. The moment the text is theirs, chips go back to only
- * switching the kind.
+ * a different chip.
  */
 
 /**
  * Turns a typewriter placeholder example (`e.g. "Directory of …"`) into
- * submittable prompt text. The placeholder lists are already each surface's
- * source of truth for "what a good prompt for this kind looks like", so
- * seeding from them keeps the example and the seed from drifting apart.
+ * submittable prompt text. Seeding from the placeholder lists keeps the
+ * example and the seed from drifting apart.
  */
 export function seedFromExample(example: string): string {
     return example
@@ -35,8 +30,7 @@ export interface PromptSeedOptions {
     readonly onChange: (next: string) => void;
     /**
      * `inputId` of the composer's textarea. When set, focus returns to the
-     * input with the caret at the end so the user can keep typing where the
-     * seeded sentence left off.
+     * input with the caret at the end of the seeded sentence.
      */
     readonly inputId?: string;
 }
@@ -47,7 +41,7 @@ export interface PromptSeedOptions {
  */
 export function usePromptSeed({ value, onChange, inputId }: PromptSeedOptions) {
     // The exact string we last seeded. Anything else in the box came from the
-    // user (typed, pasted, or dictated) and is off limits.
+    // user — typed, pasted or dictated — and is off limits.
     const seededRef = useRef<string | null>(null);
 
     return useCallback(
@@ -59,8 +53,8 @@ export function usePromptSeed({ value, onChange, inputId }: PromptSeedOptions) {
             onChange(seed);
 
             if (!inputId || typeof document === 'undefined') return;
-            // After the value has actually rendered — `setSelectionRange` on
-            // the pre-update value would put the caret in the wrong place.
+            // After the new value renders — `setSelectionRange` on the
+            // pre-update value would put the caret in the wrong place.
             requestAnimationFrame(() => {
                 const el = document.getElementById(inputId);
                 if (!(el instanceof HTMLTextAreaElement)) return;

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -298,8 +298,8 @@ export function DashboardSidebar({
                 >
                     <ul
                         className={cn(
-                            'pb-4',
-                            isCollapsed ? 'space-y-1 flex flex-col items-center' : 'space-y-0.5',
+                            'pb-4 space-y-0.5',
+                            isCollapsed && 'flex flex-col items-center',
                         )}
                     >
                         {navigation.map((item) => {

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -23,6 +23,7 @@ import {
     type ComposerAttachment,
 } from '@/components/common/PromptComposer';
 import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
+import { seedFromExample, usePromptSeed } from '@/components/common/composer/use-prompt-seed';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
@@ -211,6 +212,8 @@ export interface NewPageClientProps {
     disabledKinds?: string[];
 }
 
+const PROMPT_INPUT_ID = 'new-prompt';
+
 const CHIP_INTENT_LABEL: Record<ChipType, string> = {
     mission: 'Mission',
     idea: 'Idea',
@@ -255,6 +258,11 @@ export function NewPageClient({
     const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [submitting, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
+    const seedPrompt = usePromptSeed({
+        value: prompt,
+        onChange: setPrompt,
+        inputId: PROMPT_INPUT_ID,
+    });
     // EW-662 Phase 10 — Company chip is a special chip whose submit
     // opens the Register-Company dialog instead of going through the
     // chat-AI / canvas pipeline. We hold the dialog open-state here so
@@ -489,7 +497,7 @@ export function NewPageClient({
                 website's landing layout — chips sit outside the input
                 container, not inside). */}
             <PromptComposer
-                inputId="new-prompt"
+                inputId={PROMPT_INPUT_ID}
                 value={prompt}
                 onChange={setPrompt}
                 onSubmit={submit}
@@ -516,6 +524,10 @@ export function NewPageClient({
                                     return;
                                 }
                                 setSelectedChip(next);
+                                // Picking a chip writes that chip's example
+                                // into the input — the chip hands over a
+                                // real prompt to edit, not just a hint.
+                                seedPrompt(seedFromExample(PLACEHOLDERS_BY_CHIP[next][0]));
                             }}
                             ariaLabel={t('chipLabel')}
                             testIdPrefix="new-chip"

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -392,3 +392,45 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
         });
     });
 });
+
+describe('NewPageClient chip seeding', () => {
+    const DIRECTORY_SEED =
+        'Directory of AI coding assistants with reviews, pricing tiers, and editor compatibility';
+    const BLOG_SEED =
+        'Personal blog about indie game development with postmortems and tooling tags';
+
+    function clickChip(container: HTMLElement, value: string) {
+        const chip = container.querySelector(`button[data-testid="new-chip-${value}"]`);
+        if (!chip) throw new Error(`chip ${value} not found`);
+        fireEvent.click(chip);
+    }
+
+    it('writes the picked chip\u2019s example into the input', () => {
+        const { container } = render(<NewPageClient />);
+        expect(getTextarea(container).value).toBe('');
+
+        clickChip(container, 'directory');
+
+        // The `e.g. "…"` wrapper is stripped — what lands in the box is a
+        // prompt the user can send as-is.
+        expect(getTextarea(container).value).toBe(DIRECTORY_SEED);
+    });
+
+    it('replaces its own seed when the user switches chips', () => {
+        const { container } = render(<NewPageClient />);
+        clickChip(container, 'directory');
+        clickChip(container, 'blog');
+        expect(getTextarea(container).value).toBe(BLOG_SEED);
+    });
+
+    it('never overwrites text the user typed', () => {
+        const { container } = render(<NewPageClient />);
+        fireEvent.change(getTextarea(container), {
+            target: { value: 'My own brief, in my own words' },
+        });
+
+        clickChip(container, 'directory');
+
+        expect(getTextarea(container).value).toBe('My own brief, in my own words');
+    });
+});

--- a/apps/web/src/components/works/WorksCreateComposer.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { PromptComposer } from '@/components/common/PromptComposer';
 import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
+import { seedFromExample, usePromptSeed } from '@/components/common/composer/use-prompt-seed';
 import { Button } from '@/components/ui/button';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
@@ -78,6 +79,8 @@ const PLACEHOLDERS_BY_KIND: Record<InitialWorkKind, ReadonlyArray<string>> = {
     ],
 };
 
+const PROMPT_INPUT_ID = 'works-quick-add';
+
 const KIND_INTENT_LABEL: Record<InitialWorkKind, string> = {
     website: 'website',
     'landing-page': 'landing page',
@@ -93,6 +96,11 @@ export function WorksCreateComposer() {
     const [selectedKind, setSelectedKind] = useState<InitialWorkKind>('website');
     const [submitting, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
+    const seedPrompt = usePromptSeed({
+        value: prompt,
+        onChange: setPrompt,
+        inputId: PROMPT_INPUT_ID,
+    });
 
     const placeholderExamples = useMemo(
         () => PLACEHOLDERS_BY_KIND[selectedKind] ?? PLACEHOLDERS_BY_KIND.website,
@@ -128,7 +136,7 @@ export function WorksCreateComposer() {
     return (
         <div className="mb-8 space-y-3">
             <PromptComposer
-                inputId="works-quick-add"
+                inputId={PROMPT_INPUT_ID}
                 value={prompt}
                 onChange={setPrompt}
                 onSubmit={submit}
@@ -143,7 +151,14 @@ export function WorksCreateComposer() {
                         <PromptChipsRow<InitialWorkKind>
                             chips={chips}
                             value={selectedKind}
-                            onChange={(v) => v && setSelectedKind(v)}
+                            onChange={(v) => {
+                                if (!v) return;
+                                setSelectedKind(v);
+                                // Picking a kind writes that kind's example
+                                // into the input — the chip hands over a
+                                // real prompt to edit, not just a hint.
+                                seedPrompt(seedFromExample(PLACEHOLDERS_BY_KIND[v][0]));
+                            }}
                             ariaLabel={t('promptLabel')}
                             testIdPrefix="works-quick-add"
                         />

--- a/apps/web/src/components/works/WorksCreateComposer.unit.spec.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.unit.spec.tsx
@@ -76,6 +76,20 @@ describe('WorksCreateComposer chip seeding', () => {
         expect(getTextarea(container).value).toBe(BLOG_SEED);
     });
 
+    it('stops replacing a seed once the user has edited it', () => {
+        // Editing the seed makes it the user's own words — the next chip pick
+        // has to leave it alone even though we put the first draft there.
+        const { container } = render(<WorksCreateComposer />);
+        clickChip(container, 'directory');
+
+        const edited = `${DIRECTORY_SEED}, self-hosted only`;
+        fireEvent.change(getTextarea(container), { target: { value: edited } });
+
+        clickChip(container, 'blog');
+
+        expect(getTextarea(container).value).toBe(edited);
+    });
+
     it('never overwrites text the user typed', () => {
         const { container } = render(<WorksCreateComposer />);
         fireEvent.change(getTextarea(container), {

--- a/apps/web/src/components/works/WorksCreateComposer.unit.spec.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.unit.spec.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    // `Button` re-exports this as its `asChild`-less link variant, so the
+    // mock has to cover it even though these tests never navigate.
+    Link: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/hooks/use-start-from-prompt', () => ({
+    useStartFromPrompt: () => vi.fn(),
+}));
+
+import { WorksCreateComposer } from './WorksCreateComposer';
+
+function getTextarea(container: HTMLElement): HTMLTextAreaElement {
+    const el = container.querySelector('textarea[data-testid="works-quick-add"]');
+    if (!el) throw new Error('prompt textarea not found');
+    return el as HTMLTextAreaElement;
+}
+
+/**
+ * Same `usePromptSeed` contract `NewPageClient` asserts, on the `/works`
+ * quick-add composer: a chip pick writes that kind's first placeholder
+ * example into the box as submittable text, replaces a seed we put there
+ * ourselves, and never touches words the user wrote.
+ */
+describe('WorksCreateComposer chip seeding', () => {
+    const DIRECTORY_SEED =
+        'Directory of AI coding assistants with reviews, pricing tiers, and editor compatibility';
+    const BLOG_SEED =
+        'Personal blog about indie game development with postmortems and tooling tags';
+
+    function clickChip(container: HTMLElement, value: string) {
+        // `testIdPrefix="works-quick-add"` on this surface's PromptChipsRow.
+        const chip = container.querySelector(`button[data-testid="works-quick-add-${value}"]`);
+        if (!chip) throw new Error(`chip ${value} not found`);
+        fireEvent.click(chip);
+    }
+
+    it('writes the picked chip’s example into the input', () => {
+        const { container } = render(<WorksCreateComposer />);
+        expect(getTextarea(container).value).toBe('');
+
+        clickChip(container, 'directory');
+
+        // The `e.g. "…"` wrapper is stripped — what lands in the box is a
+        // prompt the user can send as-is.
+        expect(getTextarea(container).value).toBe(DIRECTORY_SEED);
+    });
+
+    it('replaces its own seed when the user switches chips', () => {
+        const { container } = render(<WorksCreateComposer />);
+        clickChip(container, 'directory');
+        clickChip(container, 'blog');
+        expect(getTextarea(container).value).toBe(BLOG_SEED);
+    });
+
+    it('never overwrites text the user typed', () => {
+        const { container } = render(<WorksCreateComposer />);
+        fireEvent.change(getTextarea(container), {
+            target: { value: 'My own brief, in my own words' },
+        });
+
+        clickChip(container, 'directory');
+
+        expect(getTextarea(container).value).toBe('My own brief, in my own words');
+    });
+});


### PR DESCRIPTION
https://github.com/user-attachments/assets/99117047-7f3c-4ae1-b787-7345d62bb5dd






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced prompt composer attachments with a dedicated attachment strip, full-screen attachment preview, and improved attachment menu UX (file/folder/GitHub support, previews/downloads).
  * Added a voice dictation toolbar with elapsed time and accessible “listening” feedback.
  * Prompt examples now reliably auto-populate when switching work kind via chips, with consistent textarea focus behavior.

* **Bug Fixes**
  * Prevent late dictation and microphone waveform updates after recording stops.

* **Style**
  * Updated prompt chip row visuals (dark-mode/typography) and refined sidebar spacing when collapsed/expanded.

* **Tests**
  * Expanded unit coverage for prompt seeding and improved dictation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->