### PR TITLE
ci: run the GitHub-release workflows on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -31,9 +31,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 300
 
+    # GitHub-hosted ON PURPOSE — do not move this back onto the
+    # self-hosted pool.
+    #
+    # This job only ever talks to github.com with the built-in
+    # GITHUB_TOKEN: checkout, push a tag, create a release. It needs no
+    # cluster network, no internal registry and no OpenBao secret, which
+    # is what the shared `RUNNER_LINUX_X64_4` pool exists to provide.
+    #
+    # Occupying a pool slot for that was actively harmful. Measured on
+    # 2026-07-31: this run was created at 20:23:21 and its job did not
+    # start until 21:48:32 — 85 minutes queued behind the deploy jobs that
+    # genuinely need the pool — and then finished in 93 seconds. The
+    # release record for a production deploy lagged the deploy itself by
+    # an hour and a half, and it held a slot the deploys were waiting for.
+    #
+    # `ubuntu-latest` was already the fallback whenever the org var is
+    # unset, so it is a target this workflow is known to run on.
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
+        os: ['ubuntu-latest']
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -32,9 +32,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 300
 
+    # GitHub-hosted ON PURPOSE — do not move this back onto the
+    # self-hosted pool.
+    #
+    # This job only ever talks to github.com with the built-in
+    # GITHUB_TOKEN: checkout, push a tag, create a release. It needs no
+    # cluster network, no internal registry and no OpenBao secret, which
+    # is what the shared `RUNNER_LINUX_X64_4` pool exists to provide.
+    #
+    # Occupying a pool slot for that was actively harmful. Measured on
+    # 2026-07-31: this run was created at 20:23:21 and its job did not
+    # start until 21:48:32 — 85 minutes queued behind the deploy jobs that
+    # genuinely need the pool — and then finished in 93 seconds. The
+    # release record for a production deploy lagged the deploy itself by
+    # an hour and a half, and it held a slot the deploys were waiting for.
+    #
+    # `ubuntu-latest` was already the fallback whenever the org var is
+    # unset, so it is a target this workflow is known to run on.
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
+        os: ['ubuntu-latest']
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -31,9 +31,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 300
 
+    # GitHub-hosted ON PURPOSE — do not move this back onto the
+    # self-hosted pool.
+    #
+    # This job only ever talks to github.com with the built-in
+    # GITHUB_TOKEN: checkout, push a tag, create a release. It needs no
+    # cluster network, no internal registry and no OpenBao secret, which
+    # is what the shared `RUNNER_LINUX_X64_4` pool exists to provide.
+    #
+    # Occupying a pool slot for that was actively harmful. Measured on
+    # 2026-07-31: this run was created at 20:23:21 and its job did not
+    # start until 21:48:32 — 85 minutes queued behind the deploy jobs that
+    # genuinely need the pool — and then finished in 93 seconds. The
+    # release record for a production deploy lagged the deploy itself by
+    # an hour and a half, and it held a slot the deploys were waiting for.
+    #
+    # `ubuntu-latest` was already the fallback whenever the org var is
+    # unset, so it is a target this workflow is known to run on.
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}"]
+        os: ['ubuntu-latest']
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
## The measurement

`Release Prod` for main `2ea2e1a` (the production cascade earlier today):

| event | time |
|---|---|
| run created | `20:23:21` |
| job started | `21:48:32` |
| job finished | `21:50:05` |

**85 minutes queued, 93 seconds of work.** The release record trailed the deploy it documents by an hour and a half — while holding a slot in the shared self-hosted pool that the *actual deploy jobs* were queued behind.

## Why it doesn't need that pool

`release-{dev,stage,prod}.yml` each do exactly three things:

1. `actions/checkout@v7`
2. `mathieudutour/github-tag-action` — pushes a tag
3. `ncipollo/release-action` — creates the release

All against github.com with the built-in `GITHUB_TOKEN`. No cluster network, no internal registry, no OpenBao secret — which is precisely what `vars.RUNNER_LINUX_X64_4` exists to provide. The workflow's own header comment already says it "deliberately does NOT deploy anything".

## Why this is safe

- `ubuntu-latest` was **already the fallback** whenever the org var is unset, so it's a target these workflows are known to run on.
- The job name changes from `release (ever-works-linux-x64-4)` to `release (ubuntu-latest)`. I checked branch protection before touching it: `develop` requires only `lint-and-test (22.x)`; `stage` and `main` require nothing. No required check references the release job. (It also fires on *push*, after merge — so it was never a PR check.)
- `concurrency.cancel-in-progress: false` is untouched — cancelling a half-finished tag bump loses a release.

## Deliberately not changed

The deploy / docker / k8s workflows, which genuinely need in-cluster access, and `release-trigger-selfhosted.yml`, whose entire purpose is the self-hosted target. This only moves the three pure-GitHub-API jobs off the contended pool, which also **frees slots for the jobs that actually need it**.

Note this reduces contention; it doesn't raise pool capacity. If the pool saturates again under a heavy multi-branch cascade, the remaining fix is scaling the ARC pool itself, which lives outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)