### PR TITLE
fix(api): serve terms + admin-usage under api/ — unblocks signup in production

### DIFF
--- a/.github/workflows/smoke-deployed.yml
+++ b/.github/workflows/smoke-deployed.yml
@@ -1,0 +1,146 @@
+name: Post-Deploy Smoke
+
+# Verifies a DEPLOYED environment, not a commit.
+#
+# `ci.yml` proves the code compiles and its unit tests pass. `e2e.yml` proves the
+# product behaves, against a local stack it builds itself. Neither can see the
+# thing that actually broke production on 2026-08-09: the deployed web app asked
+# the deployed API for `/api/terms/required` while the API served
+# `/terms/required`, so registration was impossible while every health check
+# reported ok and `/api/version` reported the right SHA.
+#
+# A local stack cannot reproduce that, because both halves are built from the
+# same config. Only a real deployment can.
+#
+# Rollout-aware on purpose: k8s replaces pods gradually, so immediately after a
+# deploy `/api/version` alternates between the old and new SHA depending on
+# which pod answers. Sampling once is a coin flip — this waits for the new SHA
+# to answer consistently before testing anything.
+
+on:
+  workflow_run:
+    workflows: ['k8s-build']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Which deployment to smoke'
+        required: true
+        default: stage
+        type: choice
+        options: [dev, stage, prod]
+
+concurrency:
+  group: smoke-${{ github.event.workflow_run.head_branch || inputs.environment }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    # Only for branches that map to an environment, and only when the deploy
+    # itself succeeded — smoking a failed deploy tests nothing.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       contains(fromJSON('["develop","stage","main"]'), github.event.workflow_run.head_branch))
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Resolve target environment
+        id: target
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ENV_NAME="${{ inputs.environment }}"
+            EXPECTED_SHA=""
+          else
+            case "${{ github.event.workflow_run.head_branch }}" in
+              develop) ENV_NAME=dev ;;
+              stage)   ENV_NAME=stage ;;
+              main)    ENV_NAME=prod ;;
+              *)       echo "unmapped branch"; exit 1 ;;
+            esac
+            EXPECTED_SHA="${{ github.event.workflow_run.head_sha }}"
+          fi
+
+          case "$ENV_NAME" in
+            dev)   API=https://apidev.ever.works;   WEB=https://appdev.ever.works;   WRITES=true ;;
+            stage) API=https://apistage.ever.works; WEB=https://appstage.ever.works; WRITES=true ;;
+            # Production is not a test fixture. Read-only checks only — which is
+            # the half that caught the 2026-08-09 outage anyway.
+            prod)  API=https://api.ever.works;      WEB=https://app.ever.works;      WRITES=false ;;
+          esac
+
+          {
+            echo "env_name=$ENV_NAME"
+            echo "api=$API"
+            echo "web=$WEB"
+            echo "writes=$WRITES"
+            echo "expected_sha=$EXPECTED_SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Smoking $ENV_NAME ($WEB) — writes=$WRITES expected_sha=${EXPECTED_SHA:-any}"
+
+      - name: Wait for the rollout to serve the new SHA consistently
+        if: steps.target.outputs.expected_sha != ''
+        run: |
+          set -uo pipefail
+          API="${{ steps.target.outputs.api }}"
+          WANT="${{ steps.target.outputs.expected_sha }}"
+          UA='Mozilla/5.0 (compatible; ever-works-smoke)'
+
+          # Up to ~15 min for pods to cycle. Requires 5 CONSECUTIVE samples on
+          # the new SHA: during a rolling update the old and new pods both
+          # answer, so a single match proves nothing.
+          for attempt in $(seq 1 90); do
+            streak=0
+            for i in 1 2 3 4 5; do
+              got=$(curl -s --max-time 15 -A "$UA" "$API/api/version" | jq -r '.gitSha // ""' || echo "")
+              if [ "$got" = "$WANT" ]; then streak=$((streak+1)); else streak=0; break; fi
+              sleep 2
+            done
+            if [ "$streak" -ge 5 ]; then
+              echo "rollout complete: $API serving ${WANT:0:8} on 5/5 samples"
+              exit 0
+            fi
+            echo "attempt $attempt: not yet consistent (last saw ${got:0:8}, want ${WANT:0:8})"
+            sleep 10
+          done
+
+          echo "::error::$API never settled on ${WANT:0:8} — the rollout did not complete"
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright chromium
+        working-directory: apps/web
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the smoke suite
+        working-directory: apps/web
+        env:
+          SMOKE_BASE_URL: ${{ steps.target.outputs.web }}
+          SMOKE_API_URL: ${{ steps.target.outputs.api }}
+          SMOKE_ALLOW_WRITES: ${{ steps.target.outputs.writes }}
+        run: npx playwright test -c playwright.smoke.config.ts --project=smoke
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-${{ steps.target.outputs.env_name }}-report
+          path: |
+            apps/web/test-results/
+            apps/web/playwright-report/
+          retention-days: 7

--- a/apps/api/src/budgets/admin-usage.controller.ts
+++ b/apps/api/src/budgets/admin-usage.controller.ts
@@ -41,7 +41,14 @@ interface AdminUsageResponse {
  * render a sortable table without N+1 lookups.
  */
 @ApiTags('Admin')
-@Controller('admin/usage')
+// `api/admin/usage`, not `admin/usage` — this app has no `setGlobalPrefix`, so
+// each controller carries the segment itself. Served un-prefixed, this route
+// answered on `/admin/usage` while `adminUsageAPI` calls
+// `serverFetch('/admin/usage')`, which resolves against an `API_URL` that
+// always ends in `/api` — so the admin usage page requested
+// `/api/admin/usage` and got a 404. Pinned by the guard in
+// `terms/terms.controller.spec.ts`.
+@Controller('api/admin/usage')
 @UseGuards(IsPlatformAdminGuard)
 export class AdminUsageController {
     constructor(

--- a/apps/api/src/terms/terms.controller.spec.ts
+++ b/apps/api/src/terms/terms.controller.spec.ts
@@ -1,0 +1,79 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Controller } from '@nestjs/common';
+import { TermsController } from './terms.controller';
+
+/**
+ * Route-prefix guard.
+ *
+ * This app has no `setGlobalPrefix`: every controller carries the `api/`
+ * segment itself. That convention is invisible until it is broken, and breaking
+ * it is silent — the route still registers, it just answers on a path nobody
+ * calls.
+ *
+ * `TermsController` was declared `@Controller('terms')`, so it served
+ * `/terms/required`. The web app reaches the API through `API_URL`, which
+ * `apps/web/src/lib/constants.ts` guarantees ends in `/api`, so the register
+ * page requested `/api/terms/required` and got a 404. It swallowed the error,
+ * passed the form an empty document list, and the form — correctly refusing to
+ * record an acceptance it could not identify — rendered the checkbox
+ * `disabled`. Every signup on stage and production was blocked, with no error
+ * anywhere: a 200 page containing a form that could not be submitted.
+ *
+ * Nothing caught it. Unit tests do not exercise route paths, and no e2e test
+ * asserts that the register page can actually be submitted.
+ */
+describe('API route prefix convention', () => {
+    it('serves TermsController under api/', () => {
+        // Reflect the real registered path rather than trusting the source text.
+        const path = Reflect.getMetadata('path', TermsController);
+        expect(path).toBe('api/terms');
+    });
+
+    it('publishes the required-documents route where the web app looks for it', () => {
+        const controllerPath = Reflect.getMetadata('path', TermsController) as string;
+        const routePath = Reflect.getMetadata(
+            'path',
+            TermsController.prototype.getRequired,
+        ) as string;
+
+        // `serverFetch` builds `${API_URL}${endpoint}` where API_URL always ends
+        // in `/api` and endpoint is `/terms/required`.
+        expect(`/${controllerPath}/${routePath}`).toBe('/api/terms/required');
+    });
+
+    /**
+     * The class-wide guard. Source-level on purpose: importing every controller
+     * drags in the DI graph and TypeORM, which is exactly what
+     * `_entity-names.ts` exists to avoid elsewhere in this repo.
+     */
+    it('declares every controller under api/ (or a deliberate exception)', () => {
+        // Routes that are intentionally NOT part of the public `/api` surface.
+        const EXEMPT = new Set(['internal/trigger']);
+
+        const srcRoot = join(__dirname, '..');
+        const offenders: string[] = [];
+
+        const walk = (dir: string): void => {
+            for (const entry of readdirSync(dir, { withFileTypes: true })) {
+                const full = join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name !== 'node_modules' && entry.name !== '__tests__') walk(full);
+                    continue;
+                }
+                if (!entry.name.endsWith('.controller.ts')) continue;
+
+                const source = readFileSync(full, 'utf-8');
+                for (const [, declared] of source.matchAll(/@Controller\(\s*'([^']*)'\s*\)/g)) {
+                    if (EXEMPT.has(declared)) continue;
+                    if (declared === 'api' || declared.startsWith('api/')) continue;
+                    offenders.push(`${entry.name}: @Controller('${declared}')`);
+                }
+            }
+        };
+
+        walk(srcRoot);
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/apps/api/src/terms/terms.controller.ts
+++ b/apps/api/src/terms/terms.controller.ts
@@ -5,7 +5,19 @@ import { Public } from '../auth/decorators/public.decorator';
 import { TermsAcceptanceService } from './terms-acceptance.service';
 
 @ApiTags('terms')
-@Controller('terms')
+// `api/terms`, not `terms`. There is no `setGlobalPrefix` in this app — every
+// controller carries the `api/` segment itself (`@Controller('api')`,
+// `@Controller('api/billing')`, …). This one did not, so it was served at
+// `/terms/required` while every consumer reaches the API through the web's
+// `API_URL`, which `constants.ts` guarantees ends in `/api`:
+//
+//     export const API_URL = apiUrl.endsWith('/api') ? apiUrl : `${apiUrl}/api`;
+//
+// so `serverFetch('/terms/required')` asked for `/api/terms/required` and got a
+// 404. The register page swallowed that, handed the form an empty document
+// list, and the form correctly refused to let anyone accept terms it could not
+// identify — disabling the checkbox and blocking every signup.
+@Controller('api/terms')
 export class TermsController {
     constructor(private readonly termsAcceptanceService: TermsAcceptanceService) {}
 

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -14,6 +14,9 @@
 /coverage
 /e2e/.auth/
 /e2e/test-results/
+# The post-deploy smoke suite (playwright.smoke.config.ts) writes here rather
+# than under /e2e, since its testDir is /e2e-smoke.
+/test-results/
 /playwright-report/
 /blob-report/
 

--- a/apps/web/e2e-smoke/deployed-api-contract.spec.ts
+++ b/apps/web/e2e-smoke/deployed-api-contract.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Does the deployed API actually serve the paths the deployed web app asks for?
+ *
+ * The web reaches the API through `API_URL`, which `apps/web/src/lib/constants.ts`
+ * normalises to always end in `/api`:
+ *
+ *     export const API_URL = apiUrl.endsWith('/api') ? apiUrl : `${apiUrl}/api`;
+ *
+ * so every `serverFetch('/x')` becomes `<api>/api/x`. A controller declared
+ * without the `api/` prefix still registers, still answers on its own path, and
+ * still passes every unit test — it is simply unreachable from the product.
+ *
+ * That is not hypothetical. On 2026-08-09 `TermsController` was `@Controller('terms')`
+ * and `AdminUsageController` was `@Controller('admin/usage')`; both answered
+ * fine on their own paths and 404'd on the path the web used. Registration was
+ * impossible in production while every health check stayed green.
+ *
+ * The distinction that makes this test work:
+ *
+ *   404 → the route does not exist where the product looks for it. FAIL.
+ *   401 → the route exists and its auth guard fired. PASS.
+ *
+ * A 401 is a success here; we are testing routing, not authorisation.
+ */
+
+const API = process.env.SMOKE_API_URL || 'http://localhost:3100';
+
+/**
+ * Critical GET routes, written exactly as the web requests them: `/api` +
+ * the path passed to `serverFetch`.
+ *
+ * Curated rather than derived from source on purpose. Nest answers 404 for a
+ * path that exists but has no handler for the METHOD, so probing every
+ * `serverFetch` call with GET would fail on POST-only routes and teach everyone
+ * to ignore this test. The exhaustive check on the prefix convention lives in
+ * `apps/api/src/terms/terms.controller.spec.ts`, where it is free and complete.
+ */
+const CRITICAL_GET_ROUTES: ReadonlyArray<{ path: string; why: string }> = [
+    { path: '/api/terms/required', why: 'signup cannot render its consent without this' },
+    { path: '/api/version', why: 'deploy verification depends on it' },
+    { path: '/api/health/ready', why: 'readiness probe' },
+    { path: '/api/plugins', why: 'plugin registry — an empty registry silently breaks chat' },
+    { path: '/api/works', why: 'core domain listing' },
+    { path: '/api/agents', why: 'agents surface' },
+    { path: '/api/agents/templates', why: 'agent creation flow' },
+    { path: '/api/auth/profile', why: 'every authenticated page reads it' },
+    { path: '/api/activity-log', why: 'dashboard feed' },
+    { path: '/api/admin/usage', why: 'admin usage page (regressed 2026-08-09)' },
+    { path: '/api/billing/overview', why: 'billing surface' },
+    { path: '/api/credits/balance', why: 'credits surface' },
+    { path: '/api/notifications', why: 'notification bell' },
+    { path: '/api/organizations', why: 'org switcher' },
+];
+
+test.describe('deployed API route contract', () => {
+    for (const { path, why } of CRITICAL_GET_ROUTES) {
+        test(`${path} is routed (${why})`, async ({ request }) => {
+            const response = await request.get(`${API}${path}`, { failOnStatusCode: false });
+
+            expect(
+                response.status(),
+                `${API}${path} returned 404 — the route is not served where the web app asks for it. ` +
+                    `Check the controller's @Controller() prefix: this app has no setGlobalPrefix, ` +
+                    `so every controller must declare 'api/...' itself.`,
+            ).not.toBe(404);
+
+            // 5xx means routed but broken, which is also not a healthy deploy.
+            expect(response.status(), `${API}${path} returned ${response.status()}`).toBeLessThan(
+                500,
+            );
+        });
+    }
+
+    test('the terms endpoint returns real, usable documents', async ({ request }) => {
+        // Routing alone is not enough: an empty list disables the signup
+        // checkbox just as effectively as a 404 does.
+        const response = await request.get(`${API}/api/terms/required`, {
+            failOnStatusCode: false,
+        });
+        expect(response.ok()).toBeTruthy();
+
+        const documents = (await response.json()) as Array<Record<string, unknown>>;
+        expect(Array.isArray(documents)).toBeTruthy();
+        expect(
+            documents.length,
+            'no required documents published — the register form will disable its consent checkbox',
+        ).toBeGreaterThan(0);
+
+        // Each document must carry the identity the acceptance is pinned to.
+        for (const doc of documents) {
+            expect(doc).toHaveProperty('documentId');
+            expect(doc).toHaveProperty('version');
+            expect(doc).toHaveProperty('sha256');
+            expect(String(doc.sha256)).toMatch(/^[a-f0-9]{64}$/);
+        }
+    });
+});

--- a/apps/web/e2e-smoke/deployed-signup.spec.ts
+++ b/apps/web/e2e-smoke/deployed-signup.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Can a real person actually create an account on this deployment?
+ *
+ * On 2026-08-09 the answer was no, on stage and production, while:
+ *   - `/api/health/ready` reported ok across all ten subsystems,
+ *   - `/api/version` reported the freshly-deployed SHA,
+ *   - `GET /register` returned HTTP 200.
+ *
+ * The page was 200 and the form was dead: the consent checkbox rendered
+ * `disabled` because the document fetch 404'd, so the submit could never be
+ * made. Every signal we watched was green.
+ *
+ * The failure mode this guards against is therefore specific: a page that
+ * *renders* but cannot be *used*. Asserting the checkbox is enabled is the
+ * cheapest possible expression of that, and it is exactly what was false.
+ */
+
+function uniqueEmail(): string {
+    // Keep it obviously-synthetic so the row is easy to find and purge in the
+    // target environment.
+    const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+    return `smoke-${stamp}@smoke.ever.works`;
+}
+
+/**
+ * Writes are opt-in. Creating accounts is fine on dev/stage and is how the
+ * signup path gets genuinely exercised, but production is not a test fixture —
+ * a smoke suite must not leave rows in the customer database. Production still
+ * gets the read-only half, which is the half that failed on 2026-08-09.
+ */
+const WRITES_ALLOWED = process.env.SMOKE_ALLOW_WRITES === 'true';
+
+test.describe('deployed signup', () => {
+    test('the register page renders a consent checkbox that can actually be ticked', async ({
+        page,
+    }) => {
+        await page.goto('/en/register', { waitUntil: 'domcontentloaded' });
+
+        const terms = page.locator('#terms');
+        await expect(terms).toBeVisible();
+
+        // The assertion that was false in production. `toBeEnabled` rather than
+        // a click, so the failure message names the real problem instead of
+        // surfacing as an action timeout.
+        await expect(
+            terms,
+            'consent checkbox is disabled — the register page could not load the required ' +
+                'legal documents, so no account can be created on this deployment',
+        ).toBeEnabled();
+    });
+
+    test('a new account can be created end to end', async ({ page }) => {
+        test.skip(!WRITES_ALLOWED, 'writes disabled — set SMOKE_ALLOW_WRITES=true (never on prod)');
+        const email = uniqueEmail();
+
+        await page.goto('/en/register', { waitUntil: 'domcontentloaded' });
+
+        await page.locator('input[name="name"]').fill('Smoke Test');
+        await page.locator('input[name="email"]').fill(email);
+        await page.locator('input[name="password"]').fill('SmokeTest1!');
+        await page.locator('input[name="confirmPassword"]').fill('SmokeTest1!');
+        await page.locator('#terms').check();
+
+        await page.locator('button[type="submit"]').click();
+
+        // Anywhere that is not an auth page counts as success: deployments
+        // differ in whether they land on the dashboard, an onboarding wizard,
+        // or an email-verification notice, and this suite should not encode
+        // one environment's onboarding policy.
+        await page.waitForURL(
+            /^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset)|$|\?)/,
+            { timeout: 60_000 },
+        );
+        await expect(page).not.toHaveURL(/\/register/);
+    });
+
+    test('the login page is reachable and interactive', async ({ page }) => {
+        await page.goto('/en/login', { waitUntil: 'domcontentloaded' });
+
+        await expect(page.locator('input[name="email"]')).toBeVisible();
+        await expect(page.locator('input[type="password"]').first()).toBeVisible();
+        await expect(page.locator('button[type="submit"]').first()).toBeEnabled();
+    });
+});

--- a/apps/web/e2e-smoke/deployed-surfaces.spec.ts
+++ b/apps/web/e2e-smoke/deployed-surfaces.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Do the main product surfaces actually render on this deployment, for a real
+ * signed-in user?
+ *
+ * Deliberately shallow. This is not a replacement for the 3,800-test suite that
+ * runs against a local stack on every push to `stage` — that suite tests
+ * behaviour. This one tests that behaviour is *reachable in this environment*:
+ * the page compiles, its data fetches resolve against the deployed API, and its
+ * primary control is present. That is the class of failure a local stack cannot
+ * produce, because locally both halves are built from the same config.
+ *
+ * The bar for each surface is "renders and is usable", not "works correctly".
+ * A surface that 500s, hangs, or renders an empty shell because its API call
+ * 404'd is what this catches — which is precisely how registration broke on
+ * 2026-08-09 while every health check stayed green.
+ */
+
+function uniqueEmail(): string {
+    const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+    return `smoke-${stamp}@smoke.ever.works`;
+}
+
+/** Register a throwaway account and land signed in. */
+async function signUp(page: import('@playwright/test').Page): Promise<string> {
+    const email = uniqueEmail();
+    await page.goto('/en/register', { waitUntil: 'domcontentloaded' });
+    await page.locator('input[name="name"]').fill('Smoke Surfaces');
+    await page.locator('input[name="email"]').fill(email);
+    await page.locator('input[name="password"]').fill('SmokeTest1!');
+    await page.locator('input[name="confirmPassword"]').fill('SmokeTest1!');
+    await page.locator('#terms').check();
+    await page.locator('button[type="submit"]').click();
+    await page.waitForURL(/^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset)|$|\?)/, {
+        timeout: 60_000,
+    });
+    return email;
+}
+
+/**
+ * Surfaces worth a smoke check. Each names the route and a locator that only
+ * exists once the page has genuinely rendered — not a spinner, not a shell.
+ */
+const SURFACES: ReadonlyArray<{ name: string; path: string }> = [
+    { name: 'dashboard', path: '/en' },
+    { name: 'works', path: '/en/works' },
+    { name: 'agents', path: '/en/agents' },
+    { name: 'tasks', path: '/en/tasks' },
+    { name: 'missions', path: '/en/missions' },
+    { name: 'ideas', path: '/en/ideas' },
+    { name: 'settings', path: '/en/settings' },
+];
+
+/**
+ * These surfaces need a signed-in user, so the whole file is a write. Skipped
+ * unless writes are explicitly allowed — production is not a test fixture.
+ */
+test.describe('deployed product surfaces', () => {
+    test.skip(
+        process.env.SMOKE_ALLOW_WRITES !== 'true',
+        'writes disabled — set SMOKE_ALLOW_WRITES=true (never on prod)',
+    );
+
+    // One account for the whole file; registering per test would multiply the
+    // rows written into the target environment for no extra signal.
+    test.describe.configure({ mode: 'serial' });
+
+    let signedInPage: import('@playwright/test').Page;
+
+    test.beforeAll(async ({ browser }) => {
+        const context = await browser.newContext();
+        signedInPage = await context.newPage();
+        await signUp(signedInPage);
+    });
+
+    test.afterAll(async () => {
+        await signedInPage?.context().close();
+    });
+
+    for (const { name, path } of SURFACES) {
+        test(`${name} renders without a server error`, async () => {
+            const failures: string[] = [];
+            const onResponse = (response: import('@playwright/test').Response): void => {
+                if (response.status() >= 500) {
+                    failures.push(`${response.status()} ${response.url()}`);
+                }
+            };
+            signedInPage.on('response', onResponse);
+
+            try {
+                const response = await signedInPage.goto(path, { waitUntil: 'domcontentloaded' });
+                expect(response?.status(), `${path} responded ${response?.status()}`).toBeLessThan(
+                    500,
+                );
+
+                // Something meaningful must be on the page — a shell with no
+                // <main> is how a failed data fetch presents.
+                await expect(signedInPage.locator('body')).toBeVisible();
+                await expect(
+                    signedInPage.locator('main, [role="main"], nav').first(),
+                    `${path} rendered no main/nav landmark — likely an empty shell`,
+                ).toBeVisible({ timeout: 30_000 });
+
+                expect(
+                    failures,
+                    `5xx responses while loading ${path}:\n${failures.join('\n')}`,
+                ).toEqual([]);
+            } finally {
+                signedInPage.off('response', onResponse);
+            }
+        });
+    }
+
+    /**
+     * The terminal is the surface most likely to break on a deployment rather
+     * than in code: it needs a websocket/relay reachable from the browser, which
+     * a local stack always has and an ingress may not.
+     */
+    test('terminal surface loads its client without a server error', async () => {
+        const response = await signedInPage.goto('/en/terminal', { waitUntil: 'domcontentloaded' });
+
+        // Not every deployment exposes a standalone terminal route; a 404 here
+        // is a routing choice, not a broken deploy. A 5xx is not.
+        const status = response?.status() ?? 0;
+        expect(status, `/en/terminal responded ${status}`).toBeLessThan(500);
+
+        if (status === 404) {
+            test.skip(true, 'no standalone /terminal route on this deployment');
+        }
+
+        await expect(signedInPage.locator('main, [role="main"]').first()).toBeVisible({
+            timeout: 30_000,
+        });
+    });
+});

--- a/apps/web/playwright.smoke.config.ts
+++ b/apps/web/playwright.smoke.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Post-deploy smoke suite — runs against a REAL deployed environment.
+ *
+ * This is deliberately not part of `playwright.config.ts`. That suite starts a
+ * local API and Next.js server and tests *the code at a commit*. This one tests
+ * *a running deployment*, which is a different question: it is the only place
+ * config drift shows up — ingress rules, env vars, the `/api` prefix, a service
+ * that came back unhealthy after a rollout.
+ *
+ * It exists because on 2026-08-09 a deploy went out where every health check was
+ * green, `/api/version` reported the new SHA, and registration was nonetheless
+ * impossible: the API served `/terms/required` while the web asked for
+ * `/api/terms/required`, so the signup form rendered with a disabled checkbox.
+ * Nothing that ran against a local stack could have seen it, because locally
+ * both halves were built from the same config.
+ *
+ * Usage:
+ *   SMOKE_BASE_URL=https://appstage.ever.works \
+ *   SMOKE_API_URL=https://apistage.ever.works \
+ *   npx playwright test -c playwright.smoke.config.ts
+ *
+ * Writes: one throwaway account per run against the target environment's
+ * database (approved for stage). Nothing else mutates state.
+ */
+const baseURL = process.env.SMOKE_BASE_URL || 'http://localhost:3000';
+
+export default defineConfig({
+    testDir: './e2e-smoke',
+    // A smoke suite that takes longer than a rollout is not a smoke suite.
+    timeout: 90_000,
+    expect: { timeout: 20_000 },
+    // Never retry into a false green: a flaky smoke run against production is
+    // itself the signal. One retry absorbs a pod mid-rollout, no more.
+    retries: 1,
+    workers: 2,
+    fullyParallel: true,
+    forbidOnly: true,
+    reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+    use: {
+        baseURL,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        locale: 'en',
+        ignoreHTTPSErrors: false,
+        // Some edges (Cloudflare) treat default automation agents differently
+        // from browsers; keep the request shape boring.
+        userAgent:
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36 ever-works-smoke',
+    },
+    projects: [{ name: 'smoke', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
@@ -596,19 +596,37 @@ describe('StepPipelineExecutorService', () => {
                 name: 'Start',
                 run: jest.fn().mockResolvedValue(undefined),
             };
+
+            // Concurrency is measured by OVERLAP, not by elapsed time.
+            //
+            // This used to assert `duration < 200ms` on the theory that parallel
+            // is ~50ms and sequential ~100ms. That was wrong in both directions:
+            // sequential (~100ms) also passes a 200ms bar, so a regression to
+            // sequential execution would NOT have been caught; and on a loaded
+            // runner even the parallel path overshoots — it was observed at
+            // 247ms, failing a PR that touched an unrelated package.
+            //
+            // Counting how many step bodies are in flight at once decides the
+            // question exactly: 2 only if they genuinely overlap, 1 if they are
+            // serialised. It is independent of how fast the machine is.
+            let inFlight = 0;
+            let maxInFlight = 0;
+            const overlappingBody = async (): Promise<void> => {
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await new Promise((resolve) => setTimeout(resolve, 50));
+                inFlight -= 1;
+            };
+
             const parallel1 = {
                 id: 'p1',
                 name: 'Parallel 1',
-                run: jest
-                    .fn()
-                    .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 50))),
+                run: jest.fn().mockImplementation(overlappingBody),
             };
             const parallel2 = {
                 id: 'p2',
                 name: 'Parallel 2',
-                run: jest
-                    .fn()
-                    .mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 50))),
+                run: jest.fn().mockImplementation(overlappingBody),
             };
 
             // Mock the build method to return our manual parallel structure
@@ -638,17 +656,11 @@ describe('StepPipelineExecutorService', () => {
             standardPlugin.registerStepExecutor('p1', parallel1);
             standardPlugin.registerStepExecutor('p2', parallel2);
 
-            const startTime = Date.now();
             await service.execute(standardPlugin, mockWork, mockRequest, mockExisting);
-            const duration = Date.now() - startTime;
 
-            // Verification
-            // Both parallel steps take 50ms.
-            // If sequential: 50 + 50 = 100ms (+ overhead)
-            // If parallel: max(50, 50) = 50ms (+ overhead)
-            // We expect the total duration to be closer to 50ms than 100ms
-            // Using a slightly loose check to account for test overhead
-            expect(duration).toBeLessThan(200);
+            // Both bodies were in flight at the same moment — the definition of
+            // running concurrently. Serialised execution leaves this at 1.
+            expect(maxInFlight).toBe(2);
             expect(parallel1.run).toHaveBeenCalled();
             expect(parallel2.run).toHaveBeenCalled();
         });

--- a/packages/plugins/opencode/src/__tests__/taxonomy-watcher.spec.ts
+++ b/packages/plugins/opencode/src/__tests__/taxonomy-watcher.spec.ts
@@ -26,14 +26,25 @@ describe('taxonomy-watcher', () => {
 			const item = JSON.stringify({ name: 'Tool', category: 'Cloud Services', tags: ['cloud'] });
 			await writeFile(join(workspacePath, 'tool.json'), item, 'utf-8');
 
-			// Wait for debounce (50ms) + file read + processing
-			await sleep(300);
-
-			// Check that _meta/categories.json was created
+			// Poll for the file the watcher is supposed to write, rather than
+			// sleeping a guessed 300ms and reading once.
+			//
+			// The old `sleep(300)` was a bet that debounce + fs event + read +
+			// write always fits in 300ms. On a loaded runner it does not: the
+			// read then hits an absent (or half-written) file and the test fails
+			// with ENOENT rather than a real assertion. That is what happened on
+			// the develop -> stage cascade (#2008), where this test burned all
+			// its retries. Retrying a too-short sleep just re-rolls the same
+			// dice; waiting for the actual condition removes the bet, and
+			// returns as soon as the watcher is done.
 			const { readFile: rf } = await import('node:fs/promises');
-			const catContent = await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8');
-			const categories = JSON.parse(catContent);
-			expect(categories).toEqual([{ id: 'cloud-services', name: 'Cloud Services' }]);
+			await vi.waitFor(
+				async () => {
+					const catContent = await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8');
+					expect(JSON.parse(catContent)).toEqual([{ id: 'cloud-services', name: 'Cloud Services' }]);
+				},
+				{ timeout: 5_000, interval: 25 }
+			);
 		} finally {
 			watcher.stop();
 		}


### PR DESCRIPTION
Cascade `stage → main`. `stage` and `develop` are identical; `main` is the only branch still missing
these four commits, and one of them is a production-blocking fix.

## Why this is urgent

**Email + password registration is currently impossible on `app.ever.works`.**

Verified in a real browser at `https://app.ever.works/register`: the "I agree to the Terms of Service
and Privacy Policy" checkbox renders `disabled`, and "Create account" is permanently `disabled`. Every
other field is enabled. **No error message is shown.** Only the four OAuth buttons still work.

### Root cause

This app has **no `setGlobalPrefix`** — every controller carries the `api/` segment itself.
`TermsController` was declared `@Controller('terms')`, so it mounted at `/terms/required` while the web
app asks for `/api/terms/required` (`API_URL` is guaranteed to end in `/api`). The register page
catches the 404, hands the form an empty legal-document list, and the form then *correctly* fails
closed — it refuses to record an acceptance it cannot identify, which is what disables the checkbox.

The fail-closed behaviour is right. The 404 underneath it is the bug.

`admin-usage.controller.ts` had the identical mistake, so `/api/admin/usage` is also 404 in production.

### Evidence

| Env | `GET /api/terms/required` | `GET /terms/required` | Nest boot mapping |
|---|---|---|---|
| prod (`3b0b0d0`) | `404` | **200** + 2 docs | `TermsController {/terms}` |
| stage (`0b75260` image) | `404` | 200 | `TermsController {/terms}` |
| dev (`446aac4`) | **200** + 2 docs | 404 | `TermsController {/api/terms}` |

The 404 reproduces **inside the prod pod** against `127.0.0.1:3100`, so it is not an ingress problem.
Enumerating the live route table from each pod's boot log makes the whole bug class visible — routes
mounted outside `/api`:

```
prod / stage           develop
GET /                  GET /
GET /.well-known/…     GET /.well-known/…
GET /admin/usage       —          ← fixed
GET /terms/required    —          ← fixed
…/internal/trigger/…   …/internal/trigger/…
```

After this cascade `develop`, `stage` and `main` all mount every public route under `/api`.

## What is in the cascade

| Commit | |
|---|---|
| `446aac49` | **fix(api): serve terms and admin-usage under api/ — signup was blocked (#2012)** |
| `299b39ed` | test(smoke): verify the deployed platform, not just the commit (#2014) |
| `66655128` | test(pipeline): prove concurrency by overlap, not by wall-clock duration (#2011) |
| `7559df4c` | test(opencode): wait for the watcher's output instead of sleeping 300ms (#2010) |

Whole-branch cascade, no cherry-picks. The other three commits are test-only.

## Verification plan

1. Stage build lands → verify in a browser that signup completes on `app-stage.ever.works`.
2. Merge here → prod build → verify in a browser that signup completes on `app.ever.works`, and that
   `GET /api/terms/required` returns 200 while `/terms/required` no longer resolves.
3. Follow-up PR adds e2e coverage that asserts the **mounted path** — a controller unit spec cannot
   catch a prefix mistake, which is exactly why ~700 e2e specs missed this one.

Found during an owner-directed end-to-end browser verification pass over the whole platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)