### PR TITLE
fix(onboarding): drop the invalid Turnstile size that blocked anonymous signup

### DIFF
--- a/apps/web/src/components/onboarding/use-turnstile.ts
+++ b/apps/web/src/components/onboarding/use-turnstile.ts
@@ -39,7 +39,23 @@ type TurnstileRenderOptions = {
     sitekey: string;
     appearance: 'always' | 'execute' | 'interaction-only';
     execution: 'render' | 'execute';
-    size: 'normal' | 'compact' | 'invisible';
+    /**
+     * Cloudflare accepts exactly `normal`, `compact` and `flexible` here.
+     *
+     * `invisible` was in this union and was being passed to `render()`, which
+     * made Turnstile throw before the widget existed:
+     *
+     *     Uncaught TurnstileError: [Cloudflare Turnstile] Invalid value for
+     *     parameter "size", expected "compact", "flexible", or "normal",
+     *     got "invisible".
+     *
+     * No widget meant no token, so every anonymous visitor arriving from the
+     * marketing site's prompt hand-off saw "We couldn't verify your browser."
+     * Invisibility is not a `size` — it comes from `appearance: 'execute'` +
+     * `execution: 'execute'`, which are already set below, and the container
+     * is positioned off-screen. So the option was invalid AND redundant.
+     */
+    size?: 'normal' | 'compact' | 'flexible';
     callback?: (token: string) => void;
     'error-callback'?: (errorCode: string) => void;
     'expired-callback'?: () => void;
@@ -128,7 +144,9 @@ export function useTurnstile(sitekey: string = TURNSTILE_SITEKEY) {
             sitekey,
             appearance: 'execute',
             execution: 'execute',
-            size: 'invisible',
+            // No `size` — see TurnstileRenderOptions. `appearance`/`execution`
+            // give the invisible behaviour; the container above is already
+            // parked off-screen.
             retry: 'auto',
             callback: (token: string) => {
                 pendingResolveRef.current?.(token);

--- a/apps/web/src/components/onboarding/use-turnstile.unit.spec.ts
+++ b/apps/web/src/components/onboarding/use-turnstile.unit.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTurnstile, TURNSTILE_SITEKEY } from './use-turnstile';
+
+/**
+ * Guard for the options handed to `window.turnstile.render()`.
+ *
+ * The hook passed `size: 'invisible'`. Cloudflare accepts exactly `normal`,
+ * `compact` and `flexible` there, so `render()` threw before a widget ever
+ * existed:
+ *
+ *     Uncaught TurnstileError: [Cloudflare Turnstile] Invalid value for
+ *     parameter "size", expected "compact", "flexible", or "normal",
+ *     got "invisible".
+ *
+ * No widget meant no token, so `/onboarding` — the page the marketing site's
+ * prompt hand-off lands on — showed "We couldn't verify your browser. Please
+ * sign up to continue." for every anonymous visitor. Observed live on
+ * app.ever.works.
+ *
+ * Invisibility is not a size: it comes from `appearance: 'execute'` +
+ * `execution: 'execute'`, which the hook already sets, with the container
+ * parked off-screen. So the option was invalid AND redundant.
+ *
+ * These tests assert the OPTIONS OBJECT rather than any rendered output,
+ * because the defect lives entirely in the argument we hand to a third-party
+ * script. A test that stubs `render()` as a no-op returning an id would pass
+ * against the bug — the real Cloudflare script is what rejected it — so the
+ * allowed-value list is pinned here explicitly.
+ */
+
+/** The only values Cloudflare documents for `size`. */
+const CLOUDFLARE_ALLOWED_SIZES = ['normal', 'compact', 'flexible'];
+
+type RenderOptions = Record<string, unknown>;
+
+describe('useTurnstile — render options', () => {
+    let renderSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        renderSpy = vi.fn(() => 'widget-id-1');
+        (window as unknown as { turnstile?: unknown }).turnstile = {
+            render: renderSpy,
+            execute: vi.fn(),
+            reset: vi.fn(),
+            remove: vi.fn(),
+            getResponse: vi.fn(),
+        };
+
+        // The hook injects the Cloudflare script and waits for its load event
+        // before rendering. Resolve that immediately so the effect proceeds.
+        const realCreate = document.createElement.bind(document);
+        vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+            const el = realCreate(tag as 'div');
+            if (tag === 'script') {
+                queueMicrotask(() => el.dispatchEvent(new Event('load')));
+            }
+            return el;
+        }) as typeof document.createElement);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete (window as unknown as { turnstile?: unknown }).turnstile;
+        document.getElementById('ew617-turnstile-container')?.remove();
+    });
+
+    async function capturedOptions(): Promise<RenderOptions> {
+        renderHook(() => useTurnstile(TURNSTILE_SITEKEY));
+        await waitFor(() => expect(renderSpy).toHaveBeenCalled());
+        return renderSpy.mock.calls[0][1] as RenderOptions;
+    }
+
+    it('never sends a size Cloudflare would reject', async () => {
+        const options = await capturedOptions();
+
+        // Control: the call really did carry options, so a passing assertion
+        // cannot be one that inspected nothing.
+        expect(Object.keys(options).length).toBeGreaterThan(0);
+
+        if ('size' in options && options.size !== undefined) {
+            expect(CLOUDFLARE_ALLOWED_SIZES).toContain(options.size);
+        }
+        expect(options.size).not.toBe('invisible');
+    });
+
+    it('gets its invisibility from appearance/execution, not from size', async () => {
+        const options = await capturedOptions();
+
+        expect(options.appearance).toBe('execute');
+        expect(options.execution).toBe('execute');
+    });
+
+    it('renders against the configured sitekey', async () => {
+        const options = await capturedOptions();
+
+        expect(options.sitekey).toBe(TURNSTILE_SITEKEY);
+    });
+});


### PR DESCRIPTION
The zero-friction funnel is **broken in production**. The marketing site's prompt hand-off lands
anonymous visitors on `/onboarding`, which shows:

> We couldn't verify your browser. Please sign up to continue.

## Root cause

Turnstile never produced a token, because `render()` threw before a widget existed:

```
Uncaught TurnstileError: [Cloudflare Turnstile] Invalid value for parameter "size",
expected "compact", "flexible", or "normal", got "invisible".
```

Cloudflare accepts exactly `normal`, `compact` and `flexible` for `size`. **Invisibility is not a
size** — it comes from `appearance: 'execute'` + `execution: 'execute'`, which this hook already sets,
and the container is already parked off-screen at `-9999px`.

So `size: 'invisible'` was **invalid and redundant**. Removing it is the whole fix.

**This is not bot-blocking working as intended.** The value is rejected by an argument validator before
any challenge is attempted, so it fails for every visitor, in every browser, deterministically.

## Reproduction (production)

1. Typed a prompt on `https://ever.works/en/get-started` and pressed submit.
2. Landed on `https://app.ever.works/onboarding#prompt=…&corrId=…` — the hand-off itself works.
3. Page rendered "We couldn't verify your browser", with the `TurnstileError` above in the console.

## Test

`use-turnstile.unit.spec.ts` asserts the **options object** handed to `window.turnstile.render()`,
because the defect lives entirely in an argument to a third-party script. A test that stubs `render()`
as a no-op returning an id would pass against the bug — the real Cloudflare script is what rejected it
— so the allowed-value list is pinned explicitly, together with the `appearance`/`execution` pair that
actually provides the invisible behaviour.

**Verified both ways.** Reintroducing `size: 'invisible'`:

```
× never sends a size Cloudflare would reject
  AssertionError: expected [ 'normal', 'compact', 'flexible' ] to include 'invisible'
Tests  1 failed | 2 passed (3)
```

With the fix: **3/3 pass**. `tsc --noEmit` on `apps/web` exits 0 with zero errors.

Found during an owner-directed end-to-end browser verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)