### PR TITLE
cascade: Work startup fixes (#1965) develop -> stage

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -1422,7 +1422,7 @@ export class DeployService {
         }
         try {
             const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(work.id);
-            if (databaseUrl) env.DATABASE_URL = databaseUrl;
+            if (databaseUrl) env.DATABASE_URL = DeployService.externalizeDatabaseHost(databaseUrl);
         } catch (error: unknown) {
             this.logger.error(
                 `Runtime-env DATABASE_URL lookup failed for work ${work.id}: ${
@@ -1490,10 +1490,15 @@ export class DeployService {
                 typeof githubSettings?.readPackagesPatClassic === 'string'
                     ? githubSettings.readPackagesPatClassic.trim()
                     : '';
-            if (fineGrained || classic) return fineGrained || classic;
+            // Classic FIRST. Verified 2026-07-31 against
+            // ghcr.io/v2/ever-works/awesome-mcp-servers-website/manifests/prod:
+            // the fine-grained PAT returns 403, the classic ghp_ one returns 200.
+            // Preferring fineGrained would silently re-break image pulls the
+            // moment someone adds a fine-grained PAT to the platform secret.
+            if (classic || fineGrained) return classic || fineGrained;
 
             const platformDefaults = this.getPlatformGhcrCredentials(work.getRepoOwner('website'));
-            const platformToken = platformDefaults.fineGrained || platformDefaults.classic;
+            const platformToken = platformDefaults.classic || platformDefaults.fineGrained;
             if (platformToken) return platformToken;
         } catch (error: unknown) {
             this.logger.warn(
@@ -1503,6 +1508,47 @@ export class DeployService {
             );
         }
         return gitToken ?? '';
+    }
+
+    /**
+     * Rewrite an in-cluster Postgres host to the address a Work can actually
+     * reach from ITS OWN cluster.
+     *
+     * The platform runs on ever-k8s and talks to Postgres over the in-cluster
+     * service DNS (`pg-rw.databases.svc.cluster.local`). A Work deployed to
+     * k8s-works / k8s-works-shared is on a DIFFERENT cluster, where that name
+     * does not resolve at all — verified from inside a Work pod on
+     * k8s-works-shared: ENOTFOUND, while the LoadBalancer address connects.
+     * Handing the Work the platform's own URL made it die on startup with
+     * "Database initialization failed", which reads like a migration bug and is
+     * really a DNS one.
+     *
+     * `DB_EVER_WORKS_SHARED_HOST` already carries the externally-reachable
+     * address for exactly this purpose; this only swaps host:port and leaves
+     * credentials, database name and query string untouched. No-op when the
+     * host is not an in-cluster name (custom-kubeconfig Works pointing at their
+     * own database keep working unchanged).
+     */
+    static externalizeDatabaseHost(databaseUrl: string): string {
+        const externalHost = (process.env.DB_EVER_WORKS_SHARED_HOST || '').trim();
+        if (!externalHost) return databaseUrl;
+        let parsed: URL;
+        try {
+            parsed = new URL(databaseUrl);
+        } catch {
+            return databaseUrl;
+        }
+        if (!parsed.hostname.endsWith('.svc.cluster.local') && !parsed.hostname.endsWith('.svc')) {
+            return databaseUrl;
+        }
+        parsed.hostname = externalHost;
+        const externalPort = (process.env.DB_EVER_WORKS_SHARED_PORT || '').trim();
+        if (externalPort) parsed.port = externalPort;
+        const sslMode = (process.env.DB_EVER_WORKS_SHARED_SSLMODE || '').trim();
+        if (sslMode && !parsed.searchParams.has('sslmode')) {
+            parsed.searchParams.set('sslmode', sslMode);
+        }
+        return parsed.toString();
     }
 
     private providerTokenSecretName(providerId: string): string {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -567,6 +567,12 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				pullSecretName,
 				envFromSecretName: runtimeEnvSecretName,
 				imagePullPolicy: opts.imagePullPolicy,
+				// Per-Work sizing, resolved through the same settings merge as the
+				// rest (settingsOverride layers the work tier over the plugin's own).
+				cpuRequest: settings.cpuRequest,
+				memoryRequest: settings.memoryRequest,
+				cpuLimit: settings.cpuLimit,
+				memoryLimit: settings.memoryLimit,
 				// Makes the pod template differ between deploys of the same branch.
 				// The image tag is a mutable alias, so without this the manifest is
 				// identical every time and server-side apply rolls nothing.

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -36,19 +36,53 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				// side-load an image (the kind-based e2e runbook) opt back out.
 				imagePullPolicy: input.imagePullPolicy ?? 'Always',
 				ports: [{ containerPort: input.containerPort, name: 'http' }],
+				// A directory Work renders its whole catalogue on first request, so
+				// the default 1s probe timeout could never pass on a large one — the
+				// pod stayed 0/1 forever while the app was healthy. Readiness stays
+				// comparatively tight (an unready pod must leave the Service), but it
+				// gets a realistic timeout; a startupProbe absorbs the cold start so
+				// liveness never kills a warming container and loses its cache.
+				startupProbe: {
+					httpGet: { path: '/', port: 'http' },
+					periodSeconds: 10,
+					timeoutSeconds: 10,
+					failureThreshold: input.startupFailureThreshold ?? 30
+				},
 				readinessProbe: {
 					httpGet: { path: '/', port: 'http' },
-					periodSeconds: 5,
-					initialDelaySeconds: 5
+					periodSeconds: 10,
+					timeoutSeconds: 5,
+					failureThreshold: 3
 				},
 				livenessProbe: {
 					httpGet: { path: '/', port: 'http' },
-					periodSeconds: 10,
-					initialDelaySeconds: 30
+					periodSeconds: 20,
+					timeoutSeconds: 10,
+					failureThreshold: 6
 				},
+				// 512Mi OOM-killed a real catalogue — the mcp-servers Work restarted
+				// 4x and never served. Measured usage of the seven live Works:
+				// 441Mi / 487 / 567 / 586 / 616 / 1557, and mcp-servers at 3980Mi.
+				//
+				// 2Gi covers six of the seven with headroom and — critically — FITS.
+				// k8s-works and k8s-works-shared workers have only ~3.72Gi allocatable
+				// EACH, so a larger default would be a limit no node could ever honour:
+				// requests are small enough that such a pod schedules happily and then
+				// gets OOM-killed climbing toward a ceiling that does not physically
+				// exist. A Work genuinely needing more (mcp-servers) needs a bigger
+				// node or a smaller footprint, not a bigger number here.
+				//
+				// Requests stay small so scheduling is cheap. All four are overridable
+				// per Work via plugin settings.
 				resources: {
-					requests: { cpu: '100m', memory: '128Mi' },
-					limits: { cpu: '500m', memory: '512Mi' }
+					requests: {
+						cpu: input.cpuRequest ?? '100m',
+						memory: input.memoryRequest ?? '256Mi'
+					},
+					limits: {
+						cpu: input.cpuLimit ?? '2',
+						memory: input.memoryLimit ?? '2Gi'
+					}
 				},
 				// Server-side deploys (EW — platform-managed clusters) mount the
 				// per-work runtime-env Secret the platform applied just before

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -86,6 +86,11 @@ export type ClusterSource = 'k8s-works' | 'k8s-works-shared' | 'custom-kubeconfi
  * Plugin settings as stored in `plugin_settings`.
  */
 export interface KubernetesSettings {
+	/** Per-Work container sizing (optional; sensible defaults in the renderer). */
+	cpuRequest?: string;
+	memoryRequest?: string;
+	cpuLimit?: string;
+	memoryLimit?: string;
 	/** Where the kubeconfig for the target cluster comes from. Defaults
 	 *  to `'custom-kubeconfig'` so existing Works (which pre-date this
 	 *  field and have a user-pasted `kubeconfig`) keep working without
@@ -188,6 +193,13 @@ export interface ManifestRenderInputs {
 	envFromSecretName?: string;
 	/** Per-deploy pod-template annotations — required to force a rollout when the image tag is a mutable alias. */
 	podAnnotations?: Record<string, string>;
+	/** Per-Work sizing. Defaults suit a large directory catalogue; small Works can shrink these. */
+	cpuRequest?: string;
+	memoryRequest?: string;
+	cpuLimit?: string;
+	memoryLimit?: string;
+	/** startupProbe failureThreshold (x10s). Default 30 = 5 min of cold start before liveness engages. */
+	startupFailureThreshold?: number;
 	/** Defaults to 'Always'; only side-loaded (kind) images should use 'IfNotPresent'. */
 	imagePullPolicy?: 'Always' | 'IfNotPresent' | 'Never';
 	hosts: string[];


### PR DESCRIPTION
Cascade of #1965 — five fixes that let a deployed Work actually start.

Found by running the first real deploy through the server-side path:
- DATABASE_URL used ever-k8s in-cluster DNS (pg-rw.databases.svc.cluster.local),
  unreachable from any other cluster — proved ENOTFOUND from inside the pod while
  the pooler LB 192.168.1.185:5432 connects. Off-cluster Works now get the LB.
- GHCR read token preference flipped to classic-first (the fine-grained PAT 403s
  against ghcr.io; only the classic ghp_ one returns 200).
- Readiness/startup probes sized for a real catalogue cold start.
- Default memory limit set to 2Gi — NOT 4Gi. Measured the seven live Works:
  441/487/567/586/616/1557Mi, plus mcp-servers at 3980Mi. Worker nodes had only
  ~3.72Gi allocatable, so 4Gi was a limit no node could honour.

Infra note: k8s-works-shared workers have since been resized 4GB -> 8GB
(allocatable 3.72Gi -> 7.66Gi) so the largest Work fits.