### PR TITLE
fix(api): serve terms and admin-usage under api/ — signup is currently blocked

### DIFF
--- a/apps/api/src/budgets/admin-usage.controller.ts
+++ b/apps/api/src/budgets/admin-usage.controller.ts
@@ -41,7 +41,14 @@ interface AdminUsageResponse {
  * render a sortable table without N+1 lookups.
  */
 @ApiTags('Admin')
-@Controller('admin/usage')
+// `api/admin/usage`, not `admin/usage` — this app has no `setGlobalPrefix`, so
+// each controller carries the segment itself. Served un-prefixed, this route
+// answered on `/admin/usage` while `adminUsageAPI` calls
+// `serverFetch('/admin/usage')`, which resolves against an `API_URL` that
+// always ends in `/api` — so the admin usage page requested
+// `/api/admin/usage` and got a 404. Pinned by the guard in
+// `terms/terms.controller.spec.ts`.
+@Controller('api/admin/usage')
 @UseGuards(IsPlatformAdminGuard)
 export class AdminUsageController {
     constructor(

--- a/apps/api/src/terms/terms.controller.spec.ts
+++ b/apps/api/src/terms/terms.controller.spec.ts
@@ -1,0 +1,79 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Controller } from '@nestjs/common';
+import { TermsController } from './terms.controller';
+
+/**
+ * Route-prefix guard.
+ *
+ * This app has no `setGlobalPrefix`: every controller carries the `api/`
+ * segment itself. That convention is invisible until it is broken, and breaking
+ * it is silent — the route still registers, it just answers on a path nobody
+ * calls.
+ *
+ * `TermsController` was declared `@Controller('terms')`, so it served
+ * `/terms/required`. The web app reaches the API through `API_URL`, which
+ * `apps/web/src/lib/constants.ts` guarantees ends in `/api`, so the register
+ * page requested `/api/terms/required` and got a 404. It swallowed the error,
+ * passed the form an empty document list, and the form — correctly refusing to
+ * record an acceptance it could not identify — rendered the checkbox
+ * `disabled`. Every signup on stage and production was blocked, with no error
+ * anywhere: a 200 page containing a form that could not be submitted.
+ *
+ * Nothing caught it. Unit tests do not exercise route paths, and no e2e test
+ * asserts that the register page can actually be submitted.
+ */
+describe('API route prefix convention', () => {
+    it('serves TermsController under api/', () => {
+        // Reflect the real registered path rather than trusting the source text.
+        const path = Reflect.getMetadata('path', TermsController);
+        expect(path).toBe('api/terms');
+    });
+
+    it('publishes the required-documents route where the web app looks for it', () => {
+        const controllerPath = Reflect.getMetadata('path', TermsController) as string;
+        const routePath = Reflect.getMetadata(
+            'path',
+            TermsController.prototype.getRequired,
+        ) as string;
+
+        // `serverFetch` builds `${API_URL}${endpoint}` where API_URL always ends
+        // in `/api` and endpoint is `/terms/required`.
+        expect(`/${controllerPath}/${routePath}`).toBe('/api/terms/required');
+    });
+
+    /**
+     * The class-wide guard. Source-level on purpose: importing every controller
+     * drags in the DI graph and TypeORM, which is exactly what
+     * `_entity-names.ts` exists to avoid elsewhere in this repo.
+     */
+    it('declares every controller under api/ (or a deliberate exception)', () => {
+        // Routes that are intentionally NOT part of the public `/api` surface.
+        const EXEMPT = new Set(['internal/trigger']);
+
+        const srcRoot = join(__dirname, '..');
+        const offenders: string[] = [];
+
+        const walk = (dir: string): void => {
+            for (const entry of readdirSync(dir, { withFileTypes: true })) {
+                const full = join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name !== 'node_modules' && entry.name !== '__tests__') walk(full);
+                    continue;
+                }
+                if (!entry.name.endsWith('.controller.ts')) continue;
+
+                const source = readFileSync(full, 'utf-8');
+                for (const [, declared] of source.matchAll(/@Controller\(\s*'([^']*)'\s*\)/g)) {
+                    if (EXEMPT.has(declared)) continue;
+                    if (declared === 'api' || declared.startsWith('api/')) continue;
+                    offenders.push(`${entry.name}: @Controller('${declared}')`);
+                }
+            }
+        };
+
+        walk(srcRoot);
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/apps/api/src/terms/terms.controller.ts
+++ b/apps/api/src/terms/terms.controller.ts
@@ -5,7 +5,19 @@ import { Public } from '../auth/decorators/public.decorator';
 import { TermsAcceptanceService } from './terms-acceptance.service';
 
 @ApiTags('terms')
-@Controller('terms')
+// `api/terms`, not `terms`. There is no `setGlobalPrefix` in this app — every
+// controller carries the `api/` segment itself (`@Controller('api')`,
+// `@Controller('api/billing')`, …). This one did not, so it was served at
+// `/terms/required` while every consumer reaches the API through the web's
+// `API_URL`, which `constants.ts` guarantees ends in `/api`:
+//
+//     export const API_URL = apiUrl.endsWith('/api') ? apiUrl : `${apiUrl}/api`;
+//
+// so `serverFetch('/terms/required')` asked for `/api/terms/required` and got a
+// 404. The register page swallowed that, handed the form an empty document
+// list, and the form correctly refused to let anyone accept terms it could not
+// identify — disabling the checkbox and blocking every signup.
+@Controller('api/terms')
 export class TermsController {
     constructor(private readonly termsAcceptanceService: TermsAcceptanceService) {}
 


### PR DESCRIPTION
## P0 — nobody can register, on stage or production

`https://app.ever.works/register` returns **HTTP 200** with a form that cannot be submitted:

```html
<input id="terms" type="checkbox" required="" disabled="" .../>
```
```
termsDocuments\":[]
```

No error is logged for a user to see, no check goes red. A healthy-looking page containing a dead form.

## Root cause

There is no `setGlobalPrefix` in this app — every controller carries the `api/` segment itself (`@Controller('api')`, `@Controller('api/billing')`, …). `TermsController` was declared `@Controller('terms')`.

Consumers reach the API through the web's `API_URL`, normalised in `apps/web/src/lib/constants.ts`:

```ts
export const API_URL = apiUrl.endsWith('/api') ? apiUrl : `${apiUrl}/api`;
```

So `serverFetch('/terms/required')` asks for `/api/terms/required`. Measured live on both environments:

| path | stage | prod |
|---|---|---|
| `/terms/required` | **200** | **200** |
| `/api/terms/required` | **404** | **404** |

`register/page.tsx` catches the 404 and passes an empty list; `register-form.tsx` sets `termsUnavailable = termsDocuments.length === 0` and disables the checkbox.

**The form is behaving correctly** — it refuses to record an acceptance whose text it cannot identify, which is the entire point of the feature. The routing was wrong.

## Second instance, found by the new guard

`AdminUsageController` had the identical defect — `@Controller('admin/usage')` against `adminUsageAPI` calling `serverFetch('/admin/usage')`:

| path | stage |
|---|---|
| `/admin/usage` | **401** (exists, behind the admin guard) |
| `/api/admin/usage` | **404** (where the web asks) |

The admin usage page was broken the same silent way.

## The guard

Rather than pinning these two routes, `terms.controller.spec.ts` now pins the convention:

1. reflects the registered path for `TermsController`;
2. asserts the full route equals the URL the web builds (`/api/terms/required`);
3. scans every `*.controller.ts` for a declared prefix outside `api/`, exempting `internal/trigger`.

Test 3 is what found the admin-usage instance. It is source-level on purpose — importing every controller drags in the DI graph and TypeORM, the hazard `_entity-names.ts` exists to avoid. `@Controller()` with no argument is correctly ignored: those hardcode `api/…` in their `@Get()` decorators.

## Why nothing caught it

Unit tests do not exercise route paths, and no e2e test submits the register form. A 200 response carrying an unusable form is invisible to health checks, to `lint-and-test`, and to the deploy pipeline. Worth a follow-up: an e2e that actually completes a signup.

## Verification

```
jest src/terms src/budgets   → 6 suites, 69 tests passed
prettier --check             → clean
```

Needs to reach production promptly — registration is blocked there now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated administrative usage endpoints to use the `/api/admin/usage` path.
  * Updated terms endpoints to use the `/api/terms` path, including required-documents access at `/api/terms/required`.

* **Tests**
  * Added coverage to verify API route prefixes and detect incorrectly registered endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->