### PR TITLE
fix(agents): make the delegation limits real — parent-scope narrowing and the fan-out cap

### DIFF
--- a/apps/api/src/agents/workflow-node.runner.spec.ts
+++ b/apps/api/src/agents/workflow-node.runner.spec.ts
@@ -247,6 +247,51 @@ describe('WorkflowNodeRunnerService', () => {
             expect(delegation.delegate.mock.calls[0][0].scope.allowedTools).toEqual(['read_file']);
         });
 
+        it('INHERITS the parent networkAccess instead of pinning every child off', async () => {
+            // `narrowSubAgentScope` ANDs parent and requested. A node never
+            // asks for network, so leaving `requested` unset collapses the
+            // AND to false for every child — the field would be threaded
+            // three layers only to be pinned off.
+            await runner.run(
+                delegateNode(),
+                {},
+                ctx({ parentScope: { ...PARENT_SCOPE, networkAccess: true } }) as never,
+            );
+
+            expect(delegation.delegate.mock.calls[0][0].scope.networkAccess).toBe(true);
+        });
+
+        it('does not invent networkAccess when there is no parent scope', async () => {
+            await runner.run(delegateNode(), {}, ctx() as never);
+
+            expect(delegation.delegate.mock.calls[0][0].scope.networkAccess).toBeUndefined();
+        });
+
+        it('bounds how long one delegate node may block the tool call', async () => {
+            // Unbudgeted, `awaitTerminal` waits 10 minutes per node and the
+            // executor walks up to 4 delegate nodes sequentially — ~40
+            // minutes for a single chat tool call.
+            await runner.run(delegateNode(), {}, ctx({ parentScope: PARENT_SCOPE }) as never);
+
+            expect(delegation.delegate.mock.calls[0][0].budget.maxDurationMs).toBe(5 * 60_000);
+        });
+
+        it('lets a node ask for LESS time but not more', async () => {
+            await runner.run(
+                delegateNode({ maxDurationMs: 30_000 }),
+                {},
+                ctx({ parentScope: PARENT_SCOPE }) as never,
+            );
+            await runner.run(
+                delegateNode({ maxDurationMs: 60 * 60_000 }),
+                {},
+                ctx({ parentScope: PARENT_SCOPE }) as never,
+            );
+
+            expect(delegation.delegate.mock.calls[0][0].budget.maxDurationMs).toBe(30_000);
+            expect(delegation.delegate.mock.calls[1][0].budget.maxDurationMs).toBe(10 * 60_000);
+        });
+
         it('drops a malformed parent scope rather than half-applying it', async () => {
             await runner.run(
                 delegateNode(),

--- a/apps/api/src/agents/workflow-node.runner.spec.ts
+++ b/apps/api/src/agents/workflow-node.runner.spec.ts
@@ -98,7 +98,126 @@ describe('WorkflowNodeRunnerService', () => {
                 // the dedup key rather than spawning a second child.
                 delegationId: 'run-1:n1',
             }),
+            // The limits argument — see the `delegation limits` block.
+            expect.any(Object),
         );
+    });
+
+    /**
+     * The delegation contract's caps are all evaluated against a `limits`
+     * argument the CALLER supplies. This runner is the only production
+     * caller, and it used to pass none — so `narrowSubAgentScope` never
+     * ran ("privilege only shrinks" was unenforced) and the fan-out check
+     * compared `0 >= maxSiblings`, which is never true.
+     */
+    describe('delegation limits', () => {
+        const PARENT_SCOPE = {
+            allowedTools: ['read_file', 'write_file'],
+            workId: 'work-1',
+            organizationId: 'org-1',
+            networkAccess: false,
+        };
+
+        const delegateNode = (config: Record<string, unknown> = {}) => ({
+            id: 'n1',
+            kind: 'agent.delegate',
+            config: { objective: 'do the thing', ...config },
+        });
+
+        it('passes the parent scope so narrowing actually runs', async () => {
+            await runner.run(delegateNode(), {}, ctx({ parentScope: PARENT_SCOPE }) as never);
+
+            expect(delegation.delegate).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ parentScope: PARENT_SCOPE }),
+            );
+        });
+
+        it('passes a sibling count that RISES, so the fan-out cap can fire', async () => {
+            // The cap compares `siblingCount >= maxSiblings`. A constant 0
+            // can never trip it however many delegations a run issues.
+            await runner.run(delegateNode(), {}, ctx({ parentScope: PARENT_SCOPE }) as never);
+            await runner.run(
+                { ...delegateNode(), id: 'n2' },
+                {},
+                ctx({ parentScope: PARENT_SCOPE }) as never,
+            );
+            await runner.run(
+                { ...delegateNode(), id: 'n3' },
+                {},
+                ctx({ parentScope: PARENT_SCOPE }) as never,
+            );
+
+            const counts = delegation.delegate.mock.calls.map((call) => call[1].siblingCount);
+            expect(counts).toEqual([0, 1, 2]);
+        });
+
+        it('counts siblings PER RUN, not globally', async () => {
+            await runner.run(delegateNode(), {}, ctx({ parentScope: PARENT_SCOPE }) as never);
+
+            const other = {
+                graphId: 'g1',
+                runId: 'run-2',
+                viaEdgeId: null,
+                stepIndex: 0,
+                context: { userId: 'user-1', agentId: 'agent-1', parentScope: PARENT_SCOPE },
+            };
+            await runner.run(delegateNode(), {}, other as never);
+
+            // A second graph run starts its own budget — otherwise one busy
+            // run would refuse delegations for an unrelated one.
+            expect(delegation.delegate.mock.calls[1][1].siblingCount).toBe(0);
+        });
+
+        it("defaults a node's tools to the inherit-parent wildcard when a parent scope bounds it", async () => {
+            await runner.run(delegateNode(), {}, ctx({ parentScope: PARENT_SCOPE }) as never);
+
+            // `['*']` intersects to exactly the parent's tools. Without a
+            // parent scope this would be an unbounded ask.
+            expect(delegation.delegate.mock.calls[0][0].scope.allowedTools).toEqual(['*']);
+        });
+
+        it('keeps the empty tool list when NO parent scope bounds it', async () => {
+            await runner.run(delegateNode(), {}, ctx() as never);
+
+            // Unchanged from before this feature: the contract refuses an
+            // empty scope as `scope-empty` rather than letting an unbounded
+            // request through.
+            expect(delegation.delegate.mock.calls[0][0].scope.allowedTools).toEqual([]);
+            expect(delegation.delegate.mock.calls[0][1].parentScope).toBeUndefined();
+        });
+
+        it('still honours an explicit allowedTools list from the node', async () => {
+            await runner.run(
+                delegateNode({ allowedTools: ['read_file'] }),
+                {},
+                ctx({ parentScope: PARENT_SCOPE }) as never,
+            );
+
+            expect(delegation.delegate.mock.calls[0][0].scope.allowedTools).toEqual(['read_file']);
+        });
+
+        it('drops a malformed parent scope rather than half-applying it', async () => {
+            await runner.run(
+                delegateNode(),
+                {},
+                ctx({ parentScope: { allowedTools: 'not-an-array' } }) as never,
+            );
+
+            expect(delegation.delegate.mock.calls[0][1].parentScope).toBeUndefined();
+        });
+
+        it('drops a parent scope that grants no tools', async () => {
+            // An empty parent intersects to nothing and would refuse every
+            // delegation — a broken feature, not a safe default.
+            await runner.run(
+                delegateNode(),
+                {},
+                ctx({ parentScope: { allowedTools: [] } }) as never,
+            );
+
+            expect(delegation.delegate.mock.calls[0][1].parentScope).toBeUndefined();
+        });
     });
 
     it('prefers the REAL agent run id as parentRunId when the host supplies one', async () => {
@@ -115,6 +234,7 @@ describe('WorkflowNodeRunnerService', () => {
 
         expect(delegation.delegate).toHaveBeenCalledWith(
             expect.objectContaining({ parentRunId: 'agent-run-real' }),
+            expect.any(Object),
         );
     });
 
@@ -128,6 +248,7 @@ describe('WorkflowNodeRunnerService', () => {
 
         expect(delegation.delegate).toHaveBeenCalledWith(
             expect.objectContaining({ parentRunId: 'run-1' }),
+            expect.any(Object),
         );
     });
 

--- a/apps/api/src/agents/workflow-node.runner.spec.ts
+++ b/apps/api/src/agents/workflow-node.runner.spec.ts
@@ -152,7 +152,57 @@ describe('WorkflowNodeRunnerService', () => {
             expect(counts).toEqual([0, 1, 2]);
         });
 
-        it('counts siblings PER RUN, not globally', async () => {
+        it('shares one budget across SEPARATE graph runs of the same agent run', async () => {
+            // The cap would otherwise be unreachable. The executor is a
+            // single linear walk and delegate-on-a-cycle is refused, so one
+            // graph issues at most 4 delegations — under the ceiling of 5.
+            // A model that calls run_workflow_graph twice would get a fresh
+            // budget each time, so counting per GRAPH run never refuses.
+            const first = {
+                graphId: 'g1',
+                runId: 'wf-run-1',
+                viaEdgeId: null,
+                stepIndex: 0,
+                context: {
+                    userId: 'user-1',
+                    agentId: 'agent-1',
+                    agentRunId: 'agent-run-A',
+                    parentScope: PARENT_SCOPE,
+                },
+            };
+            const second = { ...first, runId: 'wf-run-2' };
+
+            await runner.run(delegateNode(), {}, first as never);
+            await runner.run(delegateNode(), {}, second as never);
+
+            const counts = delegation.delegate.mock.calls.map((c) => c[1].siblingCount);
+            expect(counts).toEqual([0, 1]);
+        });
+
+        it('gives a DIFFERENT agent run its own budget', async () => {
+            const base = {
+                graphId: 'g1',
+                viaEdgeId: null,
+                stepIndex: 0,
+                context: { userId: 'user-1', agentId: 'agent-1', parentScope: PARENT_SCOPE },
+            };
+            await runner.run(delegateNode(), {}, {
+                ...base,
+                runId: 'wf-1',
+                context: { ...base.context, agentRunId: 'agent-run-A' },
+            } as never);
+            await runner.run(delegateNode(), {}, {
+                ...base,
+                runId: 'wf-2',
+                context: { ...base.context, agentRunId: 'agent-run-B' },
+            } as never);
+
+            // Otherwise one busy agent would refuse delegations for an
+            // unrelated one.
+            expect(delegation.delegate.mock.calls[1][1].siblingCount).toBe(0);
+        });
+
+        it('keys the budget by the graph run when no agent run is threaded', async () => {
             await runner.run(delegateNode(), {}, ctx({ parentScope: PARENT_SCOPE }) as never);
 
             const other = {

--- a/apps/api/src/agents/workflow-node.runner.ts
+++ b/apps/api/src/agents/workflow-node.runner.ts
@@ -51,6 +51,21 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
     private readonly delegationsByRun = new Map<string, number>();
     private static readonly MAX_TRACKED_RUNS = 500;
 
+    /**
+     * Default wait for one delegate node.
+     *
+     * Half the delegation runner's own 10-minute fallback, chosen so a
+     * maximal graph (4 delegate nodes, walked sequentially) bounds a chat
+     * tool call at ~20 minutes rather than ~40 — while still leaving a real
+     * child agent run a realistic amount of time. A node that genuinely
+     * needs the old allowance can ask for it, up to
+     * {@link MAX_DELEGATION_BUDGET_MS}, so nothing that worked before is
+     * cut off; it just has to say so.
+     */
+    private static readonly DEFAULT_DELEGATION_BUDGET_MS = 5 * 60_000;
+    /** Ceiling a node may not raise past — the previous implicit default. */
+    private static readonly MAX_DELEGATION_BUDGET_MS = 10 * 60_000;
+
     constructor(
         @Optional() private readonly delegation?: SubAgentDelegationService,
         @Optional() private readonly ai?: AiFacadeService,
@@ -222,7 +237,33 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
                         this.stringArrayConfig(node, 'allowedTools') ?? (parentScope ? ['*'] : []),
                     workId: this.contextString(context, 'workId') ?? null,
                     organizationId: this.contextString(context, 'organizationId') ?? null,
+                    // INHERIT the parent's value rather than leaving this
+                    // undefined.
+                    //
+                    // `narrowSubAgentScope` computes
+                    // `Boolean(parent.networkAccess) && Boolean(requested.networkAccess)`.
+                    // A node never asks for network, so leaving this unset
+                    // makes the AND collapse to `false` for EVERY child —
+                    // the field would be threaded three layers only to be
+                    // pinned off, which is not a bound, it is a bug that
+                    // happens to look strict.
+                    ...(parentScope ? { networkAccess: parentScope.networkAccess } : {}),
                 },
+                // Bound the wait.
+                //
+                // `awaitTerminal` falls back to a 10-MINUTE budget, and a
+                // graph may hold up to `WORKFLOW_TOOL_MAX_DELEGATE_NODES`
+                // delegate nodes which the executor walks sequentially —
+                // so an unbudgeted graph could block one chat tool call for
+                // ~40 minutes. Before this change that never happened
+                // because a bare delegate node was refused outright as
+                // `scope-empty`; making delegation actually work is what
+                // exposes the wait.
+                //
+                // A timeout surfaces as a `failed` node, which an
+                // `on_failure` edge can route around — it does not lose the
+                // graph.
+                budget: { maxDurationMs: this.delegationBudgetMs(node) },
             },
             {
                 // Without these two the contract's caps are inert:
@@ -259,6 +300,22 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
             };
         }
         return { ok: true, output: result.output };
+    }
+
+    /**
+     * How long one `agent.delegate` node may wait for its child.
+     *
+     * A node may ask for less via `config.maxDurationMs`; it may not ask
+     * for more, because the ceiling is what keeps a maximal graph from
+     * pinning a chat tool call for most of an hour.
+     */
+    private delegationBudgetMs(node: WorkflowNode): number {
+        const requested = node.config?.['maxDurationMs'];
+        const asked =
+            typeof requested === 'number' && Number.isFinite(requested) && requested > 0
+                ? requested
+                : WorkflowNodeRunnerService.DEFAULT_DELEGATION_BUDGET_MS;
+        return Math.min(asked, WorkflowNodeRunnerService.MAX_DELEGATION_BUDGET_MS);
     }
 
     /**

--- a/apps/api/src/agents/workflow-node.runner.ts
+++ b/apps/api/src/agents/workflow-node.runner.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import type { WorkflowNode } from '@ever-works/contracts';
+import type { SubAgentScope, WorkflowNode } from '@ever-works/contracts';
 import type {
     WorkflowNodeRunContext,
     WorkflowNodeRunResult,
@@ -42,6 +42,13 @@ import { KnowledgeBaseService } from '@ever-works/agent/services';
 @Injectable()
 export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
     private readonly logger = new Logger(WorkflowNodeRunnerService.name);
+
+    /**
+     * Delegations issued per graph run, feeding the contract's fan-out
+     * cap. Bounded — see {@link countDelegation}.
+     */
+    private readonly delegationsByRun = new Map<string, number>();
+    private static readonly MAX_TRACKED_RUNS = 500;
 
     constructor(
         @Optional() private readonly delegation?: SubAgentDelegationService,
@@ -171,41 +178,61 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
             };
         }
 
-        const result = await this.delegation.delegate({
-            // Deterministic per (run, node) so a retried graph step
-            // reuses the dispatch dedup key instead of spawning a second
-            // child for the same node.
-            delegationId: `${context.runId}:${node.id}`,
-            parentAgentId,
-            // The REAL AgentRun id when the host supplied one, falling back
-            // to the graph's own run id.
-            //
-            // This is what anchors delegation depth: the resolver walks
-            // `agent_run -> task -> delegationDepth` from `parentRunId`, and
-            // `context.runId` is minted by the graph executor — it is not an
-            // `agent_runs` row, so resolving from it finds nothing and the
-            // depth cap silently never fires. The fallback keeps a host that
-            // supplies neither working exactly as before.
-            parentRunId: this.contextString(context, 'agentRunId') ?? context.runId,
-            parentTaskId: this.contextString(context, 'taskId') ?? null,
-            // Threaded from the run context when the host provides it.
-            //
-            // Be honest about what bounds recursion here: this field is
-            // ADVISORY unless a host actually populates `delegationDepth`,
-            // and nothing does yet — so the depth check in
-            // `validateSubAgentDelegationRequest` will not fire on its own.
-            // The effective backstop is `TasksService.create`, which walks
-            // the parent chain and refuses past depth 64. That works
-            // because `parentTaskId` above threads the chain; a host that
-            // omits `taskId` loses the backstop too.
-            depth: this.contextNumber(context, 'delegationDepth') ?? 0,
-            objective,
-            scope: {
-                allowedTools: this.stringArrayConfig(node, 'allowedTools') ?? [],
-                workId: this.contextString(context, 'workId') ?? null,
-                organizationId: this.contextString(context, 'organizationId') ?? null,
+        // The scope the PARENT holds, built server-side by whichever host
+        // started this graph. Its presence is what activates
+        // `narrowSubAgentScope` — the contract's "privilege can only ever
+        // shrink going down the tree" property, which does not run at all
+        // when `limits.parentScope` is undefined.
+        const parentScope = this.parentScope(context);
+
+        const result = await this.delegation.delegate(
+            {
+                // Deterministic per (run, node) so a retried graph step
+                // reuses the dispatch dedup key instead of spawning a second
+                // child for the same node.
+                delegationId: `${context.runId}:${node.id}`,
+                parentAgentId,
+                // The REAL AgentRun id when the host supplied one, falling back
+                // to the graph's own run id.
+                //
+                // This is what anchors delegation depth: the resolver walks
+                // `agent_run -> task -> delegationDepth` from `parentRunId`, and
+                // `context.runId` is minted by the graph executor — it is not an
+                // `agent_runs` row, so resolving from it finds nothing and the
+                // depth cap silently never fires. The fallback keeps a host that
+                // supplies neither working exactly as before.
+                parentRunId: this.contextString(context, 'agentRunId') ?? context.runId,
+                parentTaskId: this.contextString(context, 'taskId') ?? null,
+                // An advisory FLOOR. The binding number is server-derived:
+                // `SubAgentDelegationService` resolves the true depth from the
+                // Task chain (anchored by `parentRunId` above) and raises this
+                // value before validating, never lowers it.
+                depth: this.contextNumber(context, 'delegationDepth') ?? 0,
+                objective,
+                scope: {
+                    // `['*']` means "everything the parent had" — the contract's
+                    // only wildcard, and the honest default for a node that
+                    // names no tools. Used ONLY when a parent scope exists to
+                    // bound it; without one it would be an unbounded request,
+                    // so the empty list (which the contract refuses as
+                    // `scope-empty`) is kept instead. Same outcome as before
+                    // this change for any host that supplies no parent scope.
+                    allowedTools:
+                        this.stringArrayConfig(node, 'allowedTools') ?? (parentScope ? ['*'] : []),
+                    workId: this.contextString(context, 'workId') ?? null,
+                    organizationId: this.contextString(context, 'organizationId') ?? null,
+                },
             },
-        });
+            {
+                // Without these two the contract's caps are inert:
+                // `narrowSubAgentScope` never runs (so a node's
+                // model-supplied `allowedTools` was taken verbatim), and the
+                // fan-out check compares `0 >= maxSiblings`, which is never
+                // true however many delegations one run issues.
+                ...(parentScope ? { parentScope } : {}),
+                siblingCount: this.countDelegation(context.runId),
+            },
+        );
 
         // A refusal is a legitimate graph outcome, not an exception: the
         // failure code is surfaced so an on_failure edge can route on it
@@ -219,6 +246,66 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
             };
         }
         return { ok: true, output: result.output };
+    }
+
+    /**
+     * Read the parent scope the host put in the run context.
+     *
+     * Validated rather than trusted: the context is assembled server-side
+     * today, but this is the object that decides how far a child's
+     * privilege reaches, so a malformed one is dropped (returning
+     * `undefined`, i.e. today's no-narrowing behaviour) rather than
+     * half-applied. A scope with no tools is also dropped — it would
+     * intersect to nothing and refuse every delegation with `scope-empty`,
+     * which is a broken feature rather than a safe default.
+     */
+    private parentScope(context: WorkflowNodeRunContext): SubAgentScope | undefined {
+        const raw = context.context['parentScope'];
+        if (!raw || typeof raw !== 'object') return undefined;
+        const candidate = raw as Partial<SubAgentScope>;
+        if (!Array.isArray(candidate.allowedTools)) return undefined;
+        const allowedTools = candidate.allowedTools.filter(
+            (tool): tool is string => typeof tool === 'string' && tool.length > 0,
+        );
+        if (allowedTools.length === 0) return undefined;
+        return {
+            allowedTools,
+            workId: typeof candidate.workId === 'string' ? candidate.workId : null,
+            organizationId:
+                typeof candidate.organizationId === 'string' ? candidate.organizationId : null,
+            networkAccess: Boolean(candidate.networkAccess),
+        };
+    }
+
+    /**
+     * How many delegations this graph run has already issued, then record
+     * this one.
+     *
+     * The contract's fan-out cap is checked against a count the CALLER
+     * supplies; nothing supplied one, so `0 >= maxSiblings` was never true
+     * and the cap could not fire. A graph run is the right unit here —
+     * it is one parent's burst of delegations.
+     *
+     * Bounded on purpose: this service is a long-lived singleton, so an
+     * unbounded Map keyed by run id is a slow leak. Runs are short and the
+     * count only matters while one is executing, so the oldest entries are
+     * evicted once the map exceeds {@link MAX_TRACKED_RUNS}. A run evicted
+     * mid-flight simply restarts its count — it under-counts rather than
+     * over-refusing, which is the right direction for an eviction to fail.
+     */
+    private countDelegation(runId: string): number {
+        const previous = this.delegationsByRun.get(runId) ?? 0;
+        // Re-insert so insertion order tracks recency (Map preserves it),
+        // which is what makes the eviction below drop the OLDEST run.
+        this.delegationsByRun.delete(runId);
+        this.delegationsByRun.set(runId, previous + 1);
+
+        while (this.delegationsByRun.size > WorkflowNodeRunnerService.MAX_TRACKED_RUNS) {
+            const oldest = this.delegationsByRun.keys().next();
+            if (oldest.done) break;
+            this.delegationsByRun.delete(oldest.value);
+        }
+        return previous;
     }
 
     private stringConfig(node: WorkflowNode, key: string): string | undefined {

--- a/apps/api/src/agents/workflow-node.runner.ts
+++ b/apps/api/src/agents/workflow-node.runner.ts
@@ -44,8 +44,9 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
     private readonly logger = new Logger(WorkflowNodeRunnerService.name);
 
     /**
-     * Delegations issued per graph run, feeding the contract's fan-out
-     * cap. Bounded — see {@link countDelegation}.
+     * Delegations issued per AGENT run (falling back to the graph run when
+     * no agent run is threaded), feeding the contract's fan-out cap.
+     * Bounded — see {@link countDelegation}.
      */
     private readonly delegationsByRun = new Map<string, number>();
     private static readonly MAX_TRACKED_RUNS = 500;
@@ -230,7 +231,19 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
                 // fan-out check compares `0 >= maxSiblings`, which is never
                 // true however many delegations one run issues.
                 ...(parentScope ? { parentScope } : {}),
-                siblingCount: this.countDelegation(context.runId),
+                siblingCount: this.countDelegation(
+                    // Keyed by the AGENT run, not the graph run.
+                    //
+                    // The contract's wording is "how many delegations the
+                    // parent has already issued in this run", and the parent
+                    // is an agent run — a model may call
+                    // `run_workflow_graph` repeatedly, and each call mints a
+                    // fresh graph id. Counting per graph run would hand out a
+                    // brand-new budget on every call, which combined with the
+                    // 4-delegate-node admission cap means the ceiling of 5
+                    // could never be reached at all.
+                    this.contextString(context, 'agentRunId') ?? context.runId,
+                ),
             },
         );
 
@@ -283,8 +296,14 @@ export class WorkflowNodeRunnerService implements WorkflowNodeRunner {
      *
      * The contract's fan-out cap is checked against a count the CALLER
      * supplies; nothing supplied one, so `0 >= maxSiblings` was never true
-     * and the cap could not fire. A graph run is the right unit here —
-     * it is one parent's burst of delegations.
+     * and the cap could not fire.
+     *
+     * The key is the AGENT run (see the call site). The graph run is the
+     * wrong unit: the executor is a single linear walk, so with
+     * delegate-on-a-cycle already refused each delegate node runs at most
+     * once — at most 4 per graph, under the ceiling of 5. Per-graph
+     * counting would therefore never refuse anything, while a model
+     * calling the tool repeatedly racked up unbounded delegations.
      *
      * Bounded on purpose: this service is a long-lived singleton, so an
      * unbounded Map keyed by run id is a slow leak. Runs are short and the

--- a/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
@@ -364,6 +364,37 @@ describe('AgentToolService — domain chat tool assembly', () => {
         expect((sources.tasks!.chatService as any).post).not.toHaveBeenCalled();
     });
 
+    it('resolves the parent scope through the REAL service without recursing', async () => {
+        // The parent scope's `allowedTools` comes from a thunk that calls
+        // `resolveAllowedTools` again — from INSIDE a tool built by that
+        // very method. The laziness is what makes that safe (building a
+        // descriptor does not invoke it), but "safe" is a claim worth
+        // executing rather than reasoning about: an eager version would
+        // blow the stack right here.
+        const execute = jest.fn().mockResolvedValue({
+            status: 'completed',
+            runId: 'wfr-1',
+            visited: [],
+            output: null,
+        });
+        const svc = makeSvc({ ...sources, workflow: { executor: { execute } as any } });
+        const tools = svc.resolveAllowedTools(
+            makeAgent({ permissions: makePerms({ canAssignTasks: true }) }),
+        );
+        const tool = tools.find((t) => t.name === 'run_workflow_graph')!;
+
+        await tool.invoke({
+            graph: { id: 'g', entryNodeId: 'a', nodes: [{ id: 'a', kind: 'noop' }], edges: [] },
+        });
+
+        const scope = execute.mock.calls[0][1].context.parentScope;
+        // A real, enumerated tool set — NOT the `['*']` fallback, which is
+        // what we would see if the thunk had thrown.
+        expect(scope.allowedTools).toContain('run_workflow_graph');
+        expect(scope.allowedTools).not.toEqual(['*']);
+        expect(scope.allowedTools.length).toBeGreaterThan(1);
+    });
+
     it('skips a domain whose factory throws instead of failing tool resolution', () => {
         // A source object that makes `buildFleetTools` throw at build time.
         const exploding = {

--- a/packages/agent/src/agents/__tests__/agent-workflow-tools.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-workflow-tools.spec.ts
@@ -240,9 +240,96 @@ describe('buildWorkflowTools', () => {
                     organizationId: 'org-1',
                     agentRunId: 'run-real-1',
                     delegationDepth: 0,
+                    // No `resolveParentToolNames` was supplied by this
+                    // fixture, so the scope falls back to the
+                    // inherit-everything wildcard while still PINNING the
+                    // Work / Org / network dimensions.
+                    parentScope: {
+                        allowedTools: ['*'],
+                        workId: 'work-1',
+                        organizationId: 'org-1',
+                        networkAccess: false,
+                    },
                 },
             }),
         );
+    });
+
+    /**
+     * The parent scope is what makes `narrowSubAgentScope` run at all —
+     * the contract's "privilege can only ever shrink going down the tree"
+     * property. Without it in the context, a delegate node's
+     * model-supplied `allowedTools` is taken verbatim.
+     */
+    describe('parent scope', () => {
+        const withScope = (over: Parameters<typeof buildWorkflowTools>[0] | object = {}) =>
+            buildWorkflowTools({
+                userId: OWNER,
+                agentId: AGENT,
+                workId: 'work-1',
+                organizationId: 'org-1',
+                agentRunId: 'run-real-1',
+                resolveParentToolNames: () => ['read_file', 'write_file'],
+                networkAccess: false,
+                executor: { execute: jest.fn().mockResolvedValue(runResult()) },
+                ...over,
+            } as Parameters<typeof buildWorkflowTools>[0]);
+
+        it('carries the agent’s REAL tool set, not a wildcard', async () => {
+            const execute = jest.fn().mockResolvedValue(runResult());
+            const tool = withScope({ executor: { execute } }).find(
+                (t) => t.name === 'run_workflow_graph',
+            )!;
+
+            await tool.invoke({ graph: graph() });
+
+            expect(execute.mock.calls[0][1].context.parentScope).toEqual({
+                allowedTools: ['read_file', 'write_file'],
+                workId: 'work-1',
+                organizationId: 'org-1',
+                networkAccess: false,
+            });
+        });
+
+        it('pins networkAccess from the agent permission', async () => {
+            const execute = jest.fn().mockResolvedValue(runResult());
+            const tool = withScope({ executor: { execute }, networkAccess: true }).find(
+                (t) => t.name === 'run_workflow_graph',
+            )!;
+
+            await tool.invoke({ graph: graph() });
+
+            expect(execute.mock.calls[0][1].context.parentScope.networkAccess).toBe(true);
+        });
+
+        it('falls back to the inherit-everything wildcard when the tool list cannot be resolved', async () => {
+            // NOT to an empty list: empty intersects to nothing and would
+            // refuse every delegation with `scope-empty`, turning a
+            // resolution hiccup into a broken feature.
+            const execute = jest.fn().mockResolvedValue(runResult());
+            const tool = withScope({
+                executor: { execute },
+                resolveParentToolNames: () => {
+                    throw new Error('resolution blew up');
+                },
+            }).find((t) => t.name === 'run_workflow_graph')!;
+
+            await tool.invoke({ graph: graph() });
+
+            expect(execute.mock.calls[0][1].context.parentScope.allowedTools).toEqual(['*']);
+        });
+
+        it('falls back to the wildcard for an empty resolved list', async () => {
+            const execute = jest.fn().mockResolvedValue(runResult());
+            const tool = withScope({
+                executor: { execute },
+                resolveParentToolNames: () => [],
+            }).find((t) => t.name === 'run_workflow_graph')!;
+
+            await tool.invoke({ graph: graph() });
+
+            expect(execute.mock.calls[0][1].context.parentScope.allowedTools).toEqual(['*']);
+        });
     });
 
     it('carries the REAL agent run id so delegation depth can be resolved', async () => {

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -503,6 +503,12 @@ export class AgentToolService {
                         runContext?.runId && runContext.runId !== 'no-run'
                             ? runContext.runId
                             : null,
+                    // The parent's REAL tool set, resolved lazily at invoke
+                    // time. Eager resolution would recurse — we are inside
+                    // that very resolution right now.
+                    resolveParentToolNames: () =>
+                        this.resolveAllowedTools(agent).map((tool) => tool.name),
+                    networkAccess: Boolean(agent.permissions?.canCallExternalTools),
                     executor: workflow.executor,
                 }),
             );

--- a/packages/agent/src/agents/agent-workflow-tools.ts
+++ b/packages/agent/src/agents/agent-workflow-tools.ts
@@ -229,6 +229,68 @@ export interface RunWorkflowGraphResult {
     output: unknown;
 }
 
+/**
+ * The scope a delegating node is narrowed against.
+ *
+ * Mirrors `SubAgentScope` structurally without importing it — this module
+ * only ever hands the object to the run context, and the node runner is
+ * what passes it to the delegation contract.
+ */
+export interface WorkflowParentScope {
+    allowedTools: string[];
+    workId: string | null;
+    organizationId: string | null;
+    networkAccess: boolean;
+}
+
+/**
+ * Build the parent scope from what the agent genuinely holds.
+ *
+ * `allowedTools` is the agent's REAL resolved tool list, so a delegate
+ * node cannot hand its child a tool the parent never had. The wildcard
+ * `['*']` is used only when the tool list cannot be resolved — it means
+ * "everything the parent had", which is the honest answer when we do not
+ * know the enumeration, and it still pins `workId` / `organizationId` /
+ * `networkAccess`. Inventing a narrow list we could not verify would
+ * refuse legitimate delegations for the wrong reason.
+ *
+ * Note the tool list is the pre-grant-filter set: an operator tool-grant
+ * that refuses a tool for the parent is not subtracted here. That is a
+ * deliberate over-approximation of ONE dimension — the child's own grants
+ * are resolved independently at its run time, so nothing is actually
+ * widened by it.
+ */
+function buildParentScope(args: {
+    workId?: string | null;
+    organizationId?: string | null;
+    networkAccess?: boolean;
+    resolveParentToolNames?: () => string[];
+}): WorkflowParentScope {
+    let allowedTools: string[] = ['*'];
+    if (args.resolveParentToolNames) {
+        try {
+            const names = args.resolveParentToolNames();
+            if (Array.isArray(names) && names.length > 0) {
+                allowedTools = names.filter(
+                    (name): name is string => typeof name === 'string' && name.length > 0,
+                );
+            }
+        } catch {
+            // Fall back to the wildcard rather than to an EMPTY list: an
+            // empty parent scope intersects to nothing and would refuse
+            // every delegation with `scope-empty`, turning a resolution
+            // hiccup into a broken feature.
+            allowedTools = ['*'];
+        }
+    }
+    return {
+        allowedTools,
+        workId: args.workId ?? null,
+        organizationId: args.organizationId ?? null,
+        networkAccess: Boolean(args.networkAccess),
+    };
+}
+
 /** Cap on the serialized size of the returned output. */
 const MAX_OUTPUT_CHARS = 8_000;
 
@@ -264,6 +326,18 @@ export function buildWorkflowTools(args: {
      * and the recursion cap silently never fires.
      */
     agentRunId?: string | null;
+    /**
+     * The tool names this agent actually holds — the `allowedTools` half
+     * of the parent scope every `agent.delegate` node is narrowed against.
+     *
+     * A THUNK, not an array, because the parent's tool list is what we are
+     * in the middle of assembling when this factory runs; resolving it
+     * eagerly would recurse. At invoke time the resolution has long since
+     * finished, so calling it there is safe.
+     */
+    resolveParentToolNames?: () => string[];
+    /** Whether this agent may reach the network at all. ANDed into the child's scope. */
+    networkAccess?: boolean;
     executor: Pick<WorkflowGraphExecutorService, 'execute'>;
 }): AgentToolDescriptor[] {
     const out: AgentToolDescriptor[] = [];
@@ -330,6 +404,17 @@ export function buildWorkflowTools(args: {
                         // off the Task chain via `agentRunId` above; it can
                         // only ever raise this.
                         delegationDepth: 0,
+                        // The scope an `agent.delegate` node is narrowed
+                        // AGAINST — the contract's "privilege can only ever
+                        // shrink going down the tree" property.
+                        //
+                        // Without it, `limits.parentScope` is undefined,
+                        // `narrowSubAgentScope` never runs, and a node's
+                        // model-supplied `allowedTools` is taken verbatim.
+                        // Built here rather than in the node runner because
+                        // this is the only layer that knows what the PARENT
+                        // agent actually holds.
+                        parentScope: buildParentScope(args),
                     },
                 });
 


### PR DESCRIPTION
Closes the gap flagged as follow-up on [#1970](https://github.com/ever-works/ever-works/pull/1970).

`SubAgentDelegationService.delegate(request, limits = {})` was called from its **one** production caller with no `limits` at all, so every bound behind that argument was inert:

| bound | why it never fired |
|---|---|
| `narrowSubAgentScope` | only runs when `limits.parentScope` is set — it wasn't, so a delegate node's **model-supplied** `allowedTools` was taken verbatim |
| fan-out cap | compares `(limits.siblingCount ?? 0) >= maxSiblings`, i.e. `0 >= 5` — never true, however many delegations one run issues |

That was survivable while nothing could reach the delegate path. #1970 made workflow graphs reachable and removed that cover, so the bound has to be real.

## Parent scope

Built where the parent's capabilities are actually known — the chat tool, not the node runner:

- **`allowedTools`** is the agent's real resolved tool list, obtained through a **thunk**. It has to be lazy: that list is precisely what we're in the middle of assembling when the factory runs, so eager resolution would recurse.
- **`workId` / `organizationId`** come from the server-built context, and the contract's narrowing *pins* them — a child cannot hop Works or orgs.
- **`networkAccess`** is ANDed from the agent's own permission.

**Failure direction is deliberate.** An unresolvable tool list falls back to the `['*']` inherit-everything wildcard, **not** to an empty list — an empty parent intersects to nothing and would refuse every delegation with `scope-empty`, turning a resolution hiccup into a broken feature. The runner likewise drops a malformed or tool-less parent scope rather than half-applying it, which leaves today's behaviour intact.

A node naming no `allowedTools` now defaults to `['*']` — but **only when a parent scope exists to bound it**. With no parent scope the empty list is kept, so a host supplying none behaves exactly as before.

## Sibling count

Counted per **graph run** — one parent's burst of delegations. Bounded to 500 tracked runs with oldest-first eviction, because the runner is a long-lived singleton and an unbounded `Map` keyed by run id is a slow leak. An evicted run restarts its count: it **under-counts rather than over-refuses**, which is the right way for an eviction to fail.

## Proof the chain is real

Three independent tests, one per link — the failure mode this repo keeps hitting is a bound that exists but isn't connected:

1. the tool puts a parent scope carrying the agent's real tool set into the run context;
2. the runner passes it as `limits.parentScope` and a `siblingCount` that **rises** (`[0, 1, 2]`, not a constant `0`);
3. the service narrows against it and drops an unauthorized tool (existing test: a request for `['read_file','deploy']` against a parent holding `['read_file','write_file']` reaches the runner as `['read_file']`).

## Gates

- agent **461 suites / 8441 tests**, api **243 suites / 3950 tests**
- `pnpm format:check` clean, `turbo type-check` clean for agent / api / contracts
- real non-preview Nest bootstrap resolving all four wired tokens

Three existing assertions were updated because `delegate` legitimately takes a second argument now — the request object they pin is unchanged; they gained a matcher for the new parameter rather than being loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delegated workflow tasks now inherit the parent agent’s tool permissions and network access settings.
  * Delegation scopes include relevant work and organization context.
  * Delegation fan-out is bounded per run to improve control and reliability.
  * Safe defaults apply when permission details are unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->