### PR TITLE
feat(workflows): persist workflow graphs — entity, migration, repository, CRUD API

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -51,6 +51,7 @@ import { AgentsModule } from './agents/agents.module';
 import { AgentApprovalsModule } from './agent-approvals/agent-approvals.module';
 import { SkillsModule } from './skills/skills.module';
 import { TasksModule } from './tasks/tasks.module';
+import { WorkflowsModule } from './workflows/workflows.module';
 import { TerminalModule } from './terminal/terminal.module';
 import { TeamsModule } from './teams/teams.module';
 import { SchedulesModule } from './schedules/schedules.module';
@@ -186,6 +187,10 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // Phase 12 — Tasks API (CRUD + transitions + member CRUD).
         // Chat + attachments + per-task spend land in Phase 13.
         TasksModule,
+        // Saved workflow graphs (judgment layer G5) — the persistence and
+        // CRUD surface for graphs the executor could already run but
+        // nothing could keep.
+        WorkflowsModule,
         // Streaming-terminal M3 — relay registry + WS gateway on this
         // process's HTTP server + attach-token/internal-publish endpoints.
         TerminalModule,

--- a/apps/api/src/migrations/1784820000000-CreateWorkflows.ts
+++ b/apps/api/src/migrations/1784820000000-CreateWorkflows.ts
@@ -1,0 +1,128 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Judgment layer G5 — the `workflows` table.
+ *
+ * `WorkflowGraphExecutorService` could already execute a graph, and its
+ * only caller was an agent chat tool handed an inline, model-authored
+ * one. So a graph could be RUN but never KEPT: nothing could be authored
+ * once and re-run, and no UI could point at one. This is the row that
+ * makes a workflow something a user owns.
+ *
+ * ## Deliberately NO scope XOR CHECK
+ *
+ * `work_knowledge_documents` carries a CHECK enforcing that exactly one
+ * of `workId` / `organizationId` is set. Copying it here would abort the
+ * migration — and that is not hypothetical, it happened once already
+ * when the pattern was copied onto `work_knowledge_uploads`.
+ * `ScopeStampingSubscriber` stamps `organizationId` on EVERY insert for
+ * any entity declaring both `tenantId` and `organizationId`, so ordinary
+ * rows have BOTH populated and the XOR fails on real data.
+ *
+ * Here `workId` is an optional NARROWING — "this workflow belongs to one
+ * Work" — never an alternative to the organization. No constraint should
+ * encode a relationship the stamping subscriber contradicts.
+ *
+ * ## Portable DDL
+ *
+ * Built with TypeORM's `Table`/`TableIndex`/`TableForeignKey` API rather
+ * than raw SQL, because the e2e stack and CI run better-sqlite3 while
+ * production runs Postgres. Raw `gen_random_uuid()` /
+ * `CREATE INDEX IF NOT EXISTS` would work in prod and fail every CI run.
+ *
+ * `graph` is `text` (what TypeORM's `simple-json` maps to on every
+ * supported driver) holding the whole `WorkflowGraph`. Nodes and edges
+ * are only ever read and written WHOLE — the executor takes a complete
+ * graph, validates it and walks it — so separate tables would buy
+ * referential integrity over a structure nothing queries into, at the
+ * cost of a join-heavy read and a migration per future node kind.
+ * `validateWorkflowGraph` is the integrity check, applied on write.
+ *
+ * Forward-only with an idempotent guard (house pattern, mirrors
+ * 1784780000000-CreateToolGrants).
+ */
+export class CreateWorkflows1784820000000 implements MigrationInterface {
+    name = 'CreateWorkflows1784820000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('workflows')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'workflows',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'name', type: 'varchar', length: '200' },
+                    { name: 'description', type: 'text', isNullable: true },
+                    { name: 'status', type: 'varchar', length: '16', default: "'draft'" },
+                    // The whole graph. `simple-json` ⇒ text on every driver.
+                    { name: 'graph', type: 'text' },
+                    // Optional narrowing to one Work. NOT an XOR partner
+                    // for organizationId — see the class note.
+                    { name: 'workId', type: 'uuid', isNullable: true },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    // Denormalized display state so a list view needs no
+                    // aggregate join. Advisory: the authoritative record
+                    // of a run is its own row (a later slice).
+                    { name: 'runCount', type: 'int', default: 0 },
+                    { name: 'lastRunAt', type: 'timestamp', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'workflows',
+            new TableIndex({
+                name: 'idx_workflows_user_status',
+                columnNames: ['userId', 'status'],
+            }),
+        );
+        await queryRunner.createIndex(
+            'workflows',
+            new TableIndex({ name: 'idx_workflows_org', columnNames: ['organizationId'] }),
+        );
+        await queryRunner.createIndex(
+            'workflows',
+            new TableIndex({ name: 'idx_workflows_work', columnNames: ['workId'] }),
+        );
+
+        // Guarded on the table existing: the migration must not explode
+        // on a fresh database whose user table has not been created yet.
+        if (await queryRunner.hasTable('users')) {
+            await queryRunner.createForeignKey(
+                'workflows',
+                new TableForeignKey({
+                    name: 'fk_workflows_user',
+                    columnNames: ['userId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // This DOES destroy user-authored content — unlike the additive
+        // column migrations around it, reverting here discards every
+        // saved workflow. Acceptable only because it removes a feature
+        // wholesale rather than mangling rows something else still
+        // reads; an operator running it is choosing that.
+        if (await queryRunner.hasTable('workflows')) {
+            await queryRunner.dropTable('workflows');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateWorkflows.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateWorkflows.spec.ts
@@ -1,0 +1,124 @@
+import { DataSource } from 'typeorm';
+import { CreateWorkflows1784820000000 } from '../1784820000000-CreateWorkflows';
+
+/**
+ * Migration test for the `workflows` table.
+ *
+ * Runs on the same in-memory better-sqlite3 harness the sibling specs
+ * use — which is the point, not an incidental detail. Production is
+ * Postgres and CI/e2e are sqlite, so a migration written with raw
+ * `gen_random_uuid()` / `CREATE INDEX IF NOT EXISTS` would pass in prod
+ * and fail every CI run. Building it with TypeORM's portable Table API
+ * is what makes both work, and this spec is what proves it.
+ *
+ * Also pinned: NO scope XOR CHECK. Copying that constraint from
+ * `work_knowledge_documents` aborted a migration once already, because
+ * `ScopeStampingSubscriber` stamps `organizationId` on every insert and
+ * so ordinary rows have both scope columns populated.
+ */
+describe('CreateWorkflows1784820000000', () => {
+    let dataSource: DataSource;
+    const migration = new CreateWorkflows1784820000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('creates the table with every expected column', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('workflows');
+        expect(table).toBeDefined();
+        for (const column of [
+            'id',
+            'userId',
+            'name',
+            'description',
+            'status',
+            'graph',
+            'workId',
+            'tenantId',
+            'organizationId',
+            'runCount',
+            'lastRunAt',
+            'createdAt',
+            'updatedAt',
+        ]) {
+            expect(table?.findColumnByName(column)).toBeDefined();
+        }
+
+        await runner.release();
+    });
+
+    it('is idempotent — a second up() does not throw', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.not.toThrow();
+        await runner.release();
+    });
+
+    // NOTE: these raw inserts supply createdAt/updatedAt explicitly. The
+    // columns default to `now()`, which Postgres has and sqlite does not —
+    // harmless in practice because every real insert goes through TypeORM,
+    // whose @CreateDateColumn supplies the value from the ORM side. Only a
+    // hand-written INSERT like this one would ever hit the DB default.
+    it('accepts a row with BOTH workId and organizationId set', async () => {
+        // The scope-stamping subscriber populates organizationId on every
+        // insert, so this is the ORDINARY shape. A copied XOR CHECK would
+        // reject it — that is the exact defect this pins against.
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        await expect(
+            dataSource.query(
+                `INSERT INTO "workflows"
+                    ("id","userId","name","status","graph","workId","organizationId","runCount","createdAt","updatedAt")
+                 VALUES ('w1','u1','Nightly digest','draft','{}','work-1','org-1',0,'2026-08-02','2026-08-02')`,
+            ),
+        ).resolves.not.toThrow();
+
+        const rows = await dataSource.query(
+            `SELECT "workId", "organizationId" FROM "workflows" WHERE "id" = 'w1'`,
+        );
+        expect(rows[0]).toMatchObject({ workId: 'work-1', organizationId: 'org-1' });
+
+        await runner.release();
+    });
+
+    it('accepts an organization-level workflow with no workId', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        await dataSource.query(
+            `INSERT INTO "workflows"
+                ("id","userId","name","status","graph","organizationId","runCount","createdAt","updatedAt")
+             VALUES ('w2','u1','Org workflow','active','{}','org-1',0,'2026-08-02','2026-08-02')`,
+        );
+
+        const rows = await dataSource.query(`SELECT "workId" FROM "workflows" WHERE "id" = 'w2'`);
+        expect(rows[0].workId).toBeNull();
+
+        await runner.release();
+    });
+
+    it('down() drops the table', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+
+        expect(await runner.hasTable('workflows')).toBe(false);
+
+        await runner.release();
+    });
+});

--- a/apps/api/src/workflows/workflows.controller.ts
+++ b/apps/api/src/workflows/workflows.controller.ts
@@ -1,0 +1,231 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Param,
+    ParseUUIDPipe,
+    Patch,
+    Post,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { Type } from 'class-transformer';
+import {
+    IsIn,
+    IsInt,
+    IsObject,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    Min,
+    MinLength,
+} from 'class-validator';
+import { WorkflowsService } from '@ever-works/agent/services';
+import { WorkflowStatus } from '@ever-works/agent/entities';
+import { AuthSessionGuard, CurrentUser } from '../auth';
+import type { AuthenticatedUser } from '@src/auth/types/auth.types';
+
+const WORKFLOW_STATUSES: string[] = [
+    WorkflowStatus.DRAFT,
+    WorkflowStatus.ACTIVE,
+    WorkflowStatus.ARCHIVED,
+];
+
+export class CreateWorkflowDto {
+    @IsString()
+    @MinLength(1)
+    @MaxLength(200)
+    name: string;
+
+    /**
+     * The graph, validated by the service against
+     * `validateWorkflowGraph`.
+     *
+     * `@IsObject()` with NO nested DTO on purpose: the global pipe runs
+     * `whitelist: true`, which strips undecorated properties, so
+     * modelling nodes/edges as nested DTOs would silently delete every
+     * field of the graph that a DTO had not enumerated — and the graph's
+     * `node.config` is deliberately open-ended. Structure is checked by
+     * the contract validator, which is the one definition of a valid
+     * graph.
+     */
+    @IsObject()
+    graph: Record<string, unknown>;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(2000)
+    description?: string;
+
+    @IsOptional()
+    @IsIn(WORKFLOW_STATUSES)
+    status?: WorkflowStatus;
+
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+}
+
+export class UpdateWorkflowDto {
+    @IsOptional()
+    @IsString()
+    @MinLength(1)
+    @MaxLength(200)
+    name?: string;
+
+    @IsOptional()
+    @IsObject()
+    graph?: Record<string, unknown>;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(2000)
+    description?: string;
+
+    @IsOptional()
+    @IsIn(WORKFLOW_STATUSES)
+    status?: WorkflowStatus;
+
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+}
+
+export class ListWorkflowsDto {
+    @IsOptional()
+    @IsIn(WORKFLOW_STATUSES)
+    status?: WorkflowStatus;
+
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    limit?: number;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    offset?: number;
+}
+
+/**
+ * Saved workflow graphs (judgment layer G5).
+ *
+ * `WorkflowGraphExecutorService` could execute a graph long before this
+ * existed, but the only caller was an agent chat tool handed an inline,
+ * model-authored one — so a graph could be run and never kept. These
+ * routes are what make a workflow something a user owns, edits and
+ * re-runs.
+ *
+ * Every route is owner-scoped, and a workflow belonging to someone else
+ * is reported as 404 rather than 403 so the collection cannot be used to
+ * probe which ids exist.
+ *
+ * Running is deliberately NOT here. A graph may hold delegate nodes that
+ * each wait minutes for a child agent run — up to ~40 minutes for a
+ * maximal graph — against a ~100-second edge timeout, so a synchronous
+ * run endpoint could not work. It lands in its own slice as a dispatched
+ * job that returns a run id immediately.
+ */
+@ApiTags('workflows')
+@ApiBearerAuth()
+@UseGuards(AuthSessionGuard)
+@Controller('api/workflows')
+export class WorkflowsController {
+    constructor(private readonly workflows: WorkflowsService) {}
+
+    @Get()
+    @ApiOperation({
+        summary: 'List the current user’s saved workflows',
+        description:
+            'Owner-scoped. `workId` narrows to workflows attached to one Work; omit it for everything the user owns. Ordered by most recently updated.',
+    })
+    @ApiQuery({ name: 'status', required: false, enum: WORKFLOW_STATUSES })
+    @ApiQuery({ name: 'workId', required: false, type: String })
+    @ApiQuery({ name: 'limit', required: false, type: Number })
+    @ApiQuery({ name: 'offset', required: false, type: Number })
+    @ApiResponse({ status: 200, description: '{ items, total }' })
+    async list(@CurrentUser() auth: AuthenticatedUser, @Query() query: ListWorkflowsDto) {
+        return this.workflows.list(auth.userId, {
+            status: query.status,
+            workId: query.workId,
+            limit: query.limit ?? 50,
+            offset: query.offset ?? 0,
+        });
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Read one saved workflow' })
+    @ApiResponse({ status: 200, description: 'The workflow' })
+    @ApiResponse({ status: 404, description: 'No such workflow for this user' })
+    async get(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ) {
+        return this.workflows.get(auth.userId, id);
+    }
+
+    @Post()
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Save a workflow',
+        description:
+            'The graph is validated on write, so a stored workflow is one that can actually be executed — a malformed graph is refused here rather than discovered mid-run. Returns 400 with the specific structural errors when it is not valid.',
+    })
+    @ApiResponse({ status: 201, description: 'The created workflow' })
+    @ApiResponse({ status: 400, description: 'The graph is not valid' })
+    async create(@CurrentUser() auth: AuthenticatedUser, @Body() body: CreateWorkflowDto) {
+        return this.workflows.create(auth.userId, {
+            name: body.name,
+            graph: body.graph,
+            description: body.description ?? null,
+            status: body.status,
+            workId: body.workId ?? null,
+        });
+    }
+
+    @Patch(':id')
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Update a saved workflow',
+        description:
+            'Partial update. A supplied graph is re-validated — the "a stored workflow is runnable" guarantee would otherwise be a one-time property any edit could quietly break.',
+    })
+    @ApiResponse({ status: 200, description: 'The updated workflow' })
+    @ApiResponse({ status: 400, description: 'The graph is not valid' })
+    @ApiResponse({ status: 404, description: 'No such workflow for this user' })
+    async update(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+        @Body() body: UpdateWorkflowDto,
+    ) {
+        return this.workflows.update(auth.userId, id, body);
+    }
+
+    @Delete(':id')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({
+        summary: 'Delete a saved workflow',
+        description:
+            'Hard delete — a workflow is authored configuration, not a record of something that happened, so there is nothing here to preserve for audit. Run records are separate rows and are unaffected.',
+    })
+    @ApiResponse({ status: 204, description: 'Deleted' })
+    @ApiResponse({ status: 404, description: 'No such workflow for this user' })
+    async remove(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ) {
+        await this.workflows.remove(auth.userId, id);
+    }
+}

--- a/apps/api/src/workflows/workflows.module.ts
+++ b/apps/api/src/workflows/workflows.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { WorkflowsModule as AgentWorkflowsModule } from '@ever-works/agent/services';
+import { AuthModule } from '../auth/auth.module';
+import { WorkflowsController } from './workflows.controller';
+
+/**
+ * API surface for saved workflow graphs (judgment layer G5).
+ *
+ * Mounts the controller only; the service + repository live in the
+ * agent-side `WorkflowsModule`, which this imports for
+ * `WorkflowsService`. `AuthModule` is imported because the controller's
+ * `AuthSessionGuard` is resolved through DI — without it the module
+ * compiles and then fails to instantiate the guard at boot, which no
+ * unit test would catch.
+ */
+@Module({
+    imports: [AgentWorkflowsModule, AuthModule],
+    controllers: [WorkflowsController],
+})
+export class WorkflowsModule {}

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -131,6 +131,7 @@ import { TerminalTranscriptChunk } from '../entities/terminal-transcript-chunk.e
 
 import { FleetJob } from '../entities/fleet-job.entity';
 import { ToolGrant } from '../entities/tool-grant.entity';
+import { Workflow } from '../entities/workflow.entity';
 
 import {
     PluginEntity,
@@ -318,4 +319,7 @@ export const ENTITIES = [
     // Tool-grant matrix (audit item G4) — one row per (owner, scope)
     // carrying that scope's tool allow/deny contribution.
     ToolGrant,
+    // Workflows (judgment layer G5) — saved graphs. Until this row
+    // existed a graph could be executed but never KEPT.
+    Workflow,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -184,4 +184,5 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'WorkProposal',
     'WorkProposalAttachment',
     'WorkSchedule',
+    'Workflow',
 ] as const;

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -76,3 +76,4 @@ export * from './repositories/user-notification-category-mute.repository';
 export * from './repositories/organization-notification-default.repository';
 export * from './repositories/organization-onboarding-profile.repository';
 export * from './database-init.service';
+export * from './repositories/workflow.repository';

--- a/packages/agent/src/database/repositories/workflow.repository.ts
+++ b/packages/agent/src/database/repositories/workflow.repository.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { WorkflowGraph } from '@ever-works/contracts';
+import { Workflow, WorkflowStatus } from '../../entities/workflow.entity';
+
+export interface CreateWorkflowInput {
+    userId: string;
+    name: string;
+    graph: WorkflowGraph;
+    description?: string | null;
+    status?: WorkflowStatus;
+    workId?: string | null;
+}
+
+export interface UpdateWorkflowInput {
+    name?: string;
+    description?: string | null;
+    status?: WorkflowStatus;
+    graph?: WorkflowGraph;
+    workId?: string | null;
+}
+
+export interface ListWorkflowsFilter {
+    status?: WorkflowStatus;
+    workId?: string | null;
+    limit?: number;
+    offset?: number;
+}
+
+/**
+ * Persistence for saved workflow graphs (judgment layer G5).
+ *
+ * Owner-scoped by construction: every read takes a `userId` and every
+ * lookup is `(id, userId)`. There is deliberately NO bare `findById` —
+ * a caller that cannot name the owner has no business reading the row,
+ * and the absence of the method is what stops one being written by
+ * accident. A foreign id therefore resolves to `null`, which the service
+ * turns into a 404 rather than a 403, so the endpoint cannot be used to
+ * probe which workflow ids exist for other users.
+ *
+ * Scope columns (`tenantId` / `organizationId`) are NOT set here —
+ * `ScopeStampingSubscriber` stamps them from the active request scope on
+ * insert. Setting them explicitly would defeat that, and setting them to
+ * `null` would actively suppress it (the subscriber only fills
+ * `undefined`).
+ */
+@Injectable()
+export class WorkflowRepository {
+    constructor(
+        @InjectRepository(Workflow)
+        private readonly repository: Repository<Workflow>,
+    ) {}
+
+    async create(input: CreateWorkflowInput): Promise<Workflow> {
+        const workflow = this.repository.create({
+            userId: input.userId,
+            name: input.name,
+            description: input.description ?? null,
+            status: input.status ?? WorkflowStatus.DRAFT,
+            graph: input.graph,
+            workId: input.workId ?? null,
+            runCount: 0,
+            lastRunAt: null,
+        });
+        return this.repository.save(workflow);
+    }
+
+    /** The ONLY read by id. Owner-scoped on purpose — see the class note. */
+    async findByIdAndUser(id: string, userId: string): Promise<Workflow | null> {
+        return this.repository.findOne({ where: { id, userId } });
+    }
+
+    async list(
+        userId: string,
+        filter: ListWorkflowsFilter = {},
+    ): Promise<{ items: Workflow[]; total: number }> {
+        const qb = this.repository
+            .createQueryBuilder('workflow')
+            .where('workflow.userId = :userId', { userId });
+
+        if (filter.status) {
+            qb.andWhere('workflow.status = :status', { status: filter.status });
+        }
+        // `null` is a MEANINGFUL filter here ("organization-level only"),
+        // so it is distinguished from an absent one rather than folded
+        // into it by a truthiness check.
+        if (filter.workId === null) {
+            qb.andWhere('workflow.workId IS NULL');
+        } else if (filter.workId !== undefined) {
+            qb.andWhere('workflow.workId = :workId', { workId: filter.workId });
+        }
+
+        qb.orderBy('workflow.updatedAt', 'DESC');
+
+        const total = await qb.getCount();
+        if (filter.limit !== undefined) qb.take(filter.limit);
+        if (filter.offset !== undefined) qb.skip(filter.offset);
+
+        return { items: await qb.getMany(), total };
+    }
+
+    /**
+     * Owner-scoped update. Returns null when the row is not the user's,
+     * so a caller cannot patch a workflow it could not read.
+     */
+    async update(id: string, userId: string, patch: UpdateWorkflowInput): Promise<Workflow | null> {
+        const existing = await this.findByIdAndUser(id, userId);
+        if (!existing) return null;
+
+        // Explicit assignment rather than a spread: a spread would let a
+        // future caller smuggle `userId` or a scope column into the patch
+        // and silently reassign ownership.
+        if (patch.name !== undefined) existing.name = patch.name;
+        if (patch.description !== undefined) existing.description = patch.description;
+        if (patch.status !== undefined) existing.status = patch.status;
+        if (patch.graph !== undefined) existing.graph = patch.graph;
+        if (patch.workId !== undefined) existing.workId = patch.workId;
+
+        return this.repository.save(existing);
+    }
+
+    async remove(id: string, userId: string): Promise<boolean> {
+        const result = await this.repository.delete({ id, userId });
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Advisory display counters. Best-effort by design: a failure here
+     * must never fail the run it is recording, because the authoritative
+     * account of a run is its own record — this only drives a list view.
+     */
+    async recordRun(id: string, at: Date): Promise<void> {
+        await this.repository.increment({ id }, 'runCount', 1);
+        await this.repository.update({ id }, { lastRunAt: at });
+    }
+}

--- a/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
+++ b/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
@@ -27,6 +27,7 @@ import { WorkKnowledgeCitation } from '../work-knowledge-citation.entity';
 import { WorkKnowledgeTag } from '../work-knowledge-tag.entity';
 import { WorkKnowledgeUpload } from '../work-knowledge-upload.entity';
 import { WorkMember } from '../work-member.entity';
+import { Workflow } from '../workflow.entity';
 
 /**
  * EW-657 (Tenants & Organizations Phase 5a) — Tier C scope-column
@@ -82,6 +83,7 @@ describe('Tier C entities — Phase 5a scope columns', () => {
         { name: 'UsageLedgerEntry', target: UsageLedgerEntry },
         { name: 'PluginUsageEvent', target: PluginUsageEvent },
         { name: 'ActivityLog', target: ActivityLog },
+        { name: 'Workflow', target: Workflow },
     ];
 
     for (const { name, target } of tierC) {

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -147,3 +147,4 @@ export * from './terminal-transcript-chunk.entity';
 export * from './fleet-job.entity';
 // Tool-grant matrix (audit item G4) — per-scope tool allow/deny rows.
 export * from './tool-grant.entity';
+export * from './workflow.entity';

--- a/packages/agent/src/entities/workflow.entity.ts
+++ b/packages/agent/src/entities/workflow.entity.ts
@@ -1,0 +1,119 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { PortableDateColumn } from './_types';
+import type { WorkflowGraph } from '@ever-works/contracts';
+
+/**
+ * Workflow lifecycle. Deliberately small — a workflow is a saved graph,
+ * not a scheduled job (that would be a Goal or a Task).
+ *
+ * `DRAFT`    — being authored. Runnable on demand, but marked as
+ *              unfinished so a future scheduler ignores it.
+ * `ACTIVE`   — ready to run.
+ * `ARCHIVED` — retired. Kept readable and re-activatable; never deleted
+ *              out from under a run that references it.
+ */
+export enum WorkflowStatus {
+    DRAFT = 'draft',
+    ACTIVE = 'active',
+    ARCHIVED = 'archived',
+}
+
+/**
+ * A SAVED workflow graph (judgment layer G5).
+ *
+ * `WorkflowGraphExecutorService` could already execute a graph, and the
+ * only caller was an agent chat tool handed an inline, model-authored
+ * one — so a graph could be run but never KEPT. Nothing could be
+ * authored once and re-run, versioned, or pointed at from a UI. This is
+ * the row that makes a workflow a thing a user owns.
+ *
+ * ## The graph is a snapshot column, not a schema
+ *
+ * `graph` holds the whole `WorkflowGraph` as `simple-json`. Modelling
+ * nodes and edges as their own tables would buy referential integrity
+ * over a structure that is only ever read and written WHOLE — the
+ * executor takes a complete graph, validates it, and walks it — and
+ * would cost a join-heavy read plus migrations for every future node
+ * kind. `validateWorkflowGraph` is the integrity check, applied on
+ * write.
+ *
+ * ## Scope
+ *
+ * Tier C: declaring BOTH `tenantId` and `organizationId` opts this
+ * entity into `ScopeStampingSubscriber`, which stamps them from the
+ * active request scope on insert. So EVERY row carries an
+ * `organizationId` — which is exactly why this table must NOT copy the
+ * `workId`/`organizationId` XOR CHECK from `work_knowledge_documents`:
+ * that constraint aborts a migration here, because the stamp makes both
+ * columns populated on ordinary rows. `workId` is an optional NARROWING
+ * (a workflow that belongs to one Work), never an alternative to the org.
+ */
+@Entity({ name: 'workflows' })
+@Index('idx_workflows_user_status', ['userId', 'status'])
+@Index('idx_workflows_org', ['organizationId'])
+@Index('idx_workflows_work', ['workId'])
+export class Workflow {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner. Every read is scoped to this — a foreign id resolves to "not found". */
+    @Column('uuid')
+    userId: string;
+
+    @Column({ type: 'varchar', length: 200 })
+    name: string;
+
+    @Column({ type: 'text', nullable: true })
+    description?: string | null;
+
+    @Column({ type: 'varchar', length: 16, default: WorkflowStatus.DRAFT })
+    status: WorkflowStatus;
+
+    /**
+     * The graph itself. Validated against `validateWorkflowGraph` plus
+     * the admission clamps on every write, so a row that exists is a row
+     * that can be executed — an unrunnable graph is refused at the API
+     * rather than discovered at run time.
+     */
+    @Column({ type: 'simple-json' })
+    graph: WorkflowGraph;
+
+    /**
+     * Optional narrowing to a single Work. Null = an organization-level
+     * workflow. NOT an XOR with `organizationId` — see the class note.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    workId?: string | null;
+
+    // Tenant + Organization scope FKs (Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, same posture as agent-run.entity.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    /** Denormalized run counters, so a list view needs no aggregate join. */
+    @Column({ type: 'int', default: 0 })
+    runCount: number;
+
+    // MUST be @PortableDateColumn, not a raw `type: 'timestamp'`: the e2e
+    // stack and CI run better-sqlite3, which has no `timestamp` type, so a
+    // raw one makes TypeORM's metadata validation throw
+    // `DataTypeNotSupportedError` and the API cannot boot AT ALL there.
+    @PortableDateColumn({ nullable: true })
+    lastRunAt?: Date | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/services/__tests__/workflows.service.spec.ts
+++ b/packages/agent/src/services/__tests__/workflows.service.spec.ts
@@ -1,0 +1,232 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { WorkflowsService } from '../workflows.service';
+import { WorkflowStatus } from '../../entities/workflow.entity';
+import type { WorkflowRepository } from '../../database/repositories/workflow.repository';
+
+/**
+ * Saved workflow graphs (judgment layer G5).
+ *
+ * Two properties carry this service:
+ *
+ *  1. A STORED graph is validated on write, so a row that exists is a
+ *     row that can be executed. Deferring the check to run time would
+ *     let a user save something that fails later with no idea which edit
+ *     broke it, and would put the error in a background log instead of
+ *     in the response to the request that caused it.
+ *  2. Reads are owner-scoped and a foreign id is 404, never 403 — the
+ *     collection must not be usable to discover which ids exist for
+ *     other users.
+ */
+
+const validGraph = () => ({
+    id: 'g-1',
+    entryNodeId: 'a',
+    nodes: [{ id: 'a', kind: 'noop' }],
+    edges: [],
+});
+
+describe('WorkflowsService', () => {
+    let repo: {
+        create: jest.Mock;
+        findByIdAndUser: jest.Mock;
+        list: jest.Mock;
+        update: jest.Mock;
+        remove: jest.Mock;
+    };
+    let service: WorkflowsService;
+
+    beforeEach(() => {
+        repo = {
+            create: jest.fn().mockImplementation(async (input) => ({ id: 'w1', ...input })),
+            findByIdAndUser: jest.fn().mockResolvedValue({ id: 'w1', userId: 'u1' }),
+            list: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+            update: jest.fn().mockImplementation(async (id, userId, patch) => ({ id, ...patch })),
+            remove: jest.fn().mockResolvedValue(true),
+        };
+        service = new WorkflowsService(repo as unknown as WorkflowRepository);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    describe('create', () => {
+        it('persists a valid graph and defaults to draft', async () => {
+            await service.create('u1', { name: 'Nightly', graph: validGraph() });
+
+            expect(repo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    name: 'Nightly',
+                    status: WorkflowStatus.DRAFT,
+                }),
+            );
+        });
+
+        it('trims the name rather than storing the whitespace', async () => {
+            await service.create('u1', { name: '  Nightly  ', graph: validGraph() });
+
+            expect(repo.create.mock.calls[0][0].name).toBe('Nightly');
+        });
+
+        it('REFUSES a structurally invalid graph before it is stored', async () => {
+            // The point of validating on write: an unrunnable row never
+            // exists, so nothing discovers it mid-run.
+            await expect(
+                service.create('u1', {
+                    name: 'Broken',
+                    graph: { ...validGraph(), entryNodeId: 'missing' },
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(repo.create).not.toHaveBeenCalled();
+        });
+
+        it('returns the SPECIFIC structural errors, not just "invalid"', async () => {
+            // A human is editing this graph; "invalid graph" with no
+            // detail is the least useful thing an editor can say.
+            await expect(
+                service.create('u1', {
+                    name: 'Broken',
+                    graph: { ...validGraph(), entryNodeId: 'missing' },
+                }),
+            ).rejects.toMatchObject({
+                response: expect.objectContaining({ errors: expect.any(Array) }),
+            });
+        });
+
+        it('refuses a non-object graph', async () => {
+            await expect(
+                service.create('u1', { name: 'x', graph: 'not-a-graph' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('refuses a graph whose nodes are not an array', async () => {
+            await expect(
+                service.create('u1', { name: 'x', graph: { nodes: {}, edges: [] } }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('refuses a graph past the size ceiling', async () => {
+            const nodes = Array.from({ length: WorkflowsService.MAX_NODES + 1 }, (_, i) => ({
+                id: `n${i}`,
+                kind: 'noop',
+            }));
+            await expect(
+                service.create('u1', {
+                    name: 'huge',
+                    graph: { ...validGraph(), entryNodeId: 'n0', nodes },
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('allows a graph far larger than the MODEL-authored cap', async () => {
+            // A stored workflow is authored by a human, deliberately, and
+            // is visible before it runs — the model clamps exist for a
+            // situation that does not apply, and capping a hand-built
+            // workflow at 4 delegate nodes would be borrowed strictness.
+            const nodes = Array.from({ length: 50 }, (_, i) => ({
+                id: `n${i}`,
+                kind: 'agent.delegate',
+            }));
+            const edges = nodes.slice(0, -1).map((n, i) => ({
+                id: `e${i}`,
+                kind: 'sequential',
+                from: n.id,
+                to: nodes[i + 1].id,
+            }));
+
+            await expect(
+                service.create('u1', {
+                    name: 'big but legal',
+                    graph: { id: 'g', entryNodeId: 'n0', nodes, edges },
+                }),
+            ).resolves.toBeDefined();
+        });
+    });
+
+    it('REFUSES a node kind the runner cannot execute', async () => {
+        // `validateWorkflowGraph` treats `kind` as opaque, so a graph
+        // naming `shell.exec` validates cleanly and fails at RUN time.
+        // Catching it on write is what makes "a stored workflow is
+        // runnable" actually true rather than aspirational.
+        await expect(
+            service.create('u1', {
+                name: 'sneaky',
+                graph: {
+                    id: 'g',
+                    entryNodeId: 'a',
+                    nodes: [{ id: 'a', kind: 'shell.exec' }],
+                    edges: [],
+                },
+            }),
+        ).rejects.toMatchObject({
+            response: expect.objectContaining({
+                message: expect.stringContaining('shell.exec'),
+            }),
+        });
+        expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts every kind the runner DOES implement', async () => {
+        for (const kind of ['noop', 'ai.ask', 'kb.search', 'agent.delegate']) {
+            await expect(
+                service.create('u1', {
+                    name: kind,
+                    graph: { id: 'g', entryNodeId: 'a', nodes: [{ id: 'a', kind }], edges: [] },
+                }),
+            ).resolves.toBeDefined();
+        }
+    });
+
+    describe('get', () => {
+        it('reports another user’s workflow as 404, not 403', async () => {
+            // The repository returns null for "missing" and "not yours"
+            // alike, so the response cannot be used to probe which ids
+            // exist elsewhere.
+            repo.findByIdAndUser.mockResolvedValue(null);
+
+            await expect(service.get('u1', 'w-someone-else')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('scopes the lookup to the acting user', async () => {
+            await service.get('u1', 'w1');
+
+            expect(repo.findByIdAndUser).toHaveBeenCalledWith('w1', 'u1');
+        });
+    });
+
+    describe('update', () => {
+        it('RE-VALIDATES a supplied graph', async () => {
+            // Otherwise "a stored workflow is runnable" is a one-time
+            // property that any PATCH could quietly break.
+            await expect(
+                service.update('u1', 'w1', { graph: { ...validGraph(), entryNodeId: 'nope' } }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(repo.update).not.toHaveBeenCalled();
+        });
+
+        it('leaves the graph alone when the patch does not mention it', async () => {
+            await service.update('u1', 'w1', { name: 'Renamed' });
+
+            const patch = repo.update.mock.calls[0][2];
+            expect(patch).not.toHaveProperty('graph');
+            expect(patch.name).toBe('Renamed');
+        });
+
+        it('reports a foreign workflow as 404', async () => {
+            repo.update.mockResolvedValue(null);
+
+            await expect(service.update('u1', 'w1', { name: 'x' })).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+    });
+
+    describe('remove', () => {
+        it('reports a foreign workflow as 404 rather than silently succeeding', async () => {
+            repo.remove.mockResolvedValue(false);
+
+            await expect(service.remove('u1', 'w1')).rejects.toBeInstanceOf(NotFoundException);
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -57,3 +57,5 @@ export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';
 export type { SourceValidationSettingsDto } from '@ever-works/contracts/api';
+export * from './workflows.service';
+export * from './workflows.module';

--- a/packages/agent/src/services/workflows.module.ts
+++ b/packages/agent/src/services/workflows.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Workflow } from '../entities/workflow.entity';
+import { WorkflowRepository } from '../database/repositories/workflow.repository';
+import { WorkflowsService } from './workflows.service';
+
+/**
+ * Saved workflow graphs (judgment layer G5).
+ *
+ * `WorkflowRepository` is provided HERE rather than added to
+ * `_repository-inventory.ts`: that list is only for repositories owned
+ * by `DatabaseModule` itself, and this one is feature-owned. It needs
+ * nothing but `@InjectRepository(Workflow)`, which the `forFeature`
+ * below supplies.
+ *
+ * The entity must ALSO be in the `ENTITIES` array
+ * (`database/_entities-inventory.ts`) — this repo has no
+ * `autoLoadEntities`, so a `forFeature`'d-but-unregistered entity throws
+ * `EntityMetadataNotFoundError` on the first query, in production, with
+ * a green build and green unit tests behind it.
+ */
+@Module({
+    imports: [TypeOrmModule.forFeature([Workflow])],
+    providers: [WorkflowRepository, WorkflowsService],
+    exports: [WorkflowRepository, WorkflowsService],
+})
+export class WorkflowsModule {}

--- a/packages/agent/src/services/workflows.service.ts
+++ b/packages/agent/src/services/workflows.service.ts
@@ -1,0 +1,201 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { validateWorkflowGraph, type WorkflowGraph } from '@ever-works/contracts';
+import { WORKFLOW_TOOL_ALLOWED_NODE_KINDS } from '../agents/agent-workflow-tools';
+import { Workflow, WorkflowStatus } from '../entities/workflow.entity';
+import {
+    WorkflowRepository,
+    type ListWorkflowsFilter,
+    type UpdateWorkflowInput,
+} from '../database/repositories/workflow.repository';
+
+export interface CreateWorkflowRequest {
+    name: string;
+    graph: unknown;
+    description?: string | null;
+    status?: WorkflowStatus;
+    workId?: string | null;
+}
+
+export type UpdateWorkflowRequest = Partial<CreateWorkflowRequest>;
+
+/**
+ * Saved workflow graphs (judgment layer G5).
+ *
+ * ## Validation happens on WRITE, not on run
+ *
+ * A stored graph is validated before it is persisted, so a row that
+ * exists is a row that can be executed. Deferring the check to run time
+ * would let a user save something that fails later with no idea which
+ * edit broke it — and would put the error in a background run's log
+ * instead of in the response to the request that caused it.
+ *
+ * ## Why a stored graph is validated but NOT admission-clamped
+ *
+ * `admitModelAuthoredGraph` exists because a MODEL authors a graph
+ * inline, in the middle of a tool call, with no human between the
+ * generation and the execution — so node counts, delegate counts and
+ * cycles all have to be bounded defensively.
+ *
+ * A stored workflow is authored by a USER, deliberately, and is visible
+ * and editable before it ever runs. Applying the model clamps here would
+ * cap a hand-built workflow at 4 delegate nodes for a reason that does
+ * not apply to it. The cost limits that DO matter still apply, because
+ * they live where execution happens: `maxSteps` is clamped by the
+ * executor, delegation depth is server-derived, the fan-out cap is
+ * enforced per agent run, and each delegate node's wait is bounded.
+ *
+ * What is enforced here is STRUCTURE — `validateWorkflowGraph` — plus a
+ * size ceiling generous enough for a real workflow but small enough that
+ * a single row cannot become a denial-of-service payload.
+ */
+@Injectable()
+export class WorkflowsService {
+    private readonly logger = new Logger(WorkflowsService.name);
+
+    /**
+     * Ceiling on a STORED graph. An order of magnitude above the
+     * model-authored cap because a human may legitimately build
+     * something large; still bounded so one row cannot hold a payload
+     * that costs more to parse than to run.
+     */
+    static readonly MAX_NODES = 200;
+    static readonly MAX_EDGES = 400;
+
+    constructor(private readonly workflows: WorkflowRepository) {}
+
+    async create(userId: string, input: CreateWorkflowRequest): Promise<Workflow> {
+        const graph = this.assertUsableGraph(input.graph);
+        return this.workflows.create({
+            userId,
+            name: input.name.trim(),
+            description: input.description ?? null,
+            status: input.status ?? WorkflowStatus.DRAFT,
+            graph,
+            workId: input.workId ?? null,
+        });
+    }
+
+    async list(
+        userId: string,
+        filter: ListWorkflowsFilter = {},
+    ): Promise<{ items: Workflow[]; total: number }> {
+        return this.workflows.list(userId, filter);
+    }
+
+    /**
+     * Throws NotFound — never Forbidden — for a workflow belonging to
+     * someone else, so the endpoint cannot be used to discover which ids
+     * exist for other users.
+     */
+    async get(userId: string, id: string): Promise<Workflow> {
+        const workflow = await this.workflows.findByIdAndUser(id, userId);
+        if (!workflow) {
+            throw new NotFoundException({ status: 'error', message: 'Workflow not found' });
+        }
+        return workflow;
+    }
+
+    async update(userId: string, id: string, input: UpdateWorkflowRequest): Promise<Workflow> {
+        const patch: UpdateWorkflowInput = {};
+        if (input.name !== undefined) patch.name = input.name.trim();
+        if (input.description !== undefined) patch.description = input.description;
+        if (input.status !== undefined) patch.status = input.status;
+        if (input.workId !== undefined) patch.workId = input.workId;
+        // Re-validated on every edit: the same guarantee as create, which
+        // would otherwise be a one-time property that any PATCH could
+        // quietly break.
+        if (input.graph !== undefined) patch.graph = this.assertUsableGraph(input.graph);
+
+        const updated = await this.workflows.update(id, userId, patch);
+        if (!updated) {
+            throw new NotFoundException({ status: 'error', message: 'Workflow not found' });
+        }
+        return updated;
+    }
+
+    async remove(userId: string, id: string): Promise<void> {
+        const removed = await this.workflows.remove(id, userId);
+        if (!removed) {
+            throw new NotFoundException({ status: 'error', message: 'Workflow not found' });
+        }
+    }
+
+    /**
+     * Structural + size validation for a stored graph.
+     *
+     * Returns the graph rather than a boolean so the caller persists
+     * exactly what was checked — validating one value and storing another
+     * is how a "validated" column ends up holding something that was not.
+     */
+    private assertUsableGraph(raw: unknown): WorkflowGraph {
+        if (!raw || typeof raw !== 'object') {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'graph must be an object',
+            });
+        }
+        const graph = raw as WorkflowGraph;
+
+        if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'graph.nodes and graph.edges must be arrays',
+            });
+        }
+        if (graph.nodes.length > WorkflowsService.MAX_NODES) {
+            throw new BadRequestException({
+                status: 'error',
+                message: `graph has ${graph.nodes.length} nodes; the limit is ${WorkflowsService.MAX_NODES}`,
+            });
+        }
+        if (graph.edges.length > WorkflowsService.MAX_EDGES) {
+            throw new BadRequestException({
+                status: 'error',
+                message: `graph has ${graph.edges.length} edges; the limit is ${WorkflowsService.MAX_EDGES}`,
+            });
+        }
+
+        // Node KINDS, not just structure.
+        //
+        // `validateWorkflowGraph` treats `kind` as an opaque string — the
+        // graph model deliberately knows nothing about what a node does —
+        // so a graph naming `shell.exec` validates cleanly and then fails
+        // at run time with `unknown-node-kind`. That would make the
+        // promise this service is built on ("a stored workflow is one
+        // that can be executed") false, and would move the error from the
+        // response that caused it into a background run's log.
+        //
+        // The allowlist is imported rather than re-listed: the runner's
+        // supported set is the one definition, and a copy here would
+        // drift the moment a node kind is added.
+        const unsupported = graph.nodes.find(
+            (node) =>
+                !node ||
+                typeof node !== 'object' ||
+                !WORKFLOW_TOOL_ALLOWED_NODE_KINDS.includes(node.kind),
+        );
+        if (unsupported) {
+            throw new BadRequestException({
+                status: 'error',
+                message:
+                    `node '${unsupported?.id ?? '<malformed>'}' has unsupported kind ` +
+                    `'${unsupported?.kind}'; supported kinds are ` +
+                    WORKFLOW_TOOL_ALLOWED_NODE_KINDS.join(', '),
+            });
+        }
+
+        const validation = validateWorkflowGraph(graph);
+        if (!validation.valid) {
+            // The reasons are returned verbatim: the author is a human
+            // editing this graph, and "invalid graph" with no detail is
+            // the least useful thing an editor can say.
+            throw new BadRequestException({
+                status: 'error',
+                message: 'graph is not valid',
+                errors: validation.errors,
+            });
+        }
+
+        return graph;
+    }
+}


### PR DESCRIPTION
**PR 1 of 3** making workflow graphs a product surface. `WorkflowGraphExecutorService` could execute a graph, and its only caller was an agent chat tool handed an inline, model-authored one — so a graph could be **run but never kept**. Nothing could be authored once and re-run; no UI could point at one.

- **PR1 (this)** — entity, migration, repository, service, CRUD API
- **PR2** — `POST /api/workflows/:id/run` + run records
- **PR3** — web UI

## Design calls worth reviewing

**The graph is a column, not a schema.** Nodes and edges are only ever read and written *whole* — the executor takes a complete graph, validates it, walks it. Separate tables would buy referential integrity over a structure nothing queries into, and cost a join-heavy read plus a migration per future node kind.

**Validated on write, including node kinds.** A row that exists is a row that can be executed. `validateWorkflowGraph` treats `kind` as *opaque*, so a graph naming `shell.exec` validates cleanly and fails at run time — the allowlist is imported from the runner's own set (never re-listed, so they can't drift). Re-validated on PATCH, or the guarantee is a one-time property any edit could break.

**`admitModelAuthoredGraph` is deliberately NOT applied.** Those clamps exist because a *model* authors a graph mid-tool-call with no human in between. A stored workflow is authored deliberately and is visible before it runs, so capping it at 4 delegate nodes would be borrowed strictness. The limits that matter still apply where execution happens: `maxSteps` clamped by the executor, delegation depth server-derived, fan-out capped per agent run, each delegate node's wait bounded.

**Running is not in this PR, and that's forced by arithmetic.** A graph may hold delegate nodes each waiting minutes for a child agent run — **~40 min worst case** — against a **~100-second edge timeout**. A synchronous run endpoint cannot work, so PR2 dispatches and returns a run id immediately. PR1's shape doesn't contradict that.

## Two traps this repo has been bitten by, avoided deliberately

**No scope XOR CHECK.** Copying that constraint from `work_knowledge_documents` aborted a migration once already on `work_knowledge_uploads`: `ScopeStampingSubscriber` stamps `organizationId` on *every* Tier C insert, so ordinary rows have both scope columns populated and the XOR fails on real data. Here `workId` is an optional **narrowing**, never an alternative to the org — and a spec pins that a row with both set is accepted.

**Portable DDL.** Built with TypeORM's `Table`/`TableIndex` API, not raw SQL. Production is Postgres; CI and e2e are better-sqlite3. `gen_random_uuid()` / `CREATE INDEX IF NOT EXISTS` would pass in prod and fail every CI run. The migration spec runs on sqlite precisely to prove it. Same reason `lastRunAt` is `@PortableDateColumn` — a raw `type: 'timestamp'` makes the API fail to boot *at all* under sqlite.

## Registration — four places, all required

entities barrel · `ENTITIES` inventory (no `autoLoadEntities`, so an unregistered entity throws `EntityMetadataNotFoundError` on first query, in production, behind a green build) · `_entity-names.ts` (a drift spec enforces it) · the Tier C drift spec. `WorkflowRepository` is feature-owned, so it's provided by its own module rather than the DatabaseModule inventory.

## Gates

agent **463 suites / 8467 tests** · api **245 suites / 3965 tests** · `pnpm format:check` clean · type-check clean · real non-preview Nest bootstrap resolving `WorkflowsService` · migration spec green under better-sqlite3 · OpenAPI spec showing all five routes at `/api/workflows`.

Reads are owner-scoped throughout, and a workflow belonging to someone else is **404, never 403**, so the collection can't be used to probe which ids exist. There is deliberately no bare `findById` on the repository — the absence is what stops one being written by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated workflow management through the API.
  * Create, view, update, delete, filter, and paginate saved workflows.
  * Added workflow statuses: Draft, Active, and Archived.
  * Added validation for workflow structure, supported nodes, and graph size limits.
  * Added optional Work associations, ownership controls, run tracking, and scoped metadata.

* **Bug Fixes**
  * Prevented unauthorized access to workflows owned by other users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->