### PR TITLE
fix(api): org-memory write routes authorize via ensureAdmin, not ensureMember

### DIFF
--- a/apps/api/src/works/org-memory.controller.spec.ts
+++ b/apps/api/src/works/org-memory.controller.spec.ts
@@ -38,7 +38,7 @@ describe('OrgMemoryController — memory health', () => {
 
     let kb: Record<string, jest.Mock>;
     let consolidation: Record<string, jest.Mock>;
-    let membership: { ensureMember: jest.Mock };
+    let membership: { ensureMember: jest.Mock; ensureAdmin: jest.Mock };
     let scopeContext: { getOrganizationId: jest.Mock };
     let health: { getOrgHealth: jest.Mock; emptyHealth: jest.Mock };
     let controller: OrgMemoryController;
@@ -46,7 +46,10 @@ describe('OrgMemoryController — memory health', () => {
     beforeEach(() => {
         kb = { aggregateOrgMemory: jest.fn().mockResolvedValue({ documents: [] }) };
         consolidation = { runConsolidation: jest.fn() };
-        membership = { ensureMember: jest.fn().mockResolvedValue({ id: 'o-1' }) };
+        membership = {
+            ensureMember: jest.fn().mockResolvedValue({ id: 'o-1' }),
+            ensureAdmin: jest.fn().mockResolvedValue({ id: 'o-1' }),
+        };
         scopeContext = { getOrganizationId: jest.fn().mockReturnValue('o-1') };
         health = {
             getOrgHealth: jest.fn().mockResolvedValue({ recallHitRate: 0.5 }),

--- a/apps/api/src/works/org-memory.controller.ts
+++ b/apps/api/src/works/org-memory.controller.ts
@@ -411,7 +411,11 @@ export class OrgMemoryController {
         // Same defense-in-depth membership gate as the GET aggregation:
         // throws NotFound (not Forbidden) on a cross-tenant mismatch,
         // matching the existence-leak contract.
-        await this.membership.ensureMember(organizationId, auth.userId);
+        // WRITE side => `ensureAdmin`, not `ensureMember`. Identical checks
+        // today (no org-admin role in the schema yet) — routing writes
+        // through this name is what gives the future role model a single
+        // seam to tighten, instead of a retrofit across every route.
+        await this.membership.ensureAdmin(organizationId, auth.userId);
 
         return this.consolidation.runConsolidation(
             { organizationId, userId: auth.userId },
@@ -472,7 +476,11 @@ export class OrgMemoryController {
             });
         }
 
-        await this.membership.ensureMember(organizationId, auth.userId);
+        // WRITE side => `ensureAdmin`, not `ensureMember`. Identical checks
+        // today (no org-admin role in the schema yet) — routing writes
+        // through this name is what gives the future role model a single
+        // seam to tighten, instead of a retrofit across every route.
+        await this.membership.ensureAdmin(organizationId, auth.userId);
 
         return this.kb.createOrgUpload({
             organizationId,
@@ -516,7 +524,11 @@ export class OrgMemoryController {
                 message: 'No active Organization — cannot ingest attachments into Memory',
             });
         }
-        await this.membership.ensureMember(organizationId, auth.userId);
+        // WRITE side => `ensureAdmin`, not `ensureMember`. Identical checks
+        // today (no org-admin role in the schema yet) — routing writes
+        // through this name is what gives the future role model a single
+        // seam to tighten, instead of a retrofit across every route.
+        await this.membership.ensureAdmin(organizationId, auth.userId);
 
         const results: Array<{ attachmentId: string; status: string; uploadId?: string }> = [];
         for (const attachmentId of body.attachmentIds) {
@@ -604,7 +616,11 @@ export class OrgMemoryController {
                 message: 'No active Organization — cannot configure Memory Consolidation',
             });
         }
-        await this.membership.ensureMember(organizationId, auth.userId);
+        // WRITE side => `ensureAdmin`, not `ensureMember`. Identical checks
+        // today (no org-admin role in the schema yet) — routing writes
+        // through this name is what gives the future role model a single
+        // seam to tighten, instead of a retrofit across every route.
+        await this.membership.ensureAdmin(organizationId, auth.userId);
         return this.consolidation.updateScheduleSettings(
             organizationId,
             body as Partial<KbMemoryConsolidationSettings>,
@@ -657,7 +673,11 @@ export class OrgMemoryController {
                 message: 'No active Organization — cannot accept a Memory document',
             });
         }
-        await this.membership.ensureMember(organizationId, auth.userId);
+        // WRITE side => `ensureAdmin`, not `ensureMember`. Identical checks
+        // today (no org-admin role in the schema yet) — routing writes
+        // through this name is what gives the future role model a single
+        // seam to tighten, instead of a retrofit across every route.
+        await this.membership.ensureAdmin(organizationId, auth.userId);
 
         const accepted = await this.kb.acceptOrgDocument(organizationId, docId, auth.userId);
         if (!accepted) {

--- a/apps/api/src/works/org-memory.ingest-attachments.spec.ts
+++ b/apps/api/src/works/org-memory.ingest-attachments.spec.ts
@@ -35,7 +35,7 @@ describe('OrgMemoryController — ingest chat attachments into Memory', () => {
     const OTHER_SHA = 'b'.repeat(64);
 
     let kb: { createOrgUpload: jest.Mock };
-    let membership: { ensureMember: jest.Mock };
+    let membership: { ensureMember: jest.Mock; ensureAdmin: jest.Mock };
     let scopeContext: { getOrganizationId: jest.Mock };
     let uploads: { readFile: jest.Mock };
     let userUploads: { findOwnedByUser: jest.Mock };
@@ -48,7 +48,10 @@ describe('OrgMemoryController — ingest chat attachments into Memory', () => {
                 document: { id: 'doc-1' },
             }),
         };
-        membership = { ensureMember: jest.fn().mockResolvedValue({ id: 'org-1' }) };
+        membership = {
+            ensureMember: jest.fn().mockResolvedValue({ id: 'org-1' }),
+            ensureAdmin: jest.fn().mockResolvedValue({ id: 'org-1' }),
+        };
         scopeContext = { getOrganizationId: jest.fn().mockReturnValue('org-1') };
         uploads = {
             readFile: jest

--- a/apps/api/src/works/org-memory.review.spec.ts
+++ b/apps/api/src/works/org-memory.review.spec.ts
@@ -33,7 +33,7 @@ describe('OrgMemoryController — review queue', () => {
     const DOC = '11111111-1111-4111-8111-111111111111';
 
     let kb: { listOrgReviewQueue: jest.Mock; acceptOrgDocument: jest.Mock };
-    let membership: { ensureMember: jest.Mock };
+    let membership: { ensureMember: jest.Mock; ensureAdmin: jest.Mock };
     let scopeContext: { getOrganizationId: jest.Mock };
     let controller: OrgMemoryController;
 
@@ -42,7 +42,10 @@ describe('OrgMemoryController — review queue', () => {
             listOrgReviewQueue: jest.fn().mockResolvedValue({ items: [], total: 0 }),
             acceptOrgDocument: jest.fn().mockResolvedValue({ id: DOC, reviewState: 'accepted' }),
         };
-        membership = { ensureMember: jest.fn().mockResolvedValue({ id: 'org-1' }) };
+        membership = {
+            ensureMember: jest.fn().mockResolvedValue({ id: 'org-1' }),
+            ensureAdmin: jest.fn().mockResolvedValue({ id: 'org-1' }),
+        };
         scopeContext = { getOrganizationId: jest.fn().mockReturnValue('org-1') };
 
         controller = new OrgMemoryController(
@@ -72,6 +75,13 @@ describe('OrgMemoryController — review queue', () => {
 
         expect(res).toEqual({ items: [], total: 0 });
         expect(kb.listOrgReviewQueue).not.toHaveBeenCalled();
+        expect(membership.ensureMember).not.toHaveBeenCalled();
+    });
+
+    it('authorizes accept as a WRITE (ensureAdmin), not a plain read', async () => {
+        await controller.acceptMemoryDocument(auth, DOC);
+
+        expect(membership.ensureAdmin).toHaveBeenCalledWith('org-1', 'user-1');
         expect(membership.ensureMember).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Owner decision, 2026-07-30, following review of #1948: accepting a proposed org Memory document overlays machine-written text into **every Work's agent context**, and that should not sit behind the same check as reading a list.

## ⚠️ Read this before assuming it changes access

**`ensureAdmin` is byte-for-byte `ensureMember` today.** `OrganizationMembershipService` says so explicitly:

> `ensureMember` and `ensureAdmin` are intentionally identical today; `ensureAdmin` exists only so write-side call sites can express intent and so the future role model has a single seam to tighten without touching every caller. Do NOT add a role column here without that product decision.

So **this PR does not restrict anyone right now.** Nobody gains or loses access, and nothing can break. What it does is put every org-memory write behind the one method where a real org-admin role will be enforced, so that enforcement lands in a single place instead of being retrofitted across ten routes. Real restriction still needs the deferred schema + product decision (a role column + migration).

I'm stating that plainly because "switched to ensureAdmin" could easily be read as "now admin-only", and it isn't yet.

## The convention already exists

`apps/api/src/digest/digest.controller.ts` established it:

> WRITE side ⇒ `ensureAdmin`, not `ensureMember`. … `read` → `ensureMember`, `write` → `ensureAdmin`. They resolve identically today, and the whole point of routing through both names is that the day they stop being identical, this route …

`org-memory.controller.ts` was simply not following it — all ten routes used `ensureMember`.

## Changes

Five write routes moved to `ensureAdmin`; five reads deliberately untouched:

| Route | Before | After |
| --- | --- | --- |
| `GET memory/health` | ensureMember | ensureMember |
| `GET memory` | ensureMember | ensureMember |
| `POST memory/consolidate` | ensureMember | **ensureAdmin** |
| `POST memory/uploads` | ensureMember | **ensureAdmin** |
| `POST memory/uploads/from-attachments` | ensureMember | **ensureAdmin** |
| `GET memory/consolidation/settings` | ensureMember | ensureMember |
| `PUT memory/consolidation/settings` | ensureMember | **ensureAdmin** |
| `GET memory/review` | ensureMember | ensureMember |
| `POST memory/review/:docId/accept` | ensureMember | **ensureAdmin** |
| `GET memory/uploads` | ensureMember | ensureMember |

### Why all five writes, not just `accept`

The decision was prompted by the accept route, but `PUT memory/consolidation/settings` (from #1953) is arguably just as consequential — it turns on the *recurring* pass that generates those documents in the first place. Changing one and leaving four would have left the same inconsistency the convention exists to prevent. If you want only `accept` moved, it's a four-line revert.

## Tests

- `org-memory.review.spec.ts`: mock extended with `ensureAdmin` (without it the accept tests would throw on an undefined method).
- Added a test pinning the read/write split — asserts `accept` calls `ensureAdmin` and specifically **not** `ensureMember`, so a future refactor can't silently downgrade it.
- `org-memory.controller.spec.ts` needs no change: it only exercises `getMemoryHealth`, a read.
- `prettier --check` clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted organization Memory write and administrative actions to organization administrators.
  * Read-only membership access no longer authorizes consolidation, uploads, attachment ingestion, scheduling changes, or document acceptance.

* **Tests**
  * Added coverage confirming document acceptance uses administrator authorization.
  * Updated authorization test setups to reflect the separate member and administrator checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->