### PR TITLE
fix(search): case-insensitive matching on Postgres, and one search path that 500s on SQLite

### DIFF
--- a/apps/web/e2e/flow-missions-ideas-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-missions-ideas-ui-journey.spec.ts
@@ -38,15 +38,16 @@ import { clickAndExpectUrl } from './helpers/nav';
  *         outstandingIdeasCap,sourceMissionId,...}
  *   POST /api/me/missions/:id/pause -> 200 {status:'paused'}
  *   GET  /api/me/missions?status=active|paused              (works on sqlite)
- *   GET  /api/me/missions?search=<t>  (works on sqlite; ILIKE not used)
+ *   GET  /api/me/missions?search=<t>  (works on sqlite; portable LIKE)
  *   POST /api/me/work-proposals {description,title?} -> 201
  *        {id,title,description,slugSuggestion,status:'pending',
  *         source:'user-manual',missionId:null,...}
  *   PATCH /api/me/work-proposals/:id/dismiss -> 204
  *   GET  /api/me/work-proposals?statuses=dismissed          (works)
- *   GET  /api/me/work-proposals?search=<t> -> 500 on sqlite (ILIKE is
- *        Postgres-only) => /ideas?search= renders the "Could not load
- *        Ideas." alert. Asserted TOLERANTLY (idea OR alert).
+ *   GET  /api/me/work-proposals?search=<t> -> 200 on every driver (portable
+ *        `LOWER(col) LIKE :p ESCAPE '\'`) => /ideas?search= renders the
+ *        matching card. This used to be a Postgres-only ILIKE that 500'd on
+ *        sqlite and the assertion tolerated the "Could not load Ideas." alert.
  *   GET  /api/me/missions/<unknown-uuid> -> 404 (=> detail page notFound()).
  */
 
@@ -458,14 +459,14 @@ test.describe('Ideas catalog — /en/ideas UI', () => {
         await expect(card.getByText('Dismissed')).toBeVisible();
     });
 
-    test('the /ideas search filter is env-adaptive on sqlite (idea card OR load-error alert)', async ({
+    test('the /ideas search filter renders the matching card on every driver', async ({
         page,
         request,
     }) => {
-        // The work-proposal search path uses ILIKE, which sqlite (the local
-        // stack) does not implement -> the API 500s -> the page renders its
-        // "Could not load Ideas." alert instead of results. On Postgres the
-        // same URL returns the matching card. Assert either outcome.
+        // The work-proposal search path is portable now (`LOWER(col) LIKE :p
+        // ESCAPE '\'`), so sqlite executes it exactly as Postgres does. This
+        // assertion used to also accept the "Could not load Ideas." alert,
+        // which meant it could not fail while the endpoint was 500ing.
         const token = await seededToken(request);
         const marker = uniq('SearchMarker');
         await createIdea(request, token, `${marker} unique searchable idea body`);
@@ -477,10 +478,8 @@ test.describe('Ideas catalog — /en/ideas UI', () => {
         await expect(page.getByRole('heading', { name: 'Ideas' }).first()).toBeVisible({
             timeout: 30_000,
         });
-        const card = page.getByText(marker).first();
-        const loadError = page.getByText('Could not load Ideas.');
-        const emptyState = page.getByText('No Ideas match these filters.');
-        await expect(card.or(loadError).or(emptyState).first()).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByText(marker).first()).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByText('Could not load Ideas.')).toHaveCount(0);
     });
 
     test('clicking an idea card navigates to its detail page', async ({ page, request }) => {

--- a/apps/web/e2e/flow-work-community-pr-multistep.spec.ts
+++ b/apps/web/e2e/flow-work-community-pr-multistep.spec.ts
@@ -48,9 +48,10 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *    kind:'linked', createdAt, workName, workSlug}]}; link-less Idea → {links:[]}.
  *  PATCH /api/me/work-proposals/:id/dismiss         → 204; PENDING→DISMISSED.
  *  GET  /api/me/work-proposals?statuses=a&statuses=b→ 200 union of the partitions.
- *  GET  /api/me/work-proposals?search=<t>           → ENV-ADAPTIVE: 200 (real DB,
- *    case-insensitive title/description ILIKE) OR 500 {statusCode:500,
- *    message:"Internal server error"} on sqlite (ILIKE unsupported).
+ *  GET  /api/me/work-proposals?search=<t>           → 200, case-insensitive
+ *    title/description substring match on EVERY driver (portable
+ *    `LOWER(col) LIKE :p ESCAPE '\'`; it used to be a Postgres-only ILIKE that
+ *    500'd on sqlite, and this spec tolerated the 500).
  *  PUT  /api/works/:id {communityPrEnabled?, communityPrAutoClose?} → 200; bad type
  *    → 400 ["communityPrEnabled must be a boolean value"].
  *  POST /api/works/:id/process-community-prs         → 400 "…not enabled…" (disabled)
@@ -698,7 +699,7 @@ test.describe('Idea create → list → accept/reject partitioning ⟷ community
         expect((await readIdea(request, token, dismissedIdea.id)).acceptedWorkId).toBeNull();
     });
 
-    test('?search= is env-adaptive: 200 filters by a case-insensitive description substring (matching Idea present, non-matching excluded) OR 500 sqlite ILIKE', async ({
+    test('?search= returns 200 and filters by a case-insensitive description substring (matching Idea present, non-matching excluded)', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -720,26 +721,25 @@ test.describe('Idea create → list → accept/reject partitioning ⟷ community
         const res = await request.get(`${proposalsUrl()}?search=${token36}`, {
             headers: authedHeaders(token),
         });
-        // sqlite has no ILIKE → the repo query throws → a raw 500. A real Postgres
-        // stack filters and returns 200. Both are the truthful contract.
-        expect([200, 500]).toContain(res.status());
-        if (res.status() === 500) {
-            const body = await res.json();
-            expect(body.statusCode).toBe(500);
-            expect(String(body.message)).toMatch(/internal server error/i);
-        } else {
-            const rows = (await res.json()) as IdeaRow[];
-            const ids = rows.map((p) => p.id);
-            expect(ids).toContain(marked.id);
-            expect(ids).not.toContain(unmarked.id);
+        // The predicate is portable (`LOWER(col) LIKE :p ESCAPE '\'`), so sqlite
+        // and Postgres both execute it. 200 is the only correct outcome — this
+        // assertion previously also accepted 500, which is why the sqlite
+        // breakage went unnoticed for as long as it existed.
+        expect(res.status()).toBe(200);
 
-            // Case-insensitivity: an UPPERCASE search still matches the same Idea.
-            const upper = await request.get(`${proposalsUrl()}?search=${token36.toUpperCase()}`, {
-                headers: authedHeaders(token),
-            });
-            expect(upper.status()).toBe(200);
-            expect(((await upper.json()) as IdeaRow[]).map((p) => p.id)).toContain(marked.id);
-        }
+        const rows = (await res.json()) as IdeaRow[];
+        const ids = rows.map((p) => p.id);
+        expect(ids).toContain(marked.id);
+        expect(ids).not.toContain(unmarked.id);
+
+        // Case-insensitivity: an UPPERCASE search still matches the same Idea.
+        // On Postgres a bare LIKE would miss here; on sqlite it would match by
+        // accident. Both drivers must agree.
+        const upper = await request.get(`${proposalsUrl()}?search=${token36.toUpperCase()}`, {
+            headers: authedHeaders(token),
+        });
+        expect(upper.status()).toBe(200);
+        expect(((await upper.json()) as IdeaRow[]).map((p) => p.id)).toContain(marked.id);
     });
 
     test('GET :id/works after accept binds the link display fields (workName / workSlug) to the accepted community-PR Work; a link-less pending Idea → []', async ({

--- a/apps/web/e2e/flow-work-proposals-list-filter.spec.ts
+++ b/apps/web/e2e/flow-work-proposals-list-filter.spec.ts
@@ -12,9 +12,9 @@ import {
  * `GET /api/me/work-proposals`. This file owns the runtime BEHAVIOUR of the list
  * projection: the generatedAt-DESC ordering contract (status-agnostic, tie-
  * tolerant), the limit/offset windowing algebra, the `?statuses=` UNION semantics
- * (repeated params union — comma does NOT), the env-adaptive `?search=` ILIKE
- * execution, ORDER-BY injection hardening, and own-only scoping under every one
- * of those axes.
+ * (repeated params union — comma does NOT), the `?search=` substring filter,
+ * ORDER-BY injection hardening, and own-only scoping under every one of those
+ * axes.
  *
  * Every status code, ordering rule, and env-adaptive branch asserted below was
  * probed against the LIVE API at http://127.0.0.1:3100 (sqlite in-memory,
@@ -63,10 +63,12 @@ import {
  *      string is a single invalid enum member — comma is NOT a union operator
  *      here); one bogus among repeated valid values → 400.
  *    · ?search: a whitespace-only / empty ?search trims to undefined in the
- *      controller → the ILIKE branch never runs → 200 with the UNFILTERED own
- *      set. A non-empty ?search builds a Postgres ILIKE the sqlite CI stack
- *      can't execute → env-adaptive [200 (pg) | 500 (sqlite)]; NEVER a 4xx once
- *      it passed maxLength validation.
+ *      controller → the search branch never runs → 200 with the UNFILTERED own
+ *      set. A non-empty ?search builds a portable, case-insensitive
+ *      `LOWER(col) LIKE :p ESCAPE '\'` predicate that executes identically on
+ *      Postgres and sqlite → always 200. (It used to build a Postgres-only
+ *      `ILIKE` and 500 on sqlite; these assertions tolerated the 500, which is
+ *      why nothing failed. Fixed in `work-proposal.repository.ts`.)
  *    · HARDENING: ?sort / ?order / ?orderBy / ?direction (ORDER-BY injection
  *      vectors) are rejected 400 "property <x> should not exist" — no attacker-
  *      controlled ORDER BY ever reaches the query builder.
@@ -444,7 +446,13 @@ test.describe('Work-Proposals list — ?statuses union semantics', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// D. ?search — trim-to-no-op 200 path + env-adaptive ILIKE execution
+// D. ?search — trim-to-no-op 200 path + portable search execution
+//
+// These assertions used to read `expect([200, 500]).toContain(...)` because the
+// repository built a Postgres-only `ILIKE` that threw on sqlite. A test that
+// accepts a 500 cannot fail when the 500 spreads, so it hid the defect for as
+// long as it existed. The predicate is now portable, so 200 is the ONLY correct
+// outcome on every driver.
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Work-Proposals list — ?search execution', () => {
     test('a whitespace-only / empty ?search trims to a no-op → 200 with the UNFILTERED own set', async ({
@@ -454,8 +462,7 @@ test.describe('Work-Proposals list — ?search execution', () => {
         const created = await createFastIdeas(request, user.access_token, 3, `noop-${stamp()}`);
 
         // The controller does `search?.trim() || undefined`, so a blank search
-        // never builds an ILIKE — it can NEVER hit the sqlite ILIKE 500 and always
-        // returns the full unfiltered list.
+        // never builds a predicate at all and always returns the full list.
         for (const qs of ['?search=', '?search=%20%20%20', '?search=%09%09']) {
             const res = await listRes(request, user.access_token, qs);
             expect(res.status(), `blank search ${qs}`).toBe(200);
@@ -466,7 +473,7 @@ test.describe('Work-Proposals list — ?search execution', () => {
         }
     });
 
-    test('a real ?search term is env-adaptive [200 | 500] and, when it executes, filters by title/description', async ({
+    test('a real ?search term returns 200 on every driver and filters by title/description', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -477,40 +484,47 @@ test.describe('Work-Proposals list — ?search execution', () => {
         const other = await createIdea(request, token, `${IDEA_DESC_MIN} unrelated ${stamp()}`);
 
         const res = await listRes(request, token, `?search=${term}`);
-        // Postgres runs the ILIKE (200); the sqlite CI driver cannot (500). Never a
-        // 4xx — the input already passed @MaxLength(500) validation.
-        expect([200, 500]).toContain(res.status());
-        if (res.status() === 200) {
-            const rows = (await res.json()) as IdeaRow[];
-            const ids = rows.map((r) => r.id);
-            expect(ids).toContain(match.id);
-            expect(ids).not.toContain(other.id);
-            // A term nothing matches → an empty result (still 200).
-            const none = await listRes(request, token, `?search=nomatch${term}`);
-            if (none.status() === 200) {
-                expect(await none.json()).toEqual([]);
-            }
-        }
+        expect(res.status()).toBe(200);
+
+        const rows = (await res.json()) as IdeaRow[];
+        const ids = rows.map((r) => r.id);
+        expect(ids).toContain(match.id);
+        expect(ids).not.toContain(other.id);
+
+        // A term nothing matches → an empty result (still 200).
+        const none = await listRes(request, token, `?search=nomatch${term}`);
+        expect(none.status()).toBe(200);
+        expect(await none.json()).toEqual([]);
+
+        // Case-insensitive on EVERY driver: the repository lowers both the
+        // column and the pattern. A bare LIKE would match here on sqlite and
+        // silently miss on Postgres.
+        const upper = await listRes(request, token, `?search=${term.toUpperCase()}`);
+        expect(upper.status()).toBe(200);
+        expect(((await upper.json()) as IdeaRow[]).map((r) => r.id)).toContain(match.id);
     });
 
-    test('degenerate LIKE-wildcard searches (%, _, %%) are env-adaptive and never a 4xx', async ({
+    test('degenerate LIKE-wildcard searches (%, _, %%) return 200 and are escaped, not wildcards', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
-        await createFastIdeas(request, user.access_token, 2, `wild-${stamp()}`);
+        const created = await createFastIdeas(request, user.access_token, 2, `wild-${stamp()}`);
 
-        // Raw LIKE metacharacters are still valid INPUT (they only affect the SQL
-        // pattern) — validation passes, so the only outcomes are 200 (pg) or 500
-        // (sqlite ILIKE), never a client error.
+        // Raw LIKE metacharacters are valid INPUT — they are escaped into the
+        // pattern, so they match literally instead of acting as wildcards.
         for (const qs of ['?search=%25', '?search=_', '?search=%25%25']) {
             const res = await listRes(request, user.access_token, qs);
-            expect([200, 500], `wildcard ${qs}`).toContain(res.status());
+            expect(res.status(), `wildcard ${qs}`).toBe(200);
+            // The decisive property: an UNESCAPED `%` would match every one of
+            // the caller's Ideas (filter bypass). Escaped, it cannot.
+            const ids = ((await res.json()) as IdeaRow[]).map((r) => r.id);
+            expect(ids, `wildcard ${qs} must not return the whole own set`).not.toEqual(
+                expect.arrayContaining(created),
+            );
         }
     });
 
-    test('?search composes with ?statuses — still env-adaptive [200 | 500], never a 4xx', async ({
-        request,
-    }) => {
+    test('?search composes with ?statuses — 200, never a 4xx or 5xx', async ({ request }) => {
         const user = await registerUserViaAPI(request);
         await createFastIdeas(request, user.access_token, 2, `combo-${stamp()}`);
 
@@ -519,8 +533,7 @@ test.describe('Work-Proposals list — ?search execution', () => {
             user.access_token,
             '?statuses=pending&search=somethingHere',
         );
-        // Both fields validate cleanly; the ILIKE execution is what varies by driver.
-        expect([200, 500]).toContain(res.status());
+        expect(res.status()).toBe(200);
     });
 });
 

--- a/apps/web/e2e/flow-work-proposals-validation-authz-matrix.spec.ts
+++ b/apps/web/e2e/flow-work-proposals-validation-authz-matrix.spec.ts
@@ -61,8 +61,9 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *  GET  /api/me/work-proposals?search=…
  *    · 501 chars → 400 "search must be shorter than or equal to 500 characters"
  *      (validation fires BEFORE the handler). A ≤500 well-formed search PASSES
- *      validation but EXECUTES a Postgres ILIKE the sqlite CI stack can't run →
- *      env-adaptive [200 (pg) | 500 (sqlite ILIKE)]. Tolerated, not asserted 200.
+ *      validation and EXECUTES a portable `LOWER(col) LIKE :p ESCAPE '\'` on
+ *      every driver → 200. (It used to build a Postgres-only ILIKE and 500 on
+ *      sqlite; this spec tolerated the 500 instead of failing on it.)
  *  GET  /api/me/work-proposals?<unknown>=… → 400 "property <x> should not exist".
  *  AUTHZ: every route without a bearer → 401; a garbage bearer → 401. A stranger
  *    reading/dismissing/listing-works another user's Idea → 404 (NEVER 403), and
@@ -342,16 +343,14 @@ test.describe('Work-Proposals list — ?search validation & env-adaptive executi
             /search must be shorter than or equal to 500 characters/i,
         );
 
-        // A 500-char search is VALID input, but the repo builds a Postgres
-        // `ILIKE` predicate the sqlite in-memory CI stack can't execute → 500.
-        // On a Postgres deployment the same query is a 200. Env-adaptive: accept
-        // either, but NEVER a 4xx (the input already passed validation) other
-        // than the 500 server-error we know sqlite raises.
+        // A 500-char search is VALID input and the repo now builds a portable
+        // `LOWER(col) LIKE :p ESCAPE '\'` predicate, so this executes on the
+        // sqlite CI stack exactly as it does on a Postgres deployment → 200.
         const maxLen = await request.get(
             `${API_BASE}/api/me/work-proposals?search=${'s'.repeat(500)}`,
             { headers },
         );
-        expect([200, 500]).toContain(maxLen.status());
+        expect(maxLen.status()).toBe(200);
     });
 });
 

--- a/packages/agent/src/database/repositories/agent.repository.ts
+++ b/packages/agent/src/database/repositories/agent.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
+    Brackets,
     EntityManager,
     FindOptionsWhere,
     In,
@@ -11,7 +12,7 @@ import {
 } from 'typeorm';
 import { Agent, AgentScope, AgentStatus, type AgentTarget } from '../../entities/agent.entity';
 import { AgentMembership } from '../../entities/agent-membership.entity';
-import { sanitizeLikePattern } from '../utils';
+import { buildCaseInsensitiveLikeClause, prepareCaseInsensitiveContainsPattern } from '../utils';
 
 /**
  * Filter shape for `findByUserIdScoped`. All fields optional — caller
@@ -145,20 +146,38 @@ export class AgentRepository {
             });
         }
         if (filter.search) {
-            // Security: escape LIKE wildcards (%/_/\) in the user-supplied
-            // search term and pair each predicate with an explicit ESCAPE
-            // clause. The value is already bound, so this is not SQLi, but
-            // unescaped wildcards otherwise let a caller bypass the filter
-            // (e.g. `%`) or force an index-defeating leading-wildcard scan
-            // (DoS amplification). Mirrors work.repository.ts /
-            // activity-log.repository.ts. Escape-only (no LOWER()) preserves
-            // the existing case-sensitive matching for legitimate input.
-            qb.andWhere(
-                "(agent.name LIKE :q ESCAPE '\\' OR agent.slug LIKE :q ESCAPE '\\' OR agent.title LIKE :q ESCAPE '\\')",
-                {
-                    q: `%${sanitizeLikePattern(filter.search)}%`,
-                },
-            );
+            // Escape LIKE wildcards (%/_/\) in the user-supplied search term
+            // and pair each predicate with an explicit ESCAPE clause. The
+            // value is already bound, so this is not SQLi, but unescaped
+            // wildcards otherwise let a caller bypass the filter (e.g. `%`)
+            // or force an index-defeating leading-wildcard scan (DoS
+            // amplification).
+            //
+            // `buildCaseInsensitiveLikeClause` also folds the column with
+            // LOWER() while `prepareCaseInsensitiveContainsPattern` folds the
+            // pattern. Both halves are required: SQLite's LIKE is
+            // case-insensitive for ASCII but PostgreSQL's is not, so a bare
+            // `LIKE` matched case-SENSITIVELY in stage and production only —
+            // searching `deploy` silently missed an Agent named `Deploy Bot`,
+            // with no error and no log line. Mirrors work.repository.ts /
+            // skill.repository.ts / activity-log.repository.ts.
+            const searchPattern = prepareCaseInsensitiveContainsPattern(filter.search);
+            if (searchPattern) {
+                qb.andWhere(
+                    new Brackets((searchQb) => {
+                        searchQb
+                            .where(buildCaseInsensitiveLikeClause('agent.name', 'q'), {
+                                q: searchPattern,
+                            })
+                            .orWhere(buildCaseInsensitiveLikeClause('agent.slug', 'q'), {
+                                q: searchPattern,
+                            })
+                            .orWhere(buildCaseInsensitiveLikeClause('agent.title', 'q'), {
+                                q: searchPattern,
+                            });
+                    }),
+                );
+            }
         }
 
         const total = await qb.getCount();

--- a/packages/agent/src/database/repositories/search-case-insensitivity-sql.integration.spec.ts
+++ b/packages/agent/src/database/repositories/search-case-insensitivity-sql.integration.spec.ts
@@ -1,0 +1,347 @@
+import { DataSource, Repository } from 'typeorm';
+import { ENTITIES } from '../_entities-inventory';
+import { User } from '../../entities/user.entity';
+import { Agent, AgentScope, AgentStatus } from '../../entities/agent.entity';
+import { Task, TaskStatus } from '../../entities/task.entity';
+import { WorkKnowledgeDocument } from '../../entities/work-knowledge-document.entity';
+import { KbDocumentClass, KbDocumentStatus } from '../../entities/kb-types';
+import { AgentRepository } from './agent.repository';
+import { TaskRepository } from './task.repository';
+import { WorkKnowledgeDocumentRepository } from './work-knowledge-document.repository';
+
+/**
+ * Guard for the three search surfaces that matched case-SENSITIVELY on
+ * Postgres — i.e. in stage and production — while looking perfectly
+ * healthy in CI.
+ *
+ * SQLite's `LIKE` is case-insensitive for ASCII by default. PostgreSQL's
+ * is not. Three repositories built a bare `col LIKE :q` against a
+ * non-lowered column and paired it with a non-lowered pattern:
+ *
+ *     agent.repository.ts                    — GET /api/me/agents?search=
+ *     task.repository.ts                     — GET /api/me/tasks?search= and ?label=
+ *     work-knowledge-document.repository.ts  — KB document search (Work + Org scope)
+ *
+ * On Postgres, searching Agents for `deploy` therefore did NOT match an
+ * Agent named `Deploy Bot`. No error, no log line — just silently fewer
+ * results, the same "looks like empty data, not like a failure" signature
+ * as the `getPeriodTotals` unquoted-column bug.
+ *
+ * Why CI could never catch it: `config/index.ts` defaults `DATABASE_TYPE`
+ * to `better-sqlite3`, so unit specs AND the Playwright e2e stack both run
+ * SQLite. A behavioural assertion on SQLite passes for the WRONG reason —
+ * the driver is case-insensitive, so the defective query returns the right
+ * answer there and only there.
+ *
+ * This spec closes that hole two independent ways:
+ *
+ *  1. `PRAGMA case_sensitive_like = ON` makes SQLite's `LIKE` behave
+ *     exactly like Postgres's, so the behavioural assertions below really
+ *     do execute the production semantics. The first test is a control
+ *     that proves the pragma took effect — without it, every "found the
+ *     mixed-case row" assertion would be a false clean.
+ *  2. Assertions on the emitted SQL text, which is driver-independent:
+ *     every searched column must be wrapped in `LOWER(...)` AND the bound
+ *     pattern must itself be lower-cased. Lowering only one side is still
+ *     case-sensitive.
+ *
+ * Reverting any of the three repositories to a bare `LIKE` fails this spec.
+ */
+describe('search predicates are case-insensitive on Postgres semantics (integration)', () => {
+    let dataSource: DataSource;
+    let captured: Array<{ query: string; parameters?: unknown[] }>;
+
+    let users: Repository<User>;
+    let agents: Repository<Agent>;
+    let tasks: Repository<Task>;
+    let kbDocs: Repository<WorkKnowledgeDocument>;
+
+    let agentRepository: AgentRepository;
+    let taskRepository: TaskRepository;
+    let kbRepository: WorkKnowledgeDocumentRepository;
+
+    let userId: string;
+
+    const ORG_ID = '33333333-3333-4333-8333-333333333333';
+
+    beforeAll(async () => {
+        captured = [];
+
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+            logging: ['query'],
+            logger: {
+                logQuery: (query: string, parameters?: unknown[]) =>
+                    captured.push({ query, parameters }),
+                logQueryError: () => undefined,
+                logQuerySlow: () => undefined,
+                logSchemaBuild: () => undefined,
+                logMigration: () => undefined,
+                log: () => undefined,
+            },
+        });
+
+        await dataSource.initialize();
+
+        // The whole point of this spec: make SQLite's LIKE case-SENSITIVE so
+        // it matches PostgreSQL. Without this the defective queries below
+        // return the correct rows and nothing can fail.
+        await dataSource.query('PRAGMA case_sensitive_like = ON');
+
+        users = dataSource.getRepository(User);
+        agents = dataSource.getRepository(Agent);
+        tasks = dataSource.getRepository(Task);
+        kbDocs = dataSource.getRepository(WorkKnowledgeDocument);
+
+        agentRepository = new AgentRepository(agents);
+        taskRepository = new TaskRepository(tasks);
+        kbRepository = new WorkKnowledgeDocumentRepository(kbDocs);
+
+        const user = await users.save(
+            users.create({
+                username: 'searcher',
+                email: 'searcher@example.com',
+                password: 'x',
+            } as Partial<User>),
+        );
+        userId = user.id;
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    beforeEach(() => {
+        captured.length = 0;
+    });
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    const escapeRe = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    /** The statement that actually carries the user's search predicate. */
+    const searchStatement = (table: string) => {
+        const entry = captured.find((c) => c.query.includes(table) && / LIKE /i.test(c.query));
+        expect(entry).toBeDefined();
+        return entry!;
+    };
+
+    /**
+     * The decisive, driver-independent assertion. A column is only matched
+     * case-insensitively when BOTH sides are folded: `LOWER(col) LIKE
+     * '%lowered%'`. This checks the column half; `expectLoweredPattern`
+     * checks the parameter half.
+     */
+    const expectLoweredLike = (sql: string, alias: string, column: string) => {
+        const quoted = `"${alias}"."${column}"`;
+
+        // Control: the statement really does reference this column, so a
+        // passing test below cannot be one that simply matched nothing.
+        expect(sql).toContain(quoted);
+
+        expect(sql).toContain(`LOWER(${quoted}) LIKE`);
+        // The defect: a LIKE applied straight to the un-folded column.
+        expect(sql).not.toMatch(new RegExp(`(?<!LOWER\\()${escapeRe(quoted)}\\s+LIKE`, 'i'));
+    };
+
+    const expectLoweredPattern = (parameters: unknown[] | undefined, expected: string) => {
+        expect(parameters).toBeDefined();
+        expect(parameters).toContain(expected);
+    };
+
+    // ── control ──────────────────────────────────────────────────────────
+
+    it('CONTROL: the pragma is in effect, so a bare LIKE is case-sensitive here', async () => {
+        const [bare] = (await dataSource.query(
+            `SELECT ('Deploy Bot' LIKE '%deploy%') AS hit`,
+        )) as Array<{ hit: number }>;
+        // 0 → this connection now behaves like Postgres. If this ever reads 1
+        // the pragma silently failed and every assertion below is worthless.
+        expect(bare.hit).toBe(0);
+
+        const [folded] = (await dataSource.query(
+            `SELECT (LOWER('Deploy Bot') LIKE '%deploy%') AS hit`,
+        )) as Array<{ hit: number }>;
+        expect(folded.hit).toBe(1);
+    });
+
+    // ── agents ───────────────────────────────────────────────────────────
+
+    describe('AgentRepository.findByUserIdScoped', () => {
+        beforeAll(async () => {
+            await agents.save(
+                agents.create({
+                    userId,
+                    scope: AgentScope.TENANT,
+                    name: 'Deploy Bot',
+                    slug: 'Deploy-Bot',
+                    title: 'Release Captain',
+                    status: AgentStatus.ACTIVE,
+                    permissions: {},
+                } as Partial<Agent>),
+            );
+        });
+
+        it('finds a mixed-case name from a lower-case query', async () => {
+            const { rows } = await agentRepository.findByUserIdScoped(userId, {
+                search: 'deploy',
+            });
+            expect(rows.map((r) => r.name)).toContain('Deploy Bot');
+        });
+
+        it('finds a lower-case query term from a mixed-case query', async () => {
+            const { rows } = await agentRepository.findByUserIdScoped(userId, {
+                search: 'RELEASE captain',
+            });
+            expect(rows.map((r) => r.name)).toContain('Deploy Bot');
+        });
+
+        it('emits LOWER() on every searched column and a lower-cased pattern', async () => {
+            await agentRepository.findByUserIdScoped(userId, { search: 'DePloy' });
+
+            const { query, parameters } = searchStatement('agents');
+            expectLoweredLike(query, 'agent', 'name');
+            expectLoweredLike(query, 'agent', 'slug');
+            expectLoweredLike(query, 'agent', 'title');
+            expectLoweredPattern(parameters, '%deploy%');
+        });
+    });
+
+    // ── tasks ────────────────────────────────────────────────────────────
+
+    describe('TaskRepository.findByUserIdFiltered', () => {
+        beforeAll(async () => {
+            await tasks.save(
+                tasks.create({
+                    userId,
+                    slug: 'T-1',
+                    title: 'Ship The Release',
+                    description: 'Cut A Tag',
+                    status: TaskStatus.BACKLOG,
+                    labels: ['Bug', 'Ops'],
+                    createdByType: 'user',
+                    createdById: userId,
+                } as Partial<Task>),
+            );
+        });
+
+        it('finds a mixed-case title from a lower-case query', async () => {
+            const { rows } = await taskRepository.findByUserIdFiltered(userId, {
+                search: 'ship the release',
+            });
+            expect(rows.map((r) => r.slug)).toContain('T-1');
+        });
+
+        it('finds a mixed-case label from a lower-case ?label filter', async () => {
+            const { rows } = await taskRepository.findByUserIdFiltered(userId, { label: 'bug' });
+            expect(rows.map((r) => r.slug)).toContain('T-1');
+        });
+
+        it('still scopes the label filter to a whole JSON token', async () => {
+            // `"bu"` must not match the stored `"Bug"` — case folding must not
+            // widen the quoted-token boundary into a substring match.
+            const { rows } = await taskRepository.findByUserIdFiltered(userId, { label: 'bu' });
+            expect(rows).toHaveLength(0);
+        });
+
+        it('emits LOWER() on every searched column and a lower-cased pattern', async () => {
+            await taskRepository.findByUserIdFiltered(userId, { search: 'Ship' });
+
+            const { query, parameters } = searchStatement('tasks');
+            expectLoweredLike(query, 'task', 'title');
+            expectLoweredLike(query, 'task', 'slug');
+            expectLoweredLike(query, 'task', 'description');
+            expectLoweredPattern(parameters, '%ship%');
+        });
+
+        it('emits LOWER() on the labels column and a lower-cased token pattern', async () => {
+            await taskRepository.findByUserIdFiltered(userId, { label: 'Bug' });
+
+            const { query, parameters } = searchStatement('tasks');
+            expectLoweredLike(query, 'task', 'labels');
+            expectLoweredPattern(parameters, '%"bug"%');
+        });
+    });
+
+    // ── knowledge-base documents ─────────────────────────────────────────
+
+    describe('WorkKnowledgeDocumentRepository search', () => {
+        beforeAll(async () => {
+            await kbDocs.save(
+                kbDocs.create({
+                    organizationId: ORG_ID,
+                    workId: null,
+                    path: 'brand/Voice.md',
+                    slug: 'voice',
+                    title: 'Brand Voice Guide',
+                    description: 'How We Write',
+                    kbDocumentClass: KbDocumentClass.STYLE,
+                    status: KbDocumentStatus.ACTIVE,
+                    metadata: { body: 'Prefer Plain English.' },
+                } as Partial<WorkKnowledgeDocument>),
+            );
+        });
+
+        it('finds a mixed-case title from a lower-case query', async () => {
+            const { items } = await kbRepository.list({ organizationId: ORG_ID, q: 'brand voice' });
+            expect(items.map((d) => d.slug)).toContain('voice');
+        });
+
+        it('finds a mixed-case body from a lower-case query when searchBody is on', async () => {
+            const { items } = await kbRepository.list({
+                organizationId: ORG_ID,
+                q: 'plain english',
+                searchBody: true,
+            });
+            expect(items.map((d) => d.slug)).toContain('voice');
+        });
+
+        it('finds a mixed-case title through the org-aggregate feed', async () => {
+            const { items } = await kbRepository.listForOrgAggregate({
+                organizationId: ORG_ID,
+                q: 'brand voice',
+            });
+            expect(items.map((d) => d.slug)).toContain('voice');
+        });
+
+        it('emits LOWER() on title/description and a lower-cased pattern (list)', async () => {
+            await kbRepository.list({ organizationId: ORG_ID, q: 'Brand' });
+
+            const { query, parameters } = searchStatement('work_knowledge_documents');
+            expectLoweredLike(query, 'doc', 'title');
+            expectLoweredLike(query, 'doc', 'description');
+            expectLoweredPattern(parameters, '%brand%');
+        });
+
+        it('emits LOWER() on the metadata column too when searchBody is on', async () => {
+            await kbRepository.list({ organizationId: ORG_ID, q: 'Plain', searchBody: true });
+
+            const { query, parameters } = searchStatement('work_knowledge_documents');
+            expectLoweredLike(query, 'doc', 'metadata');
+            expectLoweredPattern(parameters, '%plain%');
+        });
+
+        it('emits LOWER() on title/description in the org-aggregate scope', async () => {
+            await kbRepository.listForOrgAggregate({ organizationId: ORG_ID, q: 'Brand' });
+
+            const { query, parameters } = searchStatement('work_knowledge_documents');
+            expectLoweredLike(query, 'doc', 'title');
+            expectLoweredLike(query, 'doc', 'description');
+            expectLoweredPattern(parameters, '%brand%');
+        });
+    });
+
+    // ── the escaping contract the previous code already got right ────────
+
+    it('still escapes LIKE metacharacters so `%` cannot bypass the filter', async () => {
+        const { rows } = await agentRepository.findByUserIdScoped(userId, { search: '%' });
+        // A literal `%` matches no agent name; an unescaped one would match all.
+        expect(rows).toHaveLength(0);
+
+        const { query } = searchStatement('agents');
+        expect(query).toMatch(/ESCAPE/i);
+    });
+});

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -1,8 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { LessThanOrEqual, Repository } from 'typeorm';
+import { Brackets, LessThanOrEqual, Repository } from 'typeorm';
 import { Task, TaskStatus } from '../../entities/task.entity';
-import { sanitizeLikePattern } from '../utils';
+import {
+    buildCaseInsensitiveLikeClause,
+    prepareCaseInsensitiveContainsPattern,
+    sanitizeLikePattern,
+} from '../utils';
 
 export interface ListTasksFilter {
     status?: TaskStatus | TaskStatus[];
@@ -145,19 +149,35 @@ export class TaskRepository {
             qb.andWhere('task.parentTaskId = :parentTaskId', { parentTaskId: filter.parentTaskId });
 
         if (filter.search) {
-            // Security: escape LIKE wildcards (%/_/\) in the user-supplied
-            // search term and pair each predicate with an explicit ESCAPE
-            // clause. The value is already bound, so this is not SQLi, but
-            // unescaped wildcards otherwise let a caller bypass the filter
-            // (e.g. `%`) or force an index-defeating leading-wildcard scan.
-            // Mirrors agent.repository.ts. Escape-only (no LOWER()) preserves
-            // the existing case-sensitive matching for legitimate input.
-            qb.andWhere(
-                "(task.title LIKE :q ESCAPE '\\' OR task.slug LIKE :q ESCAPE '\\' OR task.description LIKE :q ESCAPE '\\')",
-                {
-                    q: `%${sanitizeLikePattern(filter.search)}%`,
-                },
-            );
+            // Escape LIKE wildcards (%/_/\) in the user-supplied search term
+            // and pair each predicate with an explicit ESCAPE clause. The
+            // value is already bound, so this is not SQLi, but unescaped
+            // wildcards otherwise let a caller bypass the filter (e.g. `%`)
+            // or force an index-defeating leading-wildcard scan.
+            //
+            // Both the column (LOWER(), via `buildCaseInsensitiveLikeClause`)
+            // and the pattern (via `prepareCaseInsensitiveContainsPattern`)
+            // are folded — a bare LIKE is case-SENSITIVE on PostgreSQL and
+            // case-INSENSITIVE on SQLite, so the previous clause silently
+            // returned fewer rows in stage and production than it did in CI.
+            // Mirrors agent.repository.ts / work.repository.ts.
+            const searchPattern = prepareCaseInsensitiveContainsPattern(filter.search);
+            if (searchPattern) {
+                qb.andWhere(
+                    new Brackets((searchQb) => {
+                        searchQb
+                            .where(buildCaseInsensitiveLikeClause('task.title', 'q'), {
+                                q: searchPattern,
+                            })
+                            .orWhere(buildCaseInsensitiveLikeClause('task.slug', 'q'), {
+                                q: searchPattern,
+                            })
+                            .orWhere(buildCaseInsensitiveLikeClause('task.description', 'q'), {
+                                q: searchPattern,
+                            });
+                    }),
+                );
+            }
         }
 
         // `labels` is a simple-json array; we hit it as a substring match
@@ -168,10 +188,15 @@ export class TaskRepository {
             // label before wrapping it in the `"<label>"` JSON-token match,
             // and add an explicit ESCAPE clause. Bound param (not SQLi), but
             // unescaped wildcards would let `%` match every labelled task and
-            // break out of the intended quoted-token boundary. Escape-only
-            // preserves the exact match for legitimate, wildcard-free labels.
-            qb.andWhere("task.labels LIKE :label ESCAPE '\\'", {
-                label: `%"${sanitizeLikePattern(filter.label)}"%`,
+            // break out of the intended quoted-token boundary.
+            //
+            // BOTH sides are lower-cased so the filter behaves identically on
+            // PostgreSQL and SQLite: `?label=bug` previously did not match the
+            // stored label `Bug` in stage or production, while matching fine
+            // in CI. The surrounding `"` quotes are preserved, so folding case
+            // does not widen the match from a whole JSON token to a substring.
+            qb.andWhere(buildCaseInsensitiveLikeClause('task.labels', 'label'), {
+                label: `%"${sanitizeLikePattern(filter.label).toLowerCase()}"%`,
             });
         }
 

--- a/packages/agent/src/database/repositories/work-knowledge-document.metadata-key.integration.spec.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.metadata-key.integration.spec.ts
@@ -1,0 +1,172 @@
+import { DataSource, Repository } from 'typeorm';
+import { ENTITIES } from '../_entities-inventory';
+import { User } from '../../entities/user.entity';
+import { Work } from '../../entities/work.entity';
+import { WorkKnowledgeDocument } from '../../entities/work-knowledge-document.entity';
+import { KbDocumentClass, KbDocumentStatus } from '../../entities/kb-types';
+import { WorkKnowledgeDocumentRepository } from './work-knowledge-document.repository';
+
+/**
+ * Guard for `findByMetadataKey` — the transcribe idempotency check.
+ *
+ * The predicate was `(doc.metadata::jsonb) ->> :key = :value`. Both `::`
+ * and `->>` are PostgreSQL-only, so the statement is a syntax error on
+ * SQLite and the whole transcribe pipeline crashed at the point that is
+ * supposed to stop a Trigger.dev retry creating a duplicate transcript.
+ *
+ * Nothing could catch it: the method's own docstring conceded the gap
+ * ("the test DB uses an in-memory mock at the repo layer (no SQL is
+ * exercised)") and `knowledge-base-transcribe.service.spec.ts` mocks
+ * `findByMetadataKey` outright.
+ *
+ * The fix follows the precedent already in this codebase —
+ * `work-knowledge-chunk.repository.ts` branches on
+ * `manager.connection.options.type` for its pgvector query. Postgres keeps
+ * the indexed `jsonb` path; every other driver gets a portable pre-filter
+ * plus an exact in-JS comparison.
+ *
+ * Both halves are tested: the SQLite path by execution, the Postgres path
+ * by asserting the emitted clause still carries the cast (a mocked
+ * connection is the only way to reach it without a live Postgres).
+ */
+describe('WorkKnowledgeDocumentRepository.findByMetadataKey (integration)', () => {
+    const UPLOAD_ID = 'upload-abc-123';
+
+    describe('on better-sqlite3 (demo / OSS self-host / CI)', () => {
+        let dataSource: DataSource;
+        let kbDocs: Repository<WorkKnowledgeDocument>;
+        let repository: WorkKnowledgeDocumentRepository;
+        let workId: string;
+        let otherWorkId: string;
+
+        beforeAll(async () => {
+            dataSource = new DataSource({
+                type: 'better-sqlite3',
+                database: ':memory:',
+                entities: ENTITIES,
+                synchronize: true,
+            });
+            await dataSource.initialize();
+
+            kbDocs = dataSource.getRepository(WorkKnowledgeDocument);
+            repository = new WorkKnowledgeDocumentRepository(kbDocs);
+
+            const users = dataSource.getRepository(User);
+            const user = await users.save(
+                users.create({
+                    username: 'transcriber',
+                    email: 'transcriber@example.com',
+                    password: 'x',
+                } as Partial<User>),
+            );
+
+            const works = dataSource.getRepository(Work);
+            const makeWork = async (slug: string) =>
+                (
+                    await works.save(
+                        works.create({
+                            userId: user.id,
+                            name: slug,
+                            slug,
+                            description: slug,
+                        } as Partial<Work>),
+                    )
+                ).id;
+
+            workId = await makeWork('primary-work');
+            otherWorkId = await makeWork('other-work');
+
+            const seed = (
+                path: string,
+                metadata: Record<string, unknown> | null,
+                owner: string = workId,
+            ) =>
+                kbDocs.save(
+                    kbDocs.create({
+                        workId: owner,
+                        path,
+                        slug: path.replace(/\W+/g, '-'),
+                        title: path,
+                        kbDocumentClass: KbDocumentClass.FREEFORM,
+                        status: KbDocumentStatus.ACTIVE,
+                        metadata,
+                    } as Partial<WorkKnowledgeDocument>),
+                );
+
+            await seed('transcripts/one.md', { transcribedFromUploadId: UPLOAD_ID, lang: 'en' });
+            await seed('transcripts/two.md', { transcribedFromUploadId: 'upload-other' });
+            await seed('notes/plain.md', null);
+            // Same metadata value, different Work — must never leak across scope.
+            await seed(
+                'transcripts/other-work.md',
+                { transcribedFromUploadId: UPLOAD_ID },
+                otherWorkId,
+            );
+        });
+
+        afterAll(async () => {
+            if (dataSource?.isInitialized) await dataSource.destroy();
+        });
+
+        it('finds the document whose metadata key holds the value', async () => {
+            const found = await repository.findByMetadataKey(
+                workId,
+                'transcribedFromUploadId',
+                UPLOAD_ID,
+            );
+            expect(found?.path).toBe('transcripts/one.md');
+        });
+
+        it('returns null when no document carries that value', async () => {
+            const found = await repository.findByMetadataKey(
+                workId,
+                'transcribedFromUploadId',
+                'upload-never-seen',
+            );
+            expect(found).toBeNull();
+        });
+
+        it('does not match a different key that happens to hold the same value', async () => {
+            const found = await repository.findByMetadataKey(workId, 'lang', UPLOAD_ID);
+            expect(found).toBeNull();
+        });
+
+        it('stays scoped to the Work — an identical value elsewhere is a different row', async () => {
+            const found = await repository.findByMetadataKey(
+                otherWorkId,
+                'transcribedFromUploadId',
+                UPLOAD_ID,
+            );
+            expect(found?.path).toBe('transcripts/other-work.md');
+        });
+    });
+
+    describe('on postgres', () => {
+        it('keeps the indexed jsonb predicate', async () => {
+            const clauses: string[] = [];
+            const qb = {
+                where: jest.fn(() => qb),
+                andWhere: jest.fn((clause: string) => {
+                    clauses.push(clause);
+                    return qb;
+                }),
+                getOne: jest.fn(async () => null),
+                getMany: jest.fn(async () => []),
+            };
+            const fake = {
+                createQueryBuilder: jest.fn(() => qb),
+                manager: { connection: { options: { type: 'postgres' } } },
+            } as unknown as Repository<WorkKnowledgeDocument>;
+
+            const repository = new WorkKnowledgeDocumentRepository(fake);
+            await repository.findByMetadataKey(
+                '44444444-4444-4444-8444-444444444444',
+                'transcribedFromUploadId',
+                UPLOAD_ID,
+            );
+
+            expect(clauses.join(' | ')).toContain('::jsonb');
+            expect(clauses.join(' | ')).toContain('->>');
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
@@ -10,7 +10,11 @@ import {
     KbLockMode,
     KbReviewState,
 } from '../../entities/kb-types';
-import { sanitizeLikePattern } from '../utils';
+import {
+    buildCaseInsensitiveLikeClause,
+    prepareCaseInsensitiveContainsPattern,
+    sanitizeLikePattern,
+} from '../utils';
 
 export interface KbDocumentListOptions {
     workId?: string;
@@ -121,28 +125,53 @@ export class WorkKnowledgeDocumentRepository {
      * for idempotency on `metadata.transcribedFromUploadId` so a
      * Trigger.dev retry never produces a duplicate transcript document.
      *
-     * The `metadata` column is `text` (TypeORM `simple-json`), not
-     * `jsonb`, so we must cast before applying `->>` — otherwise
-     * PostgreSQL throws `operator does not exist: text ->> unknown`
-     * and the entire transcribe pipeline crashes at the idempotency
-     * check (Greptile P2 on PR #1219). The cast is cheap and runs
-     * once per query. SQLite + Postgres path-pick differs but the
-     * `simple-json` columnar comparison still works because TypeORM
-     * stringifies on read and `LIKE` matches the JSON literal —
-     * we use the Postgres-shaped query because the production DB
-     * is Postgres; the test DB uses an in-memory mock at the repo
-     * layer (no SQL is exercised).
+     * Driver-branched, exactly like `work-knowledge-chunk.repository.ts`
+     * does for its pgvector query:
+     *
+     * - **PostgreSQL.** The `metadata` column is `text` (TypeORM
+     *   `simple-json`), not `jsonb`, so it must be cast before applying
+     *   `->>` — otherwise PostgreSQL throws
+     *   `operator does not exist: text ->> unknown` and the whole
+     *   transcribe pipeline crashes at the idempotency check (Greptile P2
+     *   on PR #1219). The cast is cheap and runs once per query.
+     * - **Everything else** (SQLite: demo, OSS self-host, local dev, CI).
+     *   `::` and `->>` are PostgreSQL-only syntax, so the statement above
+     *   is a hard syntax error there — the transcribe pipeline used to die
+     *   at exactly the check that is supposed to make it retry-safe. The
+     *   portable path narrows candidates with a LIKE over the serialized
+     *   JSON, then compares the parsed value in JS. The LIKE is only a
+     *   pre-filter (it looks for the JSON-encoded VALUE, so it is immune
+     *   to key ordering and whitespace); the in-JS `===` is authoritative,
+     *   so a nested or same-valued-different-key document cannot produce a
+     *   false positive.
      */
     async findByMetadataKey(
         workId: string,
         key: string,
         value: string,
     ): Promise<WorkKnowledgeDocument | null> {
-        return this.repository
+        const driverType = this.repository.manager.connection.options.type;
+
+        if (driverType === 'postgres') {
+            return this.repository
+                .createQueryBuilder('doc')
+                .where('doc.workId = :workId', { workId })
+                .andWhere(`(doc.metadata::jsonb) ->> :key = :value`, { key, value })
+                .getOne();
+        }
+
+        const candidates = await this.repository
             .createQueryBuilder('doc')
             .where('doc.workId = :workId', { workId })
-            .andWhere(`(doc.metadata::jsonb) ->> :key = :value`, { key, value })
-            .getOne();
+            .andWhere(buildCaseInsensitiveLikeClause('doc.metadata', 'metadataMarker'), {
+                // `JSON.stringify` produces exactly the encoding TypeORM's
+                // `simple-json` writes, so the encoded value is a substring of
+                // the stored text whenever the document really carries it.
+                metadataMarker: `%${sanitizeLikePattern(JSON.stringify(value)).toLowerCase()}%`,
+            })
+            .getMany();
+
+        return candidates.find((doc) => doc.metadata?.[key] === value) ?? null;
     }
 
     /**
@@ -259,14 +288,33 @@ export class WorkKnowledgeDocumentRepository {
             // unescaped wildcards otherwise let a caller bypass the filter
             // (e.g. `%`) or force an index-defeating leading-wildcard scan
             // (DoS amplification within the caller's authorized Work/Org).
-            // Mirrors agent.repository.ts; escape-only (no LOWER()) preserves
-            // the existing matching for legitimate input.
-            const predicate = opts.searchBody
-                ? "(doc.title LIKE :q ESCAPE '\\' OR doc.description LIKE :q ESCAPE '\\' OR doc.metadata LIKE :q ESCAPE '\\')"
-                : "(doc.title LIKE :q ESCAPE '\\' OR doc.description LIKE :q ESCAPE '\\')";
-            qb.andWhere(predicate, {
-                q: `%${sanitizeLikePattern(opts.q)}%`,
-            });
+            //
+            // Both sides are lower-cased (LOWER() on the column via
+            // `buildCaseInsensitiveLikeClause`, `.toLowerCase()` on the
+            // pattern via `prepareCaseInsensitiveContainsPattern`). SQLite's
+            // LIKE folds ASCII case for free; PostgreSQL's does not, so the
+            // previous bare LIKE made KB search case-SENSITIVE in stage and
+            // production while CI (SQLite) saw the correct results.
+            // Mirrors agent.repository.ts / work.repository.ts.
+            const searchPattern = prepareCaseInsensitiveContainsPattern(opts.q);
+            if (searchPattern) {
+                qb.andWhere(
+                    new Brackets((searchQb) => {
+                        searchQb
+                            .where(buildCaseInsensitiveLikeClause('doc.title', 'q'), {
+                                q: searchPattern,
+                            })
+                            .orWhere(buildCaseInsensitiveLikeClause('doc.description', 'q'), {
+                                q: searchPattern,
+                            });
+                        if (opts.searchBody) {
+                            searchQb.orWhere(buildCaseInsensitiveLikeClause('doc.metadata', 'q'), {
+                                q: searchPattern,
+                            });
+                        }
+                    }),
+                );
+            }
         }
 
         qb.orderBy('doc.updatedAt', 'DESC');
@@ -326,10 +374,22 @@ export class WorkKnowledgeDocumentRepository {
             // pair each predicate with an explicit ESCAPE clause — mirrors
             // `list()` above. Value is bound (not SQLi); escaping stops a
             // caller bypassing the filter or forcing a leading-wildcard scan.
-            qb.andWhere(
-                "(doc.title LIKE :aggQ ESCAPE '\\' OR doc.description LIKE :aggQ ESCAPE '\\')",
-                { aggQ: `%${sanitizeLikePattern(opts.q)}%` },
-            );
+            // Case-folded on both sides for the same PostgreSQL-vs-SQLite
+            // reason documented in `list()`.
+            const searchPattern = prepareCaseInsensitiveContainsPattern(opts.q);
+            if (searchPattern) {
+                qb.andWhere(
+                    new Brackets((searchQb) => {
+                        searchQb
+                            .where(buildCaseInsensitiveLikeClause('doc.title', 'aggQ'), {
+                                aggQ: searchPattern,
+                            })
+                            .orWhere(buildCaseInsensitiveLikeClause('doc.description', 'aggQ'), {
+                                aggQ: searchPattern,
+                            });
+                    }),
+                );
+            }
         }
     }
 

--- a/packages/agent/src/user-research/__tests__/work-proposal.search-portability.integration.spec.ts
+++ b/packages/agent/src/user-research/__tests__/work-proposal.search-portability.integration.spec.ts
@@ -1,0 +1,170 @@
+import { DataSource, Repository } from 'typeorm';
+import { ENTITIES } from '../../database/_entities-inventory';
+import { User } from '../../entities/user.entity';
+import {
+    WorkProposal,
+    WorkProposalSource,
+    WorkProposalStatus,
+} from '../../entities/work-proposal.entity';
+import { WorkProposalRepository } from '../work-proposal.repository';
+
+/**
+ * Guard for the Ideas search path — the ONE search surface in the monorepo
+ * that used PostgreSQL's `ILIKE` with no driver guard.
+ *
+ *     GET /api/me/work-proposals?search=<term>
+ *
+ * `ILIKE` does not exist in SQLite, so the query threw and the endpoint
+ * returned a raw 500 on every SQLite-backed deployment — the demo stack,
+ * OSS self-hosts, and local dev. The /ideas page rendered its
+ * "Could not load Ideas." alert instead of results.
+ *
+ * The e2e suite did not fail on this; it ENCODED the breakage as the
+ * contract, asserting `expect([200, 500]).toContain(res.status())`. A test
+ * that accepts a 500 cannot fail when the 500 spreads, so those assertions
+ * are tightened to 200 alongside this fix.
+ *
+ * Secondary defect fixed at the same time: this was also the only search
+ * path that skipped `sanitizeLikePattern`, so `?search=%` matched every
+ * row instead of matching a literal percent sign.
+ *
+ * Routing the clause through `buildCaseInsensitiveLikeClause` fixes both
+ * the portability defect and the case-sensitivity defect with one
+ * mechanism: `LOWER(col) LIKE :p ESCAPE '\'` runs on Postgres, MySQL and
+ * SQLite and is case-insensitive on all three.
+ */
+describe('WorkProposalRepository.findByUser — search runs on SQLite too (integration)', () => {
+    let dataSource: DataSource;
+    let captured: Array<{ query: string; parameters?: unknown[] }>;
+
+    let users: Repository<User>;
+    let proposals: Repository<WorkProposal>;
+    let repository: WorkProposalRepository;
+
+    let userId: string;
+
+    beforeAll(async () => {
+        captured = [];
+
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+            logging: ['query'],
+            logger: {
+                logQuery: (query: string, parameters?: unknown[]) =>
+                    captured.push({ query, parameters }),
+                logQueryError: () => undefined,
+                logQuerySlow: () => undefined,
+                logSchemaBuild: () => undefined,
+                logMigration: () => undefined,
+                log: () => undefined,
+            },
+        });
+
+        await dataSource.initialize();
+
+        // Same trick as `search-case-insensitivity-sql.integration.spec.ts`:
+        // make SQLite's LIKE case-SENSITIVE so the case-insensitivity
+        // assertions below execute PostgreSQL's semantics rather than
+        // SQLite's forgiving default.
+        await dataSource.query('PRAGMA case_sensitive_like = ON');
+
+        users = dataSource.getRepository(User);
+        proposals = dataSource.getRepository(WorkProposal);
+        repository = new WorkProposalRepository(proposals);
+
+        const user = await users.save(
+            users.create({
+                username: 'ideator',
+                email: 'ideator@example.com',
+                password: 'x',
+            } as Partial<User>),
+        );
+        userId = user.id;
+
+        const seed = (title: string, description: string) =>
+            proposals.save(
+                proposals.create({
+                    userId,
+                    title,
+                    description,
+                    slugSuggestion: title.toLowerCase().replace(/\s+/g, '-'),
+                    suggestedCategories: [],
+                    suggestedFields: [],
+                    recommendedPlugins: [],
+                    generatedPrompt: description,
+                    reasoning: 'seed',
+                    source: WorkProposalSource.USER_MANUAL,
+                    status: WorkProposalStatus.PENDING,
+                } as Partial<WorkProposal>),
+            );
+
+        await seed('Deploy Bot Directory', 'A Curated List Of Release Tooling.');
+        await seed('Unrelated Idea', 'Nothing To See Here.');
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    beforeEach(() => {
+        captured.length = 0;
+    });
+
+    it('CONTROL: the pragma is in effect, so a bare LIKE is case-sensitive here', async () => {
+        const [bare] = (await dataSource.query(
+            `SELECT ('Deploy Bot' LIKE '%deploy%') AS hit`,
+        )) as Array<{ hit: number }>;
+        expect(bare.hit).toBe(0);
+    });
+
+    it('executes a search instead of throwing (no ILIKE anywhere in the SQL)', async () => {
+        const rows = await repository.findByUser(userId, [WorkProposalStatus.PENDING], {
+            search: 'deploy',
+        });
+
+        expect(rows.map((r) => r.title)).toEqual(['Deploy Bot Directory']);
+
+        const statement = captured.find((c) => c.query.includes('work_proposals'));
+        expect(statement).toBeDefined();
+        // Control: this really is the search statement.
+        expect(statement!.query).toMatch(/ LIKE /i);
+        expect(statement!.query).not.toMatch(/ILIKE/i);
+    });
+
+    it('matches a mixed-case description from a lower-case term', async () => {
+        const rows = await repository.findByUser(userId, [WorkProposalStatus.PENDING], {
+            search: 'release tooling',
+        });
+        expect(rows.map((r) => r.title)).toEqual(['Deploy Bot Directory']);
+    });
+
+    it('lowers both the column and the bound pattern', async () => {
+        await repository.findByUser(userId, [WorkProposalStatus.PENDING], { search: 'DePloy' });
+
+        const statement = captured.find(
+            (c) => c.query.includes('work_proposals') && / LIKE /i.test(c.query),
+        );
+        expect(statement).toBeDefined();
+        expect(statement!.query).toContain('LOWER("p"."title") LIKE');
+        expect(statement!.query).toContain('LOWER("p"."description") LIKE');
+        expect(statement!.parameters).toContain('%deploy%');
+    });
+
+    it('escapes LIKE metacharacters so `?search=%` cannot match every row', async () => {
+        const rows = await repository.findByUser(userId, [WorkProposalStatus.PENDING], {
+            search: '%',
+        });
+        // A literal percent sign appears in neither seeded Idea.
+        expect(rows).toHaveLength(0);
+    });
+
+    it('still treats a whitespace-only search as a no-op (unfiltered own set)', async () => {
+        const rows = await repository.findByUser(userId, [WorkProposalStatus.PENDING], {
+            search: '   ',
+        });
+        expect(rows).toHaveLength(2);
+    });
+});

--- a/packages/agent/src/user-research/work-proposal.repository.ts
+++ b/packages/agent/src/user-research/work-proposal.repository.ts
@@ -10,6 +10,10 @@ import {
     type WorkProposalField,
     type WorkProposalRecommendedPlugin,
 } from '../entities/work-proposal.entity';
+import {
+    buildCaseInsensitiveLikeClause,
+    prepareCaseInsensitiveContainsPattern,
+} from '../database/utils';
 
 export interface CreateWorkProposalInput {
     userId: string;
@@ -75,13 +79,29 @@ export class WorkProposalRepository {
             qb.andWhere('p.missionId = :missionId', { missionId: opts.missionId });
         }
 
-        const search = opts.search?.trim();
-        if (search) {
+        // `ILIKE` is PostgreSQL-only. SQLite has no such operator, so the
+        // previous clause threw and `GET /api/me/work-proposals?search=`
+        // returned a raw 500 on every SQLite-backed deployment (demo, OSS
+        // self-host, local dev) — the /ideas page rendered its
+        // "Could not load Ideas." alert instead of results.
+        //
+        // `buildCaseInsensitiveLikeClause` emits `LOWER(col) LIKE :p ESCAPE
+        // '\'`, which runs on PostgreSQL, MySQL and SQLite alike and is
+        // case-insensitive on all three — the same mechanism every other
+        // search surface in the repo already uses.
+        //
+        // It also closes a second gap: this was the only search path that
+        // skipped `sanitizeLikePattern`, so `?search=%` matched every row
+        // instead of a literal percent sign.
+        const searchPattern = prepareCaseInsensitiveContainsPattern(opts.search);
+        if (searchPattern) {
             qb.andWhere(
                 new Brackets((subQb) => {
                     subQb
-                        .where('p.title ILIKE :search', { search: `%${search}%` })
-                        .orWhere('p.description ILIKE :search', { search: `%${search}%` });
+                        .where(buildCaseInsensitiveLikeClause('p.title'), { search: searchPattern })
+                        .orWhere(buildCaseInsensitiveLikeClause('p.description'), {
+                            search: searchPattern,
+                        });
                 }),
             );
         }


### PR DESCRIPTION
Three confirmed PostgreSQL-vs-SQLite divergences in `packages/agent`, none of
which any existing test could fail on.

## Why CI could never catch any of them

`packages/agent/src/config/index.ts` defaults `DATABASE_TYPE` to
**`better-sqlite3`**. The Jest suite *and* the Playwright e2e stack both run
SQLite; stage and production run PostgreSQL. Every defect below lives exactly
in the gap between the two drivers, so the test driver is structurally
incapable of observing it — and for defect 1 the SQLite result is *correct*,
just for the wrong reason, which is worse than a hard failure.

---

## Defect 1 — search was case-SENSITIVE in production only (HIGH)

SQLite's `LIKE` folds ASCII case by default. PostgreSQL's does not. Three
repositories built a bare `col LIKE :q` against a non-lowered column, bound to
a non-lowered pattern:

| File | Endpoint |
|---|---|
| `packages/agent/src/database/repositories/agent.repository.ts` | `GET /api/me/agents?search=` |
| `packages/agent/src/database/repositories/task.repository.ts` | `GET /api/me/tasks?search=` and `?label=` |
| `packages/agent/src/database/repositories/work-knowledge-document.repository.ts` | KB document search (`list()` + `applyOrgAggregateScope()`) |

**User-visible consequence.** On Postgres, searching Agents for `deploy` did
not match an Agent named `Deploy Bot`; filtering Tasks by `?label=bug` did not
match the label `Bug`; KB search missed every mixed-case title. No error, no
log line — just silently fewer results. Same "looks like empty data, not like a
failure" signature as the `getPeriodTotals` unquoted-column bug.

**Fix.** Routed every clause through the helper the repo already has and
already uses in `work.repository.ts`, `skill.repository.ts` and
`activity-log.repository.ts`:

```ts
const searchPattern = prepareCaseInsensitiveContainsPattern(filter.search);
if (searchPattern) {
    qb.andWhere(new Brackets((searchQb) => {
        searchQb
            .where(buildCaseInsensitiveLikeClause('agent.name', 'q'), { q: searchPattern })
            .orWhere(buildCaseInsensitiveLikeClause('agent.slug', 'q'), { q: searchPattern })
            .orWhere(buildCaseInsensitiveLikeClause('agent.title', 'q'), { q: searchPattern });
    }));
}
```

Both halves matter: `buildCaseInsensitiveLikeClause` folds the **column**
(`LOWER(col) LIKE :p ESCAPE '\'`) and `prepareCaseInsensitiveContainsPattern`
folds the **pattern**. Folding only one side is still case-sensitive.

For the Task `?label=` filter the surrounding `"` quotes are preserved, so
case-folding does not widen the match from a whole JSON token to a substring
(there is a regression test for exactly that).

No new helper, no new convention, no change to the LIKE-metacharacter escaping
that was already correct.

---

## Defect 2 — `ILIKE` threw on SQLite (MEDIUM-HIGH)

`packages/agent/src/user-research/work-proposal.repository.ts` used the raw SQL
string `p.title ILIKE :search` with no driver guard.

Worth noting *why* this one is different from the other `ILIKE` in the
codebase: `missions.service.ts` uses TypeORM's **`ILike()` FindOperator**,
which TypeORM itself degrades to `UPPER(..) LIKE UPPER(..)` on non-Postgres
drivers (`QueryBuilder.js` `computeFindOperatorExpression`, case `"ilike"`).
A hand-written `ILIKE` string gets no such treatment.

**User-visible consequence.** `GET /api/me/work-proposals?search=` returned a
raw **500** on every SQLite-backed deployment — demo, OSS self-host, local
dev — and `/ideas?search=` rendered its "Could not load Ideas." alert instead
of results. Secondary: this was the only search path in the monorepo that
skipped `sanitizeLikePattern`, so `?search=%` matched every row instead of a
literal percent sign.

**Fix.** Same helper. `LOWER(col) LIKE :p ESCAPE '\'` runs on PostgreSQL,
MySQL and SQLite and is case-insensitive on all three, so one mechanism fixes
the portability defect, the case-sensitivity defect and the missing escaping.

**The e2e suite encoded this breakage as the contract** rather than failing on
it — `expect([200, 500]).toContain(res.status())` in four proposal-search
specs. A test that accepts a 500 cannot fail when the 500 spreads. All four are
tightened to the single correct expectation:

- `apps/web/e2e/flow-work-proposals-list-filter.spec.ts` (3 assertions; the
  real-term test now also asserts an UPPERCASE query matches, and the
  wildcard test asserts escaping actually holds rather than just "not a 4xx")
- `apps/web/e2e/flow-work-proposals-validation-authz-matrix.spec.ts`
- `apps/web/e2e/flow-work-community-pr-multistep.spec.ts` (the
  case-insensitivity assertion was previously inside an `if (200)` branch that
  never ran on CI — it now always runs)
- `apps/web/e2e/flow-missions-ideas-ui-journey.spec.ts` (no longer accepts the
  "Could not load Ideas." alert as a pass; asserts it is absent)

---

## Defect 3 — Postgres-only `::jsonb` cast on a path with no SQL coverage (MEDIUM)

`work-knowledge-document.repository.ts` → `findByMetadataKey`, the **transcribe
idempotency check** that stops a Trigger.dev retry creating a duplicate
transcript:

```ts
.andWhere(`(doc.metadata::jsonb) ->> :key = :value`, { key, value })
```

`::` and `->>` are PostgreSQL-only. On SQLite this is a hard syntax error
(`unrecognized token: ":"`), so the transcribe pipeline died at precisely the
check that is supposed to make it retry-safe. The method's own docstring
conceded the gap — *"the test DB uses an in-memory mock at the repo layer (no
SQL is exercised)"* — and `knowledge-base-transcribe.service.spec.ts` mocks
`findByMetadataKey` outright.

**Fix.** Driver-branched on `manager.connection.options.type`, following the
existing precedent in `work-knowledge-chunk.repository.ts` (which guards its
pgvector query the same way). Postgres keeps the indexed `jsonb` path
unchanged. Every other driver gets a portable LIKE pre-filter over the
serialized JSON plus an exact `===` comparison in JS — the LIKE looks for the
JSON-encoded *value* so it is immune to key ordering and whitespace, and the
in-JS check is authoritative, so a same-value-different-key document cannot
produce a false positive. Both branches are tested.

---

## Tests

Three new integration specs. Each **fails on the code before this commit and
passes after**, and each opens with a control so a green run cannot be a green
run that read nothing.

- `packages/agent/src/database/repositories/search-case-insensitivity-sql.integration.spec.ts`
- `packages/agent/src/user-research/__tests__/work-proposal.search-portability.integration.spec.ts`
- `packages/agent/src/database/repositories/work-knowledge-document.metadata-key.integration.spec.ts`

**A behavioural test on default SQLite cannot catch defect 1** — SQLite returns
the right answer for the wrong reason. So the specs attack it two independent
ways, following the pattern set by
`credit-ledger.period-totals-sql.integration.spec.ts`:

1. **Assertions on the emitted SQL**, which is driver-independent: every
   searched column must appear as `LOWER("alias"."col") LIKE`, no bare
   `"alias"."col" LIKE` may survive anywhere in the statement, and the bound
   parameter must itself be lower-cased.
2. **`PRAGMA case_sensitive_like = ON`** on the test connection, which makes
   SQLite's `LIKE` behave exactly like PostgreSQL's — so the behavioural
   assertions really do execute production semantics. The first test in each
   suite is a control proving the pragma took effect (`'Deploy Bot' LIKE
   '%deploy%'` must evaluate to 0); without it every "found the mixed-case row"
   assertion would be a false clean.

### Before (source files at `origin/develop`, new specs applied)

```
FAIL src/user-research/__tests__/work-proposal.search-portability.integration.spec.ts
    √ CONTROL: the pragma is in effect, so a bare LIKE is case-sensitive here
    × executes a search instead of throwing (no ILIKE anywhere in the SQL)
    × matches a mixed-case description from a lower-case term
    × lowers both the column and the bound pattern
    × escapes LIKE metacharacters so `?search=%` cannot match every row
    √ still treats a whitespace-only search as a no-op (unfiltered own set)
FAIL src/database/repositories/search-case-insensitivity-sql.integration.spec.ts
    √ CONTROL: the pragma is in effect, so a bare LIKE is case-sensitive here
    √ still escapes LIKE metacharacters so `%` cannot bypass the filter
      × finds a mixed-case name from a lower-case query
      × finds a lower-case query term from a mixed-case query
      × emits LOWER() on every searched column and a lower-cased pattern
      × finds a mixed-case title from a lower-case query
      × finds a mixed-case label from a lower-case ?label filter
      √ still scopes the label filter to a whole JSON token
      × emits LOWER() on every searched column and a lower-cased pattern
      × emits LOWER() on the labels column and a lower-cased token pattern
      × finds a mixed-case title from a lower-case query
      × finds a mixed-case body from a lower-case query when searchBody is on
      × finds a mixed-case title through the org-aggregate feed
      × emits LOWER() on title/description and a lower-cased pattern (list)
      × emits LOWER() on the metadata column too when searchBody is on
      × emits LOWER() on title/description in the org-aggregate scope
FAIL src/database/repositories/work-knowledge-document.metadata-key.integration.spec.ts
      × finds the document whose metadata key holds the value
      × returns null when no document carries that value
      × does not match a different key that happens to hold the same value
      × stays scoped to the Work — an identical value elsewhere is a different row
      √ keeps the indexed jsonb predicate

Test Suites: 3 failed, 3 total
Tests:       21 failed, 6 passed, 27 total
```

Representative failures, one per defect:

```
● … AgentRepository.findByUserIdScoped › emits LOWER() on every searched column …

    Expected substring: "LOWER(\"agent\".\"name\") LIKE"
    Received string:    "SELECT COUNT(1) AS \"cnt\" FROM \"agents\" \"agent\"
                         WHERE \"agent\".\"userId\" = ? AND \"agent\".\"status\" != ?
                         AND (\"agent\".\"name\" LIKE ? ESCAPE '\\'
                           OR \"agent\".\"slug\" LIKE ? ESCAPE '\\'
                           OR \"agent\".\"title\" LIKE ? ESCAPE '\\')"

● … WorkProposalRepository.findByUser › executes a search instead of throwing …

    SqliteError: near "ILIKE": syntax error

● … findByMetadataKey › finds the document whose metadata key holds the value

    SqliteError: unrecognized token: ":"
```

Note the two `√` marks in the "before" column that are *not* accidents: both
CONTROL tests pass before and after (they must, or the suite proves nothing),
and `still scopes the label filter to a whole JSON token` passes before and
after because it guards against the fix over-reaching.

### After (this branch)

```
PASS src/database/repositories/work-knowledge-document.metadata-key.integration.spec.ts
      √ finds the document whose metadata key holds the value
      √ returns null when no document carries that value
      √ does not match a different key that happens to hold the same value
      √ stays scoped to the Work — an identical value elsewhere is a different row
      √ keeps the indexed jsonb predicate
PASS src/user-research/__tests__/work-proposal.search-portability.integration.spec.ts
      √ CONTROL: the pragma is in effect, so a bare LIKE is case-sensitive here
      √ executes a search instead of throwing (no ILIKE anywhere in the SQL)
      √ matches a mixed-case description from a lower-case term
      √ lowers both the column and the bound pattern
      √ escapes LIKE metacharacters so `?search=%` cannot match every row
      √ still treats a whitespace-only search as a no-op (unfiltered own set)
PASS src/database/repositories/search-case-insensitivity-sql.integration.spec.ts
      √ CONTROL: the pragma is in effect, so a bare LIKE is case-sensitive here
      √ still escapes LIKE metacharacters so `%` cannot bypass the filter
      √ finds a mixed-case name from a lower-case query
      √ finds a lower-case query term from a mixed-case query
      √ emits LOWER() on every searched column and a lower-cased pattern
      √ finds a mixed-case title from a lower-case query
      √ finds a mixed-case label from a lower-case ?label filter
      √ still scopes the label filter to a whole JSON token
      √ emits LOWER() on every searched column and a lower-cased pattern
      √ emits LOWER() on the labels column and a lower-cased token pattern
      √ finds a mixed-case title from a lower-case query
      √ finds a mixed-case body from a lower-case query when searchBody is on
      √ finds a mixed-case title through the org-aggregate feed
      √ emits LOWER() on title/description and a lower-cased pattern (list)
      √ emits LOWER() on the metadata column too when searchBody is on
      √ emits LOWER() on title/description in the org-aggregate scope

Test Suites: 3 passed, 3 total
Tests:       27 passed, 27 total
```

### No regressions

```
$ pnpm --filter @ever-works/agent test
Test Suites: 471 passed, 471 total
Tests:       3 skipped, 8582 passed, 8585 total
```

`tsc --noEmit` clean for `packages/agent` and `apps/web`; `prettier --check`
clean on every changed file.

---

## Not touched

`credit-ledger.repository.ts`, the `/admin` pages,
`apps/web/src/components/works/WorkAICreator.tsx`, `apps/web/e2e/e2e-smoke/*`
and `.github/workflows/smoke-deployed.yml` — other PRs are open against those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search reliability across supported database environments.
  - Search is now consistently case-insensitive for ideas, proposals, agents, tasks, and knowledge documents.
  - Searches correctly handle special wildcard characters without returning unrelated results.
  - Empty or whitespace-only searches no longer produce unexpected errors.
  - Proposal searches now reliably return matching results, exclude non-matches, and work alongside status filters.
  - Metadata-key filtering is more accurate and properly scoped to the selected work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->