### PR TITLE
fix(email): ship the Handlebars templates with the build — every templated email was failing

### DIFF
--- a/.deploy/docker/api/Dockerfile
+++ b/.deploy/docker/api/Dockerfile
@@ -53,6 +53,35 @@ COPY scripts/strip-non-core-plugins.js scripts/strip-non-core-plugins.js
 RUN pnpm exec turbo build --filter=ever-works-api...
 RUN pnpm exec turbo build --filter="./packages/plugins/*"
 RUN pnpm deploy --filter=ever-works-api --prod --legacy /app/deploy
+
+# Packaging gate: the Handlebars email templates MUST reach the runtime image.
+#
+# They previously did not. `apps/api/nest-cli.json` declared
+# `assets: ["src/templates/**/*"]`, but the Nest CLI resolves asset globs
+# relative to `sourceRoot` — so it globbed `apps/api/src/src/templates/**/*`,
+# matched nothing, and copied nothing. The build stayed green, the image
+# shipped with zero `.hbs` files, and every templated email (signup
+# confirmation, password reset, magic link, invitations, budget alerts) threw
+# `ENOENT: /app/src/templates/<name>.hbs` in every environment — which left
+# new accounts unable to verify their email and therefore locked out.
+#
+# Compare against the count in the source tree rather than a hard-coded
+# number: that is a known-good control, so an empty result can never be
+# mistaken for "there are no templates to ship".
+RUN set -e; \
+    src_count="$(find /app/apps/api/src/templates -name '*.hbs' | wc -l)"; \
+    out_count="$(find /app/deploy/dist/templates -name '*.hbs' 2>/dev/null | wc -l)"; \
+    echo "==> email templates: source=${src_count} shipped=${out_count}"; \
+    if [ "$src_count" -eq 0 ]; then \
+        echo "FATAL: no .hbs templates found in apps/api/src/templates — the control failed, not the build." >&2; \
+        exit 1; \
+    fi; \
+    if [ "$out_count" -ne "$src_count" ]; then \
+        echo "FATAL: ${out_count}/${src_count} email templates reached dist/templates." >&2; \
+        echo "       Check apps/api/nest-cli.json compilerOptions.assets (globs are relative to sourceRoot)." >&2; \
+        exit 1; \
+    fi
+
 RUN node scripts/prepare-docker-plugins.js
 
 # EW-693 / T29 — dual-mode image.

--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -6,6 +6,6 @@
         "builder": "swc",
         "deleteOutDir": true,
         "typeCheck": true,
-        "assets": ["src/templates/**/*"]
+        "assets": ["templates/**/*"]
     }
 }

--- a/apps/api/src/health/service-detection.ts
+++ b/apps/api/src/health/service-detection.ts
@@ -8,6 +8,8 @@
  * mode label. It never reads or echoes the secret values themselves.
  */
 
+import { inspectTemplatesDir } from '../mail/templates';
+
 export interface ServiceStatus {
     /** Stable key used as the health-indicator name (snake_case). */
     key: string;
@@ -92,9 +94,17 @@ export function detectInformationalServices(): ServiceStatus[] {
             mode: stripeConfigured ? 'enabled' : 'disabled',
         },
         {
+            // `configured` reflects the env only; `mode` additionally reports
+            // whether the Handlebars templates were actually shipped in this
+            // image. Before this check, production reported
+            // `email: { configured: true, mode: 'enabled' }` while EVERY
+            // templated email threw ENOENT — the status surface asserted a
+            // working mailer that could not send a single message. `degraded`
+            // is a non-secret label (no vendor name), consistent with the
+            // stripping note above.
             key: 'email',
             configured: emailConfigured,
-            mode: emailConfigured ? 'enabled' : 'disabled',
+            mode: !emailConfigured ? 'disabled' : inspectTemplatesDir().ok ? 'enabled' : 'degraded',
         },
         {
             key: 'storage',

--- a/apps/api/src/mail/mail.module.ts
+++ b/apps/api/src/mail/mail.module.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { Module } from '@nestjs/common';
 import { MailerModule } from '@nestjs-modules/mailer';
 import { HandlebarsAdapter } from '@nestjs-modules/mailer/adapters/handlebars.adapter';
@@ -9,6 +8,7 @@ import { MailService } from './mail.service';
 import { FakerMailerService } from './providers/faker-mailer.service';
 import { config } from '@src/config/constants';
 import { MailerService } from './providers/mailer.service';
+import { TEMPLATES_DIR } from './templates';
 
 @Module({
     imports: [
@@ -53,7 +53,13 @@ import { MailerService } from './providers/mailer.service';
                     from: config.mail.from(),
                 },
                 template: {
-                    dir: path.join(process.cwd(), 'src/templates'),
+                    // Resolved from this module's own location, not from
+                    // `process.cwd()`. The old cwd-relative path only existed
+                    // when the API was started from `apps/api` with the TS
+                    // sources present; in the container the process starts in
+                    // `/app` and there is no `/app/src`, so every SMTP
+                    // templated email failed with ENOENT. See ./templates.ts.
+                    dir: TEMPLATES_DIR,
                     adapter: new HandlebarsAdapter(undefined, { inlineCssEnabled: true }),
                     options: {
                         strict: true,

--- a/apps/api/src/mail/providers/mailer.service.templates.spec.ts
+++ b/apps/api/src/mail/providers/mailer.service.templates.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * Regression proof for the production defect where EVERY templated email
+ * failed to send, in EVERY environment, because the Handlebars templates
+ * were not present in the built container image.
+ *
+ * ## Why the pre-existing tests did not catch it
+ *
+ * `mailer.service.spec.ts` mocks `fs/promises` wholesale and then asserts on
+ * the *shape* of the path handed to `readFile`
+ * (`expect(filePath).toMatch(/src[\\/]templates[\\/]welcome\.hbs$/)`). A
+ * mocked filesystem always resolves, so the suite stayed green while the
+ * real one threw `ENOENT: /app/src/templates/<name>.hbs` on every send.
+ *
+ * Two independent faults had to line up:
+ *
+ *   1. **Packaging.** `nest-cli.json` declared `assets: ["src/templates/**\/*"]`,
+ *      but the Nest CLI resolves asset globs relative to `sourceRoot`
+ *      (`@nestjs/cli/lib/compiler/assets-manager.js`), so it globbed
+ *      `apps/api/src/src/templates/**\/*`, matched nothing, and copied
+ *      nothing into `dist`.
+ *   2. **Resolution.** The runtime path came from `process.cwd()`. Under Jest
+ *      that is `apps/api`, where `src/templates` genuinely exists — which is
+ *      precisely why no unit test could see the bug. In the container the
+ *      process starts in `/app` and there is no `/app/src`.
+ *
+ * ## How these tests avoid repeating that mistake
+ *
+ * Nothing here is mocked. The templates are read from the real filesystem,
+ * rendered by the real Handlebars, and — the key move — the send is
+ * performed with the process working directory moved somewhere unrelated,
+ * which reproduces the container's condition inside a unit test.
+ *
+ * This file imports only `MailerService`, so it runs verbatim against the
+ * pre-fix tree, where it fails.
+ */
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { MailerService } from './mailer.service';
+import type { FakerMailerService } from './faker-mailer.service';
+import type { MailerService as SmtpMailerService } from '@nestjs-modules/mailer';
+import type { Resend } from 'resend';
+
+const API_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SOURCE_TEMPLATES_DIR = path.join(API_ROOT, 'src', 'templates');
+
+/** Every template `MailService` asks `MailerService` to render. */
+const TEMPLATES_USED_BY_MAIL_SERVICE = [
+    'account-deletion',
+    'budget-alert',
+    'forgot-password',
+    'magic-link',
+    'member-invitation',
+    'new-device-login',
+    'password-changed',
+    'signup-confirmation',
+    'welcome',
+    'work-invitation-claim',
+];
+
+describe('MailerService template packaging (no mocks)', () => {
+    const originalCwd = process.cwd();
+    let scratchDir: string;
+    let smtp: { sendMail: jest.Mock };
+    let faker: { sendMail: jest.Mock };
+    let resend: { emails: { send: jest.Mock } };
+
+    const buildService = () => {
+        const service = new MailerService(
+            smtp as unknown as SmtpMailerService,
+            faker as unknown as FakerMailerService,
+            resend as unknown as Resend,
+        );
+        jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        jest.spyOn((service as any).logger, 'debug').mockImplementation(() => undefined);
+        jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+        jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+        return service;
+    };
+
+    beforeAll(() => {
+        scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ew-mailer-cwd-'));
+    });
+
+    beforeEach(() => {
+        process.env.MAILER_PROVIDER = 'resend';
+        process.env.RESEND_EMAIL_FROM = 'from@resend.test';
+        smtp = { sendMail: jest.fn().mockResolvedValue(undefined) };
+        faker = { sendMail: jest.fn().mockResolvedValue(undefined) };
+        resend = { emails: { send: jest.fn().mockResolvedValue({ data: { id: 'r-1' } }) } };
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        delete process.env.MAILER_PROVIDER;
+        delete process.env.RESEND_EMAIL_FROM;
+        jest.restoreAllMocks();
+    });
+
+    afterAll(() => {
+        process.chdir(originalCwd);
+        fs.rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    it('CONTROL: the templates exist in the source tree', () => {
+        // Without this control an empty/failing result below could be read as
+        // "there are no templates" rather than "the templates cannot be
+        // found". Three false "all clear" verdicts have come from exactly
+        // that ambiguity.
+        expect(fs.existsSync(SOURCE_TEMPLATES_DIR)).toBe(true);
+        const onDisk = fs
+            .readdirSync(SOURCE_TEMPLATES_DIR)
+            .filter((f) => f.endsWith('.hbs'))
+            .map((f) => path.basename(f, '.hbs'))
+            .sort();
+        expect(onDisk).toEqual([...TEMPLATES_USED_BY_MAIL_SERVICE].sort());
+    });
+
+    describe('sending from a container-like working directory', () => {
+        /**
+         * The production condition: `cwd` is not `apps/api`, and there is no
+         * `<cwd>/src/templates`. Pre-fix this throws
+         * `ENOENT ... /src/templates/<name>.hbs` for every template.
+         */
+        beforeEach(() => {
+            process.chdir(scratchDir);
+            expect(fs.existsSync(path.join(process.cwd(), 'src', 'templates'))).toBe(false);
+        });
+
+        it.each(TEMPLATES_USED_BY_MAIL_SERVICE)(
+            'renders %s to non-empty HTML and hands it to the provider',
+            async (template) => {
+                const service = buildService();
+
+                await service.sendMail({
+                    to: 'user@test.example',
+                    subject: `subject for ${template}`,
+                    template,
+                    context: {
+                        appName: 'Ever Works',
+                        companyOwner: 'Ever Co. LTD',
+                        platformWebsite: 'https://ever.works',
+                        currentYear: 2026,
+                        firstName: 'Ada',
+                    },
+                });
+
+                expect(resend.emails.send).toHaveBeenCalledTimes(1);
+                const sent = resend.emails.send.mock.calls[0][0];
+                expect(typeof sent.html).toBe('string');
+                expect(sent.html.trim().length).toBeGreaterThan(0);
+                expect(sent.html.toLowerCase()).toContain('<html');
+            },
+        );
+
+        it('substitutes the verification URL into the signup-confirmation email', async () => {
+            // The template whose absence locked new production accounts out:
+            // without it `users.emailVerified` can never flip, so the account
+            // can never authenticate against the API.
+            const service = buildService();
+
+            await service.sendMail({
+                to: 'newuser@test.example',
+                subject: 'Confirm your Ever Works account',
+                template: 'signup-confirmation',
+                context: {
+                    appName: 'Ever Works',
+                    companyOwner: 'Ever Co. LTD',
+                    platformWebsite: 'https://ever.works',
+                    currentYear: 2026,
+                    firstName: 'Ada',
+                    confirmationUrl: 'https://app.ever.works/verify?token=abc123',
+                    confirmationToken: 'abc123',
+                },
+            });
+
+            const sent = resend.emails.send.mock.calls[0][0];
+            // `{{confirmationUrl}}` is a double-brace expression, so Handlebars
+            // HTML-escapes it and `?token=abc123` renders as
+            // `?token&#x3D;abc123`. Assert on the parts that escaping leaves
+            // untouched rather than pinning the escaped form.
+            expect(sent.html).toContain('https://app.ever.works/verify?token');
+            expect(sent.html).toContain('abc123');
+            expect(sent.html).toContain('Ada');
+        });
+    });
+
+    describe('degraded case: a template that genuinely does not exist', () => {
+        it('throws, never calls the provider, and never reports a send', async () => {
+            const service = buildService();
+            const logSpy = (service as any).logger.log as jest.Mock;
+
+            await expect(
+                service.sendMail({
+                    to: 'user@test.example',
+                    subject: 'nope',
+                    template: 'definitely-not-a-template',
+                }),
+            ).rejects.toThrow();
+
+            // No message was queued anywhere...
+            expect(resend.emails.send).not.toHaveBeenCalled();
+            expect(smtp.sendMail).not.toHaveBeenCalled();
+            expect(faker.sendMail).not.toHaveBeenCalled();
+            // ...and nothing in the log claims one was.
+            const logged = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+            expect(logged.some((line) => /Email sent/.test(line))).toBe(false);
+        });
+    });
+});
+
+describe('nest-cli.json asset globs', () => {
+    /**
+     * The Nest CLI joins each asset glob onto `sourceRoot`:
+     *   sourceRoot  = join(process.cwd(), configuration.sourceRoot)
+     *   includePath = join(sourceRoot, include)
+     * (see `@nestjs/cli/lib/compiler/assets-manager.js`).
+     *
+     * So `"src/templates/**\/*"` globbed `apps/api/src/src/templates/**\/*`,
+     * matched zero files and copied nothing — while reading as obviously
+     * correct in review. This asserts the declared globs actually land on
+     * the templates that exist.
+     */
+    const nestCli = JSON.parse(fs.readFileSync(path.join(API_ROOT, 'nest-cli.json'), 'utf8'));
+
+    it('point at the real .hbs templates once resolved relative to sourceRoot', () => {
+        expect(nestCli.sourceRoot).toBeTruthy();
+        const assets: Array<string | { include: string }> = nestCli.compilerOptions?.assets ?? [];
+        expect(assets.length).toBeGreaterThan(0);
+
+        const sourceRoot = path.join(API_ROOT, nestCli.sourceRoot);
+        const matched = new Set<string>();
+
+        for (const entry of assets) {
+            const include = typeof entry === 'string' ? entry : entry.include;
+            const globRoot = path.join(sourceRoot, include.replace(/[\\/]?\*\*[\\/]\*$/, ''));
+            if (!fs.existsSync(globRoot) || !fs.statSync(globRoot).isDirectory()) {
+                continue;
+            }
+            for (const file of fs.readdirSync(globRoot)) {
+                if (file.endsWith('.hbs')) {
+                    matched.add(path.basename(file, '.hbs'));
+                }
+            }
+        }
+
+        expect([...matched].sort()).toEqual([...TEMPLATES_USED_BY_MAIL_SERVICE].sort());
+    });
+});
+
+describe('build output packaging', () => {
+    /**
+     * Source-level correctness was never the problem — packaging was. When
+     * `dist/` has been built, assert the templates landed beside the
+     * compiled code, which is what the container image copies
+     * (`COPY --from=installer /app/deploy/dist ./dist`).
+     *
+     * Skipped rather than failed when `dist/` is absent so `pnpm test` on a
+     * clean checkout stays green; CI builds before it tests, and the API
+     * Dockerfile carries a hard gate for the image itself.
+     */
+    const distDir = path.join(API_ROOT, 'dist');
+    const hasBuild = fs.existsSync(path.join(distDir, 'main.js'));
+    const maybe = hasBuild ? it : it.skip;
+
+    maybe('emits every .hbs into dist/templates', () => {
+        const distTemplates = path.join(distDir, 'templates');
+        expect(fs.existsSync(distTemplates)).toBe(true);
+
+        const shipped = fs
+            .readdirSync(distTemplates)
+            .filter((f) => f.endsWith('.hbs'))
+            .map((f) => path.basename(f, '.hbs'))
+            .sort();
+
+        expect(shipped).toEqual([...TEMPLATES_USED_BY_MAIL_SERVICE].sort());
+    });
+
+    maybe('the COMPILED resolver finds them with a container-like cwd', () => {
+        // End-to-end proof against the actual build output: run
+        // dist/mail/templates.js from an unrelated directory, exactly as the
+        // image does (`cwd=/app`).
+        const compiled = path.join(distDir, 'mail', 'templates.js');
+        expect(fs.existsSync(compiled)).toBe(true);
+
+        const script = `
+            const fs = require('fs');
+            const t = require(${JSON.stringify(compiled)});
+            const status = t.inspectTemplatesDir({ refresh: true });
+            const sample = fs.readFileSync(t.resolveTemplatePath('signup-confirmation'), 'utf8');
+            process.stdout.write(JSON.stringify({
+                cwd: process.cwd(),
+                ok: status.ok,
+                dir: status.dir,
+                missing: status.missing,
+                available: status.available.length,
+                sampleLength: sample.length,
+            }));
+        `;
+
+        const result = JSON.parse(
+            execFileSync(process.execPath, ['-e', script], {
+                cwd: os.tmpdir(),
+                encoding: 'utf8',
+            }),
+        );
+
+        expect(fs.realpathSync(result.cwd)).not.toBe(fs.realpathSync(API_ROOT));
+        expect(result.dir).toBe(path.join(distDir, 'templates'));
+        expect(result.missing).toEqual([]);
+        expect(result.ok).toBe(true);
+        expect(result.available).toBe(TEMPLATES_USED_BY_MAIL_SERVICE.length);
+        expect(result.sampleLength).toBeGreaterThan(0);
+    });
+});

--- a/apps/api/src/mail/providers/mailer.service.ts
+++ b/apps/api/src/mail/providers/mailer.service.ts
@@ -1,12 +1,43 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import Handlebars from 'handlebars';
 import { Resend } from 'resend';
 import { MailerService as SmtpMailerService } from '@nestjs-modules/mailer';
 import { FakerMailerService } from './faker-mailer.service';
 import { config } from '@src/config/constants';
 import { Address, SendMailOptions } from '../types';
+import { describeTemplatesDir, inspectTemplatesDir, resolveTemplatePath } from '../templates';
+
+/**
+ * Raised when a templated email cannot be rendered because the `.hbs` file
+ * is not on disk. Distinct from a transport failure on purpose: a transport
+ * failure is transient and worth retrying, this one means the *image is
+ * mis-built* and every templated email will fail until it is rebuilt.
+ */
+export class EmailTemplateUnavailableError extends Error {
+    /**
+     * Declared explicitly: `tsconfig` targets ES2021, whose `Error` type has
+     * no `cause` (that landed in ES2022), so the inherited property is not
+     * visible to the compiler.
+     */
+    readonly cause?: unknown;
+
+    constructor(
+        readonly templateName: string,
+        readonly templatePath: string,
+        cause?: unknown,
+    ) {
+        super(
+            `Email template "${templateName}" is not available at ${templatePath}. ` +
+                `No mail was sent. This almost always means the Handlebars templates were ` +
+                `not copied into the build output — check apps/api/nest-cli.json ` +
+                `(compilerOptions.assets, resolved relative to sourceRoot) and the API image. ` +
+                describeTemplatesDir(),
+        );
+        this.name = 'EmailTemplateUnavailableError';
+        this.cause = cause;
+    }
+}
 
 @Injectable()
 export class MailerService {
@@ -18,6 +49,36 @@ export class MailerService {
         @Optional() @Inject('RESEND_CLIENT') private readonly resend?: Resend,
     ) {
         this.logger.log(`Mailer service initialized with provider: ${config.mail.provider()}`);
+        this.assertTemplatesAvailable();
+    }
+
+    /**
+     * Boot-time packaging check. The templates are baked into the image and
+     * cannot appear later, so a missing directory here means *every*
+     * templated email will fail for the lifetime of this pod — password
+     * reset and signup verification included, which locks new users out of
+     * the platform entirely. Say so once, loudly, at startup rather than
+     * leaving it to be discovered by a customer who never got their mail.
+     *
+     * Deliberately does NOT throw: refusing to boot would take the whole API
+     * down over an email fault. The failure is loud in logs, reported as
+     * `email: degraded` on /api/health/ready, and every individual send
+     * still fails hard instead of pretending success.
+     */
+    private assertTemplatesAvailable(): void {
+        const status = inspectTemplatesDir({ refresh: true });
+        if (status.ok) {
+            this.logger.log(
+                `Email templates loaded: ${status.available.length} from ${status.dir}`,
+            );
+            return;
+        }
+
+        this.logger.error(
+            `EMAIL TEMPLATES MISSING — every templated email (signup confirmation, ` +
+                `password reset, magic link, invitations, budget alerts) will FAIL. ` +
+                describeTemplatesDir(),
+        );
     }
 
     async sendMail(data: SendMailOptions): Promise<void> {
@@ -41,6 +102,12 @@ export class MailerService {
                 }
 
                 const from = config.mail.resend.emailFrom();
+                // Render BEFORE announcing the send. When the template is
+                // missing this throws here, so `resend.emails.send()` is never
+                // reached and no message is queued at the provider — and the
+                // log does not carry a "Sending ..." line for a message that
+                // never left the process.
+                const html = await this.readHtmlTemplate(data);
                 this.logger.log(
                     `Sending email via Resend to=${recipient} from="${from}" subject="${data.subject}"`,
                 );
@@ -48,7 +115,7 @@ export class MailerService {
                     to: data.to ? this.getDestination(data.to) : [],
                     from,
                     subject: data.subject,
-                    html: await this.readHtmlTemplate(data),
+                    html,
                 });
                 this.logger.log(
                     `Email sent via Resend to=${recipient} id=${result.data?.id ?? 'unknown'}`,
@@ -70,23 +137,29 @@ export class MailerService {
 
     private async readHtmlTemplate(data: SendMailOptions) {
         if (data.template) {
-            // Security: prevent path traversal via a user-supplied template name.
-            // Restrict to a safe charset (no `/`, `\`, `.` or `..` segments) so a
-            // value like `../../config/constants` can never escape the templates
-            // directory and read arbitrary `.hbs`-suffixed files from the tree.
-            if (!/^[a-z0-9-]+$/i.test(data.template)) {
-                throw new Error(`Invalid template name: ${JSON.stringify(data.template)}`);
-            }
+            // Security: prevent path traversal via a user-supplied template
+            // name. `resolveTemplatePath` restricts to a safe charset (no `/`,
+            // `\`, `.` or `..` segments) and then re-checks that the resolved
+            // path stays inside the templates directory, so a value like
+            // `../../config/constants` can never escape it and read arbitrary
+            // `.hbs`-suffixed files from the tree.
+            const templatePath = resolveTemplatePath(data.template);
 
-            const templatesDir = path.resolve(process.cwd(), 'src/templates');
-            const templatePath = path.resolve(templatesDir, `${data.template}.hbs`);
-            // Security: defence-in-depth — ensure the resolved path stays inside
-            // the templates directory before reading it.
-            if (!templatePath.startsWith(templatesDir + path.sep)) {
-                throw new Error(`Invalid template name: ${JSON.stringify(data.template)}`);
+            let content: string;
+            try {
+                content = await fs.readFile(templatePath, { encoding: 'utf8' });
+            } catch (error) {
+                // Do NOT degrade to an empty body: an email with no content
+                // still counts as "delivered" to the provider and to the
+                // caller, which is how a broken image can masquerade as a
+                // working one. Fail loudly and send nothing.
+                this.logger.error(
+                    `Cannot render email template "${data.template}" — NOT sending. ` +
+                        describeTemplatesDir(),
+                    (error as Error)?.stack,
+                );
+                throw new EmailTemplateUnavailableError(data.template, templatePath, error);
             }
-
-            const content = await fs.readFile(templatePath, { encoding: 'utf8' });
 
             const template = Handlebars.compile(content);
             const result = template(data.context || {});

--- a/apps/api/src/mail/templates.spec.ts
+++ b/apps/api/src/mail/templates.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the email-template resolver.
+ *
+ * The end-to-end regression proof for the "no templated email was ever
+ * sent" defect lives in `providers/mailer.service.templates.spec.ts` — it is
+ * deliberately written so it can also run against the pre-fix tree. This
+ * file covers the helper's own contract.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+    KNOWN_EMAIL_TEMPLATES,
+    TEMPLATES_DIR,
+    describeTemplatesDir,
+    inspectTemplatesDir,
+    listAvailableTemplates,
+    resolveTemplatePath,
+} from './templates';
+
+const API_ROOT = path.resolve(__dirname, '..', '..');
+
+describe('email templates resolver', () => {
+    const originalCwd = process.cwd();
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+    });
+
+    it('anchors TEMPLATES_DIR to this module, not to the process working directory', () => {
+        const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'ew-tpl-'));
+        try {
+            process.chdir(scratch);
+            // Control: prove the chdir actually took effect, so a pass here
+            // cannot be an artefact of chdir silently doing nothing.
+            expect(fs.realpathSync(process.cwd())).not.toBe(fs.realpathSync(API_ROOT));
+
+            // `templates.ts` lives in `src/mail/`, the templates in
+            // `src/templates/` — and after compilation, `dist/mail/` and
+            // `dist/templates/`. The `..` hop is what makes the same
+            // expression correct in both trees and in the container.
+            expect(TEMPLATES_DIR).toBe(path.resolve(__dirname, '..', 'templates'));
+            expect(fs.existsSync(TEMPLATES_DIR)).toBe(true);
+            expect(TEMPLATES_DIR.startsWith(fs.realpathSync(process.cwd()))).toBe(false);
+        } finally {
+            process.chdir(originalCwd);
+            fs.rmSync(scratch, { recursive: true, force: true });
+        }
+    });
+
+    it('agrees with the directory contents in both directions', () => {
+        // Forward: every registered template is on disk. Reverse: every
+        // `.hbs` on disk is registered — otherwise the boot check and the
+        // Docker packaging gate would not notice the build dropping it.
+        expect(listAvailableTemplates()).toEqual([...KNOWN_EMAIL_TEMPLATES].sort());
+    });
+
+    it('reports a healthy directory with nothing missing', () => {
+        const status = inspectTemplatesDir({ refresh: true });
+        expect(status.dir).toBe(TEMPLATES_DIR);
+        expect(status.missing).toEqual([]);
+        expect(status.ok).toBe(true);
+        expect(status.available.length).toBe(KNOWN_EMAIL_TEMPLATES.length);
+    });
+
+    it('describes the directory without a MISSING marker when healthy', () => {
+        const description = describeTemplatesDir({ refresh: true });
+        expect(description).toContain(TEMPLATES_DIR);
+        expect(description).toContain('signup-confirmation');
+        expect(description).not.toContain('MISSING=');
+    });
+
+    it('resolves a known template to an existing absolute path', () => {
+        const resolved = resolveTemplatePath('forgot-password');
+        expect(path.isAbsolute(resolved)).toBe(true);
+        expect(resolved).toBe(path.join(TEMPLATES_DIR, 'forgot-password.hbs'));
+        expect(fs.existsSync(resolved)).toBe(true);
+    });
+
+    it.each([
+        '../../config/constants',
+        '..\\..\\config\\constants',
+        'nested/template',
+        '',
+        'welcome.hbs',
+    ])('rejects the traversal-shaped template name %j', (name) => {
+        expect(() => resolveTemplatePath(name)).toThrow(/Invalid template name/);
+    });
+});

--- a/apps/api/src/mail/templates.spec.ts
+++ b/apps/api/src/mail/templates.spec.ts
@@ -42,7 +42,14 @@ describe('email templates resolver', () => {
             // expression correct in both trees and in the container.
             expect(TEMPLATES_DIR).toBe(path.resolve(__dirname, '..', 'templates'));
             expect(fs.existsSync(TEMPLATES_DIR)).toBe(true);
-            expect(TEMPLATES_DIR.startsWith(fs.realpathSync(process.cwd()))).toBe(false);
+
+            // The property that actually broke production: the old
+            // `path.resolve(process.cwd(), 'src/templates')` resolves to
+            // nothing from here, while TEMPLATES_DIR still resolves. Stated
+            // as "cwd-relative misses, module-relative hits" rather than a
+            // prefix comparison, which would be wrong on a runner whose
+            // temp dir happens to be an ancestor of the workspace.
+            expect(fs.existsSync(path.resolve(process.cwd(), 'src/templates'))).toBe(false);
         } finally {
             process.chdir(originalCwd);
             fs.rmSync(scratch, { recursive: true, force: true });

--- a/apps/api/src/mail/templates.ts
+++ b/apps/api/src/mail/templates.ts
@@ -1,0 +1,156 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Handlebars email-template packaging + resolution.
+ *
+ * ## Why this file exists
+ *
+ * Both consumers of the `.hbs` templates used to resolve them from
+ * `process.cwd()`:
+ *
+ *   - `mail.module.ts`   -> `path.join(process.cwd(), 'src/templates')`
+ *     (the `@nestjs-modules/mailer` HandlebarsAdapter, i.e. the SMTP path)
+ *   - `mailer.service.ts` -> `path.resolve(process.cwd(), 'src/templates')`
+ *     (the Resend path)
+ *
+ * That only ever worked when the process happened to be started from
+ * `apps/api` with the TypeScript sources on disk — i.e. local dev and Jest.
+ * In the published container the process starts in `/app`, there is no
+ * `/app/src`, and the compiled app lives in `/app/dist` — so every templated
+ * email (signup confirmation, password reset, magic link, invitations,
+ * budget alerts, ...) threw `ENOENT: /app/src/templates/<name>.hbs` in
+ * every environment.
+ *
+ * Two independent faults had to line up, and both are fixed:
+ *
+ *  1. **Packaging.** `nest-cli.json` declared `assets: ["src/templates/**\/*"]`,
+ *     but the Nest CLI resolves asset globs *relative to `sourceRoot`* — so
+ *     it actually globbed `apps/api/src/src/templates/**\/*`, matched nothing,
+ *     and copied nothing. The declaration looked right, which is why the
+ *     omission survived review. It is now `templates/**\/*`.
+ *  2. **Resolution.** The runtime path is now derived from **this module's
+ *     own location** instead of the working directory. The layout is
+ *     deliberately identical on both sides:
+ *
+ *        apps/api/src/mail/templates.ts  -> apps/api/src/templates/*.hbs
+ *        apps/api/dist/mail/templates.js -> apps/api/dist/templates/*.hbs
+ *
+ *     so `<dirname>/../templates` is correct for the sources, for the
+ *     compiled output and for the container, regardless of where `node`
+ *     was invoked from.
+ */
+export const TEMPLATES_DIR = path.resolve(__dirname, '..', 'templates');
+
+/**
+ * Every Handlebars template that must ship with the API, i.e. every value
+ * passed as `template:` to `MailerService.sendMail()` by `MailService`.
+ *
+ * Kept as an explicit list (rather than "whatever happens to be on disk")
+ * so the packaging test and the boot-time check have a known-good control:
+ * a template that is deleted, renamed or dropped by the build then breaks a
+ * test instead of a customer's password reset. `templates.spec.ts` asserts
+ * this list and the directory agree in *both* directions, so adding a
+ * `.hbs` file without registering it here fails too.
+ */
+export const KNOWN_EMAIL_TEMPLATES = [
+    'account-deletion',
+    'budget-alert',
+    'forgot-password',
+    'magic-link',
+    'member-invitation',
+    'new-device-login',
+    'password-changed',
+    'signup-confirmation',
+    'welcome',
+    'work-invitation-claim',
+] as const;
+
+export type EmailTemplateName = (typeof KNOWN_EMAIL_TEMPLATES)[number];
+
+export interface TemplatesDirStatus {
+    /** True when the directory exists AND every known template is present. */
+    ok: boolean;
+    /** Absolute path the templates were looked for in. */
+    dir: string;
+    /** Template slugs actually found on disk. */
+    available: string[];
+    /** Known templates that are NOT on disk. */
+    missing: string[];
+}
+
+/**
+ * Security: template names reach this function from call sites that may
+ * carry user-influenced data, so restrict to a safe charset (no `/`, `\`,
+ * `.` or `..` segments) and then re-check that the resolved path is still
+ * inside `TEMPLATES_DIR` (defence-in-depth against path traversal).
+ */
+export function resolveTemplatePath(templateName: string): string {
+    if (!/^[a-z0-9-]+$/i.test(templateName)) {
+        throw new Error(`Invalid template name: ${JSON.stringify(templateName)}`);
+    }
+
+    const templatePath = path.resolve(TEMPLATES_DIR, `${templateName}.hbs`);
+    if (!templatePath.startsWith(TEMPLATES_DIR + path.sep)) {
+        throw new Error(`Invalid template name: ${JSON.stringify(templateName)}`);
+    }
+
+    return templatePath;
+}
+
+/** Template slugs present in `TEMPLATES_DIR` right now. */
+export function listAvailableTemplates(): string[] {
+    try {
+        return fs
+            .readdirSync(TEMPLATES_DIR)
+            .filter((file) => file.endsWith('.hbs'))
+            .map((file) => path.basename(file, '.hbs'))
+            .sort();
+    } catch {
+        // Directory missing (the shipped-image regression) — report empty
+        // rather than throwing, so callers can log the full picture.
+        return [];
+    }
+}
+
+let cachedStatus: TemplatesDirStatus | null = null;
+
+/**
+ * Describe the state of the template directory. `ok` is false when the
+ * directory is missing or any known template is not shipped — the exact
+ * packaging regression that silently broke every templated email.
+ *
+ * The result is cached because the templates are baked into the image and
+ * cannot change at runtime, and because the health endpoint calls this on
+ * every readiness probe. Pass `{ refresh: true }` in tests.
+ */
+export function inspectTemplatesDir(options?: { refresh?: boolean }): TemplatesDirStatus {
+    if (cachedStatus && !options?.refresh) {
+        return cachedStatus;
+    }
+
+    const available = listAvailableTemplates();
+    const missing = KNOWN_EMAIL_TEMPLATES.filter((name) => !available.includes(name));
+    cachedStatus = {
+        ok: available.length > 0 && missing.length === 0,
+        dir: TEMPLATES_DIR,
+        available,
+        missing,
+    };
+    return cachedStatus;
+}
+
+/**
+ * Human-readable one-liner used by the boot-time check and by the per-send
+ * failure path, so an operator can tell a *packaging* fault ("no templates
+ * shipped at all") from a *content* fault ("this one template is missing")
+ * straight from the log line, without reading the source.
+ */
+export function describeTemplatesDir(options?: { refresh?: boolean }): string {
+    const { dir, available, missing } = inspectTemplatesDir(options);
+    return (
+        `templatesDir=${dir} available=${available.length}` +
+        `[${available.join(', ')}]` +
+        (missing.length > 0 ? ` MISSING=[${missing.join(', ')}]` : '')
+    );
+}

--- a/docs/api/mail.md
+++ b/docs/api/mail.md
@@ -15,6 +15,7 @@ The mail system handles all transactional email delivery for the platform, suppo
 apps/api/src/mail/
   mail.service.ts                   # Event listeners and email orchestration
   mail.module.ts                    # Module config (SMTP, Resend, templates)
+  templates.ts                      # Template dir resolution + packaging checks
   types.ts                          # SendMailOptions interface
   providers/
     mailer.service.ts               # Multi-provider dispatch (SMTP, Resend, faker)
@@ -103,6 +104,30 @@ async sendSignupConfirmation(data: UserCreatedEvent): Promise<void> {
 
 All email sends are wrapped in try/catch blocks and errors are logged without throwing, ensuring email failures do not break the calling flow.
 
+## Template Packaging
+
+The `.hbs` templates are **not** TypeScript, so they only reach the runtime
+because `apps/api/nest-cli.json` lists them under `compilerOptions.assets`.
+Two rules matter, and both were violated at once in the defect that made
+every templated email fail in every environment:
+
+- **Asset globs are relative to `sourceRoot`.** `"templates/**/*"` is
+  correct; `"src/templates/**/*"` silently resolves to
+  `apps/api/src/src/templates/**/*`, matches nothing and copies nothing —
+  with no build error.
+- **The runtime path must be relative to the compiled module, not to
+  `process.cwd()`.** The container starts the process in `/app` with the app
+  in `/app/dist`; a cwd-relative `src/templates` does not exist there. Both
+  consumers now go through `TEMPLATES_DIR` in
+  `apps/api/src/mail/templates.ts`, which resolves `<dirname>/../templates`
+  and is therefore correct for `src/`, `dist/` and the image alike.
+
+Three independent guards keep this from regressing: a Jest suite that renders
+every template with the working directory moved elsewhere, a boot-time check
+that logs `EMAIL TEMPLATES MISSING` and reports `email: degraded` on
+`/api/health/ready`, and a `RUN` step in `.deploy/docker/api/Dockerfile` that
+fails the image build unless every source template reached `dist/templates`.
+
 ## Adding a New Template
 
 1. Create a `.hbs` file in `apps/api/src/templates/`:
@@ -112,6 +137,12 @@ All email sends are wrapped in try/catch blocks and errors are logged without th
     <p>Your notification from {{appName}}.</p>
     <p>&copy; {{currentYear}} {{companyOwner}}</p>
     ```
+
+    Then register its slug in `KNOWN_EMAIL_TEMPLATES`
+    (`apps/api/src/mail/templates.ts`). `templates.spec.ts` asserts the list
+    and the directory match in both directions, so an unregistered template
+    fails the suite — that registry is what the boot-time check and the API
+    Dockerfile's packaging gate compare against.
 
 2. Define a new event class in `apps/api/src/events/`.
 
@@ -163,7 +194,13 @@ interface SendMailOptions {
 				transport: { host, port, secure, auth: { user, pass } },
 				defaults: { from: config.mail.from() },
 				template: {
-					dir: path.join(process.cwd(), 'src/templates'),
+					// Resolved from the module's own location (see
+					// `apps/api/src/mail/templates.ts`), NOT from
+					// `process.cwd()`. In the container the process starts in
+					// `/app` and the compiled app lives in `/app/dist`, so a
+					// cwd-relative `src/templates` does not exist and every
+					// templated email fails with ENOENT.
+					dir: TEMPLATES_DIR,
 					adapter: new HandlebarsAdapter(undefined, { inlineCssEnabled: true })
 				}
 			})


### PR DESCRIPTION
## Summary

Every templated email failed to send, in every environment, because **no `.hbs` file was present in the built API image**. All ten templates were affected: signup confirmation, password reset, magic link, welcome, password-changed, new-device-login, account deletion, member invitation, work-invitation claim and budget alerts.

This is worse than "emails don't arrive": **new production accounts are permanently locked out.** Registration mints `emailVerificationToken` and sets `users.emailVerified = false`, then the verification email that would clear it can never be sent. `POST /api/auth/login` then rejects the same correct credentials with `403 {"statusCode":403,"message":"Email not verified"}`, so the account cannot authenticate against the API, CLI or MCP at all — and once the browser session cookie expires there is no way back in. Password reset is dead for the same reason, so there is no recovery path either.

## Root cause

Two independent faults had to line up, and both are fixed here.

**1. Packaging — the templates never reached `dist`.**

`apps/api/nest-cli.json` declared:

```json
"sourceRoot": "src",
"compilerOptions": { "assets": ["src/templates/**/*"] }
```

The Nest CLI resolves asset globs **relative to `sourceRoot`** (`@nestjs/cli/lib/compiler/assets-manager.js`):

```js
sourceRoot  = join(process.cwd(), sourceRoot);   // apps/api/src
includePath = join(sourceRoot, include);         // apps/api/src/src/templates/**/*
```

So it globbed `apps/api/src/src/templates/**/*`, matched zero files and copied nothing — **with no build error and no warning**. The declaration reads as obviously correct, which is why the omission survived review for as long as it did. It is now `"templates/**/*"`.

**2. Resolution — the runtime path came from `process.cwd()`.**

Both consumers resolved the directory from the working directory:

- `apps/api/src/mail/providers/mailer.service.ts:81` — `path.resolve(process.cwd(), 'src/templates')` (the Resend branch)
- `apps/api/src/mail/mail.module.ts:56` — `path.join(process.cwd(), 'src/templates')` (the `@nestjs-modules/mailer` HandlebarsAdapter, i.e. the SMTP branch)

`process.cwd()` is `apps/api` under Jest and in local dev, where `src/templates` genuinely exists. In the container the process starts in `/app`, the compiled app lives in `/app/dist`, and there is no `/app/src` at all.

### Why it affected every environment

Neither fault is environment-specific. Fault 1 is in the build config, so **every** image built from this repo shipped without templates regardless of branch or tag. Fault 2 is in the runtime path, and the entrypoint starts the process in `/app` in **every** deployment. Local dev and CI were the only places it worked — precisely the two places where the cwd happens to be `apps/api` with the TypeScript sources on disk, which is also why no test caught it.

The two branches fail in different ways but both fail: dev/stage/prod run `MAILER_PROVIDER=resend` and throw `ENOENT` out of `fs.readFile`; an SMTP deployment throws out of the HandlebarsAdapter for the same missing directory.

## Evidence from the running pods

Read-only, with a **known-good control** in the same command so an empty result cannot be mistaken for a broken one.

Production — `ever-works-app-prod`, `ghcr.io/ever-works/ever-works-api:prod@sha256:99612a12…`:

```
$ kubectl exec -n ever-works-app-prod ever-works-api-6c54ff6977-7wn8j -- sh -c '...'
PWD=/app
-rw-r--r--    1 node     node         13158 /app/dist/main.js
js_count=795            <-- CONTROL: the find works
hbs_total=0             <-- zero .hbs anywhere in /app, node_modules included
ls: /app/src: No such file or directory
MAILER_PROVIDER=resend  RESEND_APIKEY_set=yes  NODE_ENV=production
```

Reproducing the old resolution inside the prod pod (again with a control):

```
$ kubectl exec -n ever-works-app-prod ever-works-api-6c54ff6977-7wn8j -- node -e '...'
resolved templatesDir = /app/src/templates
exists = false
READ FAILED: ENOENT ENOENT: no such file or directory, open '/app/src/templates/forgot-password.hbs'
CONTROL readFile /app/package.json = 3048 bytes
```

Dev — `ever-works-app-dev`, `…ever-works-api:dev@sha256:fdfdb114…` — is byte-identical in this respect: `hbs_outside_nm_count=0`, `hbs_total_count=0`, `js_count=795`, no `/app/src`, `MAILER_PROVIDER=resend`.

A real signup on `app.ever.works` produced, in the prod API log:

```
[MailService] Failed to send signup confirmation to qa-ew-20260811@ever.works
Error: ENOENT: no such file or directory, open '/app/src/templates/signup-confirmation.hbs'
```

followed by repeated `[ExceptionsHandler] [APIError: Email not verified]` on every subsequent login attempt.

### Was Resend ever reached?

**No — it threw before the provider call, and nothing was queued anywhere.** In the old code the render was an argument expression:

```ts
const result = await this.resend.emails.send({
    to: …, from, subject: data.subject,
    html: await this.readHtmlTemplate(data),   // throws here
});
```

JavaScript evaluates the argument list before invoking the callee, so `resend.emails.send()` was never called. No message reached Resend, no message was buffered, nothing will arrive late. The regression test `throws, never calls the provider, and never reports a send` asserts this and passes against both the old and new code.

One caveat worth knowing when reading old logs: the old code emitted `Sending email via Resend to=… subject="…"` *immediately before* the throw, so the logs read as though a delivery had been attempted. This PR moves the render ahead of that log line, so a template failure now produces no "Sending" line at all.

## The fix

- **`apps/api/nest-cli.json`** — asset glob corrected to `templates/**/*` so the Nest CLI actually copies the templates into `dist/templates/`.
- **`apps/api/src/mail/templates.ts`** (new) — single source of truth for the directory. `TEMPLATES_DIR = path.resolve(__dirname, '..', 'templates')`. The layout is deliberately symmetric — `src/mail/templates.ts → src/templates/`, `dist/mail/templates.js → dist/templates/` — so one expression is correct for the sources, the build output and the image, regardless of where `node` was started. Also exports `KNOWN_EMAIL_TEMPLATES`, a path-traversal-safe `resolveTemplatePath()`, and `inspectTemplatesDir()`.
- **`apps/api/src/mail/providers/mailer.service.ts`** and **`apps/api/src/mail/mail.module.ts`** — both now resolve through `TEMPLATES_DIR` instead of `process.cwd()`.

### Degraded case — it must never masquerade as a send

- A missing template raises a dedicated `EmailTemplateUnavailableError` naming the resolved path and listing what *is* on disk, preceded by a `logger.error`. It never degrades to an empty body (an empty email still counts as "delivered" to the provider, which is exactly how a broken image can look healthy).
- The Resend branch renders **before** it logs `Sending …`, so a failure produces no log line claiming a send, and never reaches the provider.
- `MailerService` checks the directory **at boot** and logs `EMAIL TEMPLATES MISSING — every templated email … will FAIL` at error level. It deliberately does not throw: refusing to boot would take the whole API down over an email fault.
- **`/api/health/ready` now reports `email: degraded`** instead of `enabled` when the templates are absent. Previously it reported `configured: true, mode: enabled` for a mailer that could not send a single message — a status surface asserting something it had not checked.
- **`.deploy/docker/api/Dockerfile`** fails the image build unless every source template reached `dist/templates`, comparing against the source count as a known-good control so "zero templates" can never pass as "nothing to copy".

I did **not** touch the "email must be verified" rule, and I did not change the registration toast copy: it lives in `apps/web/messages/*.json` across 21 locales, and with the templates shipped the mail genuinely is sent. The honesty gap is closed at the source instead — the API no longer reports a healthy mailer it has not verified, and a send that cannot happen now fails loudly rather than silently.

## Tests

The existing suite passed throughout the outage because `mailer.service.spec.ts` mocks `fs/promises` wholesale and then asserts on the *shape* of the path handed to `readFile`. A mocked filesystem always resolves.

The new `apps/api/src/mail/providers/mailer.service.templates.spec.ts` mocks nothing. It renders all ten templates through the real `MailerService` **with the process working directory moved to a scratch dir** — reproducing the container's condition inside a unit test — checks that the nest-cli asset globs land on real files, and inspects `dist/` when a build is present. It imports only `MailerService`, so it runs verbatim against the pre-fix tree.

### Before — against the unfixed code

`apps/api/nest-cli.json`, `mailer.service.ts`, `mail.module.ts` and `service-detection.ts` reverted to `origin/develop`, `templates.ts` removed, `dist/` rebuilt from that tree (`hbs in src = 10, hbs in dist = 0, js in dist = 796`):

```
    √ CONTROL: the templates exist in the source tree (7 ms)
      × renders account-deletion to non-empty HTML and hands it to the provider (4 ms)
      × renders budget-alert to non-empty HTML and hands it to the provider (3 ms)
      × renders forgot-password to non-empty HTML and hands it to the provider (2 ms)
      × renders magic-link to non-empty HTML and hands it to the provider (2 ms)
      × renders member-invitation to non-empty HTML and hands it to the provider (2 ms)
      × renders new-device-login to non-empty HTML and hands it to the provider (1 ms)
      × renders password-changed to non-empty HTML and hands it to the provider (2 ms)
      × renders signup-confirmation to non-empty HTML and hands it to the provider (2 ms)
      × renders welcome to non-empty HTML and hands it to the provider (2 ms)
      × renders work-invitation-claim to non-empty HTML and hands it to the provider (2 ms)
      × substitutes the verification URL into the signup-confirmation email (2 ms)
      √ throws, never calls the provider, and never reports a send (2 ms)
    × point at the real .hbs templates once resolved relative to sourceRoot (5 ms)
    × emits every .hbs into dist/templates (1 ms)
    × the COMPILED resolver finds them with a container-like cwd

Test Suites: 1 failed, 1 total
Tests:       14 failed, 2 passed, 16 total
```

The failure is the production error, reproduced in a unit test:

```
● … › renders account-deletion to non-empty HTML and hands it to the provider

  ENOENT: no such file or directory, open 'E:\temp\ew-mailer-cwd-Tyxwnv\src\templates\account-deletion.hbs'

  > 89 |     const content = await fs.readFile(templatePath, { encoding: 'utf8' });
    at MailerService.readHtmlTemplate (mail/providers/mailer.service.ts:89:29)
```

and the packaging fault is caught directly:

```
● nest-cli.json asset globs › point at the real .hbs templates once resolved relative to sourceRoot

  - Expected  - 12
  + Received  +  1

  - Array [ "account-deletion", "budget-alert", "forgot-password", "magic-link",
  -   "member-invitation", "new-device-login", "password-changed",
  -   "signup-confirmation", "welcome", "work-invitation-claim" ]
  + Array []
```

The two tests that pass pre-fix are load-bearing on purpose: the CONTROL proves the templates *do* exist in the source tree (so the failures above mean "cannot be found", not "there are none"), and the degraded-case test documents that Resend was never reached.

### After — against this branch

```
Test Suites: 5 passed, 5 total
Tests:       70 passed, 70 total

PASS src/mail/providers/mailer.service.templates.spec.ts (53.67 s)
PASS src/mail/mail.service.spec.ts
PASS src/mail/providers/mailer.service.spec.ts
PASS src/mail/providers/faker-mailer.service.spec.ts
PASS src/mail/templates.spec.ts
```

with all 16 of the new suite's cases green, including the two that require a real build:

```
    √ point at the real .hbs templates once resolved relative to sourceRoot (2 ms)
    √ emits every .hbs into dist/templates (1 ms)
    √ the COMPILED resolver finds them with a container-like cwd (100 ms)
```

`tsc -p tsconfig.build.json --noEmit` is clean and `src/health` still passes (7/7).

CI runs `pnpm build` before `pnpm test`, so the two `dist/` assertions are not skipped there — this becomes a standing packaging check on every PR, independent of the Docker gate.

## Packaging verified end to end

Not just the source — the artefact.

```
# before (origin/develop)
CONTROL: hbs in src  = 10
         hbs in dist = 0
         dist/templates -> No such file or directory

# after (this branch)
CONTROL: hbs in src  = 10
         hbs in dist = 10
$ ls apps/api/dist/templates
account-deletion.hbs   budget-alert.hbs        forgot-password.hbs
magic-link.hbs         member-invitation.hbs   new-device-login.hbs
password-changed.hbs   signup-confirmation.hbs welcome.hbs
work-invitation-claim.hbs
```

The strongest check runs the **compiled** resolver in a child process started from an unrelated directory — exactly what the image does with `cwd=/app` — and confirms it still finds `dist/templates/*.hbs` (`the COMPILED resolver finds them with a container-like cwd`).

### The actual container image

`docker build -f .deploy/docker/api/Dockerfile .` was run to completion on this branch (the packaging gate is a `RUN` step, so a successful build already means it passed). Inspecting the resulting runtime image, again with a control:

```
$ docker run --rm --entrypoint sh ever-works-api:templates-fix-test -c '...'
PWD=/app
CONTROL js_count=798        <-- the find works
hbs_count=10                <-- was 0 in every published image
--- /app/dist/templates ---
account-deletion.hbs   budget-alert.hbs        forgot-password.hbs
magic-link.hbs         member-invitation.hbs   new-device-login.hbs
password-changed.hbs   signup-confirmation.hbs welcome.hbs
work-invitation-claim.hbs
```

and rendering a real template inside that image, at the real `cwd=/app`:

```
$ docker run --rm --entrypoint node ever-works-api:templates-fix-test -e '...'
cwd            = /app
templatesDir   = /app/dist/templates
ok             = true
missing        = []
available      = 10
renderedBytes  = 4207
containsName   = true
containsUrl    = true
```

That is the exact call the signup flow makes, in the exact environment that was failing.

### The build-time gate

The new Dockerfile gate was exercised in `node:22-alpine` across four states, including a deliberately broken control:

```
CASE pre-fix: dist/templates absent            -> ==> source=10 shipped=0   FATAL … exit=1
CASE partial: 9/10 shipped                     -> ==> source=10 shipped=9   FATAL … exit=1
CASE fixed:   10/10 shipped                    -> ==> source=10 shipped=10  GATE PASSED  exit=0
CASE control broken: 0 source templates        -> FATAL: the control failed, not the build  exit=1
```

## Scope

`apps/api/**` (mail + the email entry in the health report), `.deploy/docker/api/Dockerfile`, `docs/api/mail.md`. Nothing under `apps/web/e2e/**` or `.github/workflows/**` is touched.
