### PR TITLE
feat(deploy): apply manifests server-side for platform-managed clusters

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
@@ -290,8 +290,10 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
 
         await service.deploy('work-1', 'user-1');
 
+        // setActionSecret({ key, value, owner, repo }, publicKey, token) — the
+        // secret NAME is a field of the first argument, not a positional arg.
         const pushedNames = githubPlugin.setActionSecret.mock.calls.map(
-            (c: unknown[]) => c[3] ?? c[2],
+            (c: unknown[]) => (c[0] as { key: string }).key,
         );
         const pushedPairs = githubPlugin.setActionSecret.mock.calls.map((c: unknown[]) =>
             JSON.stringify(c),
@@ -370,8 +372,10 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
 
         expect(plugin.deploy).not.toHaveBeenCalled();
         expect(githubPlugin.dispatchWorkflow).toHaveBeenCalled();
+        // setActionSecret({ key, value, owner, repo }, publicKey, token) — the
+        // secret NAME is a field of the first argument, not a positional arg.
         const pushedNames = githubPlugin.setActionSecret.mock.calls.map(
-            (c: unknown[]) => c[3] ?? c[2],
+            (c: unknown[]) => (c[0] as { key: string }).key,
         );
         expect(pushedNames).toContain('K8S_TOKEN');
     });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
@@ -274,9 +274,20 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
         expect(plugin.deploy).toHaveBeenCalledTimes(1);
         const [config, kubeconfig] = plugin.deploy.mock.calls[0];
         expect(kubeconfig).toBe(SHARED_KC);
-        expect(config.projectName).toBe('my-site');
-        expect(config.options.imageName).toBe('acme-site');
+        // The website repo, NOT the work slug. The plugin names every object
+        // sanitiseSlug(projectName), and DeploymentVerifierService reads them
+        // back with lookupExistingDeployment(work.getWebsiteRepo()). Asserting
+        // the slug here is what let the writer/reader mismatch ship: the apply
+        // succeeded, verification never found the Deployment, and the deploy
+        // ended TIMEOUT — which DeployReadyPollerService cannot rescue.
+        expect(config.projectName).toBe('acme-site');
+        expect(config.projectName).toBe(config.options.imageName);
         expect(config.options.githubOwner).toBe('acme');
+        // A read:packages token must reach the plugin: with registry.visibility
+        // 'auto' and an unknown repo visibility it resolves to 'private', mints
+        // a pull secret, and throws GITHUB_NOT_CONNECTED on an empty token
+        // BEFORE applying anything.
+        expect(config.options.githubReadPackagesToken).toBeTruthy();
         // No workflow dispatch on the managed path.
         expect(githubPlugin.dispatchWorkflow).not.toHaveBeenCalled();
     });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
@@ -303,7 +303,7 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
         expect(pushedNames).toContain('WORK_ID');
     });
 
-    it('managed tier → branch alias image tag when no commit SHA (main → prod)', async () => {
+    it('managed tier → branch alias image tag (main → prod)', async () => {
         const plugin = managedPlugin();
         const { service } = buildService({
             plugin,
@@ -314,6 +314,26 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
 
         const [config] = plugin.deploy.mock.calls[0];
         expect(config.options.gitSha).toBe('prod');
+    });
+
+    it('managed tier → alias even when a commit SHA is supplied (tag must exist)', async () => {
+        // Regression guard. `k8s-build.yml` publishes only `:<alias>` and
+        // `:sha-<full-sha>`; the bare short-SHA tag came from `deploy_k8s.yaml`,
+        // which is now gated off. Pinning a short SHA here would reference a
+        // tag that does not exist and park the pod in ImagePullBackOff.
+        const plugin = managedPlugin();
+        const { service } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+
+        await service.deploy('work-1', 'user-1', {
+            commitSha: 'abcdef1234567890abcdef1234567890abcdef12',
+        });
+
+        const [config] = plugin.deploy.mock.calls[0];
+        expect(config.options.gitSha).toBe('prod');
+        expect(config.options.gitSha).not.toContain('abcdef');
     });
 
     it('managed tier → plugin error marks the deployment terminal and reports failure', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
@@ -1,0 +1,358 @@
+jest.mock('@ever-works/agent/database', () => ({
+    WorkRepository: class {},
+    WorkCustomDomainRepository: class {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({
+    Work: class {},
+    User: class {},
+    DeploymentEnvironment: { PRODUCTION: 'production', PREVIEW: 'preview' },
+    DeploymentTriggerSource: {
+        MANUAL: 'manual',
+        SCHEDULED: 'scheduled',
+    },
+}));
+jest.mock('@ever-works/agent/plugins', () => ({ PluginRegistryService: class {} }));
+jest.mock('@ever-works/agent/services', () => ({
+    PlatformSyncSecretService: class {},
+    ZeroFrictionFunnelService: class {},
+}));
+jest.mock('@ever-works/agent/facades', () => ({
+    DeployFacadeService: class {},
+    GitFacadeService: class {},
+}));
+jest.mock('@ever-works/agent/generators', () => ({
+    WebsiteUpdateService: class {},
+    getWebsiteTemplateBranch: () => 'main',
+    getWebsiteTemplateConfig: () => ({ branch: 'main' }),
+}));
+jest.mock('@ever-works/agent/events', () => ({
+    DeploymentDispatchedEvent: class {
+        static EVENT_NAME = 'deployment.dispatched';
+        constructor(public readonly payload: unknown) {}
+    },
+}));
+
+import { DeployService } from './deploy.service';
+
+/**
+ * Tests focused on the capability-driven contract changes:
+ *
+ *  - DeployService now calls `plugin.getWorkflowFilenames()` instead of
+ *    using a hardcoded list, so each plugin owns its own dispatch surface.
+ *  - DeployService now calls `plugin.getDeploymentSecrets(settings)` after
+ *    pushing the standard secrets, so plugins (k8s especially) can
+ *    contribute extra GitHub Actions secrets without touching this service.
+ *
+ * The non-network methods (`setActionSecret`, `setActionVariable`,
+ * `dispatchWorkflow`, `getRepositoryPublicKey`, `enableDeploymentWorkflows`)
+ * are stubbed via the `pluginRegistry` mock so we never touch a real GitHub.
+ */
+/**
+ * EW — server-side deploy for platform-managed cluster tiers.
+ *
+ * The GitHub Actions deploy path cannot reach a platform-managed cluster
+ * (ARC runner pods have no egress to the cluster APIs; customer repos run on
+ * GitHub-hosted runners that can never reach a private RFC1918 endpoint), so
+ * DeployService now applies manifests server-side via
+ * KubernetesPlugin.deploy() when the work targets `k8s-works` /
+ * `k8s-works-shared` — and, critically, STOPS writing the platform
+ * kubeconfig to the website repo, honouring the documented contract for the
+ * customer default: "No cluster credentials to manage; the platform runs it
+ * for you." `custom-kubeconfig` (bring-your-own cluster, incl. forks) keeps
+ * the workflow-dispatch path byte-identical.
+ *
+ * The DI harness below is the one from deploy.service.spec.ts, copied
+ * verbatim so constructor-arg order can never drift between the two files.
+ */
+describe('DeployService — server-side deploy for managed cluster tiers', () => {
+    const buildService = (overrides: {
+        plugin: Record<string, unknown>;
+        token?: string;
+        settings?: Record<string, unknown>;
+        deployProvider?: string;
+        /** Owner returned by `work.getRepoOwner('website')`. Defaults to
+         *  the customer-owned org `'acme'` so most tests run on the
+         *  permissive EW-616 cell. Tests that exercise the platform-owned
+         *  orgs override this. */
+        websiteOwner?: string;
+        /** Settings returned by deployFacade.getOtherPluginSettings('github', ...).
+         *  Defaults to an empty object (no PAT saved). Tests for the GHCR PAT
+         *  flow override this with `{ readPackagesPat: '...' }`. */
+        githubPluginSettings?: Record<string, unknown>;
+        /** EW-120 dual-mode Activity Feed sync. Defaults to `push` to keep
+         *  pre-dual-mode tests behaving as before. */
+        activitySyncMode?: 'pull' | 'push' | 'disabled';
+        githubPluginOverrides?: Record<string, unknown>;
+        /** Work's public `website` URL — drives the per-Work k8s Ingress host. */
+        website?: string;
+        /** Whether the Work owner is a platform admin — gates `k8s-works`. */
+        isPlatformAdmin?: boolean;
+    }) => {
+        const websiteOwner = overrides.websiteOwner ?? 'acme';
+        const work = {
+            id: 'work-1',
+            slug: 'my-site',
+            website: overrides.website,
+            deployProvider: overrides.deployProvider ?? 'k8s',
+            gitProvider: 'github',
+            websiteTemplateId: 'directory-web-template',
+            activitySyncMode: overrides.activitySyncMode ?? 'push',
+            user: { id: 'user-1', isPlatformAdmin: overrides.isPlatformAdmin ?? false },
+            getRepoOwner: () => websiteOwner,
+            getDataRepo: () => `${websiteOwner}/data`,
+            getWebsiteRepo: () => `${websiteOwner}-site`,
+            resolveCommitter: () => ({ name: 'a', email: 'a@b' }),
+        };
+
+        const deployFacade = {
+            getPluginAndTokenAndSettings: jest.fn().mockResolvedValue({
+                plugin: overrides.plugin,
+                token: overrides.token ?? 'kubeconfig:::yaml',
+                work,
+                settings: overrides.settings ?? {},
+            }),
+            getOtherPluginSettings: jest
+                .fn()
+                .mockResolvedValue(overrides.githubPluginSettings ?? {}),
+        };
+
+        const gitFacade = {
+            getAccessToken: jest.fn().mockResolvedValue('gh-token'),
+        };
+
+        const workRepository = {
+            findById: jest.fn().mockResolvedValue(work),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        const deploymentRepository = {
+            create: jest.fn().mockResolvedValue({ id: 'deployment-1' }),
+            markTerminal: jest.fn().mockResolvedValue(undefined),
+        };
+
+        // Single shared GitHub plugin stub returned by every
+        // pluginRegistry.get('github') call. Capturing its call history is
+        // what tests assert against.
+        const githubPlugin = {
+            setActionSecret: jest.fn().mockResolvedValue(undefined),
+            setActionVariable: jest.fn().mockResolvedValue(undefined),
+            dispatchWorkflow: jest.fn().mockResolvedValue(undefined),
+            getRepositoryPublicKey: jest.fn().mockResolvedValue({ key_id: 'k', key: 'pubkey' }),
+            enableDeploymentWorkflows: jest.fn().mockResolvedValue(undefined),
+            ...(overrides.githubPluginOverrides ?? {}),
+        };
+
+        const pluginRegistry = {
+            get: jest.fn(() => ({
+                plugin: githubPlugin,
+                state: 'loaded',
+                manifest: { capabilities: ['git-provider'] },
+            })),
+        };
+
+        const websiteUpdateService = {
+            updateRepository: jest.fn().mockResolvedValue(undefined),
+        };
+
+        const websiteTemplateResolver = {
+            resolveForWork: jest.fn().mockResolvedValue({ branch: 'main' }),
+        };
+
+        const eventEmitter = {
+            emit: jest.fn(),
+        };
+
+        const platformSyncSecretService = {
+            getOrGenerate: jest.fn().mockResolvedValue('hex'.repeat(21) + 'h'), // 64 hex chars
+        };
+
+        // Same per-Work-persistent shape as PlatformSyncSecretService.
+        const webhookSecretService = {
+            getOrGenerate: jest.fn().mockResolvedValue('webhook'.repeat(9) + 'a'), // 64 chars
+        };
+
+        const workRuntimeEnvService = {
+            getOrGenerateAuthSecret: jest.fn().mockResolvedValue('auth-secret-base64'),
+            getOrGenerateCookieSecret: jest.fn().mockResolvedValue('cookie-secret-base64'),
+            getDatabaseUrl: jest.fn().mockResolvedValue(null),
+        };
+
+        // EW-617 G5: DNS automation no-ops in tests (no env vars). The
+        // dns service still needs to be present so the constructor wires
+        // — `getProvider` returns null and `ensureWorkSubdomain` is a
+        // safe stub.
+        const dnsService = {
+            getProvider: jest.fn(() => null),
+            ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
+            ensureWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+            removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+        };
+
+        // EW-617 G8: funnel emit sink — no-op stub by default.
+        const funnel = { emit: jest.fn() };
+
+        // EW-734 / EW-737 — collision-safe allocator. Tests that exercise the
+        // gated managed-subdomain path stub `allocate`; the default no-op
+        // keeps the legacy + EW-741 paths working without forcing every test
+        // to wire it explicitly.
+        const subdomainAllocator = {
+            allocate: jest.fn().mockResolvedValue({
+                subdomain: 'allocated',
+                fqdn: 'allocated.ever.works',
+                rootDomain: 'ever.works',
+                allocated: true,
+            }),
+        };
+
+        // EW-741 — `WorkCustomDomain` rows for this Work. Default = none, so
+        // most tests see no `extraHosts` in the merged settings. Tests that
+        // exercise reconciliation override `findByWork` to return rows.
+        const customDomainRepository = {
+            findByWork: jest.fn().mockResolvedValue([]),
+        };
+
+        const service = new DeployService(
+            deployFacade as any,
+            gitFacade as any,
+            workRepository as any,
+            deploymentRepository as any,
+            pluginRegistry as any,
+            websiteUpdateService as any,
+            websiteTemplateResolver as any,
+            eventEmitter as any,
+            platformSyncSecretService as any,
+            webhookSecretService as any,
+            workRuntimeEnvService as any,
+            dnsService as any,
+            subdomainAllocator as any,
+            funnel as any,
+            customDomainRepository as any,
+        );
+
+        return {
+            service,
+            work,
+            deployFacade,
+            gitFacade,
+            deploymentRepository,
+            pluginRegistry,
+            githubPlugin,
+            eventEmitter,
+            platformSyncSecretService,
+            webhookSecretService,
+            dnsService,
+            funnel,
+            subdomainAllocator,
+            customDomainRepository,
+        };
+    };
+
+    const SHARED_KC = 'shared-cluster-kubeconfig-yaml';
+    const managedPlugin = () => ({
+        id: 'k8s',
+        deploy: jest.fn().mockResolvedValue({ status: 'deploying', id: 'd', createdAt: 't' }),
+        getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+        getDeploymentSecrets: jest.fn().mockResolvedValue({ K8S_NAMESPACE: 'ns' }),
+    });
+
+    beforeEach(() => {
+        process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = SHARED_KC;
+    });
+    afterEach(() => {
+        delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+    });
+
+    it('managed tier → plugin.deploy applies server-side with the platform kubeconfig', async () => {
+        const plugin = managedPlugin();
+        const { service, githubPlugin } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+
+        const result = await service.deploy('work-1', 'user-1');
+
+        expect(result.dispatched).toBe(true);
+        expect(plugin.deploy).toHaveBeenCalledTimes(1);
+        const [config, kubeconfig] = plugin.deploy.mock.calls[0];
+        expect(kubeconfig).toBe(SHARED_KC);
+        expect(config.projectName).toBe('my-site');
+        expect(config.options.imageName).toBe('acme-site');
+        expect(config.options.githubOwner).toBe('acme');
+        // No workflow dispatch on the managed path.
+        expect(githubPlugin.dispatchWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('managed tier → the platform kubeconfig is NEVER written to the repo', async () => {
+        const plugin = managedPlugin();
+        const { service, githubPlugin } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+
+        await service.deploy('work-1', 'user-1');
+
+        const pushedNames = githubPlugin.setActionSecret.mock.calls.map(
+            (c: unknown[]) => c[3] ?? c[2],
+        );
+        const pushedPairs = githubPlugin.setActionSecret.mock.calls.map((c: unknown[]) =>
+            JSON.stringify(c),
+        );
+        expect(pushedPairs.join(' | ')).not.toContain(SHARED_KC);
+        expect(pushedNames).not.toContain('K8S_TOKEN');
+        expect(pushedNames).not.toContain('DEPLOY_TOKEN');
+        // Everything non-credential still pushes (CI builds keep working).
+        expect(pushedNames).toContain('WORK_ID');
+    });
+
+    it('managed tier → branch alias image tag when no commit SHA (main → prod)', async () => {
+        const plugin = managedPlugin();
+        const { service } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+
+        await service.deploy('work-1', 'user-1');
+
+        const [config] = plugin.deploy.mock.calls[0];
+        expect(config.options.gitSha).toBe('prod');
+    });
+
+    it('managed tier → plugin error marks the deployment terminal and reports failure', async () => {
+        const plugin = managedPlugin();
+        plugin.deploy.mockResolvedValue({
+            status: 'error',
+            error: 'boom',
+            id: 'd',
+            createdAt: 't',
+        });
+        const { service, deploymentRepository } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+
+        const result = await service.deploy('work-1', 'user-1');
+
+        expect(result.dispatched).toBe(false);
+        expect(deploymentRepository.markTerminal).toHaveBeenCalledWith(
+            'deployment-1',
+            'ERROR',
+            expect.objectContaining({ lastError: 'boom' }),
+        );
+    });
+
+    it('custom-kubeconfig → workflow dispatch unchanged, plugin.deploy never called', async () => {
+        const plugin = managedPlugin();
+        const { service, githubPlugin } = buildService({
+            plugin,
+            settings: { clusterSource: 'custom-kubeconfig' },
+        });
+
+        await service.deploy('work-1', 'user-1');
+
+        expect(plugin.deploy).not.toHaveBeenCalled();
+        expect(githubPlugin.dispatchWorkflow).toHaveBeenCalled();
+        const pushedNames = githubPlugin.setActionSecret.mock.calls.map(
+            (c: unknown[]) => c[3] ?? c[2],
+        );
+        expect(pushedNames).toContain('K8S_TOKEN');
+    });
+});

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -343,6 +343,8 @@ export class DeployService {
                   userId,
                   plugin,
                   kubeconfig: effectiveDeployToken,
+                  gitToken,
+                  revision: env.commitSha,
                   deploySettings: deploySettings ?? {},
                   deploymentId: deployment.id,
                   targetBranch,
@@ -1224,11 +1226,23 @@ export class DeployService {
         userId: string;
         plugin: IDeploymentPlugin;
         kubeconfig: string;
+        gitToken: string;
         deploySettings: Record<string, unknown>;
         deploymentId: string;
         targetBranch: string;
+        revision?: string;
     }): Promise<boolean> {
-        const { work, plugin, kubeconfig, deploySettings, deploymentId, targetBranch } = args;
+        const {
+            work,
+            userId,
+            plugin,
+            kubeconfig,
+            gitToken,
+            deploySettings,
+            deploymentId,
+            targetBranch,
+            revision,
+        } = args;
         try {
             // ALWAYS the branch alias — never a commit SHA. `k8s-build.yml`
             // (the workflow that actually publishes these images) pushes exactly
@@ -1258,7 +1272,8 @@ export class DeployService {
                 }
             }
 
-            const runtimeEnv = await this.collectServerSideRuntimeEnv(work, hosts[0]);
+            const ghcrReadToken = await this.resolveGhcrReadToken(work, userId, gitToken);
+            const runtimeEnv = await this.collectServerSideRuntimeEnv(work, hosts[0], gitToken);
 
             const namespace =
                 typeof deploySettings.namespace === 'string' && deploySettings.namespace.trim()
@@ -1274,7 +1289,14 @@ export class DeployService {
                 }
             ).deploy(
                 {
-                    projectName: work.slug || work.id,
+                    // MUST match what DeploymentVerifierService reads back:
+                    // it calls lookupExistingDeployment(work.getWebsiteRepo()),
+                    // and the plugin names every object sanitiseSlug(projectName).
+                    // Naming these after work.slug made the writer and the reader
+                    // disagree for every Work whose website repo is <slug>-website
+                    // (the default), so verification could never find the
+                    // Deployment and every deploy ended TIMEOUT.
+                    projectName: work.getWebsiteRepo(),
                     // Required by `DeploymentConfig`. The k8s plugin applies
                     // pre-built manifests and never reads it — there is no
                     // local checkout server-side — so '.' is the same inert
@@ -1287,6 +1309,24 @@ export class DeployService {
                         namespaceOverride: namespace,
                         hosts,
                         runtimeEnv,
+                        // BLOCK-1: without a read:packages token the plugin
+                        // resolves visibility 'auto' -> 'private' (it errs on the
+                        // safe side when websiteRepoIsPrivate is unknown), mints a
+                        // pull secret, finds an empty password and throws
+                        // GITHUB_NOT_CONNECTED *before* applying anything. The
+                        // workflow path had secrets.GITHUB_TOKEN as a last resort;
+                        // this is the server-side equivalent.
+                        githubReadPackagesToken: ghcrReadToken,
+                        // Annotation only — NEVER the image tag. CI publishes
+                        // `sha-<full>`, and the plugin truncates a gitSha to 12
+                        // chars, so a SHA can't address the image; it can still
+                        // make the pod template differ between deploys.
+                        revision: revision,
+                        // Per-Work settings (replicas, registry, kubeContext, ...)
+                        // never reach the plugin otherwise: its context is built
+                        // unscoped, so getSettings() resolves admin -> env ->
+                        // schema default and silently discards what the Work set.
+                        settingsOverride: deploySettings,
                     },
                 },
                 kubeconfig,
@@ -1342,13 +1382,34 @@ export class DeployService {
     private async collectServerSideRuntimeEnv(
         work: Work,
         primaryHost?: string,
+        gitToken?: string,
     ): Promise<Record<string, string>> {
+        // DATA_REPOSITORY must be a CLONE URL, not a bare repo name. The
+        // workflow this replaces rewrote it exactly this way
+        // ("DATA_REPOSITORY=https://github.com/<owner>/<repo>"); the running app
+        // parses it with zod .url().catch(undefined), so a bare name is silently
+        // discarded and the site renders an empty directory while reporting Ready.
+        const dataRepo = work.getDataRepo();
+        const alreadyQualified =
+            dataRepo.startsWith('https://') ||
+            dataRepo.startsWith('http://') ||
+            dataRepo.startsWith('git@');
+        const dataRepositoryUrl = alreadyQualified
+            ? dataRepo
+            : `https://github.com/${work.getRepoOwner('data').toLowerCase()}/${dataRepo}`;
+
         const env: Record<string, string> = {
             TENANT_ID: work.id,
             WORK_ID: work.id,
-            DATA_REPOSITORY: work.getDataRepo(),
+            DATA_REPOSITORY: dataRepositoryUrl,
             COOKIE_SECURE: 'true',
         };
+        // GH_TOKEN is not optional: item.repository.ts throws
+        // "DATA_REPOSITORY and GH_TOKEN environment variables are required",
+        // which kills sync, moderation, /api/items/* and every admin route.
+        // envFrom optional:true means its absence fails silently at runtime.
+        if (gitToken) env.GH_TOKEN = gitToken;
+        if (primaryHost) env.COOKIE_DOMAIN = primaryHost;
         try {
             env.AUTH_SECRET = await this.workRuntimeEnvService.getOrGenerateAuthSecret(work.id);
             env.COOKIE_SECRET = await this.workRuntimeEnvService.getOrGenerateCookieSecret(work.id);
@@ -1396,6 +1457,52 @@ export class DeployService {
             }
         }
         return env;
+    }
+
+    /**
+     * The read:packages credential the server-side deploy hands the k8s plugin
+     * so it can mint the image-pull Secret for a private GHCR image.
+     *
+     * Same resolution order `setKubernetesGhcrPullSecret` uses for the workflow
+     * path (per-Work GitHub plugin settings -> platform defaults for the repo
+     * owner), with the caller's git token as the last resort — the server-side
+     * equivalent of the workflow's `secrets.GITHUB_TOKEN` fallback.
+     *
+     * Never throws: a missing token is not worth failing a deploy that might be
+     * pulling a public image, and the plugin raises GITHUB_NOT_CONNECTED with a
+     * far better message if it turns out one was needed.
+     */
+    private async resolveGhcrReadToken(
+        work: Work,
+        userId: string,
+        gitToken?: string,
+    ): Promise<string> {
+        try {
+            const githubSettings = await this.deployFacade.getOtherPluginSettings('github', {
+                userId,
+                workId: work.id,
+            });
+            const fineGrained =
+                typeof githubSettings?.readPackagesPat === 'string'
+                    ? githubSettings.readPackagesPat.trim()
+                    : '';
+            const classic =
+                typeof githubSettings?.readPackagesPatClassic === 'string'
+                    ? githubSettings.readPackagesPatClassic.trim()
+                    : '';
+            if (fineGrained || classic) return fineGrained || classic;
+
+            const platformDefaults = this.getPlatformGhcrCredentials(work.getRepoOwner('website'));
+            const platformToken = platformDefaults.fineGrained || platformDefaults.classic;
+            if (platformToken) return platformToken;
+        } catch (error: unknown) {
+            this.logger.warn(
+                `GHCR read-token lookup failed for work ${work.id}; falling back to the git token: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+        return gitToken ?? '';
     }
 
     private providerTokenSecretName(providerId: string): string {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -42,7 +42,7 @@ import {
     WebsiteTemplateResolverService,
 } from '@ever-works/agent/generators';
 import { DeploymentDispatchedEvent } from '@ever-works/agent/events';
-import type { IDeploymentPlugin } from '@ever-works/plugin';
+import type { DeploymentConfig, DeploymentResult, IDeploymentPlugin } from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
 import {
     ClusterSource,
@@ -1260,13 +1260,18 @@ export class DeployService {
             const result = await (
                 plugin as IDeploymentPlugin & {
                     deploy: (
-                        config: { projectName: string; options?: Record<string, unknown> },
+                        config: DeploymentConfig,
                         kubeconfig: string,
-                    ) => Promise<{ status?: string; error?: string; url?: string }>;
+                    ) => Promise<DeploymentResult>;
                 }
             ).deploy(
                 {
                     projectName: work.slug || work.id,
+                    // Required by `DeploymentConfig`. The k8s plugin applies
+                    // pre-built manifests and never reads it — there is no
+                    // local checkout server-side — so '.' is the same inert
+                    // value the plugin's own tests pass.
+                    sourceDir: '.',
                     options: {
                         gitSha,
                         githubOwner: work.getRepoOwner('website'),

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -346,7 +346,6 @@ export class DeployService {
                   deploySettings: deploySettings ?? {},
                   deploymentId: deployment.id,
                   targetBranch,
-                  commitSha: env.commitSha,
               })
             : await this.dispatchWithRetry(
                   work,
@@ -1211,10 +1210,10 @@ export class DeployService {
      * KubernetesPlugin.deploy().
      *
      * Image: CI (k8s-build.yml, synced from the template into every website
-     * repo) pushes `ghcr.io/<owner>/<WEBSITE-REPO>:<tag>` where tag is the
-     * 12-char commit SHA and the branch alias (develop→dev, stage→stage,
-     * main|master→prod). When the caller supplied a commit SHA we pin it;
-     * otherwise we deploy the branch alias, which always exists.
+     * repo) pushes `ghcr.io/<owner>/<WEBSITE-REPO>` tagged with the branch
+     * alias (develop→dev, stage→stage, main|master→prod) and with
+     * `sha-<full-sha>`. We deploy the alias — see the note at the tag
+     * computation for why a short-SHA pin would not resolve.
      *
      * Runtime env: the same values the workflow used to copy out of GitHub
      * secrets are assembled here from their sources of truth and applied as
@@ -1228,15 +1227,24 @@ export class DeployService {
         deploySettings: Record<string, unknown>;
         deploymentId: string;
         targetBranch: string;
-        commitSha?: string;
     }): Promise<boolean> {
-        const { work, plugin, kubeconfig, deploySettings, deploymentId, targetBranch, commitSha } =
-            args;
+        const { work, plugin, kubeconfig, deploySettings, deploymentId, targetBranch } = args;
         try {
-            const gitSha =
-                commitSha && commitSha.trim().length > 0
-                    ? commitSha.trim().slice(0, 12)
-                    : DeployService.branchImageAlias(targetBranch);
+            // ALWAYS the branch alias — never a commit SHA. `k8s-build.yml`
+            // (the workflow that actually publishes these images) pushes exactly
+            // two tag shapes:
+            //     :<alias>          dev | stage | prod
+            //     :sha-<full-sha>   40 hex chars, `sha-` prefixed
+            // The bare 12-char SHA tag this used to pin was published by
+            // `deploy_k8s.yaml`, which is now gated off — so pinning a short SHA
+            // would reference a tag that does not exist and the pod would sit in
+            // ImagePullBackOff. `sha-<full>` cannot be used either: the plugin
+            // truncates gitSha to 12 chars (see `sanitiseDockerTag` in
+            // k8s.plugin.ts), which would mangle it to `sha-abcd1234`.
+            // The alias is republished on every push to the branch, so it is
+            // both always-present and always-current — the same contract
+            // ArgoCD Image Updater relies on elsewhere in this fleet.
+            const gitSha = DeployService.branchImageAlias(targetBranch);
 
             const hosts: string[] = [];
             const ingressHost = deploySettings.ingressHost;

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -266,7 +266,28 @@ export class DeployService {
             deploySettings = { ...(deploySettings ?? {}), namespace: enforcedNamespace };
         }
 
-        await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, deploySettings);
+        // EW — server-side deploy for platform-managed cluster tiers.
+        //
+        // The GitHub Actions deploy path is structurally unable to reach a
+        // platform-managed cluster: our ARC runner pods have no egress to the
+        // cluster APIs, and a customer repo runs on GitHub-hosted runners that
+        // can never reach a private RFC1918 endpoint. The platform API pod CAN
+        // reach them (verified), already holds the kubeconfig, and
+        // KubernetesPlugin.deploy() applies the manifests directly — which is
+        // exactly what docs/features/k8s-deployment.md promises for the
+        // customer default: "No cluster credentials to manage; the platform
+        // runs it for you." `custom-kubeconfig` (bring-your-own cluster, incl.
+        // forks) keeps the workflow-dispatch path unchanged.
+        const serverSide = this.isServerSideManagedDeploy(
+            work.deployProvider,
+            plugin,
+            settings ?? {},
+            effectiveDeployToken,
+        );
+
+        await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, deploySettings, {
+            omitDeployToken: serverSide,
+        });
         await this.setKubernetesGhcrPullSecret(ctx, work, userId, plugin);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
@@ -316,18 +337,29 @@ export class DeployService {
             });
         }
 
-        const dispatched = await this.dispatchWithRetry(
-            work,
-            user,
-            gitToken,
-            plugin,
-            env.environment,
-            targetBranch,
-            env.prNumber,
-            env.commitSha,
-        );
+        const dispatched = serverSide
+            ? await this.deployServerSideManaged({
+                  work,
+                  userId,
+                  plugin,
+                  kubeconfig: effectiveDeployToken,
+                  deploySettings: deploySettings ?? {},
+                  deploymentId: deployment.id,
+                  targetBranch,
+                  commitSha: env.commitSha,
+              })
+            : await this.dispatchWithRetry(
+                  work,
+                  user,
+                  gitToken,
+                  plugin,
+                  env.environment,
+                  targetBranch,
+                  env.prNumber,
+                  env.commitSha,
+              );
 
-        if (!dispatched) {
+        if (!dispatched && !serverSide) {
             await this.deploymentRepository.markTerminal(deployment.id, 'ERROR', {
                 lastError: 'Workflow dispatch failed',
             });
@@ -871,6 +903,17 @@ export class DeployService {
         work: Work,
         plugin?: IDeploymentPlugin,
         settings?: Record<string, unknown>,
+        options?: {
+            /**
+             * Server-side (platform-managed) deploys: the resolved deploy
+             * token is the PLATFORM's cluster kubeconfig. It must never be
+             * written to the website repo — the documented contract for the
+             * managed tiers is "no cluster credentials to manage". Everything
+             * else (tenant ids, sync secrets, plugin extras) still pushes, so
+             * CI builds keep working unchanged.
+             */
+            omitDeployToken?: boolean;
+        },
     ) {
         const provider = work.deployProvider || EVER_WORKS_DEPLOY_PROVIDER_ID;
         const tokenSecretProvider = plugin?.id || provider;
@@ -886,8 +929,16 @@ export class DeployService {
             this.setSecret(ctx, 'TENANT_ID', work.id),
             this.setSecret(ctx, 'WORK_ID', work.id),
             this.setSecret(ctx, 'DATA_REPOSITORY', work.getDataRepo()),
-            this.setSecret(ctx, this.providerTokenSecretName(tokenSecretProvider), deployToken),
-            this.setSecret(ctx, 'DEPLOY_TOKEN', deployToken),
+            ...(options?.omitDeployToken
+                ? []
+                : [
+                      this.setSecret(
+                          ctx,
+                          this.providerTokenSecretName(tokenSecretProvider),
+                          deployToken,
+                      ),
+                      this.setSecret(ctx, 'DEPLOY_TOKEN', deployToken),
+                  ]),
         ]);
 
         // SITE_URL — used by the deployed site for canonical URLs, sitemap.xml,
@@ -1124,6 +1175,214 @@ export class DeployService {
             deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID ||
             pluginId === KUBERNETES_DEPLOY_PROVIDER_ID
         );
+    }
+
+    /**
+     * True when this deploy should be applied server-side by the platform
+     * instead of dispatched to a GitHub Actions workflow.
+     *
+     * Conditions, all required:
+     *  - kubernetes-family provider (`k8s` or the managed `ever-works`),
+     *  - the plugin actually implements `deploy()` (older/lazy plugins may not),
+     *  - a non-empty resolved kubeconfig (for managed tiers this is the
+     *    platform-held kubeconfig; empty means resolution failed upstream),
+     *  - and the work targets a platform-managed cluster: either the managed
+     *    `ever-works` provider (always platform-held) or a k8s clusterSource
+     *    of `k8s-works` / `k8s-works-shared`. `custom-kubeconfig` stays on
+     *    the workflow path — that cluster is reachable from GitHub runners by
+     *    definition (the user pasted its kubeconfig for exactly that reason).
+     */
+    private isServerSideManagedDeploy(
+        deployProvider: string | undefined,
+        plugin: IDeploymentPlugin | undefined,
+        settings: Record<string, unknown>,
+        resolvedKubeconfig: string,
+    ): boolean {
+        if (!this.isKubernetesDeploy(deployProvider, plugin?.id)) return false;
+        if (typeof (plugin as { deploy?: unknown } | undefined)?.deploy !== 'function')
+            return false;
+        if (!resolvedKubeconfig || !resolvedKubeconfig.trim()) return false;
+        if (deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID) return true;
+        return coerceClusterSource(settings.clusterSource) !== 'custom-kubeconfig';
+    }
+
+    /**
+     * Apply the work's manifests directly to the managed cluster via
+     * KubernetesPlugin.deploy().
+     *
+     * Image: CI (k8s-build.yml, synced from the template into every website
+     * repo) pushes `ghcr.io/<owner>/<WEBSITE-REPO>:<tag>` where tag is the
+     * 12-char commit SHA and the branch alias (develop→dev, stage→stage,
+     * main|master→prod). When the caller supplied a commit SHA we pin it;
+     * otherwise we deploy the branch alias, which always exists.
+     *
+     * Runtime env: the same values the workflow used to copy out of GitHub
+     * secrets are assembled here from their sources of truth and applied as
+     * the `<slug>-runtime-env` Secret — they never touch the repo.
+     */
+    private async deployServerSideManaged(args: {
+        work: Work;
+        userId: string;
+        plugin: IDeploymentPlugin;
+        kubeconfig: string;
+        deploySettings: Record<string, unknown>;
+        deploymentId: string;
+        targetBranch: string;
+        commitSha?: string;
+    }): Promise<boolean> {
+        const { work, plugin, kubeconfig, deploySettings, deploymentId, targetBranch, commitSha } =
+            args;
+        try {
+            const gitSha =
+                commitSha && commitSha.trim().length > 0
+                    ? commitSha.trim().slice(0, 12)
+                    : DeployService.branchImageAlias(targetBranch);
+
+            const hosts: string[] = [];
+            const ingressHost = deploySettings.ingressHost;
+            if (typeof ingressHost === 'string' && ingressHost.trim()) {
+                hosts.push(ingressHost.trim());
+            }
+            const extraHosts = deploySettings.extraHosts;
+            if (Array.isArray(extraHosts)) {
+                for (const h of extraHosts) {
+                    if (typeof h === 'string' && h.trim()) hosts.push(h.trim());
+                }
+            }
+
+            const runtimeEnv = await this.collectServerSideRuntimeEnv(work, hosts[0]);
+
+            const namespace =
+                typeof deploySettings.namespace === 'string' && deploySettings.namespace.trim()
+                    ? deploySettings.namespace.trim()
+                    : undefined;
+
+            const result = await (
+                plugin as IDeploymentPlugin & {
+                    deploy: (
+                        config: { projectName: string; options?: Record<string, unknown> },
+                        kubeconfig: string,
+                    ) => Promise<{ status?: string; error?: string; url?: string }>;
+                }
+            ).deploy(
+                {
+                    projectName: work.slug || work.id,
+                    options: {
+                        gitSha,
+                        githubOwner: work.getRepoOwner('website'),
+                        imageName: work.getWebsiteRepo(),
+                        namespaceOverride: namespace,
+                        hosts,
+                        runtimeEnv,
+                    },
+                },
+                kubeconfig,
+            );
+
+            if (result?.status === 'error') {
+                await this.deploymentRepository.markTerminal(deploymentId, 'ERROR', {
+                    lastError: result.error ?? 'Server-side deploy failed',
+                });
+                this.logger.error(
+                    `Server-side deploy failed for work ${work.id}: ${result.error ?? 'unknown error'}`,
+                );
+                return false;
+            }
+            this.logger.log(
+                `Server-side deploy applied for work ${work.id} (image tag ${gitSha}${
+                    hosts[0] ? `, host ${hosts[0]}` : ''
+                })`,
+            );
+            return true;
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            await this.deploymentRepository.markTerminal(deploymentId, 'ERROR', {
+                lastError: message,
+            });
+            this.logger.error(`Server-side deploy threw for work ${work.id}: ${message}`);
+            return false;
+        }
+    }
+
+    /** develop→dev, stage→stage, main|master→prod — mirrors k8s-build.yml. */
+    private static branchImageAlias(branch: string): string {
+        switch (branch) {
+            case 'develop':
+                return 'dev';
+            case 'stage':
+                return 'stage';
+            case 'main':
+            case 'master':
+                return 'prod';
+            default:
+                return branch.replace(/\//g, '-');
+        }
+    }
+
+    /**
+     * The core runtime environment for a server-side deploy — the same values
+     * the GitHub Actions path pushed as repo secrets for the workflow to copy
+     * into the cluster, assembled from their sources of truth instead.
+     * Best-effort per value: a failed lookup logs and omits the key rather
+     * than failing the deploy (matching the workflow path's posture).
+     */
+    private async collectServerSideRuntimeEnv(
+        work: Work,
+        primaryHost?: string,
+    ): Promise<Record<string, string>> {
+        const env: Record<string, string> = {
+            TENANT_ID: work.id,
+            WORK_ID: work.id,
+            DATA_REPOSITORY: work.getDataRepo(),
+            COOKIE_SECURE: 'true',
+        };
+        try {
+            env.AUTH_SECRET = await this.workRuntimeEnvService.getOrGenerateAuthSecret(work.id);
+            env.COOKIE_SECRET = await this.workRuntimeEnvService.getOrGenerateCookieSecret(work.id);
+        } catch (error: unknown) {
+            this.logger.error(
+                `Runtime-env auth/cookie secret generation failed for work ${work.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+        try {
+            const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(work.id);
+            if (databaseUrl) env.DATABASE_URL = databaseUrl;
+        } catch (error: unknown) {
+            this.logger.error(
+                `Runtime-env DATABASE_URL lookup failed for work ${work.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+        if (primaryHost) {
+            const url = `https://${primaryHost}`;
+            env.SITE_URL = url;
+            env.NEXT_PUBLIC_SITE_URL = url;
+            env.NEXT_PUBLIC_APP_URL = url;
+        }
+        // Activity Feed sync — same transport selection as the secret-push path.
+        const syncMode = work.activitySyncMode ?? 'pull';
+        if (syncMode === 'push') {
+            if (process.env.PLATFORM_API_URL && process.env.PLATFORM_API_SECRET_TOKEN) {
+                env.PLATFORM_API_URL = process.env.PLATFORM_API_URL;
+                env.PLATFORM_API_SECRET_TOKEN = process.env.PLATFORM_API_SECRET_TOKEN;
+            }
+        } else if (syncMode === 'pull') {
+            try {
+                env.PLATFORM_SYNC_SECRET = await this.platformSyncSecretService.getOrGenerate(
+                    work.id,
+                );
+            } catch (error: unknown) {
+                this.logger.error(
+                    `Runtime-env PLATFORM_SYNC_SECRET generation failed for work ${work.id}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+        return env;
     }
 
     private providerTokenSecretName(providerId: string): string {

--- a/packages/plugins/k8s/src/__tests__/e2e/cluster.e2e.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/e2e/cluster.e2e.spec.ts
@@ -91,7 +91,12 @@ describeE2E('k8s plugin e2e — against real cluster', () => {
 			image: IMAGE,
 			replicas: 1,
 			containerPort: 8080, // nginx-unprivileged listens on 8080
-			hosts: []
+			hosts: [],
+			// The default is now 'Always' (the server-side deploy path pins a
+			// MUTABLE branch alias, so a cached layer would pin a stale build).
+			// This suite side-loads its image with `kind load docker-image` and
+			// there is no registry to pull from, so it opts back out explicitly.
+			imagePullPolicy: 'IfNotPresent'
 		});
 		const service = buildService({
 			workId: WORK_ID,

--- a/packages/plugins/k8s/src/__tests__/server-side-deploy.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/server-side-deploy.spec.ts
@@ -78,9 +78,7 @@ describe('manifest.renderer — server-side inputs', () => {
 	it('mounts the runtime-env Secret via optional envFrom when named', () => {
 		const manifest = buildDeployment({ ...base, envFromSecretName: 'my-site-runtime-env' });
 		const container = (manifest as any).spec.template.spec.containers[0];
-		expect(container.envFrom).toEqual([
-			{ secretRef: { name: 'my-site-runtime-env', optional: true } }
-		]);
+		expect(container.envFrom).toEqual([{ secretRef: { name: 'my-site-runtime-env', optional: true } }]);
 	});
 
 	it('adds no envFrom when no secret is named (pre-existing behaviour)', () => {

--- a/packages/plugins/k8s/src/__tests__/server-side-deploy.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/server-side-deploy.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { PluginContext } from '@ever-works/plugin';
+import { KubernetesPlugin } from '../k8s.plugin';
+import { KubernetesApiService } from '../k8s-api.service';
+import { buildDeployment, buildRuntimeEnvSecret } from '../manifest.renderer';
+
+const VALID = readFileSync(resolve(__dirname, 'fixtures/kubeconfig-valid.yml'), 'utf-8');
+
+/**
+ * Server-side (platform-managed) deploy support — EW: the platform applies
+ * manifests directly instead of dispatching a GitHub Actions workflow, so
+ * three new inputs flow through `KubernetesPlugin.deploy()`:
+ *
+ *  - `namespaceOverride` — the namespace the platform ENFORCED server-side,
+ *    which must beat the plugin's own persisted settings;
+ *  - `imageName` — the website-repo name CI actually pushed the image under,
+ *    which is not always the work slug (legacy works);
+ *  - `runtimeEnv` — the runtime environment, applied as the
+ *    `<slug>-runtime-env` Secret and `envFrom`'d into the container.
+ */
+
+function createMockContext(settings: Record<string, unknown> = {}): PluginContext {
+	return {
+		pluginId: 'k8s',
+		logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		cache: {
+			get: vi.fn(),
+			set: vi.fn(),
+			delete: vi.fn(),
+			clear: vi.fn()
+		} as unknown as PluginContext['cache'],
+		http: {} as PluginContext['http'],
+		env: {} as PluginContext['env'],
+		envVars: {} as PluginContext['envVars'],
+		services: {} as PluginContext['services'],
+		getSettings: vi.fn().mockResolvedValue(settings),
+		getResolvedSettings: vi.fn(),
+		updateSettings: vi.fn(),
+		onEvent: vi.fn(),
+		emitEvent: vi.fn(),
+		registerCustomCapability: vi.fn(),
+		getCustomCapability: vi.fn()
+	} as unknown as PluginContext;
+}
+
+function makeMockApi(): KubernetesApiService {
+	return {
+		listIngressClasses: vi.fn(async () => [
+			{
+				name: 'nginx',
+				controller: 'k8s.io/ingress-nginx',
+				isDefault: true,
+				hasStrategy: true
+			}
+		]),
+		applyDeployment: vi.fn(async () => undefined),
+		applyService: vi.fn(async () => undefined),
+		applyIngress: vi.fn(async () => undefined),
+		applyImagePullSecret: vi.fn(async () => undefined),
+		applySecret: vi.fn(async () => undefined),
+		ensureNamespace: vi.fn(async () => undefined)
+	} as unknown as KubernetesApiService;
+}
+
+describe('manifest.renderer — server-side inputs', () => {
+	const base = {
+		workId: 'work-1',
+		workSlug: 'my-site',
+		namespace: 'ns-1',
+		image: 'ghcr.io/acme/site:abc',
+		replicas: 1,
+		containerPort: 3000,
+		hosts: []
+	};
+
+	it('mounts the runtime-env Secret via optional envFrom when named', () => {
+		const manifest = buildDeployment({ ...base, envFromSecretName: 'my-site-runtime-env' });
+		const container = (manifest as any).spec.template.spec.containers[0];
+		expect(container.envFrom).toEqual([
+			{ secretRef: { name: 'my-site-runtime-env', optional: true } }
+		]);
+	});
+
+	it('adds no envFrom when no secret is named (pre-existing behaviour)', () => {
+		const manifest = buildDeployment(base);
+		const container = (manifest as any).spec.template.spec.containers[0];
+		expect(container.envFrom).toBeUndefined();
+	});
+
+	it('builds the runtime-env Secret with stringData and managed labels', () => {
+		const secret = buildRuntimeEnvSecret({
+			name: 'my-site-runtime-env',
+			namespace: 'ns-1',
+			workId: 'work-1',
+			workSlug: 'my-site',
+			env: { AUTH_SECRET: 's3cret', SITE_URL: 'https://my-site.ever.works' }
+		}) as any;
+		expect(secret.kind).toBe('Secret');
+		expect(secret.type).toBe('Opaque');
+		expect(secret.metadata.namespace).toBe('ns-1');
+		expect(secret.stringData).toEqual({
+			AUTH_SECRET: 's3cret',
+			SITE_URL: 'https://my-site.ever.works'
+		});
+		expect(secret.metadata.labels['ever-works.io/managed']).toBe('true');
+		expect(secret.metadata.labels['ever-works.io/work-id']).toBe('work-1');
+	});
+});
+
+describe('KubernetesPlugin.deploy — server-side inputs (mocked api)', () => {
+	let plugin: KubernetesPlugin;
+	let api: KubernetesApiService;
+	const ctx = createMockContext({
+		kubeconfig: VALID,
+		namespace: 'settings-namespace',
+		registry: { kind: 'github', visibility: 'auto' }
+	});
+
+	beforeEach(async () => {
+		api = makeMockApi();
+		plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(ctx);
+	});
+
+	it('namespaceOverride beats the plugin-settings namespace', async () => {
+		const result = await plugin.deploy(
+			{
+				projectName: 'my-site',
+				sourceDir: '.',
+				options: {
+					gitSha: 'abc123def456',
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					namespaceOverride: 'enforced-ns'
+				}
+			},
+			VALID
+		);
+		expect(result.status).toBe('deploying');
+		expect(api.ensureNamespace).toHaveBeenCalledWith(VALID, 'enforced-ns', undefined);
+		const deployment = (api.applyDeployment as any).mock.calls[0][1];
+		expect(deployment.metadata.namespace).toBe('enforced-ns');
+	});
+
+	it('imageName pins the image repo while manifests keep the slug', async () => {
+		await plugin.deploy(
+			{
+				projectName: 'mcpserver',
+				sourceDir: '.',
+				options: {
+					gitSha: 'abc123def456',
+					githubOwner: 'ever-works',
+					websiteRepoIsPrivate: false,
+					imageName: 'awesome-mcp-servers-website'
+				}
+			},
+			VALID
+		);
+		const deployment = (api.applyDeployment as any).mock.calls[0][1];
+		expect(deployment.metadata.name).toBe('mcpserver');
+		expect(deployment.spec.template.spec.containers[0].image).toBe(
+			'ghcr.io/ever-works/awesome-mcp-servers-website:abc123def456'
+		);
+	});
+
+	it('runtimeEnv applies the Secret BEFORE the Deployment and wires envFrom', async () => {
+		const order: string[] = [];
+		(api.applySecret as any).mockImplementation(async () => {
+			order.push('secret');
+		});
+		(api.applyDeployment as any).mockImplementation(async () => {
+			order.push('deployment');
+		});
+
+		await plugin.deploy(
+			{
+				projectName: 'my-site',
+				sourceDir: '.',
+				options: {
+					gitSha: 'abc123def456',
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					runtimeEnv: { AUTH_SECRET: 's3cret' }
+				}
+			},
+			VALID
+		);
+
+		expect(order).toEqual(['secret', 'deployment']);
+		const secret = (api.applySecret as any).mock.calls[0][1];
+		expect(secret.metadata.name).toBe('my-site-runtime-env');
+		expect(secret.stringData).toEqual({ AUTH_SECRET: 's3cret' });
+		const deployment = (api.applyDeployment as any).mock.calls[0][1];
+		expect(deployment.spec.template.spec.containers[0].envFrom).toEqual([
+			{ secretRef: { name: 'my-site-runtime-env', optional: true } }
+		]);
+	});
+
+	it('no runtimeEnv → no Secret applied, no envFrom (pre-existing behaviour)', async () => {
+		await plugin.deploy(
+			{
+				projectName: 'my-site',
+				sourceDir: '.',
+				options: {
+					gitSha: 'abc123def456',
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false
+				}
+			},
+			VALID
+		);
+		expect(api.applySecret).not.toHaveBeenCalled();
+		const deployment = (api.applyDeployment as any).mock.calls[0][1];
+		expect(deployment.spec.template.spec.containers[0].envFrom).toBeUndefined();
+	});
+});

--- a/packages/plugins/k8s/src/k8s-api.service.ts
+++ b/packages/plugins/k8s/src/k8s-api.service.ts
@@ -439,6 +439,21 @@ export class KubernetesApiService {
 		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
+	/**
+	 * SSA-apply an arbitrary Secret manifest (runtime-env for server-side
+	 * deploys). Same mechanics as `applyImagePullSecret` — kept as its own
+	 * method so call sites say what they mean.
+	 */
+	async applySecret(
+		kubeconfigYaml: string,
+		manifest: Record<string, unknown>,
+		contextOverride?: string
+	): Promise<void> {
+		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
+	}
+
 	async readIngress(
 		kubeconfigYaml: string,
 		namespace: string,

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -14,6 +14,8 @@ import type {
 	PluginManifest
 } from '@ever-works/plugin';
 
+import { createHash } from 'node:crypto';
+
 import { K8sPluginError, buildSecretPattern, scrubError } from './errors.js';
 import { KubernetesApiService } from './k8s-api.service.js';
 import { defaultIngressStrategyRegistry, IngressStrategyRegistry } from './ingress/strategy.registry.js';
@@ -52,6 +54,17 @@ function isClusterSource(value: unknown): value is ClusterSource {
 	return typeof value === 'string' && (VALID_CLUSTER_SOURCES as readonly string[]).includes(value);
 }
 
+function hashRuntimeEnv(env: Record<string, string>): string {
+	// Rolls the pods when the runtime env genuinely changes (rotated secret,
+	// new host) and leaves them alone when it does not. Not a security
+	// boundary — just a change detector — but sha256 keeps it collision-free.
+	const canonical = Object.keys(env)
+		.sort()
+		.map((key) => `${key}=${env[key]}`)
+		.join('\n');
+	return createHash('sha256').update(canonical).digest('hex').slice(0, 16);
+}
+
 const DEFAULT_NAMESPACE = 'ever-works';
 const DEFAULT_REPLICAS = 1;
 const CONTAINER_PORT = 3000;
@@ -88,6 +101,19 @@ interface DeployOptions {
 	namespaceOverride?: string;
 	imageName?: string;
 	runtimeEnv?: Record<string, string>;
+	/**
+	 * Work-scoped plugin settings, layered over the ones this plugin loads for
+	 * itself. The singleton's PluginContext is built WITHOUT a user/work scope
+	 * (createContext takes only a pluginId), so `getSettings()` resolves
+	 * admin -> env -> schema default and silently discards everything the Work
+	 * configured — replicas would clamp to 1, a per-Work registry override
+	 * would be ignored, kubeContext dropped. The caller has the scoped values.
+	 */
+	settingsOverride?: Record<string, unknown>;
+	/** Escape hatch for side-loaded images (kind e2e). Production leaves this unset -> 'Always'. */
+	imagePullPolicy?: 'Always' | 'IfNotPresent' | 'Never';
+	/** Full commit SHA — used only as a pod annotation to force a rollout, never as the image tag. */
+	revision?: string;
 }
 
 const REGISTRY_SCHEMA: JsonSchema = {
@@ -442,8 +468,11 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 	}
 
 	async deploy(config: DeploymentConfig, kubeconfig: string): Promise<DeploymentResult> {
-		const settings = await this.loadSettings();
 		const opts = (config.options ?? {}) as DeployOptions;
+		const settings = {
+			...(await this.loadSettings()),
+			...((opts.settingsOverride ?? {}) as Partial<KubernetesSettings>)
+		} as KubernetesSettings;
 		// `namespaceOverride` is the namespace the PLATFORM enforced server-side
 		// (per-tenant override + reserved-namespace blocklist). It must win over
 		// the plugin's own persisted `namespace`, which is free-text the user
@@ -537,6 +566,19 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				containerPort: CONTAINER_PORT,
 				pullSecretName,
 				envFromSecretName: runtimeEnvSecretName,
+				imagePullPolicy: opts.imagePullPolicy,
+				// Makes the pod template differ between deploys of the same branch.
+				// The image tag is a mutable alias, so without this the manifest is
+				// identical every time and server-side apply rolls nothing.
+				podAnnotations: {
+					// NOT gitSha: that is the branch alias and is identical on every
+					// deploy, which would leave the pod template unchanged and defeat
+					// the point. Fall back to a per-deploy timestamp.
+					'ever-works.io/revision': opts.revision?.trim() || `t${Date.now().toString(36)}`,
+					...(opts.runtimeEnv && Object.keys(opts.runtimeEnv).length
+						? { 'ever-works.io/runtime-env-hash': hashRuntimeEnv(opts.runtimeEnv) }
+						: {})
+				},
 				hosts,
 				ingressClass,
 				tlsIssuer: settings.tlsIssuer,

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -21,6 +21,7 @@ import { defaultRegistryProviderRegistry, RegistryProviderRegistry } from './reg
 import { mapDeploymentToStatus } from './status.mapper.js';
 import {
 	buildDeployment,
+	buildRuntimeEnvSecret,
 	buildImagePullSecret,
 	buildIngress,
 	buildService,
@@ -66,6 +67,27 @@ interface DeployOptions {
 	githubReadPackagesToken?: string;
 	/** Custom hosts to add as Ingress rules (in addition to settings.ingressHost). */
 	hosts?: string[];
+	/**
+	 * Server-side (platform-managed) deploys — overrides for values the
+	 * GitHub Actions path derived inside the workflow:
+	 *
+	 * `namespaceOverride` — the namespace the platform ENFORCED server-side
+	 * (per-tenant override + reserved-namespace blocklist). Without it this
+	 * method would fall back to the plugin's own persisted settings, i.e.
+	 * whatever free-text the user typed.
+	 *
+	 * `imageName` — the image repository name when it differs from the work
+	 * slug. CI (k8s-build.yml) pushes `ghcr.io/<owner>/<WEBSITE-REPO>:<tag>`,
+	 * so the platform passes the website repo name here; manifest names and
+	 * labels keep using `projectName` (the work slug).
+	 *
+	 * `runtimeEnv` — key→value map applied as the `<slug>-runtime-env`
+	 * Opaque Secret and `envFrom`'d into the container. Replaces the
+	 * workflow's toJSON(secrets) copy step; values never touch the repo.
+	 */
+	namespaceOverride?: string;
+	imageName?: string;
+	runtimeEnv?: Record<string, string>;
 }
 
 const REGISTRY_SCHEMA: JsonSchema = {
@@ -421,7 +443,11 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 
 	async deploy(config: DeploymentConfig, kubeconfig: string): Promise<DeploymentResult> {
 		const settings = await this.loadSettings();
-		const namespace = settings.namespace?.trim() || DEFAULT_NAMESPACE;
+		const optsForNamespace = (config.options ?? {}) as DeployOptions;
+		const namespace =
+			optsForNamespace.namespaceOverride?.trim() ||
+			settings.namespace?.trim() ||
+			DEFAULT_NAMESPACE;
 		const replicas = clampReplicas(settings.replicas);
 		const registry = settings.registry ?? { kind: 'github' as const };
 		const opts = (config.options ?? {}) as DeployOptions;
@@ -432,6 +458,11 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		// unaffected. Fall back to a timestamp tag if nothing valid remains.
 		const gitSha = sanitiseDockerTag((opts.gitSha ?? '').slice(0, 12)) || Date.now().toString(36).slice(0, 12);
 		const slug = sanitiseSlug(config.projectName);
+		// CI pushes images named after the WEBSITE REPO, which is not always
+		// the work slug (legacy works: slug `mcpserver`, repo
+		// `awesome-mcp-servers-website`). `imageName` lets the caller pin the
+		// repo name for the image ref while manifests keep the slug.
+		const imageName = sanitiseSlug(opts.imageName ?? config.projectName);
 		const createdAt = new Date().toISOString();
 
 		const provider = this.registries.resolve(registry.kind);
@@ -442,7 +473,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		};
 		const visibility: ResolvedImageVisibility = provider.resolveVisibility(registry, registryCtx);
 		const imageBase = provider.imageBase(registry, registryCtx);
-		const image = `${imageBase}/${slug}:${gitSha}`;
+		const image = `${imageBase}/${imageName}:${gitSha}`;
 
 		const ingressClass = settings.ingressClass;
 		const controller = await this.controllerForClassName(kubeconfig, settings.kubeContext, ingressClass);
@@ -480,6 +511,23 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				await this.api.applyImagePullSecret(kubeconfig, secret, settings.kubeContext);
 			}
 
+			// Server-side runtime env: apply the Secret BEFORE the Deployment so
+			// the first pod generation already sees it (envFrom is resolved at
+			// pod creation). Applied every deploy — SSA makes it idempotent and
+			// picks up rotated values.
+			let runtimeEnvSecretName: string | undefined;
+			if (opts.runtimeEnv && Object.keys(opts.runtimeEnv).length > 0) {
+				runtimeEnvSecretName = `${slug}-runtime-env`;
+				const runtimeEnvSecret = buildRuntimeEnvSecret({
+					name: runtimeEnvSecretName,
+					namespace,
+					workId: config.projectName,
+					workSlug: slug,
+					env: opts.runtimeEnv
+				});
+				await this.api.applySecret(kubeconfig, runtimeEnvSecret, settings.kubeContext);
+			}
+
 			const renderInputs = {
 				workId: config.projectName,
 				workSlug: slug,
@@ -488,6 +536,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				replicas,
 				containerPort: CONTAINER_PORT,
 				pullSecretName,
+				envFromSecretName: runtimeEnvSecretName,
 				hosts,
 				ingressClass,
 				tlsIssuer: settings.tlsIssuer,

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -443,14 +443,15 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 
 	async deploy(config: DeploymentConfig, kubeconfig: string): Promise<DeploymentResult> {
 		const settings = await this.loadSettings();
-		const optsForNamespace = (config.options ?? {}) as DeployOptions;
+		const opts = (config.options ?? {}) as DeployOptions;
+		// `namespaceOverride` is the namespace the PLATFORM enforced server-side
+		// (per-tenant override + reserved-namespace blocklist). It must win over
+		// the plugin's own persisted `namespace`, which is free-text the user
+		// typed and carries no such guarantee.
 		const namespace =
-			optsForNamespace.namespaceOverride?.trim() ||
-			settings.namespace?.trim() ||
-			DEFAULT_NAMESPACE;
+			opts.namespaceOverride?.trim() || settings.namespace?.trim() || DEFAULT_NAMESPACE;
 		const replicas = clampReplicas(settings.replicas);
 		const registry = settings.registry ?? { kind: 'github' as const };
-		const opts = (config.options ?? {}) as DeployOptions;
 		// Security: the caller-supplied gitSha is interpolated into the Docker
 		// image tag below. Strip any character outside the Docker tag charset so
 		// a crafted value (e.g. `latest@sha256:...`) cannot pin an unintended

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -448,8 +448,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		// (per-tenant override + reserved-namespace blocklist). It must win over
 		// the plugin's own persisted `namespace`, which is free-text the user
 		// typed and carries no such guarantee.
-		const namespace =
-			opts.namespaceOverride?.trim() || settings.namespace?.trim() || DEFAULT_NAMESPACE;
+		const namespace = opts.namespaceOverride?.trim() || settings.namespace?.trim() || DEFAULT_NAMESPACE;
 		const replicas = clampReplicas(settings.replicas);
 		const registry = settings.registry ?? { kind: 'github' as const };
 		// Security: the caller-supplied gitSha is interpolated into the Docker

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -45,7 +45,19 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				resources: {
 					requests: { cpu: '100m', memory: '128Mi' },
 					limits: { cpu: '500m', memory: '512Mi' }
-				}
+				},
+				// Server-side deploys (EW — platform-managed clusters) mount the
+				// per-work runtime-env Secret the platform applied just before
+				// this manifest. `optional: true` keeps the pod schedulable when
+				// the Secret is absent (older works, custom clusters) — the app
+				// then boots on its baked-in defaults exactly as before.
+				...(input.envFromSecretName
+					? {
+							envFrom: [
+								{ secretRef: { name: input.envFromSecretName, optional: true } }
+							]
+						}
+					: {})
 			}
 		]
 	};
@@ -67,6 +79,35 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				spec: podSpec
 			}
 		}
+	};
+}
+
+/**
+ * Build the per-work runtime-env Secret the app container `envFrom`s.
+ *
+ * Server-side (platform-managed) deploys only: the platform assembles the
+ * runtime environment it used to push as GitHub Actions secrets and applies
+ * it directly to the target namespace instead — no cluster credential and no
+ * runtime value ever lands in the website repo. `stringData` so the values
+ * are written verbatim (the API server base64-encodes on persist).
+ */
+export function buildRuntimeEnvSecret(input: {
+	name: string;
+	namespace: string;
+	workId: string;
+	workSlug: string;
+	env: Record<string, string>;
+}): Record<string, unknown> {
+	return {
+		apiVersion: 'v1',
+		kind: 'Secret',
+		metadata: {
+			name: input.name,
+			namespace: input.namespace,
+			labels: COMMON_LABELS(input.workId, input.workSlug)
+		},
+		type: 'Opaque',
+		stringData: input.env
 	};
 }
 

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -53,9 +53,7 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				// then boots on its baked-in defaults exactly as before.
 				...(input.envFromSecretName
 					? {
-							envFrom: [
-								{ secretRef: { name: input.envFromSecretName, optional: true } }
-							]
+							envFrom: [{ secretRef: { name: input.envFromSecretName, optional: true } }]
 						}
 					: {})
 			}

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -30,7 +30,11 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 			{
 				name: 'app',
 				image: input.image,
-				imagePullPolicy: 'IfNotPresent',
+				// The server-side path pins a MUTABLE branch alias (:dev/:stage/:prod)
+				// that CI republishes, so a node with a cached layer would keep
+				// serving the old build forever under IfNotPresent. Callers that
+				// side-load an image (the kind-based e2e runbook) opt back out.
+				imagePullPolicy: input.imagePullPolicy ?? 'Always',
 				ports: [{ containerPort: input.containerPort, name: 'http' }],
 				readinessProbe: {
 					httpGet: { path: '/', port: 'http' },
@@ -73,7 +77,18 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 			selector: { matchLabels: selector },
 			strategy: { type: 'RollingUpdate', rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } },
 			template: {
-				metadata: { labels: { ...selector, ...labels } },
+				// Without a per-deploy annotation the rendered Deployment is
+				// byte-identical between deploys of the same branch (the tag is a
+				// fixed alias), so server-side apply produces no generation bump,
+				// no new ReplicaSet and no rollout — the deploy reports success and
+				// nothing changes. Re-applying the runtime-env Secret does not help
+				// either: envFrom is materialised at container start.
+				metadata: {
+					labels: { ...selector, ...labels },
+					...(input.podAnnotations && Object.keys(input.podAnnotations).length
+						? { annotations: input.podAnnotations }
+						: {})
+				},
 				spec: podSpec
 			}
 		}

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -179,6 +179,13 @@ export interface ManifestRenderInputs {
 	replicas: number;
 	containerPort: number;
 	pullSecretName?: string;
+	/**
+	 * Name of an existing (or just-applied) Opaque Secret in the target
+	 * namespace to `envFrom` into the app container. Marked `optional: true`
+	 * in the manifest so a missing Secret never blocks pod scheduling —
+	 * the app falls back to its baked-in defaults, exactly as it does today.
+	 */
+	envFromSecretName?: string;
 	hosts: string[];
 	ingressClass?: string;
 	tlsIssuer?: string;

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -186,6 +186,10 @@ export interface ManifestRenderInputs {
 	 * the app falls back to its baked-in defaults, exactly as it does today.
 	 */
 	envFromSecretName?: string;
+	/** Per-deploy pod-template annotations — required to force a rollout when the image tag is a mutable alias. */
+	podAnnotations?: Record<string, string>;
+	/** Defaults to 'Always'; only side-loaded (kind) images should use 'IfNotPresent'. */
+	imagePullPolicy?: 'Always' | 'IfNotPresent' | 'Never';
 	hosts: string[];
 	ingressClass?: string;
 	tlsIssuer?: string;


### PR DESCRIPTION
Finishes what `docs/features/k8s-deployment.md` already promises for the customer default:

> `k8s-works-shared` — the Ever Works shared customer cluster. **No cluster credentials to manage; the platform runs it for you.**

`KubernetesPlugin.deploy()` was fully implemented for exactly this — along with `getDeploymentStatus`, `addDomain`, `listClusterNodes` — and **never called**. `DeployService` pushed secrets to the website repo and dispatched a GitHub Actions workflow instead.

## Why the workflow path cannot work for managed clusters

Probed from **inside an ARC runner pod**:

```
UNREACHABLE 192.168.1.210:6443   (k8s-works)
UNREACHABLE 192.168.1.244:6443   (k8s-works-shared)
UNREACHABLE 192.168.1.170:6443   (ever-k8s — its OWN api server)
UNREACHABLE 192.168.1.231/.251/.180:80
```

Runner pods have no LAN egress at all. And a **customer** repo runs on GitHub-hosted runners, which can never reach a private RFC1918 endpoint like `https://192.168.1.244:6443`. So the path is broken for us by network policy and impossible for customers by design.

The platform API pod, by contrast, reaches both clusters — verified from the running pod — and already holds `EVER_WORKS_K8S_WORKS_KUBECONFIG` / `..._SHARED_KUBECONFIG`.

## What changes

`DeployService.deploy()` branches once, on `isServerSideManagedDeploy(...)`:

| clusterSource | path |
| --- | --- |
| `k8s-works`, `k8s-works-shared`, or the managed `ever-works` provider | **server-side** `plugin.deploy()` |
| `custom-kubeconfig` (bring-your-own, incl. forks) | **unchanged** workflow dispatch |

The guard also requires the plugin to actually expose `deploy()` and a non-empty resolved kubeconfig, so a lazy/older plugin or a failed env-var resolution falls back to today's behaviour rather than breaking.

**The platform kubeconfig is no longer written to the repo on the managed path.** `setRequiredSecrets` gains `omitDeployToken`, which drops `K8S_TOKEN` / `DEPLOY_TOKEN` — that is the "no cluster credentials to manage" contract made real. Every other secret still pushes, so CI image builds are untouched.

## Plugin side — three server-side inputs

- **`namespaceOverride`** — the namespace the platform *enforced* (per-tenant override + reserved-namespace blocklist). Without it the plugin falls back to its own persisted free-text `namespace`, silently discarding that enforcement.
- **`imageName`** — CI pushes `ghcr.io/<owner>/<WEBSITE-REPO>`, which is **not** always the work slug. Legacy works have slug `mcpserver` but repo `awesome-mcp-servers-website`. The image ref uses the repo; manifest names and labels keep the slug.
- **`runtimeEnv`** — applied as the `<slug>-runtime-env` Opaque Secret and `envFrom`-ed with `optional: true`, replacing the workflow step that copied GitHub secrets into the cluster. `optional: true` means a missing Secret never blocks scheduling — the app falls back to baked-in defaults exactly as today.

The Secret is applied **before** the Deployment so the first pod generation sees it, and re-applied every deploy (SSA is idempotent and picks up rotations).

## Image tag

Mirrors `k8s-build.yml`: pin the 12-char commit SHA when the caller supplied one, else the branch alias (`develop→dev`, `stage→stage`, `main|master→prod`) — which always exists.

## Tests

`packages/plugins/k8s/src/__tests__/server-side-deploy.spec.ts`
- `envFrom` wired when a secret is named; **absent when not** (proves no behaviour change for existing deploys)
- runtime-env Secret shape: `stringData`, namespace, managed labels
- `namespaceOverride` beats plugin settings — asserted on both `ensureNamespace` and the rendered manifest
- `imageName` pins the image while the manifest keeps the slug
- **ordering**: Secret applied strictly before Deployment
- no `runtimeEnv` → no Secret, no `envFrom`

`apps/api/.../deploy.service.server-side.spec.ts`
- managed tier → `plugin.deploy()` called with the platform kubeconfig, **no** workflow dispatch
- managed tier → the kubeconfig value never appears in any pushed secret, and neither `K8S_TOKEN` nor `DEPLOY_TOKEN` is pushed, while `WORK_ID` still is
- branch-alias tag (`main` → `prod`)
- plugin error → deployment marked terminal, `dispatched: false`
- `custom-kubeconfig` → dispatch unchanged and `K8S_TOKEN` still pushed

The DI harness is copied verbatim from `deploy.service.spec.ts` so constructor-arg order cannot drift between the two files.

`prettier --check` clean on all changed files (plugin package uses tabs; `apps/api` uses the root 4-space config — both verified against their own settings).

## Companion

directory-web-template PRs #998–#1002 made the template workflows repo-agnostic and gated the Actions k8s deploy behind `GHA_K8S_DEPLOY_ENABLED` (unset ⇒ skips), so the two halves land together: Actions stop failing, the platform takes over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployments to platform-managed Kubernetes clusters can now run directly through the platform.
  - Runtime environment variables are securely provided through Kubernetes Secrets.
  - Deployment settings support namespace overrides, custom image repositories, and configurable image pull policies.
  - Managed deployments automatically generate branch-based image references, ingress configuration, and rollout metadata.

- **Bug Fixes**
  - Platform credentials are no longer written to application repositories during managed deployments.
  - Deployment failures are reported as terminal errors for clearer status visibility.
  - Customer-managed Kubernetes deployments continue to use existing workflow-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->