### PR TITLE
fix(works): keep the form when Work creation fails for a missing Git provider

### DIFF
--- a/apps/web/e2e/work-create-ui-journey.spec.ts
+++ b/apps/web/e2e/work-create-ui-journey.spec.ts
@@ -103,17 +103,35 @@ test.describe('Work create — full UI wizard', () => {
             await promptField.fill(`e2e ui description ${name}`);
         }
 
-        // The real submit button is "Generate with AI". Best-effort click to
-        // exercise the submit path; in the git-less e2e stack this surfaces a
-        // `requiresGitProvider` toast + redirect rather than a Work, which we
-        // tolerate — the deterministic Work creation happens via the API below.
+        // The real submit button is "Generate with AI". In the git-less e2e stack
+        // this takes the `requiresGitProvider` branch: an error toast, and NO Work.
+        //
+        // That branch used to also `router.push(ROUTES.DASHBOARD_WORKS_NEW)` — this
+        // page minus its query string — and `works/new/page.tsx` redirects to `/new`
+        // whenever `mode` is absent. So the single most likely outcome for a new user
+        // threw away everything they had typed and dropped them on an empty composer.
+        // This spec previously tolerated that ("we only need to exercise the click,
+        // not its aftermath"), which is how the data loss stayed invisible.
+        //
+        // The aftermath IS the contract now: the user must still be on the form, with
+        // their input intact, next to the "Connect" control that resolves the error.
         const submit = page.getByRole('button', { name: /generate|create|save|submit/i }).first();
         if (await submit.isVisible({ timeout: 5_000 }).catch(() => false)) {
-            // noWaitAfter: the submit fires the createWorkWithAI server action,
-            // whose git-less redirect back to /works/new would otherwise make
-            // Playwright's click auto-wait on a navigation that stalls the whole
-            // test. We only need to exercise the click, not its aftermath.
-            await submit.click({ noWaitAfter: true, timeout: 8_000 }).catch(() => undefined);
+            await submit.click({ timeout: 8_000 }).catch(() => undefined);
+
+            // Give the server action time to resolve and any navigation to settle,
+            // so this asserts the settled state rather than racing it.
+            await page.waitForLoadState('networkidle').catch(() => {});
+
+            await expect(
+                page,
+                'a failed git-less submit must NOT bounce the user to the empty composer',
+            ).not.toHaveURL(/\/new(\?|$)/);
+
+            await expect(
+                page.locator('input[name="name"]'),
+                'the work-name field must survive a failed submit',
+            ).toHaveValue(name, { timeout: 10_000 });
         }
 
         // --- Create the Work deterministically (git-less) as the browser user. ---

--- a/apps/web/src/components/works/WorkAICreator.tsx
+++ b/apps/web/src/components/works/WorkAICreator.tsx
@@ -285,8 +285,19 @@ export function WorkAICreator({
                     router.push(ROUTES.DASHBOARD_WORKS);
                 }
             } else if (result.requiresGitProvider) {
+                // Stay put. This used to `router.push(ROUTES.DASHBOARD_WORKS_NEW)`,
+                // which is THIS page minus its query string — and
+                // `works/new/page.tsx` redirects to `/new` whenever `mode` is
+                // absent. So the one branch a user is most likely to hit (no Git
+                // provider connected yet) threw away everything they had typed —
+                // name, slug, prompt, template, provider selections — and dropped
+                // them on an empty composer, with no way back to the filled form.
+                //
+                // There is nowhere to send them anyway: the Git-provider
+                // "Connect" control lives on this very page, right above the
+                // button they just pressed. Showing the error and leaving the
+                // form intact is what makes the toast actionable.
                 toast.error(result.error || t('errors.githubRequired'));
-                router.push(ROUTES.DASHBOARD_WORKS_NEW);
             } else {
                 toast.error(result.error || t('errors.createFailed'));
             }


### PR DESCRIPTION
Filling in the New Work form and pressing **"Generate with AI"** without a Git provider connected threw
away everything the user had typed and dropped them on an empty composer.

## Root cause

The `requiresGitProvider` branch in `WorkAICreator.tsx` did:

```ts
toast.error(result.error || t('errors.githubRequired'));
router.push(ROUTES.DASHBOARD_WORKS_NEW);   // '/works/new'
```

`/works/new` is **this page minus its query string**, and `works/new/page.tsx` redirects to `/new`
whenever `mode` is absent:

```ts
const initialMode = VALID_CREATION_MODES.includes(params.mode ?? '') ? params.mode : …
…
redirect(ROUTES.DASHBOARD_NEW);
```

So the push resolved to the empty "Start something new" composer, discarding the name, slug, prompt,
chosen template and provider selections — with no way back to the filled form.

This is the **single most likely outcome for a new user**: a fresh account has no Git provider
connected, so the first press of the primary CTA on the primary creation flow loses their input.

There was nowhere useful to navigate to anyway — the Git-provider **"Connect"** control lives on this
very page, a few rows above the button they just pressed. Removing the push leaves the error toast next
to the control that resolves it, with the form intact, which is what makes the toast actionable rather
than merely informative.

## Reproduction

On `app-dev.ever.works`, as a freshly registered user: filled name → slug auto-derived
(`k8s-database-operators-directory`) → prompt → pressed **Generate with AI** → landed on `/new` with an
empty composer. Confirmed against the database that **no Work was created** (zero rows in `works` for
that user), so the navigation was pure loss.

## The test that watched it happen

`work-create-ui-journey.spec.ts` exercised exactly this path and **tolerated the bug, in as many
words**:

```ts
// ...this surfaces a `requiresGitProvider` toast + redirect rather than a Work, which we tolerate
// noWaitAfter: ...We only need to exercise the click, not its aftermath.
```

The aftermath *was* the defect, so opting out of observing it is precisely what kept the data loss
invisible. The spec now asserts the aftermath **is** the contract: after a failed git-less submit the
user must still be on the form, must not be bounced to `/new`, and the work-name field must still hold
what they typed.

## Verification

- `tsc --noEmit` on `apps/web`: **exit 0, zero errors**
- `prettier --check`: clean

Found during an owner-directed end-to-end browser verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed AI work creation no longer redirects users away from the form when Git-provider setup is required.
  * Error notifications are shown while preserving the entered work name and form state.
  * Improved handling and verification of failed submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->