### PR TITLE
test(opencode): wait for the watcher's output instead of sleeping 300ms

### DIFF
--- a/packages/plugins/opencode/src/__tests__/taxonomy-watcher.spec.ts
+++ b/packages/plugins/opencode/src/__tests__/taxonomy-watcher.spec.ts
@@ -26,14 +26,25 @@ describe('taxonomy-watcher', () => {
 			const item = JSON.stringify({ name: 'Tool', category: 'Cloud Services', tags: ['cloud'] });
 			await writeFile(join(workspacePath, 'tool.json'), item, 'utf-8');
 
-			// Wait for debounce (50ms) + file read + processing
-			await sleep(300);
-
-			// Check that _meta/categories.json was created
+			// Poll for the file the watcher is supposed to write, rather than
+			// sleeping a guessed 300ms and reading once.
+			//
+			// The old `sleep(300)` was a bet that debounce + fs event + read +
+			// write always fits in 300ms. On a loaded runner it does not: the
+			// read then hits an absent (or half-written) file and the test fails
+			// with ENOENT rather than a real assertion. That is what happened on
+			// the develop -> stage cascade (#2008), where this test burned all
+			// its retries. Retrying a too-short sleep just re-rolls the same
+			// dice; waiting for the actual condition removes the bet, and
+			// returns as soon as the watcher is done.
 			const { readFile: rf } = await import('node:fs/promises');
-			const catContent = await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8');
-			const categories = JSON.parse(catContent);
-			expect(categories).toEqual([{ id: 'cloud-services', name: 'Cloud Services' }]);
+			await vi.waitFor(
+				async () => {
+					const catContent = await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8');
+					expect(JSON.parse(catContent)).toEqual([{ id: 'cloud-services', name: 'Cloud Services' }]);
+				},
+				{ timeout: 5_000, interval: 25 }
+			);
 		} finally {
 			watcher.stop();
 		}


### PR DESCRIPTION
## Why now

This test failed the **develop → stage cascade** (#2008, job `93310454429`) after exhausting its retries:

```
❯ src/__tests__/taxonomy-watcher.spec.ts (8 tests | 1 failed) 8806ms
  × should pick up new .json files and sync taxonomy 2888ms (retry x2)
```

The same commit passed on the parallel run, so it is a flake — but it flaked on a cascade, which is the most expensive place to lose 40 minutes of CI.

## The defect

```ts
await writeFile(join(workspacePath, 'tool.json'), item, 'utf-8');

// Wait for debounce (50ms) + file read + processing
await sleep(300);

const catContent = await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8');
```

That is a bet that debounce + fs event + read + write always completes within 300ms. Under CI contention it does not, and the read then hits an absent or half-written file — so the test fails on **ENOENT**, not on anything it is actually asserting.

**Retries were already configured and did not save it.** A retry re-rolls the same dice: every attempt sleeps the same too-short 300ms. That is why the older `fix/deflake-taxonomy-watcher` branch (which added the retries) did not solve this.

## The fix

Poll for the condition — the file the watcher is supposed to write:

```ts
await vi.waitFor(async () => {
    const catContent = await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8');
    expect(JSON.parse(catContent)).toEqual([{ id: 'cloud-services', name: 'Cloud Services' }]);
}, { timeout: 5_000, interval: 25 });
```

`waitFor` retries on the thrown ENOENT until the file appears with the right content. Faster in the common case, and tolerant of a slow machine up to a 5s ceiling.

## Scope

Deliberately limited to the one test that actually flaked. The file contains **ten other fixed `sleep()` calls** with the same weakness — worth revisiting, but converting them all mid-cascade is churn I did not want to add without evidence they hurt.

## Verification

```
vitest run taxonomy-watcher.spec.ts   → 8/8 passed
turbo run test --filter=opencode      → 53/53 passed, 6 files
prettier --check                      → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved taxonomy synchronization test reliability by waiting for generated category data to become available.
  * Added retry handling with a defined timeout and polling interval to reduce timing-related test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->