### PR TITLE
ci(e2e): run the Playwright suite on stage only, not develop

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,21 +3,27 @@ name: E2E Tests
 # Playwright e2e suite â€” auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope (intentionally DEVELOP-ONLY â€” never runs on feature/fix branches,
-# and no longer re-runs on the stage/main release cascade):
-#   - push to `develop`              â†’ run (the single integration gate)
-#   - workflow_dispatch on any branch â†’ run (one-off pre-merge verification)
+# Scope (intentionally STAGE-ONLY — owner decision 2026-07-30):
+#   - push to `stage`                 → run (the pre-production gate)
+#   - workflow_dispatch on any branch  → run (one-off verification)
 #
-# There is deliberately NO `pull_request` trigger, and (since 2026-06-12)
-# NO `stage` / `main` / `master` push trigger either. The full suite is
-# sharded 16Ã— (~25 min wall-clock per shard on ubicloud-standard-8), so:
-#   - running it on every feature/fix PR burned runners without gating
-#     anything the post-merge develop push doesn't already catch; and
-#   - re-running the IDENTICAL suite again when develop cascades to stage
-#     and then to main was pure duplicate work â€” the code is byte-for-byte
-#     what already passed e2e on develop. `develop` is the integration
-#     point: once code is green there, promotion to stage/main is a
-#     fast-forward cascade, not a re-test.
+# There is deliberately NO `pull_request` trigger, and NO `develop` or
+# `main`/`master` push trigger.
+#
+# Why it moved off `develop`. The suite is sharded 32× on the x64-8 pool,
+# and each of those runners requests 4 CPU / 26 GiB — so a single run asks
+# the self-hosted fleet for roughly 128 CPU and 832 GiB. `develop` is by
+# far the busiest branch, and firing that fan-out on every merge starved
+# `ci.yml` — whose `lint-and-test` job is the ONLY required status check
+# on main/develop/stage. On 2026-07-29 that queued a two-file docs PR for
+# ~2.5 hours behind e2e runs which then never reached a verdict at all.
+#
+# `stage` is the right home: it is the promotion gate immediately before
+# production, it moves far less often than develop, and a red result there
+# actually blocks something. develop stays fast for iteration; nothing
+# reaches production without passing through stage.
+#
+# Use `workflow_dispatch` for pre-merge verification on a feature branch.
 #
 # Nothing downstream depends on this workflow (no `workflow_run` consumer),
 # so trimming the cascade triggers cannot break a deploy/release chain â€”
@@ -39,7 +45,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: [develop]
+    branches: [stage]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.


### PR DESCRIPTION
Owner decision, 2026-07-30: **run e2e on `stage` only — not `develop`, not `main`/`master`.**

## Why

The suite is sharded **32×** on the x64-8 pool, and each of those runners requests **4 CPU / 26 GiB** — so one run asks the self-hosted fleet for roughly **128 CPU and 832 GiB**. `develop` is by far the busiest branch, so that fan-out fired on every merge.

The victim was `ci.yml`, whose `lint-and-test` job is the **only required status check** on main/develop/stage. On 2026-07-29 a two-file docs PR sat queued for ~2.5 hours behind e2e runs that then never reached a verdict at all — the last four were `queued`, `cancelled`, `cancelled`, `cancelled`, because each new develop push cancelled the in-flight run and queued a fresh one that couldn't get runners.

`stage` is the right home: it's the promotion gate immediately before production, it moves far less often than develop, and a red result there actually blocks something. develop stays fast for iteration, and nothing reaches production without passing through stage.

## Changes

- `on.push.branches`: `[develop]` → `[stage]`. `workflow_dispatch` untouched, so any branch can still be verified on demand pre-merge.
- Rewrote the scope comment block, which documented the *opposite* rule ("intentionally DEVELOP-ONLY … deliberately NO `stage`/`main` push trigger"). Leaving that stale would have been worse than the trigger itself — a future reader would have "fixed" it straight back.
- Corrected the header's stale `sharded 16×` to `32×`. The matrix comment lower down already documented 32 ("was 24, 16, 8, 4"); only the header lagged.

## Safety

No `workflow_run` consumer depends on this workflow — a pre-existing comment in the file already records that, and contrasts it with `ci.yml`, whose stage/main push runs *are* load-bearing for the `release-trigger-{stage,prod}` Trigger.dev releases. Those are untouched. e2e is not a required status check either, so this cannot block merges.

`js-yaml` parses the result.

## Not addressed here — and it's the actual problem

This is a scheduling change, not a fix. **7 of 32 shards are failing across 5 spec files**, and the suite has not passed in 10+ runs:

- `e2e/flow-onboarding-wizard-catalog-work-chain.spec.ts` (many)
- `e2e/flow-fleet-enrollment-contract.spec.ts`
- `e2e/flow-agent-inbox-messaging.spec.ts` (`expect(sendBtn).toBeEnabled()` times out at 30s)
- `e2e/flow-onboarding-wizard.spec.ts`
- `e2e/flow-settings-data-management-ui.spec.ts`

Moving the trigger stops it starving the required check; it does not make the suite green. Those specs still need real work, and until they pass, e2e provides no signal on `stage` either.

One possibly-connected observation: this workflow's own matrix comment explains the 4→8→16→24→32 shard escalation as a workaround for *"the API's in-memory sqlite + resident memory grow over a shard's run"*. `mcpserver.ever.works` is currently unusable for what looks like the same reason — unbounded memory accumulation under a large catalogue. These may share one root cause rather than being three separate bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end testing automation to run on changes to the `stage` branch.
  * Retained the option to trigger end-to-end tests manually.
  * Updated workflow guidance to reflect the revised triggering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->