### PR TITLE
feat(workflows): execute a saved graph as a dispatched job, with a persisted run record

### DIFF
--- a/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
@@ -17,9 +17,7 @@
 
 const betterAuthMock = jest.fn().mockReturnValue({ __betterAuthInstance: true });
 const bearerMock = jest.fn().mockReturnValue({ __bearerPlugin: true });
-const termsAcceptancePluginMock = jest
-    .fn()
-    .mockReturnValue({ __termsAcceptancePlugin: true });
+const termsAcceptancePluginMock = jest.fn().mockReturnValue({ __termsAcceptancePlugin: true });
 
 jest.mock('better-auth', () => ({
     betterAuth: betterAuthMock,

--- a/apps/api/src/migrations/1784830000000-CreateWorkflowRuns.ts
+++ b/apps/api/src/migrations/1784830000000-CreateWorkflowRuns.ts
@@ -1,0 +1,156 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Judgment layer G5 — the `workflow_runs` table.
+ *
+ * PR #1986 made a graph something a user OWNS. This makes running one
+ * leave a TRACE: until now the only way to execute a graph was an agent
+ * chat tool whose result was handed to a model and then discarded, so
+ * nothing could be reviewed or debugged after the fact.
+ *
+ * ## Deliberately NO scope XOR CHECK
+ *
+ * Same reason as `workflows` (1784820000000): `ScopeStampingSubscriber`
+ * stamps `organizationId` on EVERY insert for any entity declaring both
+ * scope columns, so ordinary rows have both populated and a copied XOR
+ * would abort this migration on real data. That is not hypothetical — it
+ * happened once already when the pattern was copied onto
+ * `work_knowledge_uploads`.
+ *
+ * ## `workflowId` CASCADEs, and that is a deliberate reversal
+ *
+ * `workflows.controller.ts` currently claims deleting a workflow leaves
+ * run records "unaffected". That was written before this table existed
+ * and is not the behaviour shipped here: the FK below is `ON DELETE
+ * CASCADE`, matching `agent_runs`' documented posture on `agents.id`
+ * ("archiving an Agent does NOT lose run history but delete-Agent DOES").
+ *
+ * The alternative — no FK, letting run rows outlive their graph — leaves
+ * permanent orphans whose `workflowId` points at nothing, in a table that
+ * only grows, for rows nobody can interpret without the graph they ran.
+ * A workflow is authored configuration and its delete is already a hard
+ * delete; removing it removes the feature wholesale, history included.
+ * The stale docstring is corrected in the same change so the code and the
+ * comment agree.
+ *
+ * ## Portable DDL
+ *
+ * Built with TypeORM's `Table`/`TableIndex`/`TableForeignKey` API rather
+ * than raw SQL, because production is Postgres while CI and the e2e stack
+ * run better-sqlite3. Raw `gen_random_uuid()` / `CREATE INDEX IF NOT
+ * EXISTS` would work in prod and fail every CI run.
+ *
+ * `trace` and `output` are `text` — what TypeORM's `simple-json` maps to
+ * on every supported driver. Both are written already CAPPED by
+ * `summarizeWorkflowRun`; the raw `nodeOutputs` map (which can hold whole
+ * Knowledge Base documents for a `kb.search` node) is never persisted.
+ *
+ * Forward-only with an idempotent guard (house pattern, mirrors
+ * 1784820000000-CreateWorkflows).
+ */
+export class CreateWorkflowRuns1784830000000 implements MigrationInterface {
+    name = 'CreateWorkflowRuns1784830000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('workflow_runs')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'workflow_runs',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'workflowId', type: 'uuid' },
+                    // Denormalized from the workflow so an owner-scoped
+                    // read of a run needs no join.
+                    { name: 'userId', type: 'uuid' },
+                    // queued | running | completed | failed | cancelled.
+                    { name: 'status', type: 'varchar', length: '16' },
+                    { name: 'triggerRunId', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'startedAt', type: 'timestamp', isNullable: true },
+                    { name: 'finishedAt', type: 'timestamp', isNullable: true },
+                    { name: 'durationMs', type: 'int', isNullable: true },
+                    { name: 'errorMessage', type: 'text', isNullable: true },
+                    // The capped walk record. `simple-json` ⇒ text.
+                    { name: 'trace', type: 'text', isNullable: true },
+                    { name: 'output', type: 'text', isNullable: true },
+                    { name: 'outputTruncated', type: 'boolean', default: false },
+                    { name: 'failureCode', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'failedNodeId', type: 'varchar', length: '128', isNullable: true },
+                    { name: 'stepCount', type: 'int', default: 0 },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // The run-history list for one workflow, newest first, is the
+        // query this table exists to serve. Mirrors
+        // `idx_agent_runs_agent_started`.
+        await queryRunner.createIndex(
+            'workflow_runs',
+            new TableIndex({
+                name: 'idx_workflow_runs_workflow_started',
+                columnNames: ['workflowId', 'startedAt'],
+            }),
+        );
+        await queryRunner.createIndex(
+            'workflow_runs',
+            new TableIndex({ name: 'idx_workflow_runs_status', columnNames: ['status'] }),
+        );
+        await queryRunner.createIndex(
+            'workflow_runs',
+            new TableIndex({ name: 'idx_workflow_runs_user', columnNames: ['userId'] }),
+        );
+        await queryRunner.createIndex(
+            'workflow_runs',
+            new TableIndex({ name: 'idx_workflow_runs_org', columnNames: ['organizationId'] }),
+        );
+
+        // Both FKs are guarded on the referenced table existing so this
+        // cannot explode on a fresh database whose tables are created in a
+        // different order.
+        if (await queryRunner.hasTable('workflows')) {
+            await queryRunner.createForeignKey(
+                'workflow_runs',
+                new TableForeignKey({
+                    name: 'fk_workflow_runs_workflow',
+                    columnNames: ['workflowId'],
+                    referencedTableName: 'workflows',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+        if (await queryRunner.hasTable('users')) {
+            await queryRunner.createForeignKey(
+                'workflow_runs',
+                new TableForeignKey({
+                    name: 'fk_workflow_runs_user',
+                    columnNames: ['userId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Reverting discards run history. Acceptable only because it
+        // removes a feature wholesale rather than mangling rows something
+        // else still reads; an operator running it is choosing that.
+        if (await queryRunner.hasTable('workflow_runs')) {
+            await queryRunner.dropTable('workflow_runs');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateWorkflowRuns.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateWorkflowRuns.spec.ts
@@ -1,0 +1,158 @@
+import { DataSource } from 'typeorm';
+import { CreateWorkflowRuns1784830000000 } from '../1784830000000-CreateWorkflowRuns';
+
+/**
+ * Migration test for the `workflow_runs` table.
+ *
+ * Runs on the same in-memory better-sqlite3 harness as
+ * `CreateWorkflows.spec.ts`, and for the same reason: production is
+ * Postgres while CI and the e2e stack are sqlite, so a migration written
+ * with raw `gen_random_uuid()` / `CREATE INDEX IF NOT EXISTS` would pass
+ * in prod and fail every CI run. Building it with TypeORM's portable
+ * Table API is what makes both work; this spec is what proves it.
+ *
+ * Also pinned: NO scope XOR CHECK. `ScopeStampingSubscriber` stamps
+ * `organizationId` on every insert, so ordinary rows carry both scope
+ * columns and a copied XOR would abort the migration on real data.
+ */
+describe('CreateWorkflowRuns1784830000000', () => {
+    let dataSource: DataSource;
+    const migration = new CreateWorkflowRuns1784830000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('creates the table with every expected column', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('workflow_runs');
+        expect(table).toBeDefined();
+        for (const column of [
+            'id',
+            'workflowId',
+            'userId',
+            'status',
+            'triggerRunId',
+            'startedAt',
+            'finishedAt',
+            'durationMs',
+            'errorMessage',
+            'trace',
+            'output',
+            'outputTruncated',
+            'failureCode',
+            'failedNodeId',
+            'stepCount',
+            'tenantId',
+            'organizationId',
+            'createdAt',
+        ]) {
+            expect(table?.findColumnByName(column)).toBeDefined();
+        }
+
+        await runner.release();
+    });
+
+    it('creates the run-history index the list route depends on', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('workflow_runs');
+        const names = (table?.indices ?? []).map((index) => index.name);
+        expect(names).toEqual(
+            expect.arrayContaining([
+                'idx_workflow_runs_workflow_started',
+                'idx_workflow_runs_status',
+                'idx_workflow_runs_user',
+                'idx_workflow_runs_org',
+            ]),
+        );
+
+        await runner.release();
+    });
+
+    it('is idempotent — a second up() does not throw', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.not.toThrow();
+        await runner.release();
+    });
+
+    // NOTE: these raw inserts supply createdAt explicitly. The column
+    // defaults to `now()`, which Postgres has and sqlite does not —
+    // harmless in practice because every real insert goes through TypeORM,
+    // whose @CreateDateColumn supplies the value from the ORM side.
+    it('accepts a row with BOTH workId-scope org and a tenant set', async () => {
+        // The scope-stamping subscriber populates organizationId on every
+        // insert, so this is the ORDINARY shape. A copied XOR CHECK would
+        // reject it — that is the exact defect this pins against.
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        await expect(
+            dataSource.query(
+                `INSERT INTO "workflow_runs"
+                    ("id","workflowId","userId","status","stepCount","outputTruncated","tenantId","organizationId","createdAt")
+                 VALUES ('r1','w1','u1','queued',0,0,'tenant-1','org-1','2026-08-03')`,
+            ),
+        ).resolves.not.toThrow();
+
+        const rows = await dataSource.query(
+            `SELECT "tenantId", "organizationId", "status" FROM "workflow_runs" WHERE "id" = 'r1'`,
+        );
+        expect(rows[0]).toMatchObject({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            status: 'queued',
+        });
+
+        await runner.release();
+    });
+
+    it('accepts a terminal row carrying a trace and a failure code', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        await dataSource.query(
+            `INSERT INTO "workflow_runs"
+                ("id","workflowId","userId","status","stepCount","outputTruncated","trace","output","failureCode","failedNodeId","durationMs","createdAt")
+             VALUES ('r2','w1','u1','failed',2,0,'{"visited":["a","b"]}','null','node-failed','b',1234,'2026-08-03')`,
+        );
+
+        const rows = await dataSource.query(
+            `SELECT "status","failureCode","failedNodeId","stepCount","durationMs","trace" FROM "workflow_runs" WHERE "id" = 'r2'`,
+        );
+        expect(rows[0]).toMatchObject({
+            status: 'failed',
+            failureCode: 'node-failed',
+            failedNodeId: 'b',
+            stepCount: 2,
+            durationMs: 1234,
+        });
+        expect(JSON.parse(rows[0].trace)).toEqual({ visited: ['a', 'b'] });
+
+        await runner.release();
+    });
+
+    it('down() drops the table', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+
+        expect(await runner.hasTable('workflow_runs')).toBe(false);
+
+        await runner.release();
+    });
+});

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -15,10 +15,14 @@ import {
     SUB_AGENT_DELEGATION_RUNNER,
     SUB_AGENT_DELEGATION_DEPTH_RESOLVER,
     WORKFLOW_NODE_RUNNER,
+    // Moved out of apps/api so the `workflow-run` Trigger.dev task can
+    // bind it too — a worker cannot import from apps/api. The binding
+    // below is unchanged, so the `run_workflow_graph` chat-tool path
+    // behaves exactly as before.
+    WorkflowNodeRunnerService,
 } from '@ever-works/agent/agents';
 import { SubAgentDelegationRunnerService } from '../agents/sub-agent-delegation.runner';
 import { SubAgentDelegationDepthResolverService } from '../agents/sub-agent-delegation-depth.resolver';
-import { WorkflowNodeRunnerService } from '../agents/workflow-node.runner';
 // Memory upgrades M6 — `DecisionConflictService` (the re-litigation
 // guard behind `GET /api/tasks/:id/decision-conflicts`) is provided and
 // exported by `KnowledgeBaseModule`. NestJS only resolves a controller's

--- a/apps/api/src/terms/terms-acceptance.service.ts
+++ b/apps/api/src/terms/terms-acceptance.service.ts
@@ -10,7 +10,11 @@ import { BetterAuthAcceptanceAdapter } from 'terms-acceptance/better-auth';
 import type { BetterAuthDatabase } from 'terms-acceptance/better-auth';
 import { AUTH_RUNTIME_INSTANCE } from '../auth/providers/auth-provider.constants';
 import type { createAuthRuntimeInstance } from '../auth/providers/auth-runtime.instance';
-import { TERMS_ACCEPTANCE_MODEL, corpus, getRequiredTermsDocuments } from './terms-acceptance.corpus';
+import {
+    TERMS_ACCEPTANCE_MODEL,
+    corpus,
+    getRequiredTermsDocuments,
+} from './terms-acceptance.corpus';
 
 /** One document a signup form says it displayed. */
 export interface TermsAcceptanceClaim {
@@ -114,12 +118,14 @@ export class TermsAcceptanceService {
     ): Promise<AcceptanceRecord[]> {
         const recorder = await this.getRecorder();
 
-        const documents: RequiredDocument[] = claims.map(({ documentId, version, sha256, locale }) => ({
-            documentId,
-            version,
-            sha256,
-            locale,
-        }));
+        const documents: RequiredDocument[] = claims.map(
+            ({ documentId, version, sha256, locale }) => ({
+                documentId,
+                version,
+                sha256,
+                locale,
+            }),
+        );
 
         return recorder.recordMany(documents, {
             subjectId: userId,

--- a/apps/api/src/workflows/workflows.controller.ts
+++ b/apps/api/src/workflows/workflows.controller.ts
@@ -26,7 +26,7 @@ import {
     Min,
     MinLength,
 } from 'class-validator';
-import { WorkflowsService } from '@ever-works/agent/services';
+import { WorkflowRunsService, WorkflowsService } from '@ever-works/agent/services';
 import { WorkflowStatus } from '@ever-works/agent/entities';
 import { AuthSessionGuard, CurrentUser } from '../auth';
 import type { AuthenticatedUser } from '@src/auth/types/auth.types';
@@ -119,6 +119,20 @@ export class ListWorkflowsDto {
     offset?: number;
 }
 
+export class ListWorkflowRunsDto {
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    limit?: number;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    offset?: number;
+}
+
 /**
  * Saved workflow graphs (judgment layer G5).
  *
@@ -132,18 +146,27 @@ export class ListWorkflowsDto {
  * is reported as 404 rather than 403 so the collection cannot be used to
  * probe which ids exist.
  *
- * Running is deliberately NOT here. A graph may hold delegate nodes that
- * each wait minutes for a child agent run — up to ~40 minutes for a
+ * Running is dispatched, never awaited. A graph may hold delegate nodes
+ * that each wait minutes for a child agent run — up to ~40 minutes for a
  * maximal graph — against a ~100-second edge timeout, so a synchronous
- * run endpoint could not work. It lands in its own slice as a dispatched
- * job that returns a run id immediately.
+ * run endpoint could not work. `POST :id/run` records a `workflow_runs`
+ * row, hands it to the Trigger.dev `workflow-run` task and answers 202
+ * with the run id; the two GET routes below are how a caller follows it.
+ *
+ * That the endpoint cannot accidentally start awaiting the walk is
+ * structural rather than a convention: `WorkflowRunsService` holds a
+ * DISPATCHER and no executor, and the executor lives in a service only
+ * the worker boots.
  */
 @ApiTags('workflows')
 @ApiBearerAuth()
 @UseGuards(AuthSessionGuard)
 @Controller('api/workflows')
 export class WorkflowsController {
-    constructor(private readonly workflows: WorkflowsService) {}
+    constructor(
+        private readonly workflows: WorkflowsService,
+        private readonly runs: WorkflowRunsService,
+    ) {}
 
     @Get()
     @ApiOperation({
@@ -163,6 +186,28 @@ export class WorkflowsController {
             limit: query.limit ?? 50,
             offset: query.offset ?? 0,
         });
+    }
+
+    // Declared ABOVE `:id` deliberately. `runs/:runId` is two segments and
+    // `:id` is one, so under path-to-regexp v8 they cannot actually
+    // collide — but a future single-segment static route (`@Get('runs')`)
+    // WOULD be shadowed, and because `:id` is piped through
+    // `ParseUUIDPipe` the symptom would be a 400 "uuid is expected" that
+    // reads like a client bug rather than a routing one. Static-before-
+    // param is the house order in the agents/tasks/works controllers.
+    @Get('runs/:runId')
+    @ApiOperation({
+        summary: 'Read one workflow run in full',
+        description:
+            'Includes the capped trace: which nodes ran, each one’s outcome, the edges traversed, any `llm_decide` choices, and the truncated final output. Per-node outputs are deliberately not persisted — a `kb.search` node’s output can be entire Knowledge Base documents.',
+    })
+    @ApiResponse({ status: 200, description: 'The run' })
+    @ApiResponse({ status: 404, description: 'No such run for this user' })
+    async getRun(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('runId', new ParseUUIDPipe()) runId: string,
+    ) {
+        return this.runs.getRun(auth.userId, runId);
     }
 
     @Get(':id')
@@ -213,12 +258,52 @@ export class WorkflowsController {
         return this.workflows.update(auth.userId, id, body);
     }
 
+    @Post(':id/run')
+    @HttpCode(HttpStatus.ACCEPTED)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Run a saved workflow',
+        description:
+            'Records a run and hands it to the job runtime, then returns immediately — it does NOT wait for the graph. A maximal graph walks for ~40 minutes, far past any HTTP timeout. Poll `GET /api/workflows/runs/:runId` for the outcome. The returned run is `queued` when the job runtime accepted it, and `failed` when it did not (rather than a queued row nothing will ever pick up).',
+    })
+    @ApiResponse({ status: 202, description: '{ runId, status }' })
+    @ApiResponse({ status: 404, description: 'No such workflow for this user' })
+    @ApiResponse({ status: 409, description: 'The workflow is archived' })
+    async run(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ) {
+        const run = await this.runs.start(auth.userId, id);
+        return { runId: run.id, status: run.status };
+    }
+
+    @Get(':id/runs')
+    @ApiOperation({
+        summary: 'List a workflow’s run history',
+        description:
+            'Newest first. Returns list ROWS, not full runs — `trace` and `output` are the two columns that can be kilobytes each, so selecting them here would make the list cost scale with what the graphs produced rather than with how many runs there are. Fetch one run for those.',
+    })
+    @ApiQuery({ name: 'limit', required: false, type: Number })
+    @ApiQuery({ name: 'offset', required: false, type: Number })
+    @ApiResponse({ status: 200, description: '{ items, total }' })
+    @ApiResponse({ status: 404, description: 'No such workflow for this user' })
+    async listRuns(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+        @Query() query: ListWorkflowRunsDto,
+    ) {
+        return this.runs.listForWorkflow(auth.userId, id, {
+            limit: query.limit ?? 50,
+            offset: query.offset ?? 0,
+        });
+    }
+
     @Delete(':id')
     @HttpCode(HttpStatus.NO_CONTENT)
     @ApiOperation({
         summary: 'Delete a saved workflow',
         description:
-            'Hard delete — a workflow is authored configuration, not a record of something that happened, so there is nothing here to preserve for audit. Run records are separate rows and are unaffected.',
+            'Hard delete — a workflow is authored configuration, not a record of something that happened, so there is nothing here to preserve for audit. Its run history goes with it: `workflow_runs.workflowId` is ON DELETE CASCADE, matching how deleting an Agent discards its runs. A run record is not interpretable without the graph it ran.',
     })
     @ApiResponse({ status: 204, description: 'Deleted' })
     @ApiResponse({ status: 404, description: 'No such workflow for this user' })

--- a/apps/api/src/workflows/workflows.module.spec.ts
+++ b/apps/api/src/workflows/workflows.module.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * api-side WorkflowsModule — the durable guard that a saved workflow can
+ * actually be RUN.
+ *
+ * `WORKFLOW_RUN_DISPATCHER` is bound in this module, but its only
+ * consumer — `WorkflowRunsService` — is declared in the agent-side
+ * `WorkflowsModule` that this module IMPORTS. NestJS resolves a
+ * provider's dependencies in the injector of the module that DECLARES
+ * it and never walks upward into an importer, so a plain `@Module`
+ * binding here is invisible to the service and its `@Optional()`
+ * injection resolves to `undefined`.
+ *
+ * That failure is total and completely silent: every
+ * `POST /api/workflows/:id/run` takes the "no dispatcher bound" branch,
+ * records the run as dispatch-failed, and still answers 202. The graph is
+ * never walked, while the 202, the persisted row, green unit tests and
+ * green CI all read as a working feature.
+ *
+ * Nothing else in the pipeline catches it:
+ *   - no boot error, because the token is deliberately `@Optional()`;
+ *   - `workflow-runs.service.spec.ts` constructs the service directly
+ *     with a mock dispatcher, so DI is never exercised;
+ *   - CI and e2e run without Trigger.dev configured, where a
+ *     dispatch-failed run is the EXPECTED result anyway;
+ *   - `generate:openapi` runs Nest in PREVIEW mode and never instantiates
+ *     a provider.
+ *
+ * The repo has hit this exact trap twice before —
+ * `IdeaBuildExecutorDispatchModule` and `TasksModule`, the latter marked
+ * "PASS-4 review fix (CRITICAL)" — and both fixed it with `@Global()`.
+ * This spec is what stops a fourth.
+ *
+ * Mocking posture mirrors `agents/agents.module.spec.ts`: stub the heavy
+ * workspace barrels at module scope so the decorator metadata can be
+ * asserted without dragging the entity/zod graph through Jest's CJS
+ * transformer. The dispatcher token is a SYMBOL, so the stub declares it
+ * once and both this spec and the module under test receive the same
+ * instance — the assertion stays honest.
+ */
+
+jest.mock('@ever-works/agent/services', () => ({
+    WorkflowsModule: class AgentWorkflowsModule {},
+}));
+jest.mock('@ever-works/agent/tasks', () => ({
+    WORKFLOW_RUN_DISPATCHER: Symbol('WORKFLOW_RUN_DISPATCHER'),
+}));
+jest.mock('@ever-works/trigger-tasks', () => ({
+    workflowRunTriggerAdapter: { dispatchWorkflowRun: async () => null },
+}));
+jest.mock('../auth/auth.module', () => ({ AuthModule: class AuthModule {} }));
+jest.mock('./workflows.controller', () => ({
+    WorkflowsController: class WorkflowsController {},
+}));
+
+import { WORKFLOW_RUN_DISPATCHER } from '@ever-works/agent/tasks';
+import { workflowRunTriggerAdapter } from '@ever-works/trigger-tasks';
+import { WorkflowsModule } from './workflows.module';
+
+describe('WorkflowsModule (api) — run dispatch wiring', () => {
+    /** Nest's own metadata key, read as the framework writes it. */
+    const GLOBAL_MODULE_METADATA = '__module:global__';
+
+    it('is @Global() — without it the dispatcher never reaches WorkflowRunsService', () => {
+        expect(Reflect.getMetadata(GLOBAL_MODULE_METADATA, WorkflowsModule)).toBe(true);
+    });
+
+    it('binds WORKFLOW_RUN_DISPATCHER to the Trigger.dev adapter', () => {
+        const providers = Reflect.getMetadata('providers', WorkflowsModule) ?? [];
+        const binding = providers.find(
+            (provider: unknown) =>
+                typeof provider === 'object' &&
+                provider !== null &&
+                (provider as { provide?: unknown }).provide === WORKFLOW_RUN_DISPATCHER,
+        );
+        expect(binding).toBeDefined();
+        // Bound to the real adapter, not a placeholder — a `useValue: null`
+        // would satisfy "the token exists" and still never enqueue.
+        expect((binding as { useValue?: unknown }).useValue).toBe(workflowRunTriggerAdapter);
+    });
+
+    it('exports the token so an importing module can consume it too', () => {
+        const exported = Reflect.getMetadata('exports', WorkflowsModule) ?? [];
+        expect(exported).toContain(WORKFLOW_RUN_DISPATCHER);
+    });
+
+    it('still mounts the controller and imports the agent-side module', () => {
+        // Guards the other half: a module that binds the dispatcher but
+        // stops serving the routes would pass every check above.
+        expect(Reflect.getMetadata('controllers', WorkflowsModule) ?? []).toHaveLength(1);
+        expect(Reflect.getMetadata('imports', WorkflowsModule) ?? []).toHaveLength(2);
+    });
+});

--- a/apps/api/src/workflows/workflows.module.ts
+++ b/apps/api/src/workflows/workflows.module.ts
@@ -1,20 +1,61 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { WorkflowsModule as AgentWorkflowsModule } from '@ever-works/agent/services';
+import { WORKFLOW_RUN_DISPATCHER } from '@ever-works/agent/tasks';
+import { workflowRunTriggerAdapter } from '@ever-works/trigger-tasks';
 import { AuthModule } from '../auth/auth.module';
 import { WorkflowsController } from './workflows.controller';
 
 /**
- * API surface for saved workflow graphs (judgment layer G5).
+ * API surface for saved workflow graphs and their runs (judgment layer
+ * G5).
  *
- * Mounts the controller only; the service + repository live in the
- * agent-side `WorkflowsModule`, which this imports for
- * `WorkflowsService`. `AuthModule` is imported because the controller's
- * `AuthSessionGuard` is resolved through DI — without it the module
- * compiles and then fails to instantiate the guard at boot, which no
- * unit test would catch.
+ * Mounts the controller only; the services + repositories live in the
+ * agent-side `WorkflowsModule`, which this imports for `WorkflowsService`
+ * and `WorkflowRunsService`. `AuthModule` is imported because the
+ * controller's `AuthSessionGuard` is resolved through DI — without it the
+ * module compiles and then fails to instantiate the guard at boot, which
+ * no unit test would catch.
+ *
+ * ## The dispatcher binding
+ *
+ * `WORKFLOW_RUN_DISPATCHER` is bound HERE rather than inside the agent
+ * package because the adapter carries the `@trigger.dev/sdk` dependency,
+ * which `@ever-works/agent` deliberately does not take. Same shape as
+ * `IdeaBuildExecutorDispatchModule`.
+ *
+ * `WorkflowRunsService` injects the token `@Optional()`, so an install
+ * without a job runtime still boots and still serves the read routes —
+ * `POST :id/run` then records the run as dispatch-failed with the reason
+ * rather than leaving a `queued` row nothing will ever pick up.
+ *
+ * ## `@Global()` is LOAD-BEARING, not decoration
+ *
+ * The consumer, `WorkflowRunsService`, is declared in the agent-side
+ * `WorkflowsModule` that this module IMPORTS. NestJS resolves a
+ * provider's dependencies in the injector of the module that DECLARES
+ * it — it never walks upward into an importer — so a plain `@Module`
+ * binding here is invisible to the service, and the `@Optional()`
+ * injection silently resolves to `undefined`.
+ *
+ * The failure mode is total and silent: every `POST :id/run` takes the
+ * "no dispatcher bound" branch, records the run dispatch-failed, and
+ * answers 202 — so the feature looks complete while never enqueuing
+ * anything. Nothing else catches it. There is no boot error (the token
+ * is `@Optional()`), unit tests construct the service with a mock, and
+ * CI/e2e have no Trigger.dev configured so a failed run is the expected
+ * result there anyway.
+ *
+ * This is the third time the repo has hit it —
+ * `IdeaBuildExecutorDispatchModule` and `TasksModule` (the latter marked
+ * "PASS-4 review fix (CRITICAL)") both carry `@Global()` for exactly
+ * this reason. `workflows.module.spec.ts` pins it so a fourth is caught
+ * by a unit test rather than in production.
  */
+@Global()
 @Module({
     imports: [AgentWorkflowsModule, AuthModule],
     controllers: [WorkflowsController],
+    providers: [{ provide: WORKFLOW_RUN_DISPATCHER, useValue: workflowRunTriggerAdapter }],
+    exports: [WORKFLOW_RUN_DISPATCHER],
 })
 export class WorkflowsModule {}

--- a/packages/agent/src/agents/__tests__/workflow-run-trace.spec.ts
+++ b/packages/agent/src/agents/__tests__/workflow-run-trace.spec.ts
@@ -1,0 +1,166 @@
+import type { WorkflowRunResult } from '../workflow-graph-executor.service';
+import {
+    summarizeWorkflowRun,
+    WORKFLOW_RUN_MAX_ERROR_CHARS,
+    WORKFLOW_RUN_MAX_ERRORS,
+    WORKFLOW_RUN_MAX_NODE_ID_CHARS,
+    WORKFLOW_RUN_MAX_OUTPUT_CHARS,
+    WORKFLOW_RUN_MAX_RATIONALE_CHARS,
+    WORKFLOW_RUN_MAX_TRACE_ENTRIES,
+} from '../workflow-run-trace';
+
+/**
+ * What a run row is allowed to hold.
+ *
+ * The failure this guards against is not a crash — it is a table whose
+ * row size is a function of how much content the user's Knowledge Base
+ * happens to contain. `WorkflowRunResult.nodeOutputs` maps every visited
+ * node to its FULL output, and a `kb.search` node's output is up to ten
+ * entire KB documents. `agent-workflow-tools.ts` already truncates its
+ * own projection for exactly this reason before letting the value near a
+ * model context; a persisted row needs the same discipline, forever.
+ */
+describe('summarizeWorkflowRun', () => {
+    const result = (over: Partial<WorkflowRunResult> = {}): WorkflowRunResult =>
+        ({
+            status: 'completed',
+            runId: 'run-1',
+            visited: ['a', 'b'],
+            traversedEdges: ['e-ab'],
+            nodes: [
+                { nodeId: 'a', viaEdgeId: null, ok: true },
+                { nodeId: 'b', viaEdgeId: 'e-ab', ok: true },
+            ],
+            decisions: [],
+            output: { ok: true },
+            nodeOutputs: { a: { huge: 'x' }, b: { huge: 'y' } },
+            errors: [],
+            ...over,
+        }) as WorkflowRunResult;
+
+    it('keeps the visited list, the per-node outcome and the traversed edges', async () => {
+        const summary = summarizeWorkflowRun(result());
+        expect(summary.trace.visited).toEqual(['a', 'b']);
+        expect(summary.trace.traversedEdges).toEqual(['e-ab']);
+        expect(summary.trace.nodes).toEqual([
+            { nodeId: 'a', ok: true },
+            { nodeId: 'b', ok: true },
+        ]);
+        expect(summary.stepCount).toBe(2);
+    });
+
+    it('NEVER carries nodeOutputs — the unbounded field this cap exists for', () => {
+        const summary = summarizeWorkflowRun(result());
+        // Serialize the whole trace: the per-node payloads must not be
+        // reachable anywhere inside it, by any key.
+        expect(JSON.stringify(summary.trace)).not.toContain('huge');
+        expect(summary.trace).not.toHaveProperty('nodeOutputs');
+    });
+
+    it('passes a small output through unchanged and flags nothing', () => {
+        const summary = summarizeWorkflowRun(result({ output: { small: true } }));
+        expect(summary.output).toEqual({ small: true });
+        expect(summary.outputTruncated).toBe(false);
+    });
+
+    it('truncates an oversized output and says that it did', () => {
+        const huge = { blob: 'x'.repeat(WORKFLOW_RUN_MAX_OUTPUT_CHARS * 2) };
+        const summary = summarizeWorkflowRun(result({ output: huge }));
+
+        expect(summary.outputTruncated).toBe(true);
+        expect(typeof summary.output).toBe('string');
+        expect(summary.output as string).toContain('[truncated');
+        // The marker itself is short — the point is the row stays bounded.
+        expect((summary.output as string).length).toBeLessThan(WORKFLOW_RUN_MAX_OUTPUT_CHARS + 100);
+    });
+
+    it('survives a non-serializable output instead of losing the whole record', () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        const summary = summarizeWorkflowRun(result({ output: circular }));
+        expect(summary.output).toBe('[unserializable output]');
+        expect(summary.outputTruncated).toBe(true);
+    });
+
+    it('caps a node error string', () => {
+        const summary = summarizeWorkflowRun(
+            result({
+                status: 'failed',
+                nodes: [
+                    {
+                        nodeId: 'a',
+                        viaEdgeId: null,
+                        ok: false,
+                        failureCode: 'node-threw',
+                        error: 'E'.repeat(WORKFLOW_RUN_MAX_ERROR_CHARS * 3),
+                    },
+                ],
+            }),
+        );
+        const error = summary.trace.nodes[0].error as string;
+        expect(error.length).toBeLessThan(WORKFLOW_RUN_MAX_ERROR_CHARS + 60);
+        expect(error).toContain('[truncated');
+    });
+
+    it('caps decision rationale — model prose, useful only in the first sentence', () => {
+        const summary = summarizeWorkflowRun(
+            result({
+                decisions: [
+                    {
+                        nodeId: 'a',
+                        choice: 'left',
+                        rationale: 'R'.repeat(WORKFLOW_RUN_MAX_RATIONALE_CHARS * 3),
+                    },
+                ],
+            }),
+        );
+        const rationale = summary.trace.decisions[0].rationale as string;
+        expect(rationale.length).toBeLessThan(WORKFLOW_RUN_MAX_RATIONALE_CHARS + 60);
+    });
+
+    it('caps the trace lists and marks the trace as truncated', () => {
+        const many = Array.from({ length: WORKFLOW_RUN_MAX_TRACE_ENTRIES + 50 }, (_, i) => `n${i}`);
+        const summary = summarizeWorkflowRun(result({ visited: many }));
+
+        expect(summary.trace.visited).toHaveLength(WORKFLOW_RUN_MAX_TRACE_ENTRIES);
+        expect(summary.trace.truncated).toBe(true);
+        // stepCount reports the HONEST count, not what the trace kept.
+        expect(summary.stepCount).toBe(many.length);
+    });
+
+    it('caps the run error list', () => {
+        const errors = Array.from({ length: WORKFLOW_RUN_MAX_ERRORS + 5 }, (_, i) => `err ${i}`);
+        const summary = summarizeWorkflowRun(result({ status: 'failed', errors }));
+        expect(summary.trace.errors).toHaveLength(WORKFLOW_RUN_MAX_ERRORS);
+        expect(summary.trace.truncated).toBe(true);
+    });
+
+    it('truncates a long failedNodeId to fit its varchar(128) column', () => {
+        // Node ids are user-authored and `validateWorkflowGraph` does not
+        // bound their length. Overflowing here would throw on Postgres on
+        // the very write that records a failure, stranding the run in
+        // `running` — and sqlite would never catch it in CI.
+        const summary = summarizeWorkflowRun(
+            result({ status: 'failed', failureCode: 'node-failed', failedNodeId: 'n'.repeat(400) }),
+        );
+        expect((summary.failedNodeId as string).length).toBe(WORKFLOW_RUN_MAX_NODE_ID_CHARS);
+        expect(WORKFLOW_RUN_MAX_NODE_ID_CHARS).toBeLessThan(128);
+    });
+
+    it('carries the failure code and failed node through', () => {
+        const summary = summarizeWorkflowRun(
+            result({ status: 'failed', failureCode: 'max-steps-exceeded', failedNodeId: 'b' }),
+        );
+        expect(summary.failureCode).toBe('max-steps-exceeded');
+        expect(summary.failedNodeId).toBe('b');
+    });
+
+    it('nulls the codes on a clean run rather than leaving them undefined', () => {
+        // `undefined` and `null` round-trip differently through a
+        // simple-json column; the row should read the same either way.
+        const summary = summarizeWorkflowRun(result());
+        expect(summary.failureCode).toBeNull();
+        expect(summary.failedNodeId).toBeNull();
+        expect(summary.trace.truncated).toBeUndefined();
+    });
+});

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -36,6 +36,13 @@ export * from './run-dispatch-gate.service';
 export * from './workflow-graph.ports';
 export * from './workflow-graph-executor.service';
 export * from './workflow-ai-decision.adapter';
+// The real node runner. It lives here rather than api-side because the
+// Trigger.dev worker that executes a saved graph has to bind
+// WORKFLOW_NODE_RUNNER too, and a worker cannot import from apps/api.
+export * from './workflow-node.runner';
+// What of a run is worth persisting — the cap that keeps a run row from
+// scaling with the size of the data the graph touched.
+export * from './workflow-run-trace';
 // Judgment layer G9 — scoped sub-agent delegation with a typed result.
 export * from './sub-agent-delegation.port';
 export * from './sub-agent-delegation.service';

--- a/packages/agent/src/agents/workflow-node.runner.spec.ts
+++ b/packages/agent/src/agents/workflow-node.runner.spec.ts
@@ -1,16 +1,16 @@
-// Mock the agent barrels this spec injects through. Importing
-// `@ever-works/agent/services` for real pulls the whole services barrel,
-// which reaches `@src/*` path aliases that do not resolve under the API
-// jest config. The classes are only needed as DI tokens here.
-jest.mock('@ever-works/agent/services', () => ({ KnowledgeBaseService: class {} }));
-jest.mock('@ever-works/agent/agents', () => ({ SubAgentDelegationService: class {} }));
-jest.mock('@ever-works/agent/facades', () => ({ AiFacadeService: class {} }));
+// The three collaborators are only needed as DI TOKENS here — every test
+// injects a stub. Mocking them keeps this spec from dragging in the real
+// KB service and AI facade (and their repository/plugin chains) just to
+// have a class to key the provider off.
+jest.mock('../services/knowledge-base.service', () => ({ KnowledgeBaseService: class {} }));
+jest.mock('./sub-agent-delegation.service', () => ({ SubAgentDelegationService: class {} }));
+jest.mock('../facades/ai.facade', () => ({ AiFacadeService: class {} }));
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { WorkflowNodeRunnerService } from './workflow-node.runner';
-import { SubAgentDelegationService } from '@ever-works/agent/agents';
-import { AiFacadeService } from '@ever-works/agent/facades';
-import { KnowledgeBaseService } from '@ever-works/agent/services';
+import { SubAgentDelegationService } from './sub-agent-delegation.service';
+import { AiFacadeService } from '../facades/ai.facade';
+import { KnowledgeBaseService } from '../services/knowledge-base.service';
 
 /**
  * The real workflow node runner.

--- a/packages/agent/src/agents/workflow-node.runner.ts
+++ b/packages/agent/src/agents/workflow-node.runner.ts
@@ -4,10 +4,14 @@ import type {
     WorkflowNodeRunContext,
     WorkflowNodeRunResult,
     WorkflowNodeRunner,
-} from '@ever-works/agent/agents';
-import { SubAgentDelegationService } from '@ever-works/agent/agents';
-import { AiFacadeService } from '@ever-works/agent/facades';
-import { KnowledgeBaseService } from '@ever-works/agent/services';
+} from './workflow-graph.ports';
+import { SubAgentDelegationService } from './sub-agent-delegation.service';
+import { AiFacadeService } from '../facades/ai.facade';
+// `agents/ -> services/` is an established value-import direction here
+// (`agent-run.service.ts` imports VisionContextService and memory-recall
+// the same way). The forbidden direction is `agents/ -> tasks-domain`,
+// which is what AGENT_DOMAIN_TOOL_SOURCES exists to prevent.
+import { KnowledgeBaseService } from '../services/knowledge-base.service';
 
 /**
  * The real workflow node runner (judgment layer G5).

--- a/packages/agent/src/agents/workflow-run-trace.ts
+++ b/packages/agent/src/agents/workflow-run-trace.ts
@@ -1,0 +1,240 @@
+import type { WorkflowRunResult } from './workflow-graph-executor.service';
+
+/**
+ * What of a graph run is worth KEEPING (judgment layer G5).
+ *
+ * A `WorkflowRunResult` is built to be handed straight back to a caller
+ * that is about to discard it. A `workflow_runs` row is the opposite: it
+ * outlives the run, and there may be one per execution forever. So the
+ * two cannot store the same thing, and this module is where that
+ * difference is decided — as a pure function, so the rule is testable
+ * without a database.
+ *
+ * ## Why `nodeOutputs` is NOT persisted
+ *
+ * `WorkflowRunResult.nodeOutputs` maps every visited node id to that
+ * node's FULL output. For a `kb.search` node that output is
+ * `KnowledgeBaseService.listDocuments(...)` — up to ten entire Knowledge
+ * Base documents, content included. A graph may hold many such nodes, and
+ * `agent-workflow-tools.ts` already truncates its own projection at
+ * `MAX_OUTPUT_CHARS` (8 000) for exactly this reason before letting the
+ * value near a model context.
+ *
+ * Writing that map to a column would make a single row's size a function
+ * of how much content the user's KB happens to hold — unbounded, on the
+ * hot path of every run, in a table that only ever grows. What a human
+ * reading a run record actually needs is WHICH nodes ran, WHETHER each
+ * one succeeded, and WHY it stopped. That is what is kept.
+ *
+ * The final output is kept too, but capped, because "what did this
+ * produce" is the second question anyone asks after "did it work".
+ */
+
+/**
+ * Cap on the serialized final output. Deliberately the SAME number as
+ * `agent-workflow-tools.ts`'s `MAX_OUTPUT_CHARS`: both answer "how much
+ * of an arbitrary node output is worth carrying", and two different
+ * answers would just be drift.
+ */
+export const WORKFLOW_RUN_MAX_OUTPUT_CHARS = 8_000;
+
+/**
+ * Cap on one node's error string. Node errors are provider/exception
+ * messages, which can carry a whole stack or an echoed request body.
+ */
+export const WORKFLOW_RUN_MAX_ERROR_CHARS = 500;
+
+/**
+ * Cap on decision rationale. Model prose — useful for "why did the graph
+ * go left", worthless past a couple of sentences.
+ */
+export const WORKFLOW_RUN_MAX_RATIONALE_CHARS = 300;
+
+/**
+ * Cap on how many entries each trace list keeps. The executor already
+ * stops at `WORKFLOW_MAX_STEPS_CEILING` (500), so this is not the
+ * primary bound — it is the guard that keeps the row bounded even if
+ * that ceiling is ever raised, and it is what makes `truncated` mean
+ * something.
+ */
+export const WORKFLOW_RUN_MAX_TRACE_ENTRIES = 200;
+
+/** Cap on run-level error strings, mirroring the tool's `slice(0, 10)`. */
+export const WORKFLOW_RUN_MAX_ERRORS = 10;
+
+/**
+ * Cap on the persisted `failedNodeId`, which is a `varchar(128)` column.
+ *
+ * Node ids come from a USER-AUTHORED graph and `validateWorkflowGraph`
+ * bounds their uniqueness but NOT their length, so a 200-character node
+ * id is a legal graph. Without this cap the terminal write would throw on
+ * Postgres (sqlite silently ignores varchar limits, so CI and e2e would
+ * never see it) — and it would throw on the very path that records a
+ * failure, leaving the run stuck in `running` forever. Truncating loses a
+ * little of an id; not truncating loses the whole run record.
+ */
+export const WORKFLOW_RUN_MAX_NODE_ID_CHARS = 120;
+
+export interface WorkflowRunNodeTraceEntry {
+    readonly nodeId: string;
+    readonly ok: boolean;
+    readonly failureCode?: string;
+    readonly error?: string;
+}
+
+export interface WorkflowRunDecisionTraceEntry {
+    readonly nodeId: string;
+    readonly choice: string;
+    readonly rationale?: string;
+    readonly degraded?: boolean;
+}
+
+/**
+ * The persisted account of a run. Everything here is bounded by a
+ * constant above — nothing scales with the size of the data the graph
+ * touched.
+ */
+export interface WorkflowRunTrace {
+    /** Node ids in execution order — the headline "what ran". */
+    readonly visited: readonly string[];
+    /** Per-node outcome. NOT per-node output — see the module note. */
+    readonly nodes: readonly WorkflowRunNodeTraceEntry[];
+    /** Edge ids in traversal order. */
+    readonly traversedEdges: readonly string[];
+    readonly decisions: readonly WorkflowRunDecisionTraceEntry[];
+    readonly errors: readonly string[];
+    /** True when any list above was cut short by a cap. */
+    readonly truncated?: boolean;
+}
+
+export interface SummarizedWorkflowRun {
+    readonly trace: WorkflowRunTrace;
+    /**
+     * The last green node's output, capped. Mirrors the tool's
+     * `projectOutput`: the VALUE when it serializes small enough, and a
+     * truncation marker string when it does not — so a consumer never
+     * has to guess whether it is looking at data or at a notice.
+     */
+    readonly output: unknown;
+    readonly outputTruncated: boolean;
+    readonly failureCode: string | null;
+    readonly failedNodeId: string | null;
+    /** How many nodes actually executed. */
+    readonly stepCount: number;
+}
+
+function capString(value: string, max: number): string {
+    if (value.length <= max) return value;
+    return `${value.slice(0, max)}… [truncated ${value.length - max} chars]`;
+}
+
+/**
+ * Cap an arbitrary output the way the chat tool does.
+ *
+ * Returns `{ value, truncated }` rather than just the value so the caller
+ * can record that a cap fired — otherwise "the output was the string
+ * '… [truncated N chars]'" is indistinguishable from a node that genuinely
+ * returned that text.
+ */
+function capOutput(value: unknown): { value: unknown; truncated: boolean } {
+    if (value === null || value === undefined) return { value: null, truncated: false };
+    let serialized: string;
+    try {
+        serialized = JSON.stringify(value) ?? '';
+    } catch {
+        // A circular or non-serializable output is a runner bug, not a
+        // reason to lose the whole run record after the work happened.
+        return { value: '[unserializable output]', truncated: true };
+    }
+    if (serialized.length <= WORKFLOW_RUN_MAX_OUTPUT_CHARS) return { value, truncated: false };
+    return {
+        value: `${serialized.slice(0, WORKFLOW_RUN_MAX_OUTPUT_CHARS)}… [truncated ${
+            serialized.length - WORKFLOW_RUN_MAX_OUTPUT_CHARS
+        } chars]`,
+        truncated: true,
+    };
+}
+
+/**
+ * Reduce an executor result to the bounded record that goes on the row.
+ *
+ * Pure and total: it never throws, because it runs on the completion path
+ * of a run that has already done its work — losing the record there would
+ * turn a successful run into an invisible one.
+ */
+export function summarizeWorkflowRun(result: WorkflowRunResult): SummarizedWorkflowRun {
+    const capList = <T>(items: readonly T[] | undefined): { items: T[]; truncated: boolean } => {
+        const list = items ?? [];
+        if (list.length <= WORKFLOW_RUN_MAX_TRACE_ENTRIES) {
+            return { items: [...list], truncated: false };
+        }
+        return { items: list.slice(0, WORKFLOW_RUN_MAX_TRACE_ENTRIES), truncated: true };
+    };
+
+    const visited = capList(result.visited);
+    const traversedEdges = capList(result.traversedEdges);
+    const rawNodes = capList(result.nodes);
+    const rawDecisions = capList(result.decisions);
+
+    const nodes: WorkflowRunNodeTraceEntry[] = rawNodes.items.map((node) => {
+        const entry: WorkflowRunNodeTraceEntry = { nodeId: node.nodeId, ok: node.ok };
+        // Explicit property adds rather than conditional spreads: `...(x &&
+        // {k: v})` widens to `false` and breaks this package's declaration
+        // emit (the DTS gotcha in CLAUDE.md).
+        const out = entry as { failureCode?: string; error?: string };
+        if (node.failureCode) out.failureCode = node.failureCode;
+        if (node.error) out.error = capString(node.error, WORKFLOW_RUN_MAX_ERROR_CHARS);
+        return entry;
+    });
+
+    const decisions: WorkflowRunDecisionTraceEntry[] = rawDecisions.items.map((decision) => {
+        const entry: WorkflowRunDecisionTraceEntry = {
+            nodeId: decision.nodeId,
+            choice: decision.choice,
+        };
+        const out = entry as { rationale?: string; degraded?: boolean };
+        if (decision.rationale) {
+            out.rationale = capString(decision.rationale, WORKFLOW_RUN_MAX_RATIONALE_CHARS);
+        }
+        if (decision.degraded) out.degraded = true;
+        return entry;
+    });
+
+    const errors = (result.errors ?? [])
+        .slice(0, WORKFLOW_RUN_MAX_ERRORS)
+        .map((error) => capString(error, WORKFLOW_RUN_MAX_ERROR_CHARS));
+
+    const truncated =
+        visited.truncated ||
+        traversedEdges.truncated ||
+        rawNodes.truncated ||
+        rawDecisions.truncated ||
+        (result.errors?.length ?? 0) > WORKFLOW_RUN_MAX_ERRORS;
+
+    const trace: WorkflowRunTrace = {
+        visited: visited.items,
+        nodes,
+        traversedEdges: traversedEdges.items,
+        decisions,
+        errors,
+    };
+    if (truncated) (trace as { truncated?: boolean }).truncated = true;
+
+    const output = capOutput(result.output);
+
+    return {
+        trace,
+        output: output.value,
+        outputTruncated: output.truncated,
+        failureCode: result.failureCode ?? null,
+        // Hard-truncated (not marked): this feeds a varchar(128) column.
+        // See WORKFLOW_RUN_MAX_NODE_ID_CHARS — a truncation marker would
+        // itself push the value back over the limit.
+        failedNodeId: result.failedNodeId
+            ? result.failedNodeId.slice(0, WORKFLOW_RUN_MAX_NODE_ID_CHARS)
+            : null,
+        // `visited` BEFORE the cap — the count is the honest number of
+        // executed nodes, not the number the trace happened to keep.
+        stepCount: result.visited?.length ?? 0,
+    };
+}

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -133,6 +133,7 @@ import { TerminalTranscriptChunk } from '../entities/terminal-transcript-chunk.e
 import { FleetJob } from '../entities/fleet-job.entity';
 import { ToolGrant } from '../entities/tool-grant.entity';
 import { Workflow } from '../entities/workflow.entity';
+import { WorkflowRun } from '../entities/workflow-run.entity';
 
 import {
     PluginEntity,
@@ -324,4 +325,7 @@ export const ENTITIES = [
     // Workflows (judgment layer G5) — saved graphs. Until this row
     // existed a graph could be executed but never KEPT.
     Workflow,
+    // One execution of a saved graph. The row is created `queued` by the
+    // API and finished by the `workflow-run` Trigger.dev task.
+    WorkflowRun,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -149,6 +149,9 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     // ──────────────────────────────────────────────────────────
     // Streaming-terminal M9 / D1 — persisted terminal transcripts.
     'TerminalTranscriptChunk',
+    // Signup terms acceptance. Already in `_entities-inventory.ts`; this
+    // list was the missed half of the two-step registration.
+    'TermsAcceptance',
     // Tool-grant matrix (audit item G4) — per-scope tool allow/deny rows.
     'ToolGrant',
     'UsageLedgerEntry',
@@ -185,4 +188,5 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'WorkProposalAttachment',
     'WorkSchedule',
     'Workflow',
+    'WorkflowRun',
 ] as const;

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -77,3 +77,4 @@ export * from './repositories/organization-notification-default.repository';
 export * from './repositories/organization-onboarding-profile.repository';
 export * from './database-init.service';
 export * from './repositories/workflow.repository';
+export * from './repositories/workflow-run.repository';

--- a/packages/agent/src/database/repositories/workflow-run.repository.ts
+++ b/packages/agent/src/database/repositories/workflow-run.repository.ts
@@ -1,0 +1,263 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkflowRun, type WorkflowRunStatus } from '../../entities/workflow-run.entity';
+
+/** Source states a run may still be moved out of. */
+const NON_TERMINAL: WorkflowRunStatus[] = ['queued', 'running'];
+/** Narrower source set for a dispatch rollback — see `markDispatchFailed`. */
+const QUEUED_ONLY: WorkflowRunStatus[] = ['queued'];
+
+export interface CreateWorkflowRunInput {
+    workflowId: string;
+    userId: string;
+}
+
+/**
+ * Everything a finished walk writes back. Typed off the entity so adding
+ * a column cannot drift the patch shape out of sync with the row.
+ */
+export type WorkflowRunTerminalPatch = Partial<
+    Pick<
+        WorkflowRun,
+        | 'trace'
+        | 'output'
+        | 'outputTruncated'
+        | 'failureCode'
+        | 'failedNodeId'
+        | 'stepCount'
+        | 'errorMessage'
+    >
+>;
+
+/** The projection behind `GET /api/workflows/:id/runs`. */
+export type WorkflowRunListRow = Pick<
+    WorkflowRun,
+    | 'id'
+    | 'workflowId'
+    | 'status'
+    | 'startedAt'
+    | 'finishedAt'
+    | 'durationMs'
+    | 'failureCode'
+    | 'stepCount'
+    | 'createdAt'
+>;
+
+const LIST_COLUMNS: (keyof WorkflowRun)[] = [
+    'id',
+    'workflowId',
+    'status',
+    'startedAt',
+    'finishedAt',
+    'durationMs',
+    'failureCode',
+    'stepCount',
+    'createdAt',
+];
+
+/**
+ * Persistence for workflow graph runs (judgment layer G5).
+ *
+ * Owner-scoped like `WorkflowRepository`: every read by id takes a
+ * `userId`, so a foreign run resolves to `null` and the service reports
+ * 404 rather than 403 — the collection cannot be used to probe which run
+ * ids exist.
+ *
+ * ## Every status move is a CAS
+ *
+ * Transitions are conditional UPDATEs that name the states they are
+ * allowed to move FROM, and report success as `affected > 0`. The API
+ * creates the row and a separately-deployed worker finishes it, so two
+ * writers genuinely race: an unconditional `update({id}, {status})` would
+ * let a dispatch-rollback overwrite a run the worker had already started,
+ * or a late sweeper reopen a finished one. Same posture, and the same
+ * `NON_TERMINAL` / `QUEUED_ONLY` split, as `AgentRunRepository`.
+ *
+ * Scope columns (`tenantId` / `organizationId`) are never written here —
+ * `ScopeStampingSubscriber` stamps them from the active request scope on
+ * insert, and it only fills `undefined`, so assigning them (even to
+ * `null`) would suppress it.
+ */
+@Injectable()
+export class WorkflowRunRepository {
+    private readonly logger = new Logger(WorkflowRunRepository.name);
+
+    constructor(
+        @InjectRepository(WorkflowRun)
+        private readonly repository: Repository<WorkflowRun>,
+    ) {}
+
+    async createQueued(input: CreateWorkflowRunInput): Promise<WorkflowRun> {
+        const run = this.repository.create({
+            workflowId: input.workflowId,
+            userId: input.userId,
+            status: 'queued',
+            stepCount: 0,
+            outputTruncated: false,
+        });
+        return this.repository.save(run);
+    }
+
+    /**
+     * The ONLY read by id, and it is owner-scoped on purpose — a caller
+     * that cannot name the owner has no business reading the row, and the
+     * absence of a bare `findById` is what stops one being written by
+     * accident.
+     */
+    async findByIdAndUser(id: string, userId: string): Promise<WorkflowRun | null> {
+        return this.repository.findOne({ where: { id, userId } });
+    }
+
+    /**
+     * Run history for one workflow, newest first. Returns a PROJECTION,
+     * not the entity: a list view has no use for `trace` or `output`, and
+     * those are the two columns that can be kilobytes each — selecting
+     * them would make the list cost scale with how much the graphs
+     * produced rather than with how many runs there are.
+     */
+    async listForWorkflow(
+        workflowId: string,
+        userId: string,
+        options: { limit?: number; offset?: number } = {},
+    ): Promise<{ items: WorkflowRunListRow[]; total: number }> {
+        const [items, total] = await this.repository.findAndCount({
+            where: { workflowId, userId },
+            select: LIST_COLUMNS,
+            order: { createdAt: 'DESC' },
+            take: options.limit ?? 50,
+            skip: options.offset ?? 0,
+        });
+        return { items, total };
+    }
+
+    /**
+     * `queued | running → running`.
+     *
+     * `running` is an allowed source so a Trigger.dev retry of the same
+     * run re-resolves an already-started row instead of failing to claim
+     * it. `triggerRunId` is only written when supplied, so a caller
+     * without one cannot erase an enqueue-time stamp.
+     */
+    async markStarted(runId: string, triggerRunId?: string | null): Promise<boolean> {
+        const patch: Partial<WorkflowRun> = { status: 'running', startedAt: new Date() };
+        if (triggerRunId) patch.triggerRunId = triggerRunId;
+
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(WorkflowRun)
+            .set(patch)
+            .where('id = :runId', { runId })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /** Stamp the Trigger.dev run id without disturbing status. */
+    async setTriggerRunId(runId: string, triggerRunId: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(WorkflowRun)
+            .set({ triggerRunId })
+            .where('id = :runId', { runId })
+            .andWhere('"triggerRunId" IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    async markCompleted(runId: string, patch: WorkflowRunTerminalPatch = {}): Promise<boolean> {
+        return this.casTerminal(runId, NON_TERMINAL, { ...patch, status: 'completed' });
+    }
+
+    async markFailed(
+        runId: string,
+        errorMessage: string | null,
+        patch: WorkflowRunTerminalPatch = {},
+    ): Promise<boolean> {
+        return this.casTerminal(runId, NON_TERMINAL, {
+            ...patch,
+            status: 'failed',
+            errorMessage: errorMessage ?? patch.errorMessage ?? null,
+        });
+    }
+
+    /**
+     * `queued → failed`, and deliberately NOT from `running`.
+     *
+     * Used when the enqueue call itself failed. If the dispatcher threw
+     * AFTER Trigger.dev had already accepted the job, the worker owns the
+     * row from `markStarted` onward and this rollback must no-op rather
+     * than kill a live run. Mirrors `AgentRunRepository.markDispatchFailed`.
+     */
+    async markDispatchFailed(runId: string, errorMessage: string): Promise<boolean> {
+        return this.casTerminal(runId, QUEUED_ONLY, { status: 'failed', errorMessage });
+    }
+
+    async markCancelled(runId: string, userId: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(WorkflowRun)
+            .set({ status: 'cancelled', finishedAt: new Date() })
+            .where('id = :runId', { runId })
+            .andWhere('"userId" = :userId', { userId })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * The shared terminal write: stamps `finishedAt` + `durationMs` and
+     * applies the patch in ONE conditional update, so the two can never
+     * disagree.
+     *
+     * The `startedAt` read is deliberately not atomic with the write —
+     * same trade `AgentRunRepository.casTerminal` documents. A
+     * `markStarted` landing in between yields `durationMs: null` for a run
+     * that had executed ~0 ms anyway, and pushing the subtraction into SQL
+     * would be dialect-specific (prod Postgres, CI/e2e better-sqlite3).
+     * Nothing branches on `durationMs`; it is a reporting field.
+     */
+    private async casTerminal(
+        runId: string,
+        allowedFrom: WorkflowRunStatus[],
+        patch: Partial<WorkflowRun>,
+    ): Promise<boolean> {
+        const now = new Date();
+        const existing = await this.repository.findOne({
+            where: { id: runId },
+            select: ['id', 'startedAt'],
+        });
+        const durationMs = existing?.startedAt
+            ? now.getTime() - new Date(existing.startedAt).getTime()
+            : null;
+
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(WorkflowRun)
+            .set({ ...patch, finishedAt: now, durationMs })
+            .where('id = :runId', { runId })
+            .andWhere('status IN (:...statuses)', { statuses: allowedFrom })
+            .execute();
+
+        const ok = (result.affected ?? 0) > 0;
+        if (!ok) await this.warnTerminalNoOp(runId, String(patch.status));
+        return ok;
+    }
+
+    /**
+     * A refused transition is logged with the status that actually won,
+     * so an operator can tell "the row vanished" from "a worker beat us
+     * to it" — the two have completely different causes.
+     */
+    private async warnTerminalNoOp(runId: string, intent: string): Promise<void> {
+        const current = await this.repository.findOne({
+            where: { id: runId },
+            select: ['id', 'status'],
+        });
+        this.logger.warn(
+            current
+                ? `workflow run ${runId}: refused to mark ${intent} — status is already '${current.status}'`
+                : `workflow run ${runId}: refused to mark ${intent} — no such row`,
+        );
+    }
+}

--- a/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
+++ b/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
@@ -28,6 +28,7 @@ import { WorkKnowledgeTag } from '../work-knowledge-tag.entity';
 import { WorkKnowledgeUpload } from '../work-knowledge-upload.entity';
 import { WorkMember } from '../work-member.entity';
 import { Workflow } from '../workflow.entity';
+import { WorkflowRun } from '../workflow-run.entity';
 
 /**
  * EW-657 (Tenants & Organizations Phase 5a) — Tier C scope-column
@@ -84,6 +85,7 @@ describe('Tier C entities — Phase 5a scope columns', () => {
         { name: 'PluginUsageEvent', target: PluginUsageEvent },
         { name: 'ActivityLog', target: ActivityLog },
         { name: 'Workflow', target: Workflow },
+        { name: 'WorkflowRun', target: WorkflowRun },
     ];
 
     for (const { name, target } of tierC) {

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -149,3 +149,6 @@ export * from './fleet-job.entity';
 // Tool-grant matrix (audit item G4) — per-scope tool allow/deny rows.
 export * from './tool-grant.entity';
 export * from './workflow.entity';
+// One execution of a saved graph — what makes running a workflow leave a
+// trace instead of vanishing into a chat tool's return value.
+export * from './workflow-run.entity';

--- a/packages/agent/src/entities/workflow-run.entity.ts
+++ b/packages/agent/src/entities/workflow-run.entity.ts
@@ -1,0 +1,159 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { PortableDateColumn } from './_types';
+import type { WorkflowRunTrace } from '../agents/workflow-run-trace';
+
+/**
+ * Run lifecycle. Deliberately the SAME five members as
+ * {@link AgentRunStatus}, because a workflow run and an agent run are the
+ * same kind of thing to everything that watches them — a dispatcher
+ * creates the row, a worker picks it up, it ends one of three ways.
+ *
+ * - `queued`    — row inserted by the API; the Trigger.dev run is pending.
+ * - `running`   — the worker picked it up.
+ * - `completed` — the graph walked off the end with its last node green.
+ * - `failed`    — a node failed uncaught, or the run could not proceed.
+ * - `cancelled` — stopped by a human.
+ */
+export type WorkflowRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * One execution of a saved {@link Workflow} graph (judgment layer G5).
+ *
+ * PR #1986 made a graph something a user OWNS. This is what makes running
+ * one something that LEAVES A TRACE — until now the only way to execute a
+ * graph was an agent chat tool whose result was handed to a model and then
+ * discarded, so nothing could be reviewed, re-read, or debugged after the
+ * fact.
+ *
+ * ## Why the row is created by the API and finished by the worker
+ *
+ * The row is inserted `queued` by `POST /api/workflows/:id/run` BEFORE the
+ * Trigger.dev task is enqueued, exactly as `dispatchAgentRun` pre-creates
+ * an `agent_runs` row. That ordering is what makes the run observable from
+ * the moment it is asked for: a request that returns 202 has already
+ * produced something the caller can poll, even if the worker never starts.
+ *
+ * ## Why `blocked` is not a status here
+ *
+ * `WorkflowGraphExecutorService` distinguishes `failed` (the graph's
+ * fault) from `blocked` (no node runner or decider was bound — retryable,
+ * not the author's mistake). That distinction is preserved in
+ * {@link failureCode} (`no-node-runner`, `llm-decide-unavailable`), which
+ * is what those machine tokens are FOR, rather than by adding a sixth
+ * status every consumer would have to learn. A blocked walk lands `failed`
+ * with the code that says why.
+ *
+ * ## The trace is capped, and does not hold node outputs
+ *
+ * See `agents/workflow-run-trace.ts`. In short: `WorkflowRunResult.
+ * nodeOutputs` can hold entire Knowledge Base documents for a `kb.search`
+ * node, so persisting it verbatim would make one row's size a function of
+ * how much content the user's KB holds. What is kept is which nodes ran,
+ * whether each succeeded, and a capped final output.
+ *
+ * ## Scope
+ *
+ * Tier C: declaring BOTH `tenantId` and `organizationId` opts this entity
+ * into `ScopeStampingSubscriber`, which stamps them from the active
+ * request scope on insert — which is why the row must be created in the
+ * API request context, and why neither column is ever set by hand (the
+ * subscriber only fills `undefined`, so assigning `null` would suppress
+ * it). As with `workflows`, there is NO scope XOR CHECK: the stamp means
+ * ordinary rows carry an `organizationId`, and a copied XOR would abort
+ * the migration on real data.
+ */
+@Entity({ name: 'workflow_runs' })
+// Mirrors `idx_agent_runs_agent_started` — the run-history list for one
+// workflow, newest first, is the only query this table exists to serve.
+@Index('idx_workflow_runs_workflow_started', ['workflowId', 'startedAt'])
+@Index('idx_workflow_runs_status', ['status'])
+@Index('idx_workflow_runs_user', ['userId'])
+@Index('idx_workflow_runs_org', ['organizationId'])
+export class WorkflowRun {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** The saved graph this run executed. */
+    @Column('uuid')
+    workflowId: string;
+
+    /**
+     * Owner. Denormalized from the workflow rather than joined, so an
+     * owner-scoped read of a run never has to load the workflow — which is
+     * what lets `GET /api/workflows/runs/:runId` answer 404 for a foreign
+     * id with a single query.
+     */
+    @Column('uuid')
+    userId: string;
+
+    @Column({ type: 'varchar', length: 16 })
+    status: WorkflowRunStatus;
+
+    /** Trigger.dev run id — the handle for cancellation and log lookup. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    triggerRunId?: string | null;
+
+    // MUST be @PortableDateColumn, not a raw `type: 'timestamp'`: CI and
+    // the e2e stack run better-sqlite3, which has no `timestamp` type, so
+    // a raw one makes TypeORM's metadata validation throw
+    // `DataTypeNotSupportedError` and the API cannot boot AT ALL there.
+    // Same decorator as agent_runs' startedAt/finishedAt.
+    @PortableDateColumn({ nullable: true })
+    startedAt?: Date | null;
+
+    @PortableDateColumn({ nullable: true })
+    finishedAt?: Date | null;
+
+    @Column({ type: 'int', nullable: true })
+    durationMs?: number | null;
+
+    @Column({ type: 'text', nullable: true })
+    errorMessage?: string | null;
+
+    /**
+     * The bounded record of the walk — `visited`, per-node outcome,
+     * traversed edges, decisions, run errors. Built by
+     * `summarizeWorkflowRun`; never the raw executor result.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    trace?: WorkflowRunTrace | null;
+
+    /**
+     * The last green node's output, capped at
+     * `WORKFLOW_RUN_MAX_OUTPUT_CHARS`. Holds the VALUE when it fits and a
+     * truncation marker string when it does not — {@link outputTruncated}
+     * is what tells the two apart.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    output?: unknown;
+
+    @Column({ type: 'boolean', default: false })
+    outputTruncated: boolean;
+
+    /**
+     * Why the run stopped, as a stable machine token
+     * (`node-failed`, `max-steps-exceeded`, `no-node-runner`, …). NULL on
+     * a completed run. Never rename these — they are persisted.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    failureCode?: string | null;
+
+    /** The node the run stopped on. NULL when nothing had run yet. */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    failedNodeId?: string | null;
+
+    /** How many nodes executed. 0 on a queued row — nothing has run. */
+    @Column({ type: 'int', default: 0 })
+    stepCount: number;
+
+    // Tenant + Organization scope FKs (Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, same posture as agent-run.entity.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/services/__tests__/workflow-run-executor.service.spec.ts
+++ b/packages/agent/src/services/__tests__/workflow-run-executor.service.spec.ts
@@ -1,0 +1,223 @@
+import { DataSource } from 'typeorm';
+import type { WorkflowGraph, WorkflowNode } from '@ever-works/contracts';
+import { Workflow, WorkflowStatus } from '../../entities/workflow.entity';
+import { WorkflowRun } from '../../entities/workflow-run.entity';
+import { WorkflowRepository } from '../../database/repositories/workflow.repository';
+import { WorkflowRunRepository } from '../../database/repositories/workflow-run.repository';
+import { WorkflowGraphExecutorService } from '../../agents/workflow-graph-executor.service';
+import type { WorkflowNodeRunner, WorkflowNodeRunResult } from '../../agents/workflow-graph.ports';
+import { WorkflowRunExecutorService } from '../workflow-run-executor.service';
+
+/**
+ * The test that matters for the persisted-run slice.
+ *
+ * "A run row was created" passes even if nothing ever executes — which is
+ * exactly the failure this whole PR exists to make impossible. So these
+ * specs run a REAL `WorkflowGraphExecutorService` against a REAL
+ * better-sqlite3 database and assert that the row's TERMINAL STATE
+ * reflects what the node runner actually did:
+ *
+ *   - a runner that fails ⇒ the row lands `failed`, carrying the failure
+ *     code and the node it stopped on;
+ *   - a runner that succeeds ⇒ the row lands `completed`, carrying the
+ *     visited node list in execution order.
+ *
+ * Only the node runner is a stub, because it is the seam whose behaviour
+ * is being varied. Everything between it and the column — edge selection,
+ * trace summarization, the CAS terminal write — is the real code.
+ */
+describe('WorkflowRunExecutorService', () => {
+    let dataSource: DataSource;
+    let workflows: WorkflowRepository;
+    let runs: WorkflowRunRepository;
+
+    /** Two sequential noop nodes, a → b. */
+    const graph: WorkflowGraph = {
+        id: 'g-1',
+        entryNodeId: 'a',
+        nodes: [
+            { id: 'a', kind: 'noop' } as WorkflowNode,
+            { id: 'b', kind: 'noop' } as WorkflowNode,
+        ],
+        edges: [{ id: 'e-ab', from: 'a', to: 'b', kind: 'sequential' }],
+    } as WorkflowGraph;
+
+    /** A node runner with the behaviour each test wants to observe. */
+    const runnerOf = (impl: (node: WorkflowNode) => WorkflowNodeRunResult): WorkflowNodeRunner => ({
+        run: async (node) => impl(node),
+    });
+
+    const buildExecutor = (runner: WorkflowNodeRunner) =>
+        new WorkflowRunExecutorService(workflows, runs, new WorkflowGraphExecutorService(runner));
+
+    const seed = async (over: Partial<Workflow> = {}) => {
+        const workflow = await workflows.create({
+            userId: 'user-1',
+            name: 'Nightly digest',
+            graph,
+            status: WorkflowStatus.ACTIVE,
+            ...over,
+        });
+        const run = await runs.createQueued({ workflowId: workflow.id, userId: 'user-1' });
+        return { workflow, run };
+    };
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [Workflow, WorkflowRun],
+            synchronize: true,
+        });
+        await dataSource.initialize();
+        workflows = new WorkflowRepository(dataSource.getRepository(Workflow));
+        runs = new WorkflowRunRepository(dataSource.getRepository(WorkflowRun));
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('lands `completed` with the visited node list when every node succeeds', async () => {
+        const { run } = await seed();
+
+        const status = await buildExecutor(
+            runnerOf(() => ({ ok: true, output: { done: true } })),
+        ).execute({ workflowRunId: run.id, userId: 'user-1' });
+
+        expect(status).toBe('completed');
+
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('completed');
+        // The whole point: the row knows WHICH nodes ran, in order.
+        expect(row?.trace?.visited).toEqual(['a', 'b']);
+        expect(row?.stepCount).toBe(2);
+        expect(row?.failureCode).toBeNull();
+        expect(row?.trace?.nodes.every((node) => node.ok)).toBe(true);
+        expect(row?.output).toEqual({ done: true });
+    });
+
+    it('lands `failed` with the failure code when the node runner fails', async () => {
+        const { run } = await seed();
+
+        const status = await buildExecutor(
+            runnerOf(() => ({ ok: false, failureCode: 'kb-unavailable', error: 'KB not bound' })),
+        ).execute({ workflowRunId: run.id, userId: 'user-1' });
+
+        expect(status).toBe('failed');
+
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('failed');
+        // `node-failed` is the EXECUTOR's verdict (nothing caught the
+        // failure); the runner's own `kb-unavailable` is preserved on the
+        // node entry, so both halves of the story survive.
+        expect(row?.failureCode).toBe('node-failed');
+        expect(row?.failedNodeId).toBe('a');
+        expect(row?.trace?.nodes[0]).toMatchObject({
+            nodeId: 'a',
+            ok: false,
+            failureCode: 'kb-unavailable',
+        });
+        // It stopped at the failing node — `b` never ran.
+        expect(row?.trace?.visited).toEqual(['a']);
+        expect(row?.errorMessage).toContain('a');
+    });
+
+    it('records the SECOND node failing, so the status tracks the run and not the graph', async () => {
+        // Guards against a terminal status derived from anything other
+        // than the walk: same graph, same first node, different outcome.
+        const { run } = await seed();
+
+        await buildExecutor(
+            runnerOf((node) =>
+                node.id === 'b'
+                    ? { ok: false, failureCode: 'ai-unavailable' }
+                    : { ok: true, output: 1 },
+            ),
+        ).execute({ workflowRunId: run.id, userId: 'user-1' });
+
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('failed');
+        expect(row?.failedNodeId).toBe('b');
+        expect(row?.trace?.visited).toEqual(['a', 'b']);
+        expect(row?.stepCount).toBe(2);
+    });
+
+    it('stamps startedAt, finishedAt and a duration on the terminal row', async () => {
+        const { run } = await seed();
+        expect((await runs.findByIdAndUser(run.id, 'user-1'))?.startedAt).toBeNull();
+
+        await buildExecutor(runnerOf(() => ({ ok: true }))).execute({
+            workflowRunId: run.id,
+            userId: 'user-1',
+            triggerRunId: 'run_abc123',
+        });
+
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.startedAt).toBeInstanceOf(Date);
+        expect(row?.finishedAt).toBeInstanceOf(Date);
+        expect(row?.durationMs).toBeGreaterThanOrEqual(0);
+        expect(row?.triggerRunId).toBe('run_abc123');
+    });
+
+    it('does not re-walk a run that is already terminal (Trigger.dev retry)', async () => {
+        const { run } = await seed();
+        const runner = jest.fn(async () => ({ ok: true }));
+
+        await buildExecutor({ run: runner }).execute({
+            workflowRunId: run.id,
+            userId: 'user-1',
+        });
+        expect(runner).toHaveBeenCalledTimes(2);
+
+        // Second delivery of the same payload. Re-walking would re-pay for
+        // every ai.ask node and re-spawn every delegate node's child run.
+        const status = await buildExecutor({ run: runner }).execute({
+            workflowRunId: run.id,
+            userId: 'user-1',
+        });
+        expect(status).toBe('completed');
+        expect(runner).toHaveBeenCalledTimes(2);
+    });
+
+    it('records a run whose workflow was deleted mid-flight rather than throwing', async () => {
+        const { workflow, run } = await seed();
+        await workflows.remove(workflow.id, 'user-1');
+
+        const status = await buildExecutor(runnerOf(() => ({ ok: true }))).execute({
+            workflowRunId: run.id,
+            userId: 'user-1',
+        });
+
+        expect(status).toBe('failed');
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.failureCode).toBe('workflow-deleted');
+    });
+
+    it('refuses to execute another user’s run', async () => {
+        const { run } = await seed();
+        await expect(
+            buildExecutor(runnerOf(() => ({ ok: true }))).execute({
+                workflowRunId: run.id,
+                userId: 'someone-else',
+            }),
+        ).rejects.toThrow(/not found/i);
+    });
+
+    it('reports `no-node-runner` as a failed row when nothing can execute a node', async () => {
+        // The executor calls this `blocked`; the row has no such status,
+        // and the distinction survives in the failure code.
+        const { run } = await seed();
+
+        const status = await new WorkflowRunExecutorService(
+            workflows,
+            runs,
+            new WorkflowGraphExecutorService(),
+        ).execute({ workflowRunId: run.id, userId: 'user-1' });
+
+        expect(status).toBe('failed');
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.failureCode).toBe('no-node-runner');
+        expect(row?.trace?.visited).toEqual([]);
+    });
+});

--- a/packages/agent/src/services/__tests__/workflow-runs.service.spec.ts
+++ b/packages/agent/src/services/__tests__/workflow-runs.service.spec.ts
@@ -1,0 +1,218 @@
+import { DataSource } from 'typeorm';
+import type { WorkflowGraph, WorkflowNode } from '@ever-works/contracts';
+import { Workflow, WorkflowStatus } from '../../entities/workflow.entity';
+import { WorkflowRun } from '../../entities/workflow-run.entity';
+import { WorkflowRepository } from '../../database/repositories/workflow.repository';
+import { WorkflowRunRepository } from '../../database/repositories/workflow-run.repository';
+import type { WorkflowRunDispatcher } from '../../tasks/workflow-run-dispatcher';
+import { WorkflowRunsService } from '../workflow-runs.service';
+
+/**
+ * The REQUEST side of running a workflow.
+ *
+ * The property these specs exist to protect is that `POST :id/run`
+ * returns without waiting for the graph. A maximal graph walks for ~40
+ * minutes, so an endpoint that awaited it could never answer — and the
+ * regression would not be a crash, it would be a slow timeout under load
+ * that nothing else catches.
+ */
+describe('WorkflowRunsService', () => {
+    let dataSource: DataSource;
+    let workflows: WorkflowRepository;
+    let runs: WorkflowRunRepository;
+
+    const graph: WorkflowGraph = {
+        id: 'g-1',
+        entryNodeId: 'a',
+        nodes: [{ id: 'a', kind: 'noop' } as WorkflowNode],
+        edges: [],
+    } as WorkflowGraph;
+
+    const seedWorkflow = (over: Parameters<WorkflowRepository['create']>[0] | object = {}) =>
+        workflows.create({
+            userId: 'user-1',
+            name: 'Nightly digest',
+            graph,
+            status: WorkflowStatus.ACTIVE,
+            ...over,
+        } as Parameters<WorkflowRepository['create']>[0]);
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [Workflow, WorkflowRun],
+            synchronize: true,
+        });
+        await dataSource.initialize();
+        workflows = new WorkflowRepository(dataSource.getRepository(Workflow));
+        runs = new WorkflowRunRepository(dataSource.getRepository(WorkflowRun));
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    describe('start', () => {
+        it('returns a QUEUED run — it does not walk the graph', async () => {
+            const workflow = await seedWorkflow();
+            const dispatcher: WorkflowRunDispatcher = {
+                dispatchWorkflowRun: jest.fn().mockResolvedValue('run_abc'),
+            };
+            const service = new WorkflowRunsService(workflows, runs, dispatcher);
+
+            const run = await service.start('user-1', workflow.id);
+
+            // If anyone ever made this await the execution, the row would
+            // already be `completed`/`failed` here. `queued` is the proof
+            // that the request handed the work off and returned.
+            expect(run.status).toBe('queued');
+            expect(run.startedAt).toBeNull();
+            expect(run.finishedAt).toBeNull();
+            expect(run.stepCount).toBe(0);
+            expect(run.trace).toBeNull();
+        });
+
+        it('hands the ids to the dispatcher and stamps the returned handle', async () => {
+            const workflow = await seedWorkflow();
+            const dispatch = jest.fn().mockResolvedValue('run_abc');
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: dispatch,
+            });
+
+            const run = await service.start('user-1', workflow.id);
+
+            expect(dispatch).toHaveBeenCalledWith({
+                workflowRunId: run.id,
+                workflowId: workflow.id,
+                userId: 'user-1',
+            });
+            expect(run.triggerRunId).toBe('run_abc');
+        });
+
+        it('bumps the workflow’s runCount and lastRunAt', async () => {
+            // `WorkflowRepository.recordRun` shipped in PR #1986 with no
+            // caller at all — this is the slice that makes it real.
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: jest.fn().mockResolvedValue('run_abc'),
+            });
+
+            await service.start('user-1', workflow.id);
+            await service.start('user-1', workflow.id);
+
+            const after = await workflows.findByIdAndUser(workflow.id, 'user-1');
+            expect(after?.runCount).toBe(2);
+            expect(after?.lastRunAt).toBeInstanceOf(Date);
+        });
+
+        it('records the run as FAILED when the job runtime is not configured', async () => {
+            // A `queued` row nothing will ever pick up reads as "in
+            // progress" forever. The row is the account of what happened,
+            // so it says what happened.
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: jest.fn().mockResolvedValue(null),
+            });
+
+            const run = await service.start('user-1', workflow.id);
+
+            expect(run.status).toBe('failed');
+            // Records that dispatch was not accepted WITHOUT asserting why:
+            // an unconfigured runtime and an auth failure both surface as
+            // `null`, and the adapter is what logs the real cause.
+            expect(run.errorMessage).toMatch(/did not accept the run/i);
+        });
+
+        it('records the run as FAILED when no dispatcher is bound at all', async () => {
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs);
+
+            const run = await service.start('user-1', workflow.id);
+
+            expect(run.status).toBe('failed');
+            expect(run.errorMessage).toMatch(/no workflow run dispatcher/i);
+        });
+
+        it('does not 500 when the dispatcher throws — the row already exists', async () => {
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: jest.fn().mockRejectedValue(new Error('socket hang up')),
+            });
+
+            const run = await service.start('user-1', workflow.id);
+
+            expect(run.status).toBe('failed');
+            expect(run.errorMessage).toBe('socket hang up');
+        });
+
+        it('reports 404 — never 403 — for another user’s workflow', async () => {
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs);
+            await expect(service.start('someone-else', workflow.id)).rejects.toMatchObject({
+                status: 404,
+            });
+        });
+
+        it('refuses to start an archived workflow', async () => {
+            const workflow = await seedWorkflow({ status: WorkflowStatus.ARCHIVED });
+            const service = new WorkflowRunsService(workflows, runs);
+            await expect(service.start('user-1', workflow.id)).rejects.toMatchObject({
+                status: 409,
+            });
+        });
+
+        it('starts a DRAFT workflow — draft is unfinished, not unrunnable', async () => {
+            const workflow = await seedWorkflow({ status: WorkflowStatus.DRAFT });
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: jest.fn().mockResolvedValue('run_abc'),
+            });
+            await expect(service.start('user-1', workflow.id)).resolves.toMatchObject({
+                status: 'queued',
+            });
+        });
+    });
+
+    describe('reads', () => {
+        it('lists a workflow’s runs newest first, without the heavy columns', async () => {
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: jest.fn().mockResolvedValue('run_abc'),
+            });
+            await service.start('user-1', workflow.id);
+            await service.start('user-1', workflow.id);
+
+            const page = await service.listForWorkflow('user-1', workflow.id);
+
+            expect(page.total).toBe(2);
+            expect(page.items).toHaveLength(2);
+            // The projection is the point: `trace` and `output` are the two
+            // columns that can be kilobytes each.
+            expect(page.items[0]).not.toHaveProperty('trace');
+            expect(page.items[0]).not.toHaveProperty('output');
+            expect(page.items[0]).toHaveProperty('status');
+        });
+
+        it('reports 404 for a run list on another user’s workflow', async () => {
+            // Not an empty page — that would read as "no runs yet".
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs);
+            await expect(
+                service.listForWorkflow('someone-else', workflow.id),
+            ).rejects.toMatchObject({ status: 404 });
+        });
+
+        it('reports 404 for another user’s run id', async () => {
+            const workflow = await seedWorkflow();
+            const service = new WorkflowRunsService(workflows, runs, {
+                dispatchWorkflowRun: jest.fn().mockResolvedValue('run_abc'),
+            });
+            const run = await service.start('user-1', workflow.id);
+
+            await expect(service.getRun('someone-else', run.id)).rejects.toMatchObject({
+                status: 404,
+            });
+            await expect(service.getRun('user-1', run.id)).resolves.toMatchObject({ id: run.id });
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -59,3 +59,7 @@ export * from './types/trigger-context.types';
 export type { SourceValidationSettingsDto } from '@ever-works/contracts/api';
 export * from './workflows.service';
 export * from './workflows.module';
+// Graph RUNS — the request side (start/list/read) and the worker side
+// (the walk). Split so the API cannot reach an executor.
+export * from './workflow-runs.service';
+export * from './workflow-run-executor.service';

--- a/packages/agent/src/services/workflow-run-executor.service.ts
+++ b/packages/agent/src/services/workflow-run-executor.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { WorkflowGraphExecutorService } from '../agents/workflow-graph-executor.service';
+import { summarizeWorkflowRun } from '../agents/workflow-run-trace';
+import type { WorkflowRunStatus } from '../entities/workflow-run.entity';
+import { WorkflowRepository } from '../database/repositories/workflow.repository';
+import { WorkflowRunRepository } from '../database/repositories/workflow-run.repository';
+
+export interface ExecuteWorkflowRunInput {
+    readonly workflowRunId: string;
+    readonly userId: string;
+    /** Trigger.dev run id, stamped on the row when the worker claims it. */
+    readonly triggerRunId?: string | null;
+}
+
+/**
+ * Walking a saved graph and recording what happened (judgment layer G5) —
+ * the WORKER side.
+ *
+ * Only the Trigger.dev `workflow-run` task boots this. Its counterpart,
+ * `WorkflowRunsService`, holds a dispatcher and no executor; this one
+ * holds an executor and no dispatcher. Splitting them is what makes "the
+ * API never awaits a graph walk" structural rather than a convention.
+ *
+ * ## The terminal status is the executor's verdict, not a guess
+ *
+ * Whatever `WorkflowGraphExecutorService` returns decides the row. The
+ * executor is documented never to throw on a graph's account — every stop
+ * is a typed `WorkflowRunResult` — so there is exactly one mapping:
+ *
+ *   `completed` → `completed`
+ *   `failed`    → `failed` (+ `failureCode`, `failedNodeId`)
+ *   `blocked`   → `failed` (+ the code that says it was blocked)
+ *
+ * `blocked` collapses into `failed` because the row's status set is the
+ * same five as `agent_runs`, and the distinction the executor draws
+ * (retryable infrastructure gap vs the author's mistake) survives intact
+ * in `failureCode` — `no-node-runner` and `llm-decide-unavailable` say it
+ * precisely. Adding a sixth status would make every consumer learn a
+ * distinction that a column already carries.
+ *
+ * ## Idempotency
+ *
+ * A Trigger.dev retry re-runs this with the same payload. A run already
+ * in a terminal state is returned as-is rather than re-walked, because
+ * re-walking would spend real money (`ai.ask` nodes) and, once delegation
+ * is bound, spawn real child agent runs a second time.
+ */
+@Injectable()
+export class WorkflowRunExecutorService {
+    private readonly logger = new Logger(WorkflowRunExecutorService.name);
+
+    constructor(
+        private readonly workflows: WorkflowRepository,
+        private readonly runs: WorkflowRunRepository,
+        private readonly executor: WorkflowGraphExecutorService,
+    ) {}
+
+    async execute(input: ExecuteWorkflowRunInput): Promise<WorkflowRunStatus> {
+        const run = await this.runs.findByIdAndUser(input.workflowRunId, input.userId);
+        if (!run) {
+            // The row is the work order. Without it there is nothing to
+            // record against, so failing loudly is the only honest option —
+            // a silent return would look like a successful no-op run.
+            throw new Error(
+                `workflow run ${input.workflowRunId} not found for user ${input.userId}`,
+            );
+        }
+        if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
+            this.logger.log(
+                `workflow run ${run.id}: already '${run.status}' — not re-executing on retry`,
+            );
+            return run.status;
+        }
+
+        const workflow = await this.workflows.findByIdAndUser(run.workflowId, run.userId);
+        if (!workflow) {
+            // Deleting a workflow mid-run is legal (the delete route is a
+            // hard delete and says so). The run record outlives it and has
+            // to say why it stopped.
+            await this.runs.markFailed(run.id, 'the workflow was deleted before the run started', {
+                failureCode: 'workflow-deleted',
+            });
+            return 'failed';
+        }
+
+        const claimed = await this.runs.markStarted(run.id, input.triggerRunId ?? null);
+        if (!claimed) {
+            // Another worker won the claim. Report what actually happened
+            // rather than executing a second walk against the same row.
+            const current = await this.runs.findByIdAndUser(run.id, run.userId);
+            return current?.status ?? 'failed';
+        }
+
+        const result = await this.executor.execute(workflow.graph, {
+            // The PERSISTED run id, so a node's context carries an id that
+            // can be looked up afterwards instead of the executor's own
+            // ephemeral `wf-…` token.
+            runId: run.id,
+            context: {
+                userId: run.userId,
+                workId: workflow.workId ?? null,
+                organizationId: workflow.organizationId ?? null,
+            },
+        });
+
+        const summary = summarizeWorkflowRun(result);
+        const patch = {
+            trace: summary.trace,
+            output: summary.output,
+            outputTruncated: summary.outputTruncated,
+            failureCode: summary.failureCode,
+            failedNodeId: summary.failedNodeId,
+            stepCount: summary.stepCount,
+        };
+
+        if (result.status === 'completed') {
+            await this.runs.markCompleted(run.id, patch);
+            return 'completed';
+        }
+
+        await this.runs.markFailed(run.id, summary.trace.errors[0] ?? null, patch);
+        return 'failed';
+    }
+}

--- a/packages/agent/src/services/workflow-runs.service.ts
+++ b/packages/agent/src/services/workflow-runs.service.ts
@@ -1,0 +1,185 @@
+import {
+    ConflictException,
+    Inject,
+    Injectable,
+    Logger,
+    NotFoundException,
+    Optional,
+} from '@nestjs/common';
+import { WorkflowStatus } from '../entities/workflow.entity';
+import type { WorkflowRun } from '../entities/workflow-run.entity';
+import { WorkflowRepository } from '../database/repositories/workflow.repository';
+import {
+    WorkflowRunRepository,
+    type WorkflowRunListRow,
+} from '../database/repositories/workflow-run.repository';
+import {
+    WORKFLOW_RUN_DISPATCHER,
+    type WorkflowRunDispatcher,
+} from '../tasks/workflow-run-dispatcher';
+
+/**
+ * Starting and reading workflow graph runs (judgment layer G5) — the
+ * REQUEST side.
+ *
+ * ## Why this service cannot execute anything
+ *
+ * It holds a dispatcher, never an executor. That is the design, not an
+ * omission: `POST /api/workflows/:id/run` must return the moment the run
+ * is recorded, because a graph with delegate nodes can walk for tens of
+ * minutes. Making the walk unreachable from here means "the endpoint does
+ * not await execution" is a property of the TYPE, not of a reviewer
+ * remembering not to add an `await`. The walk lives in
+ * `WorkflowRunExecutorService`, which only the Trigger.dev worker boots.
+ *
+ * ## Why a failed enqueue is recorded as failed, not left queued
+ *
+ * When Trigger.dev is not configured — the ordinary case in dev and e2e —
+ * the dispatcher returns `null` rather than throwing, so the endpoint
+ * still answers 202. But the run is then marked `failed` with the reason,
+ * because a `queued` row that nothing will ever pick up is a lie: it
+ * reads as "in progress" forever and would need a sweeper to become
+ * honest. The row is the account of what happened, so it says what
+ * happened.
+ */
+@Injectable()
+export class WorkflowRunsService {
+    private readonly logger = new Logger(WorkflowRunsService.name);
+
+    constructor(
+        private readonly workflows: WorkflowRepository,
+        private readonly runs: WorkflowRunRepository,
+        // @Optional() so an install without a job runtime still boots and
+        // still answers the read routes. Appended LAST per the positional-
+        // spec arity rule.
+        @Optional()
+        @Inject(WORKFLOW_RUN_DISPATCHER)
+        private readonly dispatcher?: WorkflowRunDispatcher,
+    ) {}
+
+    /**
+     * Record a run and enqueue it. Returns as soon as the row exists and
+     * the job is handed off — never waits for the graph.
+     */
+    async start(userId: string, workflowId: string): Promise<WorkflowRun> {
+        const workflow = await this.workflows.findByIdAndUser(workflowId, userId);
+        if (!workflow) {
+            // 404, never 403 — same posture as the rest of the collection,
+            // so the route cannot be used to probe which ids exist.
+            throw new NotFoundException({ status: 'error', message: 'Workflow not found' });
+        }
+        if (workflow.status === WorkflowStatus.ARCHIVED) {
+            // Archived means retired. The row stays readable and can be
+            // re-activated, but starting new work against something a user
+            // deliberately shelved would make "archived" mean nothing.
+            throw new ConflictException({
+                status: 'error',
+                message: 'Workflow is archived; re-activate it before running',
+            });
+        }
+
+        // DOCUMENTED dispatch-gate bypass.
+        //
+        // `dispatch-paths-gated.spec.ts` guards that every `createQueued(`
+        // sits behind `RunDispatchGateService`, because the AgentRun
+        // concurrency valve was once consulted on one path and decorative
+        // on four. This call is a different thing wearing the same method
+        // name: it creates a `workflow_runs` row, not an `agent_runs` one,
+        // so there is no agent-run admission to make here and no
+        // concurrency slot to take.
+        //
+        // The expensive parts of a graph ARE gated, where they are
+        // actually created: an `agent.delegate` node goes through
+        // `SubAgentDelegationService` into the api-side delegation runner,
+        // which dispatches its child through `TaskTransitionService` — the
+        // gated path — and an `ai.ask` node spends through `AiFacadeService`
+        // behind `BudgetGuardService`. Gating here as well would charge a
+        // graph an agent-run slot it never uses.
+        //
+        // What is NOT bounded yet is how many workflow runs one user may
+        // have in flight; today only the route's 30/min throttle limits
+        // that. Worth its own admission rule, not a borrowed one.
+        const run = await this.runs.createQueued({ workflowId, userId });
+
+        // Advisory display counters. Best-effort BY DESIGN: the
+        // authoritative account of a run is its own row, and failing the
+        // request because a denormalized counter did not increment would
+        // trade something that matters for something that does not.
+        try {
+            await this.workflows.recordRun(workflowId, new Date());
+        } catch (err) {
+            this.logger.warn(
+                `workflow ${workflowId}: run counters not updated (${(err as Error).message})`,
+            );
+        }
+
+        await this.enqueue(run, workflowId, userId);
+
+        // Re-read so the caller sees the status the enqueue actually
+        // produced rather than the pre-dispatch snapshot.
+        return (await this.runs.findByIdAndUser(run.id, userId)) ?? run;
+    }
+
+    async listForWorkflow(
+        userId: string,
+        workflowId: string,
+        options: { limit?: number; offset?: number } = {},
+    ): Promise<{ items: WorkflowRunListRow[]; total: number }> {
+        // Prove the workflow is the caller's BEFORE listing. Without this
+        // a foreign workflowId would simply return an empty page, which
+        // reads as "no runs yet" instead of "not yours".
+        const workflow = await this.workflows.findByIdAndUser(workflowId, userId);
+        if (!workflow) {
+            throw new NotFoundException({ status: 'error', message: 'Workflow not found' });
+        }
+        return this.runs.listForWorkflow(workflowId, userId, options);
+    }
+
+    async getRun(userId: string, runId: string): Promise<WorkflowRun> {
+        const run = await this.runs.findByIdAndUser(runId, userId);
+        if (!run) {
+            throw new NotFoundException({ status: 'error', message: 'Workflow run not found' });
+        }
+        return run;
+    }
+
+    private async enqueue(run: WorkflowRun, workflowId: string, userId: string): Promise<void> {
+        if (!this.dispatcher) {
+            await this.runs.markDispatchFailed(
+                run.id,
+                'no workflow run dispatcher is bound — the job runtime is not configured',
+            );
+            return;
+        }
+
+        let triggerRunId: string | null;
+        try {
+            triggerRunId = await this.dispatcher.dispatchWorkflowRun({
+                workflowRunId: run.id,
+                workflowId,
+                userId,
+            });
+        } catch (err) {
+            // A throwing dispatcher must not lose the row. Record why and
+            // let the caller see a failed run instead of a 500 on a run
+            // that was already persisted.
+            await this.runs.markDispatchFailed(run.id, (err as Error).message);
+            return;
+        }
+
+        if (!triggerRunId) {
+            // Deliberately does NOT name a cause. `null` from the
+            // dispatcher means "not accepted" and nothing more — an
+            // unconfigured job runtime is the common case, but an auth
+            // failure or an unreachable API returns the same value. The
+            // adapter logs the real error; asserting a reason here would
+            // put a confident wrong answer on a row an operator reads.
+            await this.runs.markDispatchFailed(
+                run.id,
+                'the job runtime did not accept the run; see the dispatcher log for the cause',
+            );
+            return;
+        }
+        await this.runs.setTriggerRunId(run.id, triggerRunId);
+    }
+}

--- a/packages/agent/src/services/workflows.module.ts
+++ b/packages/agent/src/services/workflows.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Workflow } from '../entities/workflow.entity';
+import { WorkflowRun } from '../entities/workflow-run.entity';
 import { WorkflowRepository } from '../database/repositories/workflow.repository';
+import { WorkflowRunRepository } from '../database/repositories/workflow-run.repository';
 import { WorkflowsService } from './workflows.service';
+import { WorkflowRunsService } from './workflow-runs.service';
 
 /**
  * Saved workflow graphs (judgment layer G5).
@@ -19,9 +22,19 @@ import { WorkflowsService } from './workflows.service';
  * `EntityMetadataNotFoundError` on the first query, in production, with
  * a green build and green unit tests behind it.
  */
+/**
+ * `WorkflowRunExecutorService` is deliberately NOT provided here.
+ *
+ * It needs `WorkflowGraphExecutorService`, which lives in `AgentsModule` —
+ * importing that to satisfy one worker-only service would drag the whole
+ * agents graph into every consumer of this module, including the API's
+ * request path, which never executes a walk. The Trigger.dev
+ * `workflow-run` module provides the executor locally instead, which is
+ * also what keeps the API structurally unable to await a graph.
+ */
 @Module({
-    imports: [TypeOrmModule.forFeature([Workflow])],
-    providers: [WorkflowRepository, WorkflowsService],
-    exports: [WorkflowRepository, WorkflowsService],
+    imports: [TypeOrmModule.forFeature([Workflow, WorkflowRun])],
+    providers: [WorkflowRepository, WorkflowRunRepository, WorkflowsService, WorkflowRunsService],
+    exports: [WorkflowRepository, WorkflowRunRepository, WorkflowsService, WorkflowRunsService],
 })
 export class WorkflowsModule {}

--- a/packages/agent/src/tasks/_tasks-symbols.ts
+++ b/packages/agent/src/tasks/_tasks-symbols.ts
@@ -77,6 +77,9 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     // resolver and P4 worker host layer it in independently.
     'TenantCredentialCache',
     'WEBHOOK_DELIVERY_DISPATCHER',
+    // Judgment layer G5 — enqueues a saved workflow graph's run. The walk
+    // can take ~40 minutes, so it can never happen in an API request.
+    'WORKFLOW_RUN_DISPATCHER',
     'WORK_GENERATION_DISPATCHER',
     'WORK_GENERATION_MODE',
     'WORK_IMPORT_DISPATCHER',

--- a/packages/agent/src/tasks/index.ts
+++ b/packages/agent/src/tasks/index.ts
@@ -25,6 +25,8 @@ export * from './kb-backfill-skeleton.types';
 export * from './kb-backfill-skeleton-dispatcher';
 export * from './kb-embed-document.types';
 export * from './kb-embed-document-dispatcher';
+export * from './workflow-run.types';
+export * from './workflow-run-dispatcher';
 export * from './kb-org-overlay-fanout.types';
 export * from './kb-org-overlay-fanout-dispatcher';
 export * from './kb-normalize-media.types';

--- a/packages/agent/src/tasks/workflow-run-dispatcher.ts
+++ b/packages/agent/src/tasks/workflow-run-dispatcher.ts
@@ -1,0 +1,39 @@
+import type { WorkflowRunPayload } from './workflow-run.types';
+
+/**
+ * Producer-side seam for enqueuing a workflow graph run (judgment layer
+ * G5). Implemented api-side by the Trigger.dev adapter in
+ * `packages/tasks/src/dispatchers/workflow-run.dispatcher.ts`.
+ *
+ * ## Why a graph run is dispatched rather than awaited
+ *
+ * A graph may hold delegate nodes that each wait minutes for a child
+ * agent run, walked sequentially — up to roughly 40 minutes for a
+ * maximal graph. Two obvious alternatives were rejected:
+ *
+ *   - Running it in-process after a 202. API pods restart on every
+ *     deploy, so the promise dies on the NORMAL path and a stuck-row
+ *     sweeper becomes the primary mechanism. The repo states the
+ *     opposite rule outright in `agent-heartbeat.task.ts`: "the stuck-row
+ *     sweep in the dispatcher is a backstop, not a primary path."
+ *   - A task that RPCs the walk back to the API. `TriggerInternalApi-
+ *     Client` has no timeout and no AbortSignal and retries network
+ *     errors up to 4 attempts with no idempotency key, so a long call
+ *     dies at the ingress hop (~60s nginx / ~100s Cloudflare) and is
+ *     re-executed — and delegate nodes spawn real child agent runs, so
+ *     that would be duplicated side effects.
+ *
+ * ## Returning `null`
+ *
+ * `null` means the run could not be enqueued — Trigger.dev is not
+ * configured (the ordinary case in dev and e2e) or the transport failed.
+ * The `workflow_runs` row still exists in `queued`, and the caller marks
+ * it dispatch-failed rather than pretending it is pending forever. This
+ * mirrors every other dispatcher on `TriggerService`, which return `null`
+ * instead of throwing precisely so an unconfigured install does not 500.
+ */
+export interface WorkflowRunDispatcher {
+    dispatchWorkflowRun(payload: WorkflowRunPayload): Promise<string | null>;
+}
+
+export const WORKFLOW_RUN_DISPATCHER = Symbol('WORKFLOW_RUN_DISPATCHER');

--- a/packages/agent/src/tasks/workflow-run.types.ts
+++ b/packages/agent/src/tasks/workflow-run.types.ts
@@ -1,0 +1,36 @@
+/**
+ * Payload contract for the Trigger.dev `workflow-run` task
+ * (judgment layer G5).
+ *
+ * Deliberately just IDS. Everything the walk needs — the graph, the
+ * owner, the org scope — is read from the `workflows` / `workflow_runs`
+ * rows by the worker, which already shares the API's database.
+ *
+ * That is not incidental. A payload is written by the producer and read
+ * by a consumer that deploys on its OWN release workflow
+ * (`.github/workflows/release-trigger-prod.yml`), so an old worker can be
+ * handed a payload shape it does not understand and will silently drop
+ * the fields it does not know. Carrying the graph — or worse, any scope
+ * or limit — on the payload would make correctness depend on deploy
+ * ordering. Carrying an id makes the worker re-read the authoritative
+ * row every time.
+ */
+export interface WorkflowRunPayload {
+    /** The pre-created `workflow_runs` row this task must finish. */
+    readonly workflowRunId: string;
+
+    /**
+     * The `workflows` row to execute. Carried alongside the run id purely
+     * so the worker can log and validate the pair without a second query;
+     * the run row remains the authority and is re-checked.
+     */
+    readonly workflowId: string;
+
+    /**
+     * Owner of the run. Threaded into the graph's execution context so
+     * `ai.ask` and `kb.search` nodes run AS that user — `kb.search` in
+     * particular is gated by `ensureCanView`, so a missing or wrong
+     * userId is a permission failure, not a convenience.
+     */
+    readonly userId: string;
+}

--- a/packages/tasks/src/dispatchers/workflow-run.dispatcher.ts
+++ b/packages/tasks/src/dispatchers/workflow-run.dispatcher.ts
@@ -1,0 +1,66 @@
+import { logger, tasks } from '@trigger.dev/sdk';
+import type { WorkflowRunDispatcher, WorkflowRunPayload } from '@ever-works/agent/tasks';
+
+/**
+ * Judgment layer G5 — production dispatcher adapter that hands a
+ * pre-created `workflow_runs` row to the Trigger.dev `workflow-run` task.
+ *
+ * Bound to the `WORKFLOW_RUN_DISPATCHER` token by the API-side
+ * `WorkflowsModule`. Keeps `@trigger.dev/sdk` out of the
+ * `@ever-works/agent` dependency graph — the same shape as
+ * `ideaBuildExecuteTriggerAdapter`.
+ *
+ * ## Why this is a standalone adapter rather than a `TriggerService` method
+ *
+ * `TriggerService` exposes no way to pass an `idempotencyKey` —
+ * `stampTenantOptions` documents it as never touched, and no dispatch
+ * method takes an options argument. A graph run needs one, so it takes
+ * the same path the agent-task and idea-build dispatchers already do.
+ *
+ * `idempotencyKey = workflowRunId`: the run ROW is the unit of work, so a
+ * double-fired enqueue collapses to one execution. That matters more here
+ * than for most tasks, because a second walk would re-pay for every
+ * `ai.ask` node and — once delegation is bound — spawn a second set of
+ * real child agent runs.
+ *
+ * ## Returning `null`
+ *
+ * Errors are caught and reported as `null` rather than thrown, matching
+ * the `WorkflowRunDispatcher` contract: the caller has already persisted
+ * the run row and marks it dispatch-failed, which is a better outcome
+ * than a 500 on a request whose row exists. An unconfigured install (dev,
+ * e2e) hits the same path.
+ */
+export const workflowRunTriggerAdapter: WorkflowRunDispatcher = {
+    async dispatchWorkflowRun(payload: WorkflowRunPayload): Promise<string | null> {
+        try {
+            const handle = await tasks.trigger<
+                typeof import('../tasks/trigger/workflow-run.task').workflowRunTask
+            >(
+                'workflow-run',
+                {
+                    workflowRunId: payload.workflowRunId,
+                    workflowId: payload.workflowId,
+                    userId: payload.userId,
+                } satisfies WorkflowRunPayload,
+                { idempotencyKey: payload.workflowRunId },
+            );
+            return handle.id;
+        } catch (err) {
+            // LOG before collapsing to `null`. The contract is to return
+            // null rather than throw — the caller has already persisted
+            // the run row and a throw would 500 a request whose work is
+            // recorded. But a bare `catch { return null }` DESTROYS the
+            // only account of why: an auth failure, a malformed payload
+            // and an unreachable Trigger.dev API would all reach the
+            // operator as the same shrug. The row records that dispatch
+            // failed; this records what actually happened.
+            logger.error('workflow-run dispatch failed', {
+                workflowRunId: payload.workflowRunId,
+                workflowId: payload.workflowId,
+                error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+        }
+    },
+};

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -13,3 +13,6 @@ export * from './dispatchers/agent-task-dispatchers';
 // IdeaBuildExecutorDispatchModule binds this to the
 // IDEA_BUILD_EXECUTE_DISPATCHER token.
 export * from './dispatchers/idea-build-execute.dispatcher';
+// Judgment layer G5 — workflow graph run dispatch adapter. API-side
+// WorkflowsModule binds this to the WORKFLOW_RUN_DISPATCHER token.
+export * from './dispatchers/workflow-run.dispatcher';

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -36,6 +36,9 @@ export * from './work-import.task';
 export * from './work-onboarding.task';
 export * from './work-schedule-dispatcher.task';
 export * from './webhook-delivery.task';
+// Judgment layer G5 — execute a SAVED workflow graph. The walk can run
+// for ~40 minutes, so it cannot live in an API request.
+export * from './workflow-run.task';
 // EW-693 — long-running plugin execution (Phase 7 / T27).
 export * from './run-plugin-operation.task';
 // Pricing Wave 9 M1 — daily free-credit grant (idempotent per user/day).

--- a/packages/tasks/src/tasks/trigger/workflow-run.task.ts
+++ b/packages/tasks/src/tasks/trigger/workflow-run.task.ts
@@ -1,0 +1,107 @@
+import { logger, task } from '@trigger.dev/sdk';
+import type { WorkflowRunPayload } from '@ever-works/agent/tasks';
+import { WorkflowRunExecutorService } from '@ever-works/agent/services';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+import { TriggerWorkflowRunModule } from '../../trigger/worker/modules/trigger-workflow-run.module';
+import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+// Security: validate payload ids before any DB access (defence in depth,
+// mirrors every other task that takes ids off a queue payload).
+import { assertUuid } from '../../trigger/worker/utils/task-context.utils';
+
+/**
+ * Judgment layer G5 — execute a SAVED workflow graph.
+ *
+ * `POST /api/workflows/:id/run` creates the `workflow_runs` row in
+ * `queued` and enqueues this task, then returns 202 immediately. This
+ * task does the walk and writes the terminal row.
+ *
+ * ## Why the walk lives here and not in the API
+ *
+ * A graph can hold up to four delegate nodes, each waiting up to ten
+ * minutes for a child agent run, walked SEQUENTIALLY — roughly 40 minutes
+ * for a maximal graph. Two shapes were considered and rejected:
+ *
+ *   - In-process fire-and-forget after the 202. API pods restart on every
+ *     deploy, so the promise dies on the NORMAL path and a stuck-row
+ *     sweeper becomes the primary mechanism. `agent-heartbeat.task.ts`
+ *     states the opposite rule outright: "the stuck-row sweep in the
+ *     dispatcher is a backstop, not a primary path."
+ *   - A task that RPCs the walk back to the API. `TriggerInternalApi-
+ *     Client` has no timeout and no `AbortSignal` and retries network
+ *     errors up to 4 attempts with no idempotency key — a long call dies
+ *     at the ingress hop and is re-executed, duplicating the real child
+ *     agent runs a delegate node spawns.
+ *
+ * ## Producer/consumer skew
+ *
+ * `packages/tasks` deploys on its OWN workflow
+ * (`.github/workflows/release-trigger-prod.yml`), separately from the
+ * API. If the API starts dispatching `workflow-run` before a worker
+ * carrying this file lands, `tasks.trigger` still returns a handle and
+ * the run parks in `PENDING_VERSION` — it executes late rather than
+ * failing. Nothing breaks on an OLD worker: it simply never sees the id.
+ * That is also why the payload is ids only — an old worker silently drops
+ * fields it does not know, so nothing load-bearing may ride on it.
+ *
+ * ## Retries
+ *
+ * `maxAttempts: 1`. A graph walk is NOT safely retryable at the task
+ * level: `ai.ask` nodes have already been paid for and delegate nodes
+ * spawn real child runs, so a blind re-run duplicates side effects. The
+ * executor's own `on_failure` edges are the retry mechanism that
+ * understands the graph. `WorkflowRunExecutorService` is nonetheless
+ * idempotent — it returns early on a row already in a terminal state —
+ * so a runtime-level redelivery cannot double-walk.
+ */
+export const workflowRunTask = task<'workflow-run', WorkflowRunPayload>({
+    id: 'workflow-run',
+    // Comfortably above the ~40-minute worst case (4 delegate nodes at
+    // the 10-minute ceiling), with room for the AI calls between them.
+    maxDuration: 60 * 60,
+    retry: { maxAttempts: 1 },
+    run: async (payload: WorkflowRunPayload, { ctx }: { ctx?: { run?: { id?: string } } } = {}) => {
+        assertUuid(payload.workflowRunId, 'payload.workflowRunId');
+        assertUuid(payload.workflowId, 'payload.workflowId');
+        assertUuid(payload.userId, 'payload.userId');
+
+        return withWorkerContext(
+            'WorkflowRun',
+            async (appContext) => {
+                // NOT optional. The plugin registry starts EMPTY and is
+                // filled only by the bootstrap this triggers; skip it and
+                // every `ai.ask` node and `llm_decide` edge throws
+                // `NoProviderError` at run time, which no unit test
+                // catches.
+                await appContext.get(TriggerPluginHydratorService).initialize();
+
+                const executor = appContext.get(WorkflowRunExecutorService);
+                const status = await executor.execute({
+                    workflowRunId: payload.workflowRunId,
+                    userId: payload.userId,
+                    triggerRunId: ctx?.run?.id ?? null,
+                });
+
+                logger.log('workflow-run finished', {
+                    workflowRunId: payload.workflowRunId,
+                    workflowId: payload.workflowId,
+                    status,
+                });
+
+                // Returned, never thrown, even for `failed`. A graph that
+                // failed is a RECORDED outcome, not an infrastructure
+                // fault — throwing would mark the Trigger.dev run red and
+                // invite a retry that re-walks a graph whose failure is
+                // already persisted with its failure code.
+                return {
+                    workflowRunId: payload.workflowRunId,
+                    workflowId: payload.workflowId,
+                    status,
+                };
+            },
+            // NOTE the third argument: `withWorkerContext` defaults to
+            // `TriggerWorkerModule`, which provides none of this task's
+            // services — omitting it fails at runtime, on every fire.
+            TriggerWorkflowRunModule,
+        );
+    },
+});

--- a/packages/tasks/src/trigger/worker/modules/__tests__/trigger-workflow-run.module.spec.ts
+++ b/packages/tasks/src/trigger/worker/modules/__tests__/trigger-workflow-run.module.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplicationContext } from '@nestjs/common';
+import { WorkflowGraphExecutorService, WORKFLOW_NODE_RUNNER } from '@ever-works/agent/agents';
+import { KnowledgeBaseService, WorkflowRunExecutorService } from '@ever-works/agent/services';
+import { TriggerWorkflowRunModule } from '../trigger-workflow-run.module';
+
+/**
+ * Does the `workflow-run` worker context actually BOOT?
+ *
+ * Nothing else in the pipeline answers that question. The module is
+ * instantiated only inside a Trigger.dev task, which CI never runs; the
+ * API's own DI bootstrap never touches it; and `tsc` cannot see a missing
+ * injection token. So a DI fault here fails for the first time in
+ * production, on every workflow run, silently.
+ *
+ * That is not hypothetical — this module shipped its first draft unable
+ * to boot at all. `TriggerPluginsModule` provides
+ * `PluginContextFactoryService`, whose sixth constructor argument is a
+ * NON-optional `@Inject(CACHE_MANAGER)` that nothing in the plugins
+ * module supplies, so the context died with:
+ *
+ *     Nest can't resolve dependencies of the PluginContextFactoryService
+ *     (..., ?). Please make sure that the argument "CACHE_MANAGER" at
+ *     index [5] is available in the TriggerPluginsModule module.
+ *
+ * The fix was importing `TriggerRemoteCacheModule.forRoot()`, which
+ * `TriggerWorkerModule` had been carrying all along. This spec is what
+ * makes the next such gap fail in a unit test instead.
+ *
+ * It asserts more than "it booted": a context that boots but leaves
+ * `WORKFLOW_NODE_RUNNER` unbound would validate a graph and then refuse
+ * to execute a single node, reporting `no-node-runner` on every run —
+ * which is precisely the silent-no-op the whole seam exists to prevent.
+ */
+describe('TriggerWorkflowRunModule', () => {
+    let context: INestApplicationContext;
+
+    beforeAll(async () => {
+        // `TriggerPluginsModule` imports `TriggerInternalModule`, whose
+        // API client THROWS in its constructor when the URL is unset — so
+        // this must be present even though the module talks to the DB
+        // directly. In-memory sqlite keeps the DataSource real without a
+        // server.
+        process.env.TRIGGER_INTERNAL_API_URL ??= 'http://localhost:3100';
+        process.env.TRIGGER_INTERNAL_SECRET ??= 'test-secret';
+        process.env.DATABASE_TYPE ??= 'better-sqlite3';
+        process.env.DATABASE_PATH ??= ':memory:';
+        process.env.DATABASE_AUTOMIGRATE ??= 'true';
+        process.env.RUN_MIGRATIONS ??= 'false';
+
+        context = await NestFactory.createApplicationContext(TriggerWorkflowRunModule, {
+            abortOnError: false,
+            logger: false,
+        });
+    }, 120_000);
+
+    afterAll(async () => {
+        await context?.close();
+    });
+
+    it('boots — every non-optional dependency in the graph resolves', () => {
+        expect(context).toBeDefined();
+    });
+
+    it('provides the service the task actually calls', () => {
+        expect(context.get(WorkflowRunExecutorService, { strict: false })).toBeDefined();
+    });
+
+    it('binds WORKFLOW_NODE_RUNNER — without it every run reports `no-node-runner`', () => {
+        // The token, and the executor's own view of it. Checking only the
+        // token would pass while the executor still injected `undefined`.
+        expect(context.get(WORKFLOW_NODE_RUNNER, { strict: false })).toBeDefined();
+        const executor = context.get(WorkflowGraphExecutorService, {
+            strict: false,
+        }) as unknown as {
+            runner?: unknown;
+            decider?: unknown;
+        };
+        expect(executor.runner).toBeDefined();
+    });
+
+    it('binds the llm_decide decider, so a decision goes through the AI facade', () => {
+        const executor = context.get(WorkflowGraphExecutorService, {
+            strict: false,
+        }) as unknown as {
+            decider?: unknown;
+        };
+        expect(executor.decider).toBeDefined();
+    });
+
+    it('provides KnowledgeBaseService, so a kb.search node is not dead on arrival', () => {
+        expect(context.get(KnowledgeBaseService, { strict: false })).toBeDefined();
+    });
+});

--- a/packages/tasks/src/trigger/worker/modules/trigger-workflow-run.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-workflow-run.module.ts
@@ -1,0 +1,139 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@ever-works/agent/database';
+import {
+    WorkKnowledgeCitationRepository,
+    WorkKnowledgeDocumentRepository,
+    WorkKnowledgeTagRepository,
+    WorkKnowledgeUploadRepository,
+} from '@ever-works/agent/database';
+import { FacadesModule } from '@ever-works/agent/facades';
+import {
+    WorkflowGraphExecutorService,
+    WorkflowAiDecisionAdapter,
+    WorkflowNodeRunnerService,
+    WORKFLOW_DECISION_PORT,
+    WORKFLOW_NODE_RUNNER,
+} from '@ever-works/agent/agents';
+import {
+    KnowledgeBaseService,
+    WorkOwnershipService,
+    WorkflowRunExecutorService,
+    WorkflowsModule,
+} from '@ever-works/agent/services';
+import { TriggerPluginsModule } from './trigger-plugins.module';
+import { TriggerRemoteCacheModule } from './trigger-remote-cache.module';
+
+/**
+ * Nest module booted inside the Trigger.dev `workflow-run` task
+ * (judgment layer G5).
+ *
+ * # Why it imports `DatabaseModule` directly
+ *
+ * Same rationale as {@link TriggerWebhookDeliveryModule}: this worker
+ * already shares the API's database — it has to, because it reads the
+ * `workflows` row and writes the `workflow_runs` row — so layering an RPC
+ * proxy on top would add a network hop with zero correctness benefit.
+ *
+ * Here it is more than an optimization. The alternative shape (a task
+ * that RPCs the walk back to the API) is actively unsafe:
+ * `TriggerInternalApiClient` has no timeout and no `AbortSignal` and
+ * retries network errors up to 4 attempts with no idempotency key, so a
+ * long call dies at the ingress hop (~60s nginx / ~100s Cloudflare) and
+ * is re-executed — and a graph's delegate nodes spawn real child agent
+ * runs, which would be duplicated side effects.
+ *
+ * # Why the plugins + facades modules are here
+ *
+ * An `ai.ask` node and every `llm_decide` edge go through
+ * `AiFacadeService`, which takes `PluginRegistryService` and
+ * `PluginSettingsService` NON-optionally. Those come only from a
+ * `@Global()` plugins module, so without `TriggerPluginsModule.forRoot()`
+ * this module does not merely lose AI — it fails to instantiate at boot.
+ *
+ * DI is still not enough: the registry's maps start EMPTY and are filled
+ * only by `PluginBootstrapService`. The task therefore calls
+ * `TriggerPluginHydratorService.initialize()` before executing, or every
+ * model call throws `NoProviderError` — the same shape as the documented
+ * empty-registry production incident.
+ *
+ * # `agent.delegate` is deliberately NOT bound
+ *
+ * `SUB_AGENT_DELEGATION_RUNNER` is bound api-side by `TasksModule`,
+ * because the real runner creates a child Task and dispatches it through
+ * `TaskTransitionService` — it depends on `tasks-domain`, which
+ * `packages/agent/src/agents/` may not import (that is what
+ * `AGENT_DOMAIN_TOOL_SOURCES` exists to prevent). Binding it here would
+ * mean either importing the whole tasks/agents graph into a worker that
+ * should boot fast, or proxying a call that WAITS UP TO TEN MINUTES over
+ * the very RPC client described above.
+ *
+ * So a delegate node in a worker-executed graph fails with
+ * `delegation-unavailable` — a typed failure code an `on_failure` edge
+ * can route on, not a silent no-op. Making delegation work from the
+ * worker means moving the runner into `tasks-domain`, which is its own
+ * change.
+ *
+ * # Knowledge Base: six providers, not `KnowledgeBaseModule`
+ *
+ * Importing `KnowledgeBaseModule` would instantiate ~14 services —
+ * three of which take `GitFacadeService` / `AiFacadeService` /
+ * `VectorStoreFacadeService` non-optionally — plus `ActivityLogModule`
+ * and `NotificationsModule`, all so one node can call `listDocuments`.
+ * `KnowledgeBaseService`'s other 14 constructor params are `@Optional()`
+ * and construct fine as `undefined`; the only behavioural loss is
+ * `semanticSearch`, so `kb.search` degrades to lexical ranking — the
+ * documented fallback, not a failure. `TriggerWorkerModule` provides
+ * `KnowledgeBaseGitMirrorService` directly for the same reason.
+ */
+@Module({
+    imports: [
+        // Real repositories — `workflows`, `workflow_runs`, and the KB
+        // tables — against the same database the API writes.
+        DatabaseModule,
+        // @Global(): PluginRegistryService + PluginSettingsService, which
+        // AiFacadeService requires to even be constructed.
+        TriggerPluginsModule.forRoot(),
+        // NOT optional, and not obvious: `TriggerPluginsModule` provides
+        // `PluginContextFactoryService`, whose 6th constructor argument is
+        // a NON-optional `@Inject(CACHE_MANAGER)`. Nothing in the plugins
+        // module supplies that token, so without this import the context
+        // fails to boot with "argument CACHE_MANAGER at index [5] is not
+        // available in the TriggerPluginsModule module" — on every run, in
+        // production only, because nothing in CI boots this module.
+        // `TriggerWorkerModule` imports it for the same reason.
+        TriggerRemoteCacheModule.forRoot(),
+        // AiFacadeService (+ its optional usage/budget attribution).
+        FacadesModule,
+        // WorkflowRepository + WorkflowRunRepository.
+        WorkflowsModule,
+    ],
+    providers: [
+        // The walk itself. Provided locally rather than by importing
+        // AgentsModule, which would pull ~120 providers into a worker
+        // cold start to obtain three classes.
+        WorkflowGraphExecutorService,
+        WorkflowNodeRunnerService,
+        { provide: WORKFLOW_NODE_RUNNER, useExisting: WorkflowNodeRunnerService },
+        // The `llm_decide` decider. Bound to the facade adapter — never a
+        // raw provider SDK — so a decision still goes through the plugin
+        // seam, budgets and provider selection.
+        WorkflowAiDecisionAdapter,
+        { provide: WORKFLOW_DECISION_PORT, useExisting: WorkflowAiDecisionAdapter },
+        // `kb.search` support. These four repository CLASSES are
+        // deliberately absent from `_repository-inventory.ts` (they are
+        // feature-owned), so they must be listed here even though
+        // DatabaseModule supplies their `@InjectRepository` tokens.
+        WorkKnowledgeDocumentRepository,
+        WorkKnowledgeUploadRepository,
+        WorkKnowledgeTagRepository,
+        WorkKnowledgeCitationRepository,
+        // The KB's only authorization boundary — `listDocuments` runs
+        // `ensureCanView(workId, userId)` through it. Never make this
+        // optional to "fix" a permission failure.
+        WorkOwnershipService,
+        KnowledgeBaseService,
+        WorkflowRunExecutorService,
+    ],
+    exports: [WorkflowRunExecutorService],
+})
+export class TriggerWorkflowRunModule {}


### PR DESCRIPTION
PR2 of the workflows arc. PR1 (#1986) made a workflow graph something a user **owns**; this makes running one leave a **trace**. PR3 is the web UI.

Until now the only caller of `WorkflowGraphExecutorService` was an agent chat tool whose result was handed to a model and discarded — so a run could happen but never be reviewed, re-read, or debugged.

## What lands

- `POST /api/workflows/:id/run` → 202 `{ runId, status }`, `GET :id/runs` (list rows), `GET runs/:runId` (detail). Owner-scoped; a foreign id is 404, never 403.
- `workflow_runs` entity + portable migration (`1784830000000`), registered in all four required places.
- New Trigger.dev `workflow-run` task + a dedicated Nest module that imports `DatabaseModule` directly.
- `WorkflowNodeRunnerService` moved `apps/api` → `packages/agent` (unchanged), so the worker can bind it.
- `WorkflowRepository.recordRun` — shipped in #1986 with no caller — now has one.

## Why a dispatched job

A maximal graph is four delegate nodes at a 10-minute ceiling, walked sequentially: ~40 minutes.

- **Rejected — in-process fire-and-forget after the 202.** API pods restart on every deploy, so the promise dies on the *normal* path and a stuck-row sweeper becomes the primary mechanism. `agent-heartbeat.task.ts` states the opposite rule outright: "the stuck-row sweep in the dispatcher is a backstop, not a primary path."
- **Rejected — a task that RPCs the walk back to the API.** `TriggerInternalApiClient` has no timeout and no `AbortSignal`, and retries network errors up to 4 attempts with no idempotency key. A long call dies at the ingress hop (~60s nginx / ~100s Cloudflare) and is re-executed — and delegate nodes spawn real child agent runs, so that is duplicated side effects. (Filed separately as its own hardening task.)

That the API cannot accidentally await the walk is **structural**: `WorkflowRunsService` holds a dispatcher and no executor; `WorkflowRunExecutorService` holds the executor and is only ever booted by the worker.

## The trace is capped

`WorkflowRunResult.nodeOutputs` maps every visited node to its full output — for a `kb.search` node that is up to ten entire KB documents. Persisting it would make one row's size a function of how much content the user's KB holds. What is kept: `visited`, per-node status/failure code, traversed edges, decisions, and a truncated final output — all bounded by named constants in `workflow-run-trace.ts`.

## Two criticals found by review, fixed before merge

Both invisible to `tsc` and to every unit test; each reproduced at runtime before fixing.

1. **`WORKFLOW_RUN_DISPATCHER` was bound in a non-`@Global()` module.** Its consumer is declared in the *imported* agent-side module, and Nest never walks upward into an importer — so the `@Optional()` injection resolved to `undefined` and **every run recorded dispatch-failed while no graph was ever walked**. This is the third time the repo has hit this trap (`IdeaBuildExecutorDispatchModule`, `TasksModule`). Now pinned by `workflows.module.spec.ts`.
2. **The worker module could not boot at all** — `PluginContextFactoryService` takes a non-optional `CACHE_MANAGER` that only `TriggerRemoteCacheModule` supplies. A real boot spec now covers it, since nothing else in CI boots that context.

Also fixed: `failedNodeId` is `varchar(128)` but node ids are user-authored and unbounded by `validateWorkflowGraph` — a long one would throw on the *terminal write* in Postgres and strand the run as `running`. sqlite would never have caught it.

## Gates

| Gate | Result |
|---|---|
| `pnpm format:check` (root, exact CI command) | pass |
| `packages/agent` jest | 467 suites, 8524 passed, 0 failed |
| `packages/tasks` vitest | 29 files, 466 passed |
| `apps/api` jest | 245 passed, 1 **pre-existing** failure |
| Migration spec on better-sqlite3 | 6 passed |
| Real non-preview `createApplicationContext(ApiModule)` | pass |
| Worker module real boot | pass — runner + decider bound |

The test that matters runs a **real** executor against a **real** database: a failing node runner lands `failed` with the failure code and failed node; a succeeding one lands `completed` with `visited: ['a','b']`; and POST returns a `queued` row — which fails if anyone makes it await the walk.

## Known gap, deliberate

`agent.delegate` is **not** bound in the worker. The real delegation runner depends on `tasks-domain`, which `packages/agent/src/agents/` may not import (that is what `AGENT_DOMAIN_TOOL_SOURCES` exists to prevent). A delegate node therefore fails with the typed `delegation-unavailable` — catchable by an `on_failure` edge, not a silent no-op. Moving that runner is its own change.

## Producer/consumer skew

`packages/tasks` deploys on its own workflow. If the API dispatches `workflow-run` before a worker carrying it lands, `tasks.trigger` still returns a handle and the run parks in `PENDING_VERSION` — it executes late rather than failing. An old worker cannot break; it simply never sees the id. The payload is ids only for the same reason.

## Pre-existing `develop` breakage (not from this PR)

Commit `92594eb3c` landed with four gaps, each verified on clean `develop`:

- `apps/api` **does not build** — `TS2322` at `auth-runtime.instance.ts:327`.
- `pnpm-lock.yaml` missing `terms-acceptance` / `@ever-co/legal` → frozen-lockfile install fails. **Not fixed here** to keep this PR scoped.
- `auth-runtime.instance.spec.ts` fails on mock isolation (41 calls, expected 1) — the one API failure above.
- `TriggerTerminalModule` has the same latent `CACHE_MANAGER` boot gap.

Folded in only the two mechanical fixes that block this PR's own gates: `TermsAcceptance` added to `_entity-names.ts` (already in the entities inventory — the missed half of a documented two-step), and prettier on two unformatted files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Start workflow executions asynchronously and monitor their queued, running, completed, failed, or cancelled status.
  * View individual workflow run details and browse paginated run history.
  * Persist execution timing, step counts, failure information, and bounded trace/output details.
  * Automatically execute queued runs in the background with duplicate-execution protection.
  * Run history is removed automatically when its workflow is deleted.

* **Bug Fixes**
  * Improved handling and recording of dispatch failures, execution errors, and invalid or inaccessible runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->