### PR TITLE
fix(auth): tell an unverified user why sign-in failed instead of blaming their password

### DIFF
--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -46,8 +46,29 @@ function isRelativeOrAllowedRedirectHost(redirectUrl: string): boolean {
     }
 }
 
+/**
+ * Does this rejection mean "the credentials were right, the address is not
+ * confirmed"? The API answers `403 { message: 'Email not verified' }`.
+ *
+ * Matched on the status AND the message so a future unrelated 403 on this
+ * route doesn't silently start telling people to check their inbox. The
+ * message check is tolerant of case and wording drift around the two words
+ * that carry the meaning.
+ */
+function isEmailNotVerifiedError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    const looksUnverified = /email.*not.*verif/i.test(message);
+    if (!looksUnverified) return false;
+
+    const statusCode = (error as { statusCode?: number } | null)?.statusCode;
+    return statusCode === undefined || statusCode === 403;
+}
+
 export async function login(identifier: string, password: string, redirectUrl: string | null) {
     const t = await getTranslations('validation.auth');
+    // `validation.auth` has no key for an unverified email; the message already
+    // exists (and is already translated into all 21 locales) under `auth.error`.
+    const tAuthError = await getTranslations('auth.error');
 
     // Validation schemas
     const loginSchema = z.object({
@@ -77,9 +98,17 @@ export async function login(identifier: string, password: string, redirectUrl: s
     } catch (error) {
         console.error(error);
 
+        // Only `suspended` was ever distinguished, so every other rejection —
+        // including the API's `403 Email not verified` — was reported as
+        // "Invalid email or password". That is not merely vague, it is wrong:
+        // the credentials ARE correct, and the message sends the user to
+        // "Forgot password?" to fix a problem a password reset cannot fix.
+        // Tell them what actually happened so the next step is the right one.
         let message = t('invalidCredentials');
         if (error instanceof Error && error.message.includes('suspended')) {
             message = t('account.suspended');
+        } else if (isEmailNotVerifiedError(error)) {
+            message = tAuthError('emailNotVerified');
         }
 
         return {

--- a/apps/web/src/app/actions/auth.unit.spec.ts
+++ b/apps/web/src/app/actions/auth.unit.spec.ts
@@ -14,9 +14,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 // Hoisted because vi.mock factory runs before regular module code.
-const { setOAuthStateCookieMock, getOAuthAuthUrlMock } = vi.hoisted(() => ({
+const { setOAuthStateCookieMock, getOAuthAuthUrlMock, loginMock } = vi.hoisted(() => ({
     setOAuthStateCookieMock: vi.fn(),
     getOAuthAuthUrlMock: vi.fn(),
+    loginMock: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -29,8 +30,7 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@/lib/api', () => ({
     authAPI: {
         getOAuthAuthUrl: getOAuthAuthUrlMock,
-        // satisfy the import — connectProvider only touches getOAuthAuthUrl
-        login: vi.fn(),
+        login: loginMock,
         register: vi.fn(),
         logout: vi.fn(),
     },
@@ -111,5 +111,77 @@ describe('connectProvider — C-03 state round-trip', () => {
         const urlState = new URL(result.url!).searchParams.get('state');
         expect(cookieValue).toBe(urlState);
         expect(cookieValue).toBe(minted);
+    });
+});
+
+/**
+ * `login` error mapping.
+ *
+ * The catch distinguished only `suspended`; every other rejection collapsed to
+ * `invalidCredentials`. So a user whose address is unconfirmed — whose email and
+ * password are CORRECT — was told "Invalid email or password" and pointed at
+ * "Forgot password?", which cannot fix an unverified address. Observed live on
+ * app.ever.works: the API answered `403 { message: 'Email not verified' }` while
+ * the form said the credentials were wrong.
+ *
+ * `getTranslations` is mocked to echo its key, so each branch is identifiable by
+ * the key it returns rather than by prose that may be re-worded.
+ */
+describe('login — which failure the user is told about', () => {
+    beforeEach(() => {
+        loginMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+    });
+
+    /** The API's real rejection shape for an unconfirmed address. */
+    function emailNotVerifiedRejection() {
+        const err = new Error('Email not verified') as Error & { statusCode?: number };
+        err.statusCode = 403;
+        return err;
+    }
+
+    it('names the unverified email instead of blaming the credentials', async () => {
+        loginMock.mockRejectedValue(emailNotVerifiedRejection());
+
+        const { login } = await import('./auth');
+        const result = await login('someone@example.com', 'correct-horse', null);
+
+        expect(result).toEqual({ success: false, error: 'emailNotVerified' });
+    });
+
+    it('still blames the credentials when they are genuinely wrong', async () => {
+        // Control: the mapping must stay narrow. If this also returned
+        // `emailNotVerified`, the first test would pass for the wrong reason.
+        const err = new Error('Invalid credentials') as Error & { statusCode?: number };
+        err.statusCode = 401;
+        loginMock.mockRejectedValue(err);
+
+        const { login } = await import('./auth');
+        const result = await login('someone@example.com', 'wrong', null);
+
+        expect(result).toEqual({ success: false, error: 'invalidCredentials' });
+    });
+
+    it('still reports a suspended account', async () => {
+        loginMock.mockRejectedValue(new Error('This account has been suspended'));
+
+        const { login } = await import('./auth');
+        const result = await login('someone@example.com', 'correct-horse', null);
+
+        expect(result).toEqual({ success: false, error: 'account.suspended' });
+    });
+
+    it('does not mistake an unrelated 403 for an unverified email', async () => {
+        const err = new Error('Forbidden: region blocked') as Error & { statusCode?: number };
+        err.statusCode = 403;
+        loginMock.mockRejectedValue(err);
+
+        const { login } = await import('./auth');
+        const result = await login('someone@example.com', 'correct-horse', null);
+
+        expect(result).toEqual({ success: false, error: 'invalidCredentials' });
     });
 });


### PR DESCRIPTION
Signing in with **correct** credentials on an account whose email is not yet confirmed showed:

> Invalid email or password

## Root cause

The API answers `403 { message: 'Email not verified' }`, but the catch in the login action
distinguished only `suspended` — everything else collapsed to `invalidCredentials`:

```ts
let message = t('invalidCredentials');
if (error instanceof Error && error.message.includes('suspended')) {
    message = t('account.suspended');
}
```

So the one message the user got was the one thing that was **not** true, and it points at
"Forgot password?" — which cannot fix an unverified address. A user in this state has no way to work
out what is wrong, and the obvious next step is a dead end.

## Reproduction (production)

Registered a fresh account on `app.ever.works`, signed out, signed back in with the same credentials.
The form said the credentials were wrong at **16:38:00Z**; the prod API logged
`[APIError: Email not verified]` at the same second.

## The fix

The message already exists — and is already translated in **all 21 locale files** — as
`auth.error.emailNotVerified` ("Please verify your email address before signing in."). It was simply
never reached. `validation.auth` has no equivalent key, so the action resolves that namespace too
rather than duplicating a string into 21 files.

The match is deliberately narrow — **message AND status**. A future unrelated 403 on this route must
not start telling people to check their inbox.

## Tests

Four cases, three of which exist specifically to stop the first one passing for the wrong reason:

| Case | Expected |
|---|---|
| unverified email | `emailNotVerified` |
| wrong password | `invalidCredentials` — mapping stays narrow |
| suspended account | `account.suspended` — existing branch intact |
| unrelated 403 | `invalidCredentials` — status alone is not enough |

**Verified both ways.** Removing the new branch fails exactly one test
(`expected "error": "emailNotVerified"`) and leaves the other six green. With the fix: 7/7 pass.
`tsc --noEmit` on `apps/web` exits 0.

## Related

The reason accounts are stuck unverified *at all* is that no email template ships in the API image, so
the verification mail never sends — a separate, larger defect on its own branch. **This change makes
the failure legible; it does not weaken the verification requirement.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)