### PR TITLE
fix(dashboard): the upcoming-schedules block was silently empty in every environment

### DIFF
--- a/apps/api/src/schedules/dto/schedules-query.dto.spec.ts
+++ b/apps/api/src/schedules/dto/schedules-query.dto.spec.ts
@@ -1,0 +1,161 @@
+import 'reflect-metadata';
+import { BadRequestException, ValidationPipe, type ArgumentMetadata } from '@nestjs/common';
+import { getMetadataStorage } from 'class-validator';
+import { ScheduleQueryDto } from './schedules-query.dto';
+
+/**
+ * Contract pin for `GET /api/schedules`' query surface.
+ *
+ * This is the server half of a two-sided contract test. The client half lives
+ * in `apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-data.unit.spec.ts`,
+ * which asserts that the dashboard's Soon block only ever emits parameters from
+ * {@link SUPPORTED_QUERY_PARAMS}. This spec asserts that that same set is
+ * *exactly* what the DTO accepts — so if anyone adds, renames, or drops a filter
+ * here, this file fails and the web-side whitelist has to be updated with it.
+ *
+ * Why it exists: the Soon block shipped calling
+ * `?status=active&sort=nextRunAt:asc&limit=3`. None of those three are
+ * whitelisted, the global pipe runs with `forbidNonWhitelisted`, and the web
+ * caller swallowed the resulting 400 — so the block was permanently empty in
+ * every environment and nothing surfaced it.
+ *
+ * The pipe below is constructed with the *same* options as the global one in
+ * `apps/api/src/main.ts` (`whitelist` + `transform` + `forbidNonWhitelisted`);
+ * that triple is what makes an unknown parameter a 400 rather than a silent
+ * drop, so the test would be meaningless without it.
+ */
+
+// Mirrors `app.useGlobalPipes(...)` in apps/api/src/main.ts.
+const GLOBAL_PIPE_OPTIONS = {
+    whitelist: true,
+    transform: true,
+    forbidNonWhitelisted: true,
+} as const;
+
+/**
+ * Every query parameter `GET /api/schedules` supports. Kept as a literal (not
+ * derived from the DTO) so it reads as the published contract; the
+ * "no undeclared filters" test below proves the DTO has not drifted from it.
+ */
+const SUPPORTED_QUERY_PARAMS = ['sourceType', 'entityKind', 'enabledOnly'] as const;
+
+/**
+ * The parameters the dashboard's Soon block used to send. Every one of them is
+ * rejected — this is the reproduction of the defect, kept as a regression pin
+ * so nobody "fixes" the caller by re-adding them.
+ */
+const LEGACY_SOON_BLOCK_PARAMS = { status: 'active', sort: 'nextRunAt:asc', limit: '3' };
+
+const pipe = new ValidationPipe(GLOBAL_PIPE_OPTIONS);
+const metadata: ArgumentMetadata = { type: 'query', metatype: ScheduleQueryDto, data: undefined };
+
+const transform = (query: Record<string, unknown>) => pipe.transform(query, metadata);
+
+/** Collect the BadRequestException's `message` array, whatever its nesting. */
+async function rejectionMessages(query: Record<string, unknown>): Promise<string[]> {
+    try {
+        await transform(query);
+    } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const response = (error as BadRequestException).getResponse();
+        const message = (response as { message?: unknown }).message;
+        return Array.isArray(message) ? (message as string[]) : [String(message)];
+    }
+    throw new Error(`expected ${JSON.stringify(query)} to be rejected, but it validated cleanly`);
+}
+
+describe('ScheduleQueryDto — GET /api/schedules query contract', () => {
+    describe('the supported filter surface', () => {
+        it('accepts an empty query (every filter is optional)', async () => {
+            await expect(transform({})).resolves.toEqual({});
+        });
+
+        it.each([
+            ['sourceType', { sourceType: 'work_schedule' }],
+            ['entityKind', { entityKind: 'work' }],
+            ['enabledOnly', { enabledOnly: 'true' }],
+        ])('accepts %s on its own', async (_name, query) => {
+            await expect(transform(query)).resolves.toBeDefined();
+        });
+
+        it('accepts all three together — the full surface a client may send', async () => {
+            await expect(
+                transform({
+                    sourceType: 'mission_tick',
+                    entityKind: 'mission',
+                    enabledOnly: 'true',
+                }),
+            ).resolves.toEqual({
+                sourceType: 'mission_tick',
+                entityKind: 'mission',
+                enabledOnly: true,
+            });
+        });
+
+        it('coerces the enabledOnly query string to a real boolean', async () => {
+            await expect(transform({ enabledOnly: 'true' })).resolves.toEqual({
+                enabledOnly: true,
+            });
+            await expect(transform({ enabledOnly: 'false' })).resolves.toEqual({
+                enabledOnly: false,
+            });
+        });
+
+        it('declares no filters beyond SUPPORTED_QUERY_PARAMS', () => {
+            // Derived from class-validator's metadata: the properties the DTO
+            // actually validates. If a filter is added to the DTO without being
+            // added to the published set above (and to the web-side whitelist
+            // this set is shared with), this fails.
+            const declared = new Set(
+                getMetadataStorage()
+                    .getTargetValidationMetadatas(ScheduleQueryDto, '', false, false)
+                    .map((meta) => meta.propertyName),
+            );
+            expect([...declared].sort()).toEqual([...SUPPORTED_QUERY_PARAMS].sort());
+        });
+    });
+
+    describe('unknown parameters are rejected, not ignored', () => {
+        it('400s on the exact params the dashboard Soon block used to send', async () => {
+            const messages = await rejectionMessages(LEGACY_SOON_BLOCK_PARAMS);
+            // The precise strings observed in the dev web pod logs.
+            expect(messages).toEqual(
+                expect.arrayContaining([
+                    'property status should not exist',
+                    'property sort should not exist',
+                    'property limit should not exist',
+                ]),
+            );
+        });
+
+        it.each(Object.keys(LEGACY_SOON_BLOCK_PARAMS))(
+            'rejects %s even alongside otherwise-valid filters',
+            async (param) => {
+                const messages = await rejectionMessages({ enabledOnly: 'true', [param]: 'x' });
+                expect(messages).toContain(`property ${param} should not exist`);
+            },
+        );
+
+        it('rejects a typo of a supported filter rather than silently ignoring it', async () => {
+            const messages = await rejectionMessages({ sourcetype: 'work_schedule' });
+            expect(messages).toContain('property sourcetype should not exist');
+        });
+    });
+
+    describe('supported filters still police their own values', () => {
+        it('rejects an out-of-enum sourceType', async () => {
+            const messages = await rejectionMessages({ sourceType: 'not_a_source' });
+            expect(messages.join(' ')).toMatch(/sourceType/);
+        });
+
+        it('rejects an out-of-enum entityKind', async () => {
+            const messages = await rejectionMessages({ entityKind: 'organization' });
+            expect(messages.join(' ')).toMatch(/entityKind/);
+        });
+
+        it('rejects a non-boolean enabledOnly', async () => {
+            const messages = await rejectionMessages({ enabledOnly: 'yes' });
+            expect(messages.join(' ')).toMatch(/enabledOnly/);
+        });
+    });
+});

--- a/apps/api/src/schedules/schedules.controller.spec.ts
+++ b/apps/api/src/schedules/schedules.controller.spec.ts
@@ -1,0 +1,116 @@
+import 'reflect-metadata';
+
+// The controller imports `SchedulesService` as a value (DI token). Pulling the
+// real `@ever-works/agent/schedules` barrel drags the whole entity/TypeORM
+// graph into this spec for no benefit — the handler under test only calls
+// `getSchedules`. Stub the barrel, same approach as missions/dto/mission.dto.spec.ts.
+jest.mock('@ever-works/agent/schedules', () => ({
+    SchedulesService: class {},
+}));
+jest.mock('../scope', () => ({
+    ScopeContextService: class {},
+}));
+
+import { SchedulesController } from './schedules.controller';
+import type { ScheduleView } from '@ever-works/agent/schedules';
+
+/**
+ * Response-shape pin for `GET /api/schedules`.
+ *
+ * The dashboard's Soon block destructured `{ items, total }` out of this
+ * handler's response. The handler returns a bare array, so `items` was always
+ * `undefined` and the block rendered nothing — the second half of the defect,
+ * and one that would have survived fixing the query parameters alone.
+ *
+ * These tests deliberately assert the *absence* of a pagination envelope.
+ * `apps/web/src/lib/api/schedules.ts` (`schedulesAPI.getAll`) and the Schedules
+ * view built on it both consume a bare array, so wrapping this response would
+ * be a breaking change to a shipped consumer — which is exactly why the fix
+ * went into the caller rather than here.
+ */
+
+const view = (over: Partial<ScheduleView> = {}): ScheduleView => ({
+    id: 'work_schedule:w1',
+    sourceType: 'work_schedule',
+    ownerType: 'work',
+    ownerId: 'w1',
+    ownerName: 'Directory refresh',
+    ownerLink: '/works/w1',
+    cadenceRaw: '0 9 * * *',
+    cadenceHuman: 'Every day at 09:00',
+    nextRunAt: '2026-08-12T09:00:00.000Z',
+    lastRunAt: null,
+    lastRunStatus: null,
+    status: 'active',
+    enabled: true,
+    ...over,
+});
+
+function build(rows: ScheduleView[]) {
+    const getSchedules = jest.fn().mockResolvedValue(rows);
+    const controller = new SchedulesController(
+        { getSchedules } as never,
+        { getOrganizationId: () => null } as never,
+    );
+    return { controller, getSchedules };
+}
+
+const auth = { userId: 'user-1' } as never;
+
+describe('SchedulesController.list — response shape', () => {
+    it('returns a bare array, not an { items, total } envelope', async () => {
+        const rows = [view(), view({ id: 'mission_tick:m1', sourceType: 'mission_tick' })];
+        const { controller } = build(rows);
+
+        const result = await controller.list(auth, {});
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(2);
+        // The two properties the Soon block used to read off this response.
+        expect((result as unknown as { items?: unknown }).items).toBeUndefined();
+        expect((result as unknown as { total?: unknown }).total).toBeUndefined();
+    });
+
+    it('returns an empty array — never an envelope — when there is nothing to list', async () => {
+        const { controller } = build([]);
+
+        const result = await controller.list(auth, {});
+
+        expect(result).toEqual([]);
+        expect((result as unknown as { items?: unknown }).items).toBeUndefined();
+    });
+
+    it('passes each supported filter through to the service', async () => {
+        const { controller, getSchedules } = build([]);
+
+        await controller.list(auth, {
+            sourceType: 'work_schedule',
+            entityKind: 'work',
+            enabledOnly: true,
+        });
+
+        expect(getSchedules).toHaveBeenCalledWith(
+            { userId: 'user-1', organizationId: null },
+            // note the rename across the boundary: `entityKind` on the wire is
+            // `ownerType` on the service.
+            { sourceType: 'work_schedule', ownerType: 'work', enabledOnly: true },
+        );
+    });
+
+    it('sends no filters at all for an empty query', async () => {
+        const { controller, getSchedules } = build([]);
+
+        await controller.list(auth, {});
+
+        expect(getSchedules).toHaveBeenCalledWith({ userId: 'user-1', organizationId: null }, {});
+    });
+
+    it('does not limit or re-slice the service result — the aggregation is un-paginated', async () => {
+        const rows = Array.from({ length: 25 }, (_, i) =>
+            view({ id: `work_schedule:w${i}`, ownerId: `w${i}` }),
+        );
+        const { controller } = build(rows);
+
+        await expect(controller.list(auth, {})).resolves.toHaveLength(25);
+    });
+});

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-data.ts
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-data.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { serverFetch } from '@/lib/api/server-api';
+import { schedulesAPI, type ScheduleEntry } from '@/lib/api/schedules';
 import { ROUTES } from '@/lib/constants';
 import type { Agent } from '@/lib/api/agents';
 import type { Task } from '@/lib/api/tasks';
@@ -13,10 +14,13 @@ import type { AttentionItem, SoonRunItem } from '@/components/dashboard/dashboar
  * additive home changes: the Teams count tile, the Attention block,
  * and the Soon block.
  *
- * Every network path here is defensively caught: the Teams and Soon
- * backends land in sibling PRs (Teams #1647, Schedules front), so a
- * 404 must degrade to "omit the tile / render nothing", never a 500
- * bubbling up to the home page (spec §6 — graceful absence).
+ * Every network path here is defensively caught so a failing or absent
+ * backend degrades to "omit the tile / render nothing" rather than
+ * 500-ing the home page (spec §6 — graceful absence). Degrading is not
+ * the same as staying silent: each catch logs which call failed, because
+ * a swallowed error here is invisible by construction — the block it
+ * feeds renders nothing when it has no data, which looks identical to a
+ * healthy-but-quiet dashboard.
  */
 
 // The account-budgets settings anchor the Month Spend tile already
@@ -58,7 +62,8 @@ export async function getTeamsTotal(): Promise<number | undefined> {
     try {
         const res = await serverFetch<Array<{ id: string }>>('/organizations', { method: 'GET' });
         orgs = Array.isArray(res) ? res : [];
-    } catch {
+    } catch (error) {
+        console.error('[dashboard] Teams tile: GET /api/organizations failed', error);
         return undefined;
     }
 
@@ -92,25 +97,80 @@ export async function getTeamsTotal(): Promise<number | undefined> {
     return anyWired ? total : undefined;
 }
 
+// The Soon block previews the soonest few runs; `total` still counts every
+// upcoming run so SoonSection can render its "+N more" link (spec §4.4).
+const SOON_MAX = 3;
+
+/**
+ * `GET /api/schedules` projects seven scheduled sources, but `SoonRunItem`
+ * models exactly two kinds — Work schedules and Mission ticks (dashboard-blocks
+ * spec §2.2), and `SoonSection` only has badge copy for those two
+ * (`dashboard.soon.source.{work,mission}`). Rows from the other five sources
+ * are skipped rather than mislabelled as one of these; widening the block to
+ * cover them is a product change (a new badge string in all 21 locale files),
+ * not part of this fix.
+ */
+const SOON_SOURCE_KINDS: Partial<Record<ScheduleEntry['sourceType'], SoonRunItem['sourceKind']>> = {
+    work_schedule: 'work-schedule',
+    mission_tick: 'mission',
+};
+
 /**
  * Upcoming scheduled runs for the Soon block (spec §3.3, change 4).
  *
- * REUSES `GET /api/schedules` from the Schedules front, which does not
- * exist on this branch yet. Until it ships this resolves to an empty
- * set (404 → catch) and the Soon block renders nothing (spec §4.4).
+ * REUSES `GET /api/schedules` from the Schedules front, via the same typed
+ * client (`schedulesAPI`) the Schedules view itself uses.
+ *
+ * The dashboard-blocks spec sketched this call as
+ * `?status=active&sort=nextRunAt:asc&limit=3 → { items, total }`, but that was
+ * written before the Schedules front shipped and the endpoint it describes was
+ * never built. The real contract (schedules spec §4.1) is narrower and is the
+ * authority here:
+ *   - filters are `sourceType` / `entityKind` / `enabledOnly` only, policed by
+ *     `forbidNonWhitelisted` — the three sketched params were rejected with a
+ *     400, not ignored;
+ *   - the aggregation is deliberately un-paginated and returns a bare
+ *     `ScheduleView[]`, already sorted by `nextRunAt` ascending (nulls last).
+ * So `status=active` becomes the server-side `enabledOnly`, and the ordering
+ * and limiting happen here.
  */
 export async function getSoonRuns(): Promise<{ items: SoonRunItem[]; total: number }> {
+    let schedules: ScheduleEntry[];
     try {
-        const res = await serverFetch<{ items?: SoonRunItem[]; total?: number }>(
-            '/schedules?status=active&sort=nextRunAt:asc&limit=3',
-            { method: 'GET' },
-        );
-        const items = Array.isArray(res?.items) ? res.items : [];
-        const total = typeof res?.total === 'number' ? res.total : items.length;
-        return { items, total };
-    } catch {
+        const rows = await schedulesAPI.getAll({ enabledOnly: true });
+        schedules = Array.isArray(rows) ? rows : [];
+    } catch (error) {
+        // `serverFetch` logs the failing response body but not the endpoint, so
+        // before this line a 400 here was unattributable in the pod logs — and
+        // the Soon block renders nothing when empty, so nothing on the page
+        // gave the failure away either. Name the call.
+        console.error('[dashboard] Soon block: GET /api/schedules failed', error);
         return { items: [], total: 0 };
     }
+
+    const upcoming: SoonRunItem[] = [];
+    for (const schedule of schedules) {
+        const sourceKind = SOON_SOURCE_KINDS[schedule.sourceType];
+        // `nextRunAt` is nullable on the wire (not every source can derive one)
+        // while `SoonRunItem.nextRunAt` is not — a row with no computable next
+        // run is not an upcoming run.
+        if (!sourceKind || !schedule.nextRunAt) continue;
+        upcoming.push({
+            id: schedule.id,
+            sourceKind,
+            title: schedule.ownerName,
+            nextRunAt: schedule.nextRunAt,
+            href: schedule.ownerLink,
+        });
+    }
+
+    // The API already sorts by `nextRunAt` ascending. Sorting again makes
+    // "the soonest N" a property of this function instead of an unstated
+    // dependency on the server's ordering. ISO-8601 UTC strings sort
+    // lexicographically, which is how the API compares them too.
+    upcoming.sort((a, b) => a.nextRunAt.localeCompare(b.nextRunAt));
+
+    return { items: upcoming.slice(0, SOON_MAX), total: upcoming.length };
 }
 
 /**

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-data.unit.spec.ts
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-data.unit.spec.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScheduleEntry } from '@/lib/api/schedules';
+
+/**
+ * Contract test for the dashboard Soon block's use of `GET /api/schedules`.
+ *
+ * The block was permanently empty in every environment because of two stacked
+ * mismatches with the API, both swallowed by a bare `catch`:
+ *
+ *   1. it sent `?status=active&sort=nextRunAt:asc&limit=3`; `ScheduleQueryDto`
+ *      whitelists only `sourceType`/`entityKind`/`enabledOnly` and the global
+ *      pipe runs with `forbidNonWhitelisted`, so the API answered 400;
+ *   2. it destructured `{ items, total }`; the handler returns a bare array,
+ *      so even with the parameters fixed `items` would be `undefined`.
+ *
+ * Only the *transport* (`serverFetch`) is mocked here, and it is mocked with a
+ * simulator that enforces the real server's rules rather than returning the
+ * shape the caller wishes for. A fixture shaped like `{ items, total }` would
+ * have passed for the entire life of this bug and proved nothing.
+ *
+ * The server half of this contract is pinned in
+ * `apps/api/src/schedules/dto/schedules-query.dto.spec.ts`, which asserts that
+ * {@link API_WHITELISTED_QUERY_PARAMS} below is *exactly* the DTO's filter
+ * surface and that anything else is a 400.
+ */
+
+const { serverFetch } = vi.hoisted(() => ({ serverFetch: vi.fn() }));
+vi.mock('@/lib/api/server-api', () => ({ serverFetch }));
+
+import { getSoonRuns } from './dashboard-data';
+
+/** Mirrors `ScheduleQueryDto` — see the api-side spec that pins this set. */
+const API_WHITELISTED_QUERY_PARAMS = ['sourceType', 'entityKind', 'enabledOnly'];
+
+/** Nest's 400 body for a non-whitelisted query parameter. */
+class ForbiddenParamError extends Error {
+    constructor(unknownParams: string[]) {
+        super(unknownParams.map((p) => `property ${p} should not exist`).join(', '));
+        this.name = 'ApiResponseError';
+    }
+}
+
+/**
+ * Stands in for the real endpoint: rejects non-whitelisted query parameters
+ * exactly as `forbidNonWhitelisted` does, and answers with a bare
+ * `ScheduleView[]` — the handler's actual return type — never an envelope.
+ */
+function apiSimulator(rows: ScheduleEntry[]) {
+    return vi.fn(async (endpoint: string) => {
+        const url = new URL(endpoint, 'https://api.test');
+        expect(url.pathname).toBe('/schedules');
+        const unknownParams = [...url.searchParams.keys()].filter(
+            (key) => !API_WHITELISTED_QUERY_PARAMS.includes(key),
+        );
+        if (unknownParams.length > 0) {
+            throw new ForbiddenParamError(unknownParams);
+        }
+        return rows;
+    });
+}
+
+const entry = (over: Partial<ScheduleEntry> = {}): ScheduleEntry => ({
+    id: 'work_schedule:w1',
+    sourceType: 'work_schedule',
+    ownerType: 'work',
+    ownerId: 'w1',
+    ownerName: 'Directory refresh',
+    ownerLink: '/works/w1',
+    cadenceRaw: '0 9 * * *',
+    cadenceHuman: 'Every day at 09:00',
+    nextRunAt: '2026-08-12T09:00:00.000Z',
+    lastRunAt: null,
+    lastRunStatus: null,
+    status: 'active',
+    enabled: true,
+    ...over,
+});
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+    serverFetch.mockReset();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+    errorSpy.mockRestore();
+});
+
+describe('getSoonRuns — query contract with GET /api/schedules', () => {
+    it('sends only query parameters the API whitelists', async () => {
+        serverFetch.mockImplementation(apiSimulator([]));
+
+        await getSoonRuns();
+
+        expect(serverFetch).toHaveBeenCalled();
+        const endpoint = serverFetch.mock.calls[0][0] as string;
+        const sent = [...new URL(endpoint, 'https://api.test').searchParams.keys()];
+        // Fails on the unfixed caller with ['status', 'sort', 'limit'].
+        expect(sent.filter((k) => !API_WHITELISTED_QUERY_PARAMS.includes(k))).toEqual([]);
+    });
+
+    it('asks the server for enabled schedules only', async () => {
+        serverFetch.mockImplementation(apiSimulator([]));
+
+        await getSoonRuns();
+
+        const endpoint = serverFetch.mock.calls[0][0] as string;
+        expect(new URL(endpoint, 'https://api.test').searchParams.get('enabledOnly')).toBe('true');
+    });
+
+    it('does not 400 against a server that enforces the real whitelist', async () => {
+        const simulator = apiSimulator([entry()]);
+        serverFetch.mockImplementation(simulator);
+
+        const { items } = await getSoonRuns();
+
+        await expect(simulator.mock.results[0].value).resolves.toBeDefined();
+        expect(items).toHaveLength(1);
+    });
+});
+
+describe('getSoonRuns — response shape', () => {
+    it("reads the handler's bare array, not an { items, total } envelope", async () => {
+        serverFetch.mockImplementation(apiSimulator([entry(), entry({ id: 'work_schedule:w2' })]));
+
+        const { items, total } = await getSoonRuns();
+
+        // Fails on the unfixed caller: it destructures `.items` off an array.
+        expect(items).toHaveLength(2);
+        expect(total).toBe(2);
+    });
+
+    it('maps a ScheduleView row onto the SoonRunItem the SoonSection renders', async () => {
+        serverFetch.mockImplementation(
+            apiSimulator([
+                entry({
+                    id: 'work_schedule:w9',
+                    ownerName: 'Nightly crawl',
+                    ownerLink: '/works/w9',
+                    nextRunAt: '2026-08-12T09:00:00.000Z',
+                }),
+            ]),
+        );
+
+        const { items } = await getSoonRuns();
+
+        expect(items[0]).toEqual({
+            id: 'work_schedule:w9',
+            sourceKind: 'work-schedule',
+            title: 'Nightly crawl',
+            nextRunAt: '2026-08-12T09:00:00.000Z',
+            href: '/works/w9',
+        });
+    });
+
+    it('maps mission_tick rows to the mission badge kind', async () => {
+        serverFetch.mockImplementation(
+            apiSimulator([
+                entry({ id: 'mission_tick:m1', sourceType: 'mission_tick', ownerType: 'mission' }),
+            ]),
+        );
+
+        const { items } = await getSoonRuns();
+
+        expect(items[0].sourceKind).toBe('mission');
+    });
+});
+
+describe('getSoonRuns — selection', () => {
+    it('previews the three soonest runs but reports the full total', async () => {
+        const rows = ['05', '01', '04', '02', '03'].map((day) =>
+            entry({
+                id: `work_schedule:w${day}`,
+                ownerId: `w${day}`,
+                nextRunAt: `2026-08-${day}T09:00:00.000Z`,
+            }),
+        );
+        serverFetch.mockImplementation(apiSimulator(rows));
+
+        const { items, total } = await getSoonRuns();
+
+        expect(items.map((i) => i.nextRunAt)).toEqual([
+            '2026-08-01T09:00:00.000Z',
+            '2026-08-02T09:00:00.000Z',
+            '2026-08-03T09:00:00.000Z',
+        ]);
+        // SoonSection renders "+{total - 3} more" from this.
+        expect(total).toBe(5);
+    });
+
+    it('skips rows with no computable next run', async () => {
+        serverFetch.mockImplementation(
+            apiSimulator([
+                entry({ id: 'work_schedule:w1', nextRunAt: null }),
+                entry({ id: 'work_schedule:w2' }),
+            ]),
+        );
+
+        const { items, total } = await getSoonRuns();
+
+        expect(items.map((i) => i.id)).toEqual(['work_schedule:w2']);
+        expect(total).toBe(1);
+    });
+
+    it('skips source types SoonRunItem cannot label', async () => {
+        // The aggregation projects seven sources; SoonRunItem models two.
+        serverFetch.mockImplementation(
+            apiSimulator([
+                entry({
+                    id: 'agent_heartbeat:a1',
+                    sourceType: 'agent_heartbeat',
+                    ownerType: 'agent',
+                }),
+                entry({ id: 'recurring_task:t1', sourceType: 'recurring_task', ownerType: 'task' }),
+                entry({ id: 'data_sync:w1', sourceType: 'data_sync' }),
+                entry({ id: 'work_schedule:w2' }),
+            ]),
+        );
+
+        const { items, total } = await getSoonRuns();
+
+        expect(items.map((i) => i.id)).toEqual(['work_schedule:w2']);
+        expect(total).toBe(1);
+    });
+});
+
+describe('getSoonRuns — failure is absorbed but not silent', () => {
+    it('logs the failing endpoint instead of swallowing the error', async () => {
+        serverFetch.mockImplementation(apiSimulator([]));
+        // A caller that sends a non-whitelisted parameter — i.e. the defect.
+        serverFetch.mockRejectedValueOnce(new ForbiddenParamError(['status', 'sort', 'limit']));
+
+        const result = await getSoonRuns();
+
+        // The page must still render.
+        expect(result).toEqual({ items: [], total: 0 });
+        // ...but the failure has to be attributable in the logs. Before the fix
+        // this catch was empty, and `serverFetch`'s own log prints the response
+        // body without the endpoint, so nothing identified this call.
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const logged = errorSpy.mock.calls[0].join(' ');
+        expect(logged).toContain('/api/schedules');
+        expect(logged).toContain('Soon');
+    });
+
+    it('degrades to an empty block on any transport failure', async () => {
+        serverFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        await expect(getSoonRuns()).resolves.toEqual({ items: [], total: 0 });
+        expect(errorSpy).toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
@@ -16,8 +16,8 @@ import { agentsAPI } from '@/lib/api/agents';
 import { tasksAPI } from '@/lib/api/tasks';
 import { agentApprovalsAPI } from '@/lib/api/agent-approvals';
 // Dashboard blocks (spec §3) — Teams count, Soon runs, and the
-// server-composed Attention list. All three degrade gracefully when
-// their sibling-PR backends (Teams #1647, Schedules front) are absent.
+// server-composed Attention list. All three degrade gracefully (and log)
+// when their backend call fails.
 import { composeAttentionItems, getSoonRuns, getTeamsTotal } from './dashboard-data';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -120,7 +120,10 @@ export default async function Dashboard({ searchParams }: DashboardPageProps) {
             .catch(() => ({ data: [], meta: { total: 0, limit: 6, offset: 0 } })),
         // Teams count (9th tile) — `undefined` until Teams (PR #1647) wires it.
         getTeamsTotal().catch(() => undefined),
-        // Soon runs — empty until the Schedules front ships `/api/schedules`.
+        // Soon runs — the soonest upcoming Work-schedule / Mission runs from
+        // the Schedules front's `/api/schedules` aggregation. `getSoonRuns`
+        // already logs and absorbs its own transport failures; this catch is
+        // the outer belt-and-braces so the home page still renders.
         getSoonRuns().catch(() => ({ items: [], total: 0 })),
     ]);
 

--- a/apps/web/src/components/dashboard/SoonSection.tsx
+++ b/apps/web/src/components/dashboard/SoonSection.tsx
@@ -12,10 +12,15 @@ import type { SoonRunItem } from './dashboard-signals.types';
  * Attention and above the Missions list.
  *
  * Data comes from the Schedules front's `GET /api/schedules`
- * aggregation (server-fetched in the page, reused here as a prop).
- * That endpoint does not exist on this branch yet, so `items` arrives
- * empty and the block self-suppresses (`null`) — no "no upcoming runs"
- * empty state on a healthy home page (spec §9 Q6).
+ * aggregation (server-fetched in the page via `getSoonRuns`, reused here
+ * as a prop). When the account genuinely has no upcoming Work-schedule or
+ * Mission run — or the fetch failed — `items` arrives empty and the block
+ * self-suppresses (`null`): no "no upcoming runs" empty state on a healthy
+ * home page (spec §9 Q6).
+ *
+ * That self-suppression is why a broken fetch upstream is invisible on the
+ * page; `getSoonRuns` logs the failure instead of relying on this block to
+ * show it.
  */
 
 const PREVIEW_LIMIT = 3;


### PR DESCRIPTION
The dashboard home page's **"Coming up" (Soon)** block has never rendered a single row — in dev, stage, or prod. It is not a data problem: the fetch behind it has been failing since it shipped, and every failure was swallowed.

## Root cause — two stacked contract mismatches

`apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-data.ts` → `getSoonRuns()` called:

```
GET /api/schedules?status=active&sort=nextRunAt:asc&limit=3   →  { items, total }
```

**Mismatch 1 — the query parameters are rejected, not ignored.**
`ScheduleQueryDto` whitelists only `sourceType` / `entityKind` / `enabledOnly`, and `main.ts` installs the global pipe with `whitelist + transform + forbidNonWhitelisted`. That last flag turns an unknown parameter into a **400**, so all three params the caller sent were refused:

```
API Error: {
  message: [
    'property status should not exist',
    'property sort should not exist',
    'property limit should not exist'
  ],
  error: 'Bad Request',
  statusCode: 400
}
```

Still live — 12 and 15 occurrences respectively in the two `ever-works-app-dev` web pods at the time of writing.

**Mismatch 2 — the response shape.**
The caller destructured `{ items, total }`. `SchedulesController.list()` returns a **bare `ScheduleView[]`**. So even with the parameters fixed, `res.items` would be `undefined` and the block would still have come out empty. There was also a latent third mismatch behind that one: the rows are `ScheduleView`s (`ownerName` / `ownerLink` / `sourceType`), not the `SoonRunItem`s (`title` / `href` / `sourceKind`) the section renders — no mapping existed.

## Why nobody noticed

Three things lined up:

- The `catch` was bare — `catch { return { items: [], total: 0 }; }`. No log, no signal.
- `serverFetch` **does** log the failure, but as `console.error('API Error:', errorData)` — the response body **without the endpoint**. The 400 was sitting in the pod logs the whole time, unattributable to any particular call.
- `SoonSection` deliberately self-suppresses (`return null`) when it has no items, so there is no empty state to notice. A permanently-broken fetch and a healthy-but-quiet dashboard render identically.

The caller's comment — *"which does not exist on this branch yet"* — was written before the Schedules front shipped and was never revisited, so the empty block looked expected. That comment is corrected here (also in `SoonSection` and `page.tsx`).

## Direction chosen: fix the caller, not the API

Two defensible options existed. I changed the **caller** to speak the contract the API actually publishes:

1. **A `{ items, total }` envelope would break a shipped consumer.** `apps/web/src/lib/api/schedules.ts` (`schedulesAPI.getAll`) already consumes a bare array, and `app/actions/dashboard/schedules.ts` → the Schedules view is built on it. The dashboard was the *only* caller inventing an envelope.
2. **The endpoint is intentionally un-paginated.** Schedules spec §4.1, restated in `SchedulesService` (`MAX_PER_SOURCE`: *"P1 is un-paginated — cursor pagination is a documented follow-up"*). Adding `limit` would pre-empt that design decision.
3. **`sort=nextRunAt:asc` was already redundant.** `SchedulesService.sortByNextRun` returns rows sorted by `nextRunAt` ascending, nulls last — the documented behaviour of the endpoint.
4. **`status=active` has a supported equivalent**: the server-side `enabledOnly`, which drops paused/disabled/ended rows.
5. **It matches the conventions of the sibling fetchers.** Every other data fetch on this page goes through a typed client (`agentsAPI.list`, `tasksAPI.list`, `missionsAPI.list`, `usageAPI.accountWide`). `getSoonRuns` hand-rolled a URL string; it now uses `schedulesAPI.getAll` like everything else. (`getTeamsTotal` keeps raw `serverFetch` because it is a deliberate multi-org probe.)

The dashboard-blocks spec §3.3 *does* sketch the envelope contract — but it was written before the Schedules front existed, and the endpoint it describes was never built. The schedules spec is the authority for its own endpoint. Noted in the code comment so the next reader doesn't "fix" it back.

**Scope note:** `SoonRunItem.sourceKind` is `'work-schedule' | 'mission'`, and `SoonSection` only has badge copy for those two (`dashboard.soon.source.{work,mission}`). The aggregation projects seven source types, so rows from the other five are skipped rather than mislabelled. Widening the block to cover agent heartbeats / recurring tasks means a new badge string in all **21** locale files — a product change, deliberately not bundled into this fix.

## Observability

The catch now names the call: `[dashboard] Soon block: GET /api/schedules failed`. The page still renders if it fails (the block just stays hidden, and `page.tsx` keeps its outer catch). The same one-line treatment was given to the Teams tile's `/organizations` catch, which was silent for the same reason.

## Tests

A test that mocks the API into `{ items, total }` would have passed for the entire life of this bug. These pin the **real** contract instead:

**`apps/api/src/schedules/dto/schedules-query.dto.spec.ts`** (15 tests) — runs the real `ScheduleQueryDto` through a `ValidationPipe` built with the *same* options as the global one. Asserts the three supported filters are accepted and coerced, that the exact three params the Soon block used to send are rejected with the exact messages seen in the pod logs, and — via class-validator metadata — that the DTO declares **no filters beyond** the published set, so it cannot drift from the web-side whitelist without failing.

**`apps/api/src/schedules/schedules.controller.spec.ts`** (5 tests) — pins the response shape: bare array, `.items`/`.total` `undefined`, no server-side slicing.

**`apps/web/src/.../dashboard-data.unit.spec.ts`** (11 tests) — mocks only the *transport*. `serverFetch` is replaced by a simulator that **enforces the real whitelist** (throwing the same 400 on any non-whitelisted key) and answers with a **bare array**, never an envelope. It therefore fails in exactly the way the real API did.

### Before — against the unfixed caller (fix reverted, tests kept)

```
 ❯ dashboard-data.unit.spec.ts (11 tests | 11 failed)
   × sends only query parameters the API whitelists
   × asks the server for enabled schedules only
   × does not 400 against a server that enforces the real whitelist
   × reads the handler's bare array, not an { items, total } envelope
   × maps a ScheduleView row onto the SoonRunItem the SoonSection renders
   × maps mission_tick rows to the mission badge kind
   × previews the three soonest runs but reports the full total
   × skips rows with no computable next run
   × skips source types SoonRunItem cannot label
   × logs the failing endpoint instead of swallowing the error
   × degrades to an empty block on any transport failure

AssertionError: expected [ 'status', 'sort', 'limit' ] to deeply equal []
AssertionError: promise rejected "ApiResponseError: property status should …" instead of resolving
  Caused by: ApiResponseError: property status should not exist, property sort
  should not exist, property limit should not exist
AssertionError: expected [] to have a length of 2 but got +0
AssertionError: expected "error" to be called 1 times, but got 0 times

 Test Files  1 failed (1)
      Tests  11 failed (11)
```

The three assertion failures above are, in order, mismatch 1, the 400 it produced, and mismatch 2 — reproduced locally, independent of the cluster.

### After

```
 ✓ dashboard-data.unit.spec.ts (11 tests) — 11 passed

PASS src/schedules/dto/schedules-query.dto.spec.ts
PASS src/schedules/schedules.controller.spec.ts
Test Suites: 2 passed, 2 total
Tests:       20 passed, 20 total
```

31 tests total. Note the two **api** specs pass both before and after by design — no API source changed; they are the *reproduction* and the pin of the server's real behaviour. The **web** spec is the regression: red before, green after.

`eslint` clean on every changed file; `tsc --noEmit` reports zero errors in them (the pre-existing `@ever-works/*` "cannot find module" errors are unbuilt workspace packages, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
