### PR TITLE
fix(works): honour the managed Ever Works Git storage choice when creating a Work

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5518,7 +5518,8 @@
                 "organizations": "Organizations",
                 "personalHelp": "The repository will be created under your personal GitHub account",
                 "organizationHelp": "The repository will be created under the {org} organization",
-                "connectRequired": "Connect a Git provider in the sidebar to choose where your repository will be created."
+                "connectRequired": "Connect a Git provider in the sidebar to choose where your repository will be created.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Create with AI",
@@ -5890,7 +5891,11 @@
                 "connected": "Connected",
                 "connecting": "Connecting...",
                 "connect": "Connect",
-                "connectError": "Failed to connect"
+                "connectError": "Failed to connect",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git Provider Connections",

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/git-provider-selector.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/git-provider-selector.tsx
@@ -7,13 +7,23 @@ import { toast } from 'sonner';
 import { ROUTES } from '@/lib/constants';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import { Github, GitlabIcon, Boxes, Check, Link as LinkIcon } from 'lucide-react';
+import { Github, GitlabIcon, Boxes, Check, Link as LinkIcon, ShieldCheck } from 'lucide-react';
 import type { ProviderWithConnection } from './page';
 
 interface GitProviderSelectorProps {
     providers: ProviderWithConnection[];
     selectedProviderId: string | null;
     onSelect: (providerId: string) => void;
+    /**
+     * True when the user's Works are pushed to the managed Ever Works GitHub
+     * org (onboarding storage choice `ever-works-git`, feature enabled).
+     * Resolved server-side — the flag behind it is an API env var.
+     *
+     * In that mode this section previously rendered "Not connected" with a
+     * Connect button for a connection nobody needs: the platform's own PAT
+     * creates the repository. We show where repos go instead.
+     */
+    managedGitStorage?: boolean;
     compact?: boolean;
 }
 
@@ -55,6 +65,7 @@ export function GitProviderSelector({
     providers,
     selectedProviderId,
     onSelect,
+    managedGitStorage = false,
     compact = false,
 }: GitProviderSelectorProps) {
     const [isPending, startTransition] = useTransition();
@@ -71,6 +82,40 @@ export function GitProviderSelector({
             }
         });
     };
+
+    // Managed Ever Works Git. Rendered INSTEAD of the provider list: with the
+    // platform creating the repository in its own org, picking a personal
+    // provider here changes nothing, and the old "Not connected / Connect"
+    // affordance pointed at an OAuth flow the user does not need.
+    if (managedGitStorage) {
+        return (
+            <div
+                className={cn(
+                    compact ? 'p-3' : 'p-4',
+                    'rounded-lg',
+                    'bg-surface dark:bg-surface-dark',
+                    'border border-border dark:border-border-dark',
+                )}
+            >
+                <div className="flex items-start gap-2.5">
+                    <div className="w-7 h-7 rounded-lg bg-emerald-500/10 flex items-center justify-center shrink-0">
+                        <ShieldCheck
+                            className="w-4 h-4 text-emerald-500 dark:text-emerald-400"
+                            strokeWidth={1.8}
+                        />
+                    </div>
+                    <div className="min-w-0">
+                        <p className="text-xs font-medium text-text dark:text-text-dark leading-none">
+                            {t('managed.title')}
+                        </p>
+                        <p className="text-[11px] text-text-muted dark:text-text-muted-dark mt-1.5 leading-snug">
+                            {t('managed.description')}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     if (providers.length === 0) {
         return (

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -126,6 +126,16 @@ interface NewWorkClientProps {
      * everything enabled (fail-open).
      */
     disabledKinds?: string[];
+    /**
+     * True when this user's Work repositories are created in the managed
+     * Ever Works GitHub org (wizard storage choice `ever-works-git` + the
+     * platform feature enabled). Resolved server-side in `page.tsx`; a
+     * client component cannot read the API-side env flag behind it.
+     *
+     * When true no personal git provider needs connecting, so the sidebar
+     * shows where repos actually go instead of a "Not connected" prompt.
+     */
+    managedGitStorage?: boolean;
 }
 
 export default function NewWorkClient({
@@ -141,6 +151,7 @@ export default function NewWorkClient({
     initialPrompt,
     initialKind = null,
     disabledKinds = [],
+    managedGitStorage = false,
 }: NewWorkClientProps) {
     const [creationMode, setCreationMode] = useState<CreationMode | null>(
         proposal ? 'ai' : initialMode,
@@ -393,6 +404,7 @@ export default function NewWorkClient({
                                 providers={providers}
                                 selectedProviderId={selectedProviderId}
                                 onSelect={setSelectedProviderId}
+                                managedGitStorage={managedGitStorage}
                                 compact
                             />
                         </div>
@@ -452,6 +464,7 @@ export default function NewWorkClient({
                     <WorkAICreator
                         gitProvider={selectedProviderId || undefined}
                         gitConnected={gitConnected}
+                        managedGitStorage={managedGitStorage}
                         deployProvider={selectedDeployProviderId || undefined}
                         websiteTemplates={websiteTemplates}
                         workBlueprints={workBlueprints}

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
@@ -18,6 +18,7 @@ import type { DeployProvider } from './deploy-provider-selector';
 import { workProposalsAPI } from '@/lib/api/work-proposals';
 import type { WorkProposal } from '@/lib/api/work-proposals';
 import { ROUTES } from '@/lib/constants';
+import { resolveManagedStorageStatus } from '@/lib/works/managed-storage';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('metadata.pages');
@@ -160,6 +161,15 @@ export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
     const disabledSet = await getDisabledWorkKinds(ALL_WORK_KIND_CHIP_VALUES, user.id);
     const disabledKinds = Array.from(disabledSet);
 
+    // Whether this user's Works are pushed to the managed Ever Works GitHub
+    // org. Resolved on the server from the onboarding state (the user's
+    // choice) + the onboarding catalog (the platform capability) — the same
+    // two inputs `POST /works` uses — because the flag behind it is an API
+    // env var that a client component cannot see. When it's on, the Git
+    // Provider section must not claim "Not connected": there is nothing to
+    // connect.
+    const managedStorage = await resolveManagedStorageStatus();
+
     // A kind disabled by a feature flag must not be preselectable via the
     // `?kind=` URL handoff — otherwise a user could deep-link a "Soon"
     // chip into the selected state and submit it. If the resolved kind is
@@ -181,6 +191,7 @@ export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
             initialPrompt={initialPrompt}
             initialKind={safeInitialKind}
             disabledKinds={disabledKinds}
+            managedGitStorage={managedStorage.managedGitActive}
         />
     );
 }

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -34,6 +34,11 @@ import {
 // Mirrors work-proposals.ts / work-schedule.ts.
 import { getAuthFromCookie } from '@/lib/auth';
 import { checkGitProviderConnection } from './oauth';
+import {
+    EVER_WORKS_GIT_STORAGE,
+    resolveManagedStorageStatus,
+    type ManagedStorageStatus,
+} from '@/lib/works/managed-storage';
 import { getTranslations } from 'next-intl/server';
 import { revalidatePath } from 'next/cache';
 import { ROUTES } from '@/lib/constants';
@@ -83,6 +88,11 @@ const getCreateWorkSchema = async () => {
         organization: z.boolean(),
         gitProvider: z.string().optional(),
         deployProvider: z.string().optional(),
+        // Storage provider (`ever-works-git` | `user-github` | …). zod strips
+        // unknown keys, so this MUST be declared or the field is silently
+        // dropped on its way to `CreateWorkDto` and the API is left to
+        // re-infer the choice from onboarding state.
+        storageProvider: z.string().optional(),
         websiteTemplateId: z.string().optional(),
         // Optional work-kind chip value — kept in the parsed output so it
         // reaches the API's CreateWorkDto (zod strips unknown keys).
@@ -146,6 +156,68 @@ const checkOrganization = (
     };
 };
 
+/**
+ * Outcome of the create-time git-provider gate. `ok: true` carries the
+ * connection info the owner/organization resolution needs (or `null` when no
+ * personal provider was involved at all).
+ *
+ * The reason codes exist so callers can keep their exact user-facing copy —
+ * "connect a git provider" vs "connect <provider>" — while the decision
+ * itself lives in one place.
+ */
+type CreateWorkGitGate =
+    | { readonly ok: true; readonly connectionInfo: GitProviderConnectionInfo | null }
+    | { readonly ok: false; readonly reason: 'missing-provider' }
+    | { readonly ok: false; readonly reason: 'not-connected'; readonly providerId: string };
+
+/**
+ * Decide whether creating a Work requires a *personal* connected git
+ * provider.
+ *
+ * It does NOT when the user's effective storage choice is the managed
+ * `ever-works-git` and the platform has that feature enabled: the API creates
+ * the repository in the `ever-works-cloud` org with the platform's own PAT
+ * (`WorkLifecycleService.createWork`'s `storageProvider === 'ever-works-git'`
+ * branch), so there is nothing for the user to connect. Blocking here made
+ * the single core action of the product impossible for every user who took
+ * the wizard's DEFAULT storage option — `POST /works` would have accepted the
+ * request.
+ *
+ * It DOES for every personal choice (`user-github`, …): those repositories
+ * are created with the user's own OAuth token, so an unconnected provider is
+ * a genuine, pre-flight-detectable failure. That path is unchanged.
+ */
+async function resolveCreateWorkGitGate(
+    providerId: string | undefined,
+    managedStorage: ManagedStorageStatus,
+): Promise<CreateWorkGitGate> {
+    if (managedStorage.managedGitActive) {
+        return { ok: true, connectionInfo: null };
+    }
+
+    if (!providerId) {
+        return { ok: false, reason: 'missing-provider' };
+    }
+
+    const connectionCheck = await checkGitProviderConnection(providerId);
+    if (!connectionCheck.connected) {
+        return { ok: false, reason: 'not-connected', providerId };
+    }
+
+    return { ok: true, connectionInfo: connectionCheck as GitProviderConnectionInfo };
+}
+
+/**
+ * The `storageProvider` value to send with `CreateWorkDto`. Sending it
+ * explicitly (rather than letting the API infer it from onboarding state)
+ * keeps the web's gate decision and the server's provisioning decision keyed
+ * off the SAME value — they can no longer disagree about which storage a
+ * given create used.
+ */
+function storageProviderForCreate(managedStorage: ManagedStorageStatus): string | undefined {
+    return managedStorage.managedGitActive ? EVER_WORKS_GIT_STORAGE : undefined;
+}
+
 export async function createWork(data: CreateWorkDto) {
     // Security: verify authentication at the server-action boundary.
     const user = await getAuthFromCookie();
@@ -168,33 +240,31 @@ export async function createWork(data: CreateWorkDto) {
         }
 
         const providerId = validation.data.gitProvider;
-        if (!providerId) {
+        const managedStorage = await resolveManagedStorageStatus();
+
+        const gate = await resolveCreateWorkGitGate(providerId, managedStorage);
+        if (!gate.ok) {
             return {
                 success: false,
-                error: t('oauthRequired', { provider: 'git provider' }),
+                error: t('oauthRequired', {
+                    provider: gate.reason === 'not-connected' ? gate.providerId : 'git provider',
+                }),
                 requiresGitProvider: true,
             };
         }
 
-        // Check git provider connection
-        const connectionCheck = await checkGitProviderConnection(providerId);
-        if (!connectionCheck.connected) {
-            return {
-                success: false,
-                error: t('oauthRequired', { provider: providerId }),
-                requiresGitProvider: true,
-            };
-        }
-
-        const { organization, owner } = checkOrganization(
-            connectionCheck as GitProviderConnectionInfo,
-            validation.data,
-        );
+        const { organization, owner } = checkOrganization(gate.connectionInfo, validation.data);
 
         validation.data.organization = organization;
         validation.data.owner = owner;
         validation.data.gitProvider = providerId;
         validation.data.deployProvider = data.deployProvider || undefined;
+        // An explicit caller-supplied choice wins; otherwise send the one we
+        // just resolved. Under managed storage the API replaces owner /
+        // organization with the platform org after it provisions the repo, so
+        // the two lines above only matter on the personal path.
+        validation.data.storageProvider =
+            data.storageProvider ?? storageProviderForCreate(managedStorage);
 
         // Security: do not log validated work-creation payload (contains git
         // provider id, owner/org, slug, name, description) to server stdout.
@@ -312,20 +382,15 @@ export async function createWorkWithAI(request: AIWorkOptions) {
         }
 
         const providerId = validation.data.gitProvider;
-        if (!providerId) {
-            return {
-                success: false,
-                error: t('oauthRequired', { provider: 'git provider' }),
-                requiresGitProvider: true,
-            };
-        }
+        const managedStorage = await resolveManagedStorageStatus();
 
-        // Check git provider connection
-        const connectionCheck = await checkGitProviderConnection(providerId);
-        if (!connectionCheck.connected) {
+        const gate = await resolveCreateWorkGitGate(providerId, managedStorage);
+        if (!gate.ok) {
             return {
                 success: false,
-                error: t('oauthRequired', { provider: providerId }),
+                error: t('oauthRequired', {
+                    provider: gate.reason === 'not-connected' ? gate.providerId : 'git provider',
+                }),
                 requiresGitProvider: true,
             };
         }
@@ -362,10 +427,7 @@ export async function createWorkWithAI(request: AIWorkOptions) {
         }
 
         // Determine organization settings
-        const { organization, owner } = checkOrganization(
-            connectionCheck as GitProviderConnectionInfo,
-            request,
-        );
+        const { organization, owner } = checkOrganization(gate.connectionInfo, request);
 
         const workData: CreateWorkDto = {
             name: validation.data.name,
@@ -375,6 +437,11 @@ export async function createWorkWithAI(request: AIWorkOptions) {
             owner,
             gitProvider: providerId,
             deployProvider: request.deployProvider || undefined,
+            // Explicit storage choice — see `storageProviderForCreate`. Under
+            // managed storage the API resolves `gitProvider` from this value
+            // (`gitProviderFromStorageChoice('ever-works-git')` → `github`),
+            // so an absent `providerId` above is fine.
+            storageProvider: storageProviderForCreate(managedStorage),
             websiteTemplateId: request.websiteTemplateId || undefined,
             // Persist the work-kind chip on the Work itself (not just the
             // generation prompt) so the kind-aware default website

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -240,7 +240,12 @@ export async function createWork(data: CreateWorkDto) {
         }
 
         const providerId = validation.data.gitProvider;
-        const managedStorage = await resolveManagedStorageStatus();
+        // An explicit `storageProvider` on the DTO wins, exactly as it does in
+        // `resolveProviderDefaults` — so the gate below is decided from the
+        // same value this request will carry to the API. Resolving the gate
+        // from onboarding state while sending a different provider is how the
+        // two tiers would silently disagree again.
+        const managedStorage = await resolveManagedStorageStatus(validation.data.storageProvider);
 
         const gate = await resolveCreateWorkGitGate(providerId, managedStorage);
         if (!gate.ok) {
@@ -255,16 +260,15 @@ export async function createWork(data: CreateWorkDto) {
 
         const { organization, owner } = checkOrganization(gate.connectionInfo, validation.data);
 
+        // Under managed storage the API replaces owner / organization with the
+        // platform org once it has provisioned the repo, so these two only
+        // matter on the personal path.
         validation.data.organization = organization;
         validation.data.owner = owner;
         validation.data.gitProvider = providerId;
         validation.data.deployProvider = data.deployProvider || undefined;
-        // An explicit caller-supplied choice wins; otherwise send the one we
-        // just resolved. Under managed storage the API replaces owner /
-        // organization with the platform org after it provisions the repo, so
-        // the two lines above only matter on the personal path.
         validation.data.storageProvider =
-            data.storageProvider ?? storageProviderForCreate(managedStorage);
+            validation.data.storageProvider ?? storageProviderForCreate(managedStorage);
 
         // Security: do not log validated work-creation payload (contains git
         // provider id, owner/org, slug, name, description) to server stdout.

--- a/apps/web/src/app/actions/dashboard/works.unit.spec.ts
+++ b/apps/web/src/app/actions/dashboard/works.unit.spec.ts
@@ -282,6 +282,56 @@ describe('Work creation honours the managed Ever Works Git storage choice', () =
         });
     });
 
+    describe('an explicit DTO storageProvider decides the gate too', () => {
+        // `resolveProviderDefaults` puts the DTO first, so the gate must be
+        // resolved from the SAME value the request will carry. Deciding it
+        // from onboarding state while sending a different provider is exactly
+        // how the two tiers silently disagreed in the first place — and a
+        // server action is reachable as a POST endpoint, so the override is
+        // attacker-controllable.
+        beforeEach(() => {
+            getCatalogMock.mockResolvedValue(catalogWithEverWorksGit(true));
+        });
+
+        it('keeps the gate when the DTO overrides a managed onboarding choice with user-github', async () => {
+            getStateMock.mockResolvedValue(onboardingStateWith('ever-works-git'));
+            checkGitProviderConnectionMock.mockResolvedValue({ success: true, connected: false });
+            const { createWork } = await import('./works');
+
+            const result = await createWork({
+                slug: 'k8s-operators',
+                name: 'K8s Operators',
+                description: 'A directory of open-source Kubernetes database operators.',
+                organization: false,
+                gitProvider: 'github',
+                storageProvider: 'user-github',
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+            expect(workAPICreateMock).not.toHaveBeenCalled();
+        });
+
+        it('lifts the gate when the DTO explicitly asks for ever-works-git', async () => {
+            getStateMock.mockResolvedValue(onboardingStateWith('user-github'));
+            const { createWork } = await import('./works');
+
+            const result = await createWork({
+                slug: 'k8s-operators',
+                name: 'K8s Operators',
+                description: 'A directory of open-source Kubernetes database operators.',
+                organization: false,
+                storageProvider: 'ever-works-git',
+            });
+
+            expect(result.success).toBe(true);
+            expect(checkGitProviderConnectionMock).not.toHaveBeenCalled();
+            expect(workAPICreateMock.mock.calls[0]![0]).toMatchObject({
+                storageProvider: 'ever-works-git',
+            });
+        });
+    });
+
     describe('platform capability is read from the catalog, never assumed', () => {
         it('keeps the gate when the user chose ever-works-git but the platform has it OFF (e.g. dev)', async () => {
             getStateMock.mockResolvedValue(onboardingStateWith('ever-works-git'));

--- a/apps/web/src/app/actions/dashboard/works.unit.spec.ts
+++ b/apps/web/src/app/actions/dashboard/works.unit.spec.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for the managed "Ever Works Git" storage choice.
+ *
+ * The bug: `createWork` / `createWorkWithAI` gated on a *personal* connected
+ * git provider before ever calling the API. A freshly registered user who
+ * took the onboarding wizard's DEFAULT storage option ("Ever Works Git —
+ * push your work repos to a managed Ever Works GitHub org") therefore could
+ * not create a Work at all: the form showed "Git Provider — Not connected"
+ * and Generate returned `requiresGitProvider` without creating anything.
+ *
+ * The API never required a personal provider for that choice —
+ * `WorkLifecycleService.resolveProviderDefaults` reads the user's
+ * `onboardingState`, maps `ever-works-git` → git provider `github`, and
+ * provisions the repository in the managed org with the platform's own PAT.
+ *
+ * What these specs pin:
+ *   1. managed storage + feature enabled → NOT blocked, reaches `workAPI.create`.
+ *   2. that call carries `storageProvider: 'ever-works-git'` (zod strips
+ *      undeclared keys, so this is easy to silently lose).
+ *   3. personal `user-github` + unconnected provider → STILL blocked.
+ *   4. personal choice + no provider id at all → STILL blocked.
+ *   5. the capability is read from the platform catalog, so `ever-works-git`
+ *      on an environment where the feature is OFF keeps the gate.
+ *   6. a failure reading onboarding state fails CLOSED (keeps the gate).
+ */
+
+const {
+    getAuthFromCookieMock,
+    checkGitProviderConnectionMock,
+    workAPICreateMock,
+    generateDetailsMock,
+    itemsGenerateMock,
+    getStateMock,
+    getCatalogMock,
+    redirectMock,
+} = vi.hoisted(() => ({
+    getAuthFromCookieMock: vi.fn(),
+    checkGitProviderConnectionMock: vi.fn(),
+    workAPICreateMock: vi.fn(),
+    generateDetailsMock: vi.fn(),
+    itemsGenerateMock: vi.fn(),
+    getStateMock: vi.fn(),
+    getCatalogMock: vi.fn(),
+    redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+    getAuthFromCookie: getAuthFromCookieMock,
+}));
+
+vi.mock('./oauth', () => ({
+    checkGitProviderConnection: checkGitProviderConnectionMock,
+}));
+
+vi.mock('@/lib/api/onboarding', () => ({
+    onboardingAPI: {
+        getState: getStateMock,
+        getCatalog: getCatalogMock,
+    },
+}));
+
+vi.mock('@/lib/api', () => ({
+    workAPI: {
+        create: workAPICreateMock,
+        generateDetails: generateDetailsMock,
+    },
+    itemsGeneratorAPI: {
+        generate: itemsGenerateMock,
+    },
+}));
+
+vi.mock('@/lib/api/work-proposals', () => ({
+    workProposalsAPI: { accept: vi.fn() },
+}));
+
+vi.mock('@/lib/api/server-api', () => ({
+    serverMutation: vi.fn(),
+    ApiResponseError: class ApiResponseError extends Error {},
+}));
+
+// `t('oauthRequired', { provider })` → a stable, assertable string.
+vi.mock('next-intl/server', () => ({
+    getTranslations: async () => (key: string, values?: Record<string, unknown>) =>
+        values ? `${key}:${JSON.stringify(values)}` : key,
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+vi.mock('next/navigation', () => ({ redirect: redirectMock }));
+
+/** Catalog payload with the managed-storage card flipped on or off. */
+function catalogWithEverWorksGit(available: boolean) {
+    return {
+        ai: [],
+        storage: [
+            {
+                choice: 'ever-works-git',
+                title: 'Ever Works Git',
+                description: 'Push your work repos to a managed Ever Works GitHub org.',
+                default: true,
+                available,
+                badges: available ? ['default'] : ['default', 'planned'],
+            },
+            {
+                choice: 'user-github',
+                title: 'Your GitHub',
+                description: 'Push work repos to your own GitHub account or org.',
+                default: false,
+                available: true,
+                badges: [],
+                pluginId: 'github',
+            },
+        ],
+        db: [],
+        deploy: [],
+        desktop: [],
+        plugins: [],
+    };
+}
+
+function onboardingStateWith(storageChoice: string) {
+    return {
+        completedAt: null,
+        dismissedAt: null,
+        state: {
+            version: 2,
+            lastStep: 3,
+            ai: { choice: 'ever-works' },
+            storage: { choice: storageChoice },
+            db: { choice: 'ever-works-db' },
+            deploy: { choice: 'ever-works' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        },
+    };
+}
+
+const AI_REQUEST = {
+    name: 'K8s Operators',
+    prompt: 'A directory of open-source Kubernetes database operators with maturity tags.',
+};
+
+describe('Work creation honours the managed Ever Works Git storage choice', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthFromCookieMock.mockResolvedValue({ id: 'user-1', username: 'qa-user' });
+        workAPICreateMock.mockResolvedValue({ work: { id: 'work-1', slug: 'k8s-operators' } });
+        // No AI provider is selected in these specs, so `generateDetails` is
+        // never reached; keep it defined so an accidental call is visible.
+        generateDetailsMock.mockResolvedValue({
+            name: 'K8s Operators',
+            slug: 'k8s-operators',
+            description: 'desc',
+            keywords: [],
+            categories: [],
+        });
+        itemsGenerateMock.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+    });
+
+    describe('managed storage (wizard choice `ever-works-git`, feature enabled)', () => {
+        beforeEach(() => {
+            getStateMock.mockResolvedValue(onboardingStateWith('ever-works-git'));
+            getCatalogMock.mockResolvedValue(catalogWithEverWorksGit(true));
+        });
+
+        it('createWorkWithAI does NOT return requiresGitProvider and reaches the API', async () => {
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI(AI_REQUEST);
+
+            expect(result.requiresGitProvider).toBeUndefined();
+            expect(result.success).toBe(true);
+            expect(workAPICreateMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('never asks whether a personal git provider is connected', async () => {
+            const { createWorkWithAI } = await import('./works');
+
+            await createWorkWithAI(AI_REQUEST);
+
+            expect(checkGitProviderConnectionMock).not.toHaveBeenCalled();
+        });
+
+        it('sends storageProvider=ever-works-git so the API provisions the managed repo', async () => {
+            const { createWorkWithAI } = await import('./works');
+
+            await createWorkWithAI(AI_REQUEST);
+
+            expect(workAPICreateMock.mock.calls[0]![0]).toMatchObject({
+                storageProvider: 'ever-works-git',
+            });
+        });
+
+        it('works with no gitProvider selected at all (nothing to connect)', async () => {
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: undefined });
+
+            expect(result.success).toBe(true);
+            expect(result.requiresGitProvider).toBeUndefined();
+        });
+
+        it('createWork (manual form) is unblocked on the same terms', async () => {
+            const { createWork } = await import('./works');
+
+            const result = await createWork({
+                slug: 'k8s-operators',
+                name: 'K8s Operators',
+                description: 'A directory of open-source Kubernetes database operators.',
+                organization: false,
+            });
+
+            expect(result.requiresGitProvider).toBeUndefined();
+            expect(result.success).toBe(true);
+            expect(workAPICreateMock.mock.calls[0]![0]).toMatchObject({
+                storageProvider: 'ever-works-git',
+            });
+        });
+    });
+
+    describe('personal storage still requires a connected provider', () => {
+        beforeEach(() => {
+            getStateMock.mockResolvedValue(onboardingStateWith('user-github'));
+            getCatalogMock.mockResolvedValue(catalogWithEverWorksGit(true));
+        });
+
+        it('blocks with requiresGitProvider when the selected provider is not connected', async () => {
+            checkGitProviderConnectionMock.mockResolvedValue({ success: true, connected: false });
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: 'github' });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+            expect(workAPICreateMock).not.toHaveBeenCalled();
+        });
+
+        it('blocks with requiresGitProvider when no provider was selected', async () => {
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: undefined });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+            expect(workAPICreateMock).not.toHaveBeenCalled();
+        });
+
+        it('proceeds — without a storageProvider override — once the provider IS connected', async () => {
+            checkGitProviderConnectionMock.mockResolvedValue({
+                success: true,
+                connected: true,
+                username: 'qa-user',
+            });
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: 'github' });
+
+            expect(result.success).toBe(true);
+            expect(workAPICreateMock.mock.calls[0]![0].storageProvider).toBeUndefined();
+        });
+
+        it('createWork (manual form) still blocks an unconnected provider', async () => {
+            checkGitProviderConnectionMock.mockResolvedValue({ success: true, connected: false });
+            const { createWork } = await import('./works');
+
+            const result = await createWork({
+                slug: 'k8s-operators',
+                name: 'K8s Operators',
+                description: 'A directory of open-source Kubernetes database operators.',
+                organization: false,
+                gitProvider: 'github',
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+            expect(workAPICreateMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('platform capability is read from the catalog, never assumed', () => {
+        it('keeps the gate when the user chose ever-works-git but the platform has it OFF (e.g. dev)', async () => {
+            getStateMock.mockResolvedValue(onboardingStateWith('ever-works-git'));
+            getCatalogMock.mockResolvedValue(catalogWithEverWorksGit(false));
+            checkGitProviderConnectionMock.mockResolvedValue({ success: true, connected: false });
+
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: 'github' });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+            expect(workAPICreateMock).not.toHaveBeenCalled();
+        });
+
+        it('fails CLOSED when the onboarding state cannot be read', async () => {
+            getStateMock.mockRejectedValue(new Error('upstream 503'));
+            getCatalogMock.mockResolvedValue(catalogWithEverWorksGit(true));
+            checkGitProviderConnectionMock.mockResolvedValue({ success: true, connected: false });
+
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: 'github' });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+        });
+
+        it('fails CLOSED when the catalog cannot be read', async () => {
+            getStateMock.mockResolvedValue(onboardingStateWith('ever-works-git'));
+            getCatalogMock.mockRejectedValue(new Error('upstream 503'));
+            checkGitProviderConnectionMock.mockResolvedValue({ success: true, connected: false });
+
+            const { createWorkWithAI } = await import('./works');
+
+            const result = await createWorkWithAI({ ...AI_REQUEST, gitProvider: 'github' });
+
+            expect(result.success).toBe(false);
+            expect(result.requiresGitProvider).toBe(true);
+        });
+    });
+});

--- a/apps/web/src/components/works/RepositoryOwnerCard.tsx
+++ b/apps/web/src/components/works/RepositoryOwnerCard.tsx
@@ -3,11 +3,18 @@
 import { cn } from '@/lib/utils/cn';
 import { useTranslations } from 'next-intl';
 import { OrganizationSelector } from './OrganizationSelector';
-import { GitBranch } from 'lucide-react';
+import { GitBranch, ShieldCheck } from 'lucide-react';
 
 interface RepositoryOwnerCardProps {
     gitProvider?: string;
     gitConnected?: boolean;
+    /**
+     * True when repositories are created in the managed Ever Works GitHub
+     * org. The owner is then the platform org, not something the user picks —
+     * so neither the organization selector nor the "connect a Git provider"
+     * prompt applies.
+     */
+    managedGitStorage?: boolean;
     owner: string;
     onChange: (value: string, isOrganization: boolean) => void;
     disabled?: boolean;
@@ -16,6 +23,7 @@ interface RepositoryOwnerCardProps {
 export function RepositoryOwnerCard({
     gitProvider,
     gitConnected = false,
+    managedGitStorage = false,
     owner,
     onChange,
     disabled,
@@ -37,7 +45,22 @@ export function RepositoryOwnerCard({
                     'border border-card-border dark:border-border-secondary-dark',
                 )}
             >
-                {gitProvider && gitConnected ? (
+                {managedGitStorage ? (
+                    <div className="flex items-start gap-3">
+                        <ShieldCheck
+                            className="w-8 h-8 rounded-sm bg-emerald-500/10 p-1 text-emerald-500 dark:text-emerald-400 mt-0.5 shrink-0"
+                            strokeWidth={1.4}
+                        />
+                        <div>
+                            <p className="text-sm font-normal text-text dark:text-text-dark">
+                                {t('organizationSelector.label')}
+                            </p>
+                            <p className="text-sm text-text-muted dark:text-text-muted-dark mt-1">
+                                {t('organizationSelector.managedByEverWorks')}
+                            </p>
+                        </div>
+                    </div>
+                ) : gitProvider && gitConnected ? (
                     <OrganizationSelector
                         value={owner}
                         providerId={gitProvider}

--- a/apps/web/src/components/works/WorkAICreator.tsx
+++ b/apps/web/src/components/works/WorkAICreator.tsx
@@ -64,6 +64,12 @@ type InitialWorkKind = 'website' | 'landing-page' | 'blog' | 'directory' | 'awes
 interface WorkAICreatorProps {
     gitProvider?: string;
     gitConnected?: boolean;
+    /**
+     * True when Work repositories go to the managed Ever Works GitHub org.
+     * Purely presentational here — the server action re-resolves the storage
+     * choice itself and never trusts a client-supplied value.
+     */
+    managedGitStorage?: boolean;
     deployProvider?: string;
     websiteTemplates: WebsiteTemplateOption[];
     /** Manifest Work blueprints (Works Templates catalog); may be empty. */
@@ -76,6 +82,7 @@ interface WorkAICreatorProps {
 export function WorkAICreator({
     gitProvider,
     gitConnected,
+    managedGitStorage = false,
     deployProvider,
     websiteTemplates,
     workBlueprints = [],
@@ -441,6 +448,7 @@ export function WorkAICreator({
             <RepositoryOwnerCard
                 gitProvider={gitProvider}
                 gitConnected={gitConnected}
+                managedGitStorage={managedGitStorage}
                 owner={owner}
                 onChange={(value, isOrganization) => {
                     setOwner(value);

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -83,6 +83,17 @@ export interface CreateWorkDto {
     organization: boolean;
     gitProvider?: string;
     deployProvider?: string;
+    /**
+     * Where the Work's repository lives: `ever-works-git` (the managed Ever
+     * Works GitHub org, provisioned by the platform's own PAT) or one of the
+     * personal choices (`user-github`, `user-gitlab`, `user-git`). Mirrors
+     * `CreateWorkDto.storageProvider` on the API.
+     *
+     * Omit to let the API seed it from the user's onboarding choice; send it
+     * explicitly when the caller has already resolved the choice, so both
+     * tiers key their behaviour off the same value.
+     */
+    storageProvider?: string;
     websiteTemplateId?: string;
     /** Work-kind chip value (website, landing-page, blog, directory,
      *  awesome-repo). Drives the kind-aware default website template;

--- a/apps/web/src/lib/works/managed-storage.ts
+++ b/apps/web/src/lib/works/managed-storage.ts
@@ -1,0 +1,117 @@
+import 'server-only';
+
+import { onboardingAPI } from '@/lib/api/onboarding';
+import type {
+    OnboardingCatalogResponse,
+    OnboardingStorageChoice,
+    OnboardingWizardStateV2,
+} from '@ever-works/contracts/api';
+
+/**
+ * The wizard storage choice that means "the platform owns the repo".
+ *
+ * Mirrors `CreateWorkDto.storageProvider` on the API and the
+ * `storageProvider === 'ever-works-git'` branch in
+ * `WorkLifecycleService.createWork`, which provisions the repository in the
+ * managed `ever-works-cloud` GitHub org BEFORE the Work row is written.
+ */
+export const EVER_WORKS_GIT_STORAGE: OnboardingStorageChoice = 'ever-works-git';
+
+/**
+ * The fallback the API applies when neither the DTO nor the user's persisted
+ * onboarding state names a storage provider. Kept in lockstep with
+ * `WorkLifecycleService.resolveProviderDefaults` so the web's view of "which
+ * storage will actually be used" cannot drift from the server's.
+ */
+const DEFAULT_STORAGE_CHOICE: OnboardingStorageChoice = 'user-github';
+
+export interface ManagedStorageStatus {
+    /**
+     * The storage provider the API will resolve for this user's next Work,
+     * computed with the same precedence `resolveProviderDefaults` uses.
+     */
+    readonly storageChoice: OnboardingStorageChoice;
+    /**
+     * Whether the platform currently offers the managed Ever Works Git org.
+     * Read from the server-authoritative onboarding catalog — never from an
+     * env var, which is not readable in the browser and would go stale the
+     * moment ops flipped the flag without a web release.
+     */
+    readonly everWorksGitAvailable: boolean;
+    /**
+     * True when this user's Works go to the managed Ever Works GitHub org.
+     * When true there is nothing for the user to connect: the platform's own
+     * PAT creates the repo, so requiring a personal git-provider OAuth
+     * connection blocks a flow that the API would have accepted.
+     */
+    readonly managedGitActive: boolean;
+}
+
+/**
+ * Pure resolver — exported so the precedence rules are unit-testable without
+ * standing up the onboarding endpoints.
+ *
+ * `state` is the user's persisted wizard state (`null` when they never
+ * reached the wizard, in which case the API's `user-github` fallback applies).
+ * `catalog` is the platform capability document; `null` means "we could not
+ * ask", which deliberately resolves to NOT managed so the caller keeps the
+ * personal-provider gate rather than waving an unverified user through.
+ */
+export function resolveManagedStorage(
+    state: OnboardingWizardStateV2 | null | undefined,
+    catalog: OnboardingCatalogResponse | null | undefined,
+): ManagedStorageStatus {
+    const storageChoice = state?.storage?.choice ?? DEFAULT_STORAGE_CHOICE;
+
+    const everWorksGitAvailable =
+        catalog?.storage?.find((card) => card.choice === EVER_WORKS_GIT_STORAGE)?.available ===
+        true;
+
+    return {
+        storageChoice,
+        everWorksGitAvailable,
+        managedGitActive: storageChoice === EVER_WORKS_GIT_STORAGE && everWorksGitAvailable,
+    };
+}
+
+/**
+ * Resolve, for the CURRENT request's user, whether a new Work's repository
+ * will be created in the managed Ever Works GitHub org.
+ *
+ * Two server-side reads, in parallel:
+ *
+ *   - `GET /onboarding/state`   → what this user picked in the wizard.
+ *   - `GET /onboarding/catalog` → whether the platform offers it at all
+ *     (`available` is driven by `STORAGE_EVER_WORKS_GIT_ENABLED` on the API,
+ *     which is exactly the flag `WorkLifecycleService` gates the managed
+ *     branch on).
+ *
+ * Fails CLOSED: any error on either call degrades to "not managed", which
+ * restores the pre-existing personal-provider gate. A transient blip must
+ * never let an unconnected `user-github` user through — the whole point of
+ * the gate is that their create would fail server-side.
+ */
+export async function resolveManagedStorageStatus(): Promise<ManagedStorageStatus> {
+    const [stateResult, catalogResult] = await Promise.allSettled([
+        onboardingAPI.getState(),
+        onboardingAPI.getCatalog(),
+    ]);
+
+    if (stateResult.status === 'rejected') {
+        console.warn(
+            'Failed to read onboarding state while resolving storage provider; falling back to the personal git-provider gate:',
+            stateResult.reason,
+        );
+    }
+    if (catalogResult.status === 'rejected') {
+        console.warn(
+            'Failed to read the onboarding catalog while resolving storage provider; falling back to the personal git-provider gate:',
+            catalogResult.reason,
+        );
+    }
+
+    return resolveManagedStorage(
+        stateResult.status === 'fulfilled' ? stateResult.value?.state : null,
+        catalogResult.status === 'fulfilled' ? catalogResult.value : null,
+    );
+}

--- a/apps/web/src/lib/works/managed-storage.ts
+++ b/apps/web/src/lib/works/managed-storage.ts
@@ -48,6 +48,16 @@ export interface ManagedStorageStatus {
 }
 
 /**
+ * Normalize a caller-supplied storage provider the way the API's
+ * `@Transform(trim().toLowerCase())` on `CreateWorkDto.storageProvider` does,
+ * so `'Ever-Works-Git'` is recognised here exactly as it will be there.
+ */
+function normalizeStorageOverride(value: string | undefined): string | undefined {
+    const normalized = value?.trim().toLowerCase();
+    return normalized ? normalized : undefined;
+}
+
+/**
  * Pure resolver — exported so the precedence rules are unit-testable without
  * standing up the onboarding endpoints.
  *
@@ -56,12 +66,18 @@ export interface ManagedStorageStatus {
  * `catalog` is the platform capability document; `null` means "we could not
  * ask", which deliberately resolves to NOT managed so the caller keeps the
  * personal-provider gate rather than waving an unverified user through.
+ * `override` is an explicit `CreateWorkDto.storageProvider` from the caller;
+ * it wins, mirroring `resolveProviderDefaults`' DTO-first precedence, so the
+ * gate is always decided from the SAME value the request will carry.
  */
 export function resolveManagedStorage(
     state: OnboardingWizardStateV2 | null | undefined,
     catalog: OnboardingCatalogResponse | null | undefined,
+    override?: string,
 ): ManagedStorageStatus {
-    const storageChoice = state?.storage?.choice ?? DEFAULT_STORAGE_CHOICE;
+    const storageChoice = (normalizeStorageOverride(override) ??
+        state?.storage?.choice ??
+        DEFAULT_STORAGE_CHOICE) as OnboardingStorageChoice;
 
     const everWorksGitAvailable =
         catalog?.storage?.find((card) => card.choice === EVER_WORKS_GIT_STORAGE)?.available ===
@@ -91,7 +107,9 @@ export function resolveManagedStorage(
  * never let an unconnected `user-github` user through — the whole point of
  * the gate is that their create would fail server-side.
  */
-export async function resolveManagedStorageStatus(): Promise<ManagedStorageStatus> {
+export async function resolveManagedStorageStatus(
+    override?: string,
+): Promise<ManagedStorageStatus> {
     const [stateResult, catalogResult] = await Promise.allSettled([
         onboardingAPI.getState(),
         onboardingAPI.getCatalog(),
@@ -113,5 +131,6 @@ export async function resolveManagedStorageStatus(): Promise<ManagedStorageStatu
     return resolveManagedStorage(
         stateResult.status === 'fulfilled' ? stateResult.value?.state : null,
         catalogResult.status === 'fulfilled' ? catalogResult.value : null,
+        override,
     );
 }


### PR DESCRIPTION
## The production symptom

A freshly registered user **cannot create a Work on `app.ever.works` at all** — the platform's single core action.

1. The onboarding wizard offers **"Ever Works Git — Push your work repos to a managed Ever Works GitHub org"**, marked **DEFAULT** and fully enabled. Verified live on prod (step 3, *Your Git Storage*):

   > `Ever Works Git` — *Push your work repos to a managed Ever Works GitHub org.* **DEFAULT**
   > `Your GitLab` — **COMING SOON** · `Your Git` — **COMING SOON**

   and on the running prod API pod:

   ```
   $ kubectl exec -n ever-works-app-prod ever-works-api-... -- printenv \
       STORAGE_EVER_WORKS_GIT_ENABLED EVER_WORKS_CUSTOMERS_GITHUB_ORG
   true
   ever-works-cloud
   ```
2. Selecting it persists correctly: `users.onboardingState` → `"storage":{"choice":"ever-works-git"}`.
3. The New Work form still shows only **"Git Provider — Not connected / Connect"**. No managed option, no hint that the managed org will be used.
4. **Generate with AI** returns `requiresGitProvider`, creates nothing (zero rows in `works`), and shows an error.

Blast radius is everyone, not just users who explicitly picked the option: `ONBOARDING_DEFAULT_STATE.storage.choice` is itself `'ever-works-git'`, so any user who touches the wizard lands on the managed choice.

## Root cause

`apps/web/src/app/actions/dashboard/works.ts` gated on a **personal** connected provider before it ever called the API — in `createWorkWithAI` (~line 313) and identically in `createWork`:

```ts
const providerId = validation.data.gitProvider;
if (!providerId) return { …, requiresGitProvider: true };
const connectionCheck = await checkGitProviderConnection(providerId);
if (!connectionCheck.connected) return { …, requiresGitProvider: true };
```

There was no branch for managed storage. The web UI refused what the API permits.

## Why the backend was already correct

`packages/agent/src/services/work-lifecycle.service.ts` handles this properly and needed no change:

- `resolveProviderDefaults()` reads the user's `onboardingState` and resolves storage / deploy / git, with precedence *DTO → onboarding state → `user-github`*.
- `gitProviderFromStorageChoice('ever-works-git')` → `'github'` (the managed org is a GitHub org, so the runtime git provider is still GitHub). Its docstring already says: *"Without this, picking `ever-works-git` in the wizard had no runtime effect."*
- `createWork` (~line 307) branches on `storageProvider === 'ever-works-git' && this.everWorksGit.isEnabled()` and provisions the repo in `ever-works-cloud` with the platform's own PAT **before** the Work row is written, then sets `work.owner` to the platform org.
- `CreateWorkDto` documents `storageProvider: 'ever-works-git'` as a first-class field.

And `POST /api/works` does not require a personal git provider at all — the e2e helper `createWorkViaAPI` (`apps/web/e2e/helpers/api.ts`) creates Works git-lessly, and `work-create-ui-journey.spec.ts` already comments that the UI submit cannot succeed in a git-less stack.

## The fix

**1. Stop blocking under managed storage.** A single `resolveCreateWorkGitGate()` decides whether a *personal* provider is required. It is not required when the effective storage choice is `ever-works-git` **and** the platform reports the feature available; it still is for `user-github` and the other personal choices, whose repos are created with the user's own OAuth token.

**2. Pass `storageProvider` through explicitly.** `CreateWorkDto.storageProvider` is now sent from both create actions, so the web's gate decision and the server's provisioning decision key off the *same* value instead of both inferring it independently. It also had to be declared on the action's zod schema — `z.object` strips undeclared keys, so the field would otherwise have been dropped silently on its way to the API.

**3. Fix the Git Provider section.** Under managed storage the sidebar no longer says "Not connected" with a Connect button for an OAuth flow nobody needs; it states that repos go to the managed Ever Works org. `RepositoryOwnerCard` likewise replaces "connect a Git provider" with the managed-org note instead of rendering the personal org selector.

### Where the web learns this

Both inputs are resolved **server-side** in `apps/web/src/lib/works/managed-storage.ts`:

| input | source | why |
| --- | --- | --- |
| an explicit `CreateWorkDto.storageProvider` | the request itself | mirrors `resolveProviderDefaults`' DTO-first precedence |
| the user's storage choice | `GET /onboarding/state` | per-user, and it is exactly what `resolveProviderDefaults` reads next |
| the platform capability | `GET /onboarding/catalog` | `storage[choice=ever-works-git].available` is driven by `config.everWorks.git.isEnabled()` — the same `STORAGE_EVER_WORKS_GIT_ENABLED` flag `WorkLifecycleService` gates the managed branch on |

The first row matters: the gate is decided from the **same** value the request will carry. Resolving it from onboarding state while sending a different `storageProvider` would recreate the very web/server disagreement this PR removes — and since a server action is reachable as a POST endpoint, that value is caller-controlled. No current caller passes the field; the precedence is wired up before one does.

The catalog is the established capability contract for precisely this question — its own docstring says `available` exists "so we can flip Ever Works defaults to / from 'Planned' by toggling env flags without shipping a web release", and the wizard already consumes it. Nothing is hardcoded and no server-only env var is read in a client component.

`/api/config` was considered and rejected: it is a public, anonymous, `Cache-Control: public` allow-list whose `features` key set is pinned to an exact list by two deployed-contract e2e specs (`flow-config-public-contract.spec.ts`, `flow-feature-flags-runtime.spec.ts`), so adding a key there would red those suites until prod redeploys — and unlike the catalog it is not per-user, so it could not answer half the question anyway.

Resolution **fails closed**: if either lookup errors, the pre-existing personal-provider gate applies, so a transient blip can never wave an unconnected `user-github` user through.

### Both environments

| | `STORAGE_EVER_WORKS_GIT_ENABLED` | catalog `available` | wizard card | behaviour |
| --- | --- | --- | --- | --- |
| **prod** `app.ever.works` | `true` | `true` | "Ever Works Git … **DEFAULT**" | gate lifted — the P0 fix |
| **dev** `app-dev.ever.works` | `false` | `false` | "Coming soon … **DEFAULT COMING SOON**" | gate kept, unchanged |

Both card states were confirmed live in the browser against the deployed apps.

## Scope

- The import / repo-linking actions (`analyzeRepository`, `importWork`, `analyzeForLinking`, `getUserRepositories`) keep their gate — those genuinely need the user's own token to read the user's own repos.
- `WorkAICreator.tsx`'s `requiresGitProvider` branch handling is **untouched** (#2020); only a new presentational prop was threaded in.
- Untouched: `packages/agent/src/database/repositories/*`, `/admin` pages, `apps/web/e2e/e2e-smoke/*`, `.github/workflows/smoke-deployed.yml`.

## Tests

New: `apps/web/src/app/actions/dashboard/works.unit.spec.ts` (14 cases).

### Before — `works.ts` reverted to `develop`, spec unchanged: 5 failed

```
$ git checkout origin/develop -- apps/web/src/app/actions/dashboard/works.ts
$ npx vitest run src/app/actions/dashboard/works.unit.spec.ts

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  … > managed storage (wizard choice `ever-works-git`, feature enabled) > createWorkWithAI does NOT return requiresGitProvider and reaches the API
 FAIL  … > managed storage (wizard choice `ever-works-git`, feature enabled) > sends storageProvider=ever-works-git so the API provisions the managed repo
 FAIL  … > managed storage (wizard choice `ever-works-git`, feature enabled) > works with no gitProvider selected at all (nothing to connect)
 FAIL  … > managed storage (wizard choice `ever-works-git`, feature enabled) > createWork (manual form) is unblocked on the same terms
 FAIL  … > an explicit DTO storageProvider decides the gate too > lifts the gate when the DTO explicitly asks for ever-works-git

AssertionError: expected true to be undefined
- Expected: undefined
+ Received: true
  … expect(result.requiresGitProvider).toBeUndefined();

 Test Files  1 failed (1)
      Tests  5 failed | 9 passed (14)
```

The 9 that already pass are the regression guards — the personal-provider, DTO-override-to-personal and fail-closed cases. They must behave **identically** before and after, and they do; without them a blanket "never gate" would satisfy every other assertion in the file.

### After — 14 passed

```
 ✓ managed storage … > createWorkWithAI does NOT return requiresGitProvider and reaches the API
 ✓ managed storage … > never asks whether a personal git provider is connected
 ✓ managed storage … > sends storageProvider=ever-works-git so the API provisions the managed repo
 ✓ managed storage … > works with no gitProvider selected at all (nothing to connect)
 ✓ managed storage … > createWork (manual form) is unblocked on the same terms
 ✓ personal storage still requires a connected provider > blocks with requiresGitProvider when the selected provider is not connected
 ✓ personal storage still requires a connected provider > blocks with requiresGitProvider when no provider was selected
 ✓ personal storage still requires a connected provider > proceeds — without a storageProvider override — once the provider IS connected
 ✓ personal storage still requires a connected provider > createWork (manual form) still blocks an unconnected provider
 ✓ an explicit DTO storageProvider decides the gate too > keeps the gate when the DTO overrides a managed onboarding choice with user-github
 ✓ an explicit DTO storageProvider decides the gate too > lifts the gate when the DTO explicitly asks for ever-works-git
 ✓ platform capability is read from the catalog, never assumed > keeps the gate when the user chose ever-works-git but the platform has it OFF (e.g. dev)
 ✓ platform capability is read from the catalog, never assumed > fails CLOSED when the onboarding state cannot be read
 ✓ platform capability is read from the catalog, never assumed > fails CLOSED when the catalog cannot be read

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Full suite + types, unchanged:

```
$ npx vitest run              →  Test Files 149 passed (149) · Tests 1491 passed (1491)
$ npx tsc --noEmit            →  clean
$ npx eslint <changed files>  →  clean
$ npx prettier --check        →  All matched files use Prettier code style!
```

## Follow-up noted, deliberately not bundled

The catalog's `available` for `ever-works-git` is derived from the env flag alone, while `EverWorksGitProvider.isEnabled()` additionally requires the PAT and org to be non-empty. On an environment with the flag on but the PAT missing the two disagree, and `WorkLifecycleService` would silently *skip* provisioning rather than fail. Prod has both set (verified above) and dev has the flag off, so neither is affected today. Tightening the catalog to ask the provider would change an existing contract test's fixture, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

