### PR TITLE
test(pipeline): prove concurrency by overlap, not by wall-clock duration

### DIFF
--- a/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
@@ -596,19 +596,37 @@ describe('StepPipelineExecutorService', () => {
                 name: 'Start',
                 run: jest.fn().mockResolvedValue(undefined),
             };
+
+            // Concurrency is measured by OVERLAP, not by elapsed time.
+            //
+            // This used to assert `duration < 200ms` on the theory that parallel
+            // is ~50ms and sequential ~100ms. That was wrong in both directions:
+            // sequential (~100ms) also passes a 200ms bar, so a regression to
+            // sequential execution would NOT have been caught; and on a loaded
+            // runner even the parallel path overshoots — it was observed at
+            // 247ms, failing a PR that touched an unrelated package.
+            //
+            // Counting how many step bodies are in flight at once decides the
+            // question exactly: 2 only if they genuinely overlap, 1 if they are
+            // serialised. It is independent of how fast the machine is.
+            let inFlight = 0;
+            let maxInFlight = 0;
+            const overlappingBody = async (): Promise<void> => {
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await new Promise((resolve) => setTimeout(resolve, 50));
+                inFlight -= 1;
+            };
+
             const parallel1 = {
                 id: 'p1',
                 name: 'Parallel 1',
-                run: jest
-                    .fn()
-                    .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 50))),
+                run: jest.fn().mockImplementation(overlappingBody),
             };
             const parallel2 = {
                 id: 'p2',
                 name: 'Parallel 2',
-                run: jest
-                    .fn()
-                    .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 50))),
+                run: jest.fn().mockImplementation(overlappingBody),
             };
 
             // Mock the build method to return our manual parallel structure
@@ -638,17 +656,11 @@ describe('StepPipelineExecutorService', () => {
             standardPlugin.registerStepExecutor('p1', parallel1);
             standardPlugin.registerStepExecutor('p2', parallel2);
 
-            const startTime = Date.now();
             await service.execute(standardPlugin, mockWork, mockRequest, mockExisting);
-            const duration = Date.now() - startTime;
 
-            // Verification
-            // Both parallel steps take 50ms.
-            // If sequential: 50 + 50 = 100ms (+ overhead)
-            // If parallel: max(50, 50) = 50ms (+ overhead)
-            // We expect the total duration to be closer to 50ms than 100ms
-            // Using a slightly loose check to account for test overhead
-            expect(duration).toBeLessThan(200);
+            // Both bodies were in flight at the same moment — the definition of
+            // running concurrently. Serialised execution leaves this at 1.
+            expect(maxInFlight).toBe(2);
             expect(parallel1.run).toHaveBeenCalled();
             expect(parallel2.run).toHaveBeenCalled();
         });


### PR DESCRIPTION
## The failure

Failed CI on #2010 — a PR that only touches the opencode plugin:

```
● StepPipelineExecutorService › execute() › should execute parallel steps concurrently
  expect(received).toBeLessThan(expected)
  Expected: < 200
  Received:   247
```

## The test was wrong in two directions

It ran two 50ms steps and asserted total elapsed time under 200ms:

```ts
// If sequential: 50 + 50 = 100ms (+ overhead)
// If parallel: max(50, 50) = 50ms (+ overhead)
expect(duration).toBeLessThan(200);
```

**It was too weak.** Sequential execution takes ~100ms, which *also* passes a 200ms bar. A regression from parallel to serialised execution — precisely what this test exists to catch — would have sailed through. The assertion never actually tested concurrency.

**It was also load-fragile.** On a busy runner even the genuinely-parallel path overshoots, which is how it failed here.

Those two interact badly: raising the threshold to fix the flake makes the test *weaker*, because the further the bar sits above 100ms, the more room a serialised implementation has to hide behind it.

## The fix

Concurrency has an exact definition — both bodies in flight at the same moment. Count peak in-flight:

```ts
let inFlight = 0;
let maxInFlight = 0;
const overlappingBody = async (): Promise<void> => {
    inFlight += 1;
    maxInFlight = Math.max(maxInFlight, inFlight);
    await new Promise((resolve) => setTimeout(resolve, 50));
    inFlight -= 1;
};
...
expect(maxInFlight).toBe(2);
```

- **2** when they genuinely overlap, **1** when serialised — so it now actually catches the regression.
- Independent of machine speed, so it cannot flake under load.
- Faster, since nothing is being timed.

## Verification

```
jest step-pipeline-executor.spec.ts   → 33/33 passed
prettier --check                      → clean
```

The assertion passing means an overlap of 2 was **observed**, not merely not-disproved — strictly stronger evidence than the duration check it replaces.

## Context

This is the third instance of the same defect class found tonight, after #2006 (`job-runtime-node`, a guessed 300ms sleep) and #2010 (`opencode` taxonomy-watcher, likewise). All three assert on wall-clock time in a shared CI environment. Worth watching for as a pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of parallel step execution.
  * Replaced timing-based checks with deterministic concurrency verification for more reliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->