### PR TITLE
fix(deploy): derive a namespace for k8s-works Works instead of the reserved default

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -604,6 +604,26 @@ export class DeployService {
         // honour the user's namespace, but never a platform-reserved one.
         const requested = typeof settings.namespace === 'string' ? settings.namespace.trim() : '';
         if (!requested) {
+            // `k8s-works` is OUR cluster, and leaving this undefined means the
+            // plugin falls back to its own DEFAULT_NAMESPACE ('ever-works') —
+            // which is platform-reserved. The blocklist below never catches it
+            // because it only inspects a namespace the user actually typed, so
+            // every Work created on k8s-works without an explicit namespace
+            // silently targets the reserved shared namespace. Derive one.
+            //
+            // custom-kubeconfig is deliberately left alone: that is the user's
+            // own cluster and their default namespace is their business.
+            if (clusterSource === 'k8s-works') {
+                const slug = (work.slug || work.id)
+                    .toLowerCase()
+                    .replace(/[^a-z0-9-]+/g, '-')
+                    .replace(/^-+|-+$/g, '')
+                    .slice(0, 40);
+                const derived = slug ? `ever-works-${slug}-prod` : '';
+                if (derived && !isReservedDeployNamespace(derived)) {
+                    return derived;
+                }
+            }
             return undefined;
         }
         if (isReservedDeployNamespace(requested)) {


### PR DESCRIPTION
A Work on the internal `k8s-works` cluster with no explicit namespace could never deploy correctly.

`resolveDeployNamespace` returned `undefined`, so nothing was enforced and the k8s plugin fell back to its own `DEFAULT_NAMESPACE` = `ever-works` — which is platform-reserved. The reserved-namespace blocklist immediately below never caught it, because that check only inspects a namespace the **user actually typed**.

That is why it survived review: the guard and the bug are four lines apart, and the guard cannot see the path that triggers it. It only surfaced when I moved six Works onto `k8s-works` and had to set namespaces by hand.

Now derives `ever-works-<slug>-prod` (sanitised, length-capped, still rejected if it somehow collides with a reserved name).

`custom-kubeconfig` is deliberately untouched — that is the user own cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `k8s-works` deployments without an explicit namespace now automatically use a dedicated production namespace derived from the Work identifier.
  * Custom-kubeconfig deployments continue using their existing default namespace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->