### PR TITLE
fix(mcp): pass the caller's identity upstream — every data tool returned 401

### DIFF
--- a/apps/mcp/src/api-client/api-client.service.ts
+++ b/apps/mcp/src/api-client/api-client.service.ts
@@ -1,26 +1,35 @@
 import { Injectable, Inject, Scope, Optional } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { McpConfigService } from '../config/mcp-config.service.js';
+import { CallerContextService } from '../context/caller-context.service.js';
 import { ApiError } from './api-error.js';
 import { sanitizeResponse } from './sanitize.js';
 
 /**
  * H-21 — request-scoped HTTP client.
  *
- * Reads the per-user JWT (if any) from the incoming MCP request and
+ * Reads the per-user JWT (if any) for the request in flight and
  * forwards it to the upstream API. The shared `EVER_WORKS_API_KEY` is
  * still used as a fallback when the request didn't carry a JWT (`hybrid`
- * or `shared-key` modes). In `per-user-jwt` mode, the shared key is
- * never sent — only the caller's JWT — so cross-tenant access via a
- * leaked platform key becomes impossible.
+ * or `shared-key` modes) and by the stdio transport, which has no HTTP
+ * request at all. In `per-user-jwt` mode the shared key is null on the
+ * config, so it is never sent — only the caller's JWT — and cross-tenant
+ * access via a leaked platform key stays impossible.
+ *
+ * The caller's identity arrives via `CallerContextService`
+ * (`AsyncLocalStorage`), NOT via the injected `REQUEST`. See that
+ * service for why: the MCP transport binds its own adapter wrapper to
+ * the `REQUEST` token, so `httpRequest.__callerJwt` was always
+ * `undefined` and every data tool 401'd.
  */
 @Injectable({ scope: Scope.REQUEST })
 export class ApiClientService {
 	constructor(
 		@Inject(McpConfigService) private readonly config: McpConfigService,
-		// REQUEST is the inbound HTTP request when MCP is running over the
-		// HTTP transport. For stdio transport the request is absent and we
-		// fall back to the shared key.
+		@Inject(CallerContextService) private readonly callerContext: CallerContextService,
+		// Retained as a secondary source for any transport that binds the
+		// real request object to REQUEST. Never the only channel — that is
+		// exactly what broke.
 		@Optional()
 		@Inject(REQUEST)
 		private readonly httpRequest: { __callerJwt?: string } | null = null
@@ -36,7 +45,10 @@ export class ApiClientService {
 		// H-21: forward the per-user JWT if present, fall back to shared key.
 		// In `per-user-jwt` mode the shared key is null on the config, so
 		// we never send it even if a JWT is missing — the upstream will reject.
-		const callerJwt = this.httpRequest?.__callerJwt;
+		// A missing caller identity must stay a rejection: silently upgrading
+		// it to the shared platform key would turn an auth bug into a
+		// privilege-escalation bug.
+		const callerJwt = this.callerContext.getCallerJwt() ?? this.httpRequest?.__callerJwt;
 		if (callerJwt) {
 			headers['Authorization'] = `Bearer ${callerJwt}`;
 		} else if (this.config.apiKey) {

--- a/apps/mcp/src/app.module.ts
+++ b/apps/mcp/src/app.module.ts
@@ -1,7 +1,9 @@
-import { Module, OnApplicationBootstrap, Inject } from '@nestjs/common';
+import { Module, OnApplicationBootstrap, Inject, MiddlewareConsumer, NestModule } from '@nestjs/common';
 import { McpModule, McpTransportType } from '@rekog/mcp-nest';
 import { McpConfigModule } from './config/config.module.js';
 import { ApiClientModule } from './api-client/api-client.module.js';
+import { CallerContextModule } from './context/caller-context.module.js';
+import { CallerContextMiddleware } from './context/caller-context.middleware.js';
 import { OpenApiToolsModule } from './openapi-tools/openapi-tools.module.js';
 import { ToolRegistrationService } from './openapi-tools/tool-registration.service.js';
 import { HealthController } from './health.controller.js';
@@ -37,14 +39,37 @@ const isHttp = transport === McpTransportType.STREAMABLE_HTTP;
 				: {})
 		}),
 		McpConfigModule,
+		CallerContextModule,
 		ApiClientModule,
 		OpenApiToolsModule
 	],
 	controllers: isHttp ? [HealthController] : [],
-	providers: [ToolRegistrationService, ApiKeyGuard, PingTool, RegisterWorkTool, ...KB_TOOL_PROVIDERS]
+	providers: [
+		ToolRegistrationService,
+		ApiKeyGuard,
+		CallerContextMiddleware,
+		PingTool,
+		RegisterWorkTool,
+		...KB_TOOL_PROVIDERS
+	]
 })
-export class AppModule implements OnApplicationBootstrap {
+export class AppModule implements OnApplicationBootstrap, NestModule {
 	constructor(@Inject(ToolRegistrationService) private readonly toolRegistration: ToolRegistrationService) {}
+
+	/**
+	 * Open the caller-context frame for every inbound HTTP request, before
+	 * guards run. Applied to `*` rather than just `/mcp` so any route added
+	 * later is covered by default — a route that silently ran outside the
+	 * frame would reintroduce exactly the dropped-identity bug this fixes.
+	 *
+	 * Not applicable to the stdio transport, which serves no HTTP routes;
+	 * there the AsyncLocalStorage store is simply absent and
+	 * `ApiClientService` falls back to the shared key, as before.
+	 */
+	configure(consumer: MiddlewareConsumer) {
+		if (!isHttp) return;
+		consumer.apply(CallerContextMiddleware).forRoutes('*');
+	}
 
 	onApplicationBootstrap() {
 		this.toolRegistration.registerTools();

--- a/apps/mcp/src/context/caller-context.middleware.ts
+++ b/apps/mcp/src/context/caller-context.middleware.ts
@@ -1,0 +1,30 @@
+import { Injectable, Inject, NestMiddleware } from '@nestjs/common';
+import { CallerContextService } from './caller-context.service.js';
+
+/**
+ * Opens the per-request caller-context frame.
+ *
+ * Middleware — not a guard — because only middleware has a `next()` to
+ * wrap: `AsyncLocalStorage.run(store, () => next())` keeps every later
+ * step of the request (guard, controller, the MCP tools handler, the
+ * tool method, and the upstream `fetch`) inside the same frame. A Nest
+ * guard's `canActivate` merely returns a boolean, so a `run()` opened
+ * there would already have closed by the time the tool executes.
+ *
+ * This middleware deliberately does **not** read or trust any header.
+ * It only creates an empty frame; `ApiKeyGuard` seeds the identity into
+ * it after its credential checks pass. Opening the frame and deciding
+ * who the caller is therefore stay separate concerns, and an
+ * unauthenticated request runs with an empty frame.
+ *
+ * Mirrors `ScopeContextMiddleware` in
+ * `apps/api/src/scope/scope-context.middleware.ts`.
+ */
+@Injectable()
+export class CallerContextMiddleware implements NestMiddleware {
+	constructor(@Inject(CallerContextService) private readonly callerContext: CallerContextService) {}
+
+	use(_req: unknown, _res: unknown, next: () => void): void {
+		this.callerContext.run(() => next());
+	}
+}

--- a/apps/mcp/src/context/caller-context.module.ts
+++ b/apps/mcp/src/context/caller-context.module.ts
@@ -1,0 +1,16 @@
+import { Module, Global } from '@nestjs/common';
+import { CallerContextService } from './caller-context.service.js';
+
+/**
+ * `@Global` so both `ApiKeyGuard` (which seeds the caller identity) and
+ * `ApiClientService` (which reads it) resolve the SAME singleton without
+ * every module having to import this one. Two instances would mean two
+ * `AsyncLocalStorage`s and the identity would never arrive — the exact
+ * class of silent seam failure this module exists to close.
+ */
+@Global()
+@Module({
+	providers: [CallerContextService],
+	exports: [CallerContextService]
+})
+export class CallerContextModule {}

--- a/apps/mcp/src/context/caller-context.service.ts
+++ b/apps/mcp/src/context/caller-context.service.ts
@@ -1,0 +1,112 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Mutable holder stored in the `AsyncLocalStorage`.
+ *
+ * We store a holder (`{ current }`) rather than the JWT directly because
+ * the value is not known when the frame is opened: the middleware opens
+ * the frame (it is the only place with a `next()` to wrap), but the
+ * *guard* — which runs later, inside that same frame — is what decides
+ * whether the credential is acceptable. A guard cannot restart the
+ * `run()` frame, so it seeds the holder in place.
+ *
+ * Same shape, and for the same reason, as `ScopeHolder` in
+ * `apps/api/src/scope/scope-context.service.ts`.
+ */
+interface CallerHolder {
+	/** The caller's per-user JWT, or `null` if this request has no verified caller identity. */
+	current: string | null;
+}
+
+/**
+ * Propagates the calling user's identity from the inbound MCP request to
+ * the outbound upstream API request.
+ *
+ * **Why this exists (the P1 it fixes).** Every data tool returned
+ * `API Error (401): Unauthorized` in production while the same token,
+ * on the same Work, called directly against the API returned 200. The
+ * MCP server authenticated the caller correctly and then dropped the
+ * identity on the floor.
+ *
+ * The cause was an object-identity mismatch, not a scoping mistake:
+ *
+ * - `ApiKeyGuard` receives the raw Express request from
+ *   `ExecutionContext.switchToHttp().getRequest()` and stashed the JWT
+ *   on it.
+ * - `@rekog/mcp-nest` binds a *different* object to Nest's `REQUEST`
+ *   token. Its `ExpressHttpAdapter.adaptRequest()` builds a fresh plain
+ *   wrapper `{ url, method, headers, query, body, params, get, raw }`
+ *   and the tools handler calls
+ *   `moduleRef.registerRequestByContextId(httpRequest, contextId)` with
+ *   that *wrapper*.
+ *
+ * So `@Inject(REQUEST)` yielded the wrapper, whose `__callerJwt` was
+ * always `undefined` — the guard's write had landed one level below, on
+ * `wrapper.raw`. `ApiClientService` then sent no `Authorization` header
+ * at all, and in `per-user-jwt` mode there is no shared key to fall
+ * back to, so the upstream rejected every call.
+ *
+ * **Why `AsyncLocalStorage` and not the alternatives.** Reaching through
+ * `request.raw` would be a one-line fix, but it hard-codes a private
+ * detail of the library's adapter: the day that wrapper changes shape,
+ * the identity silently vanishes again and every tool 401s again, with
+ * green unit tests — which is precisely how this defect shipped.
+ * Threading the JWT as an explicit parameter through every tool method
+ * has the same failure mode by omission: a new tool that forgets to
+ * forward it regresses silently. `AsyncLocalStorage` binds to the async
+ * context of the request itself, so it does not care which object the
+ * transport chooses to hand to the DI container.
+ *
+ * This mirrors the established house pattern in
+ * `apps/api/src/scope/scope-context.service.ts` (`ScopeContextService`),
+ * which propagates `{ tenantId, organizationId }` the same way, is
+ * seeded by a middleware, and is re-seeded in place by a guard.
+ *
+ * **Isolation.** Each request gets its own `run()` frame and therefore
+ * its own holder; concurrent callers never observe each other's token.
+ * `apps/mcp/test/caller-identity.e2e.spec.ts` pins this with two
+ * genuinely overlapping tool calls held open at the upstream.
+ *
+ * **Outside any `run()` frame `getCallerJwt()` returns `null`** — the
+ * correct answer for the stdio transport, which has no HTTP request at
+ * all and legitimately uses the shared key.
+ */
+@Injectable()
+export class CallerContextService {
+	private readonly storage = new AsyncLocalStorage<CallerHolder>();
+
+	/**
+	 * Open a fresh caller-context frame for one request and run `fn`
+	 * inside it. Called by `CallerContextMiddleware`, which is the only
+	 * place in the request lifecycle that can wrap all downstream work
+	 * (a guard's `canActivate` returns a boolean and cannot).
+	 */
+	run<T>(fn: () => T): T {
+		return this.storage.run({ current: null }, fn);
+	}
+
+	/**
+	 * Record the caller's verified identity for the remainder of this
+	 * request. Called by `ApiKeyGuard` *after* its credential checks
+	 * pass, so an unauthenticated request never seeds an identity.
+	 *
+	 * Outside a `run()` frame this is a no-op: there is nothing to seed,
+	 * and inventing a store here would let a token escape the request
+	 * that produced it.
+	 */
+	setCallerJwt(jwt: string): void {
+		const holder = this.storage.getStore();
+		if (!holder) return;
+		holder.current = jwt;
+	}
+
+	/**
+	 * The caller's JWT for the request in flight, or `null` when there
+	 * is none (stdio transport, or an HTTP request whose guard did not
+	 * seed one).
+	 */
+	getCallerJwt(): string | null {
+		return this.storage.getStore()?.current ?? null;
+	}
+}

--- a/apps/mcp/src/guards/api-key.guard.ts
+++ b/apps/mcp/src/guards/api-key.guard.ts
@@ -1,6 +1,7 @@
 import { CanActivate, ExecutionContext, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { timingSafeEqual } from 'crypto';
 import { McpConfigService } from '../config/mcp-config.service.js';
+import { CallerContextService } from '../context/caller-context.service.js';
 
 /**
  * H-21 — MCP auth, dual mode.
@@ -25,7 +26,10 @@ import { McpConfigService } from '../config/mcp-config.service.js';
  */
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
-	constructor(@Inject(McpConfigService) private readonly config: McpConfigService) {}
+	constructor(
+		@Inject(McpConfigService) private readonly config: McpConfigService,
+		@Inject(CallerContextService) private readonly callerContext: CallerContextService
+	) {}
 
 	canActivate(context: ExecutionContext): boolean {
 		const request = context.switchToHttp().getRequest<{
@@ -81,10 +85,23 @@ export class ApiKeyGuard implements CanActivate {
 			throw new UnauthorizedException('Missing Authorization Bearer header');
 		}
 
-		// 3. Stash the per-user JWT (if any) on the request so ApiClientService
-		// can forward it upstream. We do NOT verify the JWT here — that's the
-		// upstream API's job. The MCP server is a transport.
+		// 3. Publish the per-user JWT (if any) so ApiClientService can forward
+		// it upstream. We do NOT verify the JWT here — that's the upstream
+		// API's job. The MCP server is a transport.
+		//
+		// This runs only after every check above has passed, so an
+		// unauthenticated request never seeds an identity.
 		if (userJwtPresent) {
+			// The AsyncLocalStorage frame opened by CallerContextMiddleware is
+			// the load-bearing channel. The request stash below cannot be
+			// relied on: @rekog/mcp-nest binds its own adapter wrapper — not
+			// this Express request — to Nest's REQUEST token, so a value
+			// written here is invisible to a request-scoped consumer. That is
+			// the defect that made every data tool return 401. See
+			// CallerContextService for the full account.
+			this.callerContext.setCallerJwt(userJwtHeader);
+			// Kept for any consumer that does hold the real Express request
+			// (and so the stdio/None-transport shape is unchanged).
 			request.__callerJwt = userJwtHeader as string;
 		}
 

--- a/apps/mcp/test/api-client.service.spec.ts
+++ b/apps/mcp/test/api-client.service.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApiClientService } from '../src/api-client/api-client.service.js';
 import { ApiError } from '../src/api-client/api-error.js';
 import { McpConfigService } from '../src/config/mcp-config.service.js';
+import { CallerContextService } from '../src/context/caller-context.service.js';
 
 describe('ApiClientService', () => {
 	let service: ApiClientService;
@@ -15,7 +16,11 @@ describe('ApiClientService', () => {
 			transport: 'stdio'
 		} as McpConfigService;
 
-		service = new ApiClientService(config);
+		// No caller-context frame is open here, which is exactly the stdio
+		// transport's situation: no HTTP request, no per-user JWT, so the
+		// shared key remains the credential. `sends correct headers` below
+		// pins that fallback.
+		service = new ApiClientService(config, new CallerContextService());
 		fetchSpy = vi.fn();
 		globalThis.fetch = fetchSpy;
 	});

--- a/apps/mcp/test/api-key.guard.spec.ts
+++ b/apps/mcp/test/api-key.guard.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { UnauthorizedException, type ExecutionContext } from '@nestjs/common';
 import { ApiKeyGuard } from '../src/guards/api-key.guard.js';
 import { McpConfigService } from '../src/config/mcp-config.service.js';
+import { CallerContextService } from '../src/context/caller-context.service.js';
 
 function buildContext(headers: Record<string, string | string[]> | undefined): ExecutionContext {
 	const request = headers === undefined ? {} : { headers };
@@ -18,9 +19,9 @@ function buildContext(headers: Record<string, string | string[]> | undefined): E
 // EVER_WORKS_MCP_AUTH_MODE + EVER_WORKS_API_KEY at construction time).
 // Build a guard against a freshly-constructed config so each test gets the
 // env it expects.
-function buildGuard(): ApiKeyGuard {
+function buildGuard(callerContext: CallerContextService = new CallerContextService()): ApiKeyGuard {
 	const config = new McpConfigService();
-	return new ApiKeyGuard(config);
+	return new ApiKeyGuard(config, callerContext);
 }
 
 describe('ApiKeyGuard (H-08 constant-time + H-21 dual mode)', () => {

--- a/apps/mcp/test/caller-context.spec.ts
+++ b/apps/mcp/test/caller-context.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CallerContextService } from '../src/context/caller-context.service.js';
+import { CallerContextMiddleware } from '../src/context/caller-context.middleware.js';
+import { ApiClientService } from '../src/api-client/api-client.service.js';
+import { McpConfigService } from '../src/config/mcp-config.service.js';
+
+describe('CallerContextService', () => {
+	it('returns null outside any frame — the stdio transport has no HTTP request', () => {
+		const ctx = new CallerContextService();
+		expect(ctx.getCallerJwt()).toBeNull();
+	});
+
+	it('is a no-op outside a frame, so a token can never escape the request that produced it', () => {
+		const ctx = new CallerContextService();
+		expect(() => ctx.setCallerJwt('orphan-token')).not.toThrow();
+		expect(ctx.getCallerJwt()).toBeNull();
+	});
+
+	it('starts each frame empty rather than inheriting the previous caller', () => {
+		const ctx = new CallerContextService();
+		ctx.run(() => ctx.setCallerJwt('first'));
+		ctx.run(() => {
+			expect(ctx.getCallerJwt()).toBeNull();
+		});
+	});
+
+	it('lets a later reader in the same frame see what the guard seeded', () => {
+		const ctx = new CallerContextService();
+		ctx.run(() => {
+			expect(ctx.getCallerJwt()).toBeNull();
+			ctx.setCallerJwt('seeded-by-guard');
+			expect(ctx.getCallerJwt()).toBe('seeded-by-guard');
+		});
+	});
+
+	it('keeps interleaved async frames isolated from one another', async () => {
+		const ctx = new CallerContextService();
+		const observed: Array<string | null> = [];
+
+		// Deliberately interleave: each frame yields the event loop *between*
+		// seeding and reading, so a shared mutable field would cross over.
+		const caller = (token: string, delay: number) =>
+			new Promise<void>((resolve) => {
+				ctx.run(async () => {
+					ctx.setCallerJwt(token);
+					await new Promise((r) => setTimeout(r, delay));
+					observed.push(ctx.getCallerJwt());
+					resolve();
+				});
+			});
+
+		await Promise.all([caller('token-a', 20), caller('token-b', 5), caller('token-c', 12)]);
+
+		expect(observed.sort()).toEqual(['token-a', 'token-b', 'token-c']);
+	});
+
+	it('survives many concurrent frames without cross-talk', async () => {
+		const ctx = new CallerContextService();
+		const results = await Promise.all(
+			Array.from(
+				{ length: 200 },
+				(_, i) =>
+					new Promise<string | null>((resolve) =>
+						ctx.run(async () => {
+							ctx.setCallerJwt(`token-${i}`);
+							await new Promise((r) => setTimeout(r, i % 7));
+							resolve(ctx.getCallerJwt());
+						})
+					)
+			)
+		);
+		expect(results).toEqual(Array.from({ length: 200 }, (_, i) => `token-${i}`));
+	});
+});
+
+describe('CallerContextMiddleware', () => {
+	it('wraps next() so downstream work runs inside the frame', () => {
+		const ctx = new CallerContextService();
+		const middleware = new CallerContextMiddleware(ctx);
+		let insideFrame = false;
+
+		middleware.use({}, {}, () => {
+			// A guard running here can seed; a service running later can read.
+			ctx.setCallerJwt('from-guard');
+			insideFrame = ctx.getCallerJwt() === 'from-guard';
+		});
+
+		expect(insideFrame).toBe(true);
+		// ...and the frame closes with the request.
+		expect(ctx.getCallerJwt()).toBeNull();
+	});
+});
+
+describe('ApiClientService credential selection', () => {
+	let fetchSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: 'OK',
+			headers: new Headers({ 'content-type': 'application/json' }),
+			json: () => Promise.resolve({})
+		});
+		globalThis.fetch = fetchSpy;
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	const configWith = (apiKey: string | null) =>
+		({ apiUrl: 'http://upstream.test/api', apiKey, httpPort: 3200, transport: 'stdio' }) as McpConfigService;
+
+	function headersOfLastCall(): Record<string, string> {
+		return fetchSpy.mock.calls.at(-1)![1].headers as Record<string, string>;
+	}
+
+	it('forwards the caller JWT as a Bearer token when a frame carries one', async () => {
+		const ctx = new CallerContextService();
+		const client = new ApiClientService(configWith('shared-platform-key'), ctx);
+
+		await new Promise<void>((resolve) =>
+			ctx.run(async () => {
+				ctx.setCallerJwt('caller-jwt');
+				await client.request('GET', '/works');
+				resolve();
+			})
+		);
+
+		expect(headersOfLastCall()['Authorization']).toBe('Bearer caller-jwt');
+		// The caller's identity must REPLACE the platform key, not accompany it.
+		expect(headersOfLastCall()['x-api-key']).toBeUndefined();
+	});
+
+	it('falls back to the shared key with no frame at all (stdio transport)', async () => {
+		const client = new ApiClientService(configWith('shared-platform-key'), new CallerContextService());
+		await client.request('GET', '/works');
+		expect(headersOfLastCall()['x-api-key']).toBe('shared-platform-key');
+		expect(headersOfLastCall()['Authorization']).toBeUndefined();
+	});
+
+	it('sends NO credential in per-user-jwt mode when the caller identity is missing', async () => {
+		// per-user-jwt mode leaves `apiKey` null on the config. A missing JWT
+		// must stay a rejection by the upstream — quietly substituting a
+		// service key here would turn an auth bug into privilege escalation.
+		const ctx = new CallerContextService();
+		const client = new ApiClientService(configWith(null), ctx);
+
+		await new Promise<void>((resolve) =>
+			ctx.run(async () => {
+				await client.request('GET', '/works');
+				resolve();
+			})
+		);
+
+		expect(headersOfLastCall()['Authorization']).toBeUndefined();
+		expect(headersOfLastCall()['x-api-key']).toBeUndefined();
+	});
+});

--- a/apps/mcp/test/caller-identity.e2e.spec.ts
+++ b/apps/mcp/test/caller-identity.e2e.spec.ts
@@ -1,0 +1,244 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { INestApplication } from '@nestjs/common';
+
+/**
+ * EW — regression suite for the caller-identity seam.
+ *
+ * The defect this pins: every data tool returned `API Error (401)` in
+ * production while the *same* token called *directly* against the API
+ * returned 200. Auth on the MCP server itself was fine (`ApiKeyGuard`
+ * rejected an unauthenticated request correctly and `ping` answered
+ * `pong`) — the caller's identity simply never reached the upstream
+ * request.
+ *
+ * Why an end-to-end spec and not a unit test: the existing
+ * `api-client.service.spec.ts` builds `new ApiClientService(config)` by
+ * hand, so it never exercises the DI/transport seam where the bug lives.
+ * The units passed while the product was broken. These tests drive a
+ * REAL Nest application over the REAL Streamable-HTTP transport and
+ * assert on what a REAL upstream server received, so the seam is
+ * covered end to end.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SPEC_FIXTURE = join(HERE, 'fixtures', 'minimal-openapi.json');
+
+/** One observed upstream call. */
+interface UpstreamCall {
+	url: string;
+	authorization: string | undefined;
+	apiKeyHeader: string | undefined;
+}
+
+/**
+ * Stand-in for `api.ever.works`. Records the credential headers of every
+ * request so a test can assert exactly what identity the MCP server
+ * forwarded. `gate` lets a test hold responses open so two tool calls are
+ * genuinely in flight at the same time (see the concurrency test).
+ */
+class UpstreamRecorder {
+	readonly calls: UpstreamCall[] = [];
+	maxConcurrent = 0;
+	private inFlight = 0;
+	private server!: Server;
+	private release: (() => void) | null = null;
+	private gateSize = 0;
+	private gateWaiters: Array<() => void> = [];
+
+	async start(): Promise<string> {
+		this.server = createServer((req, res) => {
+			this.calls.push({
+				url: req.url ?? '',
+				authorization: header(req.headers['authorization']),
+				apiKeyHeader: header(req.headers['x-api-key'])
+			});
+			this.inFlight += 1;
+			this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
+
+			const finish = () => {
+				this.inFlight -= 1;
+				res.writeHead(200, { 'content-type': 'application/json' });
+				// Echo the credential back so a test can correlate a response
+				// with the identity that produced it.
+				res.end(
+					JSON.stringify({ items: [], total: 0, seenAuthorization: header(req.headers['authorization']) })
+				);
+			};
+
+			if (this.gateSize > 0) {
+				this.gateWaiters.push(finish);
+				if (this.gateWaiters.length >= this.gateSize) {
+					const waiters = this.gateWaiters;
+					this.gateWaiters = [];
+					this.gateSize = 0;
+					for (const w of waiters) w();
+					this.release?.();
+				}
+				return;
+			}
+			finish();
+		});
+
+		await new Promise<void>((resolve) => this.server.listen(0, '127.0.0.1', resolve));
+		const { port } = this.server.address() as AddressInfo;
+		return `http://127.0.0.1:${port}`;
+	}
+
+	/** Hold the next `n` upstream requests open until all `n` have arrived. */
+	gateFor(n: number): void {
+		this.gateSize = n;
+		this.gateWaiters = [];
+	}
+
+	async stop(): Promise<void> {
+		this.release = null;
+		await new Promise<void>((resolve) => this.server.close(() => resolve()));
+	}
+}
+
+function header(value: string | string[] | undefined): string | undefined {
+	return Array.isArray(value) ? value[0] : value;
+}
+
+/** Fire a JSON-RPC `tools/call` at the MCP server exactly as a client would. */
+async function callTool(
+	baseUrl: string,
+	tool: string,
+	args: Record<string, unknown>,
+	jwt?: string
+): Promise<{ status: number; body: string }> {
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+		Accept: 'application/json, text/event-stream'
+	};
+	if (jwt) headers['x-ever-works-jwt'] = jwt;
+
+	const response = await fetch(`${baseUrl}/mcp`, {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: { name: tool, arguments: args }
+		})
+	});
+	return { status: response.status, body: await response.text() };
+}
+
+const WORK_A = '11111111-1111-4111-8111-111111111111';
+const WORK_B = '22222222-2222-4222-8222-222222222222';
+const JWT_A = 'caller-a-token-aaaaaaaaaaaaaaaa';
+const JWT_B = 'caller-b-token-bbbbbbbbbbbbbbbb';
+
+describe('caller identity reaches the upstream API (HTTP transport)', () => {
+	let app: INestApplication;
+	let baseUrl: string;
+	let upstream: UpstreamRecorder;
+	const savedEnv = { ...process.env };
+
+	beforeAll(async () => {
+		upstream = new UpstreamRecorder();
+		const upstreamUrl = await upstream.start();
+
+		// `app.module.ts` reads MCP_TRANSPORT at module-evaluation time, so the
+		// env has to be set before the dynamic import below.
+		process.env.MCP_TRANSPORT = 'streamable-http';
+		process.env.EVER_WORKS_MCP_AUTH_MODE = 'per-user-jwt';
+		process.env.EVER_WORKS_API_URL = upstreamUrl;
+		process.env.EVER_WORKS_OPENAPI_SPEC_PATH = SPEC_FIXTURE;
+		// per-user-jwt mode must work with NO shared key configured. Leaving a
+		// key set here would mask the privilege-escalation case the third test
+		// pins, so make sure it is genuinely absent.
+		delete process.env.EVER_WORKS_API_KEY;
+		delete process.env.NODE_ENV;
+
+		const { NestFactory } = await import('@nestjs/core');
+		const { AppModule } = await import('../src/app.module.js');
+		app = await NestFactory.create(AppModule, { logger: false });
+		await app.listen(0, '127.0.0.1');
+		baseUrl = await app.getUrl();
+	});
+
+	afterAll(async () => {
+		await app?.close();
+		await upstream?.stop();
+		process.env = savedEnv;
+	});
+
+	it('forwards the caller JWT as Authorization: Bearer on the upstream request', async () => {
+		const before = upstream.calls.length;
+		const { status, body } = await callTool(baseUrl, 'kb.list', { workId: WORK_A }, JWT_A);
+
+		expect(status).toBe(200);
+		// The tool must not report an upstream auth failure.
+		expect(body).not.toContain('API Error (401)');
+
+		const calls = upstream.calls.slice(before);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toContain(`/works/${WORK_A}/kb/documents`);
+		// THE ASSERTION THAT FAILS ON THE BROKEN CODE: the caller's identity
+		// must be on the upstream request.
+		expect(calls[0].authorization).toBe(`Bearer ${JWT_A}`);
+	});
+
+	it('keeps two concurrent callers isolated — each upstream call carries its own token', async () => {
+		const before = upstream.calls.length;
+
+		// Hold both upstream requests open until BOTH have arrived, so the two
+		// tool calls genuinely overlap. A store that leaked across callers
+		// (a shared mutable field, a module-level variable) shows up here.
+		upstream.gateFor(2);
+
+		const [resA, resB] = await Promise.all([
+			callTool(baseUrl, 'kb.list', { workId: WORK_A }, JWT_A),
+			callTool(baseUrl, 'kb.list', { workId: WORK_B }, JWT_B)
+		]);
+
+		expect(resA.status).toBe(200);
+		expect(resB.status).toBe(200);
+		expect(resA.body).not.toContain('API Error (401)');
+		expect(resB.body).not.toContain('API Error (401)');
+
+		const calls = upstream.calls.slice(before);
+		expect(calls).toHaveLength(2);
+		// Prove the requests really were simultaneous — otherwise this test
+		// would pass trivially against a serialising implementation and would
+		// not be testing isolation at all.
+		expect(upstream.maxConcurrent).toBe(2);
+
+		const callA = calls.find((c) => c.url.includes(WORK_A));
+		const callB = calls.find((c) => c.url.includes(WORK_B));
+		expect(callA, 'upstream call for caller A').toBeDefined();
+		expect(callB, 'upstream call for caller B').toBeDefined();
+		expect(callA!.authorization).toBe(`Bearer ${JWT_A}`);
+		expect(callB!.authorization).toBe(`Bearer ${JWT_B}`);
+	});
+
+	it('rejects a request with no JWT and never falls back to a shared key', async () => {
+		const before = upstream.calls.length;
+		const { status, body } = await callTool(baseUrl, 'kb.list', { workId: WORK_A });
+
+		// The guard must still refuse the request outright.
+		expect(status).toBe(401);
+		expect(body).toContain('Per-user JWT required');
+
+		// And nothing may have reached the upstream API — quietly upgrading a
+		// missing caller identity to a shared service key would turn an auth
+		// bug into a privilege-escalation bug.
+		expect(upstream.calls.slice(before)).toHaveLength(0);
+	});
+
+	it('never sends a shared API key in per-user-jwt mode', async () => {
+		// Across every upstream call this suite has made, no request may have
+		// carried the platform key.
+		for (const call of upstream.calls) {
+			expect(call.apiKeyHeader).toBeUndefined();
+		}
+	});
+});

--- a/apps/mcp/test/fixtures/minimal-openapi.json
+++ b/apps/mcp/test/fixtures/minimal-openapi.json
@@ -1,0 +1,5 @@
+{
+	"openapi": "3.0.0",
+	"info": { "title": "Ever Works API (test fixture)", "version": "0.0.0" },
+	"paths": {}
+}


### PR DESCRIPTION
## The defect

`ever-works-mcp` is a public product surface — `mcp.ever.works` (5 pods, prod) and `mcpdev.ever.works` (2 pods, dev). It authenticated the caller correctly and then failed to pass that identity upstream, so **7 of its 8 tools returned 401**. Only `ping`, which makes no upstream call, worked.

### Reproduction (dev, `mcpdev.ever.works`)

Everything about auth and transport was fine:

```
POST /mcp  (no x-ever-works-jwt)
  -> 401 {"message":"Per-user JWT required (x-ever-works-jwt header) for auth mode per-user-jwt"}

initialize (with the header)
  -> 200 {"serverInfo":{"name":"ever-works","version":"0.1.0"}}

tools/list
  -> ping, register_work, kb.list, kb.get, kb.create, kb.update, kb.lock, kb.unlock

tools/call ping
  -> {"result":{"content":[{"type":"text","text":"pong"}]}}

tools/call <unknown tool>          # CONTROL
  -> {"error":{"code":-32601,"message":"MCP error -32601: Unknown tool: kb.definitely-not-a-tool"}}
```

Every tool that actually calls the API did not:

```
kb.list        API Error (401): Unauthorized
kb.get         API Error (401): Unauthorized
kb.create      API Error (401): Unauthorized
kb.update      API Error (401): Unauthorized
kb.lock        API Error (401): Unauthorized
kb.unlock      API Error (401): Unauthorized
ping           pong
```

### The decisive control

The **same token**, the **same Work**, called **directly** on the API:

```
GET https://api-dev.ever.works/api/works/806b26b8-…/kb/documents
  -> 200 {"items":[],"total":0}
```

So the credential was valid and the Work was reachable — the MCP path was losing the identity.

### Reproduced identically on production

```
prod MCP  kb.list                     -> API Error (401): Unauthorized
prod API  GET /api/works/<id>/kb/documents  (SAME token)
                                      -> 404 {"message":"Work with id '…' not found"}
prod MCP  ping                        -> pong
```

The direct call returning **404 "not found"** rather than 401 is the point: the API authenticated the caller and then looked the Work up. Through MCP the same credential never arrived.

## Root cause — verified, and not what it looked like

The obvious hypothesis was that the tools are plain `@Injectable()` singletons resolved at bootstrap (the boot log does show `McpRegistryDiscoveryService … Tool discovered: KbListTool.list` before any request), so `ApiClientService` would hold a `REQUEST` injection never bound to a real request.

**That hypothesis is wrong.** Reading `@rekog/mcp-nest@1.9.6` and then instrumenting the constructor refuted it.

`mcp-tools.handler.js` genuinely resolves per request:

```js
const contextId = ContextIdFactory.getByRequest(httpRequest);
this.moduleRef.registerRequestByContextId(httpRequest, contextId);
const toolInstance = await this.moduleRef.resolve(toolInfo.providerClass, contextId, { strict: false });
```

Nest's scope bubbling makes `KbListTool` request-scoped because it injects the request-scoped `ApiClientService`, so a fresh instance really is built per call. Temporary instrumentation in the `ApiClientService` constructor confirmed it — three constructions for three tool calls:

```
[PROBE] ApiClientService constructed. httpRequest = {
  "ctor":"Object",
  "keys":["url","method","headers","query","body","params","get","raw"],
  "hasCallerJwt":false,
  "hasRaw":true,
  "rawHasCallerJwt":true
}
```

The real cause is an **object-identity mismatch**:

- `ApiKeyGuard` writes `__callerJwt` on the object it gets from `ExecutionContext.switchToHttp().getRequest()` — the **raw Express request**.
- `ExpressHttpAdapter.adaptRequest()` builds a **fresh plain wrapper** `{ url, method, headers, query, body, params, get, raw }`, and it is *that wrapper* the handler passes to `registerRequestByContextId`.

So `@Inject(REQUEST)` yields the wrapper, whose `__callerJwt` is always `undefined` — the guard's write landed one level below, on `wrapper.raw` (`rawHasCallerJwt: true`). `ApiClientService` therefore sent no `Authorization` header, and in `per-user-jwt` mode `config.apiKey` is `null`, so there was no fallback either. Upstream: 401, every time.

## The mechanism chosen, and why

**`AsyncLocalStorage`**, following the existing house pattern — `ScopeContextService` in `apps/api/src/scope/scope-context.service.ts` propagates `{ tenantId, organizationId }` exactly this way, is seeded by a middleware, and is re-seeded in place by a guard. This change mirrors its shape, including the mutable `{ current }` holder and for the same documented reason.

- `CallerContextService` — singleton wrapping one `AsyncLocalStorage`.
- `CallerContextMiddleware` — opens the frame. **Middleware, not a guard**, because only middleware has a `next()` to wrap: `run(store, () => next())` keeps the guard, controller, tools handler, tool method and upstream `fetch` inside one frame. A guard's `canActivate` returns a boolean, so a frame opened there would already have closed before the tool ran.
- `ApiKeyGuard` seeds the JWT into the holder **after** all its credential checks pass.
- `ApiClientService` reads it.

Rejected alternatives:

- **Read `request.raw.__callerJwt`.** A one-line fix, but it hard-codes a private detail of the library's adapter. The day that wrapper changes shape the identity silently vanishes and every tool 401s again — with green unit tests. That is precisely how this defect shipped.
- **Thread the JWT as an explicit parameter.** Same failure mode by omission: a new tool that forgets to forward it regresses silently.
- **Make the tool chain request-scoped.** It already is — verified above. Scope was never the problem, so this would have changed nothing.

## Security

- **No cross-caller leakage.** Each request gets its own `run()` frame, so isolation is per-async-context, i.e. per request. Pinned two ways: an end-to-end test that holds two overlapping tool calls open at the upstream until both have arrived (asserting `maxConcurrent === 2`, so it cannot pass trivially against a serialising implementation) and checks each carried its own token; plus a 200-frame unit test for cross-talk.
- **No silent privilege escalation.** `per-user-jwt` mode leaves `apiKey` null; a missing JWT stays a 401 and no `x-api-key` is ever sent. Quietly upgrading a missing caller identity to a shared service key would turn an auth bug into a privilege-escalation bug. Two tests pin this, including one asserting the upstream received **no** request at all when the guard rejects.
- **stdio transport unchanged.** No HTTP request means no frame; `getCallerJwt()` returns `null` and the shared key is used exactly as before. Verified by booting the real stdio build.
- The guard still decides. The middleware deliberately reads no header — it only opens an empty frame — so opening the frame and deciding who the caller is stay separate concerns.

## Tests

`apps/mcp/test/caller-identity.e2e.spec.ts` drives a **real Nest application over the real Streamable-HTTP transport** against a recording upstream server. The pre-existing `api-client.service.spec.ts` builds `new ApiClientService(config)` by hand and never touches the DI/transport seam — which is why 143 tests were green while the product was broken.

### BEFORE — against the unfixed source

```
 FAIL  test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API (HTTP transport) > forwards the caller JWT as Authorization: Bearer on the upstream request
AssertionError: expected undefined to be 'Bearer caller-a-token-aaaaaaaaaaaaaaaa' // Object.is equality

- Expected:
"Bearer caller-a-token-aaaaaaaaaaaaaaaa"

+ Received:
undefined

 ❯ test/caller-identity.e2e.spec.ts:185:34
    183|   // THE ASSERTION THAT FAILS ON THE BROKEN CODE: the caller's identity
    184|   // must be on the upstream request.
    185|   expect(calls[0].authorization).toBe(`Bearer ${JWT_A}`);
       |                                  ^

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API (HTTP transport) > keeps two concurrent callers isolated — each upstream call carries its own token
AssertionError: expected undefined to be 'Bearer caller-a-token-aaaaaaaaaaaaaaaa' // Object.is equality

- Expected:
"Bearer caller-a-token-aaaaaaaaaaaaaaaa"

+ Received:
undefined

 ❯ test/caller-identity.e2e.spec.ts:217:32
    215|   expect(callA, 'upstream call for caller A').toBeDefined();
    216|   expect(callB, 'upstream call for caller B').toBeDefined();
    217|   expect(callA!.authorization).toBe(`Bearer ${JWT_A}`);
       |                                ^

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

(The two that pass are the negative cases — the guard already rejected a JWT-less request correctly. That was never the broken part.)

### AFTER — full suite

```
 ✓ test/caller-context.spec.ts > CallerContextService > returns null outside any frame — the stdio transport has no HTTP request
 ✓ test/caller-context.spec.ts > CallerContextService > is a no-op outside a frame, so a token can never escape the request that produced it
 ✓ test/caller-context.spec.ts > CallerContextService > starts each frame empty rather than inheriting the previous caller
 ✓ test/caller-context.spec.ts > CallerContextService > lets a later reader in the same frame see what the guard seeded
 ✓ test/caller-context.spec.ts > CallerContextService > keeps interleaved async frames isolated from one another
 ✓ test/caller-context.spec.ts > CallerContextService > survives many concurrent frames without cross-talk
 ✓ test/caller-context.spec.ts > CallerContextMiddleware > wraps next() so downstream work runs inside the frame
 ✓ test/caller-context.spec.ts > ApiClientService credential selection > forwards the caller JWT as a Bearer token when a frame carries one
 ✓ test/caller-context.spec.ts > ApiClientService credential selection > falls back to the shared key with no frame at all (stdio transport)
 ✓ test/caller-context.spec.ts > ApiClientService credential selection > sends NO credential in per-user-jwt mode when the caller identity is missing
 ✓ test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API (HTTP transport) > forwards the caller JWT as Authorization: Bearer on the upstream request
 ✓ test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API (HTTP transport) > keeps two concurrent callers isolated — each upstream call carries its own token
 ✓ test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API (HTTP transport) > rejects a request with no JWT and never falls back to a shared key
 ✓ test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API (HTTP transport) > never sends a shared API key in per-user-jwt mode

 Test Files  15 passed (15)
      Tests  153 passed (153)
```

`tsc --noEmit` clean; `tsup` build clean; `eslint` unchanged from the pre-existing baseline on `develop` (3 pre-existing errors in `fence-untrusted.ts` and `api-key.guard.ts`, none added).

## Live verification against the deployed API

Green tests are not the bar here — the whole defect is that the units passed while the seam was broken. The fixed build was run locally in `per-user-jwt` mode against **`https://api-dev.ever.works`**, on a Work created through `POST /api/works`:

```
=== 0. start the locally-built MCP server (per-user-jwt) against api-dev ===
{"status":"ok"}  <- health HTTP 200

=== 1. create a brand-new Work via POST /api/works ===
HTTP 200
NEW_WORK=269dc4be-cb6f-40b0-8b78-846531723e5c  slug=mcp-identity-probe-1786470472

=== 2. kb.list through the LOCAL FIXED MCP (was: API Error (401)) ===
{
  "items": [],
  "total": 0
}

=== 3. kb.create through the LOCAL FIXED MCP (a WRITE carrying the caller identity) ===
created id: 43841273-317c-4c0c-bb3b-718789daedd1 path: brand/voice title: Brand voice class: brand

=== 4. kb.list again — REAL DATA, not an empty 401 ===
total: 1
 - brand/voice | Brand voice | brand

=== 5. DIRECT API cross-check — same Work, same token, straight at the API ===
total: 1
 - brand/voice | Brand voice | brand

=== 6. the guard still refuses a request with NO caller identity ===
{"message":"Per-user JWT required (x-ever-works-jwt header) for auth mode per-user-jwt","error":"Unauthorized","statusCode":401}
  <- HTTP 401

=== 7. ping still works ===
{"result":{"content":[{"type":"text","text":"pong"}]},"jsonrpc":"2.0","id":1}
```

Both a **read** and a **write** now carry the caller's identity, and the MCP result agrees exactly with the direct-API cross-check. The stdio transport was also booted against the real build and still serves all 8 tools on the shared key:

```
initialize -> {"name":"ever-works","version":"0.1.0"}
tools/list -> ping, register_work, kb.list, kb.get, kb.create, kb.update, kb.lock, kb.unlock
```

## Files

| File | Change |
|---|---|
| `apps/mcp/src/context/caller-context.service.ts` | new — the `AsyncLocalStorage` holder, with the full root-cause account |
| `apps/mcp/src/context/caller-context.middleware.ts` | new — opens the per-request frame |
| `apps/mcp/src/context/caller-context.module.ts` | new — `@Global` so guard and client share one instance |
| `apps/mcp/src/guards/api-key.guard.ts` | seeds the verified JWT into the frame (the request stash is retained, not removed) |
| `apps/mcp/src/api-client/api-client.service.ts` | reads the caller JWT from the frame |
| `apps/mcp/src/app.module.ts` | registers the module and applies the middleware on the HTTP transport only |
| `apps/mcp/test/caller-identity.e2e.spec.ts` | new — real app, real transport, recording upstream |
| `apps/mcp/test/caller-context.spec.ts` | new — isolation, stdio fallback, no-escalation |
| `apps/mcp/test/{api-client.service,api-key.guard}.spec.ts` | updated for the new constructor dependency |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
