### PR TITLE
fix(web): a bad id in a URL should 404, not 500

### DIFF
--- a/apps/web/e2e/flow-scoped-tasks-tab-bad-id.spec.ts
+++ b/apps/web/e2e/flow-scoped-tasks-tab-bad-id.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, loginViaAPI, registerUserViaAPI } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+
+/**
+ * PAGE-level id handling for the two scope-filtered Tasks tabs,
+ * `/ideas/[id]/tasks` and `/missions/[id]/tasks`.
+ *
+ * THE DEFECT THIS PINS. Both pages passed the raw `[id]` path segment
+ * straight into `tasksAPI.list({ ideaId | missionId: id })`, which has no
+ * internal catch. The API applies `ParseUUIDPipe` to those query params, so
+ * a malformed id produced a 400 that escaped the Server Component and the
+ * ROUTE answered **HTTP 500**. Observed live on app-dev.ever.works before
+ * the fix:
+ *
+ *     GET /en/ideas/not-a-uuid/tasks     -> 500
+ *     GET /en/missions/not-a-uuid/tasks  -> 500
+ *
+ * ...while the PARENT detail routes, handed the identical id, already
+ * answered a clean 404:
+ *
+ *     GET /en/ideas/not-a-uuid           -> 404
+ *     GET /en/missions/not-a-uuid        -> 404
+ *
+ * A bad id in a URL is an ordinary client error. Neither route had any
+ * upstream ownership or existence check to catch it first: `ideas/[id]` has
+ * no layout at all, and `missions/[id]/layout.tsx` renders the tab strip
+ * without fetching anything. The fix resolves the parent Idea / Mission
+ * first and calls `notFound()` when it does not resolve — the same thing
+ * `/ideas/[id]` and `/missions/[id]` have always done.
+ *
+ * WHY THE ASSERTION IS ON HTTP STATUS. 500 and 404 both render "no tasks"
+ * to the eye, so a content-only assertion passes against the bug. Only the
+ * status code distinguishes them, so every case below asserts
+ * `response.status()` first and treats the rendered surface as corroboration.
+ * This mirrors the reasoning in `flow-admin-routes-authz.spec.ts` ("flow 9"),
+ * which pinned the same 4xx→500 class on `/admin/plugins/allowlist`.
+ *
+ * KNOWN-GOOD CONTROLS (flow 5 and flow 6). A spec that only ever asserts 404
+ * cannot tell "the fix works" from "every route in this environment 404s".
+ * flow 5 pins the parent routes as the 404 reference point, and flow 6 is the
+ * positive control: a REAL, caller-owned Mission and Idea must still render
+ * their Tasks tab at 200 with the task visible. Without flow 6 a blanket
+ * `notFound()` would pass this file.
+ *
+ * NON-DUPLICATION: `mission-idea-task-flow.spec.ts` already covers the happy
+ * path of `/missions/:id/tasks` rendering a scoped Task. This spec does not
+ * re-test the rendering contract; it pins the ID-HANDLING contract (bad,
+ * unknown, and someone else's ids) plus the minimum happy-path control that
+ * makes the negative assertions meaningful.
+ */
+
+/** Well-formed UUID that belongs to no record. */
+const UNKNOWN_UUID = '11111111-1111-1111-1111-111111111111';
+
+/** Ids that cannot be a UUID at all — each trips the API's ParseUUIDPipe (400). */
+const MALFORMED_IDS = ['not-a-uuid', '123', 'foo-bar-baz'];
+
+/**
+ * Assert a dashboard route answered the ordinary not-found status and
+ * rendered the not-found surface — never a server error.
+ */
+async function expectNotFoundPage(
+    page: import('@playwright/test').Page,
+    path: string,
+    label: string,
+): Promise<void> {
+    const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    // The regression itself. Before the fix this was 500.
+    expect(response?.status(), `${label} must never answer a server error for a bad id`).not.toBe(
+        500,
+    );
+    expect(response?.status(), `${label} answers the ordinary not-found status`).toBe(404);
+
+    // Corroboration: the scoped-Tasks chrome must not render...
+    await expect(
+        page.getByRole('heading', { name: /^Tasks$/, level: 2 }),
+        `${label} must not render the scoped Tasks section`,
+    ).toHaveCount(0);
+
+    // ...and the not-found surface must be what the user actually sees.
+    const notFound = page
+        .getByText(/page (could not be|not) found/i)
+        .or(page.getByText(/^404$/))
+        .or(page.getByRole('heading', { name: /not found/i }))
+        .first();
+    await expect(notFound, `${label} shows the not-found page`).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('Flow: scoped Tasks tabs — a malformed id in the URL (404, never 500)', () => {
+    test('flow 1: /ideas/:id/tasks answers 404 for an id that cannot be a UUID — the API 400 from ParseUUIDPipe must not escape the Server Component and become an HTTP 500', async ({
+        page,
+    }) => {
+        for (const badId of MALFORMED_IDS) {
+            await expectNotFoundPage(
+                page,
+                `/ideas/${badId}/tasks`,
+                `Idea Tasks tab with malformed id '${badId}'`,
+            );
+        }
+    });
+
+    test('flow 2: /missions/:id/tasks answers 404 for an id that cannot be a UUID — same 400→500 escape, and the mission layout fetches nothing so nothing upstream caught it', async ({
+        page,
+    }) => {
+        for (const badId of MALFORMED_IDS) {
+            await expectNotFoundPage(
+                page,
+                `/missions/${badId}/tasks`,
+                `Mission Tasks tab with malformed id '${badId}'`,
+            );
+        }
+    });
+});
+
+test.describe('Flow: scoped Tasks tabs — a well-formed id that resolves to nothing', () => {
+    test('flow 3: both Tasks tabs answer 404 for a syntactically VALID uuid that matches no record — the tab must not render an empty task list, which would claim the scope exists and simply has no tasks', async ({
+        page,
+    }) => {
+        await expectNotFoundPage(
+            page,
+            `/ideas/${UNKNOWN_UUID}/tasks`,
+            'Idea Tasks tab with an unknown uuid',
+        );
+        await expectNotFoundPage(
+            page,
+            `/missions/${UNKNOWN_UUID}/tasks`,
+            'Mission Tasks tab with an unknown uuid',
+        );
+    });
+
+    test("flow 4: both Tasks tabs answer 404 for ANOTHER user's real Mission / Idea — the scope endpoints are owner-scoped, so a valid id from a foreign account resolves to nothing here and must never render that account's scope", async ({
+        page,
+        request,
+    }) => {
+        // A second, unrelated account owns the resources referenced below.
+        const stranger = await registerUserViaAPI(request);
+        const strangerHeaders = authedHeaders(stranger.access_token);
+
+        const missionRes = await request.post(`${API_BASE}/api/me/missions`, {
+            headers: strangerHeaders,
+            data: {
+                title: `Stranger Mission ${Date.now()}`,
+                description: 'owned by another account',
+                type: 'one-shot',
+            },
+        });
+        expect(missionRes.ok(), 'stranger mission create').toBeTruthy();
+        const strangerMission = await missionRes.json();
+
+        const ideaRes = await request.post(`${API_BASE}/api/me/work-proposals`, {
+            headers: strangerHeaders,
+            data: { description: `Stranger Idea ${Date.now()}` },
+        });
+        expect(ideaRes.status(), 'stranger idea create').toBe(201);
+        const strangerIdea = await ideaRes.json();
+
+        // The browser session is the SEEDED user, not the stranger.
+        await expectNotFoundPage(
+            page,
+            `/missions/${strangerMission.id}/tasks`,
+            "Mission Tasks tab with another user's mission id",
+        );
+        await expectNotFoundPage(
+            page,
+            `/ideas/${strangerIdea.id}/tasks`,
+            "Idea Tasks tab with another user's idea id",
+        );
+    });
+});
+
+test.describe('Flow: scoped Tasks tabs — controls', () => {
+    test('flow 5: CONTROL — the PARENT detail routes already answered 404 for these same malformed ids, so 404 is the reference behaviour the tabs were diverging from, not an artifact of this environment', async ({
+        page,
+    }) => {
+        for (const badId of MALFORMED_IDS) {
+            const idea = await page.goto(`/ideas/${badId}`, { waitUntil: 'domcontentloaded' });
+            expect(idea?.status(), `/ideas/${badId} (parent) is the 404 reference point`).toBe(404);
+
+            const mission = await page.goto(`/missions/${badId}`, {
+                waitUntil: 'domcontentloaded',
+            });
+            expect(
+                mission?.status(),
+                `/missions/${badId} (parent) is the 404 reference point`,
+            ).toBe(404);
+        }
+    });
+
+    test('flow 6: POSITIVE CONTROL — a real, caller-owned Mission and Idea still render their Tasks tab at 200 with the scoped task visible; a blanket notFound() would satisfy every assertion above but fail here', async ({
+        page,
+        request,
+    }) => {
+        // Same account as the browser storageState, so what the API creates
+        // here is what the page is allowed to see.
+        const seeded = loadSeededTestUser();
+        const { access_token } = await loginViaAPI(request, {
+            email: seeded.email,
+            password: seeded.password,
+        });
+        const headers = authedHeaders(access_token);
+        const stamp = Date.now();
+
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: {
+                    title: `Bad-id control Mission ${stamp}`,
+                    description: 'positive control',
+                    type: 'one-shot',
+                },
+            })
+        ).json();
+        const missionTaskTitle = `Bad-id control Mission Task ${stamp}`;
+        const missionTaskRes = await request.post(`${API_BASE}/api/tasks`, {
+            headers,
+            data: { title: missionTaskTitle, missionId: mission.id },
+        });
+        expect(missionTaskRes.ok(), 'mission-scoped task create').toBeTruthy();
+
+        const ideaRes = await request.post(`${API_BASE}/api/me/work-proposals`, {
+            headers,
+            data: { description: `Bad-id control Idea ${stamp}` },
+        });
+        expect(ideaRes.status(), 'idea create').toBe(201);
+        const idea = await ideaRes.json();
+        const ideaTaskTitle = `Bad-id control Idea Task ${stamp}`;
+        const ideaTaskRes = await request.post(`${API_BASE}/api/tasks`, {
+            headers,
+            data: { title: ideaTaskTitle, ideaId: idea.id },
+        });
+        expect(ideaTaskRes.ok(), 'idea-scoped task create').toBeTruthy();
+
+        const missionTab = await page.goto(`/missions/${mission.id}/tasks`, {
+            waitUntil: 'domcontentloaded',
+        });
+        expect(missionTab?.status(), 'a real Mission still renders its Tasks tab, not a 404').toBe(
+            200,
+        );
+        await expect(page.getByText(missionTaskTitle).first()).toBeVisible({ timeout: 30_000 });
+
+        const ideaTab = await page.goto(`/ideas/${idea.id}/tasks`, {
+            waitUntil: 'domcontentloaded',
+        });
+        expect(ideaTab?.status(), 'a real Idea still renders its Tasks tab, not a 404').toBe(200);
+        await expect(page.getByText(ideaTaskTitle).first()).toBeVisible({ timeout: 30_000 });
+    });
+});

--- a/apps/web/src/app/[locale]/(dashboard)/ideas/[id]/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/ideas/[id]/tasks/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { tasksAPI } from '@/lib/api/tasks';
+import { workProposalsAPI } from '@/lib/api/work-proposals';
+import { ApiResponseError } from '@/lib/api/server-api';
 import { TasksScopedSection } from '@/components/tasks/TasksScopedSection';
 
 export const metadata: Metadata = { title: 'Tasks' };
@@ -13,10 +16,49 @@ export const metadata: Metadata = { title: 'Tasks' };
  * deep-links from notifications / chat mentions resolve cleanly.
  * The drawer surface lands once the shared expansion-drawer
  * primitive is extracted from the Idea card.
+ *
+ * `id` is whatever the URL carried, so it is resolved against the Idea
+ * itself BEFORE it is used as a task filter. Previously it went straight
+ * into `tasksAPI.list`, which has no internal catch: the API applies
+ * `ParseUUIDPipe` to `ideaId`, so a malformed id produced a 400 that
+ * escaped this Server Component and made the whole ROUTE answer
+ * **HTTP 500** — while `/ideas/[id]`, given the identical id, already
+ * answered a clean 404. A bad id in a URL is an ordinary client error;
+ * it must render the not-found surface, not a server error.
  */
 export default async function IdeaTasksTabPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
+
+    // Mirrors `/ideas/[id]`: resolve the Idea, 404 when it does not
+    // resolve. `workProposalsAPI.get` already maps 404 (no such Idea)
+    // and 403 (not the caller's Idea) to null; it deliberately rethrows
+    // everything else so a transient outage is never mistaken for "the
+    // Idea vanished". A 400 is neither — it is a malformed id, i.e. a
+    // definitively unresolvable Idea — so it joins the not-found path
+    // here rather than propagating as a 500.
+    const idea = await workProposalsAPI.get(id).catch((error: unknown) => {
+        if (error instanceof ApiResponseError && error.statusCode === 400) {
+            return null;
+        }
+        throw error;
+    });
+
+    if (!idea) {
+        // Logged, not swallowed: an unresolvable id is a 404 the operator
+        // should still be able to see in the logs. (`serverFetch` already
+        // console.errors every non-404 API response, so the underlying
+        // 400/403 is recorded too.)
+        console.warn(`[ideas/[id]/tasks] no Idea resolves for id "${id}" — rendering not-found`);
+        notFound();
+    }
+
+    // `id` is now a known, caller-owned Idea, so this cannot 400/403/404.
+    // It stays uncaught on purpose: a rejection here is a real backend
+    // failure and must reach the dashboard error boundary (which offers a
+    // retry) rather than render as an empty Tasks tab — "the API is down"
+    // and "this Idea has no tasks" must never look the same.
     const result = await tasksAPI.list({ ideaId: id, limit: 100, includeRun: true });
+
     return (
         <div className="p-6 max-w-screen-2xl mx-auto">
             <TasksScopedSection tasks={result.data} scopeLabel="Idea" scopeId={id} />

--- a/apps/web/src/app/[locale]/(dashboard)/missions/[id]/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/missions/[id]/tasks/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { tasksAPI } from '@/lib/api/tasks';
+import { missionsAPI } from '@/lib/api/missions';
 import { TasksScopedSection } from '@/components/tasks/TasksScopedSection';
 
 export const metadata: Metadata = { title: 'Tasks' };
@@ -11,10 +13,46 @@ export const metadata: Metadata = { title: 'Tasks' };
  * The MissionTabs strip is mounted by `missions/[id]/layout.tsx`
  * (tick 38), so Overview and Tasks both inherit the navigation
  * automatically — this page only needs to render its Tasks content.
+ *
+ * `id` is whatever the URL carried, so it is resolved against the
+ * Mission itself BEFORE it is used as a task filter. Previously it went
+ * straight into `tasksAPI.list`, which has no internal catch: the API
+ * applies `ParseUUIDPipe` to `missionId`, so a malformed id produced a
+ * 400 that escaped this Server Component and made the whole ROUTE answer
+ * **HTTP 500** — while `/missions/[id]`, given the identical id, already
+ * answered a clean 404. The layout fetches nothing, so nothing upstream
+ * caught it either. A bad id in a URL is an ordinary client error; it
+ * must render the not-found surface, not a server error.
  */
 export default async function MissionTasksTabPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
+
+    // Mirrors `/missions/[id]`: resolve the Mission, 404 when it does not
+    // resolve. `missionsAPI.get` maps every failure to null, so a
+    // malformed id (400 from ParseUUIDPipe), an unknown id (404) and
+    // another user's id (the endpoint is owner-scoped) all land here —
+    // and all three are 404s, which is what the Overview tab of this very
+    // same Mission already answers for them.
+    const mission = await missionsAPI.get(id);
+
+    if (!mission) {
+        // Logged, not swallowed: an unresolvable id is a 404 the operator
+        // should still be able to see in the logs. (`serverFetch` already
+        // console.errors every non-404 API response, so a transient
+        // failure behind this null is recorded too.)
+        console.warn(
+            `[missions/[id]/tasks] no Mission resolves for id "${id}" — rendering not-found`,
+        );
+        notFound();
+    }
+
+    // `id` is now a known, caller-owned Mission, so this cannot 400/404.
+    // It stays uncaught on purpose: a rejection here is a real backend
+    // failure and must reach the dashboard error boundary (which offers a
+    // retry) rather than render as an empty Tasks tab — "the API is down"
+    // and "this Mission has no tasks" must never look the same.
     const result = await tasksAPI.list({ missionId: id, limit: 100, includeRun: true });
+
     return (
         <div className="p-6 max-w-screen-2xl mx-auto">
             <TasksScopedSection tasks={result.data} scopeLabel="Mission" scopeId={id} />

--- a/apps/web/src/app/[locale]/(dashboard)/settings/danger/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/danger/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { authAPI } from '@/lib/api/auth';
+import { requireFreshProfile } from '@/lib/auth/require-fresh-profile';
 import { DangerZone } from '@/components/settings/DangerZone';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -9,7 +9,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function DangerZoneSettingsPage() {
-    const profile = await authAPI.getFreshProfile();
+    // Get fresh profile. A rejected session redirects to login instead of
+    // 500ing the route; a real backend failure still reaches the error
+    // boundary. See `requireFreshProfile`.
+    const profile = await requireFreshProfile('settings/danger');
 
     return <DangerZone user={profile} />;
 }

--- a/apps/web/src/app/[locale]/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { authAPI } from '@/lib/api/auth';
+import { requireFreshProfile } from '@/lib/auth/require-fresh-profile';
 import { ProfileSettings } from '@/components/settings/ProfileSettings';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -9,8 +9,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function SettingsPage() {
-    // Get fresh profile
-    const profile = await authAPI.getFreshProfile();
+    // Get fresh profile. A rejected session redirects to login instead of
+    // 500ing the route; a real backend failure still reaches the error
+    // boundary. See `requireFreshProfile`.
+    const profile = await requireFreshProfile('settings');
 
     return <ProfileSettings user={profile} />;
 }

--- a/apps/web/src/app/[locale]/(dashboard)/settings/security/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/security/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { authAPI } from '@/lib/api/auth';
+import { requireFreshProfile } from '@/lib/auth/require-fresh-profile';
 import { SecuritySettings } from '@/components/settings/SecuritySettings';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -9,8 +9,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function SecuritySettingsPage() {
-    // Get fresh profile
-    const profile = await authAPI.getFreshProfile();
+    // Get fresh profile. A rejected session redirects to login instead of
+    // 500ing the route; a real backend failure still reaches the error
+    // boundary. See `requireFreshProfile`.
+    const profile = await requireFreshProfile('settings/security');
 
     return <SecuritySettings user={profile} />;
 }

--- a/apps/web/src/app/[locale]/(dashboard)/settings/work-agent/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/work-agent/page.tsx
@@ -1,19 +1,71 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { WorkAgentSettings } from '@/components/settings/WorkAgentSettings';
-import { workAgentAPI } from '@/lib/api/work-agent';
+import { workAgentAPI, type WorkAgentRun, type WorkBuildRequest } from '@/lib/api/work-agent';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.settings');
     return { title: t('tabs.workAgent') };
 }
 
+/**
+ * `/settings/work-agent` — the Work Agent preferences form plus its
+ * build-request history and live-run panel.
+ *
+ * These three calls used to sit in a bare `Promise.all`, so ANY one
+ * rejection took the whole route down with an HTTP 500 — even though the
+ * fourth call on the next line was already written `.catch(() => [])`.
+ * They are split by role instead, because "degrade everything" would be
+ * the wrong fix here:
+ *
+ *   • `preferences()` is the page's primary datum. The form cannot be
+ *     rendered truthfully without it — synthesising defaults would show
+ *     fabricated settings as if they were the user's own, and the user
+ *     could then save them over their real ones. Its rejection is
+ *     rethrown so the dashboard error boundary offers a retry.
+ *   • `listBuildRequests()` / `activeRun()` are satellites of that form.
+ *     A flaky satellite must not take down preferences that loaded fine,
+ *     so they degrade to their empty values — but with an explicit
+ *     `console.error`, never silently. This is the posture
+ *     `/missions/[id]` already takes with its nine side-panels.
+ *
+ * None of the three takes a caller-supplied id (all are derived from the
+ * session), so no URL can force a 4xx here — unlike the `[id]/tasks`
+ * tabs. The exposure this closes is transient backend failure only.
+ */
 export default async function WorkAgentSettingsPage() {
-    const [preferences, buildRequests, activeRun] = await Promise.all([
+    const [preferencesResult, buildRequestsResult, activeRunResult] = await Promise.allSettled([
         workAgentAPI.preferences(),
         workAgentAPI.listBuildRequests(),
         workAgentAPI.activeRun(),
     ]);
+
+    if (preferencesResult.status === 'rejected') {
+        // Loud on purpose — see the note above.
+        throw preferencesResult.reason;
+    }
+    const preferences = preferencesResult.value;
+
+    let buildRequests: WorkBuildRequest[] = [];
+    if (buildRequestsResult.status === 'fulfilled') {
+        buildRequests = buildRequestsResult.value;
+    } else {
+        console.error(
+            '[settings/work-agent] build-request history unavailable; rendering the form without it',
+            buildRequestsResult.reason,
+        );
+    }
+
+    let activeRun: WorkAgentRun | null = null;
+    if (activeRunResult.status === 'fulfilled') {
+        activeRun = activeRunResult.value;
+    } else {
+        console.error(
+            '[settings/work-agent] active-run lookup unavailable; rendering the form without it',
+            activeRunResult.reason,
+        );
+    }
+
     const logs = activeRun ? await workAgentAPI.runLogs(activeRun.id).catch(() => []) : [];
 
     return (

--- a/apps/web/src/lib/auth/require-fresh-profile.ts
+++ b/apps/web/src/lib/auth/require-fresh-profile.ts
@@ -1,0 +1,47 @@
+import 'server-only';
+import { getLocale } from 'next-intl/server';
+import { authAPI } from '@/lib/api/auth';
+import { ApiResponseError } from '@/lib/api/server-api';
+import { redirect } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+
+export type FreshProfile = Awaited<ReturnType<typeof authAPI.getFreshProfile>>;
+
+/**
+ * `authAPI.getFreshProfile()` with the one outcome it was missing.
+ *
+ * The Settings pages (`/settings`, `/settings/security`, `/settings/danger`)
+ * each re-fetch the profile with `getFreshProfile()`, which has no internal
+ * catch — so a rejection escaped the Server Component and the ROUTE answered
+ * **HTTP 500**. Their own parent `(dashboard)/layout.tsx` makes the identical
+ * call guarded (`.catch(() => null)`) and redirects to login when the session
+ * is gone, but layout and page render CONCURRENTLY: the page's throw is not
+ * reliably pre-empted by the layout's redirect.
+ *
+ * The missing outcome is specifically the 401. A session that is present but
+ * no longer accepted — expired JWT, rotated secret, revoked session — is not a
+ * server error, it is a signed-out user, and the correct answer is the login
+ * page. That is exactly what the layout does for an *absent* cookie; this
+ * makes the page agree for a *rejected* one.
+ *
+ * Everything else (5xx, network failure) is deliberately rethrown. There is no
+ * honest "degraded profile" to render — a fabricated or blank profile on the
+ * Danger Zone or Security page would show made-up account state as if it were
+ * the user's own — so a real backend failure stays loud and reaches the
+ * dashboard error boundary, which offers a retry.
+ */
+export async function requireFreshProfile(routeLabel: string): Promise<FreshProfile> {
+    try {
+        return await authAPI.getFreshProfile();
+    } catch (error) {
+        if (error instanceof ApiResponseError && error.statusCode === 401) {
+            // Logged, not swallowed — a silent bounce to /login is hard to
+            // tell from a user simply signing out.
+            console.warn(
+                `[${routeLabel}] session rejected by /auth/profile/fresh (401) — redirecting to login`,
+            );
+            redirect({ locale: await getLocale(), href: ROUTES.AUTH_LOGIN });
+        }
+        throw error;
+    }
+}


### PR DESCRIPTION
A Server Component that awaits an API call with no error handling turns an
ordinary client error into an **HTTP 500**. `serverFetch`
(`apps/web/src/lib/api/server-api.ts:127-190`) throws `ApiResponseError` on
every non-OK response — 400/401/403/404 alike — so an unguarded `await` in a
page takes the whole route down.

This is the same class as the `/admin/plugins/allowlist` defect
(`fix/admin-allowlist-page-404-not-500`). A static sweep of all 117
`page/layout/template/default.tsx` files under `apps/web/src/app` (113 awaited
API calls; 82 already guarded) found six more files. This PR fixes them.
`/admin/*` is untouched — it has its own PR in flight.

---

## Site 1 — `/ideas/[id]/tasks` and `/missions/[id]/tasks` (the real bug)

Both passed the raw `[id]` path segment straight into
`tasksAPI.list({ ideaId | missionId: id })`, which has **no** internal catch
(`lib/api/tasks.ts:245-251`). `tasks.controller.ts:161-162` applies
`ParseUUIDPipe` to `ideaId`/`missionId`, so a malformed id → **400 → unhandled
→ 500**.

Nothing upstream caught it: `ideas/[id]` has no layout at all, and
`missions/[id]/layout.tsx` renders the tab strip without fetching anything.

### Live status codes observed BEFORE the fix

Measured on `https://app-dev.ever.works`, signed in as the QA account:

| URL | Before | After |
|---|---|---|
| `/en/ideas/not-a-uuid/tasks` | **500** | 404 |
| `/en/missions/not-a-uuid/tasks` | **500** | 404 |
| `/en/ideas/11111111-1111-1111-1111-111111111111/tasks` | **200**, empty tab | 404 |
| `/en/missions/11111111-1111-1111-1111-111111111111/tasks` | **200**, empty tab | 404 |
| `/en/ideas/not-a-uuid` (parent, control) | 404 | 404 |
| `/en/missions/not-a-uuid` (parent, control) | 404 | 404 |

The last two rows are the point: **the parent detail routes already answered a
clean 404 for the identical id.** Only the Tasks tabs 500'd. The tabs were
diverging from their own parents.

The 200 rows are the second half of the bug. `tasksAPI.list` is owner-scoped
server-side (`task.repository.ts:118` — `task.userId = :userId`), so a valid
id belonging to another user **does not leak** — it returns an empty list. But
the page then rendered a normal Tasks tab claiming that scope exists and simply
has no tasks. Same for a well-formed uuid matching no record at all.

### Fix

Resolve the parent Idea / Mission first and `notFound()` when it does not
resolve — exactly what `/ideas/[id]` and `/missions/[id]` already do, so all
four cases (malformed, unknown, not-yours, deleted) converge on one honest 404.

- **missions:** `missionsAPI.get` maps every failure to `null`, so the 400, the
  404 and the foreign-owner case all land in one place.
- **ideas:** `workProposalsAPI.get` deliberately maps only 404/403 to `null` and
  rethrows the rest so a poller can't mistake an outage for "the Idea vanished".
  A 400 is neither — it's a definitively unresolvable id — so it is caught
  explicitly by status and joins the not-found path. Everything else still
  propagates.

The `tasksAPI.list` call after the guard stays **uncaught on purpose**: the id
is known-good and caller-owned by then, so a rejection there is a real backend
failure and must reach the dashboard error boundary (which offers a retry)
rather than render as an empty Tasks tab. "The API is down" and "this Mission
has no tasks" must never look the same — the same reasoning
`/agents/archived` documents for its own deliberate lack of a catch.

Both `notFound()` paths log the route and id first, so a 404 is still visible
to an operator.

## Site 2 — `/settings`, `/settings/security`, `/settings/danger`

All three repeat `await authAPI.getFreshProfile()` with no catch — the
**identical call their own parent layout makes guarded**
(`(dashboard)/layout.tsx:57`: `.catch(() => null)`). Layout and page render
*concurrently*, so the layout's redirect does not reliably pre-empt the page's
throw.

New helper `apps/web/src/lib/auth/require-fresh-profile.ts` adds the one
outcome that was missing: a **401** — expired JWT, rotated secret, revoked
session — is not a server error, it is a signed-out user, so it redirects to
login. That is what the layout already does for an *absent* cookie; this makes
the page agree for a *rejected* one.

5xx and network failures are deliberately **rethrown**. There is no honest
"degraded profile" to render — a blank or synthesised profile on the Security
or Danger Zone page would show made-up account state as if it were the user's
own — so a real failure stays loud and reaches the error boundary.

## Site 3 — `/settings/work-agent`

Three unguarded calls in a bare `Promise.all`, with a guarded fourth on the
very next line — so any one rejection took the whole route down even though the
author had clearly already reached for `.catch`. Split by role via
`Promise.allSettled`:

- `preferences()` — the page's primary datum — **stays loud**. Synthesising
  defaults would show fabricated settings as if they were the user's own, and
  the user could then save them over their real ones.
- `listBuildRequests()` / `activeRun()` are satellites; they degrade to their
  empty values **with an explicit `console.error`**, never silently. Same
  posture `/missions/[id]` already takes with its nine side-panels.

None of the three takes a caller-supplied id, so no URL can force a 4xx here —
this closes transient-backend-failure exposure only.

## Deliberately NOT changed

`/agents/archived` (`agents/archived/page.tsx:26`) is unguarded **by design** —
its docstring states the rejection is deliberately allowed to reach the error
boundary so "unreachable API" and "empty archive" don't render identically.
Correct call; left alone.

---

## New coverage

`apps/web/e2e/flow-scoped-tasks-tab-bad-id.spec.ts` — 6 flows, all asserting
**`response.status()`**.

Status is the decisive signal: 500 and 404 both render "no tasks", so a
content-only assertion passes against the bug. Same reasoning as "flow 9" in
`flow-admin-routes-authz.spec.ts`.

| Flow | Asserts |
|---|---|
| 1 | `/ideas/:id/tasks` → 404 for `not-a-uuid`, `123`, `foo-bar-baz` |
| 2 | `/missions/:id/tasks` → 404 for the same three |
| 3 | Both tabs → 404 for a well-formed uuid matching no record |
| 4 | Both tabs → 404 for **another user's** real Mission / Idea |
| 5 | CONTROL — the parent routes 404 for those same ids (404 is reachable here, not an artifact) |
| 6 | POSITIVE CONTROL — a real, caller-owned Mission and Idea still render at **200** with the task visible |

Flow 6 is load-bearing: without it a blanket `notFound()` would satisfy every
other assertion in the file.

### Verification

Run against a local API + web (sqlite, the CI e2e env):

- **Fixed code: 7/7 pass** (incl. the setup project).
- **Known-dirty control** — the two page files reverted to `develop`, spec
  unchanged: **flows 1 and 2 fail with `Expected: not 500`, flows 3 and 4 fail
  with `Expected: 404 / Received: 200`, and control flows 5 and 6 still pass.**
  The spec provably catches the bug it was written for.
- The existing settings specs (`settings`, `security-settings`, `account-data`,
  `flow-settings-work-agent`, `settings-profile-ui`) were run **on this branch
  and on unmodified `develop`**: byte-identical results (29 passed / 5 failed /
  1 skipped, the same 5 tests). Those 5 are pre-existing local failures, not a
  regression from this PR.
- `tsc --noEmit` over `apps/web`: **0 errors**. ESLint and Prettier clean on
  every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
