### PR TITLE
fix(desktop): declare a homepage so the deb target can be built

### DIFF
--- a/apps/desktop-node/package.json
+++ b/apps/desktop-node/package.json
@@ -2,6 +2,7 @@
 	"name": "ever-works-desktop-node",
 	"version": "0.1.0",
 	"description": "Ever Works Desktop Node - thin Electron shell that enrolls this machine as a platform execution node: setup wizard, status window and tray",
+	"homepage": "https://ever.works",
 	"author": {
 		"name": "Ever Co. LTD",
 		"email": "ever@ever.co",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,6 +2,7 @@
 	"name": "ever-works-desktop",
 	"version": "0.1.0",
 	"description": "Ever Works Desktop App - all-in-one Electron shell: install wizard, local service supervisor (API + web), embedded web UI",
+	"homepage": "https://ever.works",
 	"author": {
 		"name": "Ever Co. LTD",
 		"email": "ever@ever.co",


### PR DESCRIPTION
## What

Adds `"homepage": "https://ever.works"` to `apps/desktop/package.json` and `apps/desktop-node/package.json`. Two lines.

## Why

The `linux` job of `desktop-build.yml` has failed on **every** run — PRs and `develop` alike — since the `deb` target was added:

```
⨯ Please specify project homepage, see https://electron.build./configuration.md#Metadata-homepage
  failedTask=build  at FpmTarget.computeFpmMetaInfoOptions
```

fpm needs a `Homepage:` field for the `.deb` control file. `AppInfo.computePackageUrl()` resolves it from the app's own `package.json` (`metadata.homepage`), falling back to a GitHub URL derived from `repository` — and `apps/desktop` declares neither:

```js
// app-builder-lib/out/appInfo.js
async computePackageUrl() {
    const url = this.info.metadata.homepage || this.notNullDevMetadata.homepage;
    if (url != null) return url;
    const info = await this.info.repositoryInfo;
    return info == null || info.type !== "github" ? null : `https://.../${info.user}/${info.project}`;
}
```

The repository root `package.json` *does* declare `homepage`, but electron-builder packages from `apps/desktop`, so the root is never consulted.

**This cannot be set in `electron-builder.yml`** next to `maintainer` and `category`, which is the intuitive place to reach for — `homepage` is package metadata, not a `linux` target option.

## Why `desktop-node` too

`apps/desktop-node/electron-builder.yml` carries the same `deb` target and the same omission. No workflow packages it today, so it has never gone red — it would fail identically the first time one does. Fixed here rather than left as a trap.

## Scope

`AppImage` was building fine; only `deb` failed, so the job produced partial artifacts and went red. This is a permanently-red job that has been masking real desktop-build regressions — `linux` is **not** a required check, so it has been failing quietly for a while.

I could not execute the fpm packaging path locally (Linux-only), so this is verified by reading `computePackageUrl` against the config rather than by a local `.deb` build. The `linux` job on this PR is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)