### PR TITLE
fix(k8s): declare the sizing settings, which were overrides in name only

### DIFF
--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -280,6 +280,33 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				default: DEFAULT_REPLICAS,
 				minimum: 1,
 				maximum: 10
+			},
+			// Per-Work sizing. `deploy()` already reads all four off `settings`,
+			// but PluginSettingsService resolves settings by iterating the SCHEMA's
+			// keys — anything not declared here is silently dropped, so without
+			// these entries the overrides existed in name only: you could persist
+			// `memoryLimit` on a Work, see it stored, and still get the default
+			// rendered into the Deployment. Verified by reading back the ReplicaSet.
+			cpuRequest: {
+				type: 'string',
+				title: 'CPU request',
+				description: "Kubernetes quantity, e.g. '100m'. Small requests keep scheduling cheap."
+			},
+			memoryRequest: {
+				type: 'string',
+				title: 'Memory request',
+				description: "Kubernetes quantity, e.g. '256Mi'."
+			},
+			cpuLimit: {
+				type: 'string',
+				title: 'CPU limit',
+				description: "Kubernetes quantity, e.g. '2'."
+			},
+			memoryLimit: {
+				type: 'string',
+				title: 'Memory limit',
+				description:
+					"Kubernetes quantity, e.g. '2Gi'. Must fit the target node: a limit larger than a node's allocatable memory schedules fine (requests are small) and then OOM-kills the pod climbing toward a ceiling that does not exist."
 			}
 		},
 		// `kubeconfig` is only required when `clusterSource === 'custom-kubeconfig'`


### PR DESCRIPTION
The k8s plugin reads `settings.cpuRequest` / `memoryRequest` / `cpuLimit` /
`memoryLimit` in `deploy()` and passes them to the manifest renderer, but none of
the four were declared in `settingsSchema`. `PluginSettingsService` resolves
settings by iterating the **schema keys**, so anything undeclared is dropped.

Net effect: a feature that looked like it worked. You could persist `memoryLimit`
on a Work, read it straight back out of `work_plugins`, and still get the default
rendered into the Deployment.

**How it surfaced.** Deploying `awesome-mcp-servers` to `k8s-works-shared`, I set
`memoryLimit: 5Gi` on the Work and then checked the rendered ReplicaSet — still
`2Gi`. Persisting a setting is not the same as it taking effect, and only reading
back the actual k8s object catches the difference.

Adds all four as string (Kubernetes quantity) properties, with the trap that
motivated this recorded on `memoryLimit`: a limit larger than the target node
allocatable schedules happily — requests are deliberately small — and then
OOM-kills the pod climbing toward a ceiling that does not physically exist.

Context: the 2Gi default is correct and proven. `awesome-mcp-servers` is live on
`k8s-works-shared` at 2Gi, 1/1 Ready, 0 restarts, serving HTTP 200 in 268ms — so
nothing depends on this fix today. It matters for the next Work that genuinely
needs different sizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU and memory requests and limits for Kubernetes Work resources.
  * Included descriptions and supported quantity formats to clarify resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->