### PR TITLE
fix(tasks): harden the Trigger worker → API remote-proxy hop (retry safety, request deadline, cancellation)

### DIFF
--- a/packages/agent/src/agents/__tests__/agent-run-abort.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-abort.spec.ts
@@ -308,4 +308,62 @@ describe('AgentRunService — cooperative mid-run abort', () => {
             expect.objectContaining({ abortSignal: controller.signal }),
         );
     });
+
+    /**
+     * A run dispatched from the Trigger.dev worker arrives over the internal
+     * RPC proxy, and SuperJSON has no transformer for `AbortSignal` — it
+     * encodes to `{}`. The worker no longer sends one, but it deploys on its
+     * own release workflow, so an OLDER worker keeps sending `{}` to a NEWER
+     * API for the whole skew window. These pin the behaviour that makes that
+     * window safe.
+     */
+    describe('a non-AbortSignal `signal` (SuperJSON-flattened over the RPC hop)', () => {
+        const rpcFlattenedSignal = {} as unknown as AbortSignal;
+
+        it('is NOT threaded into the model call — a truthy non-signal throws inside the AI SDK', async () => {
+            // `{}` is truthy, so downstream `if (signal) signal.addEventListener(...)`
+            // would blow up. `undefined` degrades correctly everywhere.
+            ai.dispatch.mockResolvedValue({
+                text: 'done',
+                toolCalls: [],
+                finishReason: 'stop',
+                usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+                model: 'gpt-4o-mini',
+            } as AgentAiDispatchResult);
+
+            await makeSvc().execute({ ...baseContext, signal: rpcFlattenedSignal });
+
+            expect(ai.dispatch).toHaveBeenCalledWith(
+                expect.objectContaining({ abortSignal: undefined }),
+            );
+        });
+
+        it('does not stop the run — an inert object must never read as "aborted"', async () => {
+            ai.dispatch.mockResolvedValue({
+                text: 'done',
+                toolCalls: [],
+                finishReason: 'stop',
+                usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+                model: 'gpt-4o-mini',
+            } as AgentAiDispatchResult);
+
+            const result = await makeSvc().execute({
+                ...baseContext,
+                signal: rpcFlattenedSignal,
+            });
+
+            expect(result.status).toBe('dispatched');
+        });
+
+        it('falls back to the DB status poll, which is the path that works across the hop', async () => {
+            // With no usable signal the readStatus reader is the ONLY way this
+            // run can learn it was cancelled.
+            runs.findById.mockResolvedValue({ id: 'r1', status: 'cancelled' });
+
+            await makeSvc().execute({ ...baseContext, signal: rpcFlattenedSignal });
+
+            expect(runs.findById).toHaveBeenCalled();
+            expect(ai.dispatch).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/agent/src/agents/agent-run-abort.ts
+++ b/packages/agent/src/agents/agent-run-abort.ts
@@ -64,7 +64,26 @@ const DEFAULT_MIN_DB_INTERVAL_MS = 0;
 export function createAgentRunAbortSource(
     opts: CreateAgentRunAbortSourceOptions,
 ): AgentRunAbortSource {
-    const { runId, signal, readStatus, now = () => Date.now() } = opts;
+    const { runId, readStatus, now = () => Date.now() } = opts;
+    // Accept ONLY a real AbortSignal. A run dispatched from the Trigger.dev
+    // worker reaches this service through the internal RPC proxy, and
+    // SuperJSON has no transformer for `AbortSignal` — it encodes to `{}`, so
+    // what arrives is a plain object that is truthy but has no `aborted` and
+    // no `addEventListener`. That is strictly worse than nothing: `{}` reports
+    // `aborted === undefined` forever, and `signal` is handed onward to the AI
+    // provider chain, where a truthy non-signal reaches
+    // `signal.addEventListener(...)` and throws.
+    //
+    // The worker no longer sends one, but it deploys on its own release
+    // workflow — so during any skew window an OLDER worker is still sending
+    // `{}` to a NEWER API. This guard is what makes that window safe, and it
+    // is why the check lives here rather than only at the sender.
+    //
+    // Degrading to `undefined` is a documented, already-supported state (see
+    // the `signal` docs above): every `signal?.aborted` guard short-circuits
+    // and the `readStatus` fallback becomes the sole cancellation path — which
+    // is the one that actually works across the RPC boundary.
+    const signal = opts.signal instanceof AbortSignal ? opts.signal : undefined;
     const minDbIntervalMs = opts.minDbIntervalMs ?? DEFAULT_MIN_DB_INTERVAL_MS;
 
     // Latched: once cancelled, always cancelled. Prevents a flaky status read

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -120,6 +120,29 @@ describe('agent/config', () => {
             expect(config.trigger.getInternalSecret()).toBe('shared-secret');
         });
 
+        describe('getInternalRequestTimeoutMs', () => {
+            // Must stay under the nginx-ingress 60s proxy_read_timeout default
+            // so the client, not the proxy, is what gives up first.
+            it('defaults to 45s, comfortably below the 60s ingress ceiling', () => {
+                delete process.env.TRIGGER_INTERNAL_REQUEST_TIMEOUT_MS;
+                expect(config.trigger.getInternalRequestTimeoutMs()).toBe(45000);
+                expect(config.trigger.getInternalRequestTimeoutMs()).toBeLessThan(60000);
+            });
+
+            it('honours a valid override', () => {
+                process.env.TRIGGER_INTERNAL_REQUEST_TIMEOUT_MS = '30000';
+                expect(config.trigger.getInternalRequestTimeoutMs()).toBe(30000);
+            });
+
+            it.each(['not-a-number', '0', '-1', ''])(
+                'falls back to the default for the unusable value %p',
+                (raw) => {
+                    process.env.TRIGGER_INTERNAL_REQUEST_TIMEOUT_MS = raw;
+                    expect(config.trigger.getInternalRequestTimeoutMs()).toBe(45000);
+                },
+            );
+        });
+
         describe('shouldUseTrigger', () => {
             it('returns true only when isEnabled() AND getInternalSecret() is set', () => {
                 process.env.TRIGGER_ENABLED = 'true';

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -61,6 +61,32 @@ export const config = {
         getInternalSecret() {
             return process.env.TRIGGER_INTERNAL_SECRET;
         },
+        /**
+         * Per-attempt deadline for one worker → API internal-RPC request.
+         *
+         * Chosen to sit BELOW the infrastructure timeouts so the client is the
+         * thing that gives up first, predictably and with an error that names
+         * the deadline — instead of inheriting whatever the hop in front of it
+         * decides. In production the worker runs on Trigger.dev cloud and
+         * reaches `https://api.ever.works/internal/trigger`, so the request
+         * crosses two proxies that will each kill it on their own schedule:
+         *
+         *  - nginx-ingress, whose `proxy_read_timeout` default is **60s** (no
+         *    override annotation exists in `.deploy/`) → 504.
+         *  - Cloudflare in front of it, ~**100s** origin read → 524.
+         *
+         * 45s leaves ~15s of headroom under the tighter of the two so TLS
+         * setup and Cloudflare→origin latency can never push us past it.
+         *
+         * A deadline does NOT cancel the work already running on the API pod —
+         * it only stops the worker waiting for it. That is precisely why
+         * timing out must not imply retrying; see `RETRY_SAFE_REMOTE_METHODS`
+         * in `trigger-internal-api.client.ts`.
+         */
+        getInternalRequestTimeoutMs() {
+            const raw = parseInt(process.env.TRIGGER_INTERNAL_REQUEST_TIMEOUT_MS || '45000', 10);
+            return Number.isFinite(raw) && raw > 0 ? raw : 45000;
+        },
         shouldUseTrigger() {
             return this.isEnabled() && Boolean(this.getInternalSecret());
         },

--- a/packages/tasks/src/__tests__/remote-proxy.spec.ts
+++ b/packages/tasks/src/__tests__/remote-proxy.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import superjson from 'superjson';
+
+import { createRemoteProxy } from '../trigger/worker/remote-proxy';
+import type { TriggerInternalApiClient } from '../trigger/worker/services/trigger-internal-api.client';
+
+/** A stub client that records the SuperJSON envelope the proxy produced. */
+const makeClient = () => {
+    const callRemote = vi.fn().mockResolvedValue(undefined);
+    return {
+        client: { callRemote } as unknown as TriggerInternalApiClient,
+        callRemote,
+        /** The args as the API would see them after deserialization. */
+        received: () => superjson.deserialize(callRemote.mock.calls[0][2]) as unknown[],
+    };
+};
+
+describe('createRemoteProxy', () => {
+    it('forwards the method name and provider to the client', async () => {
+        const { client, callRemote } = makeClient();
+        await createRemoteProxy(client, 'SomeService').doThing({ a: 1 });
+
+        expect(callRemote).toHaveBeenCalledTimes(1);
+        expect(callRemote.mock.calls[0][0]).toBe('SomeService');
+        expect(callRemote.mock.calls[0][1]).toBe('doThing');
+    });
+
+    it('runs localMethods locally instead of forwarding them', async () => {
+        const { client, callRemote } = makeClient();
+        const local = { stayHere: () => 'local-result' };
+
+        const proxy = createRemoteProxy(client, 'SomeService', local);
+
+        expect(proxy.stayHere()).toBe('local-result');
+        expect(callRemote).not.toHaveBeenCalled();
+    });
+
+    describe('AbortSignal stripping', () => {
+        /**
+         * SuperJSON has no transformer for AbortSignal: it encodes to `{}` and
+         * arrives API-side as a truthy object whose `.aborted` is `undefined`.
+         * That is strictly worse than sending nothing, because downstream
+         * `if (signal) signal.addEventListener(...)` then throws. Dropping it
+         * restores the honest shape.
+         */
+        it('drops a signal nested in an options bag', async () => {
+            const { client, received } = makeClient();
+            const controller = new AbortController();
+
+            await createRemoteProxy(client, 'AgentRunService').execute({
+                runId: 'r1',
+                signal: controller.signal,
+            });
+
+            const [options] = received() as [Record<string, unknown>];
+            expect(options).toEqual({ runId: 'r1' });
+            expect('signal' in options).toBe(false);
+        });
+
+        it('drops a signal passed as a bare positional argument', async () => {
+            const { client, received } = makeClient();
+            const controller = new AbortController();
+
+            await createRemoteProxy(client, 'S').m('keep-me', controller.signal);
+
+            expect(received()).toEqual(['keep-me', undefined]);
+        });
+
+        it('drops an ALREADY-ABORTED signal too — the aborted state does not survive either', async () => {
+            const { client, received } = makeClient();
+            const controller = new AbortController();
+            controller.abort();
+
+            await createRemoteProxy(client, 'S').m({ signal: controller.signal });
+
+            expect(received()).toEqual([{}]);
+        });
+
+        it('drops a signal nested deeper than the top level', async () => {
+            const { client, received } = makeClient();
+            const controller = new AbortController();
+
+            await createRemoteProxy(client, 'S').m({
+                outer: { inner: { signal: controller.signal, keep: true } },
+            });
+
+            expect(received()).toEqual([{ outer: { inner: { keep: true } } }]);
+        });
+
+        it('does not mutate the caller-supplied argument object', async () => {
+            const { client } = makeClient();
+            const controller = new AbortController();
+            const options = { runId: 'r1', signal: controller.signal };
+
+            await createRemoteProxy(client, 'S').m(options);
+
+            expect(options.signal).toBe(controller.signal);
+        });
+    });
+
+    describe('rich-type preservation', () => {
+        // The stripper rebuilds plain containers only. Rebuilding a Date/Map/Set
+        // would flatten it to a bare object and silently break the SuperJSON
+        // round-trip this proxy exists to provide.
+        it('preserves Date, Map and Set through the envelope', async () => {
+            const { client, received } = makeClient();
+            const when = new Date('2026-01-01T00:00:00.000Z');
+            const map = new Map([['k', 'v']]);
+            const set = new Set([1, 2]);
+
+            await createRemoteProxy(client, 'S').m({ when, map, set });
+
+            const [payload] = received() as [
+                { when: Date; map: Map<string, string>; set: Set<number> },
+            ];
+            expect(payload.when).toBeInstanceOf(Date);
+            expect(payload.when.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+            expect(payload.map).toBeInstanceOf(Map);
+            expect(payload.map.get('k')).toBe('v');
+            expect(payload.set).toBeInstanceOf(Set);
+            expect(payload.set.has(2)).toBe(true);
+        });
+
+        it('preserves a Date sitting alongside a stripped signal', async () => {
+            const { client, received } = makeClient();
+            const controller = new AbortController();
+
+            await createRemoteProxy(client, 'S').m({
+                when: new Date('2026-06-01T12:00:00.000Z'),
+                signal: controller.signal,
+            });
+
+            const [payload] = received() as [{ when: Date; signal?: unknown }];
+            expect(payload.when).toBeInstanceOf(Date);
+            expect(payload.signal).toBeUndefined();
+        });
+
+        it('leaves ordinary values untouched', async () => {
+            const { client, received } = makeClient();
+
+            await createRemoteProxy(client, 'S').m('a', 1, null, [1, { b: 2 }], { c: [3] });
+
+            expect(received()).toEqual(['a', 1, null, [1, { b: 2 }], { c: [3] }]);
+        });
+    });
+});

--- a/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
@@ -5,6 +5,7 @@ const { triggerConfig } = vi.hoisted(() => ({
     triggerConfig: {
         getInternalBaseUrl: vi.fn(),
         getInternalSecret: vi.fn(),
+        getInternalRequestTimeoutMs: vi.fn(),
     },
 }));
 
@@ -44,6 +45,7 @@ describe('TriggerInternalApiClient', () => {
         vi.clearAllMocks();
         triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com/');
         triggerConfig.getInternalSecret.mockReturnValue('secret-1');
+        triggerConfig.getInternalRequestTimeoutMs.mockReturnValue(45000);
 
         fetchSpy = vi.fn();
         // @ts-expect-error - install fetch on global
@@ -386,6 +388,223 @@ describe('TriggerInternalApiClient', () => {
 
             const result = await promise;
             expect(result).toEqual({ ok: true });
+        });
+    });
+
+    describe('request deadline', () => {
+        /** A fetch that never settles on its own — only the abort ends it. */
+        const hangUntilAborted = (init: { signal: AbortSignal }) =>
+            new Promise<Response>((_resolve, reject) => {
+                init.signal.addEventListener('abort', () => {
+                    const err = new Error('This operation was aborted');
+                    err.name = 'AbortError';
+                    reject(err);
+                });
+            });
+
+        it('passes an AbortSignal to fetch on every request', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            await client.fetchWorkContext('w', 'u');
+
+            const [, init] = fetchSpy.mock.calls[0];
+            expect(init.signal).toBeInstanceOf(AbortSignal);
+            expect(init.signal.aborted).toBe(false);
+        });
+
+        it('aborts the request once the configured deadline elapses and names the budget', async () => {
+            vi.useFakeTimers();
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockImplementation((_url: string, init: { signal: AbortSignal }) =>
+                hangUntilAborted(init),
+            );
+
+            // A non-retry-safe method, so this is a single attempt.
+            const promise = client.callRemote('AgentRunService', 'execute', { json: [] });
+            promise.catch(() => undefined);
+
+            await vi.advanceTimersByTimeAsync(44999);
+            expect(fetchSpy.mock.calls[0][1].signal.aborted).toBe(false);
+
+            await vi.advanceTimersByTimeAsync(1);
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request timed out after 45000ms',
+            );
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('honours a custom timeout from config', async () => {
+            vi.useFakeTimers();
+            triggerConfig.getInternalRequestTimeoutMs.mockReturnValue(1000);
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockImplementation((_url: string, init: { signal: AbortSignal }) =>
+                hangUntilAborted(init),
+            );
+
+            const promise = client.callRemote('AgentRunService', 'execute', { json: [] });
+            promise.catch(() => undefined);
+            await vi.advanceTimersByTimeAsync(1000);
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request timed out after 1000ms',
+            );
+        });
+
+        it('clears the deadline once the response lands, so a slow later call is unaffected', async () => {
+            vi.useFakeTimers();
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            await client.fetchWorkContext('w', 'u');
+            const { signal } = fetchSpy.mock.calls[0][1];
+
+            // Well past the deadline: a leaked timer would abort a settled request.
+            await vi.advanceTimersByTimeAsync(120_000);
+
+            expect(signal.aborted).toBe(false);
+        });
+
+        it('reports a genuine network error unchanged rather than as a timeout', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+            await expect(
+                client.callRemote('AgentRunService', 'execute', { json: [] }),
+            ).rejects.toThrow('ECONNREFUSED');
+        });
+    });
+
+    describe('retry safety — non-idempotent remote calls are never re-issued', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        const flushAll = async () => {
+            for (let i = 0; i < 10; i++) {
+                await vi.advanceTimersByTimeAsync(2000);
+            }
+        };
+
+        // The dangerous case: an entire billed agent loop with real tool side
+        // effects. Re-issuing it starts a SECOND run of work the API is very
+        // likely still executing.
+        it('does NOT retry AgentRunService.execute on a 5xx', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(503, 'unavailable'));
+
+            const promise = client.callRemote('AgentRunService', 'execute', { json: [] });
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request failed (503): unavailable',
+            );
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        // A proxy timeout is the exact signature this guard exists for: nginx
+        // answers 504 (and Cloudflare 524) while the work keeps running on the
+        // API pod, so the status code alone must not authorise a retry.
+        it('does NOT retry AgentRunService.execute on a 504 gateway timeout', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(504, 'gateway timeout'));
+
+            const promise = client.callRemote('AgentRunService', 'execute', { json: [] });
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('(504)');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does NOT retry AgentRunService.execute on a network error', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockRejectedValue(new Error('ECONNRESET'));
+
+            const promise = client.callRemote('AgentRunService', 'execute', { json: [] });
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('ECONNRESET');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            ['TaskWorkspaceService', 'finalizeRun'],
+            ['TaskChatService', 'post'],
+            ['RunDispatchGateService', 'drainForWork'],
+            ['AgentRunRepository', 'createQueued'],
+            ['AgentRepository', 'incrementErrorCount'],
+            ['TaskGateRunnerService', 'runChecks'],
+            ['TaskGateJudgeService', 'judge'],
+            ['NotificationChannelFacadeService', 'deliverToChannelOrThrow'],
+            // Sibling of the allow-listed `updateTelemetry`, but it accumulates.
+            ['AgentRunRepository', 'addTokens'],
+        ])('does NOT retry %s.%s', async (name, method) => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(500, 'down'));
+
+            const promise = client.callRemote(name, method, { json: [] });
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('(500)');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            // Pure reads.
+            ['AgentRepository', 'findByIdAndUser'],
+            ['AgentRunRepository', 'findById'],
+            ['TasksService', 'getOne'],
+            ['WorkRepository', 'findById'],
+            ['AgentRunService', 'checkBudget'],
+            // Structurally idempotent writers.
+            ['AgentRunRepository', 'markStarted'],
+            ['AgentRunRepository', 'markCompleted'],
+            ['AgentRunRepository', 'updateTelemetry'],
+            ['TaskRunDenormService', 'recordTerminal'],
+            ['AgentEscalationService', 'record'],
+        ])('DOES retry the declared-safe %s.%s', async (name, method) => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(503, 'unavailable'));
+
+            const promise = client.callRemote(name, method, { json: [] });
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('(503)');
+            // initial + 3 retries
+            expect(fetchSpy).toHaveBeenCalledTimes(4);
+        });
+
+        it('still resolves a declared-safe call that succeeds on a later attempt', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy
+                .mockResolvedValueOnce(errorResponse(500, 'down'))
+                .mockResolvedValueOnce(
+                    okJsonResponse(200, { result: superjson.serialize('recovered') }),
+                );
+
+            const promise = client.callRemote('AgentRunRepository', 'markStarted', { json: [] });
+            await flushAll();
+
+            await expect(promise).resolves.toBe('recovered');
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('never retries a 4xx, even for a declared-safe method', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(400, 'bad request'));
+
+            const promise = client.callRemote('AgentRunRepository', 'findById', { json: [] });
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('(400)');
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
@@ -71,7 +71,14 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
         payload: AgentChatReplyPayload,
         // NOTE: this annotation replaces the SDK RunFnParams, so anything omitted
         // here is silently invisible — which is exactly how `signal` went unused.
-        { ctx, signal }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
+        //
+        // `signal` stays in the type but is deliberately NOT destructured:
+        // `AgentRunService` is a remote proxy here, so an `AbortSignal` would
+        // SuperJSON-encode to `{}` and land API-side as a permanently
+        // un-aborted object. Cancellation crosses this boundary through the
+        // `agent_runs.status` poll in `createAgentRunAbortSource` instead. See
+        // the full note in `agent-task-execute.task.ts`.
+        { ctx }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
     ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors agent-heartbeat).
         // triggeringMessageId is also asserted: it is a TaskChatMessage uuid PK and its raw value
@@ -182,7 +189,7 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
                 agentId: agent.id,
                 userId: payload.userId,
                 kind: 'chat',
-                signal,
+                // No `signal` — see the note on the `run` params above.
                 taskId: payload.taskId,
                 chatMessageId: payload.triggeringMessageId,
                 immediateInput,

--- a/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
@@ -78,7 +78,14 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
         payload: AgentHeartbeatPayload,
         // NOTE: this annotation replaces the SDK RunFnParams, so anything omitted
         // here is silently invisible — which is exactly how `signal` went unused.
-        { ctx, signal }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
+        //
+        // `signal` stays in the type but is deliberately NOT destructured:
+        // `AgentRunService` is a remote proxy here, so an `AbortSignal` would
+        // SuperJSON-encode to `{}` and land API-side as a permanently
+        // un-aborted object. Cancellation crosses this boundary through the
+        // `agent_runs.status` poll in `createAgentRunAbortSource` instead. See
+        // the full note in `agent-task-execute.task.ts`.
+        { ctx }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
     ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors createTaskContext)
         assertUuid(payload.agentId, 'payload.agentId');
@@ -158,7 +165,7 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
                 agentId: agent.id,
                 userId: payload.userId,
                 kind: 'heartbeat',
-                signal,
+                // No `signal` — see the note on the `run` params above.
             });
 
             if (result.status === 'assembled') {

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -280,7 +280,24 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
         payload: AgentTaskExecutePayload,
         // NOTE: this annotation replaces the SDK RunFnParams, so anything omitted
         // here is silently invisible — which is exactly how `signal` went unused.
-        { ctx, signal }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
+        //
+        // `signal` stays in the type but is deliberately NOT destructured: it
+        // cannot reach the code that would act on it. `AgentRunService` is a
+        // remote proxy in worker scope (see `trigger-internal.module.ts`), so
+        // every argument to `runner.execute` is SuperJSON-serialized over HTTP,
+        // and SuperJSON has no transformer for `AbortSignal` — it encodes to
+        // `{}`, losing even an already-aborted state. Passing it would look
+        // like cancellation worked while `signal?.aborted` was permanently
+        // `undefined` on the far side. (`createRemoteProxy` now strips signals
+        // defensively; this is the call site not pretending in the first place.)
+        //
+        // Cancellation still works, out of band and API-side:
+        // `createAgentRunAbortSource` is built with a `readStatus` reader over
+        // `agent_runs.status` and is consulted once per model round-trip, so a
+        // run cancelled via `POST /agents/:id/runs/:runId/cancel` stops at the
+        // next checkpoint. That DB path is the authoritative one across this
+        // boundary — the signal never was.
+        { ctx }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
     ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors agent-heartbeat)
         assertUuid(payload.agentId, 'payload.agentId');
@@ -541,7 +558,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 agentId: agent.id,
                 userId: payload.userId,
                 kind: 'task',
-                signal,
+                // No `signal` — see the note on the `run` params above.
                 taskId: payload.taskId,
                 immediateInput,
                 workspaceCwd,
@@ -776,7 +793,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                                 agentId: agent.id,
                                 userId: payload.userId,
                                 kind: 'task',
-                                signal,
+                                // No `signal` — see the note on the `run` params above.
                                 taskId: payload.taskId,
                                 immediateInput: iterateMessage,
                                 workspaceCwd,

--- a/packages/tasks/src/trigger/worker/remote-proxy.ts
+++ b/packages/tasks/src/trigger/worker/remote-proxy.ts
@@ -2,6 +2,59 @@ import superjson from 'superjson';
 import { TriggerInternalApiClient } from './services/trigger-internal-api.client';
 
 /**
+ * Maximum depth `stripAbortSignals` walks. Call arguments here are shallow
+ * option bags; a bound keeps a cyclic or pathological payload from stalling
+ * the worker before the request is even sent.
+ */
+const MAX_STRIP_DEPTH = 4;
+
+/**
+ * True for a "plain" container we may safely rebuild — an object literal or an
+ * array. Everything else (Date, Map, Set, class instances) is returned by
+ * reference so SuperJSON still sees the exact value it knows how to encode.
+ * Rebuilding those would silently downgrade rich types to bare objects.
+ */
+function isPlainContainer(value: unknown): boolean {
+    if (Array.isArray(value)) return true;
+    if (typeof value !== 'object' || value === null) return false;
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Remove `AbortSignal` values from an argument tree, returning a copy.
+ *
+ * An `AbortSignal` cannot survive this hop: SuperJSON has no transformer for
+ * it, so it encodes to `{}` and the API deserializes a plain object whose
+ * `.aborted` is `undefined`. That is worse than useless. It silently disables
+ * the signal half of `createAgentRunAbortSource`, and the same `{}` is then
+ * threaded onward as a request signal into the AI provider chain, where a
+ * truthy non-signal is a latent `signal.addEventListener is not a function`.
+ *
+ * Dropping it restores the honest shape — the callee sees `undefined`, every
+ * `signal?.aborted` guard short-circuits, and cancellation runs through the
+ * path that actually works across this boundary: the `readStatus` poll of
+ * `agent_runs.status` that `createAgentRunAbortSource` already wires up.
+ *
+ * Worker-side only, so it carries no producer/consumer version-skew risk.
+ */
+function stripAbortSignals(value: unknown, depth = 0): unknown {
+    if (value instanceof AbortSignal) return undefined;
+    if (depth >= MAX_STRIP_DEPTH || !isPlainContainer(value)) return value;
+
+    if (Array.isArray(value)) {
+        return value.map((entry) => stripAbortSignals(entry, depth + 1));
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+        if (entry instanceof AbortSignal) continue;
+        out[key] = stripAbortSignals(entry, depth + 1);
+    }
+    return out;
+}
+
+/**
  * Creates a Proxy that forwards method calls to the API via the internal client.
  * Methods in `localMethods` run locally instead of being forwarded.
  *
@@ -38,7 +91,7 @@ export function createRemoteProxy(
 
             // Forward to API with SuperJSON-serialized args
             return (...args: unknown[]) => {
-                const serialized = superjson.serialize(args);
+                const serialized = superjson.serialize(stripAbortSignals(args));
                 return apiClient.callRemote(providerName, prop, serialized);
             };
         },

--- a/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
+++ b/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
@@ -3,14 +3,78 @@ import superjson from 'superjson';
 import { config } from '@ever-works/agent/config';
 import { WorkContextResponse } from '@ever-works/agent/tasks';
 
+/**
+ * Remote calls that are safe to re-issue after a transport failure.
+ *
+ * **The list is an ALLOW-list and the default is "do not retry."** Omitting a
+ * method costs at most one lost retry; adding the wrong one silently doubles a
+ * side effect in production, so the polarity is deliberate — when in doubt,
+ * leave a method out.
+ *
+ * Why this exists: a transport failure tells the caller nothing about whether
+ * the server ran the work. A client-side deadline does not cancel the API pod,
+ * and neither does an nginx 504 or a Cloudflare 524 — the request keeps
+ * executing on the other side while the worker gives up on it. Re-issuing the
+ * call therefore starts a SECOND execution of work that is very likely already
+ * running or already committed. For a pure read that is harmless; for
+ * `AgentRunService.execute` it is a second billed agent loop with real tool
+ * side effects, which is exactly the case this list exists to prevent.
+ *
+ * Retries are not the last line of defence: a call that is refused a retry
+ * here surfaces as a task failure, and Trigger.dev retries the whole task —
+ * where `dedupKey` and the `markStarted` CAS make re-execution safe. That is
+ * the right layer for a retry, because it is the layer that has deduplication.
+ *
+ * A method qualifies only if calling it twice is indistinguishable from
+ * calling it once, and that property is STRUCTURAL (a CAS, a dedup key, or an
+ * absolute-value SET) rather than incidental. Entries are grouped by which of
+ * those two reasons applies. Note `AgentRunRepository.addTokens` is
+ * deliberately absent while its sibling `updateTelemetry` is present: the
+ * former accumulates, the latter overwrites.
+ */
+const RETRY_SAFE_REMOTE_METHODS: ReadonlySet<string> = new Set<string>([
+    // ── Pure reads — no writes at all. ──────────────────────────────
+    'AgentRepository.findById',
+    'AgentRepository.findByIdAndUser',
+    'AgentRunRepository.findById',
+    'AgentRunRepository.findInFlightForAgent',
+    'AgentRunRepository.findInFlightForTaskAgent',
+    'AgentRunService.checkBudget',
+    'TasksService.getOne',
+    'WorkRepository.findById',
+
+    // ── Writers whose idempotency is structural. ────────────────────
+    // CAS on a non-terminal status: a second call matches zero rows.
+    'AgentRunRepository.markCompleted',
+    'AgentRunRepository.markFailed',
+    'AgentRunRepository.markStarted',
+    // Absolute-value SET of an explicit field whitelist; nothing accumulates.
+    'AgentRunRepository.updateGateResults',
+    'AgentRunRepository.updateTelemetry',
+    'AgentRepository.releaseAfterRun',
+    // Pointer-CAS of the same (latestRunId, latestRunStatus) pair.
+    'TaskRunDenormService.recordQueued',
+    'TaskRunDenormService.recordStarted',
+    'TaskRunDenormService.recordTerminal',
+    // Dedup key with a pre-read plus a UNIQUE-violation re-read.
+    'AgentEscalationService.record',
+    // Per-user `daily:<userId>:<date>` idempotency key checked before the write.
+    'CreditLedgerService.dispatchDailyGrants',
+    // Explicit already-marked guard / absolute SET recomputed from the anchor.
+    'WorkScheduleService.markRunCompleted',
+    'WorkScheduleService.markRunFailed',
+]);
+
 @Injectable()
 export class TriggerInternalApiClient {
     private readonly baseUrl: string;
     private readonly secret: string;
+    private readonly requestTimeoutMs: number;
 
     constructor() {
         this.baseUrl = config.trigger.getInternalBaseUrl() || '';
         this.secret = config.trigger.getInternalSecret() || '';
+        this.requestTimeoutMs = config.trigger.getInternalRequestTimeoutMs();
 
         if (!this.baseUrl) {
             throw new Error('TRIGGER_INTERNAL_API_URL is not configured');
@@ -82,6 +146,8 @@ export class TriggerInternalApiClient {
         return this.request<WorkContextResponse>({
             method: 'GET',
             path: `/works/${workId}/context?${searchParams.toString()}`,
+            // A read. Re-issuing it can only cost a duplicate query.
+            retryable: true,
         });
     }
 
@@ -98,6 +164,10 @@ export class TriggerInternalApiClient {
             method: 'POST',
             path: '/remote/call',
             body: { name, method, args },
+            // Default-deny. Only a method explicitly declared re-issuable may
+            // be retried — see `RETRY_SAFE_REMOTE_METHODS` for why an
+            // unlisted method must fail through to the task-level retry.
+            retryable: RETRY_SAFE_REMOTE_METHODS.has(`${name}.${method}`),
         });
 
         return response.result ? superjson.deserialize(response.result as any) : undefined;
@@ -107,13 +177,20 @@ export class TriggerInternalApiClient {
         method,
         path,
         body,
+        retryable,
     }: {
         method: string;
         path: string;
         body?: unknown;
+        /**
+         * Whether re-issuing this exact request is safe. `false` collapses the
+         * loop to a single attempt — a transport failure then propagates to
+         * the caller instead of being silently re-executed.
+         */
+        retryable: boolean;
     }): Promise<T> {
         const url = this.composeUrl(path);
-        const maxRetries = 3;
+        const maxRetries = retryable ? 3 : 0;
         const baseDelayMs = 500;
 
         let lastError: Error | undefined;
@@ -124,50 +201,84 @@ export class TriggerInternalApiClient {
                 await new Promise((resolve) => setTimeout(resolve, delay));
             }
 
-            let response: Response;
+            // One deadline per attempt, covering the response body as well as
+            // the headers — a stalled body read hangs the worker just as
+            // effectively as a stalled connect. `AbortController` +
+            // `setTimeout` rather than `AbortSignal.timeout()`: the former is
+            // driven by the suite's fake timers, the latter is not.
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+            timer.unref?.();
 
             try {
-                response = await fetch(url, {
-                    method,
-                    headers: {
-                        'content-type': 'application/json',
-                        'x-trigger-secret': this.secret,
-                    },
-                    body: body ? JSON.stringify(body) : undefined,
-                });
-            } catch (networkError) {
-                lastError =
-                    networkError instanceof Error ? networkError : new Error(String(networkError));
+                let response: Response;
 
-                if (attempt < maxRetries) {
-                    continue;
+                try {
+                    response = await fetch(url, {
+                        method,
+                        headers: {
+                            'content-type': 'application/json',
+                            'x-trigger-secret': this.secret,
+                        },
+                        body: body ? JSON.stringify(body) : undefined,
+                        signal: controller.signal,
+                    });
+                } catch (networkError) {
+                    lastError = this.describeTransportFailure(networkError, controller.signal);
+
+                    if (attempt < maxRetries) {
+                        continue;
+                    }
+
+                    throw lastError;
                 }
 
-                throw lastError;
-            }
+                if (response.ok) {
+                    if (response.status === 204) {
+                        return undefined as T;
+                    }
 
-            if (response.ok) {
-                if (response.status === 204) {
-                    return undefined as T;
+                    const text = await response.text();
+
+                    return text ? (JSON.parse(text) as T) : (undefined as T);
                 }
 
                 const text = await response.text();
+                lastError = new Error(
+                    `Trigger internal API request failed (${response.status}): ${text}`,
+                );
 
-                return text ? (JSON.parse(text) as T) : (undefined as T);
-            }
-
-            const text = await response.text();
-            lastError = new Error(
-                `Trigger internal API request failed (${response.status}): ${text}`,
-            );
-
-            // Only retry on 5xx server errors
-            if (response.status < 500 || attempt >= maxRetries) {
-                throw lastError;
+                // Only retry on 5xx server errors. Note this branch is what
+                // makes a proxy timeout retryable at all: nginx answers 504 and
+                // Cloudflare answers 524, both of which are >= 500 even though
+                // the work they timed out on is still running server-side. That
+                // is why `retryable` has to gate the loop rather than the
+                // status code alone.
+                if (response.status < 500 || attempt >= maxRetries) {
+                    throw lastError;
+                }
+            } finally {
+                clearTimeout(timer);
             }
         }
 
         throw lastError ?? new Error('Trigger internal API request failed after retries');
+    }
+
+    /**
+     * Turn a rejected `fetch` into the error the caller should see. An abort
+     * raised by our own deadline is reported as a timeout naming the budget,
+     * so an operator reading worker logs can tell "we gave up" apart from
+     * "the network refused us". Everything else is passed through unchanged.
+     */
+    private describeTransportFailure(cause: unknown, signal: AbortSignal): Error {
+        if (signal.aborted) {
+            return new Error(
+                `Trigger internal API request timed out after ${this.requestTimeoutMs}ms`,
+            );
+        }
+
+        return cause instanceof Error ? cause : new Error(String(cause));
     }
 
     private composeUrl(path: string): string {


### PR DESCRIPTION
Hardens the Trigger worker → API remote-proxy hop (`POST /internal/trigger/remote/call`). Found while designing workflow-run dispatch; **not** introduced by that work.

## Measured first — this does not currently fire in production

| Check | Finding |
| --- | --- |
| Worker → API path | `TRIGGER_INTERNAL_API_URL = https://api.ever.works/internal/trigger` in the Trigger.dev **prod** environment — the worker runs on Trigger.dev cloud, outside the cluster, so every RPC crosses the public internet |
| Cloudflare | `api.ever.works` **is** CF-proxied (CF IPs + `/cdn-cgi/trace` responds) → ~100s origin read, error 524 |
| nginx-ingress | `ever-works-api-ing` carries only `force-ssl-redirect` + `proxy-body-size`. Repo-wide grep for `proxy-read-timeout` / `proxy_read_timeout` / helm values / ingress ConfigMap: **zero matches**. The 60s default stands → 504 |
| Duplicate agent runs | **`agent-task-execute` has never run in prod** — 0 runs over 30 days, same for `agent-heartbeat`, `agent-chat-reply`, `idea-build-execute`. No duplicates are possible from this path |
| What actually runs | Only cron dispatchers, completing in **1.3–2.2s** — two orders of magnitude below the ceiling |

**Conclusion: worth doing, not urgent.** The exposure is real and confirmed in code and infrastructure, but the dangerous path is not being exercised today.

One correction to the original framing: the live retry trigger is not primarily a network error. nginx answers **504** and Cloudflare **524**, both `>= 500`, which the existing `if (response.status < 500) throw` branch explicitly **retries** — while the work that timed out keeps running on the API pod.

Unrelated but worth knowing: prod Trigger.dev is currently stalled. All 8 cron tasks failed simultaneously at `2026-08-03T00:25:00Z` and everything since is `QUEUED` (1,500 runs, 0 executing), against a live `20260728.1` deployment.

## 1. Retries are now default-deny

`RETRY_SAFE_REMOTE_METHODS` is an **allow-list** of `(provider, method)` pairs. Unlisted means no retry, so omitting a method costs one retry while wrongly adding one doubles a side effect — the polarity is deliberate.

A refused retry surfaces as a task failure, and Trigger.dev retries the whole task, where `dedupKey` and the `markStarted` CAS make re-execution safe. That is the layer that actually has deduplication.

Seeded with pure reads plus writers whose idempotency is **structural** (a CAS, a dedup key, or an absolute-value SET) rather than incidental. `AgentRunRepository.addTokens` is deliberately absent while its sibling `updateTelemetry` is present: the former accumulates, the latter overwrites.

### Why not an idempotency key on the wire

`apps/api/src/main.ts` sets a **global** `ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true })`. `packages/tasks` deploys via its own workflow (`release-trigger-prod.yml`), separately from the API. A worker-first deploy sending a new top-level field would get **400 `property idempotencyKey should not exist`** on **every** RPC call — and `callRemote` funnels ~55 registered services across 5 proxy modules, so that is the entire background tier, not one feature. The client does not retry 4xx, so it fails on attempt 0.

Hiding it inside `args` is also closed: the controller's `assertSuperJsonEnvelope` hard-rejects any envelope key other than `json`/`meta`. And with `forbidNonWhitelisted` off, `whitelist: true` would silently *strip* the field, so dedup would fail open with no error at all.

The allow-list needs no protocol change, so it carries zero skew risk.

## 2. An explicit per-attempt deadline

`TRIGGER_INTERNAL_REQUEST_TIMEOUT_MS`, default **45000ms** — below the 60s ingress ceiling so the client fails first, predictably, with an error naming the budget.

`AbortController` + `setTimeout` rather than `AbortSignal.timeout()`: only the former is driven by the suite's fake timers. The deadline spans the response body read too (a stalled body hangs the worker just as effectively), and is cleared in a `finally`.

Note a deadline does **not** cancel work already running on the API pod — which is exactly why timing out must not imply retrying, and why (1) is the load-bearing half of this change.

## 3. Cancellation across the boundary

Worse than a silent no-op. SuperJSON has no transformer for `AbortSignal`, so it encoded to `{}` — losing even an already-aborted state — and arrived API-side as a truthy object whose `.aborted` is `undefined`. That inert `{}` was then threaded onward as `abortSignal` into the AI provider chain, where a truthy non-signal reaches `signal.addEventListener(...)`.

- Signals are stripped in `createRemoteProxy` (plain containers are rebuilt; `Date`/`Map`/`Set` pass by reference so SuperJSON's rich types are unaffected).
- No longer passed at the three call sites — `agent-task-execute`, `agent-chat-reply` and `agent-heartbeat` all had it. `work-generation.task.ts` is deliberately untouched: its orchestrator is worker-local, so its signal is real.
- `createAgentRunAbortSource` now accepts **only** a real `AbortSignal`. This is the guard that matters for skew — an **older worker still sends `{}`** until it redeploys, so the fix has to exist on the consumer side too.

Cancellation already worked and continues to, through the `readStatus` poll of `agent_runs.status` that `createAgentRunAbortSource` wires up. Nothing is lost by dropping a signal that never functioned.

## Version skew

Additive and worker-side apart from the consumer guard. No DTO, controller or protocol change, so an old worker against a new API and a new worker against an old API both behave exactly as before.

## Gates

- `pnpm format:check` (exact CI command) — **all 11 changed files clean**.
- `packages/tasks` vitest — **500/500, 29/29 files**. Client spec 24 → 53 tests; new `remote-proxy.spec.ts` 10 tests including Date/Map/Set preservation.
- `packages/agent` jest — `agent-run-abort` 16/16, `config` + abort together 186/186.

Pre-existing failures on `develop`, unrelated to this PR and **verified to reproduce byte-identically on the parent commit** (agent: 4 suites / 11 tests; api: 10 suites / 43 tests):

- `TermsAcceptance` entity is exported but not listed in `_entity-names.ts` → `database.module.spec.ts` inventory-drift failure.
- `pnpm-lock.yaml` is missing `@ever-co/legal` and `terms-acceptance` which `apps/api/package.json` now requires → `pnpm install --frozen-lockfile` fails, and `auth-runtime.instance.spec.ts` cannot resolve its mock.
- Two files fail `format:check` on develop itself: `apps/api/src/auth/providers/auth-runtime.instance.spec.ts`, `apps/api/src/terms/terms-acceptance.service.ts`.

## Follow-up not in scope

`packages/tasks/src/trigger/worker/services/terminal-transport.client.ts` has the identical missing-timeout gap on its own `post()`, against a different endpoint. Left alone rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for agent runs, including reliable fallback detection when cancellation signals cannot be transferred.
  * Prevented invalid cancellation data from affecting remote task execution.
* **Reliability**
  * Added configurable timeouts for internal requests, with clearer timeout errors and proper cleanup.
  * Improved retry behavior by retrying only safe operations and avoiding duplicate non-idempotent actions.
  * Preserved complex values such as dates, maps, and sets during remote task communication.
* **Tests**
  * Added comprehensive coverage for cancellation, timeouts, retries, serialization, and configuration fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->