### PR TITLE
fix(k8s-plugin): take js-yaml 5 to close the open high-severity advisory

### DIFF
--- a/packages/plugins/k8s/package.json
+++ b/packages/plugins/k8s/package.json
@@ -31,14 +31,13 @@
 	},
 	"dependencies": {
 		"@kubernetes/client-node": "^1.4.0",
-		"js-yaml": "^4.1.0"
+		"js-yaml": "^5.2.3"
 	},
 	"peerDependencies": {
 		"@ever-works/plugin": "workspace:*"
 	},
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",
-		"@types/js-yaml": "^4.0.9",
 		"@types/node": "^22.0.0",
 		"tsup": "^8.4.0",
 		"typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2322,15 +2322,12 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(encoding@0.1.13)
       js-yaml:
-        specifier: '>=5.2.2'
-        version: 5.2.2
+        specifier: ^5.2.3
+        version: 5.2.3
     devDependencies:
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
@@ -16662,6 +16659,10 @@ packages:
     resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
+    hasBin: true
+
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -22837,7 +22838,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -24277,7 +24278,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -25463,7 +25464,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.3
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       lodash: 4.18.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -25938,7 +25939,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.3
       joi: 18.2.3
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -25963,7 +25964,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -26258,7 +26259,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       minimatch: 10.2.6
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -27188,7 +27189,7 @@ snapshots:
       form-data: 4.0.6
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       jsonpath-plus: 10.4.0
       node-fetch: 2.7.0(encoding@0.1.13)
       openid-client: 6.8.4
@@ -33492,7 +33493,7 @@ snapshots:
       hosted-git-info: 4.1.0
       is-ci: 3.0.1
       isbinaryfile: 5.0.7
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -34145,7 +34146,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-ci: 3.0.1
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       source-map-support: 0.5.21
       stat-mode: 1.0.0
       temp-file: 3.4.0
@@ -34831,7 +34832,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.6.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -34840,7 +34841,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -34850,7 +34851,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -35623,7 +35624,7 @@ snapshots:
       builder-util-runtime: 9.2.10
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -36330,7 +36331,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 5.2.2
+      js-yaml: 5.2.3
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -38799,6 +38800,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@5.2.2:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Why this exists

There is an **open HIGH-severity dependabot alert against `js-yaml`**, and after tonight's merge train nothing open fixes it.

#2003 carried the `js-yaml ^4.1.0 → ^5.2.3` bump. Once the overlapping `electron`/`postcss`/`tar` bumps landed via #1995 and #1996, dependabot regenerated the npm-security group as #2004 — and the replacement contains only the `next` pin. #2003 was auto-closed unmerged, so **closing it lost a security fix rather than deferring it**. This carries it forward.

## Why it's safe

The consuming code was already written for v5:

```ts
// js-yaml v5 ... dropped its default export, so `import yaml from 'js-yaml'`
// resolves to `undefined` ...
import * as yaml from 'js-yaml';
```

`yaml.load` is unchanged between 4 and 5, and `import * as` is correct for both.

## Also drops `@types/js-yaml@^4.0.9`

js-yaml 5 ships its own declarations (`types: ./dist/js-yaml.d.ts` in its exports map). The stale v4 `@types` package is redundant against a v5 runtime and can shadow the real types.

## One correction to the in-repo comment

That parser comment calls v5 "ESM-only". That is **not** true of 5.2.3 — it publishes a `require` condition (`./dist/js-yaml.cjs.js`). It matters here because this plugin ships a CJS bundle (`require: ./dist/index.cjs`) with js-yaml external, so an genuinely ESM-only dependency could have caused `ERR_REQUIRE_ESM` at runtime — invisible to a build-only check. It doesn't, and I verified the CJS output builds.

## Verification

```
turbo run build --filter=@ever-works/k8s-plugin
  ESM ⚡️ Build success
  CJS ⚡️ Build success   dist/index.cjs 67.06 KB
  DTS ⚡️ Build success   dist/index.d.ts 34.50 KB
turbo run test --filter=@ever-works/k8s-plugin   → 1 successful
```

The `dts: true` build is the real check on dropping `@types` — it would fail loudly if v5's own declarations were inadequate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)