### PR TITLE
cascade: stage -> main (delegation scope confines the child run)

### DIFF
--- a/apps/api/src/agents/sub-agent-delegation.runner.ts
+++ b/apps/api/src/agents/sub-agent-delegation.runner.ts
@@ -138,6 +138,19 @@ export class SubAgentDelegationRunnerService implements SubAgentDelegationRunner
 
         const dispatch = await this.transitions.dispatchAgentRun(childTask as never, childAgentId, {
             dedupKey: `delegation:${request.delegationId}`,
+            // The EFFECTIVE scope — `SubAgentDelegationService` already
+            // narrowed it against the parent, and the port contract says
+            // never to re-widen it.
+            //
+            // Passing it here is what makes "privilege can only ever
+            // shrink going down the tree" true at RUNTIME. Until now this
+            // runner read only `request.scope.workId` and dropped the
+            // rest, so the narrowed tool list was computed and discarded:
+            // an over-broad request was refused, but a child that WAS
+            // admitted ran with its own agent's full tool set — and
+            // `childAgentId` defaults to the parent, so by default the
+            // child was the parent with every permission it holds.
+            delegationScope: request.scope,
         });
 
         if (!dispatch.runId) {

--- a/apps/api/src/migrations/1784810000000-AddAgentRunDelegationScope.ts
+++ b/apps/api/src/migrations/1784810000000-AddAgentRunDelegationScope.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Judgment layer G9 — `agent_runs.delegationScope`.
+ *
+ * The effective, already-narrowed scope a DELEGATED run executes under.
+ * `dispatchAgentRun` snapshots it onto the pre-created run row, and the
+ * tool loop intersects the run's resolved tools against it.
+ *
+ * Why the column exists: `narrowSubAgentScope` computed a correct
+ * narrowed scope and the runner then discarded it — it read only
+ * `scope.workId`. So the delegation contract's headline property,
+ * "privilege can only ever shrink going down the tree", held at the
+ * ADMISSION boundary (an over-broad request was refused) and nowhere
+ * else: a child that was admitted ran with its own agent's full tool
+ * set, and `childAgentId` defaults to the parent, so by default the
+ * child WAS the parent with every permission it holds.
+ *
+ * Why on the run and not the Task: the run row is pre-created by
+ * `dispatchAgentRun` before the worker starts, and `AgentRunService`
+ * already injects `AgentRunRepository` — so the tool loop reads it with
+ * no new dependency and, critically, without
+ * `packages/agent/src/agents/` gaining a runtime import of
+ * `tasks-domain`, which the AGENT_DOMAIN_TOOL_SOURCES seam exists to
+ * prevent.
+ *
+ * A snapshot, not a reference: re-deriving the scope later from a parent
+ * whose permissions may since have changed could hand an in-flight child
+ * something other than what it was admitted with.
+ *
+ * **Nothing is backfilled.** Every existing run keeps NULL, which the
+ * filter treats as "no additional restriction" — the correct reading,
+ * since no run predating this column was dispatched with a scope. That
+ * also makes the rollout fail-OPEN for one deploy window (an old worker
+ * ignores the column and a child keeps full tools, exactly as today),
+ * which is a non-regression rather than a new hole.
+ *
+ * `simple-json` matches the sibling snapshot columns on this table
+ * (`resolvedChecks`, `checkResults`), which TypeORM maps to text on
+ * every supported driver. No index: the column is only ever read by
+ * primary-key lookup of the run already being executed.
+ *
+ * Forward-only, idempotent per-step guards (house pattern, mirrors
+ * 1784800000000-AddTaskDelegationDepth).
+ */
+export class AddAgentRunDelegationScope1784810000000 implements MigrationInterface {
+    name = 'AddAgentRunDelegationScope1784810000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+
+        if (!table.findColumnByName('delegationScope')) {
+            await queryRunner.query(`ALTER TABLE "agent_runs" ADD COLUMN "delegationScope" text`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+
+        // Safe to drop: the column holds a snapshot the platform wrote
+        // itself, never user content. Reverting loses the runtime half of
+        // the scope guarantee (delegated children go back to running with
+        // their agent's full tool set — the pre-change behaviour), not
+        // any data, so unlike a content column this needs no
+        // refuse-and-report guard.
+        if (table.findColumnByName('delegationScope')) {
+            await queryRunner.query(`ALTER TABLE "agent_runs" DROP COLUMN "delegationScope"`);
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddAgentRunDelegationScope.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddAgentRunDelegationScope.spec.ts
@@ -1,0 +1,102 @@
+import { DataSource } from 'typeorm';
+import { AddAgentRunDelegationScope1784810000000 } from '../1784810000000-AddAgentRunDelegationScope';
+
+/**
+ * Migration test for `agent_runs.delegationScope` — the column that makes
+ * a delegated child run actually CONFINED to the scope it was admitted
+ * under.
+ *
+ * Uses the same in-memory better-sqlite3 harness as the sibling migration
+ * specs. What matters here is unglamorous but load-bearing:
+ *
+ *  - existing rows survive with NULL, which every reader treats as "no
+ *    additional restriction" (nothing predating the column was dispatched
+ *    with a scope, so that is the correct reading rather than a lenient
+ *    one);
+ *  - up() is idempotent, because the house pattern is forward-only with
+ *    per-step guards and re-running must not throw;
+ *  - down() actually removes it.
+ */
+describe('AddAgentRunDelegationScope1784810000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddAgentRunDelegationScope1784810000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        // The subset of `agent_runs` this migration touches.
+        await dataSource.query(`
+            CREATE TABLE "agent_runs" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "agentId" varchar NOT NULL,
+                "userId" varchar NOT NULL,
+                "status" varchar NOT NULL
+            )
+        `);
+        await dataSource.query(
+            `INSERT INTO "agent_runs" ("id", "agentId", "userId", "status") VALUES ('r1', 'a1', 'u1', 'completed')`,
+        );
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('adds the column and leaves existing rows NULL', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const rows = await dataSource.query(`SELECT "delegationScope" FROM "agent_runs"`);
+        expect(rows).toHaveLength(1);
+        // NULL, not '' and not a default scope: an existing run was never
+        // delegated, and inventing an empty allowlist would strip every
+        // tool from it.
+        expect(rows[0].delegationScope).toBeNull();
+
+        await runner.release();
+    });
+
+    it('is idempotent — a second up() does not throw', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.not.toThrow();
+        await runner.release();
+    });
+
+    it('down() removes the column', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+
+        const table = await runner.getTable('agent_runs');
+        expect(table?.findColumnByName('delegationScope')).toBeUndefined();
+
+        await runner.release();
+    });
+
+    it('round-trips a scope value', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const scope = JSON.stringify({ allowedTools: ['getSkillBody'], workId: 'w1' });
+        await dataSource.query(`UPDATE "agent_runs" SET "delegationScope" = ? WHERE "id" = 'r1'`, [
+            scope,
+        ]);
+
+        const rows = await dataSource.query(
+            `SELECT "delegationScope" FROM "agent_runs" WHERE "id" = 'r1'`,
+        );
+        expect(JSON.parse(rows[0].delegationScope)).toEqual({
+            allowedTools: ['getSkillBody'],
+            workId: 'w1',
+        });
+
+        await runner.release();
+    });
+});

--- a/packages/agent/src/agents/__tests__/agent-run-delegation-scope.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-delegation-scope.spec.ts
@@ -1,0 +1,163 @@
+import { AgentRunService } from '../agent-run.service';
+import { PromptAssemblerService } from '../prompt-assembler.service';
+import type { AgentToolService, AgentToolDescriptor } from '../agent-tool.service';
+
+/**
+ * Judgment layer G9 — a delegated run is actually CONFINED to the scope
+ * it was admitted under.
+ *
+ * `narrowSubAgentScope` has always produced a correct narrowed scope, and
+ * `SubAgentDelegationRunnerService` then discarded everything but
+ * `workId`. So the contract's headline property — "privilege can only
+ * ever shrink going down the tree" — held at the admission boundary (an
+ * over-broad REQUEST was refused) and nowhere else: a child that WAS
+ * admitted resolved its tools from its own Agent row, and `childAgentId`
+ * defaults to the parent, so by default the child ran as the parent with
+ * every permission it holds.
+ *
+ * The assertion that matters is therefore not "the scope was narrowed"
+ * (a unit test of `narrowSubAgentScope` already passes and proves
+ * nothing about enforcement) but "the child was HANDED fewer tools".
+ */
+
+const descriptor = (name: string): AgentToolDescriptor => ({
+    name,
+    description: name,
+    parameters: { type: 'object', properties: {}, required: [] },
+    invoke: async () => ({ ok: true }),
+});
+
+const ALL_TOOLS = [
+    descriptor('getSkillBody'),
+    descriptor('commitToRepo'),
+    descriptor('openPullRequest'),
+    descriptor('searchWeb'),
+];
+
+describe('AgentRunService — delegation scope confines a child run', () => {
+    let runs: {
+        findById: jest.Mock;
+        markRunning: jest.Mock;
+        markCompleted: jest.Mock;
+    };
+    let runLogs: { append: jest.Mock };
+    let toolService: { resolveAllowedTools: jest.Mock; resolveGrantedTools?: jest.Mock };
+
+    beforeEach(() => {
+        runs = {
+            findById: jest.fn().mockResolvedValue({ id: 'run-1', status: 'running' }),
+            markRunning: jest.fn().mockResolvedValue(undefined),
+            markCompleted: jest.fn().mockResolvedValue(undefined),
+        };
+        runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        toolService = { resolveAllowedTools: jest.fn().mockReturnValue([...ALL_TOOLS]) };
+    });
+
+    function makeSvc(): AgentRunService {
+        return new AgentRunService(
+            { findById: jest.fn() } as never,
+            runs as never,
+            runLogs as never,
+            { findByAgentId: jest.fn().mockResolvedValue(null) } as never,
+            new PromptAssemblerService(),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            toolService as unknown as AgentToolService,
+        );
+    }
+
+    /**
+     * `resolveToolsForRun` is private; the behaviour under test is its
+     * output. The scope arrives as an ARGUMENT (off the run context),
+     * deliberately not re-read from the database here — an ordinary run
+     * must pay no extra query, and a cooperative-abort test pins that the
+     * tool loop performs no DB work it did not already do.
+     */
+    const resolve = (svc: AgentRunService, scope: unknown = undefined) =>
+        (
+            svc as unknown as {
+                resolveToolsForRun(
+                    agent: unknown,
+                    runId: string,
+                    edits: Set<string>,
+                    scope?: unknown,
+                ): Promise<AgentToolDescriptor[]>;
+            }
+        ).resolveToolsForRun({ id: 'a1', userId: 'u1' }, 'run-1', new Set(), scope);
+
+    it('HANDS a delegated child only the tools its scope allows', async () => {
+        // The whole point. A delegation admitted with one tool must not
+        // produce a run that can commit to a repo.
+        const tools = await resolve(makeSvc(), { allowedTools: ['getSkillBody'] });
+
+        expect(tools.map((t) => t.name)).toEqual(['getSkillBody']);
+        expect(tools.map((t) => t.name)).not.toContain('commitToRepo');
+    });
+
+    it('leaves an ORDINARY run completely untouched', async () => {
+        // The overwhelmingly common path: no delegation, no scope. This
+        // must be byte-for-byte the pre-change behaviour.
+        const tools = await resolve(makeSvc(), null);
+
+        expect(tools.map((t) => t.name)).toEqual([
+            'getSkillBody',
+            'commitToRepo',
+            'openPullRequest',
+            'searchWeb',
+        ]);
+    });
+
+    it('treats the wildcard as no restriction', async () => {
+        const tools = await resolve(makeSvc(), { allowedTools: ['*'] });
+
+        expect(tools).toHaveLength(ALL_TOOLS.length);
+    });
+
+    it('records WHY a tool vanished instead of dropping it silently', async () => {
+        // A tool the model was told about that quietly disappears is the
+        // single most confusing failure mode in a tool loop — the same
+        // reasoning the tool-grant refusals are logged for.
+        await resolve(makeSvc(), { allowedTools: ['getSkillBody'] });
+
+        expect(runLogs.append).toHaveBeenCalledWith(
+            expect.objectContaining({
+                level: 'WARN',
+                step: 'tools',
+                metadata: expect.objectContaining({
+                    withheld: ['commitToRepo', 'openPullRequest', 'searchWeb'],
+                }),
+            }),
+        );
+    });
+
+    it('does not log when the scope withheld nothing', async () => {
+        await resolve(makeSvc(), { allowedTools: ['*'] });
+
+        expect(runLogs.append).not.toHaveBeenCalled();
+    });
+
+    it('reads NO database row to apply the scope', async () => {
+        // The first cut of this looked the run up here, which added a
+        // query to every ordinary run's hot path and broke a
+        // cooperative-abort test asserting the tool loop touches no DB.
+        // The scope rides the run context instead.
+        await resolve(makeSvc(), { allowedTools: ['getSkillBody'] });
+
+        expect(runs.findById).not.toHaveBeenCalled();
+    });
+
+    it('applies the scope on the GRANTED path too, not just the plain one', async () => {
+        // Both paths funnel through `resolveToolsForRun`; a filter on only
+        // one of them would be enforced or not depending on whether an
+        // operator happened to bind the grant enforcer.
+        toolService.resolveGrantedTools = jest
+            .fn()
+            .mockResolvedValue({ tools: [...ALL_TOOLS], refused: [] });
+        const tools = await resolve(makeSvc(), { allowedTools: ['searchWeb'] });
+
+        expect(tools.map((t) => t.name)).toEqual(['searchWeb']);
+        expect(toolService.resolveGrantedTools).toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -42,6 +42,7 @@ import { TOOL_GRANT_ENFORCER, type ToolGrantEnforcer } from '../policy/tool-gran
 import { filterSkillsByToolGrants } from '../policy/skill-activation';
 import { isGenerationCancelledError } from '../utils/generation-cancellation.utils';
 import { redactSecrets } from '../utils/secret-scan';
+import { filterToolNamesBySubAgentScope, type SubAgentScope } from '@ever-works/contracts';
 
 export interface AgentRunContext {
     runId: string;
@@ -63,6 +64,19 @@ export interface AgentRunContext {
      * this null/undefined.
      */
     taskId?: string | null;
+    /**
+     * Judgment layer G9 — the effective scope a DELEGATED run was
+     * admitted under, read off `agent_runs.delegationScope` by the host
+     * that starts the run.
+     *
+     * Carried on the CONTEXT rather than re-read here so an ordinary run
+     * — the overwhelmingly common case — pays no extra query, and so the
+     * tool loop performs no database work it did not already do (a
+     * cooperative-abort test pins exactly that).
+     *
+     * Absent / null ⇒ no additional restriction.
+     */
+    delegationScope?: SubAgentScope | null;
     /**
      * Originating chat message — supplied for `chat` kinds. Reserved
      * for the LLM-dispatch path so the worker can tie its reply to
@@ -615,7 +629,12 @@ export class AgentRunService {
         });
         const editsThisRunByFile = new Set<string>();
         const baseDescriptors: AgentToolDescriptor[] = this.toolService
-            ? await this.resolveToolsForRun(agent, context.runId, editsThisRunByFile)
+            ? await this.resolveToolsForRun(
+                  agent,
+                  context.runId,
+                  editsThisRunByFile,
+                  context.delegationScope,
+              )
             : [];
         // Virtual transitionTask descriptor — only exposed on `task`
         // kind runs. It captures the model's transition intent rather
@@ -1453,12 +1472,17 @@ export class AgentRunService {
         agent: Agent,
         runId: string,
         editsThisRunByFile: Set<string>,
+        delegationScope?: SubAgentScope | null,
     ): Promise<AgentToolDescriptor[]> {
         const service = this.toolService;
         if (!service) return [];
         const runContext = { runId, editsThisRunByFile };
         if (typeof service.resolveGrantedTools !== 'function') {
-            return service.resolveAllowedTools(agent, runContext);
+            return this.applyDelegationScope(
+                await service.resolveAllowedTools(agent, runContext),
+                runId,
+                delegationScope,
+            );
         }
 
         const { tools, refused } = await service.resolveGrantedTools(agent, runContext);
@@ -1477,7 +1501,58 @@ export class AgentRunService {
                 })
                 .catch(() => undefined);
         }
-        return tools;
+        return this.applyDelegationScope(tools, runId, delegationScope);
+    }
+
+    /**
+     * Narrow a delegated run's tools to the scope it was admitted under
+     * (judgment layer G9).
+     *
+     * Applied HERE because this is the single funnel every run's tools
+     * pass through — built-in and domain alike, after the permission
+     * gates and after the tool-grant matrix. Filtering earlier would miss
+     * the domain tools; filtering in the tool service would duplicate the
+     * grant seam.
+     *
+     * Until this existed, `narrowSubAgentScope` produced a correct
+     * narrowed scope that the delegation runner then discarded, so a
+     * child that was admitted executed with its own agent's FULL tool
+     * set. The contract's "privilege can only ever shrink going down the
+     * tree" held at the admission boundary and nowhere else.
+     *
+     * Fail-open by construction, and deliberately so: a run with no
+     * `delegationScope` (every ordinary run, and every run predating the
+     * column) is returned untouched. Treating "no scope" as "no tools"
+     * would strip the tool loop from the overwhelmingly common path on
+     * the first read that came back empty.
+     */
+    private applyDelegationScope(
+        tools: AgentToolDescriptor[],
+        runId: string,
+        scope: SubAgentScope | null | undefined,
+    ): AgentToolDescriptor[] {
+        if (!scope) return tools;
+
+        const permitted = new Set(
+            filterToolNamesBySubAgentScope(
+                tools.map((tool) => tool.name),
+                scope,
+            ),
+        );
+        if (permitted.size === tools.length) return tools;
+
+        const withheld = tools.filter((tool) => !permitted.has(tool.name)).map((tool) => tool.name);
+        void this.runLogs
+            ?.append({
+                runId,
+                level: 'WARN',
+                step: 'tools',
+                message: `${withheld.length} tool(s) withheld by the delegation scope this run was admitted under.`,
+                metadata: { withheld, allowedTools: scope.allowedTools ?? null },
+            })
+            .catch(() => undefined);
+
+        return tools.filter((tool) => permitted.has(tool.name));
     }
 
     /**

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -5,6 +5,7 @@ import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialE
 import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
 import { RUN_COST_SETTLER, type RunCostSettler } from '../run-cost-settler';
+import type { SubAgentScope } from '@ever-works/contracts';
 
 /**
  * Statuses a run may be transitioned OUT OF by a normal terminal write.
@@ -551,6 +552,12 @@ export class AgentRunRepository {
          * behaviour for every existing call site.
          */
         persistent?: boolean;
+        /**
+         * Judgment layer G9 — the already-narrowed scope a DELEGATED run
+         * executes under. Omitted (⇒ null) for every ordinary run, which
+         * the tool filter reads as "no additional restriction".
+         */
+        delegationScope?: SubAgentScope | null;
     }): Promise<AgentRun> {
         const run = this.repository.create({
             agentId: args.agentId,
@@ -560,6 +567,7 @@ export class AgentRunRepository {
             taskId: args.taskId ?? null,
             chatMessageId: args.chatMessageId ?? null,
             workId: args.workId ?? null,
+            delegationScope: args.delegationScope ?? null,
             queuedReason: args.queuedReason ?? null,
             runnerKind: args.runnerKind ?? null,
             ...(args.persistent === true ? { persistent: true } : {}),

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -1,6 +1,11 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 import { PortableDateColumn } from './_types';
-import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
+import type {
+    GateStatus,
+    SubAgentScope,
+    TaskAcceptanceCheck,
+    TaskCheckResult,
+} from '@ever-works/contracts';
 
 /**
  * What kicked off this run.
@@ -318,6 +323,32 @@ export class AgentRun {
      */
     @Column({ type: 'boolean', default: false })
     interruptRequested: boolean;
+
+    /**
+     * The effective scope a DELEGATED run executes under (judgment layer
+     * G9). `null` for every ordinary run — which is the overwhelmingly
+     * common case, and means "no additional restriction".
+     *
+     * Snapshotted at dispatch, not referenced: it is the already-narrowed
+     * scope `validateSubAgentDelegationRequest` produced, so re-deriving
+     * it later (from a parent whose own permissions may since have
+     * changed) could hand an in-flight child something different from
+     * what it was admitted with.
+     *
+     * It lives on the RUN rather than the Task because the run row is
+     * pre-created by `dispatchAgentRun` before the worker starts, and
+     * because `AgentRunService` already holds `AgentRunRepository` — so
+     * the tool loop can read it without `packages/agent/src/agents/`
+     * gaining a runtime import of `tasks-domain`, which the
+     * AGENT_DOMAIN_TOOL_SOURCES seam exists to prevent.
+     *
+     * Without this the delegation contract's headline property —
+     * "privilege can only ever shrink going down the tree" — held only at
+     * the admission boundary: an over-broad REQUEST was refused, but a
+     * child that was admitted ran with its own agent's full tool set.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    delegationScope?: SubAgentScope | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -31,6 +31,7 @@ import { TaskRunDenormService } from './task-run-denorm.service';
 // real class reference. No cycle: run-dispatch-gate.service imports only
 // task-dispatcher (leaf), the run repository, and config.
 import { RunDispatchGateService } from '../agents/run-dispatch-gate.service';
+import type { SubAgentScope } from '@ever-works/contracts';
 
 /**
  * Tasks feature — Phase 12.1.
@@ -322,7 +323,21 @@ export class TaskTransitionService {
     async dispatchAgentRun(
         task: Task,
         agentId: string,
-        opts: { generation?: number; dedupKey?: string } = {},
+        opts: {
+            generation?: number;
+            dedupKey?: string;
+            /**
+             * Judgment layer G9 — the EFFECTIVE (already-narrowed) scope a
+             * delegated run must execute under. Snapshotted onto the run
+             * row here so the tool loop can intersect the run's resolved
+             * tools against it.
+             *
+             * Omitted for every ordinary dispatch, which the filter reads
+             * as "no additional restriction" — so the common path is
+             * byte-for-byte unchanged.
+             */
+            delegationScope?: SubAgentScope | null;
+        } = {},
     ): Promise<{
         runId: string | null;
         /** True when the job runtime accepted the run this call. */
@@ -371,6 +386,7 @@ export class TaskTransitionService {
                               queuedReason: verdict.admitted
                                   ? null
                                   : (verdict.queuedReason ?? 'concurrency-limit'),
+                              delegationScope: opts.delegationScope ?? null,
                           })
                         : null;
                 };

--- a/packages/contracts/src/delegation/__tests__/sub-agent-delegation.spec.ts
+++ b/packages/contracts/src/delegation/__tests__/sub-agent-delegation.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	filterToolNamesBySubAgentScope,
 	isSubAgentDelegationSuccessful,
 	isSubAgentScopeSubset,
 	narrowSubAgentScope,
@@ -201,5 +202,51 @@ describe('result helpers', () => {
 				})
 			).toBe(status === 'completed');
 		}
+	});
+});
+
+describe('filterToolNamesBySubAgentScope', () => {
+	const TOOLS = ['read_file', 'write_file', 'deploy', 'searchWeb'];
+
+	it('keeps only the tools the scope allows', () => {
+		expect(filterToolNamesBySubAgentScope(TOOLS, { allowedTools: ['read_file', 'deploy'] })).toEqual([
+			'read_file',
+			'deploy'
+		]);
+	});
+
+	it('treats the wildcard as no restriction at all', () => {
+		// `['*']` means "everything the parent had" — it is a statement
+		// that nothing extra is being taken away, not an allowlist of one.
+		expect(filterToolNamesBySubAgentScope(TOOLS, { allowedTools: ['*'] })).toEqual(TOOLS);
+	});
+
+	it('imposes no restriction when no scope is supplied', () => {
+		// The overwhelmingly common case: an ordinary run that was never
+		// delegated. Inventing an empty allowlist here would strip every
+		// tool from a run that never asked to be limited.
+		expect(filterToolNamesBySubAgentScope(TOOLS, null)).toEqual(TOOLS);
+		expect(filterToolNamesBySubAgentScope(TOOLS, undefined)).toEqual(TOOLS);
+		expect(filterToolNamesBySubAgentScope(TOOLS, {} as never)).toEqual(TOOLS);
+	});
+
+	it('yields nothing when the scope allows nothing', () => {
+		// Distinct from "no scope": an explicit empty list is a real
+		// decision, and the delegation contract refuses it upstream as
+		// `scope-empty` rather than dispatching a toolless child.
+		expect(filterToolNamesBySubAgentScope(TOOLS, { allowedTools: [] })).toEqual([]);
+	});
+
+	it('ignores names the run does not actually have', () => {
+		expect(filterToolNamesBySubAgentScope(TOOLS, { allowedTools: ['read_file', 'not_a_real_tool'] })).toEqual([
+			'read_file'
+		]);
+	});
+
+	it('never widens — a scope cannot add a tool the run lacks', () => {
+		const result = filterToolNamesBySubAgentScope(['read_file'], {
+			allowedTools: ['read_file', 'deploy']
+		});
+		expect(result).toEqual(['read_file']);
 	});
 });

--- a/packages/contracts/src/delegation/sub-agent-delegation.types.ts
+++ b/packages/contracts/src/delegation/sub-agent-delegation.types.ts
@@ -172,6 +172,36 @@ function isUnderAnyPrefix(path: string, prefixes: readonly string[]): boolean {
 }
 
 /**
+ * Which of `toolNames` a run under `scope` may actually call.
+ *
+ * Narrowing a delegation decides what a child is ALLOWED; this is what
+ * turns that decision into the concrete tool list handed to a child's
+ * run. Without it the narrowed scope is computed and then dropped, and a
+ * child executes with its own agent's full tool set — the contract's
+ * "privilege can only ever shrink going down the tree" holding at the
+ * admission boundary and nowhere else.
+ *
+ * Lives HERE, next to `narrowSubAgentScope`, because the wildcard rule is
+ * contract semantics: `['*']` means "everything the parent had", so it
+ * imposes no additional restriction. Reimplementing that in the run loop
+ * would let the two definitions drift.
+ *
+ * Absent / non-array `allowedTools` also imposes no restriction — the
+ * caller has not expressed a scope, and inventing an empty one would
+ * silently strip every tool from a run that never asked to be limited.
+ */
+export function filterToolNamesBySubAgentScope(
+	toolNames: readonly string[],
+	scope: Pick<SubAgentScope, 'allowedTools'> | null | undefined
+): readonly string[] {
+	const allowed = scope?.allowedTools;
+	if (!Array.isArray(allowed)) return toolNames;
+	if (hasWildcard(allowed)) return toolNames;
+	const permitted = new Set(allowed);
+	return toolNames.filter((name) => permitted.has(name));
+}
+
+/**
  * Compute the scope a child ACTUALLY runs under: the intersection of
  * what it asked for and what the parent had. Never widens — an entry
  * the parent lacks is dropped, and `networkAccess` can only go from

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -546,6 +546,12 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 immediateInput,
                 workspaceCwd,
                 scopeContext,
+                // Judgment layer G9 — the scope this run was ADMITTED
+                // under, snapshotted onto the run row at dispatch. Read
+                // from the row we already loaded, so no extra query and
+                // nothing rides the queue payload (an old worker
+                // re-delivering an old payload could not carry it).
+                delegationScope: run.delegationScope ?? null,
             });
 
             // Wave 3 M3 — the PR gate: "a red check opens no PR". After the
@@ -775,6 +781,11 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                                 immediateInput: iterateMessage,
                                 workspaceCwd,
                                 scopeContext,
+                                // Same scope on the gate-retry iteration:
+                                // omitting it here would silently restore
+                                // the child's full tool set after the
+                                // first failed quality gate.
+                                delegationScope: run.delegationScope ?? null,
                             });
                             iterateSucceeded =
                                 iterateResult.status === 'assembled' ||


### PR DESCRIPTION
Promotion of `stage` to production.

Carries [#1983](https://github.com/ever-works/ever-works/pull/1983) — **a delegated child run is now actually confined to the scope it was admitted under.**

`narrowSubAgentScope` always produced a correct narrowed scope, and the delegation runner then discarded everything but `scope.workId`. So "privilege can only ever shrink going down the tree" held at the admission boundary and nowhere else: an over-broad request was refused, but a child that WAS admitted resolved tools from its own Agent row — and since `childAgentId` defaults to the parent, by default the child ran as the parent with every permission it holds.

Now: the effective scope is snapshotted onto the queued `agent_runs` row at dispatch → the worker puts it on the run context → `resolveToolsForRun` (the single funnel, after permission gates and after the tool-grant matrix) intersects against it.

**Deliberately not carried on the Trigger.dev payload.** That worker deploys via a separate workflow from the API, so an older deployed worker would silently drop the field — there is no schema to reject an unknown one — and the child would run with its full tool set. That is fail-open on the exact property being added. Three other producers also rebuild that payload from the run row alone and would drop it.

**Failure direction:** absent/null scope ⇒ no restriction, so every ordinary run and every run predating the column is untouched. `['*']` is likewise no restriction, per the contract's wildcard rule. Withheld tools are logged WARN with their names.

## Migration

`1784810000000-AddAgentRunDelegationScope` — additive nullable `simple-json` column on `agent_runs`, **nothing backfilled**, forward-only with idempotent per-step guards, applied on API boot. A spec proves `up()` leaves existing rows NULL, is idempotent, and `down()` reverts.

## Gates

contracts 313 · agent 462 suites / 8449 tests · api 244 suites / 3960 tests · `pnpm format:check` clean · type-check clean · real non-preview Nest bootstrap resolving all four wired DI tokens · 14/14 CI green.

The enforcement tests were mutation-checked: disabling the filter turns exactly the three enforcement cases red and leaves the four "ordinary runs untouched" cases green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)