### PR TITLE
docs: document signup, the setup wizard, usage & credits, and the settings map

### DIFF
--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -51,8 +51,14 @@ const sidebars: SidebarsConfig = {
 			collapsed: false,
 			link: { type: 'doc', id: 'features/index' },
 			items: [
+				// A new user's first two screens, in the order they meet
+				// them: create the account, then walk the setup wizard.
+				// The settings map follows the wizard because every choice
+				// the wizard makes is changed there afterwards.
+				'features/creating-an-account',
 				'features/creating-a-work',
 				'features/onboarding',
+				'features/settings-map',
 				'features/missions',
 				'features/ideas',
 				'features/agents',

--- a/docs/features/creating-an-account.md
+++ b/docs/features/creating-an-account.md
@@ -1,0 +1,145 @@
+---
+id: creating-an-account
+title: Creating an Account
+sidebar_label: Creating an Account
+---
+
+# Creating an Account
+
+An Ever Works account is what your Works, Agents, credits and settings hang off. You can create one
+with an email address and a password, or with a social provider your installation has configured.
+
+Signing up is not always the first thing you do: the [onboarding page](./onboarding.md) lets a
+visitor generate a Work from a guest session first. This page covers the point where you turn that
+into a real account — or start with one.
+
+## Create an account with email and password
+
+Go to **`/register`** — on the hosted platform, `https://app.ever.works/register`. The form asks for
+four things:
+
+| Field                | Notes                                                             |
+| -------------------- | ----------------------------------------------------------------- |
+| **Full name**        | At least 3 characters. This becomes your display name.            |
+| **Email address**    | Must be a valid address; it is also your sign-in identifier.      |
+| **Password**         | At least 8 characters — the hint under the field says so.         |
+| **Confirm password** | Must match **Password** exactly, or the form refuses to submit.   |
+
+Then tick **I agree to the Terms of Service and Privacy Policy** and choose **Create account**. The
+checkbox is required: without it the form shows "Please accept the Terms of Service and Privacy
+Policy to continue" and nothing is submitted.
+
+Beyond the 8-character minimum shown in the form, a password must also contain at least one
+lowercase letter and at least one number or special character, and it cannot begin with a dot or a
+newline. If it does not, the form tells you which rule failed instead of creating the account.
+
+If the email already has an account, you are told the address is already registered — use
+[Sign in](#signing-in) or [Forgot password?](#if-you-forgot-your-password) instead.
+
+### What the terms checkbox actually records
+
+Ticking the box does not just unlock the button. The signup page fetches the legal documents you
+must accept **before it renders**, in your locale, and shows you that exact text. When you submit,
+the same documents are sent back and recorded against your new account:
+
+- the **document id** and its **version**,
+- the **SHA-256 digest** of the published document source,
+- the **locale** the text was displayed in.
+
+The digest is what makes the record meaningful: it pins the acceptance to the precise wording that
+was on screen, so the text you agreed to can be reproduced exactly later. The server re-checks every
+field against its published corpus before writing anything — a claim that points at text that was
+never published is rejected rather than stored.
+
+One consequence is worth knowing: if the required documents cannot be loaded, the checkbox and the
+**Create account** button are both disabled and registration is blocked. That is deliberate. There
+would be nothing truthful to record, so the form refuses rather than creating an account with an
+empty consent record.
+
+Acceptance is recorded once per document version, so a double-submitted form does not produce two
+records that disagree about the time.
+
+## Sign up or sign in with a social provider
+
+Under the divider **Or sign up with**, the page offers the providers your installation has
+configured. Ever Works supports four:
+
+- **GitHub**
+- **Google**
+- **Facebook**
+- **LinkedIn**
+
+The list is resolved from the API at page load, so an installation that has configured only some of
+them shows only those, and one that has configured none shows no social section at all. The same
+buttons appear on the sign-in page under **Or continue with** — for a social provider, signing up
+and signing in are the same action.
+
+:::note
+Connecting **GitHub** as a sign-in provider is not the same thing as connecting GitHub as your Git
+storage. The [setup wizard](./onboarding.md) asks for that separately, and you can change it later
+under **Settings → Git Providers**.
+:::
+
+## Signing in
+
+Go to **`/login`**, enter your email address and password, and choose **Sign in**. Wrong details
+give one undifferentiated "Invalid email or password" — the page never tells you whether the address
+exists.
+
+The sign-in page has two tabs:
+
+| Tab                 | What it does                                         |
+| ------------------- | ---------------------------------------------------- |
+| **Password**        | Email and password.                                  |
+| **Email me a link** | Sends a one-time sign-in link. No password required. |
+
+The social buttons sit below either tab. The tab strip itself only appears when your installation
+has magic links enabled — otherwise the page is just the password form.
+
+### Signing in with a magic link
+
+Choose **Email me a link**, enter your email address, and choose **Send magic link**. The page then
+says *Check your inbox* and offers **Send another link** if the first one does not arrive.
+
+A magic link **can only be used once and stays valid for 15 minutes**. Opening it takes you to a
+short "Signing you in" page that redeems the token and drops you at the dashboard. If the link has
+expired or has already been used, you get "This link can't be used" with a **Send a new link**
+action rather than a silent failure.
+
+The confirmation is phrased conditionally — *if* an account exists for that address, a sign-in link
+was sent — and reads the same either way, so the page cannot be used to discover which addresses are
+registered.
+
+## If you forgot your password
+
+On the sign-in page, choose **Forgot password?** (or go to `/forgot-password` directly). Enter your
+email address and choose **Send Reset Link**. You will see "Check your email", along with a reminder
+to look in your spam folder.
+
+The email links to `/reset-password` with a token in the URL. There you set a new password twice.
+The new password has to satisfy the same rules as a password chosen at signup — at least 8
+characters, at least one lowercase letter, at least one number or special character, and not
+starting with a dot — and the two fields have to match.
+
+Once it succeeds you are sent back to sign-in with a "Password reset successful" banner. If you open
+`/reset-password` without a valid token, the page says the link is invalid and offers **Request New
+Reset Link** instead of an unusable form.
+
+## What happens right after you sign up
+
+Creating an account signs you in immediately — there is no "now go and log in" step — and takes you
+straight to the dashboard as a new user. Two things follow:
+
+1. **A verification email is sent to your address.** Until you confirm it, **Settings → Profile**
+   shows a banner with a button to resend the message.
+2. **The setup wizard opens.** It is the 10-step walkthrough that picks your AI, Git storage,
+   database, deployment and more. Every step can be skipped, and every choice can be changed later
+   in Settings — see [Onboarding & Setup Wizard](./onboarding.md).
+
+## Related pages
+
+- [Onboarding & Setup Wizard](./onboarding.md) — the guided walkthrough that opens next.
+- [The Settings Map](./settings-map.md) — where everything you just chose lives afterwards.
+- [API Authentication](../api/authentication.md) — the REST equivalents of these flows.
+- [Teams & Organizations](../advanced/teams-and-organizations.md) — how your data is scoped once you
+  create an Organization.

--- a/docs/features/creating-an-account.md
+++ b/docs/features/creating-an-account.md
@@ -18,12 +18,12 @@ into a real account — or start with one.
 Go to **`/register`** — on the hosted platform, `https://app.ever.works/register`. The form asks for
 four things:
 
-| Field                | Notes                                                             |
-| -------------------- | ----------------------------------------------------------------- |
-| **Full name**        | At least 3 characters. This becomes your display name.            |
-| **Email address**    | Must be a valid address; it is also your sign-in identifier.      |
-| **Password**         | At least 8 characters — the hint under the field says so.         |
-| **Confirm password** | Must match **Password** exactly, or the form refuses to submit.   |
+| Field                | Notes                                                           |
+| -------------------- | --------------------------------------------------------------- |
+| **Full name**        | At least 3 characters. This becomes your display name.          |
+| **Email address**    | Must be a valid address; it is also your sign-in identifier.    |
+| **Password**         | At least 8 characters — the hint under the field says so.       |
+| **Confirm password** | Must match **Password** exactly, or the form refuses to submit. |
 
 Then tick **I agree to the Terms of Service and Privacy Policy** and choose **Create account**. The
 checkbox is required: without it the form shows "Please accept the Terms of Service and Privacy
@@ -99,14 +99,14 @@ has magic links enabled — otherwise the page is just the password form.
 ### Signing in with a magic link
 
 Choose **Email me a link**, enter your email address, and choose **Send magic link**. The page then
-says *Check your inbox* and offers **Send another link** if the first one does not arrive.
+says _Check your inbox_ and offers **Send another link** if the first one does not arrive.
 
 A magic link **can only be used once and stays valid for 15 minutes**. Opening it takes you to a
 short "Signing you in" page that redeems the token and drops you at the dashboard. If the link has
 expired or has already been used, you get "This link can't be used" with a **Send a new link**
 action rather than a silent failure.
 
-The confirmation is phrased conditionally — *if* an account exists for that address, a sign-in link
+The confirmation is phrased conditionally — _if_ an account exists for that address, a sign-in link
 was sent — and reads the same either way, so the page cannot be used to discover which addresses are
 registered.
 

--- a/docs/features/credits-and-billing.md
+++ b/docs/features/credits-and-billing.md
@@ -44,19 +44,48 @@ The purchase, payment-method and auto-recharge surfaces are flag-gated behind `P
 
 ## The Usage & Credits page
 
-**Settings → Usage** shows the period totals and four spend breakdowns:
+**Settings → Usage & Credits** (`/settings/usage`) answers "where did the credits go?". **One reporting period drives the whole page** — the tiles and all four charts always describe the same window.
+
+### Choosing the period
+
+The controls at the top-right of the page offer three ways to set it:
+
+- **7d** and **30d** — rolling windows.
+- A **calendar month** picker (*Pick a month*), listing the last twelve months newest-first.
+- The page defaults to the **current calendar month**.
+
+A `?period=` query parameter is honoured server-side, so a link like `/settings/usage?period=2026-07` renders exactly the month it names. An unrecognised value falls back to the current month rather than blanking the page. Switching back to a period you already viewed is instant — each period's snapshot is cached client-side for the session.
+
+### Period totals
 
 | Tile            | Meaning                                            |
 | --------------- | -------------------------------------------------- |
-| Balance         | Live balance (not window-bound).                   |
-| Consumed        | Credits debited inside the window.                 |
-| Added           | Purchases + grants + daily-free inside the window. |
-| Spend           | Metered provider spend in cents for the window.    |
+| Credits balance | Live balance (not window-bound).                   |
+| Credits used    | Credits debited inside the window.                 |
+| Credits added   | Purchases + grants + daily-free inside the window. |
+| Month spend     | Metered provider spend in cents for the window.    |
 | Tasks completed | Count for the window.                              |
 | Works active    | Count for the window.                              |
 | Agent runs      | Count for the window.                              |
 
-Charts break the same window down **per day** (with a 7d / 30d toggle), **per model**, **per agent** and **per Work**. `period` accepts a calendar month (`YYYY-MM`, default the current month) or a rolling `7d` / `30d`.
+A line under the tiles names the period they describe, so a screenshot is never ambiguous about what it is showing.
+
+### The four breakdowns
+
+| Chart              | Breaks the window down by                      |
+| ------------------ | ---------------------------------------------- |
+| **Usage per day**  | Each day in the period.                        |
+| **Usage by model** | The AI models the spend went to.               |
+| **Usage by agent** | The Agents that spent it.                      |
+| **Usage by Work**  | The Works it was spent on.                     |
+
+Rows that cannot be attributed to a model, agent or Work are grouped under **Unattributed** rather than dropped, so the breakdowns still add up. A period with no activity says "No usage in this period." instead of drawing an empty chart, and if a panel fails to load the page says so rather than showing a misleading zero.
+
+### Export CSV
+
+**Export CSV** downloads every usage event in the currently selected period as a CSV file, via `GET /api/credits/usage/export?period=…`. The `period` sent is whatever the selector is set to, so the export and the charts always agree.
+
+`period` accepts a calendar month (`YYYY-MM`, default the current month) or a rolling `7d` / `30d` everywhere it appears — page, API and export alike.
 
 ## Plan entitlements
 

--- a/docs/features/credits-and-billing.md
+++ b/docs/features/credits-and-billing.md
@@ -51,7 +51,7 @@ The purchase, payment-method and auto-recharge surfaces are flag-gated behind `P
 The controls at the top-right of the page offer three ways to set it:
 
 - **7d** and **30d** — rolling windows.
-- A **calendar month** picker (*Pick a month*), listing the last twelve months newest-first.
+- A **calendar month** picker (_Pick a month_), listing the last twelve months newest-first.
 - The page defaults to the **current calendar month**.
 
 A `?period=` query parameter is honoured server-side, so a link like `/settings/usage?period=2026-07` renders exactly the month it names. An unrecognised value falls back to the current month rather than blanking the page. Switching back to a period you already viewed is instant — each period's snapshot is cached client-side for the session.
@@ -72,12 +72,12 @@ A line under the tiles names the period they describe, so a screenshot is never 
 
 ### The four breakdowns
 
-| Chart              | Breaks the window down by                      |
-| ------------------ | ---------------------------------------------- |
-| **Usage per day**  | Each day in the period.                        |
-| **Usage by model** | The AI models the spend went to.               |
-| **Usage by agent** | The Agents that spent it.                      |
-| **Usage by Work**  | The Works it was spent on.                     |
+| Chart              | Breaks the window down by        |
+| ------------------ | -------------------------------- |
+| **Usage per day**  | Each day in the period.          |
+| **Usage by model** | The AI models the spend went to. |
+| **Usage by agent** | The Agents that spent it.        |
+| **Usage by Work**  | The Works it was spent on.       |
 
 Rows that cannot be attributed to a model, agent or Work are grouped under **Unattributed** rather than dropped, so the breakdowns still add up. A period with no activity says "No usage in this period." instead of drawing an empty chart, and if a panel fails to load the page says so rather than showing a misleading zero.
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,6 +13,14 @@ This section covers the individual capabilities that make that possible, beyond 
 
 > New here? Read the [Platform Overview](../overview.md) for the big picture, or the [Founder Journey guide](../guides/founder-journey.md) for the Start → Build → Sell → Scale playbook that ties these features together.
 
+## Getting started
+
+| Feature                                              | Description                                                                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Creating an Account](./creating-an-account)         | Signing up, social sign-in, magic links, password reset — and what the terms checkbox records     |
+| [Onboarding & Setup Wizard](./onboarding)            | The guided walkthrough that picks your AI, storage, database, deployment and plugins              |
+| [The Settings Map](./settings-map)                   | What lives where under Settings, including Usage & Credits                                        |
+
 ## The core loop
 
 | Feature                                        | Description                                                                                                |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,11 +15,11 @@ This section covers the individual capabilities that make that possible, beyond 
 
 ## Getting started
 
-| Feature                                              | Description                                                                                       |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [Creating an Account](./creating-an-account)         | Signing up, social sign-in, magic links, password reset — and what the terms checkbox records     |
-| [Onboarding & Setup Wizard](./onboarding)            | The guided walkthrough that picks your AI, storage, database, deployment and plugins              |
-| [The Settings Map](./settings-map)                   | What lives where under Settings, including Usage & Credits                                        |
+| Feature                                      | Description                                                                                   |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [Creating an Account](./creating-an-account) | Signing up, social sign-in, magic links, password reset — and what the terms checkbox records |
+| [Onboarding & Setup Wizard](./onboarding)    | The guided walkthrough that picks your AI, storage, database, deployment and plugins          |
+| [The Settings Map](./settings-map)           | What lives where under Settings, including Usage & Credits                                    |
 
 ## The core loop
 

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -10,8 +10,8 @@ Ever Works is built for a **zero-friction** first run: a brand-new visitor
 can land on `/onboarding`, type a prompt, and get a generated
 [Work](./creating-a-work.md) — without first creating an account or
 touching any settings. Users who want more control get a short **guided
-setup wizard** to pick their AI, storage, deployment, and plugins before
-the first Work is generated.
+setup wizard** to pick their AI, storage, database, deployment and plugins
+before the first Work is generated.
 
 This page covers the human-facing `/onboarding` page and the wizard. For
 the **agent-facing** single-call registration API (no UI, no human),
@@ -69,48 +69,267 @@ hop from the marketing site into the guest session.
 
 ## The guided setup wizard
 
-The wizard is a linear, resumable walkthrough. Its step list is computed
-from the current state (`computeStepList` in `useOnboardingFlow.ts`), so
-**config steps are shown only when they're needed** — if you keep the
-Ever Works default for a bucket (which needs no per-user config), that
-bucket's config step is skipped entirely.
+The wizard opens by itself the first time you reach the dashboard with no
+Works yet, and stays out of your way afterwards: once you complete it — or
+close it — it does not reopen on its own.
 
-| #   | Step               | Purpose                                                       |
-| --- | ------------------ | ------------------------------------------------------------- |
-| 1   | `welcome`          | Intro + preview of the upcoming steps                         |
-| 2   | `ai-choice`        | Pick the AI provider bucket (Ever Works default, or your own) |
-| 3   | `ai-config`\*      | Configure the chosen AI provider (skipped for the default)    |
-| 4   | `storage-choice`   | Pick storage (Ever Works default, or your own GitHub)         |
-| 5   | `storage-config`\* | Connect GitHub (shown only for `user-github`)                 |
-| 6   | `deploy-choice`    | Pick a deploy target (Ever Works default, Vercel, or k8s)     |
-| 7   | `deploy-config`\*  | Configure the target (shown only for `vercel` / `k8s`)        |
-| 8   | `plugins-catalog`  | Review and enable optional plugins                            |
-| 9   | `create-work`      | Enter/confirm the prompt and **Generate** the first Work      |
+It is a dialog with a **stepper down the left-hand side**. The stepper is
+not just a progress bar: every entry is clickable, so you can jump
+straight to the step you care about and back again. A progress bar across
+the top tracks how far through you are, and the footer carries **Back**,
+**Skip step** and **Next**.
 
-_\* Config steps are conditional. `ai-config` is dropped when the AI
-choice is the Ever Works default; `storage-config` appears only for the
-`user-github` choice; `deploy-config` appears only for `vercel` or
-`k8s`._
+Three things are worth knowing before you start:
 
-The four configurable buckets — **AI, Storage, Deployment, Plugins** —
-each default to a zero-config Ever Works option so a user can click
-straight through to "Generate now". Every choice can also be changed later
-from **Settings**.
+- **Every step that asks you something can be skipped.** The footer
+  carries a skip action all the way to the final step — labelled
+  *Skip — set up later* on the plugins step — and skipping is recorded,
+  not punished. You can also leave the whole thing with **Close wizard**
+  at the bottom of the stepper.
+- **Your choices are saved as you make them.** Each transition is written
+  to the server, so progress survives a reload, a new device or a wiped
+  cookie. If a save fails you are told, rather than clicking through a
+  wizard that persists nothing.
+- **Nothing here is permanent.** As the wizard's own sidebar says, you can
+  change any choice later from Settings. See
+  [The Settings Map](./settings-map.md) for where each one lives.
 
-### Wizard data
+If you close the wizard before finishing, a **Setup** badge appears in the
+dashboard header showing which step you are on, so you can pick it up
+again. Dismissing that badge does not mark setup as complete.
+
+### The ten steps
+
+With the Ever Works defaults kept, the wizard is ten steps:
+
+| #   | Step                        | What you choose                                                  |
+| --- | --------------------------- | ---------------------------------------------------------------- |
+| 1   | **Welcome**                 | Nothing — an intro plus a preview of the steps ahead.            |
+| 2   | **Your AI choice**          | Which AI provider powers content generation.                     |
+| 3   | **Your Git Storage**        | Where your Work repositories live.                               |
+| 4   | **Your DB Storage**         | Where your Works store their data.                               |
+| 5   | **Your deployment**         | Where your Works get deployed.                                   |
+| 6   | **Where it runs**           | Whether Ever Works itself runs hosted, on your machine, or on your machines. |
+| 7   | **What do you do**          | Your roles and team size — used to suggest starting points.      |
+| 8   | **Communication**           | The chat workspace your team lives in.                           |
+| 9   | **Plugins & Integrations**  | Optional power-user integrations.                                |
+| 10  | **Create your first Work**  | The prompt, and the button that generates it.                    |
+
+Picking a bring-your-own option adds a configuration step immediately
+after the choice it belongs to, so the wizard gets **longer** as you move
+away from the defaults:
+
+| Choosing…                                    | Adds                     |
+| -------------------------------------------- | ------------------------ |
+| Any AI provider other than **Ever Works AI** | **Configure AI**         |
+| **Your GitHub**                              | **Configure storage**    |
+| **Vercel** or **Kubernetes**                 | **Configure deployment** |
+
+Configuration steps are where you paste credentials or complete an OAuth
+or device-authorisation flow. They also get a **Refresh** button in the
+footer, so after connecting in another tab you can re-check the connection
+without leaving the wizard. Keeping the Ever Works default for a bucket
+skips that bucket's configuration step entirely — there would be nothing
+to fill in.
+
+:::note Options marked "Coming soon"
+Some cards render with a **Coming soon** badge, greyed out and not
+selectable. **Which ones do depends on your installation's
+configuration** — the managed Ever Works options in particular are
+switched on or off per install, so a card that is selectable on the hosted
+platform may appear as coming soon on a self-hosted one, and the other way
+round. Trust the badge in front of you over any list, including this page.
+:::
+
+### Step 1 — Welcome
+
+An introduction to what Ever Works is, and a list of the steps that
+follow. There is nothing to choose; **Next** moves on.
+
+### Step 2 — Your AI choice
+
+Pick the AI provider that powers content generation. Six options:
+
+| Option              | Notes                                                                   |
+| ------------------- | ----------------------------------------------------------------------- |
+| **Ever Works AI**   | The default. Uses the provider Ever Works has configured. No setup.     |
+| **OpenRouter**      | Route AI calls through OpenRouter with your own API key.                |
+| **Claude Code**     | Anthropic Claude via the Claude Code CLI.                               |
+| **Codex**           | OpenAI Codex CLI, connected through a device-authorisation flow.        |
+| **Gemini**          | Google Gemini via your AI Studio API key.                               |
+| **Grok (xAI)**      | xAI Grok via your xAI API key.                                          |
+
+Every option except **Ever Works AI** is marked **BYOK** — bring your own
+key — and adds the **Configure AI** step where you supply the credential.
+
+### Step 3 — Your Git Storage
+
+Where your Work repositories live. Four options:
+
+| Option              | Notes                                                     |
+| ------------------- | --------------------------------------------------------- |
+| **Ever Works Git**  | The default — a managed Ever Works GitHub org.            |
+| **Your GitHub**     | Your own GitHub account or organization.                  |
+| **Your GitLab**     | Bring your own GitLab.                                    |
+| **Your Git**        | A self-hosted Git server.                                 |
+
+**Your GitHub** adds the **Configure storage** step, where you sign in with
+GitHub so the platform can create repositories for you.
+
+### Step 4 — Your DB Storage
+
+Where your Works keep their data. Two options:
+
+- **Ever Works DB** — the managed default. **A database is provisioned per
+  Work**, automatically; there is nothing to set up.
+- **Custom DB** — your own PostgreSQL server. You supply a connection
+  string, which is used for all of your Works, with a database created per
+  Work.
+
+### Step 5 — Your deployment
+
+Where your Works get deployed. Three options:
+
+| Option           | Notes                                                                                     |
+| ---------------- | ----------------------------------------------------------------------------------------- |
+| **Ever Works**   | The default — deploy to the Ever Works tenant cluster. The card states the per-account cap on active Works. |
+| **Vercel**       | Your own Vercel team, using your API token.                                               |
+| **Kubernetes**   | Your own cluster — you paste a kubeconfig.                                                |
+
+**Vercel** and **Kubernetes** both add the **Configure deployment** step.
+
+### Step 6 — Where it runs
+
+Unlike the four steps before it, this one names no provider. It records
+where Ever Works *itself* runs, which decides the guidance you get at the
+end of the wizard. Three options, all always available:
+
+| Option                    | Meaning                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| **The hosted platform**   | The default. Everything runs on Ever Works; nothing to install.                |
+| **On my machine**         | [Ever Works Desktop](./desktop-app.md) runs the API and web app locally and supervises them. |
+| **On my own machines**    | The platform runs wherever you like, but your machines execute the work — enrolled as [Fleet](./fleet.md) nodes. |
+
+The choice decides the closing advice on the last step. Picking
+**On my machine** adds a *Finish your desktop setup* block pointing at
+**Settings → Job Runtime**; picking **On my own machines** adds an *Add
+your first node* block pointing at **Settings → Fleet**. The hosted
+default adds nothing — there is nothing left to install.
+
+### Step 7 — What do you do
+
+Two questions, both optional, used only to suggest better starting points.
+Nothing is hidden or gated based on your answers.
+
+**Your roles** is a multi-select — pick as many as apply. There are
+fourteen:
+
+| Role              | As the card describes it                        |
+| ----------------- | ----------------------------------------------- |
+| Founder / CEO     | I run the company and wear many hats            |
+| Engineering       | I build and ship software                       |
+| Product           | I define what we build and why                  |
+| Marketing         | I grow awareness, content, and campaigns        |
+| Sales             | I find, pitch, and close customers              |
+| Consultant        | I deliver projects and advice for clients       |
+| Research          | I investigate, analyze, and synthesize          |
+| Operations        | I keep the business running smoothly            |
+| Support           | I help customers succeed and resolve issues     |
+| Finance           | I manage budgets, billing, and reporting        |
+| HR                | I hire, onboard, and support our people         |
+| Legal             | I handle contracts, compliance, and policy      |
+| Education         | I teach, train, or create learning content      |
+| Other             | Something else — tell us more later             |
+
+**Team size** is a single-select: **Solo**, **Small (2–10)**,
+**Mid (11–50)**, **Large (51–200)** or **Enterprise (200+)**.
+
+Once you have picked at least one role, a **Suggested agents for you**
+block may appear with prebuilt [Agent](./agents.md) templates matched to
+those roles. You can create one at a time with **Create agent**, or take
+the lot with **Set up my starter agents**. Both are optional, and the
+block hides itself if the suggestions cannot be loaded.
+
+### Step 8 — Communication
+
+Connect the chat workspace your team lives in, so you can talk to the
+platform without leaving the conversation.
+
+- **Slack** — expand the card to enter the connector's settings and enable
+  it in place, without leaving the wizard. A link to the full plugin
+  settings page is offered as well.
+- **Discord** — shown with a **Coming soon** chip.
+
+If your installation ships without the Slack connector, the card links out
+to **Settings → Plugins** instead of connecting inline.
+
+### Step 9 — Plugins & Integrations
+
+A short catalogue of power-user integrations, presented for discovery
+rather than configuration — the step's own copy says most people skip it.
+Clicking a card expands its settings inline if you do want to set one up
+now. The integrations offered here are:
+
+- **Composio**
+- **Make.com**
+- **SIM AI**
+- **Zapier**
+- **Activepieces**
+
+The list is built from the plugins your installation has, minus anything
+already used by an earlier step, so it can be shorter — or empty, in which
+case the step says there are no additional integrations available.
+
+### Step 10 — Create your first Work
+
+The last step. If you arrived with a prompt — typed on the marketing site,
+or carried in from earlier — the step reads *Ready to generate* and shows
+the prompt in an editable box with a **Generate now** button that creates
+the Work and starts generation in one click, using the choices you just
+made. Without a prompt it reads *Create your first Work* and links into the
+full [Create a Work](./creating-a-work.md) form instead.
+
+Below the primary action sits the follow-on guidance chosen by
+[step 6](#step-6--where-it-runs), when there is any. The footer's
+**Finish** completes the wizard.
+
+## Changing any of it later
+
+Nothing chosen in the wizard is locked in. The provider buckets map onto
+the plugin categories in Settings:
+
+| Wizard step        | Where to change it afterwards         |
+| ------------------ | ------------------------------------- |
+| Your AI choice     | **Settings → AI Providers**           |
+| Your Git Storage   | **Settings → Git Providers**          |
+| Your DB Storage    | **Settings → Database**               |
+| Your deployment    | **Settings → Deployment**             |
+| Where it runs      | **Settings → Fleet** / **Job Runtime** |
+| Communication      | **Settings → Plugins**                |
+| Plugins & Integrations | **Settings → Plugins**            |
+
+See [The Settings Map](./settings-map.md) for the full layout.
+
+## Wizard data
 
 - **Catalog** — `GET /api/onboarding/catalog` returns
-  `{ ai, storage, deploy, plugins }`, the options rendered on the choice
-  steps. Each call degrades to a safe empty fallback, so even an empty or
-  anonymous catalog still lands the user on the create-work step.
-- **State** — `GET /api/onboarding/state`, `POST /api/onboarding/complete`,
-  `POST /api/onboarding/dismiss` persist wizard progress so it's resumable
-  across sessions.
+  `{ ai, storage, db, deploy, desktop, plugins }`, the options rendered on
+  the choice steps. Each card carries an `available` flag that drives the
+  **Coming soon** state, so the UI is never hard-wired to backend
+  configuration. Each call degrades to a safe empty fallback, so even an
+  empty or anonymous catalog still lands the user on the create-work step.
+- **State** — `GET /api/onboarding/state`, `PATCH /api/onboarding/state`,
+  `POST /api/onboarding/complete` and `POST /api/onboarding/dismiss`
+  persist wizard progress so it's resumable across sessions. Skipped steps
+  are recorded in the same blob.
 - **Plugins** — only plugins flagged `uiHints.includeInOnboarding` appear,
-  ordered by `onboardingPriority`.
+  ordered by `onboardingPriority`, minus the ids already claimed by the
+  AI / storage / database / deployment / communication steps.
 
 ## Related pages
 
+- [Creating an Account](./creating-an-account.md) — the signup that leads here.
+- [The Settings Map](./settings-map.md) — where every choice above lives afterwards.
 - [Zero-Friction Onboarding for Agents](/agent-services/zero-friction-onboarding) —
   the single-call `POST /api/register-work` registration for AI agents.
 - [Creating a Work](./creating-a-work.md) — what the final step generates.

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -83,7 +83,7 @@ Three things are worth knowing before you start:
 
 - **Every step that asks you something can be skipped.** The footer
   carries a skip action all the way to the final step — labelled
-  *Skip — set up later* on the plugins step — and skipping is recorded,
+  _Skip — set up later_ on the plugins step — and skipping is recorded,
   not punished. You can also leave the whole thing with **Close wizard**
   at the bottom of the stepper.
 - **Your choices are saved as you make them.** Each transition is written
@@ -102,18 +102,18 @@ again. Dismissing that badge does not mark setup as complete.
 
 With the Ever Works defaults kept, the wizard is ten steps:
 
-| #   | Step                        | What you choose                                                  |
-| --- | --------------------------- | ---------------------------------------------------------------- |
-| 1   | **Welcome**                 | Nothing — an intro plus a preview of the steps ahead.            |
-| 2   | **Your AI choice**          | Which AI provider powers content generation.                     |
-| 3   | **Your Git Storage**        | Where your Work repositories live.                               |
-| 4   | **Your DB Storage**         | Where your Works store their data.                               |
-| 5   | **Your deployment**         | Where your Works get deployed.                                   |
-| 6   | **Where it runs**           | Whether Ever Works itself runs hosted, on your machine, or on your machines. |
-| 7   | **What do you do**          | Your roles and team size — used to suggest starting points.      |
-| 8   | **Communication**           | The chat workspace your team lives in.                           |
-| 9   | **Plugins & Integrations**  | Optional power-user integrations.                                |
-| 10  | **Create your first Work**  | The prompt, and the button that generates it.                    |
+| #   | Step                       | What you choose                                                              |
+| --- | -------------------------- | ---------------------------------------------------------------------------- |
+| 1   | **Welcome**                | Nothing — an intro plus a preview of the steps ahead.                        |
+| 2   | **Your AI choice**         | Which AI provider powers content generation.                                 |
+| 3   | **Your Git Storage**       | Where your Work repositories live.                                           |
+| 4   | **Your DB Storage**        | Where your Works store their data.                                           |
+| 5   | **Your deployment**        | Where your Works get deployed.                                               |
+| 6   | **Where it runs**          | Whether Ever Works itself runs hosted, on your machine, or on your machines. |
+| 7   | **What do you do**         | Your roles and team size — used to suggest starting points.                  |
+| 8   | **Communication**          | The chat workspace your team lives in.                                       |
+| 9   | **Plugins & Integrations** | Optional power-user integrations.                                            |
+| 10  | **Create your first Work** | The prompt, and the button that generates it.                                |
 
 Picking a bring-your-own option adds a configuration step immediately
 after the choice it belongs to, so the wizard gets **longer** as you move
@@ -150,14 +150,14 @@ follow. There is nothing to choose; **Next** moves on.
 
 Pick the AI provider that powers content generation. Six options:
 
-| Option              | Notes                                                                   |
-| ------------------- | ----------------------------------------------------------------------- |
-| **Ever Works AI**   | The default. Uses the provider Ever Works has configured. No setup.     |
-| **OpenRouter**      | Route AI calls through OpenRouter with your own API key.                |
-| **Claude Code**     | Anthropic Claude via the Claude Code CLI.                               |
-| **Codex**           | OpenAI Codex CLI, connected through a device-authorisation flow.        |
-| **Gemini**          | Google Gemini via your AI Studio API key.                               |
-| **Grok (xAI)**      | xAI Grok via your xAI API key.                                          |
+| Option            | Notes                                                               |
+| ----------------- | ------------------------------------------------------------------- |
+| **Ever Works AI** | The default. Uses the provider Ever Works has configured. No setup. |
+| **OpenRouter**    | Route AI calls through OpenRouter with your own API key.            |
+| **Claude Code**   | Anthropic Claude via the Claude Code CLI.                           |
+| **Codex**         | OpenAI Codex CLI, connected through a device-authorisation flow.    |
+| **Gemini**        | Google Gemini via your AI Studio API key.                           |
+| **Grok (xAI)**    | xAI Grok via your xAI API key.                                      |
 
 Every option except **Ever Works AI** is marked **BYOK** — bring your own
 key — and adds the **Configure AI** step where you supply the credential.
@@ -166,12 +166,12 @@ key — and adds the **Configure AI** step where you supply the credential.
 
 Where your Work repositories live. Four options:
 
-| Option              | Notes                                                     |
-| ------------------- | --------------------------------------------------------- |
-| **Ever Works Git**  | The default — a managed Ever Works GitHub org.            |
-| **Your GitHub**     | Your own GitHub account or organization.                  |
-| **Your GitLab**     | Bring your own GitLab.                                    |
-| **Your Git**        | A self-hosted Git server.                                 |
+| Option             | Notes                                          |
+| ------------------ | ---------------------------------------------- |
+| **Ever Works Git** | The default — a managed Ever Works GitHub org. |
+| **Your GitHub**    | Your own GitHub account or organization.       |
+| **Your GitLab**    | Bring your own GitLab.                         |
+| **Your Git**       | A self-hosted Git server.                      |
 
 **Your GitHub** adds the **Configure storage** step, where you sign in with
 GitHub so the platform can create repositories for you.
@@ -190,30 +190,30 @@ Where your Works keep their data. Two options:
 
 Where your Works get deployed. Three options:
 
-| Option           | Notes                                                                                     |
-| ---------------- | ----------------------------------------------------------------------------------------- |
-| **Ever Works**   | The default — deploy to the Ever Works tenant cluster. The card states the per-account cap on active Works. |
-| **Vercel**       | Your own Vercel team, using your API token.                                               |
-| **Kubernetes**   | Your own cluster — you paste a kubeconfig.                                                |
+| Option         | Notes                                                                                                       |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Ever Works** | The default — deploy to the Ever Works tenant cluster. The card states the per-account cap on active Works. |
+| **Vercel**     | Your own Vercel team, using your API token.                                                                 |
+| **Kubernetes** | Your own cluster — you paste a kubeconfig.                                                                  |
 
 **Vercel** and **Kubernetes** both add the **Configure deployment** step.
 
 ### Step 6 — Where it runs
 
 Unlike the four steps before it, this one names no provider. It records
-where Ever Works *itself* runs, which decides the guidance you get at the
+where Ever Works _itself_ runs, which decides the guidance you get at the
 end of the wizard. Three options, all always available:
 
-| Option                    | Meaning                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------ |
-| **The hosted platform**   | The default. Everything runs on Ever Works; nothing to install.                |
-| **On my machine**         | [Ever Works Desktop](./desktop-app.md) runs the API and web app locally and supervises them. |
-| **On my own machines**    | The platform runs wherever you like, but your machines execute the work — enrolled as [Fleet](./fleet.md) nodes. |
+| Option                  | Meaning                                                                                                          |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **The hosted platform** | The default. Everything runs on Ever Works; nothing to install.                                                  |
+| **On my machine**       | [Ever Works Desktop](./desktop-app.md) runs the API and web app locally and supervises them.                     |
+| **On my own machines**  | The platform runs wherever you like, but your machines execute the work — enrolled as [Fleet](./fleet.md) nodes. |
 
 The choice decides the closing advice on the last step. Picking
-**On my machine** adds a *Finish your desktop setup* block pointing at
-**Settings → Job Runtime**; picking **On my own machines** adds an *Add
-your first node* block pointing at **Settings → Fleet**. The hosted
+**On my machine** adds a _Finish your desktop setup_ block pointing at
+**Settings → Job Runtime**; picking **On my own machines** adds an _Add
+your first node_ block pointing at **Settings → Fleet**. The hosted
 default adds nothing — there is nothing left to install.
 
 ### Step 7 — What do you do
@@ -224,22 +224,22 @@ Nothing is hidden or gated based on your answers.
 **Your roles** is a multi-select — pick as many as apply. There are
 fourteen:
 
-| Role              | As the card describes it                        |
-| ----------------- | ----------------------------------------------- |
-| Founder / CEO     | I run the company and wear many hats            |
-| Engineering       | I build and ship software                       |
-| Product           | I define what we build and why                  |
-| Marketing         | I grow awareness, content, and campaigns        |
-| Sales             | I find, pitch, and close customers              |
-| Consultant        | I deliver projects and advice for clients       |
-| Research          | I investigate, analyze, and synthesize          |
-| Operations        | I keep the business running smoothly            |
-| Support           | I help customers succeed and resolve issues     |
-| Finance           | I manage budgets, billing, and reporting        |
-| HR                | I hire, onboard, and support our people         |
-| Legal             | I handle contracts, compliance, and policy      |
-| Education         | I teach, train, or create learning content      |
-| Other             | Something else — tell us more later             |
+| Role          | As the card describes it                    |
+| ------------- | ------------------------------------------- |
+| Founder / CEO | I run the company and wear many hats        |
+| Engineering   | I build and ship software                   |
+| Product       | I define what we build and why              |
+| Marketing     | I grow awareness, content, and campaigns    |
+| Sales         | I find, pitch, and close customers          |
+| Consultant    | I deliver projects and advice for clients   |
+| Research      | I investigate, analyze, and synthesize      |
+| Operations    | I keep the business running smoothly        |
+| Support       | I help customers succeed and resolve issues |
+| Finance       | I manage budgets, billing, and reporting    |
+| HR            | I hire, onboard, and support our people     |
+| Legal         | I handle contracts, compliance, and policy  |
+| Education     | I teach, train, or create learning content  |
+| Other         | Something else — tell us more later         |
 
 **Team size** is a single-select: **Solo**, **Small (2–10)**,
 **Mid (11–50)**, **Large (51–200)** or **Enterprise (200+)**.
@@ -283,10 +283,10 @@ case the step says there are no additional integrations available.
 ### Step 10 — Create your first Work
 
 The last step. If you arrived with a prompt — typed on the marketing site,
-or carried in from earlier — the step reads *Ready to generate* and shows
+or carried in from earlier — the step reads _Ready to generate_ and shows
 the prompt in an editable box with a **Generate now** button that creates
 the Work and starts generation in one click, using the choices you just
-made. Without a prompt it reads *Create your first Work* and links into the
+made. Without a prompt it reads _Create your first Work_ and links into the
 full [Create a Work](./creating-a-work.md) form instead.
 
 Below the primary action sits the follow-on guidance chosen by
@@ -298,15 +298,15 @@ Below the primary action sits the follow-on guidance chosen by
 Nothing chosen in the wizard is locked in. The provider buckets map onto
 the plugin categories in Settings:
 
-| Wizard step        | Where to change it afterwards         |
-| ------------------ | ------------------------------------- |
-| Your AI choice     | **Settings → AI Providers**           |
-| Your Git Storage   | **Settings → Git Providers**          |
-| Your DB Storage    | **Settings → Database**               |
-| Your deployment    | **Settings → Deployment**             |
-| Where it runs      | **Settings → Fleet** / **Job Runtime** |
-| Communication      | **Settings → Plugins**                |
-| Plugins & Integrations | **Settings → Plugins**            |
+| Wizard step            | Where to change it afterwards          |
+| ---------------------- | -------------------------------------- |
+| Your AI choice         | **Settings → AI Providers**            |
+| Your Git Storage       | **Settings → Git Providers**           |
+| Your DB Storage        | **Settings → Database**                |
+| Your deployment        | **Settings → Deployment**              |
+| Where it runs          | **Settings → Fleet** / **Job Runtime** |
+| Communication          | **Settings → Plugins**                 |
+| Plugins & Integrations | **Settings → Plugins**                 |
 
 See [The Settings Map](./settings-map.md) for the full layout.
 

--- a/docs/features/settings-map.md
+++ b/docs/features/settings-map.md
@@ -16,24 +16,24 @@ pinned at the bottom.
 
 ## Account and platform
 
-| Entry                | What lives there                                                                                    |
-| -------------------- | --------------------------------------------------------------------------------------------------- |
-| **Profile**          | Your name, username and avatar, the budget-alert email toggle, and the banner that resends the verification email while your address is unconfirmed. Your email address is shown but cannot be changed here. This is the landing page for `/settings`. |
-| **Organization**     | The organizations you belong to, and the Vision you set on one. See [Teams & Organizations](../advanced/teams-and-organizations.md). |
-| **Security**         | Changing your password.                                                                             |
-| **API Keys**         | Programmatic keys for the REST API and the CLI. See [API Keys](./api-keys.md).                       |
-| **Data**             | Export your account data as JSON, import it back, and sync your configuration to a private GitHub repository. See [Data Management](./data-management.md). |
-| **GitHub App**       | The Ever Works GitHub App installations linked to this workspace — inspect them, re-sync the repository snapshot, and onboard a repository. |
-| **Work Agent**       | The agent that turns a high-level build request into an approval-ready plan, and the guardrails it must stay inside. See [Agents](./agents.md). |
-| **Fleet**            | Machines that are yours — enroll a node, watch it heartbeat, drain it. See [Fleet](./fleet.md).       |
-| **Job Runtime**      | Whether background jobs use the platform-default runtime, your own credentials, or a provider you pick. See [Workers](./workers.md). |
-| **Digest**           | Scheduled activity briefings and their cadence. The personal digest and the organization digest are separate settings — turning one on never changes the other. |
-| **Billing**          | Your plan, balance, invoices and the credits ledger. See [Credits & Billing](./credits-and-billing.md). |
-| **Usage & Credits**  | Where the credits went — per day, model, agent and Work. See [below](#usage--credits).               |
-| **Danger Zone**      | Exporting your account data and deleting your account, behind a typed-email confirmation. Always last in the sidebar. |
+| Entry               | What lives there                                                                                                                                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Profile**         | Your name, username and avatar, the budget-alert email toggle, and the banner that resends the verification email while your address is unconfirmed. Your email address is shown but cannot be changed here. This is the landing page for `/settings`. |
+| **Organization**    | The organizations you belong to, and the Vision you set on one. See [Teams & Organizations](../advanced/teams-and-organizations.md).                                                                                                                   |
+| **Security**        | Changing your password.                                                                                                                                                                                                                                |
+| **API Keys**        | Programmatic keys for the REST API and the CLI. See [API Keys](./api-keys.md).                                                                                                                                                                         |
+| **Data**            | Export your account data as JSON, import it back, and sync your configuration to a private GitHub repository. See [Data Management](./data-management.md).                                                                                             |
+| **GitHub App**      | The Ever Works GitHub App installations linked to this workspace — inspect them, re-sync the repository snapshot, and onboard a repository.                                                                                                            |
+| **Work Agent**      | The agent that turns a high-level build request into an approval-ready plan, and the guardrails it must stay inside. See [Agents](./agents.md).                                                                                                        |
+| **Fleet**           | Machines that are yours — enroll a node, watch it heartbeat, drain it. See [Fleet](./fleet.md).                                                                                                                                                        |
+| **Job Runtime**     | Whether background jobs use the platform-default runtime, your own credentials, or a provider you pick. See [Workers](./workers.md).                                                                                                                   |
+| **Digest**          | Scheduled activity briefings and their cadence. The personal digest and the organization digest are separate settings — turning one on never changes the other.                                                                                        |
+| **Billing**         | Your plan, balance, invoices and the credits ledger. See [Credits & Billing](./credits-and-billing.md).                                                                                                                                                |
+| **Usage & Credits** | Where the credits went — per day, model, agent and Work. See [below](#usage--credits).                                                                                                                                                                 |
+| **Danger Zone**     | Exporting your account data and deleting your account, behind a typed-email confirmation. Always last in the sidebar.                                                                                                                                  |
 
-**Fleet** sits directly above **Job Runtime** on purpose: Fleet is *where* work can run, Job Runtime
-is *how* it gets dispatched.
+**Fleet** sits directly above **Job Runtime** on purpose: Fleet is _where_ work can run, Job Runtime
+is _how_ it gets dispatched.
 
 ## The PLUGINS section
 
@@ -43,16 +43,16 @@ containing a plugin whose required settings are not filled in yet.
 
 Categories are listed alphabetically. On the hosted platform they are:
 
-| Category          | What it configures                                                  |
-| ----------------- | -------------------------------------------------------------------- |
+| Category          | What it configures                                                               |
+| ----------------- | -------------------------------------------------------------------------------- |
 | **AI Providers**  | The provider that powers generation — the [wizard's](./onboarding.md) AI choice. |
-| **Database**      | Where your Works store their data — the wizard's DB Storage choice.  |
-| **Deployment**    | Where Works get deployed — the wizard's deployment choice.           |
-| **Git Providers** | Where Work repositories live — the wizard's Git Storage choice.      |
-| **Pipeline**      | The generation pipeline a Work runs.                                 |
-| **Search**        | Search backends used during research.                                |
-| **Utility**       | Assorted helper plugins.                                             |
-| **Vector Store**  | Embedding backends behind the [Knowledge Base](./knowledge-base.md). |
+| **Database**      | Where your Works store their data — the wizard's DB Storage choice.              |
+| **Deployment**    | Where Works get deployed — the wizard's deployment choice.                       |
+| **Git Providers** | Where Work repositories live — the wizard's Git Storage choice.                  |
+| **Pipeline**      | The generation pipeline a Work runs.                                             |
+| **Search**        | Search backends used during research.                                            |
+| **Utility**       | Assorted helper plugins.                                                         |
+| **Vector Store**  | Embedding backends behind the [Knowledge Base](./knowledge-base.md).             |
 
 This section is **built from what your installation actually has**: only categories containing at
 least one enabled plugin with user-configurable settings appear, so the list is shorter or longer
@@ -77,12 +77,12 @@ period drives the whole page — the summary tiles and all four charts.
 **What the page shows.** A row of summary tiles for the period (credits balance, credits used,
 credits added, spend, tasks completed, Works active, agent runs), followed by four breakdowns:
 
-| Chart              | What it breaks down                                                   |
-| ------------------ | --------------------------------------------------------------------- |
-| **Usage per day**  | Spend for each day in the period.                                     |
-| **Usage by model** | Which AI models the spend went to.                                    |
-| **Usage by agent** | Which [Agents](./agents.md) spent it.                                  |
-| **Usage by Work**  | Which [Works](./creating-a-work.md) it was spent on.                   |
+| Chart              | What it breaks down                                  |
+| ------------------ | ---------------------------------------------------- |
+| **Usage per day**  | Spend for each day in the period.                    |
+| **Usage by model** | Which AI models the spend went to.                   |
+| **Usage by agent** | Which [Agents](./agents.md) spent it.                |
+| **Usage by Work**  | Which [Works](./creating-a-work.md) it was spent on. |
 
 Rows that cannot be attributed to a model, agent or Work are grouped as **Unattributed** rather than
 dropped. A period with no activity says so instead of drawing an empty chart.
@@ -91,7 +91,7 @@ dropped. A period with no activity says so instead of drawing an empty chart.
 own analysis or reconcile against an invoice.
 
 The full ledger behind these numbers — what counts as a credit movement, and what the tiles are
-summing — is documented in [Credits & Billing](./credits-and-billing.md). For capping spend *before*
+summing — is documented in [Credits & Billing](./credits-and-billing.md). For capping spend _before_
 it happens rather than reviewing it afterwards, see [Budgets & Usage](./budgets-and-usage.md).
 
 ## Related pages

--- a/docs/features/settings-map.md
+++ b/docs/features/settings-map.md
@@ -1,0 +1,102 @@
+---
+id: settings-map
+title: The Settings Map
+sidebar_label: Settings Map
+---
+
+# The Settings Map
+
+Everything you chose in the [setup wizard](./onboarding.md) — and a good deal you did not — lives
+under **Settings**. This page is an orientation: what each entry in the settings navigation is for,
+and which feature page covers it in depth.
+
+Settings is laid out as a sidebar next to the page content. The sidebar has three parts, in this
+order: a fixed list of account and platform pages, a **PLUGINS** section, and **Danger Zone**
+pinned at the bottom.
+
+## Account and platform
+
+| Entry                | What lives there                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------- |
+| **Profile**          | Your name, username and avatar, the budget-alert email toggle, and the banner that resends the verification email while your address is unconfirmed. Your email address is shown but cannot be changed here. This is the landing page for `/settings`. |
+| **Organization**     | The organizations you belong to, and the Vision you set on one. See [Teams & Organizations](../advanced/teams-and-organizations.md). |
+| **Security**         | Changing your password.                                                                             |
+| **API Keys**         | Programmatic keys for the REST API and the CLI. See [API Keys](./api-keys.md).                       |
+| **Data**             | Export your account data as JSON, import it back, and sync your configuration to a private GitHub repository. See [Data Management](./data-management.md). |
+| **GitHub App**       | The Ever Works GitHub App installations linked to this workspace — inspect them, re-sync the repository snapshot, and onboard a repository. |
+| **Work Agent**       | The agent that turns a high-level build request into an approval-ready plan, and the guardrails it must stay inside. See [Agents](./agents.md). |
+| **Fleet**            | Machines that are yours — enroll a node, watch it heartbeat, drain it. See [Fleet](./fleet.md).       |
+| **Job Runtime**      | Whether background jobs use the platform-default runtime, your own credentials, or a provider you pick. See [Workers](./workers.md). |
+| **Digest**           | Scheduled activity briefings and their cadence. The personal digest and the organization digest are separate settings — turning one on never changes the other. |
+| **Billing**          | Your plan, balance, invoices and the credits ledger. See [Credits & Billing](./credits-and-billing.md). |
+| **Usage & Credits**  | Where the credits went — per day, model, agent and Work. See [below](#usage--credits).               |
+| **Danger Zone**      | Exporting your account data and deleting your account, behind a typed-email confirmation. Always last in the sidebar. |
+
+**Fleet** sits directly above **Job Runtime** on purpose: Fleet is *where* work can run, Job Runtime
+is *how* it gets dispatched.
+
+## The PLUGINS section
+
+Below the fixed entries, the sidebar lists your plugins grouped by category. Each entry opens the
+plugins of that category so you can enable and configure them; a small dot marks a category
+containing a plugin whose required settings are not filled in yet.
+
+Categories are listed alphabetically. On the hosted platform they are:
+
+| Category          | What it configures                                                  |
+| ----------------- | -------------------------------------------------------------------- |
+| **AI Providers**  | The provider that powers generation — the [wizard's](./onboarding.md) AI choice. |
+| **Database**      | Where your Works store their data — the wizard's DB Storage choice.  |
+| **Deployment**    | Where Works get deployed — the wizard's deployment choice.           |
+| **Git Providers** | Where Work repositories live — the wizard's Git Storage choice.      |
+| **Pipeline**      | The generation pipeline a Work runs.                                 |
+| **Search**        | Search backends used during research.                                |
+| **Utility**       | Assorted helper plugins.                                             |
+| **Vector Store**  | Embedding backends behind the [Knowledge Base](./knowledge-base.md). |
+
+This section is **built from what your installation actually has**: only categories containing at
+least one enabled plugin with user-configurable settings appear, so the list is shorter or longer
+depending on the install. **Pipeline** is the exception — it stays listed even with no pipeline
+plugin enabled, because the page also carries a global default selector. If your installation ships
+no configurable plugins at all, the section is absent entirely.
+
+For what plugins are and how they fit together, see the
+[Plugin System](../plugin-system/index.md).
+
+## Usage & Credits
+
+**Settings → Usage & Credits** (`/settings/usage`) answers "where did my credits go?". One reporting
+period drives the whole page — the summary tiles and all four charts.
+
+**Choosing the period.** The controls at the top offer:
+
+- **7d** and **30d** — rolling windows.
+- A **calendar month** picker, offering the last twelve months, newest first. The page defaults to
+  the current month.
+
+**What the page shows.** A row of summary tiles for the period (credits balance, credits used,
+credits added, spend, tasks completed, Works active, agent runs), followed by four breakdowns:
+
+| Chart              | What it breaks down                                                   |
+| ------------------ | --------------------------------------------------------------------- |
+| **Usage per day**  | Spend for each day in the period.                                     |
+| **Usage by model** | Which AI models the spend went to.                                    |
+| **Usage by agent** | Which [Agents](./agents.md) spent it.                                  |
+| **Usage by Work**  | Which [Works](./creating-a-work.md) it was spent on.                   |
+
+Rows that cannot be attributed to a model, agent or Work are grouped as **Unattributed** rather than
+dropped. A period with no activity says so instead of drawing an empty chart.
+
+**Export CSV** downloads every usage event in the selected period as a CSV file, so you can do your
+own analysis or reconcile against an invoice.
+
+The full ledger behind these numbers — what counts as a credit movement, and what the tiles are
+summing — is documented in [Credits & Billing](./credits-and-billing.md). For capping spend *before*
+it happens rather than reviewing it afterwards, see [Budgets & Usage](./budgets-and-usage.md).
+
+## Related pages
+
+- [Onboarding & Setup Wizard](./onboarding.md) — where most of these settings are first chosen.
+- [Credits & Billing](./credits-and-billing.md) — the ledger, plans and the Billing page.
+- [Budgets & Usage](./budgets-and-usage.md) — caps that gate spend before a call runs.
+- [Plugin System](../plugin-system/index.md) — what the PLUGINS section is listing.


### PR DESCRIPTION
## What this adds

Four end-user documentation gaps on `docs.ever.works`. Everything here was **derived from live behaviour observed in a browser today**, then re-checked line by line against the source in this repo so no detail is asserted that the code does not actually do.

### New pages

| Page | Covers |
| --- | --- |
| `docs/features/creating-an-account.md` | The `/register` flow — full name, email, password (min 8 chars), confirm password, and the required *I agree to the Terms of Service and Privacy Policy* checkbox. The four social providers (GitHub, Google, Facebook, LinkedIn). Sign-in, the magic-link tab, **Forgot password?**, password reset, and what happens immediately after signup. |
| `docs/features/settings-map.md` | An orientation page for the settings navigation: Profile, Organization, Security, API Keys, Data, GitHub App, Work Agent, Fleet, Job Runtime, Digest, Billing, Usage & Credits, the **PLUGINS** section (AI Providers, Database, Deployment, Git Providers, Pipeline, Search, Utility, Vector Store) and Danger Zone. |

The signup page explains that ticking the terms box records the acceptance against **the exact published document version and digest** that was on screen — document id, version, SHA-256 of the published source, and locale — and that registration is blocked outright when those documents cannot be loaded, because there would be nothing truthful to record.

### Updated pages

- **`docs/features/onboarding.md`** — the wizard section documented a **9-step** flow that no longer exists (no DB Storage, no "Where it runs", no "What do you do", no Communication). Rewritten against `computeStepList` in `apps/web/src/components/onboarding/useOnboardingFlow.ts`: **ten steps** with the defaults kept — Welcome, Your AI choice, Your Git Storage, Your DB Storage, Your deployment, Where it runs, What do you do, Communication, Plugins & Integrations, Create your first Work — plus the three conditional configuration steps that appear when you pick a bring-your-own option. Also documents that every step is skippable, the stepper is clickable, choices are saved per transition, the **Setup** badge lets you resume, and where each choice is changed later in Settings.
- **`docs/features/credits-and-billing.md`** — the *Usage & Credits* section gains the calendar-month picker, the `?period=` deep link, the **Unattributed** bucket, the empty and load-failure states, and **Export CSV**. (A standalone Usage page would have duplicated this section, so it was extended instead.)
- **`docs/features/index.md`** — a new *Getting started* table linking the three pages.

### Accuracy note on "Coming soon"

`available` on each onboarding card is driven by each installation's configuration (`config.everWorks.git/sharedDb/deploy.isEnabled()`), so cards that render as **Coming soon** are described as *install-dependent* rather than asserted as a fixed state.

### Sidebar

`apps/docs/sidebarsPlatform.ts` — `features/creating-an-account` added before `features/creating-a-work`, and `features/settings-map` after `features/onboarding`.

### A note on file locations

The Docusaurus content root is the repo-level `docs/` directory (`apps/docs/docusaurus.config.ts` sets `docs.path` to `../../docs/`), so the pages themselves live there. The only file touched inside `apps/docs` is the sidebar.

## Verification

`pnpm --filter ever-works-docs build`, run on this exact commit after `rm -rf apps/docs/build apps/docs/.docusaurus`:

```
[SUCCESS] Generated static files in "build".

[INFO] [fr] Creating an optimized production build...
...
[SUCCESS] Generated static files in "build\fr".
[INFO] Use `npm run serve` command to test your build locally.
BUILD_EXIT=0
```

Both locales generate, exit code **0**. **No warning or broken-link/anchor report references any of the new or edited pages** — every remaining warning is pre-existing and lives under `docs/specs/**`, `docs/internal/**`, `docs/runbooks/**` or `docs/plugin-system/composio-plugin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
