### PR TITLE
test(job-runtime-node): wait for the condition, not a guessed 250ms

### DIFF
--- a/packages/plugins/job-runtime-node/src/__tests__/node-job-runtime.plugin.spec.ts
+++ b/packages/plugins/job-runtime-node/src/__tests__/node-job-runtime.plugin.spec.ts
@@ -193,6 +193,21 @@ describe('NodeWorkerHostFactory', () => {
 	// Windows timer granularity makes a tight budget flaky rather than fast.
 	const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 250));
 
+	/**
+	 * Wait for the loop to reach an observable state, rather than sleeping a
+	 * guessed duration and hoping.
+	 *
+	 * A fixed `settle()` is a bet that 250ms of wall clock is always enough.
+	 * The poll loop crosses two real timer boundaries per iteration, so on a
+	 * loaded machine that budget stretches and the bet loses — this file timed
+	 * out at 7026ms against vitest's 5s default on a saturated CI runner, with
+	 * no assertion failure, purely because the timers had not fired yet.
+	 * Polling for the condition returns as soon as it holds (microseconds when
+	 * idle) and tolerates an arbitrarily slow machine, so it is both faster and
+	 * immune to load.
+	 */
+	const until = (assertion: () => void): Promise<void> => vi.waitFor(assertion, { timeout: 5_000, interval: 5 });
+
 	it('fails a leased job whose kind has no executor, naming the kind', async () => {
 		const complete = vi.fn(async () => true);
 		let handedOut = false;
@@ -210,7 +225,7 @@ describe('NodeWorkerHostFactory', () => {
 		});
 
 		const handle = await host.start({ concurrency: 1 });
-		await settle();
+		await until(() => expect(complete).toHaveBeenCalled());
 		await handle.stop();
 
 		expect(complete).toHaveBeenCalledWith(
@@ -242,7 +257,7 @@ describe('NodeWorkerHostFactory', () => {
 		});
 
 		const handle = await host.start({ concurrency: 1 });
-		await settle();
+		await until(() => expect(complete).toHaveBeenCalled());
 		await handle.stop();
 
 		expect(complete).toHaveBeenCalledWith(


### PR DESCRIPTION
## The failure

On #2005 (job `93270701689`, run `31323749863`) this test timed out:

```
× fails a leased job whose kind has no executor, naming the kind   7026ms
  If this is a long-running test, pass a timeout value as the last argument
  or configure it globally with "testTimeout".
```

A **timeout, not an assertion** — on a PR that bumps `js-yaml` in `packages/plugins/k8s` and does not touch this package at all. The file passes locally in ~1.3s. It failed while the self-hosted ARC pool had 12 queued runs.

## Why it was slow, measured

Per-test durations before this change:

| duration | test |
|---:|---|
| 268 ms | fails a leased job whose kind has no executor |
| 263 ms | reports an executor throw as a job failure |
| 260 ms | backs off instead of hot-looping |
| 1–3 ms | *every other test in the file* |

The cost is **entirely** the fixed wait. `settle()` is `setTimeout(..., 250)` used as a synchronisation primitive — a bet that 250ms of wall clock is always long enough for the poll loop to reach its verdict.

That bet is load-sensitive by construction. The loop crosses **two real timer boundaries per iteration** — `macrotaskTick()` plus the injected `sleep` (`immediate`, itself a `setTimeout(…, 0)`):

```ts
while (!this.stopping) {
    await macrotaskTick();          // real setTimeout(0)
    ...
    if (jobs.length === 0) { await this.guarded(sleep(idleMs)); continue; }  // real setTimeout(0)
}
```

Under CPU contention those callbacks queue behind everything else, the 250ms budget stretches, and the test blows the 5s ceiling with no assertion ever failing.

## The fix

Wait for the **observable condition** instead of a duration:

```ts
await until(() => expect(complete).toHaveBeenCalled());
```

It returns as soon as `complete` has been called, and tolerates an arbitrarily slow machine up to a 5s ceiling. So it is **both faster and load-immune**, rather than trading one for the other:

```
fails a leased job whose kind has no executor   268ms -> 15ms
reports an executor throw as a job failure      263ms -> 29ms
```

**Why not just raise `testTimeout`:** it keeps paying the 250ms on every run and merely widens the window before the same bet fails again on a slower machine. It hides the cost instead of removing it.

## What is deliberately left alone

`backs off instead of hot-looping` keeps `settle()`. Its assertion is that nothing **further** happened after the loop stopped itself (`delays.length` stays under 10) — "nothing more happened" needs an observation window, not a condition to poll for. Replacing it would have weakened what the test proves. It is the remaining 253ms in the file.

## Verification

```
vitest run          → 21/21 passed, stable across repeated runs
tsc --noEmit        → clean
prettier --check    → clean
turbo run test      → 1 successful
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved worker-host test reliability by waiting for completion conditions instead of relying on fixed delays.
  * Added polling with a five-second timeout to handle asynchronous results more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->