### PR TITLE
Fix/meetings detail ux parity

### DIFF
--- a/apps/web/e2e/flow-meetings-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-meetings-ui-journey.spec.ts
@@ -357,6 +357,7 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         await expect(page.getByTestId('meeting-edit-started-at')).toBeVisible();
         await expect(page.getByTestId('meeting-edit-ended-at')).toBeVisible();
         await expect(page.getByTestId('meeting-edit-participants')).toBeVisible();
+        await expect(page.getByTestId('meeting-edit-participant-add')).toBeVisible();
         await expect(page.getByTestId('meeting-edit-cancel')).toBeVisible();
     });
 
@@ -372,18 +373,22 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         await expect(editOpen).toBeVisible({ timeout: 30_000 });
 
         const roster = page.getByTestId('meeting-edit-participants');
+        const names = page.getByTestId('meeting-edit-participant-name');
+        const emails = page.getByTestId('meeting-edit-participant-email');
+        const addRow = page.getByTestId('meeting-edit-participant-add');
+
         await clickUntil(editOpen, () => roster.isVisible().catch(() => false));
-        // Seeded from the stored roster in the same `Name <email>` shape the
-        // capture form parses — formatParticipants is the exact inverse of
-        // parseParticipants, so the textarea round-trips without edits.
-        await expect(roster).toHaveValue('Ada Lovelace <ada@example.com>');
+        // One row per stored participant, with the address in its own field
+        // rather than encoded into the name as `Name <email>`.
+        await expect(names).toHaveCount(1);
+        await expect(names.first()).toHaveValue('Ada Lovelace');
+        await expect(emails.first()).toHaveValue('ada@example.com');
 
         const save = page.getByTestId('meeting-save');
-        const next = 'Grace Hopper <grace@example.com>\nAlan Turing';
 
         // Post-condition = the PERSISTED roster (same idiom as the rename test):
-        // re-open the dialog if it closed, re-fill only if the textarea lost
-        // its value, and stop as soon as the write lands.
+        // re-open the dialog if it closed, re-fill only what actually lost its
+        // value, and stop as soon as the write lands.
         await expect(async () => {
             const current = (await readMeeting(request, token, meeting.id).catch(() => null)) as {
                 participants?: Array<{ name: string }>;
@@ -394,8 +399,39 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
                         .click({ timeout: 5_000, noWaitAfter: true })
                         .catch(() => undefined);
                 }
-                if ((await roster.inputValue().catch(() => '')) !== next) {
-                    await roster.fill(next).catch(() => undefined);
+                // Rewrite the existing row in place…
+                if (
+                    (await names
+                        .first()
+                        .inputValue()
+                        .catch(() => '')) !== 'Grace Hopper'
+                ) {
+                    await names
+                        .first()
+                        .fill('Grace Hopper')
+                        .catch(() => undefined);
+                    await emails
+                        .first()
+                        .fill('grace@example.com')
+                        .catch(() => undefined);
+                }
+                // …and add the second person on a row of their own, which is
+                // the whole point of the editor: no retyping the list.
+                if ((await names.count().catch(() => 0)) < 2) {
+                    await addRow
+                        .click({ timeout: 5_000, noWaitAfter: true })
+                        .catch(() => undefined);
+                }
+                if (
+                    (await names
+                        .nth(1)
+                        .inputValue()
+                        .catch(() => '')) !== 'Alan Turing'
+                ) {
+                    await names
+                        .nth(1)
+                        .fill('Alan Turing')
+                        .catch(() => undefined);
                 }
                 await save.click({ timeout: 5_000, noWaitAfter: true }).catch(() => undefined);
             }
@@ -406,7 +442,7 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
                 'Grace Hopper',
                 'Alan Turing',
             ]);
-            // A bare name stores no email; `Name <email>` stores both.
+            // An untouched email field stores no address; a filled one does.
             expect(persisted.participants[0].email).toBe('grace@example.com');
             expect(persisted.participants[1].email).toBeUndefined();
         }).toPass({ timeout: 60_000 });

--- a/apps/web/e2e/flow-meetings-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-meetings-ui-journey.spec.ts
@@ -340,6 +340,63 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         const recording = page.getByTestId('meeting-recording-link');
         await expect(recording).toHaveAttribute('href', 'https://example.com/recording/1');
         await expect(recording).toHaveAttribute('rel', /noopener/);
+
+        // The edit card exposes every field PATCH accepts. `startedAt` and
+        // `participants` are on that list: both were previously write-once in
+        // the UI (settable at capture, uneditable afterwards) even though the
+        // API has always patched them.
+        await expect(page.getByTestId('meeting-edit-started-at')).toBeVisible();
+        await expect(page.getByTestId('meeting-edit-ended-at')).toBeVisible();
+        await expect(page.getByTestId('meeting-edit-participants')).toBeVisible();
+    });
+
+    test('the edit card rewrites the roster and the change persists', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const meeting = await createMeeting(request, token, {
+            title: `Edit Roster ${suffix()}`,
+            participants: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+        });
+
+        await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const roster = page.getByTestId('meeting-edit-participants');
+        await expect(roster).toBeVisible({ timeout: 30_000 });
+        // Seeded from the stored roster in the same `Name <email>` shape the
+        // capture form parses — formatParticipants is the exact inverse of
+        // parseParticipants, so the textarea round-trips without edits.
+        await expect(roster).toHaveValue('Ada Lovelace <ada@example.com>');
+
+        const save = page.getByTestId('meeting-save');
+        const next = 'Grace Hopper <grace@example.com>\nAlan Turing';
+
+        // Post-condition = the PERSISTED roster (same idiom as the rename test):
+        // re-fill only if the textarea lost its value, and stop as soon as the
+        // write lands.
+        await expect(async () => {
+            const current = (await readMeeting(request, token, meeting.id).catch(() => null)) as {
+                participants?: Array<{ name: string }>;
+            } | null;
+            if (!(current?.participants ?? []).some((p) => p.name === 'Alan Turing')) {
+                if ((await roster.inputValue().catch(() => '')) !== next) {
+                    await roster.fill(next).catch(() => undefined);
+                }
+                await save.click({ timeout: 5_000, noWaitAfter: true }).catch(() => undefined);
+            }
+            const persisted = (await readMeeting(request, token, meeting.id)) as {
+                participants: Array<{ name: string; email?: string }>;
+            };
+            expect(persisted.participants.map((p) => p.name)).toEqual([
+                'Grace Hopper',
+                'Alan Turing',
+            ]);
+            // A bare name stores no email; `Name <email>` stores both.
+            expect(persisted.participants[0].email).toBe('grace@example.com');
+            expect(persisted.participants[1].email).toBeUndefined();
+        }).toPass({ timeout: 60_000 });
+
+        // …and the read-only roster beside the form reflects the new list.
+        await expect(page.getByTestId('meeting-participants')).toContainText('Alan Turing', {
+            timeout: 30_000,
+        });
     });
 
     test('a stored transcript renders in the body and hides the composer behind Replace', async ({
@@ -446,22 +503,38 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         await expect(cardFor(page, meeting.id)).toContainText(renamed, { timeout: 30_000 });
     });
 
-    test('UI Delete removes the meeting and returns to the catalog', async ({ page, request }) => {
+    test('UI Delete confirms in a dialog, removes the meeting and returns to the catalog', async ({
+        page,
+        request,
+    }) => {
         const token = await seededToken(request);
         const meeting = await createMeeting(request, token, { title: `UI Delete ${suffix()}` });
 
         await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
         const del = page.getByTestId('meeting-delete');
         await expect(del).toBeVisible({ timeout: 30_000 });
-        // The delete flow guards with window.confirm().
-        page.on('dialog', (dialog) => dialog.accept());
-        // Post-condition: the client `router.push('/meetings')` landed us back on
-        // the catalog. A click before hydration never even raises the confirm,
-        // and re-clicking is safe because we stop as soon as the URL matches.
-        await clickAndExpectUrl(page, del, /\/meetings$/);
-        await expect(cardFor(page, meeting.id)).toHaveCount(0);
-        // Cascade confirmed at the API: the row is gone.
+
+        // The delete flow guards with the shared in-page confirmation dialog
+        // (the same component the Mission and Task detail pages use), NOT
+        // window.confirm — so the header button opens a modal rather than
+        // deleting outright. A click landing before hydration never opens it.
+        const confirm = page.getByTestId('meeting-delete-confirm');
+        await clickUntil(del, () => confirm.isVisible().catch(() => false));
+        await expect(page.getByTestId('meeting-delete-cancel')).toBeVisible();
+
+        // Post-condition = the PERSISTED delete, not the URL: the confirm click
+        // is itself swallowable pre-hydration, and because clickUntil re-checks
+        // BEFORE clicking, a delete that already landed is never re-fired into
+        // a 404 that would surface the dialog's error row instead of navigating.
+        await clickUntil(
+            confirm,
+            async () => (await getMeetingStatus(request, token, meeting.id)) === 404,
+        );
         expect(await getMeetingStatus(request, token, meeting.id)).toBe(404);
+
+        // …and the successful delete pushed us back to the catalog.
+        await expect(page).toHaveURL(/\/meetings$/, { timeout: 30_000 });
+        await expect(cardFor(page, meeting.id)).toHaveCount(0);
     });
 
     test('an unknown meeting id renders the not-found surface, not a detail page', async ({

--- a/apps/web/e2e/flow-meetings-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-meetings-ui-journey.spec.ts
@@ -322,7 +322,11 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         await expect(page.getByRole('heading', { name: 'Summary' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Transcript' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Edit meeting' })).toBeVisible();
+        // Editing is an explicit act behind a header button, not a form
+        // parked open in the page body next to the read-only rows.
+        await expect(page.getByTestId('meeting-edit-open')).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Edit meeting' })).toHaveCount(0);
+        await expect(page.getByTestId('meeting-edit')).toHaveCount(0);
 
         // No transcript yet → the Summary section says so instead of implying a
         // failed summary.
@@ -341,13 +345,19 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         await expect(recording).toHaveAttribute('href', 'https://example.com/recording/1');
         await expect(recording).toHaveAttribute('rel', /noopener/);
 
-        // The edit card exposes every field PATCH accepts. `startedAt` and
+        // Opening it reveals every field PATCH accepts. `startedAt` and
         // `participants` are on that list: both were previously write-once in
         // the UI (settable at capture, uneditable afterwards) even though the
         // API has always patched them.
+        const editForm = page.getByTestId('meeting-edit');
+        await clickUntil(page.getByTestId('meeting-edit-open'), () =>
+            editForm.isVisible().catch(() => false),
+        );
+        await expect(page.getByRole('heading', { name: 'Edit meeting' })).toBeVisible();
         await expect(page.getByTestId('meeting-edit-started-at')).toBeVisible();
         await expect(page.getByTestId('meeting-edit-ended-at')).toBeVisible();
         await expect(page.getByTestId('meeting-edit-participants')).toBeVisible();
+        await expect(page.getByTestId('meeting-edit-cancel')).toBeVisible();
     });
 
     test('the edit card rewrites the roster and the change persists', async ({ page, request }) => {
@@ -358,8 +368,11 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         });
 
         await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const editOpen = page.getByTestId('meeting-edit-open');
+        await expect(editOpen).toBeVisible({ timeout: 30_000 });
+
         const roster = page.getByTestId('meeting-edit-participants');
-        await expect(roster).toBeVisible({ timeout: 30_000 });
+        await clickUntil(editOpen, () => roster.isVisible().catch(() => false));
         // Seeded from the stored roster in the same `Name <email>` shape the
         // capture form parses — formatParticipants is the exact inverse of
         // parseParticipants, so the textarea round-trips without edits.
@@ -369,13 +382,18 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         const next = 'Grace Hopper <grace@example.com>\nAlan Turing';
 
         // Post-condition = the PERSISTED roster (same idiom as the rename test):
-        // re-fill only if the textarea lost its value, and stop as soon as the
-        // write lands.
+        // re-open the dialog if it closed, re-fill only if the textarea lost
+        // its value, and stop as soon as the write lands.
         await expect(async () => {
             const current = (await readMeeting(request, token, meeting.id).catch(() => null)) as {
                 participants?: Array<{ name: string }>;
             } | null;
             if (!(current?.participants ?? []).some((p) => p.name === 'Alan Turing')) {
+                if (!(await roster.isVisible().catch(() => false))) {
+                    await editOpen
+                        .click({ timeout: 5_000, noWaitAfter: true })
+                        .catch(() => undefined);
+                }
                 if ((await roster.inputValue().catch(() => '')) !== next) {
                     await roster.fill(next).catch(() => undefined);
                 }
@@ -481,15 +499,24 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         const renamed = `After Rename ${suffix()}`;
 
         await page.goto(`/en/meetings/${meeting.id}`, { waitUntil: 'domcontentloaded' });
+        const editOpen = page.getByTestId('meeting-edit-open');
+        await expect(editOpen).toBeVisible({ timeout: 30_000 });
         const titleInput = page.getByLabel('Title');
-        await expect(titleInput).toBeVisible({ timeout: 30_000 });
         const save = page.getByTestId('meeting-save');
 
-        // Post-condition = the PERSISTED title. Re-fill only the field that
-        // actually lost its value, and stop as soon as the write lands.
+        // Post-condition = the PERSISTED title. The form lives in a dialog now,
+        // so each attempt re-opens it when a pre-hydration click never did,
+        // then re-fills only the field that actually lost its value. A save
+        // that landed closes the dialog and is never repeated, because the
+        // persisted check runs first.
         await expect(async () => {
             const current = await readMeeting(request, token, meeting.id).catch(() => null);
             if (current?.title !== renamed) {
+                if (!(await titleInput.isVisible().catch(() => false))) {
+                    await editOpen
+                        .click({ timeout: 5_000, noWaitAfter: true })
+                        .catch(() => undefined);
+                }
                 if ((await titleInput.inputValue().catch(() => '')) !== renamed) {
                     await titleInput.fill(renamed).catch(() => undefined);
                 }

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6948,7 +6948,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -7015,7 +7015,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "المشاركون",
-                "participantsHint": "واحد في كل سطر. استخدم \"الاسم <البريد الإلكتروني>\" لتسجيل عنوان."
+                "participantsHint": "واحد في كل سطر. استخدم \"الاسم '<'البريد الإلكتروني>\" لتسجيل عنوان."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -7005,17 +7005,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "صحّح الأوقات، أو أعد تسمية الاجتماع، أو عدّل قائمة المشاركين، أو اربطه بتسجيل، أو أعد توجيهه إلى عمل."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "وقت البدء",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "المشاركون",
+                "participantsHint": "واحد في كل سطر. استخدم \"الاسم <البريد الإلكتروني>\" لتسجيل عنوان."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "وقت البدء ليس تاريخًا صالحًا.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -7029,8 +7033,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "حذف هذا الاجتماع؟",
+                "body": "سيتم حذف {title} نهائيًا، مع نصه المدوّن وملخصه. لا يمكن التراجع عن هذا الإجراء.",
+                "confirm": "حذف الاجتماع",
+                "cancel": "إلغاء",
+                "deleting": "جارٍ الحذف…",
+                "error": "فشل حذف الاجتماع"
             }
         },
         "adminTenantRuntimeAllowlist": {

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6969,11 +6969,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "تعديل",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "إلغاء"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6925,7 +6925,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6948,7 +6947,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6958,6 +6956,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "أدخل بريدًا إلكترونيًا صالحًا أو اتركه فارغًا.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -7034,6 +7034,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "أدخل بريدًا إلكترونيًا صالحًا أو اتركه فارغًا.",
+                "participantDuplicate": "هذا الشخص موجود بالفعل في القائمة.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7041,6 +7042,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "تمت إضافة المشارك",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -7017,13 +7017,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "المشاركون",
-                "participantsHint": "واحد في كل سطر. استخدم \"الاسم '<'البريد الإلكتروني>\" لتسجيل عنوان."
+                "participantsHint": "واحد في كل سطر. استخدم \"الاسم '<'البريد الإلكتروني>\" لتسجيل عنوان.",
+                "participantName": "الاسم",
+                "participantEmail": "البريد الإلكتروني (اختياري)",
+                "participantAdd": "إضافة مشارك",
+                "participantRemove": "إزالة المشارك",
+                "participantsEmpty": "لم يُسجَّل أي مشارك بعد."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "وقت البدء ليس تاريخًا صالحًا.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "أدخل بريدًا إلكترونيًا صالحًا أو اتركه فارغًا.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6973,8 +6973,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "جارٍ الإرفاق…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "تعديل النص",
+                "cancelEdit": "إلغاء التعديل",
+                "saveTranscript": "حفظ النص",
+                "savingTranscript": "جارٍ الحفظ…",
                 "save": "Save changes",
                 "cancel": "إلغاء"
             },

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6972,6 +6972,7 @@
                 "edit": "تعديل",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "جارٍ الإرفاق…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6984,6 +6985,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "جارٍ إنشاء الملخص…",
+                "generatingHint": "نقرأ النص ونكتب الملخص — يستغرق ذلك عادةً بضع ثوانٍ.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -7017,7 +7017,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "المشاركون",
-                "participantsHint": "واحد في كل سطر. استخدم \"الاسم '<'البريد الإلكتروني>\" لتسجيل عنوان.",
                 "participantName": "الاسم",
                 "participantEmail": "البريد الإلكتروني (اختياري)",
                 "participantAdd": "إضافة مشارك",

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6965,61 +6965,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "العودة إلى الاجتماعات",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "فتح التسجيل",
                 "edit": "تعديل",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "حذف",
+                "attachTranscript": "إرفاق النص",
                 "attaching": "جارٍ الإرفاق…",
                 "editTranscript": "تعديل النص",
                 "cancelEdit": "إلغاء التعديل",
                 "saveTranscript": "حفظ النص",
                 "savingTranscript": "جارٍ الحفظ…",
-                "save": "Save changes",
+                "save": "حفظ التغييرات",
                 "cancel": "إلغاء"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "الملخص",
+                "transcript": "النص المدوّن",
+                "details": "التفاصيل",
+                "edit": "تعديل الاجتماع"
             },
             "summary": {
                 "generating": "جارٍ إنشاء الملخص…",
                 "generatingHint": "نقرأ النص ونكتب الملخص — يستغرق ذلك عادةً بضع ثوانٍ.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "لم يتم إنشاء ملخص لهذا النص. فعّل مزوّد ذكاء اصطناعي وأعد إرفاق النص للمحاولة مرة أخرى.",
+                "noTranscript": "أرفق نصًا مدوّنًا لإنشاء ملخص."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "نص الاجتماع المدوّن",
+                "composerPlaceholder": "الصق هنا النص المدوّن للاجتماع.",
+                "pipelineHint": "يُحفَظ أولًا، ثم يُلخَّص ويُخزَّن في الذاكرة ويُنشر في سجل نشاطك — بأفضل جهد ممكن.",
+                "storedElsewhere": "النص المدوّن محفوظ لكنه لم يُعَد مع هذا العرض."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "المصدر",
+                "startedAt": "بدأ",
+                "endedAt": "انتهى",
+                "openEnded": "ما زال مفتوحًا",
+                "duration": "المدة",
+                "work": "العمل",
+                "orgWide": "على مستوى المؤسسة",
+                "externalId": "معرّف المزوّد",
+                "createdAt": "تم الالتقاط",
+                "participants": "المشاركون",
+                "noParticipants": "لم يُسجَّل أي مشارك."
             },
             "edit": {
                 "hint": "صحّح الأوقات، أو أعد تسمية الاجتماع، أو عدّل قائمة المشاركين، أو اربطه بتسجيل، أو أعد توجيهه إلى عمل."
             },
             "fields": {
-                "title": "Title",
+                "title": "العنوان",
                 "startedAt": "وقت البدء",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "وقت الانتهاء",
+                "sourceUrl": "رابط التسجيل",
+                "work": "العمل",
+                "workNone": "على مستوى المؤسسة (بدون عمل)",
                 "participants": "المشاركون",
                 "participantName": "الاسم",
                 "participantEmail": "البريد الإلكتروني (اختياري)",
@@ -7028,23 +7028,23 @@
                 "participantsEmpty": "لم يُسجَّل أي مشارك بعد."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "العنوان مطلوب.",
                 "startedAtInvalid": "وقت البدء ليس تاريخًا صالحًا.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "وقت الانتهاء ليس تاريخًا صالحًا.",
+                "endedBeforeStarted": "لا يمكن أن يسبق وقت الانتهاء وقت البدء.",
                 "participantEmailInvalid": "أدخل بريدًا إلكترونيًا صالحًا أو اتركه فارغًا.",
                 "participantDuplicate": "هذا الشخص موجود بالفعل في القائمة.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "النص المدوّن مطلوب."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "تم إرفاق النص المدوّن",
+                "transcriptSummarized": "تم إرفاق النص المدوّن وتلخيصه",
+                "transcriptError": "تعذّر إرفاق النص المدوّن.",
+                "saved": "تم تحديث الاجتماع",
                 "participantAdded": "تمت إضافة المشارك",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "تعذّر تحديث الاجتماع.",
+                "deleted": "تم حذف الاجتماع",
+                "deleteError": "تعذّر حذف الاجتماع."
             },
             "deleteDialog": {
                 "title": "حذف هذا الاجتماع؟",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6972,6 +6972,7 @@
                 "edit": "Редактиране",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Прикачване…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6984,6 +6985,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Обобщението се генерира…",
+                "generatingHint": "Четем стенограмата и пишем резюмето — обикновено отнема няколко секунди.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -7017,7 +7017,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Участници",
-                "participantsHint": "По един на ред. Използвайте \"Име '<'имейл>\", за да запишете адрес.",
                 "participantName": "Име",
                 "participantEmail": "Имейл (по избор)",
                 "participantAdd": "Добавяне на участник",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6973,8 +6973,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Прикачване…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Редактиране на стенограмата",
+                "cancelEdit": "Отказ на редакцията",
+                "saveTranscript": "Запазване на стенограмата",
+                "savingTranscript": "Запазване…",
                 "save": "Save changes",
                 "cancel": "Отказ"
             },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -7017,13 +7017,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Участници",
-                "participantsHint": "По един на ред. Използвайте \"Име '<'имейл>\", за да запишете адрес."
+                "participantsHint": "По един на ред. Използвайте \"Име '<'имейл>\", за да запишете адрес.",
+                "participantName": "Име",
+                "participantEmail": "Имейл (по избор)",
+                "participantAdd": "Добавяне на участник",
+                "participantRemove": "Премахване на участника",
+                "participantsEmpty": "Още няма записани участници."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Началният час не е валидна дата.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Въведете валиден имейл адрес или оставете полето празно.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -7005,17 +7005,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Коригирайте часовете, преименувайте срещата, поправете списъка с участници, посочете запис или я пренасочете към Работа."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Начало",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Участници",
+                "participantsHint": "По един на ред. Използвайте \"Име <имейл>\", за да запишете адрес."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Началният час не е валидна дата.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -7029,8 +7033,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Да се изтрие ли тази среща?",
+                "body": "{title} ще бъде изтрита завинаги заедно с транскрипцията и обобщението ѝ. Това действие е необратимо.",
+                "confirm": "Изтриване на срещата",
+                "cancel": "Отказ",
+                "deleting": "Изтриване…",
+                "error": "Неуспешно изтриване на срещата"
             }
         },
         "adminTenantRuntimeAllowlist": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6969,11 +6969,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Редактиране",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Отказ"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6925,7 +6925,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6948,7 +6947,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6958,6 +6956,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Въведете валиден имейл адрес или оставете полето празно.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -7034,6 +7034,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Въведете валиден имейл адрес или оставете полето празно.",
+                "participantDuplicate": "Този човек вече е в списъка.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7041,6 +7042,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Участникът е добавен",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6965,61 +6965,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Обратно към срещите",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Отваряне на записа",
                 "edit": "Редактиране",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Изтриване",
+                "attachTranscript": "Прикачване на стенограма",
                 "attaching": "Прикачване…",
                 "editTranscript": "Редактиране на стенограмата",
                 "cancelEdit": "Отказ на редакцията",
                 "saveTranscript": "Запазване на стенограмата",
                 "savingTranscript": "Запазване…",
-                "save": "Save changes",
+                "save": "Запазване на промените",
                 "cancel": "Отказ"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Обобщение",
+                "transcript": "Стенограма",
+                "details": "Детайли",
+                "edit": "Редактиране на срещата"
             },
             "summary": {
                 "generating": "Обобщението се генерира…",
                 "generatingHint": "Четем стенограмата и пишем резюмето — обикновено отнема няколко секунди.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "За тази стенограма не беше генерирано обобщение. Активирайте доставчик на ИИ и прикачете стенограмата отново, за да опитате пак.",
+                "noTranscript": "Прикачете стенограма, за да генерирате обобщение."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Текст на стенограмата",
+                "composerPlaceholder": "Поставете стенограмата от срещата тук.",
+                "pipelineHint": "Първо се запазва, след това се обобщава, запомня се и се публикува в потока ви с дейности — по възможност.",
+                "storedElsewhere": "Стенограмата е запазена, но не беше върната с този изглед."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Източник",
+                "startedAt": "Начало",
+                "endedAt": "Край",
+                "openEnded": "Все още отворена",
+                "duration": "Продължителност",
+                "work": "Работа",
+                "orgWide": "За цялата организация",
+                "externalId": "ID при доставчика",
+                "createdAt": "Записана",
+                "participants": "Участници",
+                "noParticipants": "Няма записани участници."
             },
             "edit": {
                 "hint": "Коригирайте часовете, преименувайте срещата, поправете списъка с участници, посочете запис или я пренасочете към Работа."
             },
             "fields": {
-                "title": "Title",
+                "title": "Заглавие",
                 "startedAt": "Начало",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Край",
+                "sourceUrl": "Връзка към записа",
+                "work": "Работа",
+                "workNone": "За цялата организация (без Работа)",
                 "participants": "Участници",
                 "participantName": "Име",
                 "participantEmail": "Имейл (по избор)",
@@ -7028,23 +7028,23 @@
                 "participantsEmpty": "Още няма записани участници."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Заглавието е задължително.",
                 "startedAtInvalid": "Началният час не е валидна дата.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Крайният час не е валидна дата.",
+                "endedBeforeStarted": "Крайният час не може да е преди началния.",
                 "participantEmailInvalid": "Въведете валиден имейл адрес или оставете полето празно.",
                 "participantDuplicate": "Този човек вече е в списъка.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Текстът на стенограмата е задължителен."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Стенограмата е прикачена",
+                "transcriptSummarized": "Стенограмата е прикачена и обобщена",
+                "transcriptError": "Стенограмата не можа да бъде прикачена.",
+                "saved": "Срещата е актуализирана",
                 "participantAdded": "Участникът е добавен",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Срещата не можа да бъде актуализирана.",
+                "deleted": "Срещата е изтрита",
+                "deleteError": "Срещата не можа да бъде изтрита."
             },
             "deleteDialog": {
                 "title": "Да се изтрие ли тази среща?",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6948,7 +6948,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -7015,7 +7015,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Участници",
-                "participantsHint": "По един на ред. Използвайте \"Име <имейл>\", за да запишете адрес."
+                "participantsHint": "По един на ред. Използвайте \"Име '<'имейл>\", за да запишете адрес."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -7034,6 +7034,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Geben Sie eine gültige E-Mail-Adresse ein oder lassen Sie das Feld leer.",
+                "participantDuplicate": "Diese Person steht bereits auf der Liste.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7041,6 +7042,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Teilnehmer hinzugefügt",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6948,7 +6948,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -7015,7 +7015,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Teilnehmende",
-                "participantsHint": "Eine pro Zeile. Verwende \"Name <E-Mail>\", um eine Adresse zu erfassen."
+                "participantsHint": "Eine pro Zeile. Verwende \"Name '<'E-Mail>\", um eine Adresse zu erfassen."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -7017,7 +7017,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Teilnehmende",
-                "participantsHint": "Eine pro Zeile. Verwende \"Name '<'E-Mail>\", um eine Adresse zu erfassen.",
                 "participantName": "Name",
                 "participantEmail": "E-Mail (optional)",
                 "participantAdd": "Teilnehmer hinzufügen",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6973,8 +6973,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Wird angehängt…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Transkript bearbeiten",
+                "cancelEdit": "Bearbeitung abbrechen",
+                "saveTranscript": "Transkript speichern",
+                "savingTranscript": "Wird gespeichert…",
                 "save": "Save changes",
                 "cancel": "Abbrechen"
             },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -7017,13 +7017,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Teilnehmende",
-                "participantsHint": "Eine pro Zeile. Verwende \"Name '<'E-Mail>\", um eine Adresse zu erfassen."
+                "participantsHint": "Eine pro Zeile. Verwende \"Name '<'E-Mail>\", um eine Adresse zu erfassen.",
+                "participantName": "Name",
+                "participantEmail": "E-Mail (optional)",
+                "participantAdd": "Teilnehmer hinzufügen",
+                "participantRemove": "Teilnehmer entfernen",
+                "participantsEmpty": "Noch niemand erfasst."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Die Startzeit ist kein gültiges Datum.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Geben Sie eine gültige E-Mail-Adresse ein oder lassen Sie das Feld leer.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6925,7 +6925,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6948,7 +6947,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6958,6 +6956,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Geben Sie eine gültige E-Mail-Adresse ein oder lassen Sie das Feld leer.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6965,61 +6965,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Zurück zu Meetings",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Aufzeichnung öffnen",
                 "edit": "Bearbeiten",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Löschen",
+                "attachTranscript": "Transkript anhängen",
                 "attaching": "Wird angehängt…",
                 "editTranscript": "Transkript bearbeiten",
                 "cancelEdit": "Bearbeitung abbrechen",
                 "saveTranscript": "Transkript speichern",
                 "savingTranscript": "Wird gespeichert…",
-                "save": "Save changes",
+                "save": "Änderungen speichern",
                 "cancel": "Abbrechen"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
+                "summary": "Zusammenfassung",
+                "transcript": "Transkript",
                 "details": "Details",
-                "edit": "Edit meeting"
+                "edit": "Meeting bearbeiten"
             },
             "summary": {
                 "generating": "Zusammenfassung wird erstellt…",
                 "generatingHint": "Das Transkript wird gelesen und die Zusammenfassung geschrieben – das dauert meist ein paar Sekunden.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Für dieses Transkript wurde keine Zusammenfassung erstellt. Aktivieren Sie einen KI-Anbieter und hängen Sie das Transkript erneut an, um es noch einmal zu versuchen.",
+                "noTranscript": "Hängen Sie ein Transkript an, um eine Zusammenfassung zu erstellen."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Transkripttext",
+                "composerPlaceholder": "Fügen Sie hier das Meeting-Transkript ein.",
+                "pipelineHint": "Wird zuerst gespeichert, dann zusammengefasst, gemerkt und in Ihrem Aktivitäts-Feed veröffentlicht – nach bestem Bemühen.",
+                "storedElsewhere": "Das Transkript ist gespeichert, wurde aber mit dieser Ansicht nicht zurückgegeben."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Quelle",
+                "startedAt": "Beginn",
+                "endedAt": "Ende",
+                "openEnded": "Noch offen",
+                "duration": "Dauer",
+                "work": "Werk",
+                "orgWide": "Organisationsweit",
+                "externalId": "Anbieter-ID",
+                "createdAt": "Erfasst",
+                "participants": "Teilnehmende",
+                "noParticipants": "Keine Teilnehmenden erfasst."
             },
             "edit": {
                 "hint": "Zeiten korrigieren, Meeting umbenennen, Teilnehmendenliste anpassen, auf eine Aufzeichnung verweisen oder es einem Werk zuordnen."
             },
             "fields": {
-                "title": "Title",
+                "title": "Titel",
                 "startedAt": "Beginn",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Ende",
+                "sourceUrl": "Aufzeichnungslink",
+                "work": "Werk",
+                "workNone": "Organisationsweit (kein Werk)",
                 "participants": "Teilnehmende",
                 "participantName": "Name",
                 "participantEmail": "E-Mail (optional)",
@@ -7028,23 +7028,23 @@
                 "participantsEmpty": "Noch niemand erfasst."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Ein Titel ist erforderlich.",
                 "startedAtInvalid": "Die Startzeit ist kein gültiges Datum.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Die Endzeit ist kein gültiges Datum.",
+                "endedBeforeStarted": "Die Endzeit darf nicht vor der Startzeit liegen.",
                 "participantEmailInvalid": "Geben Sie eine gültige E-Mail-Adresse ein oder lassen Sie das Feld leer.",
                 "participantDuplicate": "Diese Person steht bereits auf der Liste.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Der Transkripttext ist erforderlich."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Transkript angehängt",
+                "transcriptSummarized": "Transkript angehängt und zusammengefasst",
+                "transcriptError": "Das Transkript konnte nicht angehängt werden.",
+                "saved": "Meeting aktualisiert",
                 "participantAdded": "Teilnehmer hinzugefügt",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Das Meeting konnte nicht aktualisiert werden.",
+                "deleted": "Meeting gelöscht",
+                "deleteError": "Das Meeting konnte nicht gelöscht werden."
             },
             "deleteDialog": {
                 "title": "Dieses Meeting löschen?",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6972,6 +6972,7 @@
                 "edit": "Bearbeiten",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Wird angehängt…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6984,6 +6985,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Zusammenfassung wird erstellt…",
+                "generatingHint": "Das Transkript wird gelesen und die Zusammenfassung geschrieben – das dauert meist ein paar Sekunden.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6969,11 +6969,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Bearbeiten",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Abbrechen"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -7005,17 +7005,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Zeiten korrigieren, Meeting umbenennen, Teilnehmendenliste anpassen, auf eine Aufzeichnung verweisen oder es einem Werk zuordnen."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Beginn",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Teilnehmende",
+                "participantsHint": "Eine pro Zeile. Verwende \"Name <E-Mail>\", um eine Adresse zu erfassen."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Die Startzeit ist kein gültiges Datum.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -7029,8 +7033,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Dieses Meeting löschen?",
+                "body": "{title} wird dauerhaft gelöscht – zusammen mit Transkript und Zusammenfassung. Dies kann nicht rückgängig gemacht werden.",
+                "confirm": "Meeting löschen",
+                "cancel": "Abbrechen",
+                "deleting": "Wird gelöscht…",
+                "error": "Meeting konnte nicht gelöscht werden"
             }
         },
         "adminTenantRuntimeAllowlist": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6281,8 +6281,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Attaching…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Edit transcript",
+                "cancelEdit": "Cancel edit",
+                "saveTranscript": "Save transcript",
+                "savingTranscript": "Saving…",
                 "save": "Save changes",
                 "cancel": "Cancel"
             },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6325,13 +6325,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address."
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
+                "participantName": "Name",
+                "participantEmail": "Email (optional)",
+                "participantAdd": "Add participant",
+                "participantRemove": "Remove participant",
+                "participantsEmpty": "No one recorded yet."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Enter a valid email address, or leave it blank.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6256,7 +6256,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6323,7 +6323,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address."
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6280,6 +6280,7 @@
                 "edit": "Edit",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Attaching…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6292,6 +6293,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Generating summary…",
+                "generatingHint": "Reading the transcript and writing the recap — this usually takes a few seconds.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6325,7 +6325,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "participantName": "Name",
                 "participantEmail": "Email (optional)",
                 "participantAdd": "Add participant",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6342,6 +6342,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Enter a valid email address, or leave it blank.",
+                "participantDuplicate": "That person is already on the list.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -6349,6 +6350,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Participant added",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6277,11 +6277,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Edit",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Cancel"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6313,17 +6313,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Correct the times, rename the meeting, fix the roster, point it at a recording, or re-route it to a Work."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Started at",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Participants",
+                "participantsHint": "One per line. Use \"Name <email>\" to record an address."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6337,8 +6341,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Delete this meeting?",
+                "body": "{title} will be permanently deleted, along with its transcript and summary. This cannot be undone.",
+                "confirm": "Delete meeting",
+                "cancel": "Cancel",
+                "deleting": "Deleting…",
+                "error": "Failed to delete the meeting"
             }
         },
         "sidebar": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6233,7 +6233,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6256,7 +6255,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6266,6 +6264,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Enter a valid email address, or leave it blank.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6965,61 +6965,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Volver a Reuniones",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Abrir la grabación",
                 "edit": "Editar",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Eliminar",
+                "attachTranscript": "Adjuntar transcripción",
                 "attaching": "Adjuntando…",
                 "editTranscript": "Editar la transcripción",
                 "cancelEdit": "Cancelar la edición",
                 "saveTranscript": "Guardar la transcripción",
                 "savingTranscript": "Guardando…",
-                "save": "Save changes",
+                "save": "Guardar cambios",
                 "cancel": "Cancelar"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Resumen",
+                "transcript": "Transcripción",
+                "details": "Detalles",
+                "edit": "Editar la reunión"
             },
             "summary": {
                 "generating": "Generando el resumen…",
                 "generatingHint": "Estamos leyendo la transcripción y redactando el resumen: suele tardar unos segundos.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "No se generó ningún resumen para esta transcripción. Activa un proveedor de IA y vuelve a adjuntar la transcripción para intentarlo de nuevo.",
+                "noTranscript": "Adjunta una transcripción para generar un resumen."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Texto de la transcripción",
+                "composerPlaceholder": "Pega aquí la transcripción de la reunión.",
+                "pipelineHint": "Primero se guarda; luego se resume, se recuerda y se publica en tu feed de actividad, en la medida de lo posible.",
+                "storedElsewhere": "La transcripción está guardada, pero no se devolvió con esta vista."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Origen",
+                "startedAt": "Inicio",
+                "endedAt": "Fin",
+                "openEnded": "Todavía abierta",
+                "duration": "Duración",
+                "work": "Trabajo",
+                "orgWide": "Toda la organización",
+                "externalId": "ID del proveedor",
+                "createdAt": "Registrada",
+                "participants": "Participantes",
+                "noParticipants": "No se registró ningún participante."
             },
             "edit": {
                 "hint": "Corrige los horarios, renombra la reunión, ajusta la lista de participantes, enlaza una grabación o reasígnala a un Trabajo."
             },
             "fields": {
-                "title": "Title",
+                "title": "Título",
                 "startedAt": "Inicio",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Fin",
+                "sourceUrl": "Enlace de la grabación",
+                "work": "Trabajo",
+                "workNone": "Toda la organización (sin Trabajo)",
                 "participants": "Participantes",
                 "participantName": "Nombre",
                 "participantEmail": "Correo electrónico (opcional)",
@@ -7028,23 +7028,23 @@
                 "participantsEmpty": "Todavía no hay nadie registrado."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "El título es obligatorio.",
                 "startedAtInvalid": "La hora de inicio no es una fecha válida.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "La hora de fin no es una fecha válida.",
+                "endedBeforeStarted": "La hora de fin no puede ser anterior a la de inicio.",
                 "participantEmailInvalid": "Introduce un correo electrónico válido o déjalo en blanco.",
                 "participantDuplicate": "Esa persona ya está en la lista.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "El texto de la transcripción es obligatorio."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Transcripción adjuntada",
+                "transcriptSummarized": "Transcripción adjuntada y resumida",
+                "transcriptError": "No se pudo adjuntar la transcripción.",
+                "saved": "Reunión actualizada",
                 "participantAdded": "Participante añadido",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "No se pudo actualizar la reunión.",
+                "deleted": "Reunión eliminada",
+                "deleteError": "No se pudo eliminar la reunión."
             },
             "deleteDialog": {
                 "title": "¿Eliminar esta reunión?",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6969,11 +6969,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Editar",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Cancelar"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -7034,6 +7034,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Introduce un correo electrónico válido o déjalo en blanco.",
+                "participantDuplicate": "Esa persona ya está en la lista.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7041,6 +7042,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Participante añadido",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -7005,17 +7005,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Corrige los horarios, renombra la reunión, ajusta la lista de participantes, enlaza una grabación o reasígnala a un Trabajo."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Inicio",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Participantes",
+                "participantsHint": "Uno por línea. Usa \"Nombre <correo>\" para registrar una dirección."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "La hora de inicio no es una fecha válida.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -7029,8 +7033,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "¿Eliminar esta reunión?",
+                "body": "{title} se eliminará de forma permanente, junto con su transcripción y su resumen. Esta acción no se puede deshacer.",
+                "confirm": "Eliminar reunión",
+                "cancel": "Cancelar",
+                "deleting": "Eliminando…",
+                "error": "No se pudo eliminar la reunión"
             }
         },
         "adminTenantRuntimeAllowlist": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6973,8 +6973,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Adjuntando…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Editar la transcripción",
+                "cancelEdit": "Cancelar la edición",
+                "saveTranscript": "Guardar la transcripción",
+                "savingTranscript": "Guardando…",
                 "save": "Save changes",
                 "cancel": "Cancelar"
             },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6948,7 +6948,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -7015,7 +7015,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participantes",
-                "participantsHint": "Uno por línea. Usa \"Nombre <correo>\" para registrar una dirección."
+                "participantsHint": "Uno por línea. Usa \"Nombre '<'correo>\" para registrar una dirección."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -7017,13 +7017,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participantes",
-                "participantsHint": "Uno por línea. Usa \"Nombre '<'correo>\" para registrar una dirección."
+                "participantsHint": "Uno por línea. Usa \"Nombre '<'correo>\" para registrar una dirección.",
+                "participantName": "Nombre",
+                "participantEmail": "Correo electrónico (opcional)",
+                "participantAdd": "Añadir participante",
+                "participantRemove": "Quitar participante",
+                "participantsEmpty": "Todavía no hay nadie registrado."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "La hora de inicio no es una fecha válida.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Introduce un correo electrónico válido o déjalo en blanco.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -7017,7 +7017,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participantes",
-                "participantsHint": "Uno por línea. Usa \"Nombre '<'correo>\" para registrar una dirección.",
                 "participantName": "Nombre",
                 "participantEmail": "Correo electrónico (opcional)",
                 "participantAdd": "Añadir participante",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6972,6 +6972,7 @@
                 "edit": "Editar",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Adjuntando…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6984,6 +6985,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Generando el resumen…",
+                "generatingHint": "Estamos leyendo la transcripción y redactando el resumen: suele tardar unos segundos.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6925,7 +6925,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6948,7 +6947,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6958,6 +6956,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Introduce un correo electrónico válido o déjalo en blanco.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6965,61 +6965,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Retour aux réunions",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Ouvrir l’enregistrement",
                 "edit": "Modifier",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Supprimer",
+                "attachTranscript": "Joindre une transcription",
                 "attaching": "Ajout en cours…",
                 "editTranscript": "Modifier la transcription",
                 "cancelEdit": "Annuler la modification",
                 "saveTranscript": "Enregistrer la transcription",
                 "savingTranscript": "Enregistrement…",
-                "save": "Save changes",
+                "save": "Enregistrer les modifications",
                 "cancel": "Annuler"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Résumé",
+                "transcript": "Transcription",
+                "details": "Détails",
+                "edit": "Modifier la réunion"
             },
             "summary": {
                 "generating": "Génération du résumé…",
                 "generatingHint": "Nous lisons la transcription et rédigeons le résumé — cela prend généralement quelques secondes.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Aucun résumé n’a été généré pour cette transcription. Activez un fournisseur d’IA et joignez de nouveau la transcription pour réessayer.",
+                "noTranscript": "Joignez une transcription pour générer un résumé."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Texte de la transcription",
+                "composerPlaceholder": "Collez ici la transcription de la réunion.",
+                "pipelineHint": "D’abord enregistrée, puis résumée, mémorisée et publiée dans votre fil d’activité — au mieux.",
+                "storedElsewhere": "La transcription est enregistrée mais n’a pas été renvoyée avec cette vue."
             },
             "details": {
                 "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
+                "startedAt": "Début",
+                "endedAt": "Fin",
+                "openEnded": "Toujours en cours",
+                "duration": "Durée",
+                "work": "Travail",
+                "orgWide": "Toute l’organisation",
+                "externalId": "ID du fournisseur",
+                "createdAt": "Enregistrée",
                 "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "noParticipants": "Aucun participant enregistré."
             },
             "edit": {
                 "hint": "Corrigez les horaires, renommez la réunion, ajustez la liste des participants, pointez vers un enregistrement ou réaffectez-la à un Travail."
             },
             "fields": {
-                "title": "Title",
+                "title": "Titre",
                 "startedAt": "Début",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Fin",
+                "sourceUrl": "Lien de l’enregistrement",
+                "work": "Travail",
+                "workNone": "Toute l’organisation (aucun Travail)",
                 "participants": "Participants",
                 "participantName": "Nom",
                 "participantEmail": "E-mail (facultatif)",
@@ -7028,23 +7028,23 @@
                 "participantsEmpty": "Personne n’est encore enregistré."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Le titre est obligatoire.",
                 "startedAtInvalid": "L'heure de début n'est pas une date valide.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "L’heure de fin n’est pas une date valide.",
+                "endedBeforeStarted": "L’heure de fin ne peut pas précéder l’heure de début.",
                 "participantEmailInvalid": "Saisissez une adresse e-mail valide ou laissez le champ vide.",
                 "participantDuplicate": "Cette personne est déjà dans la liste.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Le texte de la transcription est obligatoire."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Transcription jointe",
+                "transcriptSummarized": "Transcription jointe et résumée",
+                "transcriptError": "Impossible de joindre la transcription.",
+                "saved": "Réunion mise à jour",
                 "participantAdded": "Participant ajouté",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Impossible de mettre à jour la réunion.",
+                "deleted": "Réunion supprimée",
+                "deleteError": "Impossible de supprimer la réunion."
             },
             "deleteDialog": {
                 "title": "Supprimer cette réunion ?",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -7034,6 +7034,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Saisissez une adresse e-mail valide ou laissez le champ vide.",
+                "participantDuplicate": "Cette personne est déjà dans la liste.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7041,6 +7042,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Participant ajouté",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6973,8 +6973,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Ajout en cours…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Modifier la transcription",
+                "cancelEdit": "Annuler la modification",
+                "saveTranscript": "Enregistrer la transcription",
+                "savingTranscript": "Enregistrement…",
                 "save": "Save changes",
                 "cancel": "Annuler"
             },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -7017,13 +7017,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participants",
-                "participantsHint": "Un par ligne. Utilisez « Nom '<'e-mail> » pour enregistrer une adresse."
+                "participantsHint": "Un par ligne. Utilisez « Nom '<'e-mail> » pour enregistrer une adresse.",
+                "participantName": "Nom",
+                "participantEmail": "E-mail (facultatif)",
+                "participantAdd": "Ajouter un participant",
+                "participantRemove": "Supprimer le participant",
+                "participantsEmpty": "Personne n’est encore enregistré."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "L'heure de début n'est pas une date valide.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Saisissez une adresse e-mail valide ou laissez le champ vide.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6925,7 +6925,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6948,7 +6947,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6958,6 +6956,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Saisissez une adresse e-mail valide ou laissez le champ vide.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6969,11 +6969,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Modifier",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Annuler"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -7005,17 +7005,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Corrigez les horaires, renommez la réunion, ajustez la liste des participants, pointez vers un enregistrement ou réaffectez-la à un Travail."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Début",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Participants",
+                "participantsHint": "Un par ligne. Utilisez « Nom <e-mail> » pour enregistrer une adresse."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "L'heure de début n'est pas une date valide.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -7029,8 +7033,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Supprimer cette réunion ?",
+                "body": "{title} sera définitivement supprimée, ainsi que sa transcription et son résumé. Cette action est irréversible.",
+                "confirm": "Supprimer la réunion",
+                "cancel": "Annuler",
+                "deleting": "Suppression…",
+                "error": "Échec de la suppression de la réunion"
             }
         },
         "adminTenantRuntimeAllowlist": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6948,7 +6948,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -7015,7 +7015,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participants",
-                "participantsHint": "Un par ligne. Utilisez « Nom <e-mail> » pour enregistrer une adresse."
+                "participantsHint": "Un par ligne. Utilisez « Nom '<'e-mail> » pour enregistrer une adresse."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6972,6 +6972,7 @@
                 "edit": "Modifier",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Ajout en cours…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6984,6 +6985,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Génération du résumé…",
+                "generatingHint": "Nous lisons la transcription et rédigeons le résumé — cela prend généralement quelques secondes.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -7017,7 +7017,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participants",
-                "participantsHint": "Un par ligne. Utilisez « Nom '<'e-mail> » pour enregistrer une adresse.",
                 "participantName": "Nom",
                 "participantEmail": "E-mail (facultatif)",
                 "participantAdd": "Ajouter un participant",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -7017,13 +7017,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "משתתפים",
-                "participantsHint": "אחד בכל שורה. השתמשו ב-\"שם '<'אימייל>\" כדי לרשום כתובת."
+                "participantsHint": "אחד בכל שורה. השתמשו ב-\"שם '<'אימייל>\" כדי לרשום כתובת.",
+                "participantName": "שם",
+                "participantEmail": "אימייל (אופציונלי)",
+                "participantAdd": "הוספת משתתף",
+                "participantRemove": "הסרת המשתתף",
+                "participantsEmpty": "עדיין לא נרשם אף אחד."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "שעת ההתחלה אינה תאריך תקין.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "הזינו כתובת אימייל תקינה או השאירו ריק.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6973,8 +6973,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "מצרפים…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "עריכת התמליל",
+                "cancelEdit": "ביטול העריכה",
+                "saveTranscript": "שמירת התמליל",
+                "savingTranscript": "שומרים…",
                 "save": "Save changes",
                 "cancel": "ביטול"
             },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6925,7 +6925,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6948,7 +6947,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6958,6 +6956,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "הזינו כתובת אימייל תקינה או השאירו ריק.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6969,11 +6969,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "עריכה",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "ביטול"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6972,6 +6972,7 @@
                 "edit": "עריכה",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "מצרפים…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6984,6 +6985,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "יוצרים סיכום…",
+                "generatingHint": "קוראים את התמליל וכותבים את הסיכום — זה נמשך בדרך כלל כמה שניות.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -7034,6 +7034,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "הזינו כתובת אימייל תקינה או השאירו ריק.",
+                "participantDuplicate": "האדם הזה כבר ברשימה.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7041,6 +7042,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "המשתתף נוסף",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6965,61 +6965,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "חזרה לפגישות",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "פתיחת ההקלטה",
                 "edit": "עריכה",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "מחיקה",
+                "attachTranscript": "צירוף תמליל",
                 "attaching": "מצרפים…",
                 "editTranscript": "עריכת התמליל",
                 "cancelEdit": "ביטול העריכה",
                 "saveTranscript": "שמירת התמליל",
                 "savingTranscript": "שומרים…",
-                "save": "Save changes",
+                "save": "שמירת השינויים",
                 "cancel": "ביטול"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "סיכום",
+                "transcript": "תמליל",
+                "details": "פרטים",
+                "edit": "עריכת הפגישה"
             },
             "summary": {
                 "generating": "יוצרים סיכום…",
                 "generatingHint": "קוראים את התמליל וכותבים את הסיכום — זה נמשך בדרך כלל כמה שניות.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "לא נוצר סיכום עבור התמליל הזה. הפעילו ספק בינה מלאכותית וצרפו את התמליל מחדש כדי לנסות שוב.",
+                "noTranscript": "צרפו תמליל כדי ליצור סיכום."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "טקסט התמליל",
+                "composerPlaceholder": "הדביקו כאן את תמליל הפגישה.",
+                "pipelineHint": "נשמר תחילה, ואז מסוכם, נשמר בזיכרון ומפורסם בפיד הפעילות שלכם — כמיטב היכולת.",
+                "storedElsewhere": "התמליל שמור אך לא הוחזר בתצוגה הזו."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "מקור",
+                "startedAt": "התחילה",
+                "endedAt": "הסתיימה",
+                "openEnded": "עדיין פתוחה",
+                "duration": "משך",
+                "work": "עבודה",
+                "orgWide": "כלל־ארגוני",
+                "externalId": "מזהה אצל הספק",
+                "createdAt": "נקלטה",
+                "participants": "משתתפים",
+                "noParticipants": "לא נרשמו משתתפים."
             },
             "edit": {
                 "hint": "תקנו את הזמנים, שנו את שם הפגישה, עדכנו את רשימת המשתתפים, קשרו הקלטה או נתבו אותה לעבודה."
             },
             "fields": {
-                "title": "Title",
+                "title": "כותרת",
                 "startedAt": "שעת התחלה",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "שעת סיום",
+                "sourceUrl": "קישור להקלטה",
+                "work": "עבודה",
+                "workNone": "כלל־ארגוני (ללא עבודה)",
                 "participants": "משתתפים",
                 "participantName": "שם",
                 "participantEmail": "אימייל (אופציונלי)",
@@ -7028,23 +7028,23 @@
                 "participantsEmpty": "עדיין לא נרשם אף אחד."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "חובה להזין כותרת.",
                 "startedAtInvalid": "שעת ההתחלה אינה תאריך תקין.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "שעת הסיום אינה תאריך תקין.",
+                "endedBeforeStarted": "שעת הסיום לא יכולה להקדים את שעת ההתחלה.",
                 "participantEmailInvalid": "הזינו כתובת אימייל תקינה או השאירו ריק.",
                 "participantDuplicate": "האדם הזה כבר ברשימה.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "חובה להזין את טקסט התמליל."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "התמליל צורף",
+                "transcriptSummarized": "התמליל צורף וסוכם",
+                "transcriptError": "לא ניתן היה לצרף את התמליל.",
+                "saved": "הפגישה עודכנה",
                 "participantAdded": "המשתתף נוסף",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "לא ניתן היה לעדכן את הפגישה.",
+                "deleted": "הפגישה נמחקה",
+                "deleteError": "לא ניתן היה למחוק את הפגישה."
             },
             "deleteDialog": {
                 "title": "למחוק את הפגישה הזו?",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6948,7 +6948,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -7015,7 +7015,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "משתתפים",
-                "participantsHint": "אחד בכל שורה. השתמשו ב-\"שם <אימייל>\" כדי לרשום כתובת."
+                "participantsHint": "אחד בכל שורה. השתמשו ב-\"שם '<'אימייל>\" כדי לרשום כתובת."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -7017,7 +7017,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "משתתפים",
-                "participantsHint": "אחד בכל שורה. השתמשו ב-\"שם '<'אימייל>\" כדי לרשום כתובת.",
                 "participantName": "שם",
                 "participantEmail": "אימייל (אופציונלי)",
                 "participantAdd": "הוספת משתתף",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -7005,17 +7005,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "תקנו את הזמנים, שנו את שם הפגישה, עדכנו את רשימת המשתתפים, קשרו הקלטה או נתבו אותה לעבודה."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "שעת התחלה",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "משתתפים",
+                "participantsHint": "אחד בכל שורה. השתמשו ב-\"שם <אימייל>\" כדי לרשום כתובת."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "שעת ההתחלה אינה תאריך תקין.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -7029,8 +7033,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "למחוק את הפגישה הזו?",
+                "body": "{title} תימחק לצמיתות, יחד עם התמליל והסיכום שלה. לא ניתן לבטל פעולה זו.",
+                "confirm": "מחק פגישה",
+                "cancel": "ביטול",
+                "deleting": "מוחק…",
+                "error": "מחיקת הפגישה נכשלה"
             }
         },
         "adminTenantRuntimeAllowlist": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "संपादित करें",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "रद्द करें"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "समय ठीक करें, मीटिंग का नाम बदलें, प्रतिभागी सूची सुधारें, रिकॉर्डिंग से जोड़ें, या इसे किसी कार्य पर पुनर्निर्देशित करें।"
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "प्रारंभ समय",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "प्रतिभागी",
+                "participantsHint": "प्रति पंक्ति एक। पता दर्ज करने के लिए \"नाम <ईमेल>\" का उपयोग करें।"
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "प्रारंभ समय एक मान्य दिनांक नहीं है।",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "इस मीटिंग को हटाएँ?",
+                "body": "{title} को उसके ट्रांसक्रिप्ट और सारांश सहित स्थायी रूप से हटा दिया जाएगा। इसे पूर्ववत नहीं किया जा सकता।",
+                "confirm": "मीटिंग हटाएँ",
+                "cancel": "रद्द करें",
+                "deleting": "हटाया जा रहा है…",
+                "error": "मीटिंग हटाई नहीं जा सकी"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "जोड़ा जा रहा है…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "ट्रांसक्रिप्ट संपादित करें",
+                "cancelEdit": "संपादन रद्द करें",
+                "saveTranscript": "ट्रांसक्रिप्ट सहेजें",
+                "savingTranscript": "सहेजा जा रहा है…",
                 "save": "Save changes",
                 "cancel": "रद्द करें"
             },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "प्रतिभागी",
-                "participantsHint": "प्रति पंक्ति एक। पता दर्ज करने के लिए \"नाम '<'ईमेल>\" का उपयोग करें।"
+                "participantsHint": "प्रति पंक्ति एक। पता दर्ज करने के लिए \"नाम '<'ईमेल>\" का उपयोग करें।",
+                "participantName": "नाम",
+                "participantEmail": "ईमेल (वैकल्पिक)",
+                "participantAdd": "प्रतिभागी जोड़ें",
+                "participantRemove": "प्रतिभागी हटाएँ",
+                "participantsEmpty": "अभी तक कोई दर्ज नहीं किया गया।"
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "प्रारंभ समय एक मान्य दिनांक नहीं है।",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "मान्य ईमेल पता दर्ज करें, या इसे खाली छोड़ें।",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "मान्य ईमेल पता दर्ज करें, या इसे खाली छोड़ें।",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "प्रतिभागी",
-                "participantsHint": "प्रति पंक्ति एक। पता दर्ज करने के लिए \"नाम <ईमेल>\" का उपयोग करें।"
+                "participantsHint": "प्रति पंक्ति एक। पता दर्ज करने के लिए \"नाम '<'ईमेल>\" का उपयोग करें।"
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6942,6 +6942,7 @@
                 "edit": "संपादित करें",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "जोड़ा जा रहा है…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "सारांश तैयार किया जा रहा है…",
+                "generatingHint": "ट्रांसक्रिप्ट पढ़ा जा रहा है और सारांश लिखा जा रहा है — इसमें आम तौर पर कुछ सेकंड लगते हैं।",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "प्रतिभागी",
-                "participantsHint": "प्रति पंक्ति एक। पता दर्ज करने के लिए \"नाम '<'ईमेल>\" का उपयोग करें।",
                 "participantName": "नाम",
                 "participantEmail": "ईमेल (वैकल्पिक)",
                 "participantAdd": "प्रतिभागी जोड़ें",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "मीटिंग पर वापस जाएँ",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "रिकॉर्डिंग खोलें",
                 "edit": "संपादित करें",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "हटाएँ",
+                "attachTranscript": "ट्रांसक्रिप्ट जोड़ें",
                 "attaching": "जोड़ा जा रहा है…",
                 "editTranscript": "ट्रांसक्रिप्ट संपादित करें",
                 "cancelEdit": "संपादन रद्द करें",
                 "saveTranscript": "ट्रांसक्रिप्ट सहेजें",
                 "savingTranscript": "सहेजा जा रहा है…",
-                "save": "Save changes",
+                "save": "बदलाव सहेजें",
                 "cancel": "रद्द करें"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "सारांश",
+                "transcript": "ट्रांसक्रिप्ट",
+                "details": "विवरण",
+                "edit": "मीटिंग संपादित करें"
             },
             "summary": {
                 "generating": "सारांश तैयार किया जा रहा है…",
                 "generatingHint": "ट्रांसक्रिप्ट पढ़ा जा रहा है और सारांश लिखा जा रहा है — इसमें आम तौर पर कुछ सेकंड लगते हैं।",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "इस ट्रांसक्रिप्ट के लिए कोई सारांश तैयार नहीं हुआ। कोई AI प्रदाता सक्षम करें और दोबारा कोशिश करने के लिए ट्रांसक्रिप्ट फिर से जोड़ें।",
+                "noTranscript": "सारांश तैयार करने के लिए ट्रांसक्रिप्ट जोड़ें।"
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "ट्रांसक्रिप्ट का पाठ",
+                "composerPlaceholder": "मीटिंग का ट्रांसक्रिप्ट यहाँ चिपकाएँ।",
+                "pipelineHint": "पहले सहेजा जाता है, फिर उसका सारांश बनता है, याद रखा जाता है और आपकी गतिविधि फ़ीड में पोस्ट किया जाता है — यथासंभव।",
+                "storedElsewhere": "ट्रांसक्रिप्ट सहेजा गया है, लेकिन इस दृश्य के साथ नहीं लौटाया गया।"
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "स्रोत",
+                "startedAt": "शुरू हुई",
+                "endedAt": "समाप्त हुई",
+                "openEnded": "अभी भी चल रही है",
+                "duration": "अवधि",
+                "work": "कार्य",
+                "orgWide": "पूरे संगठन में",
+                "externalId": "प्रदाता आईडी",
+                "createdAt": "दर्ज की गई",
+                "participants": "प्रतिभागी",
+                "noParticipants": "कोई प्रतिभागी दर्ज नहीं है।"
             },
             "edit": {
                 "hint": "समय ठीक करें, मीटिंग का नाम बदलें, प्रतिभागी सूची सुधारें, रिकॉर्डिंग से जोड़ें, या इसे किसी कार्य पर पुनर्निर्देशित करें।"
             },
             "fields": {
-                "title": "Title",
+                "title": "शीर्षक",
                 "startedAt": "प्रारंभ समय",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "समाप्ति समय",
+                "sourceUrl": "रिकॉर्डिंग लिंक",
+                "work": "कार्य",
+                "workNone": "पूरे संगठन में (कोई कार्य नहीं)",
                 "participants": "प्रतिभागी",
                 "participantName": "नाम",
                 "participantEmail": "ईमेल (वैकल्पिक)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "अभी तक कोई दर्ज नहीं किया गया।"
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "शीर्षक आवश्यक है।",
                 "startedAtInvalid": "प्रारंभ समय एक मान्य दिनांक नहीं है।",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "समाप्ति समय एक मान्य दिनांक नहीं है।",
+                "endedBeforeStarted": "समाप्ति समय प्रारंभ समय से पहले नहीं हो सकता।",
                 "participantEmailInvalid": "मान्य ईमेल पता दर्ज करें, या इसे खाली छोड़ें।",
                 "participantDuplicate": "यह व्यक्ति पहले से सूची में है।",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "ट्रांसक्रिप्ट का पाठ आवश्यक है।"
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "ट्रांसक्रिप्ट जोड़ा गया",
+                "transcriptSummarized": "ट्रांसक्रिप्ट जोड़ा गया और सारांश बनाया गया",
+                "transcriptError": "ट्रांसक्रिप्ट नहीं जोड़ा जा सका।",
+                "saved": "मीटिंग अपडेट हुई",
                 "participantAdded": "प्रतिभागी जोड़ा गया",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "मीटिंग अपडेट नहीं हो सकी।",
+                "deleted": "मीटिंग हटाई गई",
+                "deleteError": "मीटिंग हटाई नहीं जा सकी।"
             },
             "deleteDialog": {
                 "title": "इस मीटिंग को हटाएँ?",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "मान्य ईमेल पता दर्ज करें, या इसे खाली छोड़ें।",
+                "participantDuplicate": "यह व्यक्ति पहले से सूची में है।",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "प्रतिभागी जोड़ा गया",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Peserta",
-                "participantsHint": "Satu per baris. Gunakan \"Nama <email>\" untuk mencatat alamat."
+                "participantsHint": "Satu per baris. Gunakan \"Nama '<'email>\" untuk mencatat alamat."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Perbaiki waktunya, ganti nama rapat, perbarui daftar peserta, tautkan ke rekaman, atau alihkan ke sebuah Karya."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Mulai",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Peserta",
+                "participantsHint": "Satu per baris. Gunakan \"Nama <email>\" untuk mencatat alamat."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Waktu mulai bukan tanggal yang valid.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Hapus rapat ini?",
+                "body": "{title} akan dihapus secara permanen, beserta transkrip dan ringkasannya. Tindakan ini tidak dapat dibatalkan.",
+                "confirm": "Hapus rapat",
+                "cancel": "Batal",
+                "deleting": "Menghapus…",
+                "error": "Gagal menghapus rapat"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Kembali ke Rapat",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Buka rekaman",
                 "edit": "Edit",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Hapus",
+                "attachTranscript": "Lampirkan transkrip",
                 "attaching": "Melampirkan…",
                 "editTranscript": "Edit transkrip",
                 "cancelEdit": "Batalkan pengeditan",
                 "saveTranscript": "Simpan transkrip",
                 "savingTranscript": "Menyimpan…",
-                "save": "Save changes",
+                "save": "Simpan perubahan",
                 "cancel": "Batal"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Ringkasan",
+                "transcript": "Transkrip",
+                "details": "Detail",
+                "edit": "Edit rapat"
             },
             "summary": {
                 "generating": "Membuat ringkasan…",
                 "generatingHint": "Membaca transkrip dan menulis ringkasannya — biasanya perlu beberapa detik.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Tidak ada ringkasan yang dibuat untuk transkrip ini. Aktifkan penyedia AI lalu lampirkan ulang transkripnya untuk mencoba lagi.",
+                "noTranscript": "Lampirkan transkrip untuk membuat ringkasan."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Teks transkrip",
+                "composerPlaceholder": "Tempelkan transkrip rapat di sini.",
+                "pipelineHint": "Disimpan lebih dulu, lalu diringkas, diingat, dan diposting ke umpan aktivitas Anda — sebisanya.",
+                "storedElsewhere": "Transkrip tersimpan, tetapi tidak disertakan pada tampilan ini."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Sumber",
+                "startedAt": "Mulai",
+                "endedAt": "Selesai",
+                "openEnded": "Masih berlangsung",
+                "duration": "Durasi",
+                "work": "Karya",
+                "orgWide": "Seluruh organisasi",
+                "externalId": "ID penyedia",
+                "createdAt": "Dicatat",
+                "participants": "Peserta",
+                "noParticipants": "Tidak ada peserta yang dicatat."
             },
             "edit": {
                 "hint": "Perbaiki waktunya, ganti nama rapat, perbarui daftar peserta, tautkan ke rekaman, atau alihkan ke sebuah Karya."
             },
             "fields": {
-                "title": "Title",
+                "title": "Judul",
                 "startedAt": "Mulai",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Selesai",
+                "sourceUrl": "Tautan rekaman",
+                "work": "Karya",
+                "workNone": "Seluruh organisasi (tanpa Karya)",
                 "participants": "Peserta",
                 "participantName": "Nama",
                 "participantEmail": "Email (opsional)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Belum ada yang dicatat."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Judul wajib diisi.",
                 "startedAtInvalid": "Waktu mulai bukan tanggal yang valid.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Waktu selesai bukan tanggal yang valid.",
+                "endedBeforeStarted": "Waktu selesai tidak boleh sebelum waktu mulai.",
                 "participantEmailInvalid": "Masukkan alamat email yang valid, atau biarkan kosong.",
                 "participantDuplicate": "Orang itu sudah ada di daftar.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Teks transkrip wajib diisi."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Transkrip dilampirkan",
+                "transcriptSummarized": "Transkrip dilampirkan dan diringkas",
+                "transcriptError": "Transkrip tidak dapat dilampirkan.",
+                "saved": "Rapat diperbarui",
                 "participantAdded": "Peserta ditambahkan",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Rapat tidak dapat diperbarui.",
+                "deleted": "Rapat dihapus",
+                "deleteError": "Rapat tidak dapat dihapus."
             },
             "deleteDialog": {
                 "title": "Hapus rapat ini?",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Peserta",
-                "participantsHint": "Satu per baris. Gunakan \"Nama '<'email>\" untuk mencatat alamat.",
                 "participantName": "Nama",
                 "participantEmail": "Email (opsional)",
                 "participantAdd": "Tambah peserta",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Masukkan alamat email yang valid, atau biarkan kosong.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6942,6 +6942,7 @@
                 "edit": "Edit",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Melampirkan…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Membuat ringkasan…",
+                "generatingHint": "Membaca transkrip dan menulis ringkasannya — biasanya perlu beberapa detik.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Melampirkan…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Edit transkrip",
+                "cancelEdit": "Batalkan pengeditan",
+                "saveTranscript": "Simpan transkrip",
+                "savingTranscript": "Menyimpan…",
                 "save": "Save changes",
                 "cancel": "Batal"
             },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Masukkan alamat email yang valid, atau biarkan kosong.",
+                "participantDuplicate": "Orang itu sudah ada di daftar.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Peserta ditambahkan",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Edit",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Batal"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Peserta",
-                "participantsHint": "Satu per baris. Gunakan \"Nama '<'email>\" untuk mencatat alamat."
+                "participantsHint": "Satu per baris. Gunakan \"Nama '<'email>\" untuk mencatat alamat.",
+                "participantName": "Nama",
+                "participantEmail": "Email (opsional)",
+                "participantAdd": "Tambah peserta",
+                "participantRemove": "Hapus peserta",
+                "participantsEmpty": "Belum ada yang dicatat."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Waktu mulai bukan tanggal yang valid.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Masukkan alamat email yang valid, atau biarkan kosong.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Modifica",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Annulla"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Partecipanti",
-                "participantsHint": "Uno per riga. Usa \"Nome '<'email>\" per registrare un indirizzo."
+                "participantsHint": "Uno per riga. Usa \"Nome '<'email>\" per registrare un indirizzo.",
+                "participantName": "Nome",
+                "participantEmail": "Email (facoltativa)",
+                "participantAdd": "Aggiungi partecipante",
+                "participantRemove": "Rimuovi partecipante",
+                "participantsEmpty": "Nessuno registrato per ora."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "L'ora di inizio non è una data valida.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Inserisci un indirizzo email valido oppure lascialo vuoto.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Partecipanti",
-                "participantsHint": "Uno per riga. Usa \"Nome <email>\" per registrare un indirizzo."
+                "participantsHint": "Uno per riga. Usa \"Nome '<'email>\" per registrare un indirizzo."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Inserisci un indirizzo email valido oppure lascialo vuoto.",
+                "participantDuplicate": "Questa persona è già nell’elenco.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Partecipante aggiunto",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6942,6 +6942,7 @@
                 "edit": "Modifica",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Allegando…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Generazione del riepilogo…",
+                "generatingHint": "Stiamo leggendo la trascrizione e scrivendo il riepilogo: di solito richiede qualche secondo.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Torna alle riunioni",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Apri la registrazione",
                 "edit": "Modifica",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Elimina",
+                "attachTranscript": "Allega trascrizione",
                 "attaching": "Allegando…",
                 "editTranscript": "Modifica la trascrizione",
                 "cancelEdit": "Annulla la modifica",
                 "saveTranscript": "Salva la trascrizione",
                 "savingTranscript": "Salvataggio…",
-                "save": "Save changes",
+                "save": "Salva le modifiche",
                 "cancel": "Annulla"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Riepilogo",
+                "transcript": "Trascrizione",
+                "details": "Dettagli",
+                "edit": "Modifica la riunione"
             },
             "summary": {
                 "generating": "Generazione del riepilogo…",
                 "generatingHint": "Stiamo leggendo la trascrizione e scrivendo il riepilogo: di solito richiede qualche secondo.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Per questa trascrizione non è stato generato alcun riepilogo. Abilita un provider di IA e allega di nuovo la trascrizione per riprovare.",
+                "noTranscript": "Allega una trascrizione per generare un riepilogo."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Testo della trascrizione",
+                "composerPlaceholder": "Incolla qui la trascrizione della riunione.",
+                "pipelineHint": "Prima viene salvata, poi riepilogata, memorizzata e pubblicata nel tuo feed delle attività — per quanto possibile.",
+                "storedElsewhere": "La trascrizione è salvata ma non è stata restituita con questa vista."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Origine",
+                "startedAt": "Inizio",
+                "endedAt": "Fine",
+                "openEnded": "Ancora in corso",
+                "duration": "Durata",
+                "work": "Lavoro",
+                "orgWide": "Tutta l'organizzazione",
+                "externalId": "ID del provider",
+                "createdAt": "Registrata",
+                "participants": "Partecipanti",
+                "noParticipants": "Nessun partecipante registrato."
             },
             "edit": {
                 "hint": "Correggi gli orari, rinomina la riunione, sistema l'elenco dei partecipanti, collega una registrazione o riassegnala a un Lavoro."
             },
             "fields": {
-                "title": "Title",
+                "title": "Titolo",
                 "startedAt": "Inizio",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Fine",
+                "sourceUrl": "Link alla registrazione",
+                "work": "Lavoro",
+                "workNone": "Tutta l'organizzazione (nessun Lavoro)",
                 "participants": "Partecipanti",
                 "participantName": "Nome",
                 "participantEmail": "Email (facoltativa)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Nessuno registrato per ora."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Il titolo è obbligatorio.",
                 "startedAtInvalid": "L'ora di inizio non è una data valida.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "L'ora di fine non è una data valida.",
+                "endedBeforeStarted": "L'ora di fine non può precedere l'ora di inizio.",
                 "participantEmailInvalid": "Inserisci un indirizzo email valido oppure lascialo vuoto.",
                 "participantDuplicate": "Questa persona è già nell’elenco.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Il testo della trascrizione è obbligatorio."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Trascrizione allegata",
+                "transcriptSummarized": "Trascrizione allegata e riepilogata",
+                "transcriptError": "Impossibile allegare la trascrizione.",
+                "saved": "Riunione aggiornata",
                 "participantAdded": "Partecipante aggiunto",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Impossibile aggiornare la riunione.",
+                "deleted": "Riunione eliminata",
+                "deleteError": "Impossibile eliminare la riunione."
             },
             "deleteDialog": {
                 "title": "Eliminare questa riunione?",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Partecipanti",
-                "participantsHint": "Uno per riga. Usa \"Nome '<'email>\" per registrare un indirizzo.",
                 "participantName": "Nome",
                 "participantEmail": "Email (facoltativa)",
                 "participantAdd": "Aggiungi partecipante",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Allegando…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Modifica la trascrizione",
+                "cancelEdit": "Annulla la modifica",
+                "saveTranscript": "Salva la trascrizione",
+                "savingTranscript": "Salvataggio…",
                 "save": "Save changes",
                 "cancel": "Annulla"
             },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Inserisci un indirizzo email valido oppure lascialo vuoto.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Correggi gli orari, rinomina la riunione, sistema l'elenco dei partecipanti, collega una registrazione o riassegnala a un Lavoro."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Inizio",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Partecipanti",
+                "participantsHint": "Uno per riga. Usa \"Nome <email>\" per registrare un indirizzo."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "L'ora di inizio non è una data valida.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Eliminare questa riunione?",
+                "body": "{title} verrà eliminata definitivamente, insieme alla sua trascrizione e al suo riepilogo. Questa azione non può essere annullata.",
+                "confirm": "Elimina riunione",
+                "cancel": "Annulla",
+                "deleting": "Eliminazione…",
+                "error": "Impossibile eliminare la riunione"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "添付しています…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "文字起こしを編集",
+                "cancelEdit": "編集をキャンセル",
+                "saveTranscript": "文字起こしを保存",
+                "savingTranscript": "保存しています…",
                 "save": "Save changes",
                 "cancel": "キャンセル"
             },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "参加者",
-                "participantsHint": "1行に1人。メールアドレスを記録するには「名前 '<'メール>」の形式を使用します。",
                 "participantName": "名前",
                 "participantEmail": "メールアドレス（任意）",
                 "participantAdd": "参加者を追加",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "有効なメールアドレスを入力するか、空欄のままにしてください。",
+                "participantDuplicate": "この参加者はすでにリストにあります。",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "参加者を追加しました",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "日時の修正、ミーティング名の変更、参加者リストの調整、録画へのリンク、ワークへの再割り当てができます。"
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "開始日時",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "参加者",
+                "participantsHint": "1行に1人。メールアドレスを記録するには「名前 <メール>」の形式を使用します。"
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "開始日時が有効な日付ではありません。",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "このミーティングを削除しますか？",
+                "body": "{title} は文字起こしと要約とともに完全に削除されます。この操作は取り消せません。",
+                "confirm": "ミーティングを削除",
+                "cancel": "キャンセル",
+                "deleting": "削除しています…",
+                "error": "ミーティングを削除できませんでした"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "参加者",
-                "participantsHint": "1行に1人。メールアドレスを記録するには「名前 <メール>」の形式を使用します。"
+                "participantsHint": "1行に1人。メールアドレスを記録するには「名前 '<'メール>」の形式を使用します。"
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "参加者",
-                "participantsHint": "1行に1人。メールアドレスを記録するには「名前 '<'メール>」の形式を使用します。"
+                "participantsHint": "1行に1人。メールアドレスを記録するには「名前 '<'メール>」の形式を使用します。",
+                "participantName": "名前",
+                "participantEmail": "メールアドレス（任意）",
+                "participantAdd": "参加者を追加",
+                "participantRemove": "参加者を削除",
+                "participantsEmpty": "まだ誰も記録されていません。"
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "開始日時が有効な日付ではありません。",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "有効なメールアドレスを入力するか、空欄のままにしてください。",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "ミーティング一覧に戻る",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "録画を開く",
                 "edit": "編集",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "削除",
+                "attachTranscript": "文字起こしを添付",
                 "attaching": "添付しています…",
                 "editTranscript": "文字起こしを編集",
                 "cancelEdit": "編集をキャンセル",
                 "saveTranscript": "文字起こしを保存",
                 "savingTranscript": "保存しています…",
-                "save": "Save changes",
+                "save": "変更を保存",
                 "cancel": "キャンセル"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "要約",
+                "transcript": "文字起こし",
+                "details": "詳細",
+                "edit": "ミーティングを編集"
             },
             "summary": {
                 "generating": "要約を生成しています…",
                 "generatingHint": "文字起こしを読み取り、要約を作成しています。通常は数秒かかります。",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "この文字起こしに対する要約は生成されませんでした。AI プロバイダーを有効にし、文字起こしを添付し直してもう一度お試しください。",
+                "noTranscript": "文字起こしを添付すると要約を生成できます。"
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "文字起こしのテキスト",
+                "composerPlaceholder": "ここにミーティングの文字起こしを貼り付けてください。",
+                "pipelineHint": "まず保存し、その後に要約・記憶して、アクティビティフィードに投稿します（ベストエフォート）。",
+                "storedElsewhere": "文字起こしは保存されていますが、このビューでは返されませんでした。"
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "ソース",
+                "startedAt": "開始",
+                "endedAt": "終了",
+                "openEnded": "進行中",
+                "duration": "所要時間",
+                "work": "ワーク",
+                "orgWide": "組織全体",
+                "externalId": "プロバイダー ID",
+                "createdAt": "記録日時",
+                "participants": "参加者",
+                "noParticipants": "参加者は記録されていません。"
             },
             "edit": {
                 "hint": "日時の修正、ミーティング名の変更、参加者リストの調整、録画へのリンク、ワークへの再割り当てができます。"
             },
             "fields": {
-                "title": "Title",
+                "title": "タイトル",
                 "startedAt": "開始日時",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "終了日時",
+                "sourceUrl": "録画のリンク",
+                "work": "ワーク",
+                "workNone": "組織全体（ワークなし）",
                 "participants": "参加者",
                 "participantName": "名前",
                 "participantEmail": "メールアドレス（任意）",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "まだ誰も記録されていません。"
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "タイトルは必須です。",
                 "startedAtInvalid": "開始日時が有効な日付ではありません。",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "終了日時が有効な日付ではありません。",
+                "endedBeforeStarted": "終了日時を開始日時より前にすることはできません。",
                 "participantEmailInvalid": "有効なメールアドレスを入力するか、空欄のままにしてください。",
                 "participantDuplicate": "この参加者はすでにリストにあります。",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "文字起こしのテキストは必須です。"
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "文字起こしを添付しました",
+                "transcriptSummarized": "文字起こしを添付して要約しました",
+                "transcriptError": "文字起こしを添付できませんでした。",
+                "saved": "ミーティングを更新しました",
                 "participantAdded": "参加者を追加しました",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "ミーティングを更新できませんでした。",
+                "deleted": "ミーティングを削除しました",
+                "deleteError": "ミーティングを削除できませんでした。"
             },
             "deleteDialog": {
                 "title": "このミーティングを削除しますか？",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6942,6 +6942,7 @@
                 "edit": "編集",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "添付しています…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "要約を生成しています…",
+                "generatingHint": "文字起こしを読み取り、要約を作成しています。通常は数秒かかります。",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "編集",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "キャンセル"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "有効なメールアドレスを入力するか、空欄のままにしてください。",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "회의 목록으로 돌아가기",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "녹화 열기",
                 "edit": "편집",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "삭제",
+                "attachTranscript": "대화록 첨부",
                 "attaching": "첨부하는 중…",
                 "editTranscript": "대화록 편집",
                 "cancelEdit": "편집 취소",
                 "saveTranscript": "대화록 저장",
                 "savingTranscript": "저장하는 중…",
-                "save": "Save changes",
+                "save": "변경사항 저장",
                 "cancel": "취소"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "요약",
+                "transcript": "대화록",
+                "details": "세부 정보",
+                "edit": "회의 편집"
             },
             "summary": {
                 "generating": "요약을 생성하는 중…",
                 "generatingHint": "대화록을 읽고 요약을 작성하고 있습니다. 보통 몇 초 정도 걸립니다.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "이 대화록에 대한 요약이 생성되지 않았습니다. AI 제공자를 활성화한 뒤 대화록을 다시 첨부해 보세요.",
+                "noTranscript": "요약을 생성하려면 대화록을 첨부하세요."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "대화록 텍스트",
+                "composerPlaceholder": "여기에 회의 대화록을 붙여넣으세요.",
+                "pipelineHint": "먼저 저장한 뒤 요약하고 기억하며 활동 피드에 게시합니다 — 가능한 범위에서 처리됩니다.",
+                "storedElsewhere": "대화록은 저장되어 있지만 이 화면에는 함께 반환되지 않았습니다."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "출처",
+                "startedAt": "시작",
+                "endedAt": "종료",
+                "openEnded": "아직 진행 중",
+                "duration": "소요 시간",
+                "work": "워크",
+                "orgWide": "조직 전체",
+                "externalId": "제공자 ID",
+                "createdAt": "기록됨",
+                "participants": "참석자",
+                "noParticipants": "기록된 참석자가 없습니다."
             },
             "edit": {
                 "hint": "시간을 수정하고, 회의 이름을 바꾸고, 참석자 목록을 정리하고, 녹화본을 연결하거나 워크로 다시 연결할 수 있습니다."
             },
             "fields": {
-                "title": "Title",
+                "title": "제목",
                 "startedAt": "시작 시각",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "종료 시각",
+                "sourceUrl": "녹화 링크",
+                "work": "워크",
+                "workNone": "조직 전체(워크 없음)",
                 "participants": "참석자",
                 "participantName": "이름",
                 "participantEmail": "이메일(선택)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "아직 기록된 사람이 없습니다."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "제목을 입력해야 합니다.",
                 "startedAtInvalid": "시작 시각이 올바른 날짜가 아닙니다.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "종료 시각이 올바른 날짜가 아닙니다.",
+                "endedBeforeStarted": "종료 시각은 시작 시각보다 앞설 수 없습니다.",
                 "participantEmailInvalid": "유효한 이메일 주소를 입력하거나 비워 두세요.",
                 "participantDuplicate": "이미 목록에 있는 사람입니다.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "대화록 텍스트를 입력해야 합니다."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "대화록을 첨부했습니다",
+                "transcriptSummarized": "대화록을 첨부하고 요약했습니다",
+                "transcriptError": "대화록을 첨부하지 못했습니다.",
+                "saved": "회의를 업데이트했습니다",
                 "participantAdded": "참석자를 추가했습니다",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "회의를 업데이트하지 못했습니다.",
+                "deleted": "회의를 삭제했습니다",
+                "deleteError": "회의를 삭제하지 못했습니다."
             },
             "deleteDialog": {
                 "title": "이 회의를 삭제할까요?",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "편집",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "취소"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "참석자",
-                "participantsHint": "한 줄에 한 명씩. 이메일 주소를 기록하려면 \"이름 '<'이메일>\" 형식을 사용하세요.",
                 "participantName": "이름",
                 "participantEmail": "이메일(선택)",
                 "participantAdd": "참가자 추가",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "참석자",
-                "participantsHint": "한 줄에 한 명씩. 이메일 주소를 기록하려면 \"이름 <이메일>\" 형식을 사용하세요."
+                "participantsHint": "한 줄에 한 명씩. 이메일 주소를 기록하려면 \"이름 '<'이메일>\" 형식을 사용하세요."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "참석자",
-                "participantsHint": "한 줄에 한 명씩. 이메일 주소를 기록하려면 \"이름 '<'이메일>\" 형식을 사용하세요."
+                "participantsHint": "한 줄에 한 명씩. 이메일 주소를 기록하려면 \"이름 '<'이메일>\" 형식을 사용하세요.",
+                "participantName": "이름",
+                "participantEmail": "이메일(선택)",
+                "participantAdd": "참가자 추가",
+                "participantRemove": "참가자 제거",
+                "participantsEmpty": "아직 기록된 사람이 없습니다."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "시작 시각이 올바른 날짜가 아닙니다.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "유효한 이메일 주소를 입력하거나 비워 두세요.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "시간을 수정하고, 회의 이름을 바꾸고, 참석자 목록을 정리하고, 녹화본을 연결하거나 워크로 다시 연결할 수 있습니다."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "시작 시각",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "참석자",
+                "participantsHint": "한 줄에 한 명씩. 이메일 주소를 기록하려면 \"이름 <이메일>\" 형식을 사용하세요."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "시작 시각이 올바른 날짜가 아닙니다.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "이 회의를 삭제할까요?",
+                "body": "{title}이(가) 스크립트와 요약과 함께 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+                "confirm": "회의 삭제",
+                "cancel": "취소",
+                "deleting": "삭제하는 중…",
+                "error": "회의를 삭제하지 못했습니다"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "유효한 이메일 주소를 입력하거나 비워 두세요.",
+                "participantDuplicate": "이미 목록에 있는 사람입니다.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "참석자를 추가했습니다",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "유효한 이메일 주소를 입력하거나 비워 두세요.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6942,6 +6942,7 @@
                 "edit": "편집",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "첨부하는 중…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "요약을 생성하는 중…",
+                "generatingHint": "대화록을 읽고 요약을 작성하고 있습니다. 보통 몇 초 정도 걸립니다.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "첨부하는 중…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "대화록 편집",
+                "cancelEdit": "편집 취소",
+                "saveTranscript": "대화록 저장",
+                "savingTranscript": "저장하는 중…",
                 "save": "Save changes",
                 "cancel": "취소"
             },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6942,6 +6942,7 @@
                 "edit": "Bewerken",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Bijvoegen…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Samenvatting genereren…",
+                "generatingHint": "We lezen het transcript en schrijven de samenvatting — dit duurt meestal een paar seconden.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Bijvoegen…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Transcript bewerken",
+                "cancelEdit": "Bewerken annuleren",
+                "saveTranscript": "Transcript opslaan",
+                "savingTranscript": "Opslaan…",
                 "save": "Save changes",
                 "cancel": "Annuleren"
             },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Deelnemers",
-                "participantsHint": "Eén per regel. Gebruik \"Naam '<'e-mail>\" om een adres vast te leggen."
+                "participantsHint": "Eén per regel. Gebruik \"Naam '<'e-mail>\" om een adres vast te leggen.",
+                "participantName": "Naam",
+                "participantEmail": "E-mail (optioneel)",
+                "participantAdd": "Deelnemer toevoegen",
+                "participantRemove": "Deelnemer verwijderen",
+                "participantsEmpty": "Nog niemand vastgelegd."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "De starttijd is geen geldige datum.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Voer een geldig e-mailadres in of laat het leeg.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Terug naar Vergaderingen",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Opname openen",
                 "edit": "Bewerken",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Verwijderen",
+                "attachTranscript": "Transcript toevoegen",
                 "attaching": "Bijvoegen…",
                 "editTranscript": "Transcript bewerken",
                 "cancelEdit": "Bewerken annuleren",
                 "saveTranscript": "Transcript opslaan",
                 "savingTranscript": "Opslaan…",
-                "save": "Save changes",
+                "save": "Wijzigingen opslaan",
                 "cancel": "Annuleren"
             },
             "sections": {
-                "summary": "Summary",
+                "summary": "Samenvatting",
                 "transcript": "Transcript",
                 "details": "Details",
-                "edit": "Edit meeting"
+                "edit": "Vergadering bewerken"
             },
             "summary": {
                 "generating": "Samenvatting genereren…",
                 "generatingHint": "We lezen het transcript en schrijven de samenvatting — dit duurt meestal een paar seconden.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Voor dit transcript is geen samenvatting gemaakt. Schakel een AI-provider in en voeg het transcript opnieuw toe om het nogmaals te proberen.",
+                "noTranscript": "Voeg een transcript toe om een samenvatting te maken."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Transcripttekst",
+                "composerPlaceholder": "Plak hier het transcript van de vergadering.",
+                "pipelineHint": "Wordt eerst opgeslagen en daarna samengevat, onthouden en in je activiteitenfeed geplaatst — naar beste vermogen.",
+                "storedElsewhere": "Het transcript is opgeslagen, maar werd niet met deze weergave meegestuurd."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Bron",
+                "startedAt": "Begin",
+                "endedAt": "Einde",
+                "openEnded": "Nog bezig",
+                "duration": "Duur",
+                "work": "Werk",
+                "orgWide": "Organisatiebreed",
+                "externalId": "Provider-ID",
+                "createdAt": "Vastgelegd",
+                "participants": "Deelnemers",
+                "noParticipants": "Geen deelnemers vastgelegd."
             },
             "edit": {
                 "hint": "Corrigeer de tijden, hernoem de vergadering, werk de deelnemerslijst bij, koppel een opname of wijs haar toe aan een Werk."
             },
             "fields": {
-                "title": "Title",
+                "title": "Titel",
                 "startedAt": "Begin",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Einde",
+                "sourceUrl": "Link naar opname",
+                "work": "Werk",
+                "workNone": "Organisatiebreed (geen Werk)",
                 "participants": "Deelnemers",
                 "participantName": "Naam",
                 "participantEmail": "E-mail (optioneel)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Nog niemand vastgelegd."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Een titel is verplicht.",
                 "startedAtInvalid": "De starttijd is geen geldige datum.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "De eindtijd is geen geldige datum.",
+                "endedBeforeStarted": "De eindtijd kan niet vóór de starttijd liggen.",
                 "participantEmailInvalid": "Voer een geldig e-mailadres in of laat het leeg.",
                 "participantDuplicate": "Deze persoon staat al op de lijst.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "De transcripttekst is verplicht."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Transcript toegevoegd",
+                "transcriptSummarized": "Transcript toegevoegd en samengevat",
+                "transcriptError": "Het transcript kon niet worden toegevoegd.",
+                "saved": "Vergadering bijgewerkt",
                 "participantAdded": "Deelnemer toegevoegd",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "De vergadering kon niet worden bijgewerkt.",
+                "deleted": "Vergadering verwijderd",
+                "deleteError": "De vergadering kon niet worden verwijderd."
             },
             "deleteDialog": {
                 "title": "Deze vergadering verwijderen?",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Voer een geldig e-mailadres in of laat het leeg.",
+                "participantDuplicate": "Deze persoon staat al op de lijst.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Deelnemer toegevoegd",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Corrigeer de tijden, hernoem de vergadering, werk de deelnemerslijst bij, koppel een opname of wijs haar toe aan een Werk."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Begin",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Deelnemers",
+                "participantsHint": "Eén per regel. Gebruik \"Naam <e-mail>\" om een adres vast te leggen."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "De starttijd is geen geldige datum.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Deze vergadering verwijderen?",
+                "body": "{title} wordt permanent verwijderd, samen met het transcript en de samenvatting. Dit kan niet ongedaan worden gemaakt.",
+                "confirm": "Vergadering verwijderen",
+                "cancel": "Annuleren",
+                "deleting": "Verwijderen…",
+                "error": "Verwijderen van vergadering mislukt"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Voer een geldig e-mailadres in of laat het leeg.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Deelnemers",
-                "participantsHint": "Eén per regel. Gebruik \"Naam '<'e-mail>\" om een adres vast te leggen.",
                 "participantName": "Naam",
                 "participantEmail": "E-mail (optioneel)",
                 "participantAdd": "Deelnemer toevoegen",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Bewerken",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Annuleren"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Deelnemers",
-                "participantsHint": "Eén per regel. Gebruik \"Naam <e-mail>\" om een adres vast te leggen."
+                "participantsHint": "Eén per regel. Gebruik \"Naam '<'e-mail>\" om een adres vast te leggen."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Uczestnicy",
-                "participantsHint": "Jeden w wierszu. Użyj \"Imię <e-mail>\", aby zapisać adres."
+                "participantsHint": "Jeden w wierszu. Użyj \"Imię '<'e-mail>\", aby zapisać adres."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Uczestnicy",
-                "participantsHint": "Jeden w wierszu. Użyj \"Imię '<'e-mail>\", aby zapisać adres.",
                 "participantName": "Imię i nazwisko",
                 "participantEmail": "E-mail (opcjonalnie)",
                 "participantAdd": "Dodaj uczestnika",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6942,6 +6942,7 @@
                 "edit": "Edytuj",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Dołączanie…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Generowanie podsumowania…",
+                "generatingHint": "Czytamy transkrypcję i piszemy podsumowanie — zwykle trwa to kilka sekund.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Edytuj",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Anuluj"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Powrót do spotkań",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Otwórz nagranie",
                 "edit": "Edytuj",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Usuń",
+                "attachTranscript": "Dołącz transkrypcję",
                 "attaching": "Dołączanie…",
                 "editTranscript": "Edytuj transkrypcję",
                 "cancelEdit": "Anuluj edycję",
                 "saveTranscript": "Zapisz transkrypcję",
                 "savingTranscript": "Zapisywanie…",
-                "save": "Save changes",
+                "save": "Zapisz zmiany",
                 "cancel": "Anuluj"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Podsumowanie",
+                "transcript": "Transkrypcja",
+                "details": "Szczegóły",
+                "edit": "Edytuj spotkanie"
             },
             "summary": {
                 "generating": "Generowanie podsumowania…",
                 "generatingHint": "Czytamy transkrypcję i piszemy podsumowanie — zwykle trwa to kilka sekund.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Dla tej transkrypcji nie wygenerowano podsumowania. Włącz dostawcę AI i dołącz transkrypcję ponownie, aby spróbować jeszcze raz.",
+                "noTranscript": "Dołącz transkrypcję, aby wygenerować podsumowanie."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Tekst transkrypcji",
+                "composerPlaceholder": "Wklej tutaj transkrypcję spotkania.",
+                "pipelineHint": "Najpierw zapisujemy, potem podsumowujemy, zapamiętujemy i publikujemy w Twoim strumieniu aktywności — w miarę możliwości.",
+                "storedElsewhere": "Transkrypcja jest zapisana, ale nie została zwrócona w tym widoku."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Źródło",
+                "startedAt": "Początek",
+                "endedAt": "Koniec",
+                "openEnded": "Wciąż trwa",
+                "duration": "Czas trwania",
+                "work": "Praca",
+                "orgWide": "Cała organizacja",
+                "externalId": "Identyfikator u dostawcy",
+                "createdAt": "Zarejestrowano",
+                "participants": "Uczestnicy",
+                "noParticipants": "Nie zapisano żadnych uczestników."
             },
             "edit": {
                 "hint": "Popraw godziny, zmień nazwę spotkania, popraw listę uczestników, wskaż nagranie lub przypisz je do Pracy."
             },
             "fields": {
-                "title": "Title",
+                "title": "Tytuł",
                 "startedAt": "Początek",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Koniec",
+                "sourceUrl": "Link do nagrania",
+                "work": "Praca",
+                "workNone": "Cała organizacja (bez Pracy)",
                 "participants": "Uczestnicy",
                 "participantName": "Imię i nazwisko",
                 "participantEmail": "E-mail (opcjonalnie)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Nikogo jeszcze nie zapisano."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Tytuł jest wymagany.",
                 "startedAtInvalid": "Godzina rozpoczęcia nie jest prawidłową datą.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Godzina zakończenia nie jest prawidłową datą.",
+                "endedBeforeStarted": "Godzina zakończenia nie może być wcześniejsza niż godzina rozpoczęcia.",
                 "participantEmailInvalid": "Wpisz prawidłowy adres e-mail lub pozostaw pole puste.",
                 "participantDuplicate": "Ta osoba jest już na liście.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Tekst transkrypcji jest wymagany."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Dołączono transkrypcję",
+                "transcriptSummarized": "Dołączono i podsumowano transkrypcję",
+                "transcriptError": "Nie udało się dołączyć transkrypcji.",
+                "saved": "Zaktualizowano spotkanie",
                 "participantAdded": "Dodano uczestnika",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Nie udało się zaktualizować spotkania.",
+                "deleted": "Usunięto spotkanie",
+                "deleteError": "Nie udało się usunąć spotkania."
             },
             "deleteDialog": {
                 "title": "Usunąć to spotkanie?",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Dołączanie…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Edytuj transkrypcję",
+                "cancelEdit": "Anuluj edycję",
+                "saveTranscript": "Zapisz transkrypcję",
+                "savingTranscript": "Zapisywanie…",
                 "save": "Save changes",
                 "cancel": "Anuluj"
             },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Wpisz prawidłowy adres e-mail lub pozostaw pole puste.",
+                "participantDuplicate": "Ta osoba jest już na liście.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Dodano uczestnika",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Wpisz prawidłowy adres e-mail lub pozostaw pole puste.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Uczestnicy",
-                "participantsHint": "Jeden w wierszu. Użyj \"Imię '<'e-mail>\", aby zapisać adres."
+                "participantsHint": "Jeden w wierszu. Użyj \"Imię '<'e-mail>\", aby zapisać adres.",
+                "participantName": "Imię i nazwisko",
+                "participantEmail": "E-mail (opcjonalnie)",
+                "participantAdd": "Dodaj uczestnika",
+                "participantRemove": "Usuń uczestnika",
+                "participantsEmpty": "Nikogo jeszcze nie zapisano."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Godzina rozpoczęcia nie jest prawidłową datą.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Wpisz prawidłowy adres e-mail lub pozostaw pole puste.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Popraw godziny, zmień nazwę spotkania, popraw listę uczestników, wskaż nagranie lub przypisz je do Pracy."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Początek",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Uczestnicy",
+                "participantsHint": "Jeden w wierszu. Użyj \"Imię <e-mail>\", aby zapisać adres."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Godzina rozpoczęcia nie jest prawidłową datą.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Usunąć to spotkanie?",
+                "body": "{title} zostanie trwale usunięte wraz z transkrypcją i podsumowaniem. Tej operacji nie można cofnąć.",
+                "confirm": "Usuń spotkanie",
+                "cancel": "Anuluj",
+                "deleting": "Usuwanie…",
+                "error": "Nie udało się usunąć spotkania"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participantes",
-                "participantsHint": "Um por linha. Use \"Nome '<'e-mail>\" para registrar um endereço.",
                 "participantName": "Nome",
                 "participantEmail": "E-mail (opcional)",
                 "participantAdd": "Adicionar participante",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participantes",
-                "participantsHint": "Um por linha. Use \"Nome <e-mail>\" para registrar um endereço."
+                "participantsHint": "Um por linha. Use \"Nome '<'e-mail>\" para registrar um endereço."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Participantes",
-                "participantsHint": "Um por linha. Use \"Nome '<'e-mail>\" para registrar um endereço."
+                "participantsHint": "Um por linha. Use \"Nome '<'e-mail>\" para registrar um endereço.",
+                "participantName": "Nome",
+                "participantEmail": "E-mail (opcional)",
+                "participantAdd": "Adicionar participante",
+                "participantRemove": "Remover participante",
+                "participantsEmpty": "Ainda ninguém registrado."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "A hora de início não é uma data válida.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Informe um e-mail válido ou deixe em branco.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Editar",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Cancelar"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Informe um e-mail válido ou deixe em branco.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6942,6 +6942,7 @@
                 "edit": "Editar",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Anexando…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Gerando o resumo…",
+                "generatingHint": "Estamos lendo a transcrição e escrevendo o resumo — normalmente leva alguns segundos.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Informe um e-mail válido ou deixe em branco.",
+                "participantDuplicate": "Essa pessoa já está na lista.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Participante adicionado",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Anexando…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Editar a transcrição",
+                "cancelEdit": "Cancelar a edição",
+                "saveTranscript": "Salvar a transcrição",
+                "savingTranscript": "Salvando…",
                 "save": "Save changes",
                 "cancel": "Cancelar"
             },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Corrija os horários, renomeie a reunião, ajuste a lista de participantes, aponte para uma gravação ou redirecione-a para um Trabalho."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Início",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Participantes",
+                "participantsHint": "Um por linha. Use \"Nome <e-mail>\" para registrar um endereço."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "A hora de início não é uma data válida.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Excluir esta reunião?",
+                "body": "{title} será excluída permanentemente, junto com sua transcrição e seu resumo. Esta ação não pode ser desfeita.",
+                "confirm": "Excluir reunião",
+                "cancel": "Cancelar",
+                "deleting": "Excluindo…",
+                "error": "Falha ao excluir a reunião"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Voltar para Reuniões",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Abrir a gravação",
                 "edit": "Editar",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Excluir",
+                "attachTranscript": "Anexar transcrição",
                 "attaching": "Anexando…",
                 "editTranscript": "Editar a transcrição",
                 "cancelEdit": "Cancelar a edição",
                 "saveTranscript": "Salvar a transcrição",
                 "savingTranscript": "Salvando…",
-                "save": "Save changes",
+                "save": "Salvar alterações",
                 "cancel": "Cancelar"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Resumo",
+                "transcript": "Transcrição",
+                "details": "Detalhes",
+                "edit": "Editar a reunião"
             },
             "summary": {
                 "generating": "Gerando o resumo…",
                 "generatingHint": "Estamos lendo a transcrição e escrevendo o resumo — normalmente leva alguns segundos.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Nenhum resumo foi gerado para esta transcrição. Ative um provedor de IA e anexe a transcrição novamente para tentar de novo.",
+                "noTranscript": "Anexe uma transcrição para gerar um resumo."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Texto da transcrição",
+                "composerPlaceholder": "Cole aqui a transcrição da reunião.",
+                "pipelineHint": "Primeiro é armazenada; depois é resumida, memorizada e publicada no seu feed de atividades — no melhor esforço.",
+                "storedElsewhere": "A transcrição está armazenada, mas não foi retornada nesta visualização."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Origem",
+                "startedAt": "Início",
+                "endedAt": "Fim",
+                "openEnded": "Ainda em aberto",
+                "duration": "Duração",
+                "work": "Trabalho",
+                "orgWide": "Toda a organização",
+                "externalId": "ID do provedor",
+                "createdAt": "Registrada",
+                "participants": "Participantes",
+                "noParticipants": "Nenhum participante registrado."
             },
             "edit": {
                 "hint": "Corrija os horários, renomeie a reunião, ajuste a lista de participantes, aponte para uma gravação ou redirecione-a para um Trabalho."
             },
             "fields": {
-                "title": "Title",
+                "title": "Título",
                 "startedAt": "Início",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Fim",
+                "sourceUrl": "Link da gravação",
+                "work": "Trabalho",
+                "workNone": "Toda a organização (sem Trabalho)",
                 "participants": "Participantes",
                 "participantName": "Nome",
                 "participantEmail": "E-mail (opcional)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Ainda ninguém registrado."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "O título é obrigatório.",
                 "startedAtInvalid": "A hora de início não é uma data válida.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "A hora de término não é uma data válida.",
+                "endedBeforeStarted": "A hora de término não pode ser anterior à de início.",
                 "participantEmailInvalid": "Informe um e-mail válido ou deixe em branco.",
                 "participantDuplicate": "Essa pessoa já está na lista.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "O texto da transcrição é obrigatório."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Transcrição anexada",
+                "transcriptSummarized": "Transcrição anexada e resumida",
+                "transcriptError": "Não foi possível anexar a transcrição.",
+                "saved": "Reunião atualizada",
                 "participantAdded": "Participante adicionado",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Não foi possível atualizar a reunião.",
+                "deleted": "Reunião excluída",
+                "deleteError": "Não foi possível excluir a reunião."
             },
             "deleteDialog": {
                 "title": "Excluir esta reunião?",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Прикрепляем…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Редактировать расшифровку",
+                "cancelEdit": "Отменить редактирование",
+                "saveTranscript": "Сохранить расшифровку",
+                "savingTranscript": "Сохраняем…",
                 "save": "Save changes",
                 "cancel": "Отмена"
             },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Назад к встречам",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Открыть запись",
                 "edit": "Изменить",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Удалить",
+                "attachTranscript": "Прикрепить расшифровку",
                 "attaching": "Прикрепляем…",
                 "editTranscript": "Редактировать расшифровку",
                 "cancelEdit": "Отменить редактирование",
                 "saveTranscript": "Сохранить расшифровку",
                 "savingTranscript": "Сохраняем…",
-                "save": "Save changes",
+                "save": "Сохранить изменения",
                 "cancel": "Отмена"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Краткое содержание",
+                "transcript": "Расшифровка",
+                "details": "Подробности",
+                "edit": "Редактирование встречи"
             },
             "summary": {
                 "generating": "Создаём краткое содержание…",
                 "generatingHint": "Читаем расшифровку и пишем краткое содержание — обычно это занимает несколько секунд.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Для этой расшифровки краткое содержание не создано. Включите провайдера ИИ и прикрепите расшифровку заново, чтобы попробовать ещё раз.",
+                "noTranscript": "Прикрепите расшифровку, чтобы создать краткое содержание."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Текст расшифровки",
+                "composerPlaceholder": "Вставьте сюда расшифровку встречи.",
+                "pipelineHint": "Сначала сохраняем, затем кратко пересказываем, запоминаем и публикуем в вашей ленте активности — по мере возможности.",
+                "storedElsewhere": "Расшифровка сохранена, но не была возвращена в этом представлении."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Источник",
+                "startedAt": "Начало",
+                "endedAt": "Окончание",
+                "openEnded": "Ещё идёт",
+                "duration": "Длительность",
+                "work": "Работа",
+                "orgWide": "Вся организация",
+                "externalId": "ID у провайдера",
+                "createdAt": "Зафиксирована",
+                "participants": "Участники",
+                "noParticipants": "Участники не записаны."
             },
             "edit": {
                 "hint": "Исправьте время, переименуйте встречу, поправьте список участников, укажите запись или перепривяжите её к Работе."
             },
             "fields": {
-                "title": "Title",
+                "title": "Название",
                 "startedAt": "Начало",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Окончание",
+                "sourceUrl": "Ссылка на запись",
+                "work": "Работа",
+                "workNone": "Вся организация (без Работы)",
                 "participants": "Участники",
                 "participantName": "Имя",
                 "participantEmail": "Эл. почта (необязательно)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Пока никто не записан."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Название обязательно.",
                 "startedAtInvalid": "Время начала не является допустимой датой.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Время окончания не является допустимой датой.",
+                "endedBeforeStarted": "Время окончания не может быть раньше времени начала.",
                 "participantEmailInvalid": "Введите корректный адрес эл. почты или оставьте поле пустым.",
                 "participantDuplicate": "Этот человек уже есть в списке.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Текст расшифровки обязателен."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Расшифровка прикреплена",
+                "transcriptSummarized": "Расшифровка прикреплена, краткое содержание создано",
+                "transcriptError": "Не удалось прикрепить расшифровку.",
+                "saved": "Встреча обновлена",
                 "participantAdded": "Участник добавлен",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Не удалось обновить встречу.",
+                "deleted": "Встреча удалена",
+                "deleteError": "Не удалось удалить встречу."
             },
             "deleteDialog": {
                 "title": "Удалить эту встречу?",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Введите корректный адрес эл. почты или оставьте поле пустым.",
+                "participantDuplicate": "Этот человек уже есть в списке.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Участник добавлен",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6942,6 +6942,7 @@
                 "edit": "Изменить",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Прикрепляем…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Создаём краткое содержание…",
+                "generatingHint": "Читаем расшифровку и пишем краткое содержание — обычно это занимает несколько секунд.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Изменить",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Отмена"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Участники",
-                "participantsHint": "По одному в строке. Используйте «Имя '<'эл. почта>», чтобы записать адрес."
+                "participantsHint": "По одному в строке. Используйте «Имя '<'эл. почта>», чтобы записать адрес.",
+                "participantName": "Имя",
+                "participantEmail": "Эл. почта (необязательно)",
+                "participantAdd": "Добавить участника",
+                "participantRemove": "Удалить участника",
+                "participantsEmpty": "Пока никто не записан."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Время начала не является допустимой датой.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Введите корректный адрес эл. почты или оставьте поле пустым.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Участники",
-                "participantsHint": "По одному в строке. Используйте «Имя <эл. почта>», чтобы записать адрес."
+                "participantsHint": "По одному в строке. Используйте «Имя '<'эл. почта>», чтобы записать адрес."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Исправьте время, переименуйте встречу, поправьте список участников, укажите запись или перепривяжите её к Работе."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Начало",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Участники",
+                "participantsHint": "По одному в строке. Используйте «Имя <эл. почта>», чтобы записать адрес."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Время начала не является допустимой датой.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Удалить эту встречу?",
+                "body": "{title} будет удалена безвозвратно вместе с расшифровкой и сводкой. Это действие нельзя отменить.",
+                "confirm": "Удалить встречу",
+                "cancel": "Отмена",
+                "deleting": "Удаление…",
+                "error": "Не удалось удалить встречу"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Введите корректный адрес эл. почты или оставьте поле пустым.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Участники",
-                "participantsHint": "По одному в строке. Используйте «Имя '<'эл. почта>», чтобы записать адрес.",
                 "participantName": "Имя",
                 "participantEmail": "Эл. почта (необязательно)",
                 "participantAdd": "Добавить участника",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "ผู้เข้าร่วม",
-                "participantsHint": "หนึ่งรายการต่อบรรทัด ใช้ \"ชื่อ '<'อีเมล>\" เพื่อบันทึกที่อยู่อีเมล"
+                "participantsHint": "หนึ่งรายการต่อบรรทัด ใช้ \"ชื่อ '<'อีเมล>\" เพื่อบันทึกที่อยู่อีเมล",
+                "participantName": "ชื่อ",
+                "participantEmail": "อีเมล (ไม่บังคับ)",
+                "participantAdd": "เพิ่มผู้เข้าร่วม",
+                "participantRemove": "ลบผู้เข้าร่วม",
+                "participantsEmpty": "ยังไม่มีผู้เข้าร่วมที่บันทึกไว้"
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "เวลาเริ่มไม่ใช่วันที่ที่ถูกต้อง",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "กรอกอีเมลที่ถูกต้อง หรือเว้นว่างไว้",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "กำลังแนบ…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "แก้ไขข้อความถอดเสียง",
+                "cancelEdit": "ยกเลิกการแก้ไข",
+                "saveTranscript": "บันทึกข้อความถอดเสียง",
+                "savingTranscript": "กำลังบันทึก…",
                 "save": "Save changes",
                 "cancel": "ยกเลิก"
             },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "กลับไปที่การประชุม",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "เปิดไฟล์บันทึก",
                 "edit": "แก้ไข",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "ลบ",
+                "attachTranscript": "แนบข้อความถอดเสียง",
                 "attaching": "กำลังแนบ…",
                 "editTranscript": "แก้ไขข้อความถอดเสียง",
                 "cancelEdit": "ยกเลิกการแก้ไข",
                 "saveTranscript": "บันทึกข้อความถอดเสียง",
                 "savingTranscript": "กำลังบันทึก…",
-                "save": "Save changes",
+                "save": "บันทึกการเปลี่ยนแปลง",
                 "cancel": "ยกเลิก"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "สรุป",
+                "transcript": "ข้อความถอดเสียง",
+                "details": "รายละเอียด",
+                "edit": "แก้ไขการประชุม"
             },
             "summary": {
                 "generating": "กำลังสร้างสรุป…",
                 "generatingHint": "กำลังอ่านข้อความถอดเสียงและเขียนสรุป โดยปกติใช้เวลาไม่กี่วินาที",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "ไม่มีการสร้างสรุปสำหรับข้อความถอดเสียงนี้ เปิดใช้งานผู้ให้บริการ AI แล้วแนบข้อความถอดเสียงอีกครั้งเพื่อลองใหม่",
+                "noTranscript": "แนบข้อความถอดเสียงเพื่อสร้างสรุป"
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "เนื้อหาข้อความถอดเสียง",
+                "composerPlaceholder": "วางข้อความถอดเสียงของการประชุมที่นี่",
+                "pipelineHint": "ระบบจะจัดเก็บก่อน จากนั้นจึงสรุป จดจำ และโพสต์ลงในฟีดกิจกรรมของคุณ — เท่าที่ทำได้",
+                "storedElsewhere": "ข้อความถอดเสียงถูกจัดเก็บไว้แล้ว แต่ไม่ได้ส่งกลับมาพร้อมมุมมองนี้"
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "แหล่งที่มา",
+                "startedAt": "เริ่ม",
+                "endedAt": "สิ้นสุด",
+                "openEnded": "ยังดำเนินอยู่",
+                "duration": "ระยะเวลา",
+                "work": "งาน",
+                "orgWide": "ทั้งองค์กร",
+                "externalId": "รหัสจากผู้ให้บริการ",
+                "createdAt": "บันทึกเมื่อ",
+                "participants": "ผู้เข้าร่วม",
+                "noParticipants": "ไม่มีผู้เข้าร่วมที่บันทึกไว้"
             },
             "edit": {
                 "hint": "แก้ไขเวลา เปลี่ยนชื่อการประชุม ปรับรายชื่อผู้เข้าร่วม เชื่อมโยงไฟล์บันทึก หรือกำหนดให้กับงาน"
             },
             "fields": {
-                "title": "Title",
+                "title": "ชื่อเรื่อง",
                 "startedAt": "เวลาเริ่ม",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "เวลาสิ้นสุด",
+                "sourceUrl": "ลิงก์ไฟล์บันทึก",
+                "work": "งาน",
+                "workNone": "ทั้งองค์กร (ไม่มีงาน)",
                 "participants": "ผู้เข้าร่วม",
                 "participantName": "ชื่อ",
                 "participantEmail": "อีเมล (ไม่บังคับ)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "ยังไม่มีผู้เข้าร่วมที่บันทึกไว้"
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "ต้องระบุชื่อเรื่อง",
                 "startedAtInvalid": "เวลาเริ่มไม่ใช่วันที่ที่ถูกต้อง",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "เวลาสิ้นสุดไม่ใช่วันที่ที่ถูกต้อง",
+                "endedBeforeStarted": "เวลาสิ้นสุดต้องไม่อยู่ก่อนเวลาเริ่ม",
                 "participantEmailInvalid": "กรอกอีเมลที่ถูกต้อง หรือเว้นว่างไว้",
                 "participantDuplicate": "บุคคลนี้อยู่ในรายการอยู่แล้ว",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "ต้องระบุเนื้อหาข้อความถอดเสียง"
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "แนบข้อความถอดเสียงแล้ว",
+                "transcriptSummarized": "แนบข้อความถอดเสียงและสรุปแล้ว",
+                "transcriptError": "ไม่สามารถแนบข้อความถอดเสียงได้",
+                "saved": "อัปเดตการประชุมแล้ว",
                 "participantAdded": "เพิ่มผู้เข้าร่วมแล้ว",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "ไม่สามารถอัปเดตการประชุมได้",
+                "deleted": "ลบการประชุมแล้ว",
+                "deleteError": "ไม่สามารถลบการประชุมได้"
             },
             "deleteDialog": {
                 "title": "ลบการประชุมนี้?",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "ผู้เข้าร่วม",
-                "participantsHint": "หนึ่งรายการต่อบรรทัด ใช้ \"ชื่อ <อีเมล>\" เพื่อบันทึกที่อยู่อีเมล"
+                "participantsHint": "หนึ่งรายการต่อบรรทัด ใช้ \"ชื่อ '<'อีเมล>\" เพื่อบันทึกที่อยู่อีเมล"
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "กรอกอีเมลที่ถูกต้อง หรือเว้นว่างไว้",
+                "participantDuplicate": "บุคคลนี้อยู่ในรายการอยู่แล้ว",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "เพิ่มผู้เข้าร่วมแล้ว",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6942,6 +6942,7 @@
                 "edit": "แก้ไข",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "กำลังแนบ…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "กำลังสร้างสรุป…",
+                "generatingHint": "กำลังอ่านข้อความถอดเสียงและเขียนสรุป โดยปกติใช้เวลาไม่กี่วินาที",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "แก้ไขเวลา เปลี่ยนชื่อการประชุม ปรับรายชื่อผู้เข้าร่วม เชื่อมโยงไฟล์บันทึก หรือกำหนดให้กับงาน"
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "เวลาเริ่ม",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "ผู้เข้าร่วม",
+                "participantsHint": "หนึ่งรายการต่อบรรทัด ใช้ \"ชื่อ <อีเมล>\" เพื่อบันทึกที่อยู่อีเมล"
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "เวลาเริ่มไม่ใช่วันที่ที่ถูกต้อง",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "ลบการประชุมนี้?",
+                "body": "{title} จะถูกลบอย่างถาวร พร้อมกับบันทึกการถอดเสียงและสรุปของการประชุมนี้ การดำเนินการนี้ไม่สามารถย้อนกลับได้",
+                "confirm": "ลบการประชุม",
+                "cancel": "ยกเลิก",
+                "deleting": "กำลังลบ…",
+                "error": "ไม่สามารถลบการประชุมได้"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "ผู้เข้าร่วม",
-                "participantsHint": "หนึ่งรายการต่อบรรทัด ใช้ \"ชื่อ '<'อีเมล>\" เพื่อบันทึกที่อยู่อีเมล",
                 "participantName": "ชื่อ",
                 "participantEmail": "อีเมล (ไม่บังคับ)",
                 "participantAdd": "เพิ่มผู้เข้าร่วม",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "กรอกอีเมลที่ถูกต้อง หรือเว้นว่างไว้",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "แก้ไข",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "ยกเลิก"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Katılımcılar",
-                "participantsHint": "Her satıra bir kişi. Adres kaydetmek için \"Ad <e-posta>\" biçimini kullanın."
+                "participantsHint": "Her satıra bir kişi. Adres kaydetmek için \"Ad '<'e-posta>\" biçimini kullanın."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Geçerli bir e-posta adresi girin veya boş bırakın.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Geçerli bir e-posta adresi girin veya boş bırakın.",
+                "participantDuplicate": "Bu kişi zaten listede.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Katılımcı eklendi",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6942,6 +6942,7 @@
                 "edit": "Düzenle",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Ekleniyor…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Özet oluşturuluyor…",
+                "generatingHint": "Döküm okunuyor ve özet yazılıyor — bu genellikle birkaç saniye sürer.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Toplantılara dön",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Kaydı aç",
                 "edit": "Düzenle",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Sil",
+                "attachTranscript": "Döküm ekle",
                 "attaching": "Ekleniyor…",
                 "editTranscript": "Dökümü düzenle",
                 "cancelEdit": "Düzenlemeyi iptal et",
                 "saveTranscript": "Dökümü kaydet",
                 "savingTranscript": "Kaydediliyor…",
-                "save": "Save changes",
+                "save": "Değişiklikleri kaydet",
                 "cancel": "İptal"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Özet",
+                "transcript": "Döküm",
+                "details": "Ayrıntılar",
+                "edit": "Toplantıyı düzenle"
             },
             "summary": {
                 "generating": "Özet oluşturuluyor…",
                 "generatingHint": "Döküm okunuyor ve özet yazılıyor — bu genellikle birkaç saniye sürer.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Bu döküm için özet oluşturulmadı. Bir yapay zekâ sağlayıcısını etkinleştirip dökümü yeniden ekleyerek tekrar deneyin.",
+                "noTranscript": "Özet oluşturmak için bir döküm ekleyin."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Döküm metni",
+                "composerPlaceholder": "Toplantı dökümünü buraya yapıştırın.",
+                "pipelineHint": "Önce saklanır, ardından özetlenir, hatırlanır ve etkinlik akışınızda paylaşılır — elden geldiğince.",
+                "storedElsewhere": "Döküm saklanıyor ancak bu görünümle birlikte döndürülmedi."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Kaynak",
+                "startedAt": "Başlangıç",
+                "endedAt": "Bitiş",
+                "openEnded": "Hâlâ sürüyor",
+                "duration": "Süre",
+                "work": "İş",
+                "orgWide": "Kuruluş genelinde",
+                "externalId": "Sağlayıcı kimliği",
+                "createdAt": "Kaydedildi",
+                "participants": "Katılımcılar",
+                "noParticipants": "Kayıtlı katılımcı yok."
             },
             "edit": {
                 "hint": "Saatleri düzeltin, toplantıyı yeniden adlandırın, katılımcı listesini düzenleyin, bir kayda bağlayın veya bir İşe yeniden yönlendirin."
             },
             "fields": {
-                "title": "Title",
+                "title": "Başlık",
                 "startedAt": "Başlangıç",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Bitiş",
+                "sourceUrl": "Kayıt bağlantısı",
+                "work": "İş",
+                "workNone": "Kuruluş genelinde (İş yok)",
                 "participants": "Katılımcılar",
                 "participantName": "Ad",
                 "participantEmail": "E-posta (isteğe bağlı)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Henüz kimse kaydedilmedi."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Başlık zorunludur.",
                 "startedAtInvalid": "Başlangıç saati geçerli bir tarih değil.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Bitiş saati geçerli bir tarih değil.",
+                "endedBeforeStarted": "Bitiş saati başlangıç saatinden önce olamaz.",
                 "participantEmailInvalid": "Geçerli bir e-posta adresi girin veya boş bırakın.",
                 "participantDuplicate": "Bu kişi zaten listede.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Döküm metni zorunludur."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Döküm eklendi",
+                "transcriptSummarized": "Döküm eklendi ve özetlendi",
+                "transcriptError": "Döküm eklenemedi.",
+                "saved": "Toplantı güncellendi",
                 "participantAdded": "Katılımcı eklendi",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Toplantı güncellenemedi.",
+                "deleted": "Toplantı silindi",
+                "deleteError": "Toplantı silinemedi."
             },
             "deleteDialog": {
                 "title": "Bu toplantı silinsin mi?",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Ekleniyor…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Dökümü düzenle",
+                "cancelEdit": "Düzenlemeyi iptal et",
+                "saveTranscript": "Dökümü kaydet",
+                "savingTranscript": "Kaydediliyor…",
                 "save": "Save changes",
                 "cancel": "İptal"
             },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Katılımcılar",
-                "participantsHint": "Her satıra bir kişi. Adres kaydetmek için \"Ad '<'e-posta>\" biçimini kullanın.",
                 "participantName": "Ad",
                 "participantEmail": "E-posta (isteğe bağlı)",
                 "participantAdd": "Katılımcı ekle",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Katılımcılar",
-                "participantsHint": "Her satıra bir kişi. Adres kaydetmek için \"Ad '<'e-posta>\" biçimini kullanın."
+                "participantsHint": "Her satıra bir kişi. Adres kaydetmek için \"Ad '<'e-posta>\" biçimini kullanın.",
+                "participantName": "Ad",
+                "participantEmail": "E-posta (isteğe bağlı)",
+                "participantAdd": "Katılımcı ekle",
+                "participantRemove": "Katılımcıyı kaldır",
+                "participantsEmpty": "Henüz kimse kaydedilmedi."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Başlangıç saati geçerli bir tarih değil.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Geçerli bir e-posta adresi girin veya boş bırakın.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Saatleri düzeltin, toplantıyı yeniden adlandırın, katılımcı listesini düzenleyin, bir kayda bağlayın veya bir İşe yeniden yönlendirin."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Başlangıç",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Katılımcılar",
+                "participantsHint": "Her satıra bir kişi. Adres kaydetmek için \"Ad <e-posta>\" biçimini kullanın."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Başlangıç saati geçerli bir tarih değil.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Bu toplantı silinsin mi?",
+                "body": "{title} dökümü ve özetiyle birlikte kalıcı olarak silinecek. Bu işlem geri alınamaz.",
+                "confirm": "Toplantıyı Sil",
+                "cancel": "İptal",
+                "deleting": "Siliniyor…",
+                "error": "Toplantı silinemedi"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Düzenle",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "İptal"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Введіть коректну адресу ел. пошти або залиште поле порожнім.",
+                "participantDuplicate": "Ця людина вже є у списку.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Учасника додано",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6942,6 +6942,7 @@
                 "edit": "Редагувати",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Прикріплюємо…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Створюємо стислий виклад…",
+                "generatingHint": "Читаємо транскрипцію та пишемо стислий виклад — зазвичай це триває кілька секунд.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Виправте час, перейменуйте зустріч, відредагуйте список учасників, вкажіть запис або перепризначте її до Роботи."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Початок",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Учасники",
+                "participantsHint": "По одному в рядку. Використовуйте «Ім'я <ел. пошта>», щоб записати адресу."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Час початку не є дійсною датою.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Видалити цю зустріч?",
+                "body": "{title} буде видалено назавжди разом із розшифровкою та підсумком. Цю дію неможливо скасувати.",
+                "confirm": "Видалити зустріч",
+                "cancel": "Скасувати",
+                "deleting": "Видалення…",
+                "error": "Не вдалося видалити зустріч"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Назад до зустрічей",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Відкрити запис",
                 "edit": "Редагувати",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Видалити",
+                "attachTranscript": "Прикріпити транскрипцію",
                 "attaching": "Прикріплюємо…",
                 "editTranscript": "Редагувати транскрипцію",
                 "cancelEdit": "Скасувати редагування",
                 "saveTranscript": "Зберегти транскрипцію",
                 "savingTranscript": "Зберігаємо…",
-                "save": "Save changes",
+                "save": "Зберегти зміни",
                 "cancel": "Скасувати"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Стислий виклад",
+                "transcript": "Транскрипція",
+                "details": "Подробиці",
+                "edit": "Редагування зустрічі"
             },
             "summary": {
                 "generating": "Створюємо стислий виклад…",
                 "generatingHint": "Читаємо транскрипцію та пишемо стислий виклад — зазвичай це триває кілька секунд.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Для цієї транскрипції стислий виклад не створено. Увімкніть постачальника ШІ та прикріпіть транскрипцію ще раз, щоб спробувати знову.",
+                "noTranscript": "Прикріпіть транскрипцію, щоб створити стислий виклад."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Текст транскрипції",
+                "composerPlaceholder": "Вставте сюди транскрипцію зустрічі.",
+                "pipelineHint": "Спершу зберігаємо, потім стисло переказуємо, запам’ятовуємо та публікуємо у вашій стрічці активності — за можливості.",
+                "storedElsewhere": "Транскрипція збережена, але не була повернута в цьому поданні."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Джерело",
+                "startedAt": "Початок",
+                "endedAt": "Завершення",
+                "openEnded": "Ще триває",
+                "duration": "Тривалість",
+                "work": "Робота",
+                "orgWide": "Уся організація",
+                "externalId": "ID у постачальника",
+                "createdAt": "Зафіксовано",
+                "participants": "Учасники",
+                "noParticipants": "Учасників не записано."
             },
             "edit": {
                 "hint": "Виправте час, перейменуйте зустріч, відредагуйте список учасників, вкажіть запис або перепризначте її до Роботи."
             },
             "fields": {
-                "title": "Title",
+                "title": "Назва",
                 "startedAt": "Початок",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Завершення",
+                "sourceUrl": "Посилання на запис",
+                "work": "Робота",
+                "workNone": "Уся організація (без Роботи)",
                 "participants": "Учасники",
                 "participantName": "Ім’я",
                 "participantEmail": "Ел. пошта (необов’язково)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Поки нікого не записано."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Назва обов’язкова.",
                 "startedAtInvalid": "Час початку не є дійсною датою.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Час завершення не є дійсною датою.",
+                "endedBeforeStarted": "Час завершення не може бути раніше за час початку.",
                 "participantEmailInvalid": "Введіть коректну адресу ел. пошти або залиште поле порожнім.",
                 "participantDuplicate": "Ця людина вже є у списку.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Текст транскрипції обов’язковий."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Транскрипцію прикріплено",
+                "transcriptSummarized": "Транскрипцію прикріплено та стисло переказано",
+                "transcriptError": "Не вдалося прикріпити транскрипцію.",
+                "saved": "Зустріч оновлено",
                 "participantAdded": "Учасника додано",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Не вдалося оновити зустріч.",
+                "deleted": "Зустріч видалено",
+                "deleteError": "Не вдалося видалити зустріч."
             },
             "deleteDialog": {
                 "title": "Видалити цю зустріч?",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Учасники",
-                "participantsHint": "По одному в рядку. Використовуйте «Ім'я <ел. пошта>», щоб записати адресу."
+                "participantsHint": "По одному в рядку. Використовуйте «Ім'я '<'ел. пошта>», щоб записати адресу."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Учасники",
-                "participantsHint": "По одному в рядку. Використовуйте «Ім'я '<'ел. пошта>», щоб записати адресу.",
                 "participantName": "Ім’я",
                 "participantEmail": "Ел. пошта (необов’язково)",
                 "participantAdd": "Додати учасника",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Учасники",
-                "participantsHint": "По одному в рядку. Використовуйте «Ім'я '<'ел. пошта>», щоб записати адресу."
+                "participantsHint": "По одному в рядку. Використовуйте «Ім'я '<'ел. пошта>», щоб записати адресу.",
+                "participantName": "Ім’я",
+                "participantEmail": "Ел. пошта (необов’язково)",
+                "participantAdd": "Додати учасника",
+                "participantRemove": "Видалити учасника",
+                "participantsEmpty": "Поки нікого не записано."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Час початку не є дійсною датою.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Введіть коректну адресу ел. пошти або залиште поле порожнім.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Редагувати",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Скасувати"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Прикріплюємо…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Редагувати транскрипцію",
+                "cancelEdit": "Скасувати редагування",
+                "saveTranscript": "Зберегти транскрипцію",
+                "savingTranscript": "Зберігаємо…",
                 "save": "Save changes",
                 "cancel": "Скасувати"
             },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Введіть коректну адресу ел. пошти або залиште поле порожнім.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Người tham dự",
-                "participantsHint": "Mỗi dòng một người. Dùng \"Tên '<'email>\" để ghi lại địa chỉ."
+                "participantsHint": "Mỗi dòng một người. Dùng \"Tên '<'email>\" để ghi lại địa chỉ.",
+                "participantName": "Tên",
+                "participantEmail": "Email (tùy chọn)",
+                "participantAdd": "Thêm người tham gia",
+                "participantRemove": "Xóa người tham gia",
+                "participantsEmpty": "Chưa có ai được ghi nhận."
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "Thời gian bắt đầu không phải là ngày hợp lệ.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Nhập địa chỉ email hợp lệ, hoặc để trống.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "Sửa thời gian, đổi tên cuộc họp, chỉnh danh sách người tham dự, liên kết bản ghi, hoặc chuyển sang một Công việc."
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "Bắt đầu",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "Người tham dự",
+                "participantsHint": "Mỗi dòng một người. Dùng \"Tên <email>\" để ghi lại địa chỉ."
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "Thời gian bắt đầu không phải là ngày hợp lệ.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "Xóa cuộc họp này?",
+                "body": "{title} sẽ bị xóa vĩnh viễn, cùng với bản ghi và bản tóm tắt của nó. Không thể hoàn tác thao tác này.",
+                "confirm": "Xóa cuộc họp",
+                "cancel": "Hủy",
+                "deleting": "Đang xóa…",
+                "error": "Không thể xóa cuộc họp"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Người tham dự",
-                "participantsHint": "Mỗi dòng một người. Dùng \"Tên <email>\" để ghi lại địa chỉ."
+                "participantsHint": "Mỗi dòng một người. Dùng \"Tên '<'email>\" để ghi lại địa chỉ."
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6942,6 +6942,7 @@
                 "edit": "Chỉnh sửa",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "Đang đính kèm…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "Đang tạo bản tóm tắt…",
+                "generatingHint": "Đang đọc bản ghi và viết bản tóm tắt — việc này thường mất vài giây.",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "Đang đính kèm…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "Chỉnh sửa bản ghi",
+                "cancelEdit": "Hủy chỉnh sửa",
+                "saveTranscript": "Lưu bản ghi",
+                "savingTranscript": "Đang lưu…",
                 "save": "Save changes",
                 "cancel": "Hủy"
             },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "Nhập địa chỉ email hợp lệ, hoặc để trống.",
+                "participantDuplicate": "Người này đã có trong danh sách.",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "Đã thêm người tham dự",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "Quay lại Cuộc họp",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "Mở bản ghi hình",
                 "edit": "Chỉnh sửa",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "Xóa",
+                "attachTranscript": "Đính kèm bản ghi",
                 "attaching": "Đang đính kèm…",
                 "editTranscript": "Chỉnh sửa bản ghi",
                 "cancelEdit": "Hủy chỉnh sửa",
                 "saveTranscript": "Lưu bản ghi",
                 "savingTranscript": "Đang lưu…",
-                "save": "Save changes",
+                "save": "Lưu thay đổi",
                 "cancel": "Hủy"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "Bản tóm tắt",
+                "transcript": "Bản ghi",
+                "details": "Chi tiết",
+                "edit": "Chỉnh sửa cuộc họp"
             },
             "summary": {
                 "generating": "Đang tạo bản tóm tắt…",
                 "generatingHint": "Đang đọc bản ghi và viết bản tóm tắt — việc này thường mất vài giây.",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "Không có bản tóm tắt nào được tạo cho bản ghi này. Hãy bật một nhà cung cấp AI và đính kèm lại bản ghi để thử lại.",
+                "noTranscript": "Đính kèm bản ghi để tạo bản tóm tắt."
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "Nội dung bản ghi",
+                "composerPlaceholder": "Dán bản ghi cuộc họp vào đây.",
+                "pipelineHint": "Được lưu trước, sau đó tóm tắt, ghi nhớ và đăng lên bảng tin hoạt động của bạn — trong khả năng có thể.",
+                "storedElsewhere": "Bản ghi đã được lưu nhưng không được trả về cùng chế độ xem này."
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "Nguồn",
+                "startedAt": "Bắt đầu",
+                "endedAt": "Kết thúc",
+                "openEnded": "Vẫn đang diễn ra",
+                "duration": "Thời lượng",
+                "work": "Công việc",
+                "orgWide": "Toàn tổ chức",
+                "externalId": "ID nhà cung cấp",
+                "createdAt": "Đã ghi nhận",
+                "participants": "Người tham dự",
+                "noParticipants": "Chưa ghi nhận người tham dự nào."
             },
             "edit": {
                 "hint": "Sửa thời gian, đổi tên cuộc họp, chỉnh danh sách người tham dự, liên kết bản ghi, hoặc chuyển sang một Công việc."
             },
             "fields": {
-                "title": "Title",
+                "title": "Tiêu đề",
                 "startedAt": "Bắt đầu",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "Kết thúc",
+                "sourceUrl": "Liên kết bản ghi hình",
+                "work": "Công việc",
+                "workNone": "Toàn tổ chức (không có Công việc)",
                 "participants": "Người tham dự",
                 "participantName": "Tên",
                 "participantEmail": "Email (tùy chọn)",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "Chưa có ai được ghi nhận."
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "Tiêu đề là bắt buộc.",
                 "startedAtInvalid": "Thời gian bắt đầu không phải là ngày hợp lệ.",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "Thời gian kết thúc không phải là ngày hợp lệ.",
+                "endedBeforeStarted": "Thời gian kết thúc không thể trước thời gian bắt đầu.",
                 "participantEmailInvalid": "Nhập địa chỉ email hợp lệ, hoặc để trống.",
                 "participantDuplicate": "Người này đã có trong danh sách.",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "Nội dung bản ghi là bắt buộc."
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "Đã đính kèm bản ghi",
+                "transcriptSummarized": "Đã đính kèm và tóm tắt bản ghi",
+                "transcriptError": "Không thể đính kèm bản ghi.",
+                "saved": "Đã cập nhật cuộc họp",
                 "participantAdded": "Đã thêm người tham dự",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "Không thể cập nhật cuộc họp.",
+                "deleted": "Đã xóa cuộc họp",
+                "deleteError": "Không thể xóa cuộc họp."
             },
             "deleteDialog": {
                 "title": "Xóa cuộc họp này?",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "Chỉnh sửa",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "Hủy"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "Người tham dự",
-                "participantsHint": "Mỗi dòng một người. Dùng \"Tên '<'email>\" để ghi lại địa chỉ.",
                 "participantName": "Tên",
                 "participantEmail": "Email (tùy chọn)",
                 "participantAdd": "Thêm người tham gia",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "Nhập địa chỉ email hợp lệ, hoặc để trống.",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6918,7 +6918,7 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name <email>\" to record an address.",
+                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6985,7 +6985,7 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "参与者",
-                "participantsHint": "每行一位。使用“姓名 <邮箱>”记录邮箱地址。"
+                "participantsHint": "每行一位。使用“姓名 '<'邮箱>”记录邮箱地址。"
             },
             "errors": {
                 "titleRequired": "Title is required.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6935,61 +6935,61 @@
             }
         },
         "meetingDetail": {
-            "backToMeetings": "Back to Meetings",
+            "backToMeetings": "返回会议列表",
             "actions": {
-                "openRecording": "Open recording",
+                "openRecording": "打开录制文件",
                 "edit": "编辑",
-                "delete": "Delete",
-                "attachTranscript": "Attach transcript",
+                "delete": "删除",
+                "attachTranscript": "附加转录内容",
                 "attaching": "正在附加…",
                 "editTranscript": "编辑转录内容",
                 "cancelEdit": "取消编辑",
                 "saveTranscript": "保存转录内容",
                 "savingTranscript": "正在保存…",
-                "save": "Save changes",
+                "save": "保存更改",
                 "cancel": "取消"
             },
             "sections": {
-                "summary": "Summary",
-                "transcript": "Transcript",
-                "details": "Details",
-                "edit": "Edit meeting"
+                "summary": "摘要",
+                "transcript": "转录内容",
+                "details": "详细信息",
+                "edit": "编辑会议"
             },
             "summary": {
                 "generating": "正在生成摘要…",
                 "generatingHint": "正在阅读转录内容并撰写摘要，通常需要几秒钟。",
-                "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
-                "noTranscript": "Attach a transcript to generate a summary."
+                "notGenerated": "未为此转录内容生成摘要。请启用 AI 提供方，然后重新附加转录内容再试一次。",
+                "noTranscript": "附加转录内容即可生成摘要。"
             },
             "transcript": {
-                "composerLabel": "Transcript text",
-                "composerPlaceholder": "Paste the meeting transcript here.",
-                "pipelineHint": "Stored first, then summarized, remembered and posted to your activity feed — best effort.",
-                "storedElsewhere": "The transcript is stored but was not returned with this view."
+                "composerLabel": "转录文本",
+                "composerPlaceholder": "在此粘贴会议的转录内容。",
+                "pipelineHint": "先存储，随后生成摘要、写入记忆并发布到你的动态信息流——尽力而为。",
+                "storedElsewhere": "转录内容已存储，但未随此视图一并返回。"
             },
             "details": {
-                "source": "Source",
-                "startedAt": "Started",
-                "endedAt": "Ended",
-                "openEnded": "Still open",
-                "duration": "Duration",
-                "work": "Work",
-                "orgWide": "Org-wide",
-                "externalId": "Provider ID",
-                "createdAt": "Captured",
-                "participants": "Participants",
-                "noParticipants": "No participants recorded."
+                "source": "来源",
+                "startedAt": "开始",
+                "endedAt": "结束",
+                "openEnded": "仍在进行",
+                "duration": "时长",
+                "work": "作品",
+                "orgWide": "全组织",
+                "externalId": "提供方 ID",
+                "createdAt": "记录于",
+                "participants": "参与者",
+                "noParticipants": "未记录任何参与者。"
             },
             "edit": {
                 "hint": "更正时间、重命名会议、调整参与者名单、关联录制文件，或将其重新指向某个作品。"
             },
             "fields": {
-                "title": "Title",
+                "title": "标题",
                 "startedAt": "开始时间",
-                "endedAt": "Ended at",
-                "sourceUrl": "Recording link",
-                "work": "Work",
-                "workNone": "Org-wide (no Work)",
+                "endedAt": "结束时间",
+                "sourceUrl": "录制文件链接",
+                "work": "作品",
+                "workNone": "全组织（不关联作品）",
                 "participants": "参与者",
                 "participantName": "姓名",
                 "participantEmail": "邮箱（可选）",
@@ -6998,23 +6998,23 @@
                 "participantsEmpty": "尚未记录任何参与者。"
             },
             "errors": {
-                "titleRequired": "Title is required.",
+                "titleRequired": "标题为必填项。",
                 "startedAtInvalid": "开始时间不是有效日期。",
-                "endedAtInvalid": "End time is not a valid date.",
-                "endedBeforeStarted": "End time cannot be before the start time.",
+                "endedAtInvalid": "结束时间不是有效日期。",
+                "endedBeforeStarted": "结束时间不能早于开始时间。",
                 "participantEmailInvalid": "请输入有效的邮箱地址，或留空。",
                 "participantDuplicate": "此人已在列表中。",
-                "transcriptRequired": "Transcript text is required."
+                "transcriptRequired": "转录文本为必填项。"
             },
             "toasts": {
-                "transcriptSaved": "Transcript attached",
-                "transcriptSummarized": "Transcript attached and summarized",
-                "transcriptError": "Couldn't attach the transcript.",
-                "saved": "Meeting updated",
+                "transcriptSaved": "已附加转录内容",
+                "transcriptSummarized": "已附加转录内容并生成摘要",
+                "transcriptError": "无法附加转录内容。",
+                "saved": "已更新会议",
                 "participantAdded": "已添加参与者",
-                "saveError": "Couldn't update the meeting.",
-                "deleted": "Meeting deleted",
-                "deleteError": "Couldn't delete the meeting."
+                "saveError": "无法更新会议。",
+                "deleted": "已删除会议",
+                "deleteError": "无法删除会议。"
             },
             "deleteDialog": {
                 "title": "删除此会议？",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6939,11 +6939,13 @@
             "backToMeetings": "Back to Meetings",
             "actions": {
                 "openRecording": "Open recording",
+                "edit": "编辑",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
-                "save": "Save changes"
+                "save": "Save changes",
+                "cancel": "取消"
             },
             "sections": {
                 "summary": "Summary",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6943,8 +6943,10 @@
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
                 "attaching": "正在附加…",
-                "replaceTranscript": "Replace transcript",
-                "cancelReplace": "Cancel replace",
+                "editTranscript": "编辑转录内容",
+                "cancelEdit": "取消编辑",
+                "saveTranscript": "保存转录内容",
+                "savingTranscript": "正在保存…",
                 "save": "Save changes",
                 "cancel": "取消"
             },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -7004,6 +7004,7 @@
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "participantEmailInvalid": "请输入有效的邮箱地址，或留空。",
+                "participantDuplicate": "此人已在列表中。",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {
@@ -7011,6 +7012,7 @@
                 "transcriptSummarized": "Transcript attached and summarized",
                 "transcriptError": "Couldn't attach the transcript.",
                 "saved": "Meeting updated",
+                "participantAdded": "已添加参与者",
                 "saveError": "Couldn't update the meeting.",
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6987,13 +6987,19 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "参与者",
-                "participantsHint": "每行一位。使用“姓名 '<'邮箱>”记录邮箱地址。"
+                "participantsHint": "每行一位。使用“姓名 '<'邮箱>”记录邮箱地址。",
+                "participantName": "姓名",
+                "participantEmail": "邮箱（可选）",
+                "participantAdd": "添加参与者",
+                "participantRemove": "移除参与者",
+                "participantsEmpty": "尚未记录任何参与者。"
             },
             "errors": {
                 "titleRequired": "Title is required.",
                 "startedAtInvalid": "开始时间不是有效日期。",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "请输入有效的邮箱地址，或留空。",
                 "transcriptRequired": "Transcript text is required."
             },
             "toasts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6975,17 +6975,21 @@
                 "noParticipants": "No participants recorded."
             },
             "edit": {
-                "hint": "Rename the meeting, close it out, point it at a recording, or re-route it to a Work."
+                "hint": "更正时间、重命名会议、调整参与者名单、关联录制文件，或将其重新指向某个作品。"
             },
             "fields": {
                 "title": "Title",
+                "startedAt": "开始时间",
                 "endedAt": "Ended at",
                 "sourceUrl": "Recording link",
                 "work": "Work",
-                "workNone": "Org-wide (no Work)"
+                "workNone": "Org-wide (no Work)",
+                "participants": "参与者",
+                "participantsHint": "每行一位。使用“姓名 <邮箱>”记录邮箱地址。"
             },
             "errors": {
                 "titleRequired": "Title is required.",
+                "startedAtInvalid": "开始时间不是有效日期。",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
                 "transcriptRequired": "Transcript text is required."
@@ -6999,8 +7003,13 @@
                 "deleted": "Meeting deleted",
                 "deleteError": "Couldn't delete the meeting."
             },
-            "confirm": {
-                "delete": "Delete this meeting? Its transcript and summary will be removed. This cannot be undone."
+            "deleteDialog": {
+                "title": "删除此会议？",
+                "body": "{title} 及其转录文本和摘要将被永久删除。此操作无法撤销。",
+                "confirm": "删除会议",
+                "cancel": "取消",
+                "deleting": "正在删除…",
+                "error": "删除会议失败"
             }
         },
         "agentsPreview": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6987,7 +6987,6 @@
                 "work": "Work",
                 "workNone": "Org-wide (no Work)",
                 "participants": "参与者",
-                "participantsHint": "每行一位。使用“姓名 '<'邮箱>”记录邮箱地址。",
                 "participantName": "姓名",
                 "participantEmail": "邮箱（可选）",
                 "participantAdd": "添加参与者",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6895,7 +6895,6 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {
@@ -6918,7 +6917,6 @@
                 "externalId": "Provider meeting ID (optional)",
                 "externalIdHint": "Used to de-duplicate against a later connector sync of the same meeting.",
                 "participants": "Participants",
-                "participantsHint": "One per line. Use \"Name '<'email>\" to record an address.",
                 "transcript": "Transcript (optional)",
                 "transcriptPlaceholder": "Ada: shipping the gate.\nGrace: reviewing the branch.",
                 "transcriptHint": "Adding a transcript runs the summary, Memory and activity pipeline. You can also attach it later from the meeting page."
@@ -6928,6 +6926,7 @@
                 "startedAtInvalid": "Start time is not a valid date.",
                 "endedAtInvalid": "End time is not a valid date.",
                 "endedBeforeStarted": "End time cannot be before the start time.",
+                "participantEmailInvalid": "请输入有效的邮箱地址，或留空。",
                 "createFailed": "Couldn't capture the meeting. Please try again."
             },
             "actions": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6942,6 +6942,7 @@
                 "edit": "编辑",
                 "delete": "Delete",
                 "attachTranscript": "Attach transcript",
+                "attaching": "正在附加…",
                 "replaceTranscript": "Replace transcript",
                 "cancelReplace": "Cancel replace",
                 "save": "Save changes",
@@ -6954,6 +6955,8 @@
                 "edit": "Edit meeting"
             },
             "summary": {
+                "generating": "正在生成摘要…",
+                "generatingHint": "正在阅读转录内容并撰写摘要，通常需要几秒钟。",
                 "notGenerated": "No summary was generated for this transcript. Enable an AI provider and re-attach the transcript to try again.",
                 "noTranscript": "Attach a transcript to generate a summary."
             },

--- a/apps/web/src/app/[locale]/globals.css
+++ b/apps/web/src/app/[locale]/globals.css
@@ -775,3 +775,112 @@ select:-webkit-autofill:focus {
         transform: translateX(400%);
     }
 }
+
+/* ─── Meeting detail (`/meetings/[id]`) — summary generation ──────────────────
+   The transcript ingest is ONE opaque round trip (store → summarize →
+   remember → post), so there is no percentage to report. Everything below
+   says "still working" rather than claiming progress: a breathing halo on
+   the section icon, skeleton lines standing in for the paragraph that is
+   coming, and an indeterminate bar. */
+
+@keyframes ms-summary-halo {
+    0%,
+    100% {
+        transform: scale(0.92);
+        opacity: 0.35;
+    }
+    50% {
+        transform: scale(1.12);
+        opacity: 0.8;
+    }
+}
+
+.ms-summary-halo {
+    animation: ms-summary-halo 2.2s ease-in-out infinite;
+}
+
+/* Skeleton lines breathe out of phase with each other; the per-line
+   delay is set inline so the stagger stays next to the widths. */
+@keyframes ms-summary-line {
+    0%,
+    100% {
+        opacity: 0.5;
+    }
+    50% {
+        opacity: 0.95;
+    }
+}
+
+.ms-summary-line {
+    position: relative;
+    overflow: hidden;
+    border-radius: 9999px;
+    background: var(--gp-bar-track);
+    animation: ms-summary-line 2s ease-in-out infinite;
+}
+
+/* Indeterminate bar: a short segment that crosses the track, easing in
+   and out so it reads as activity rather than as a measured percentage. */
+@keyframes ms-summary-slide {
+    0% {
+        transform: translateX(-110%) scaleX(0.55);
+    }
+    50% {
+        transform: translateX(120%) scaleX(1);
+    }
+    100% {
+        transform: translateX(340%) scaleX(0.55);
+    }
+}
+
+.ms-summary-slide {
+    transform-origin: left center;
+    animation: ms-summary-slide 2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+}
+
+/* The landing: the finished summary resolves into place instead of
+   snapping in where the skeleton was. */
+@keyframes ms-summary-reveal {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+        filter: blur(3px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+        filter: blur(0);
+    }
+}
+
+.ms-summary-reveal {
+    animation: ms-summary-reveal 0.5s ease-out both;
+}
+
+/* Reduced motion: keep the state legible, drop the movement. Scoped to
+   this panel so the shared `.gp-shimmer` / `.shiny-letter` rules stay
+   untouched on the surfaces that already ship them. */
+@media (prefers-reduced-motion: reduce) {
+    .ms-summary-halo,
+    .ms-summary-line,
+    .ms-summary-slide,
+    .ms-summary-reveal,
+    .ms-summary-generating .gp-shimmer,
+    .ms-summary-generating .shiny-letter {
+        animation: none;
+    }
+
+    .ms-summary-slide {
+        transform: none;
+        width: 100%;
+    }
+
+    .ms-summary-generating .gp-shimmer {
+        opacity: 0;
+    }
+
+    .ms-summary-generating .shiny-letter {
+        color: var(--color-text);
+        opacity: 1;
+    }
+}

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -6,9 +6,11 @@ import {
     ChevronLeft,
     ExternalLink,
     FileText,
-    Save,
+    Info,
+    Pencil,
     Sparkles,
     Trash2,
+    TriangleAlertIcon,
     Upload,
     Users,
     Video,
@@ -16,14 +18,28 @@ import {
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Link, useRouter } from '@/i18n/navigation';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { ShowDateTime } from '@/components/ui/show-datetime';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 import {
     MEETING_SOURCE_URL_MAX_CHARS,
     MEETING_TITLE_MAX_CHARS,
     MEETING_TRANSCRIPT_MAX_CHARS,
+    formatParticipants,
+    parseParticipants,
 } from '@/lib/api/meetings.shared';
 import type { Meeting } from '@/lib/api/meetings';
 import type { MeetingWorkOption } from './MeetingsList';
@@ -31,7 +47,6 @@ import {
     SourceBadge,
     TranscriptBadge,
     durationMinutes,
-    formatDateTime,
     formatDuration,
     isoToLocalInput,
     localInputToIso,
@@ -42,6 +57,8 @@ export interface MeetingDetailClientProps {
     meeting: Meeting;
     works?: MeetingWorkOption[];
 }
+
+// ─── Shared button classes ────────────────────────────────────────────────
 
 const btn =
     'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-border dark:border-border-dark text-text dark:text-text-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed';
@@ -62,6 +79,59 @@ const dateInput = cn(
     'focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20',
 );
 
+// ─── Section header helper ────────────────────────────────────────────────
+
+/**
+ * Neutral icon-tile styling shared by every section header on this page,
+ * lifted verbatim from `MissionDetailClient` so the two detail surfaces
+ * read as one system.
+ *
+ * Every section here used to carry the same `info` accent as the entity
+ * icon, which spent a semantic color on decoration and made four cards
+ * compete with the one badge row that actually encodes state. The tile is
+ * now design-system surface + border and the glyph secondary text; `info`
+ * survives only on the entity tile (matching MeetingCard and the catalog
+ * PageHeader), and `success`/neutral only on the source + transcript pills.
+ */
+const SECTION_ICON_TILE =
+    'bg-surface-secondary dark:bg-surface-secondary-dark border-border/60 dark:border-border-dark/60';
+
+const SECTION_ICON_GLYPH = 'text-text-secondary dark:text-text-secondary-dark';
+
+function SectionHeader({
+    icon: Icon,
+    title,
+    count,
+    action,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    title: string;
+    count?: number;
+    action?: React.ReactNode;
+}) {
+    return (
+        <div className="mb-4 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2.5">
+                <div
+                    className={cn(
+                        'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
+                        SECTION_ICON_TILE,
+                    )}
+                >
+                    <Icon className={cn('h-3.5 w-3.5', SECTION_ICON_GLYPH)} />
+                </div>
+                <h2 className="text-sm font-semibold text-text dark:text-text-dark">{title}</h2>
+            </div>
+            {action ??
+                (count !== undefined ? (
+                    <span className="rounded-full border border-border bg-surface-secondary px-2 py-0.5 text-[11px] font-medium tabular-nums text-text-muted dark:border-border-dark dark:bg-surface-secondary-dark dark:text-text-muted-dark">
+                        {count}
+                    </span>
+                ) : null)}
+        </div>
+    );
+}
+
 function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
     return (
         <div className="flex items-baseline justify-between gap-3 py-1.5">
@@ -75,6 +145,8 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
     );
 }
 
+// ─── Component ───────────────────────────────────────────────────────────
+
 /**
  * Meetings — `/meetings/:id` detail client.
  *
@@ -82,6 +154,14 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
  * provenance rows, and hosts the three mutations the API supports for a
  * single meeting: attach/replace transcript, patch the editable fields,
  * and delete.
+ *
+ * Layout mirrors `MissionDetailClient`: every page-level action sits in a
+ * single top bar on the breadcrumb line (destructive intent separated by a
+ * divider), and the body splits into a content column (what the meeting
+ * *says* — summary, transcript) and a context rail (what it *is* —
+ * provenance, editable fields). Delete goes through the same confirmation
+ * dialog the Mission and Task detail pages use, rather than a blocking
+ * `window.confirm` the design system cannot style, translate or test.
  *
  * The transcript panel is deliberately honest about the pipeline's
  * BEST-EFFORT half: the API stores the transcript and only then tries
@@ -102,10 +182,17 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
     const [transcriptDraft, setTranscriptDraft] = useState('');
     const [replacing, setReplacing] = useState(false);
 
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
     const [title, setTitle] = useState(initial.title);
     const [sourceUrl, setSourceUrl] = useState(initial.sourceUrl ?? '');
+    const [startedAt, setStartedAt] = useState(isoToLocalInput(initial.startedAt));
     const [endedAt, setEndedAt] = useState(isoToLocalInput(initial.endedAt));
     const [workId, setWorkId] = useState(initial.workId ?? '');
+    const [participantsDraft, setParticipantsDraft] = useState(
+        formatParticipants(initial.participants ?? []),
+    );
 
     const minutes = useMemo(
         () => durationMinutes(meeting.startedAt, meeting.endedAt),
@@ -149,6 +236,14 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
             return;
         }
 
+        // `startedAt` is REQUIRED by the API and is now editable here, so an
+        // emptied or unparseable field is a local error rather than a 400.
+        const startedIso = localInputToIso(startedAt);
+        if (!startedIso) {
+            toast.error(t('errors.startedAtInvalid'));
+            return;
+        }
+
         let endedIso: string | null = null;
         if (endedAt) {
             endedIso = localInputToIso(endedAt);
@@ -156,7 +251,10 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 toast.error(t('errors.endedAtInvalid'));
                 return;
             }
-            if (Date.parse(endedIso) < Date.parse(meeting.startedAt)) {
+            // Compared against the DRAFT start, not the persisted one: both
+            // ends move in a single save, so validating against the stored
+            // value would reject a legitimate "shift the whole meeting" edit.
+            if (Date.parse(endedIso) < Date.parse(startedIso)) {
                 toast.error(t('errors.endedBeforeStarted'));
                 return;
             }
@@ -166,6 +264,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
             try {
                 const updated = await updateMeetingAction(meeting.id, {
                     title: trimmedTitle.slice(0, MEETING_TITLE_MAX_CHARS),
+                    startedAt: startedIso,
                     // `null` clears the field; on `workId` it re-routes the
                     // meeting back to org-wide. class-validator's
                     // @IsOptional() skips validation for an explicit null,
@@ -175,8 +274,20 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                     sourceUrl: sourceUrl.trim()
                         ? sourceUrl.trim().slice(0, MEETING_SOURCE_URL_MAX_CHARS)
                         : null,
+                    // An emptied roster posts `[]`, which is a real edit
+                    // ("nobody recorded"), not a no-op.
+                    participants: parseParticipants(participantsDraft),
                 });
                 setMeeting(updated);
+                // Re-seed the drafts from the canonical row so the panel shows
+                // what was actually stored (truncated titles, normalized
+                // roster lines) rather than what was typed.
+                setTitle(updated.title);
+                setSourceUrl(updated.sourceUrl ?? '');
+                setStartedAt(isoToLocalInput(updated.startedAt));
+                setEndedAt(isoToLocalInput(updated.endedAt));
+                setWorkId(updated.workId ?? '');
+                setParticipantsDraft(formatParticipants(updated.participants ?? []));
                 toast.success(t('toasts.saved'));
                 router.refresh();
             } catch (err) {
@@ -185,73 +296,74 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
         });
     };
 
+    const openDelete = () => {
+        setDeleteError(null);
+        setDeleteOpen(true);
+    };
+
+    const closeDelete = () => {
+        if (pendingDelete) return;
+        setDeleteOpen(false);
+        setDeleteError(null);
+    };
+
     const handleDelete = () => {
-        if (!window.confirm(t('confirm.delete'))) return;
+        setDeleteError(null);
         startDelete(async () => {
             try {
                 await deleteMeetingAction(meeting.id);
                 toast.success(t('toasts.deleted'));
-                router.push('/meetings');
+                router.push(ROUTES.DASHBOARD_MEETINGS);
             } catch (err) {
-                toast.error(err instanceof Error ? err.message : t('toasts.deleteError'));
+                setDeleteError(err instanceof Error ? err.message : t('deleteDialog.error'));
             }
         });
     };
 
     return (
         <div className="mx-auto w-full max-w-screen-2xl space-y-6 p-6" data-testid="meeting-detail">
-            {/* Header */}
+            {/* ── Header ───────────────────────────────────────────────────── */}
             <div>
-                <Link
-                    href="/meetings"
-                    className="inline-flex items-center gap-1 text-xs text-text-muted transition-colors hover:text-text dark:text-text-muted-dark dark:hover:text-text-dark"
-                >
-                    <ChevronLeft className="h-3.5 w-3.5" />
-                    {t('backToMeetings')}
-                </Link>
+                {/* Top bar — every page-level action lives here on the
+                    breadcrumb line as a single non-wrapping row, with Delete
+                    behind a divider so the destructive intent never reads as
+                    part of the same group. The back link is the one element
+                    that can truncate without losing meaning. */}
+                <div className="flex items-center justify-between gap-3">
+                    <Link
+                        href={ROUTES.DASHBOARD_MEETINGS}
+                        className="inline-flex min-w-0 items-center gap-1 text-xs text-text-muted transition-colors hover:text-text dark:text-text-muted-dark dark:hover:text-text-dark"
+                    >
+                        <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{t('backToMeetings')}</span>
+                    </Link>
 
-                <div className="mt-3 flex flex-wrap items-start justify-between gap-4">
-                    <div className="flex min-w-0 flex-1 items-start gap-3">
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-info/20 bg-info/10">
-                            <Video className="h-5 w-5 text-info" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                            <h1 className="text-2xl font-semibold leading-tight text-text dark:text-text-dark">
-                                {meeting.title}
-                            </h1>
-                            <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                                <SourceBadge source={meeting.source} />
-                                <TranscriptBadge hasTranscript={hasTranscript} />
-                            </div>
-                            <p className="mt-2.5 flex flex-wrap items-center gap-1.5 text-sm text-text-secondary dark:text-text-secondary-dark">
-                                <CalendarClock className="h-3.5 w-3.5 shrink-0" />
-                                <time dateTime={meeting.startedAt} suppressHydrationWarning>
-                                    {formatDateTime(meeting.startedAt)}
-                                </time>
-                                <span aria-hidden="true">·</span>
-                                <span>{formatDuration(minutes)}</span>
-                            </p>
-                        </div>
-                    </div>
-
-                    <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    <div className="flex min-w-0 items-center gap-2 overflow-x-auto py-0.5">
                         {meeting.sourceUrl ? (
                             <a
                                 href={meeting.sourceUrl}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className={btn}
+                                className={cn(btn, 'shrink-0')}
                                 data-testid="meeting-recording-link"
                             >
                                 <ExternalLink className="h-3.5 w-3.5" />
                                 {t('actions.openRecording')}
                             </a>
                         ) : null}
+                        {/* The divider only earns its place when something
+                            sits to the left of it to be divided from. */}
+                        {meeting.sourceUrl ? (
+                            <span
+                                aria-hidden
+                                className="h-5 w-px shrink-0 bg-border dark:bg-border-dark"
+                            />
+                        ) : null}
                         <button
                             type="button"
-                            onClick={handleDelete}
+                            onClick={openDelete}
                             disabled={pendingDelete}
-                            className={btnDanger}
+                            className={cn(btnDanger, 'shrink-0')}
                             data-testid="meeting-delete"
                         >
                             <Trash2 className="h-3.5 w-3.5" />
@@ -259,244 +371,364 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                         </button>
                     </div>
                 </div>
+
+                {/* Icon + title + badges + when-it-happened line. */}
+                <div className="mt-3 flex min-w-0 items-start gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-info/20 bg-info/10">
+                        <Video className="h-5 w-5 text-info" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        <h1 className="text-2xl font-semibold leading-tight text-text dark:text-text-dark">
+                            {meeting.title}
+                        </h1>
+                        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                            <SourceBadge source={meeting.source} />
+                            <TranscriptBadge hasTranscript={hasTranscript} />
+                        </div>
+                        <p className="mt-2.5 flex flex-wrap items-center gap-1.5 text-sm text-text-secondary dark:text-text-secondary-dark">
+                            <CalendarClock className="h-3.5 w-3.5 shrink-0" />
+                            <time dateTime={meeting.startedAt}>
+                                <ShowDateTime value={meeting.startedAt} />
+                            </time>
+                            {minutes !== null ? (
+                                <>
+                                    <span aria-hidden="true">·</span>
+                                    <span>{formatDuration(minutes)}</span>
+                                </>
+                            ) : null}
+                        </p>
+                    </div>
+                </div>
             </div>
 
-            {/* Summary */}
-            <section className={sectionCard} data-testid="meeting-summary">
-                <div className="mb-4 flex items-center gap-2.5">
-                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-info/20 bg-info/10">
-                        <Sparkles className="h-3.5 w-3.5 text-info" />
-                    </div>
-                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
-                        {t('sections.summary')}
-                    </h2>
-                </div>
-                {meeting.summary ? (
-                    <p className="whitespace-pre-wrap text-sm leading-relaxed text-text dark:text-text-dark">
-                        {meeting.summary}
-                    </p>
-                ) : (
-                    <p className="text-xs text-text-muted dark:text-text-muted-dark">
-                        {hasTranscript ? t('summary.notGenerated') : t('summary.noTranscript')}
-                    </p>
-                )}
-            </section>
-
-            {/* Transcript */}
-            <section className={sectionCard} data-testid="meeting-transcript">
-                <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-                    <div className="flex items-center gap-2.5">
-                        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-info/20 bg-info/10">
-                            <FileText className="h-3.5 w-3.5 text-info" />
-                        </div>
-                        <h2 className="text-sm font-semibold text-text dark:text-text-dark">
-                            {t('sections.transcript')}
-                        </h2>
-                    </div>
-                    {hasTranscript ? (
-                        <button
-                            type="button"
-                            onClick={() => setReplacing((v) => !v)}
-                            className={btn}
-                            data-testid="meeting-replace-transcript-toggle"
-                        >
-                            <Upload className="h-3.5 w-3.5" />
-                            {replacing
-                                ? t('actions.cancelReplace')
-                                : t('actions.replaceTranscript')}
-                        </button>
-                    ) : null}
-                </div>
-
-                {hasTranscript ? (
-                    <pre
-                        data-testid="meeting-transcript-body"
-                        className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-surface/40 p-4 font-mono text-xs leading-relaxed text-text dark:border-border-dark/50 dark:bg-surface-dark/30 dark:text-text-dark"
-                    >
-                        {transcript || t('transcript.storedElsewhere')}
-                    </pre>
-                ) : null}
-
-                {showComposer ? (
-                    <div className={hasTranscript ? 'mt-4' : ''}>
-                        <label className={fieldLabel} htmlFor="meeting-transcript-draft">
-                            {t('transcript.composerLabel')}
-                        </label>
-                        <Textarea
-                            id="meeting-transcript-draft"
-                            data-testid="meeting-transcript-composer"
-                            value={transcriptDraft}
-                            onChange={(e) => setTranscriptDraft(e.target.value)}
-                            rows={8}
-                            maxLength={MEETING_TRANSCRIPT_MAX_CHARS}
-                            placeholder={t('transcript.composerPlaceholder')}
-                            className="font-mono text-xs"
-                        />
-                        <div className="mt-3 flex items-center gap-2">
-                            <button
-                                type="button"
-                                onClick={attachTranscript}
-                                disabled={pendingTranscript}
-                                className={btn}
-                                data-testid="meeting-attach-transcript"
-                            >
-                                <Upload className="h-3.5 w-3.5" />
-                                {t('actions.attachTranscript')}
-                            </button>
-                            <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
-                                {t('transcript.pipelineHint')}
+            {/* ── Body ─────────────────────────────────────────────────────
+                Two tracks on wide viewports: the left column carries what the
+                meeting *says* (its summary, then the transcript that produced
+                it), the right rail carries what it *is* — provenance rows and
+                the editable fields. Below @5xl the grid collapses to one
+                column and the DOM order still reads content-first. */}
+            <div className="grid items-start gap-5 @5xl/main:grid-cols-12">
+                {/* ── Content column ───────────────────────────────────── */}
+                <div className="min-w-0 space-y-5 @5xl/main:col-span-8">
+                    {/* ── Summary ──────────────────────────────────────── */}
+                    <section className={sectionCard} data-testid="meeting-summary">
+                        <SectionHeader icon={Sparkles} title={t('sections.summary')} />
+                        {meeting.summary ? (
+                            <p className="whitespace-pre-wrap text-sm leading-relaxed text-text dark:text-text-dark">
+                                {meeting.summary}
                             </p>
-                        </div>
-                    </div>
-                ) : null}
-            </section>
-
-            <div className="grid gap-5 @3xl/main:grid-cols-2">
-                {/* Details */}
-                <section className={sectionCard} data-testid="meeting-details">
-                    <h2 className="mb-3 text-sm font-semibold text-text dark:text-text-dark">
-                        {t('sections.details')}
-                    </h2>
-                    <div className="divide-y divide-border/50 dark:divide-border-dark/50">
-                        <DetailRow label={t('details.source')}>
-                            <SourceBadge source={meeting.source} />
-                        </DetailRow>
-                        <DetailRow label={t('details.startedAt')}>
-                            <time dateTime={meeting.startedAt} suppressHydrationWarning>
-                                {formatDateTime(meeting.startedAt)}
-                            </time>
-                        </DetailRow>
-                        <DetailRow label={t('details.endedAt')}>
-                            {meeting.endedAt ? (
-                                <time dateTime={meeting.endedAt} suppressHydrationWarning>
-                                    {formatDateTime(meeting.endedAt)}
-                                </time>
-                            ) : (
-                                t('details.openEnded')
-                            )}
-                        </DetailRow>
-                        <DetailRow label={t('details.duration')}>
-                            {formatDuration(minutes)}
-                        </DetailRow>
-                        <DetailRow label={t('details.work')}>
-                            {meeting.workId ? (
-                                <Link
-                                    href={`/works/${meeting.workId}`}
-                                    className="text-info hover:underline"
-                                >
-                                    {works.find((w) => w.id === meeting.workId)?.name ??
-                                        meeting.workId}
-                                </Link>
-                            ) : (
-                                t('details.orgWide')
-                            )}
-                        </DetailRow>
-                        <DetailRow label={t('details.externalId')}>
-                            {meeting.externalId ?? '—'}
-                        </DetailRow>
-                        <DetailRow label={t('details.createdAt')}>
-                            <time dateTime={meeting.createdAt} suppressHydrationWarning>
-                                {formatDateTime(meeting.createdAt)}
-                            </time>
-                        </DetailRow>
-                    </div>
-
-                    <div className="mt-4">
-                        <div className="mb-2 flex items-center gap-1.5 text-xs text-text-muted dark:text-text-muted-dark">
-                            <Users className="h-3 w-3 shrink-0" />
-                            <span>{t('details.participants')}</span>
-                        </div>
-                        {meeting.participants.length > 0 ? (
-                            <ul className="space-y-1" data-testid="meeting-participants">
-                                {meeting.participants.map((p, i) => (
-                                    <li
-                                        key={`${p.name}-${p.email ?? ''}-${i}`}
-                                        className="truncate text-xs text-text dark:text-text-dark"
-                                    >
-                                        {p.name}
-                                        {p.email ? (
-                                            <span className="text-text-muted dark:text-text-muted-dark">
-                                                {' '}
-                                                &lt;{p.email}&gt;
-                                            </span>
-                                        ) : null}
-                                    </li>
-                                ))}
-                            </ul>
                         ) : (
                             <p className="text-xs text-text-muted dark:text-text-muted-dark">
-                                {t('details.noParticipants')}
+                                {hasTranscript
+                                    ? t('summary.notGenerated')
+                                    : t('summary.noTranscript')}
                             </p>
                         )}
-                    </div>
-                </section>
+                    </section>
 
-                {/* Edit */}
-                <section className={sectionCard} data-testid="meeting-edit">
-                    <h2 className="mb-1 text-sm font-semibold text-text dark:text-text-dark">
-                        {t('sections.edit')}
-                    </h2>
-                    <p className="mb-3 text-xs text-text-muted dark:text-text-muted-dark">
-                        {t('edit.hint')}
-                    </p>
-                    <div className="space-y-4">
-                        <Input
-                            label={t('fields.title')}
-                            value={title}
-                            onChange={(e) => setTitle(e.target.value)}
-                            maxLength={MEETING_TITLE_MAX_CHARS}
+                    {/* ── Transcript ───────────────────────────────────── */}
+                    <section className={sectionCard} data-testid="meeting-transcript">
+                        <SectionHeader
+                            icon={FileText}
+                            title={t('sections.transcript')}
+                            action={
+                                hasTranscript ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => setReplacing((v) => !v)}
+                                        className={cn(btn, 'shrink-0')}
+                                        data-testid="meeting-replace-transcript-toggle"
+                                    >
+                                        <Upload className="h-3.5 w-3.5" />
+                                        {replacing
+                                            ? t('actions.cancelReplace')
+                                            : t('actions.replaceTranscript')}
+                                    </button>
+                                ) : undefined
+                            }
                         />
-                        <div>
-                            <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
-                                {t('fields.endedAt')}
-                            </label>
-                            <input
-                                id="meeting-edit-ended-at"
-                                data-testid="meeting-edit-ended-at"
-                                type="datetime-local"
-                                value={endedAt}
-                                onChange={(e) => setEndedAt(e.target.value)}
-                                className={dateInput}
-                            />
-                        </div>
-                        <Input
-                            label={t('fields.sourceUrl')}
-                            value={sourceUrl}
-                            onChange={(e) => setSourceUrl(e.target.value)}
-                            maxLength={MEETING_SOURCE_URL_MAX_CHARS}
-                            placeholder="https://example.com/recordings/123"
-                        />
-                        {works.length > 0 ? (
-                            <div>
-                                <label className={fieldLabel}>{t('fields.work')}</label>
-                                <Select
-                                    value={workId}
-                                    onValueChange={setWorkId}
-                                    placeholder={t('fields.workNone')}
-                                    data-testid="meeting-edit-work"
-                                >
-                                    <option value="">{t('fields.workNone')}</option>
-                                    {works.map((work) => (
-                                        <option key={work.id} value={work.id}>
-                                            {work.name}
-                                        </option>
-                                    ))}
-                                </Select>
+
+                        {hasTranscript ? (
+                            <pre
+                                data-testid="meeting-transcript-body"
+                                className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-surface/40 p-4 font-mono text-xs leading-relaxed text-text dark:border-border-dark/50 dark:bg-surface-dark/30 dark:text-text-dark"
+                            >
+                                {transcript || t('transcript.storedElsewhere')}
+                            </pre>
+                        ) : null}
+
+                        {showComposer ? (
+                            <div className={hasTranscript ? 'mt-4' : ''}>
+                                <label className={fieldLabel} htmlFor="meeting-transcript-draft">
+                                    {t('transcript.composerLabel')}
+                                </label>
+                                <Textarea
+                                    id="meeting-transcript-draft"
+                                    data-testid="meeting-transcript-composer"
+                                    value={transcriptDraft}
+                                    onChange={(e) => setTranscriptDraft(e.target.value)}
+                                    rows={8}
+                                    maxLength={MEETING_TRANSCRIPT_MAX_CHARS}
+                                    placeholder={t('transcript.composerPlaceholder')}
+                                    className="font-mono text-xs"
+                                />
+                                <div className="mt-3 flex items-center gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={attachTranscript}
+                                        disabled={pendingTranscript}
+                                        className={btn}
+                                        data-testid="meeting-attach-transcript"
+                                    >
+                                        <Upload className="h-3.5 w-3.5" />
+                                        {t('actions.attachTranscript')}
+                                    </button>
+                                    <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
+                                        {t('transcript.pipelineHint')}
+                                    </p>
+                                </div>
                             </div>
                         ) : null}
-                        <button
-                            type="button"
-                            onClick={saveDetails}
-                            disabled={pendingSave}
-                            className={btn}
-                            data-testid="meeting-save"
-                        >
-                            <Save className="h-3.5 w-3.5" />
-                            {t('actions.save')}
-                        </button>
-                    </div>
-                </section>
+                    </section>
+                </div>
+
+                {/* ── Context rail ─────────────────────────────────────── */}
+                <aside className="min-w-0 space-y-5 @5xl/main:col-span-4">
+                    {/* ── Details ──────────────────────────────────────── */}
+                    <section className={sectionCard} data-testid="meeting-details">
+                        <SectionHeader icon={Info} title={t('sections.details')} />
+                        <div className="divide-y divide-border/50 dark:divide-border-dark/50">
+                            <DetailRow label={t('details.source')}>
+                                <SourceBadge source={meeting.source} />
+                            </DetailRow>
+                            <DetailRow label={t('details.startedAt')}>
+                                <time dateTime={meeting.startedAt}>
+                                    <ShowDateTime value={meeting.startedAt} />
+                                </time>
+                            </DetailRow>
+                            <DetailRow label={t('details.endedAt')}>
+                                {meeting.endedAt ? (
+                                    <time dateTime={meeting.endedAt}>
+                                        <ShowDateTime value={meeting.endedAt} />
+                                    </time>
+                                ) : (
+                                    t('details.openEnded')
+                                )}
+                            </DetailRow>
+                            <DetailRow label={t('details.duration')}>
+                                {formatDuration(minutes)}
+                            </DetailRow>
+                            <DetailRow label={t('details.work')}>
+                                {meeting.workId ? (
+                                    <Link
+                                        href={ROUTES.DASHBOARD_WORK(meeting.workId)}
+                                        className="text-info hover:underline"
+                                    >
+                                        {works.find((w) => w.id === meeting.workId)?.name ??
+                                            meeting.workId}
+                                    </Link>
+                                ) : (
+                                    t('details.orgWide')
+                                )}
+                            </DetailRow>
+                            <DetailRow label={t('details.externalId')}>
+                                {meeting.externalId ?? '—'}
+                            </DetailRow>
+                            <DetailRow label={t('details.createdAt')}>
+                                <time dateTime={meeting.createdAt}>
+                                    <ShowDateTime value={meeting.createdAt} />
+                                </time>
+                            </DetailRow>
+                        </div>
+
+                        <div className="mt-4 border-t border-border/60 pt-4 dark:border-border-dark/60">
+                            <div className="mb-2 flex items-center gap-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                <Users className="h-3 w-3 shrink-0" />
+                                <span>{t('details.participants')}</span>
+                                <span className="ml-auto rounded-full border border-border bg-surface-secondary px-2 py-0.5 text-[11px] font-medium tabular-nums dark:border-border-dark dark:bg-surface-secondary-dark">
+                                    {meeting.participants.length}
+                                </span>
+                            </div>
+                            {meeting.participants.length > 0 ? (
+                                <ul className="space-y-1" data-testid="meeting-participants">
+                                    {meeting.participants.map((p, i) => (
+                                        <li
+                                            key={`${p.name}-${p.email ?? ''}-${i}`}
+                                            className="truncate text-xs text-text dark:text-text-dark"
+                                        >
+                                            {p.name}
+                                            {p.email ? (
+                                                <span className="text-text-muted dark:text-text-muted-dark">
+                                                    {' '}
+                                                    &lt;{p.email}&gt;
+                                                </span>
+                                            ) : null}
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <p
+                                    className="text-xs text-text-muted dark:text-text-muted-dark"
+                                    data-testid="meeting-participants"
+                                >
+                                    {t('details.noParticipants')}
+                                </p>
+                            )}
+                        </div>
+                    </section>
+
+                    {/* ── Edit ─────────────────────────────────────────── */}
+                    <section className={sectionCard} data-testid="meeting-edit">
+                        <SectionHeader icon={Pencil} title={t('sections.edit')} />
+                        <p className="-mt-2 mb-4 text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('edit.hint')}
+                        </p>
+                        <div className="space-y-4">
+                            <Input
+                                label={t('fields.title')}
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                                maxLength={MEETING_TITLE_MAX_CHARS}
+                            />
+                            <div>
+                                <label className={fieldLabel} htmlFor="meeting-edit-started-at">
+                                    {t('fields.startedAt')}
+                                </label>
+                                <input
+                                    id="meeting-edit-started-at"
+                                    data-testid="meeting-edit-started-at"
+                                    type="datetime-local"
+                                    value={startedAt}
+                                    onChange={(e) => setStartedAt(e.target.value)}
+                                    className={dateInput}
+                                />
+                            </div>
+                            <div>
+                                <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
+                                    {t('fields.endedAt')}
+                                </label>
+                                <input
+                                    id="meeting-edit-ended-at"
+                                    data-testid="meeting-edit-ended-at"
+                                    type="datetime-local"
+                                    value={endedAt}
+                                    onChange={(e) => setEndedAt(e.target.value)}
+                                    className={dateInput}
+                                />
+                            </div>
+                            <Input
+                                label={t('fields.sourceUrl')}
+                                value={sourceUrl}
+                                onChange={(e) => setSourceUrl(e.target.value)}
+                                maxLength={MEETING_SOURCE_URL_MAX_CHARS}
+                                placeholder="https://example.com/recordings/123"
+                            />
+                            {works.length > 0 ? (
+                                <div>
+                                    <label className={fieldLabel}>{t('fields.work')}</label>
+                                    <Select
+                                        value={workId}
+                                        onValueChange={setWorkId}
+                                        placeholder={t('fields.workNone')}
+                                        data-testid="meeting-edit-work"
+                                    >
+                                        <option value="">{t('fields.workNone')}</option>
+                                        {works.map((work) => (
+                                            <option key={work.id} value={work.id}>
+                                                {work.name}
+                                            </option>
+                                        ))}
+                                    </Select>
+                                </div>
+                            ) : null}
+                            <div>
+                                <label className={fieldLabel} htmlFor="meeting-edit-participants">
+                                    {t('fields.participants')}
+                                </label>
+                                <Textarea
+                                    id="meeting-edit-participants"
+                                    data-testid="meeting-edit-participants"
+                                    value={participantsDraft}
+                                    onChange={(e) => setParticipantsDraft(e.target.value)}
+                                    rows={4}
+                                    placeholder={'Ada Lovelace <ada@example.com>\nGrace Hopper'}
+                                    className="font-mono text-xs"
+                                />
+                                <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t('fields.participantsHint')}
+                                </p>
+                            </div>
+                        </div>
+                        <div className="mt-5 border-t border-border/60 pt-4 dark:border-border-dark/60">
+                            <button
+                                type="button"
+                                onClick={saveDetails}
+                                disabled={pendingSave}
+                                className={btn}
+                                data-testid="meeting-save"
+                            >
+                                {t('actions.save')}
+                            </button>
+                        </div>
+                    </section>
+                </aside>
             </div>
+
+            {/* ── Delete modal (mirrors the Mission detail delete dialog) ──── */}
+            <Dialog
+                open={deleteOpen}
+                onOpenChange={(next) => (next ? setDeleteOpen(true) : closeDelete())}
+            >
+                <DialogContent className="max-w-md">
+                    <DialogClose onClose={closeDelete} />
+                    <DialogHeader className="mb-0">
+                        <div className="mb-1 flex items-center gap-3">
+                            <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-red-100 dark:bg-red-950/50">
+                                <TriangleAlertIcon className="size-4 text-red-600 dark:text-red-400" />
+                            </span>
+                            <DialogTitle className="text-base font-semibold text-text dark:text-text-dark">
+                                {t('deleteDialog.title')}
+                            </DialogTitle>
+                        </div>
+                        <DialogDescription>
+                            {t('deleteDialog.body', { title: meeting.title })}
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {deleteError ? (
+                        <p
+                            role="alert"
+                            data-testid="meeting-delete-error"
+                            className="mt-4 text-xs text-danger"
+                        >
+                            {deleteError}
+                        </p>
+                    ) : null}
+
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            data-testid="meeting-delete-cancel"
+                            disabled={pendingDelete}
+                            onClick={closeDelete}
+                        >
+                            {t('deleteDialog.cancel')}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="danger"
+                            size="sm"
+                            data-testid="meeting-delete-confirm"
+                            loading={pendingDelete}
+                            onClick={handleDelete}
+                        >
+                            {pendingDelete ? t('deleteDialog.deleting') : t('deleteDialog.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -59,6 +59,7 @@ import {
     participantsFromRows,
     type ParticipantRow,
 } from './MeetingParticipantsEditor';
+import { MeetingSummary } from './MeetingSummary';
 import { MeetingSummaryGenerating } from './MeetingSummaryGenerating';
 import { deleteMeetingAction, ingestMeetingTranscriptAction, updateMeetingAction } from './actions';
 
@@ -531,12 +532,9 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                             // Keyed on the text so a freshly generated summary
                             // replays the reveal, resolving into the space the
                             // skeleton just held rather than snapping in.
-                            <p
-                                key={meeting.summary}
-                                className="ms-summary-reveal whitespace-pre-wrap text-sm leading-relaxed text-text dark:text-text-dark"
-                            >
-                                {meeting.summary}
-                            </p>
+                            <div key={meeting.summary} className="ms-summary-reveal">
+                                <MeetingSummary text={meeting.summary} />
+                            </div>
                         ) : (
                             <p className="text-xs text-text-muted dark:text-text-muted-dark">
                                 {hasTranscript

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -39,8 +39,6 @@ import {
     MEETING_SOURCE_URL_MAX_CHARS,
     MEETING_TITLE_MAX_CHARS,
     MEETING_TRANSCRIPT_MAX_CHARS,
-    formatParticipants,
-    parseParticipants,
 } from '@/lib/api/meetings.shared';
 import type { Meeting } from '@/lib/api/meetings';
 import type { MeetingWorkOption } from './MeetingsList';
@@ -52,6 +50,12 @@ import {
     isoToLocalInput,
     localInputToIso,
 } from './meeting-ui';
+import {
+    MeetingParticipantsEditor,
+    participantRowsFrom,
+    participantsFromRows,
+    type ParticipantRow,
+} from './MeetingParticipantsEditor';
 import { deleteMeetingAction, ingestMeetingTranscriptAction, updateMeetingAction } from './actions';
 
 export interface MeetingDetailClientProps {
@@ -142,7 +146,10 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
             <span className="shrink-0 text-xs text-text-muted dark:text-text-muted-dark">
                 {label}
             </span>
-            <span className="min-w-0 truncate text-right text-xs font-medium text-text dark:text-text-dark">
+            {/* One step below the label: the value is the denser column
+                (timestamps, ids, the source pill), and `text-[11px]`
+                matches the chips it sits alongside. */}
+            <span className="min-w-0 truncate text-right text-[11px] font-medium text-text dark:text-text-dark">
                 {children}
             </span>
         </div>
@@ -199,8 +206,8 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
     const [startedAt, setStartedAt] = useState(isoToLocalInput(initial.startedAt));
     const [endedAt, setEndedAt] = useState(isoToLocalInput(initial.endedAt));
     const [workId, setWorkId] = useState(initial.workId ?? '');
-    const [participantsDraft, setParticipantsDraft] = useState(
-        formatParticipants(initial.participants ?? []),
+    const [participantRows, setParticipantRows] = useState<ParticipantRow[]>(() =>
+        participantRowsFrom(initial.participants ?? []),
     );
 
     const minutes = useMemo(
@@ -249,7 +256,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
         setStartedAt(isoToLocalInput(meeting.startedAt));
         setEndedAt(isoToLocalInput(meeting.endedAt));
         setWorkId(meeting.workId ?? '');
-        setParticipantsDraft(formatParticipants(meeting.participants ?? []));
+        setParticipantRows(participantRowsFrom(meeting.participants ?? []));
         setEditOpen(true);
     };
 
@@ -289,6 +296,14 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
             }
         }
 
+        // Malformed addresses are caught here rather than at the API, so
+        // the message names the typo instead of surfacing a 400.
+        const { participants, invalidEmail } = participantsFromRows(participantRows);
+        if (invalidEmail) {
+            toast.error(t('errors.participantEmailInvalid'));
+            return;
+        }
+
         startSave(async () => {
             try {
                 const updated = await updateMeetingAction(meeting.id, {
@@ -305,7 +320,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                         : null,
                     // An emptied roster posts `[]`, which is a real edit
                     // ("nobody recorded"), not a no-op.
-                    participants: parseParticipants(participantsDraft),
+                    participants,
                 });
                 setMeeting(updated);
                 // Re-seed the drafts from the canonical row so the panel shows
@@ -316,7 +331,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 setStartedAt(isoToLocalInput(updated.startedAt));
                 setEndedAt(isoToLocalInput(updated.endedAt));
                 setWorkId(updated.workId ?? '');
-                setParticipantsDraft(formatParticipants(updated.participants ?? []));
+                setParticipantRows(participantRowsFrom(updated.participants ?? []));
                 setEditOpen(false);
                 toast.success(t('toasts.saved'));
                 router.refresh();
@@ -710,23 +725,12 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                 </Select>
                             </div>
                         ) : null}
-                        <div>
-                            <label className={fieldLabel} htmlFor="meeting-edit-participants">
-                                {t('fields.participants')}
-                            </label>
-                            <Textarea
-                                id="meeting-edit-participants"
-                                data-testid="meeting-edit-participants"
-                                value={participantsDraft}
-                                onChange={(e) => setParticipantsDraft(e.target.value)}
-                                rows={4}
-                                placeholder={'Ada Lovelace <ada@example.com>\nGrace Hopper'}
-                                className="font-mono text-xs"
-                            />
-                            <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
-                                {t('fields.participantsHint')}
-                            </p>
-                        </div>
+                        <MeetingParticipantsEditor
+                            label={t('fields.participants')}
+                            rows={participantRows}
+                            onChange={setParticipantRows}
+                            disabled={pendingSave}
+                        />
                     </div>
                     <DialogFooter>
                         <Button

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -158,10 +158,14 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
  * Layout mirrors `MissionDetailClient`: every page-level action sits in a
  * single top bar on the breadcrumb line (destructive intent separated by a
  * divider), and the body splits into a content column (what the meeting
- * *says* — summary, transcript) and a context rail (what it *is* —
- * provenance, editable fields). Delete goes through the same confirmation
- * dialog the Mission and Task detail pages use, rather than a blocking
- * `window.confirm` the design system cannot style, translate or test.
+ * *says* — summary, transcript) beside a context rail (what it *is* — the
+ * provenance rows and roster).
+ *
+ * Both mutations that change the record outright — Edit and Delete — are
+ * dialogs behind that top bar, so the page itself reads as a record rather
+ * than a form. Delete uses the same confirmation dialog the Mission and
+ * Task detail pages use, rather than a blocking `window.confirm` the design
+ * system cannot style, translate or test.
  *
  * The transcript panel is deliberately honest about the pipeline's
  * BEST-EFFORT half: the API stores the transcript and only then tries
@@ -184,6 +188,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
 
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [deleteError, setDeleteError] = useState<string | null>(null);
+    const [editOpen, setEditOpen] = useState(false);
 
     const [title, setTitle] = useState(initial.title);
     const [sourceUrl, setSourceUrl] = useState(initial.sourceUrl ?? '');
@@ -227,6 +232,26 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 toast.error(err instanceof Error ? err.message : t('toasts.transcriptError'));
             }
         });
+    };
+
+    /**
+     * Re-seed every draft from the canonical row before showing the form, so
+     * a cancelled edit is genuinely discarded rather than lingering as a
+     * stale draft the next time the dialog opens.
+     */
+    const openEdit = () => {
+        setTitle(meeting.title);
+        setSourceUrl(meeting.sourceUrl ?? '');
+        setStartedAt(isoToLocalInput(meeting.startedAt));
+        setEndedAt(isoToLocalInput(meeting.endedAt));
+        setWorkId(meeting.workId ?? '');
+        setParticipantsDraft(formatParticipants(meeting.participants ?? []));
+        setEditOpen(true);
+    };
+
+    const closeEdit = () => {
+        if (pendingSave) return;
+        setEditOpen(false);
     };
 
     const saveDetails = () => {
@@ -288,6 +313,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 setEndedAt(isoToLocalInput(updated.endedAt));
                 setWorkId(updated.workId ?? '');
                 setParticipantsDraft(formatParticipants(updated.participants ?? []));
+                setEditOpen(false);
                 toast.success(t('toasts.saved'));
                 router.refresh();
             } catch (err) {
@@ -351,14 +377,20 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                 {t('actions.openRecording')}
                             </a>
                         ) : null}
-                        {/* The divider only earns its place when something
-                            sits to the left of it to be divided from. */}
-                        {meeting.sourceUrl ? (
-                            <span
-                                aria-hidden
-                                className="h-5 w-px shrink-0 bg-border dark:bg-border-dark"
-                            />
-                        ) : null}
+                        <button
+                            type="button"
+                            onClick={openEdit}
+                            disabled={pendingSave}
+                            className={cn(btn, 'shrink-0')}
+                            data-testid="meeting-edit-open"
+                        >
+                            <Pencil className="h-3.5 w-3.5" />
+                            {t('actions.edit')}
+                        </button>
+                        <span
+                            aria-hidden
+                            className="h-5 w-px shrink-0 bg-border dark:bg-border-dark"
+                        />
                         <button
                             type="button"
                             onClick={openDelete}
@@ -576,103 +608,124 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                             )}
                         </div>
                     </section>
-
-                    {/* ── Edit ─────────────────────────────────────────── */}
-                    <section className={sectionCard} data-testid="meeting-edit">
-                        <SectionHeader icon={Pencil} title={t('sections.edit')} />
-                        <p className="-mt-2 mb-4 text-xs text-text-muted dark:text-text-muted-dark">
-                            {t('edit.hint')}
-                        </p>
-                        <div className="space-y-4">
-                            <Input
-                                label={t('fields.title')}
-                                value={title}
-                                onChange={(e) => setTitle(e.target.value)}
-                                maxLength={MEETING_TITLE_MAX_CHARS}
-                            />
-                            <div>
-                                <label className={fieldLabel} htmlFor="meeting-edit-started-at">
-                                    {t('fields.startedAt')}
-                                </label>
-                                <input
-                                    id="meeting-edit-started-at"
-                                    data-testid="meeting-edit-started-at"
-                                    type="datetime-local"
-                                    value={startedAt}
-                                    onChange={(e) => setStartedAt(e.target.value)}
-                                    className={dateInput}
-                                />
-                            </div>
-                            <div>
-                                <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
-                                    {t('fields.endedAt')}
-                                </label>
-                                <input
-                                    id="meeting-edit-ended-at"
-                                    data-testid="meeting-edit-ended-at"
-                                    type="datetime-local"
-                                    value={endedAt}
-                                    onChange={(e) => setEndedAt(e.target.value)}
-                                    className={dateInput}
-                                />
-                            </div>
-                            <Input
-                                label={t('fields.sourceUrl')}
-                                value={sourceUrl}
-                                onChange={(e) => setSourceUrl(e.target.value)}
-                                maxLength={MEETING_SOURCE_URL_MAX_CHARS}
-                                placeholder="https://example.com/recordings/123"
-                            />
-                            {works.length > 0 ? (
-                                <div>
-                                    <label className={fieldLabel}>{t('fields.work')}</label>
-                                    <Select
-                                        value={workId}
-                                        onValueChange={setWorkId}
-                                        placeholder={t('fields.workNone')}
-                                        data-testid="meeting-edit-work"
-                                    >
-                                        <option value="">{t('fields.workNone')}</option>
-                                        {works.map((work) => (
-                                            <option key={work.id} value={work.id}>
-                                                {work.name}
-                                            </option>
-                                        ))}
-                                    </Select>
-                                </div>
-                            ) : null}
-                            <div>
-                                <label className={fieldLabel} htmlFor="meeting-edit-participants">
-                                    {t('fields.participants')}
-                                </label>
-                                <Textarea
-                                    id="meeting-edit-participants"
-                                    data-testid="meeting-edit-participants"
-                                    value={participantsDraft}
-                                    onChange={(e) => setParticipantsDraft(e.target.value)}
-                                    rows={4}
-                                    placeholder={'Ada Lovelace <ada@example.com>\nGrace Hopper'}
-                                    className="font-mono text-xs"
-                                />
-                                <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
-                                    {t('fields.participantsHint')}
-                                </p>
-                            </div>
-                        </div>
-                        <div className="mt-5 border-t border-border/60 pt-4 dark:border-border-dark/60">
-                            <button
-                                type="button"
-                                onClick={saveDetails}
-                                disabled={pendingSave}
-                                className={btn}
-                                data-testid="meeting-save"
-                            >
-                                {t('actions.save')}
-                            </button>
-                        </div>
-                    </section>
                 </aside>
             </div>
+
+            {/* ── Edit modal ───────────────────────────────────────────────
+                The editable fields used to sit in a permanently-open card in
+                the rail, which put a form the reader rarely needs directly
+                beside the provenance rows they always read. It is now a
+                dialog behind the header's Edit button, so the page reads as
+                a record and editing is an explicit act. */}
+            <Dialog open={editOpen} onOpenChange={(next) => (next ? openEdit() : closeEdit())}>
+                <DialogContent className="max-w-lg">
+                    <DialogClose onClose={closeEdit} />
+                    <DialogHeader>
+                        <DialogTitle className="text-base font-semibold text-text dark:text-text-dark">
+                            {t('sections.edit')}
+                        </DialogTitle>
+                        <DialogDescription>{t('edit.hint')}</DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-4" data-testid="meeting-edit">
+                        <Input
+                            label={t('fields.title')}
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            maxLength={MEETING_TITLE_MAX_CHARS}
+                        />
+                        <div>
+                            <label className={fieldLabel} htmlFor="meeting-edit-started-at">
+                                {t('fields.startedAt')}
+                            </label>
+                            <input
+                                id="meeting-edit-started-at"
+                                data-testid="meeting-edit-started-at"
+                                type="datetime-local"
+                                value={startedAt}
+                                onChange={(e) => setStartedAt(e.target.value)}
+                                className={dateInput}
+                            />
+                        </div>
+                        <div>
+                            <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
+                                {t('fields.endedAt')}
+                            </label>
+                            <input
+                                id="meeting-edit-ended-at"
+                                data-testid="meeting-edit-ended-at"
+                                type="datetime-local"
+                                value={endedAt}
+                                onChange={(e) => setEndedAt(e.target.value)}
+                                className={dateInput}
+                            />
+                        </div>
+                        <Input
+                            label={t('fields.sourceUrl')}
+                            value={sourceUrl}
+                            onChange={(e) => setSourceUrl(e.target.value)}
+                            maxLength={MEETING_SOURCE_URL_MAX_CHARS}
+                            placeholder="https://example.com/recordings/123"
+                        />
+                        {works.length > 0 ? (
+                            <div>
+                                <label className={fieldLabel}>{t('fields.work')}</label>
+                                <Select
+                                    value={workId}
+                                    onValueChange={setWorkId}
+                                    placeholder={t('fields.workNone')}
+                                    data-testid="meeting-edit-work"
+                                >
+                                    <option value="">{t('fields.workNone')}</option>
+                                    {works.map((work) => (
+                                        <option key={work.id} value={work.id}>
+                                            {work.name}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </div>
+                        ) : null}
+                        <div>
+                            <label className={fieldLabel} htmlFor="meeting-edit-participants">
+                                {t('fields.participants')}
+                            </label>
+                            <Textarea
+                                id="meeting-edit-participants"
+                                data-testid="meeting-edit-participants"
+                                value={participantsDraft}
+                                onChange={(e) => setParticipantsDraft(e.target.value)}
+                                rows={4}
+                                placeholder={'Ada Lovelace <ada@example.com>\nGrace Hopper'}
+                                className="font-mono text-xs"
+                            />
+                            <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('fields.participantsHint')}
+                            </p>
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            data-testid="meeting-edit-cancel"
+                            disabled={pendingSave}
+                            onClick={closeEdit}
+                        >
+                            {t('actions.cancel')}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="primary"
+                            size="sm"
+                            data-testid="meeting-save"
+                            loading={pendingSave}
+                            onClick={saveDetails}
+                        >
+                            {t('actions.save')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
 
             {/* ── Delete modal (mirrors the Mission detail delete dialog) ──── */}
             <Dialog

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useTransition } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import {
     CalendarClock,
     ChevronLeft,
@@ -10,12 +10,14 @@ import {
     Info,
     Loader2,
     Pencil,
+    Save,
     Sparkles,
     Trash2,
     TriangleAlertIcon,
     Upload,
     Users,
     Video,
+    X,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
@@ -182,8 +184,8 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
  *
  * Renders the AI summary, the captured transcript, the roster and the
  * provenance rows, and hosts the three mutations the API supports for a
- * single meeting: attach/replace transcript, patch the editable fields,
- * and delete.
+ * single meeting: attach or edit the transcript, patch the editable
+ * fields, and delete.
  *
  * Layout mirrors `MissionDetailClient`: every page-level action sits in a
  * single top bar on the breadcrumb line (destructive intent separated by a
@@ -214,7 +216,10 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
     const [pendingDelete, startDelete] = useTransition();
 
     const [transcriptDraft, setTranscriptDraft] = useState('');
-    const [replacing, setReplacing] = useState(false);
+    const [editingTranscript, setEditingTranscript] = useState(false);
+
+    /** The Summary card, so a submitted transcript can scroll it into view. */
+    const summaryRef = useRef<HTMLElement | null>(null);
 
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -235,7 +240,34 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
     );
     const transcript = meeting.transcriptText ?? '';
     const hasTranscript = meeting.hasTranscript || transcript.length > 0;
-    const showComposer = !hasTranscript || replacing;
+    const showComposer = !hasTranscript || editingTranscript;
+
+    const openTranscriptEditor = () => {
+        setTranscriptDraft(transcript);
+        setEditingTranscript(true);
+    };
+
+    /** Discard the draft outright — the stored transcript is untouched. */
+    const cancelTranscriptEdit = () => {
+        if (pendingTranscript) return;
+        setEditingTranscript(false);
+        setTranscriptDraft('');
+    };
+
+    useEffect(() => {
+        if (!pendingTranscript) return;
+        const node = summaryRef.current;
+        // Absent under jsdom, which has no layout to scroll.
+        if (typeof node?.scrollIntoView !== 'function') return;
+        const reducedMotion =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        node.scrollIntoView({ behavior: reducedMotion ? 'auto' : 'smooth', block: 'start' });
+    }, [pendingTranscript]);
+    const SubmitIcon = pendingTranscript ? Loader2 : hasTranscript ? Save : Upload;
+    const submitLabel = pendingTranscript
+        ? t(hasTranscript ? 'actions.savingTranscript' : 'actions.attaching')
+        : t(hasTranscript ? 'actions.saveTranscript' : 'actions.attachTranscript');
 
     const attachTranscript = () => {
         const text = transcriptDraft.trim();
@@ -251,7 +283,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 );
                 setMeeting(result.meeting);
                 setTranscriptDraft('');
-                setReplacing(false);
+                setEditingTranscript(false);
                 // Honest reporting: the summary leg is best-effort and is
                 // simply absent on a stack with no AI provider.
                 toast.success(
@@ -481,7 +513,13 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 {/* ── Content column ───────────────────────────────────── */}
                 <div className="min-w-0 space-y-5 @5xl/main:col-span-8">
                     {/* ── Summary ──────────────────────────────────────── */}
-                    <section className={sectionCard} data-testid="meeting-summary">
+                    <section
+                        ref={summaryRef}
+                        // `scroll-mt` keeps the card clear of the dashboard's
+                        // sticky top bar when it is scrolled to.
+                        className={cn(sectionCard, 'scroll-mt-6')}
+                        data-testid="meeting-summary"
+                    >
                         <SectionHeader
                             icon={Sparkles}
                             title={t('sections.summary')}
@@ -517,30 +555,39 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                 hasTranscript ? (
                                     <button
                                         type="button"
-                                        onClick={() => setReplacing((v) => !v)}
+                                        onClick={
+                                            editingTranscript
+                                                ? cancelTranscriptEdit
+                                                : openTranscriptEditor
+                                        }
+                                        disabled={pendingTranscript}
                                         className={cn(btn, 'shrink-0')}
-                                        data-testid="meeting-replace-transcript-toggle"
+                                        data-testid="meeting-edit-transcript-toggle"
                                     >
-                                        <Upload className="h-3.5 w-3.5" />
-                                        {replacing
-                                            ? t('actions.cancelReplace')
-                                            : t('actions.replaceTranscript')}
+                                        {editingTranscript ? (
+                                            <X className="h-3.5 w-3.5" />
+                                        ) : (
+                                            <Pencil className="h-3.5 w-3.5" />
+                                        )}
+                                        {editingTranscript
+                                            ? t('actions.cancelEdit')
+                                            : t('actions.editTranscript')}
                                     </button>
                                 ) : undefined
                             }
                         />
 
-                        {hasTranscript ? (
+                        {hasTranscript && !editingTranscript ? (
                             <pre
                                 data-testid="meeting-transcript-body"
-                                className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-surface/40 p-4 font-mono text-xs leading-relaxed text-text dark:border-border-dark/50 dark:bg-surface-dark/30 dark:text-text-dark"
+                                className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-surface p-4 font-mono text-xs leading-relaxed text-text dark:border-border-dark/50 dark:bg-surface-dark dark:text-text-dark"
                             >
                                 {transcript || t('transcript.storedElsewhere')}
                             </pre>
                         ) : null}
 
                         {showComposer ? (
-                            <div className={hasTranscript ? 'mt-4' : ''}>
+                            <div>
                                 <label className={fieldLabel} htmlFor="meeting-transcript-draft">
                                     {t('transcript.composerLabel')}
                                 </label>
@@ -549,14 +596,14 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                     data-testid="meeting-transcript-composer"
                                     value={transcriptDraft}
                                     onChange={(e) => setTranscriptDraft(e.target.value)}
-                                    rows={8}
+                                    rows={hasTranscript ? 14 : 8}
                                     maxLength={MEETING_TRANSCRIPT_MAX_CHARS}
                                     placeholder={t('transcript.composerPlaceholder')}
-                                    // The text is already in flight; editing it
-                                    // mid-request would only ever describe a
-                                    // transcript the server never saw.
                                     disabled={pendingTranscript}
-                                    className="font-mono text-xs"
+                                    className={cn(
+                                        'bg-surface font-mono text-xs dark:bg-surface-dark',
+                                        'disabled:bg-surface dark:disabled:bg-surface-dark',
+                                    )}
                                 />
                                 <div className="mt-3 flex items-center gap-2">
                                     <button
@@ -566,14 +613,13 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                         className={btn}
                                         data-testid="meeting-attach-transcript"
                                     >
-                                        {pendingTranscript ? (
-                                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                        ) : (
-                                            <Upload className="h-3.5 w-3.5" />
-                                        )}
-                                        {pendingTranscript
-                                            ? t('actions.attaching')
-                                            : t('actions.attachTranscript')}
+                                        <SubmitIcon
+                                            className={cn(
+                                                'h-3.5 w-3.5',
+                                                pendingTranscript && 'animate-spin',
+                                            )}
+                                        />
+                                        {submitLabel}
                                     </button>
                                     <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
                                         {t('transcript.pipelineHint')}
@@ -670,13 +716,6 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                     </section>
                 </aside>
             </div>
-
-            {/* ── Edit modal ───────────────────────────────────────────────
-                The editable fields used to sit in a permanently-open card in
-                the rail, which put a form the reader rarely needs directly
-                beside the provenance rows they always read. It is now a
-                dialog behind the header's Edit button, so the page reads as
-                a record and editing is an explicit act. */}
             <Dialog open={editOpen} onOpenChange={(next) => (next ? openEdit() : closeEdit())}>
                 <DialogContent className="max-w-lg">
                     <DialogClose onClose={closeEdit} />
@@ -694,11 +733,6 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                             maxLength={MEETING_TITLE_MAX_CHARS}
                             className="text-xs"
                         />
-                        {/* The two ends of the meeting are one fact, so they
-                            sit on one row. Paired on the viewport breakpoint
-                            rather than a container query: the dialog is
-                            portalled out of the page's `main` container, so
-                            an @lg/main step would never match here. */}
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                             <div>
                                 <label className={fieldLabel} htmlFor="meeting-edit-started-at">
@@ -738,11 +772,6 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                         {works.length > 0 ? (
                             <div>
                                 <label className={fieldLabel}>{t('fields.work')}</label>
-                                {/* `data-icon` on every option (the org-wide
-                                    row included) keeps the folder in the
-                                    trigger whatever is selected, rather than
-                                    letting it appear and vanish with the
-                                    choice. */}
                                 <Select
                                     value={workId}
                                     onValueChange={setWorkId}

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -6,6 +6,7 @@ import {
     ChevronLeft,
     ExternalLink,
     FileText,
+    Folder,
     Info,
     Pencil,
     Sparkles,
@@ -71,8 +72,11 @@ const sectionCard =
 
 const fieldLabel = 'block text-xs font-medium text-text dark:text-text-dark mb-2';
 
+// `text-xs` throughout the edit dialog's controls, matching the Work
+// picker (Select `size="xs"`) and the roster textarea so every field in
+// the form renders at one type size.
 const dateInput = cn(
-    'w-full text-sm rounded-lg transition-colors outline-none px-4 py-2',
+    'w-full text-xs rounded-lg transition-colors outline-none px-4 py-2',
     'bg-card dark:bg-card-primary-dark',
     'border border-card-border dark:border-white/9',
     'text-text dark:text-text-dark',
@@ -624,7 +628,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                         <DialogTitle className="text-base font-semibold text-text dark:text-text-dark">
                             {t('sections.edit')}
                         </DialogTitle>
-                        <DialogDescription>{t('edit.hint')}</DialogDescription>
+                        <DialogDescription className="text-xs">{t('edit.hint')}</DialogDescription>
                     </DialogHeader>
                     <div className="space-y-4" data-testid="meeting-edit">
                         <Input
@@ -632,32 +636,40 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                             value={title}
                             onChange={(e) => setTitle(e.target.value)}
                             maxLength={MEETING_TITLE_MAX_CHARS}
+                            className="text-xs"
                         />
-                        <div>
-                            <label className={fieldLabel} htmlFor="meeting-edit-started-at">
-                                {t('fields.startedAt')}
-                            </label>
-                            <input
-                                id="meeting-edit-started-at"
-                                data-testid="meeting-edit-started-at"
-                                type="datetime-local"
-                                value={startedAt}
-                                onChange={(e) => setStartedAt(e.target.value)}
-                                className={dateInput}
-                            />
-                        </div>
-                        <div>
-                            <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
-                                {t('fields.endedAt')}
-                            </label>
-                            <input
-                                id="meeting-edit-ended-at"
-                                data-testid="meeting-edit-ended-at"
-                                type="datetime-local"
-                                value={endedAt}
-                                onChange={(e) => setEndedAt(e.target.value)}
-                                className={dateInput}
-                            />
+                        {/* The two ends of the meeting are one fact, so they
+                            sit on one row. Paired on the viewport breakpoint
+                            rather than a container query: the dialog is
+                            portalled out of the page's `main` container, so
+                            an @lg/main step would never match here. */}
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div>
+                                <label className={fieldLabel} htmlFor="meeting-edit-started-at">
+                                    {t('fields.startedAt')}
+                                </label>
+                                <input
+                                    id="meeting-edit-started-at"
+                                    data-testid="meeting-edit-started-at"
+                                    type="datetime-local"
+                                    value={startedAt}
+                                    onChange={(e) => setStartedAt(e.target.value)}
+                                    className={dateInput}
+                                />
+                            </div>
+                            <div>
+                                <label className={fieldLabel} htmlFor="meeting-edit-ended-at">
+                                    {t('fields.endedAt')}
+                                </label>
+                                <input
+                                    id="meeting-edit-ended-at"
+                                    data-testid="meeting-edit-ended-at"
+                                    type="datetime-local"
+                                    value={endedAt}
+                                    onChange={(e) => setEndedAt(e.target.value)}
+                                    className={dateInput}
+                                />
+                            </div>
                         </div>
                         <Input
                             label={t('fields.sourceUrl')}
@@ -665,19 +677,33 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                             onChange={(e) => setSourceUrl(e.target.value)}
                             maxLength={MEETING_SOURCE_URL_MAX_CHARS}
                             placeholder="https://example.com/recordings/123"
+                            className="text-xs"
                         />
                         {works.length > 0 ? (
                             <div>
                                 <label className={fieldLabel}>{t('fields.work')}</label>
+                                {/* `data-icon` on every option (the org-wide
+                                    row included) keeps the folder in the
+                                    trigger whatever is selected, rather than
+                                    letting it appear and vanish with the
+                                    choice. */}
                                 <Select
                                     value={workId}
                                     onValueChange={setWorkId}
                                     placeholder={t('fields.workNone')}
+                                    size="xs"
                                     data-testid="meeting-edit-work"
+                                    iconMap={{
+                                        work: (
+                                            <Folder className="h-3.5 w-3.5 text-text-muted dark:text-text-muted-dark" />
+                                        ),
+                                    }}
                                 >
-                                    <option value="">{t('fields.workNone')}</option>
+                                    <option value="" data-icon="work">
+                                        {t('fields.workNone')}
+                                    </option>
                                     {works.map((work) => (
-                                        <option key={work.id} value={work.id}>
+                                        <option key={work.id} value={work.id} data-icon="work">
                                             {work.name}
                                         </option>
                                     ))}

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -39,6 +39,7 @@ import {
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 import {
+    MEETING_PARTICIPANTS_MAX,
     MEETING_SOURCE_URL_MAX_CHARS,
     MEETING_TITLE_MAX_CHARS,
     MEETING_TRANSCRIPT_MAX_CHARS,
@@ -55,10 +56,12 @@ import {
 } from './meeting-ui';
 import {
     MeetingParticipantsEditor,
+    newParticipantRow,
     participantRowsFrom,
     participantsFromRows,
     type ParticipantRow,
 } from './MeetingParticipantsEditor';
+import { MeetingParticipantQuickAdd } from './MeetingParticipantQuickAdd';
 import { MeetingSummary } from './MeetingSummary';
 import { MeetingSummaryGenerating } from './MeetingSummaryGenerating';
 import { deleteMeetingAction, ingestMeetingTranscriptAction, updateMeetingAction } from './actions';
@@ -221,6 +224,11 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
 
     /** The Summary card, so a submitted transcript can scroll it into view. */
     const summaryRef = useRef<HTMLElement | null>(null);
+
+    // Plain state rather than a transition: the quick-add form awaits the
+    // result to decide whether to clear itself, and `useTransition` has no
+    // handle to await.
+    const [addingParticipant, setAddingParticipant] = useState(false);
 
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -392,6 +400,45 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
             }
         });
     };
+    const addParticipant = async (rawName: string, rawEmail: string): Promise<boolean> => {
+        const { participants: parsed, invalidEmail } = participantsFromRows([
+            newParticipantRow(rawName, rawEmail),
+        ]);
+        if (invalidEmail) {
+            toast.error(t('errors.participantEmailInvalid'));
+            return false;
+        }
+        const entry = parsed[0];
+        if (!entry) return false;
+
+        const existing = meeting.participants ?? [];
+        if (existing.length >= MEETING_PARTICIPANTS_MAX) return false;
+        const duplicate = existing.some((p) =>
+            entry.email && p.email
+                ? p.email.toLowerCase() === entry.email.toLowerCase()
+                : p.name.trim().toLowerCase() === entry.name.trim().toLowerCase(),
+        );
+        if (duplicate) {
+            toast.error(t('errors.participantDuplicate'));
+            return false;
+        }
+
+        setAddingParticipant(true);
+        try {
+            const updated = await updateMeetingAction(meeting.id, {
+                participants: [...existing, entry],
+            });
+            setMeeting(updated);
+            toast.success(t('toasts.participantAdded'));
+            router.refresh();
+            return true;
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : t('toasts.saveError'));
+            return false;
+        } finally {
+            setAddingParticipant(false);
+        }
+    };
 
     const openDelete = () => {
         setDeleteError(null);
@@ -421,11 +468,6 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
         <div className="mx-auto w-full max-w-screen-2xl space-y-6 p-6" data-testid="meeting-detail">
             {/* ── Header ───────────────────────────────────────────────────── */}
             <div>
-                {/* Top bar — every page-level action lives here on the
-                    breadcrumb line as a single non-wrapping row, with Delete
-                    behind a divider so the destructive intent never reads as
-                    part of the same group. The back link is the one element
-                    that can truncate without losing meaning. */}
                 <div className="flex items-center justify-between gap-3">
                     <Link
                         href={ROUTES.DASHBOARD_MEETINGS}
@@ -503,21 +545,10 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                     </div>
                 </div>
             </div>
-
-            {/* ── Body ─────────────────────────────────────────────────────
-                Two tracks on wide viewports: the left column carries what the
-                meeting *says* (its summary, then the transcript that produced
-                it), the right rail carries what it *is* — provenance rows and
-                the editable fields. Below @5xl the grid collapses to one
-                column and the DOM order still reads content-first. */}
             <div className="grid items-start gap-5 @5xl/main:grid-cols-12">
-                {/* ── Content column ───────────────────────────────────── */}
                 <div className="min-w-0 space-y-5 @5xl/main:col-span-8">
-                    {/* ── Summary ──────────────────────────────────────── */}
                     <section
                         ref={summaryRef}
-                        // `scroll-mt` keeps the card clear of the dashboard's
-                        // sticky top bar when it is scrolled to.
                         className={cn(sectionCard, 'scroll-mt-6')}
                         data-testid="meeting-summary"
                     >
@@ -529,9 +560,6 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                         {pendingTranscript ? (
                             <MeetingSummaryGenerating />
                         ) : meeting.summary ? (
-                            // Keyed on the text so a freshly generated summary
-                            // replays the reveal, resolving into the space the
-                            // skeleton just held rather than snapping in.
                             <div key={meeting.summary} className="ms-summary-reveal">
                                 <MeetingSummary text={meeting.summary} />
                             </div>
@@ -684,6 +712,13 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                 <span className="ml-auto rounded-full border border-border bg-surface-secondary px-2 py-0.5 text-[11px] font-medium tabular-nums dark:border-border-dark dark:bg-surface-secondary-dark">
                                     {meeting.participants.length}
                                 </span>
+                                <MeetingParticipantQuickAdd
+                                    onAdd={addParticipant}
+                                    pending={addingParticipant}
+                                    atCapacity={
+                                        meeting.participants.length >= MEETING_PARTICIPANTS_MAX
+                                    }
+                                />
                             </div>
                             {meeting.participants.length > 0 ? (
                                 <ul className="space-y-1" data-testid="meeting-participants">

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -8,6 +8,7 @@ import {
     FileText,
     Folder,
     Info,
+    Loader2,
     Pencil,
     Sparkles,
     Trash2,
@@ -56,6 +57,7 @@ import {
     participantsFromRows,
     type ParticipantRow,
 } from './MeetingParticipantsEditor';
+import { MeetingSummaryGenerating } from './MeetingSummaryGenerating';
 import { deleteMeetingAction, ingestMeetingTranscriptAction, updateMeetingAction } from './actions';
 
 export interface MeetingDetailClientProps {
@@ -111,22 +113,39 @@ function SectionHeader({
     title,
     count,
     action,
+    busy = false,
 }: {
     icon: React.ComponentType<{ className?: string }>;
     title: string;
     count?: number;
     action?: React.ReactNode;
+    /**
+     * Work is in flight for this section. The tile takes the `info` accent
+     * and a breathing halo, so the section has ONE focal point for the
+     * running state instead of a second spinner in the body.
+     */
+    busy?: boolean;
 }) {
     return (
         <div className="mb-4 flex items-center justify-between gap-3">
             <div className="flex items-center gap-2.5">
-                <div
-                    className={cn(
-                        'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
-                        SECTION_ICON_TILE,
-                    )}
-                >
-                    <Icon className={cn('h-3.5 w-3.5', SECTION_ICON_GLYPH)} />
+                <div className="relative shrink-0">
+                    {busy ? (
+                        <span
+                            aria-hidden
+                            className="ms-summary-halo pointer-events-none absolute -inset-1 rounded-lg bg-info/20"
+                        />
+                    ) : null}
+                    <div
+                        className={cn(
+                            'relative flex h-7 w-7 items-center justify-center rounded-md border transition-colors',
+                            busy ? 'border-info/30 bg-info/10' : SECTION_ICON_TILE,
+                        )}
+                    >
+                        <Icon
+                            className={cn('h-3.5 w-3.5', busy ? 'text-info' : SECTION_ICON_GLYPH)}
+                        />
+                    </div>
                 </div>
                 <h2 className="text-sm font-semibold text-text dark:text-text-dark">{title}</h2>
             </div>
@@ -463,9 +482,21 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                 <div className="min-w-0 space-y-5 @5xl/main:col-span-8">
                     {/* ── Summary ──────────────────────────────────────── */}
                     <section className={sectionCard} data-testid="meeting-summary">
-                        <SectionHeader icon={Sparkles} title={t('sections.summary')} />
-                        {meeting.summary ? (
-                            <p className="whitespace-pre-wrap text-sm leading-relaxed text-text dark:text-text-dark">
+                        <SectionHeader
+                            icon={Sparkles}
+                            title={t('sections.summary')}
+                            busy={pendingTranscript}
+                        />
+                        {pendingTranscript ? (
+                            <MeetingSummaryGenerating />
+                        ) : meeting.summary ? (
+                            // Keyed on the text so a freshly generated summary
+                            // replays the reveal, resolving into the space the
+                            // skeleton just held rather than snapping in.
+                            <p
+                                key={meeting.summary}
+                                className="ms-summary-reveal whitespace-pre-wrap text-sm leading-relaxed text-text dark:text-text-dark"
+                            >
                                 {meeting.summary}
                             </p>
                         ) : (
@@ -521,6 +552,10 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                     rows={8}
                                     maxLength={MEETING_TRANSCRIPT_MAX_CHARS}
                                     placeholder={t('transcript.composerPlaceholder')}
+                                    // The text is already in flight; editing it
+                                    // mid-request would only ever describe a
+                                    // transcript the server never saw.
+                                    disabled={pendingTranscript}
                                     className="font-mono text-xs"
                                 />
                                 <div className="mt-3 flex items-center gap-2">
@@ -531,8 +566,14 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
                                         className={btn}
                                         data-testid="meeting-attach-transcript"
                                     >
-                                        <Upload className="h-3.5 w-3.5" />
-                                        {t('actions.attachTranscript')}
+                                        {pendingTranscript ? (
+                                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                        ) : (
+                                            <Upload className="h-3.5 w-3.5" />
+                                        )}
+                                        {pendingTranscript
+                                            ? t('actions.attaching')
+                                            : t('actions.attachTranscript')}
                                     </button>
                                     <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
                                         {t('transcript.pipelineHint')}

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -510,3 +510,96 @@ describe('MeetingDetailClient — transcript', () => {
         expect(ingestMock).not.toHaveBeenCalled();
     });
 });
+
+describe('MeetingDetailClient — summary generation', () => {
+    /** A promise the spec resolves by hand, so the request can be held open. */
+    function deferred<T>() {
+        let resolve!: (value: T) => void;
+        const promise = new Promise<T>((r) => {
+            resolve = r;
+        });
+        return { promise, resolve };
+    }
+
+    it('shows the generating panel while the transcript is in flight, then the summary', async () => {
+        const pending = deferred<unknown>();
+        ingestMock.mockReturnValueOnce(pending.promise);
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        // Before the request: the empty state explains itself, nothing is
+        // pretending to work.
+        expect(screen.queryByTestId('meeting-summary-generating')).toBeNull();
+        expect(screen.getByText('summary.noTranscript')).toBeTruthy();
+
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: 'Ada: hello.' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        const panel = await screen.findByTestId('meeting-summary-generating');
+        // ShinyText renders one span per character, so the label is asserted
+        // on the concatenated text rather than as a single text node.
+        expect(panel.textContent).toContain('summary.generating');
+        expect(panel.getAttribute('role')).toBe('status');
+        expect(panel.getAttribute('aria-live')).toBe('polite');
+        // The empty-state copy steps aside rather than sitting under a
+        // panel that says a summary is coming.
+        expect(screen.queryByText('summary.noTranscript')).toBeNull();
+
+        pending.resolve({
+            meeting: mkMeeting({
+                hasTranscript: true,
+                transcriptText: 'Ada: hello.',
+                summary: 'They said hello.',
+            }),
+            summary: 'They said hello.',
+            memorySaved: true,
+            envelopeEmitted: true,
+        });
+
+        expect(await screen.findByText('They said hello.')).toBeTruthy();
+        expect(screen.queryByTestId('meeting-summary-generating')).toBeNull();
+    });
+
+    it('locks the composer and labels the button while the request is open', async () => {
+        const pending = deferred<unknown>();
+        ingestMock.mockReturnValueOnce(pending.promise);
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        const composer = screen.getByTestId('meeting-transcript-composer') as HTMLTextAreaElement;
+        fireEvent.change(composer, { target: { value: 'Ada: hello.' } });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        await screen.findByTestId('meeting-summary-generating');
+        const button = screen.getByTestId('meeting-attach-transcript') as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+        expect(button.textContent).toContain('actions.attaching');
+        expect(composer.disabled).toBe(true);
+
+        pending.resolve({
+            meeting: mkMeeting({ hasTranscript: true, transcriptText: 'Ada: hello.' }),
+            memorySaved: false,
+            envelopeEmitted: false,
+        });
+        await waitFor(() => expect(screen.queryByTestId('meeting-summary-generating')).toBeNull());
+    });
+
+    it('falls back to the not-generated copy when no summary came back', async () => {
+        ingestMock.mockResolvedValueOnce({
+            meeting: mkMeeting({ hasTranscript: true, transcriptText: 'Ada: hello.' }),
+            memorySaved: false,
+            envelopeEmitted: false,
+        });
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: 'Ada: hello.' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        // The animation must not outlive the request: with no AI provider the
+        // panel resolves to the honest explanation, not an endless shimmer.
+        expect(await screen.findByText('summary.notGenerated')).toBeTruthy();
+        expect(screen.queryByTestId('meeting-summary-generating')).toBeNull();
+    });
+});

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -1,0 +1,394 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+    useLocale: () => 'en',
+}));
+
+const routerPushMock = vi.fn();
+const routerRefreshMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: routerPushMock, refresh: routerRefreshMock }),
+    Link: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+vi.mock('sonner', () => ({
+    toast: {
+        success: (...args: unknown[]) => toastSuccessMock(...args),
+        error: (...args: unknown[]) => toastErrorMock(...args),
+    },
+}));
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+const ingestMock = vi.fn();
+vi.mock('./actions', () => ({
+    updateMeetingAction: (...args: unknown[]) => updateMock(...args),
+    deleteMeetingAction: (...args: unknown[]) => deleteMock(...args),
+    ingestMeetingTranscriptAction: (...args: unknown[]) => ingestMock(...args),
+}));
+
+import { MeetingDetailClient } from './MeetingDetailClient';
+import type { Meeting } from '@/lib/api/meetings';
+
+/**
+ * MeetingDetailClient — the `/meetings/:id` detail surface.
+ *
+ * Covers the behaviour the UX rework introduced or changed:
+ *   - Delete goes through the shared confirmation Dialog (it used to be a
+ *     blocking `window.confirm`, which jsdom cannot exercise at all).
+ *   - The edit panel now patches `startedAt` and `participants`, which the
+ *     API has always accepted but the UI could only ever set at capture.
+ *   - `endedAt` is validated against the DRAFT start, so shifting a whole
+ *     meeting forward in one save is legal.
+ *
+ * Server actions are mocked: this is component logic, not a round trip.
+ */
+
+/** A local `datetime-local` value and the exact ISO instant it maps to. */
+const LOCAL_START = '2026-05-24T09:00';
+const LOCAL_START_ISO = new Date(LOCAL_START).toISOString();
+const LOCAL_END = '2026-05-24T10:30';
+const LOCAL_END_ISO = new Date(LOCAL_END).toISOString();
+
+function mkMeeting(overrides: Partial<Meeting> = {}): Meeting {
+    return {
+        id: 'mtg-1',
+        title: 'Weekly roadmap review',
+        startedAt: LOCAL_START_ISO,
+        endedAt: null,
+        source: 'manual',
+        externalId: null,
+        workId: null,
+        organizationId: null,
+        participants: [],
+        sourceUrl: null,
+        summary: null,
+        hasTranscript: false,
+        transcriptText: null,
+        createdAt: LOCAL_START_ISO,
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    routerPushMock.mockClear();
+    routerRefreshMock.mockClear();
+    toastSuccessMock.mockClear();
+    toastErrorMock.mockClear();
+    updateMock.mockClear();
+    deleteMock.mockClear();
+    ingestMock.mockClear();
+});
+
+describe('MeetingDetailClient — header', () => {
+    it('renders the title, the badges and a back link to the catalog', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Weekly roadmap review');
+        // The source pill appears twice by design — once in the header badge
+        // row and once as the Details "source" row value.
+        expect(screen.getAllByTestId('meeting-source-badge')).toHaveLength(2);
+        expect(screen.getByTestId('meeting-transcript-badge')).toBeTruthy();
+        expect(screen.getByText('backToMeetings').closest('a')?.getAttribute('href')).toBe(
+            '/meetings',
+        );
+    });
+
+    it('shows the recording link only when the meeting carries a sourceUrl', () => {
+        const { unmount } = render(<MeetingDetailClient meeting={mkMeeting()} />);
+        expect(screen.queryByTestId('meeting-recording-link')).toBeNull();
+        unmount();
+
+        render(
+            <MeetingDetailClient meeting={mkMeeting({ sourceUrl: 'https://example.com/rec/1' })} />,
+        );
+        const link = screen.getByTestId('meeting-recording-link');
+        expect(link.getAttribute('href')).toBe('https://example.com/rec/1');
+        // Anti-tabnabbing on a user-supplied URL opened in a new tab.
+        expect(link.getAttribute('rel')).toContain('noopener');
+    });
+});
+
+describe('MeetingDetailClient — delete', () => {
+    it('opens the confirmation dialog instead of deleting straight away', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        expect(screen.queryByTestId('meeting-delete-confirm')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('meeting-delete'));
+
+        expect(screen.getByText('deleteDialog.title')).toBeTruthy();
+        expect(screen.getByTestId('meeting-delete-confirm')).toBeTruthy();
+        expect(deleteMock).not.toHaveBeenCalled();
+    });
+
+    it('Cancel closes the dialog without deleting', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.click(screen.getByTestId('meeting-delete'));
+        fireEvent.click(screen.getByTestId('meeting-delete-cancel'));
+        expect(deleteMock).not.toHaveBeenCalled();
+    });
+
+    it('Confirm deletes and returns to the catalog', async () => {
+        deleteMock.mockResolvedValueOnce({ deleted: true });
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.click(screen.getByTestId('meeting-delete'));
+        fireEvent.click(screen.getByTestId('meeting-delete-confirm'));
+
+        await waitFor(() => expect(deleteMock).toHaveBeenCalledWith('mtg-1'));
+        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/meetings'));
+    });
+
+    it('a failed delete surfaces the error inline and stays on the page', async () => {
+        deleteMock.mockRejectedValueOnce(new Error('Meeting is locked'));
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.click(screen.getByTestId('meeting-delete'));
+        fireEvent.click(screen.getByTestId('meeting-delete-confirm'));
+
+        expect(await screen.findByTestId('meeting-delete-error')).toBeTruthy();
+        expect(screen.getByText('Meeting is locked')).toBeTruthy();
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('MeetingDetailClient — edit panel', () => {
+    it('seeds the roster textarea from the stored participants', () => {
+        render(
+            <MeetingDetailClient
+                meeting={mkMeeting({
+                    participants: [
+                        { name: 'Ada Lovelace', email: 'ada@example.com' },
+                        { name: 'Grace Hopper' },
+                    ],
+                })}
+            />,
+        );
+        // formatParticipants is the exact inverse of the capture form's parser.
+        expect((screen.getByTestId('meeting-edit-participants') as HTMLTextAreaElement).value).toBe(
+            'Ada Lovelace <ada@example.com>\nGrace Hopper',
+        );
+    });
+
+    it('patches startedAt and participants — the two fields the UI could not edit before', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
+            target: { value: LOCAL_START },
+        });
+        fireEvent.change(screen.getByTestId('meeting-edit-participants'), {
+            target: { value: 'Grace Hopper <grace@example.com>\nAlan Turing' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({
+                    startedAt: LOCAL_START_ISO,
+                    participants: [
+                        { name: 'Grace Hopper', email: 'grace@example.com' },
+                        { name: 'Alan Turing' },
+                    ],
+                }),
+            ),
+        );
+    });
+
+    it('an emptied roster patches an empty array rather than skipping the field', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        render(
+            <MeetingDetailClient
+                meeting={mkMeeting({ participants: [{ name: 'Ada Lovelace' }] })}
+            />,
+        );
+
+        fireEvent.change(screen.getByTestId('meeting-edit-participants'), {
+            target: { value: '   \n  ' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({ participants: [] }),
+            ),
+        );
+    });
+
+    it('refuses to save with an emptied start time (the API requires one)', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.change(screen.getByTestId('meeting-edit-started-at'), { target: { value: '' } });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.startedAtInvalid');
+        expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses to save a title that is only whitespace', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.change(screen.getByLabelText('fields.title'), { target: { value: '   ' } });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.titleRequired');
+        expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an end time before the start time', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
+            target: { value: LOCAL_END },
+        });
+        fireEvent.change(screen.getByTestId('meeting-edit-ended-at'), {
+            target: { value: LOCAL_START },
+        });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.endedBeforeStarted');
+        expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('validates endedAt against the DRAFT start, so a whole meeting can shift in one save', async () => {
+        // Stored start is 09:00. Moving BOTH ends to 10:30 → 11:00 must pass:
+        // validating the new end against the PERSISTED start would too, but
+        // validating a new *earlier* pair proves the draft is what counts.
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        render(<MeetingDetailClient meeting={mkMeeting({ endedAt: LOCAL_END_ISO })} />);
+
+        fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
+            target: { value: '2026-05-24T07:00' },
+        });
+        fireEvent.change(screen.getByTestId('meeting-edit-ended-at'), {
+            target: { value: '2026-05-24T08:00' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({
+                    startedAt: new Date('2026-05-24T07:00').toISOString(),
+                    endedAt: new Date('2026-05-24T08:00').toISOString(),
+                }),
+            ),
+        );
+        expect(toastErrorMock).not.toHaveBeenCalled();
+    });
+
+    it('clears sourceUrl and workId with an explicit null so the API patches them', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        render(
+            <MeetingDetailClient
+                meeting={mkMeeting({ sourceUrl: 'https://example.com/rec/1', workId: 'work-1' })}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText('fields.sourceUrl'), { target: { value: '  ' } });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({ sourceUrl: null }),
+            ),
+        );
+    });
+});
+
+describe('MeetingDetailClient — transcript', () => {
+    it('shows the composer when no transcript has landed yet', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        expect(screen.getByTestId('meeting-transcript-composer')).toBeTruthy();
+        expect(screen.queryByTestId('meeting-transcript-body')).toBeNull();
+        // …and the Summary section says why there is no summary.
+        expect(screen.getByText('summary.noTranscript')).toBeTruthy();
+    });
+
+    it('collapses the composer behind Replace once a transcript exists', () => {
+        render(
+            <MeetingDetailClient
+                meeting={mkMeeting({
+                    hasTranscript: true,
+                    transcriptText: 'Ada: the gate is green.',
+                })}
+            />,
+        );
+        expect(screen.getByTestId('meeting-transcript-body').textContent).toContain(
+            'Ada: the gate is green.',
+        );
+        expect(screen.queryByTestId('meeting-transcript-composer')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('meeting-replace-transcript-toggle'));
+        expect(screen.getByTestId('meeting-transcript-composer')).toBeTruthy();
+    });
+
+    it('reports honestly when the best-effort summary leg produced nothing', async () => {
+        // The transcript WRITE is the only part that can fail the call; on a
+        // stack with no AI provider `summary` is simply absent.
+        ingestMock.mockResolvedValueOnce({
+            meeting: mkMeeting({ hasTranscript: true, transcriptText: 'Ada: hello.' }),
+            memorySaved: false,
+            envelopeEmitted: false,
+        });
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: 'Ada: hello.' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        await waitFor(() => expect(ingestMock).toHaveBeenCalledWith('mtg-1', 'Ada: hello.'));
+        await waitFor(() =>
+            expect(toastSuccessMock).toHaveBeenCalledWith('toasts.transcriptSaved'),
+        );
+        expect(toastSuccessMock).not.toHaveBeenCalledWith('toasts.transcriptSummarized');
+    });
+
+    it('claims a summary only when the API actually returned one', async () => {
+        ingestMock.mockResolvedValueOnce({
+            meeting: mkMeeting({
+                hasTranscript: true,
+                transcriptText: 'Ada: hello.',
+                summary: 'They said hello.',
+            }),
+            summary: 'They said hello.',
+            memorySaved: true,
+            envelopeEmitted: true,
+        });
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: 'Ada: hello.' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        await waitFor(() =>
+            expect(toastSuccessMock).toHaveBeenCalledWith('toasts.transcriptSummarized'),
+        );
+        expect(await screen.findByText('They said hello.')).toBeTruthy();
+    });
+
+    it('refuses to attach an empty transcript', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: '   ' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.transcriptRequired');
+        expect(ingestMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -426,6 +426,17 @@ describe('MeetingDetailClient — edit dialog', () => {
     });
 });
 
+/** A meeting whose transcript has already landed. */
+const STORED = 'Ada: the gate is green.';
+
+function withTranscript(overrides: Partial<Meeting> = {}): Meeting {
+    return mkMeeting({ hasTranscript: true, transcriptText: STORED, ...overrides });
+}
+
+function composer(): HTMLTextAreaElement {
+    return screen.getByTestId('meeting-transcript-composer') as HTMLTextAreaElement;
+}
+
 describe('MeetingDetailClient — transcript', () => {
     it('shows the composer when no transcript has landed yet', () => {
         render(<MeetingDetailClient meeting={mkMeeting()} />);
@@ -435,22 +446,69 @@ describe('MeetingDetailClient — transcript', () => {
         expect(screen.getByText('summary.noTranscript')).toBeTruthy();
     });
 
-    it('collapses the composer behind Replace once a transcript exists', () => {
-        render(
-            <MeetingDetailClient
-                meeting={mkMeeting({
-                    hasTranscript: true,
-                    transcriptText: 'Ada: the gate is green.',
-                })}
-            />,
-        );
-        expect(screen.getByTestId('meeting-transcript-body').textContent).toContain(
-            'Ada: the gate is green.',
-        );
+    it('collapses the composer behind Edit once a transcript exists', () => {
+        render(<MeetingDetailClient meeting={withTranscript()} />);
+        expect(screen.getByTestId('meeting-transcript-body').textContent).toContain(STORED);
         expect(screen.queryByTestId('meeting-transcript-composer')).toBeNull();
 
-        fireEvent.click(screen.getByTestId('meeting-replace-transcript-toggle'));
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
         expect(screen.getByTestId('meeting-transcript-composer')).toBeTruthy();
+    });
+
+    it('edits the stored transcript in place rather than opening an empty second box', () => {
+        render(<MeetingDetailClient meeting={withTranscript()} />);
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
+
+        // The whole point: the editor starts from the stored text, and the
+        // read-only copy steps aside instead of sitting above a blank box.
+        expect(composer().value).toBe(STORED);
+        expect(screen.queryByTestId('meeting-transcript-body')).toBeNull();
+    });
+
+    it('posts the edited text, not a whole re-paste', async () => {
+        ingestMock.mockResolvedValueOnce({
+            meeting: withTranscript({ transcriptText: 'Ada: the gate is GREEN.' }),
+            memorySaved: false,
+            envelopeEmitted: false,
+        });
+        render(<MeetingDetailClient meeting={withTranscript()} />);
+
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
+        fireEvent.change(composer(), { target: { value: 'Ada: the gate is GREEN.' } });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        await waitFor(() =>
+            expect(ingestMock).toHaveBeenCalledWith('mtg-1', 'Ada: the gate is GREEN.'),
+        );
+    });
+
+    it('Cancel drops the draft and leaves the stored transcript alone', () => {
+        render(<MeetingDetailClient meeting={withTranscript()} />);
+
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
+        fireEvent.change(composer(), { target: { value: 'Ada: nonsense.' } });
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
+
+        expect(ingestMock).not.toHaveBeenCalled();
+        expect(screen.getByTestId('meeting-transcript-body').textContent).toContain(STORED);
+
+        // Re-opening starts from the stored text again, not the abandoned draft.
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
+        expect(composer().value).toBe(STORED);
+    });
+
+    it('labels the button Save for an existing transcript and Attach for the first one', () => {
+        const { unmount } = render(<MeetingDetailClient meeting={mkMeeting()} />);
+        expect(screen.getByTestId('meeting-attach-transcript').textContent).toContain(
+            'actions.attachTranscript',
+        );
+        unmount();
+
+        render(<MeetingDetailClient meeting={withTranscript()} />);
+        fireEvent.click(screen.getByTestId('meeting-edit-transcript-toggle'));
+        expect(screen.getByTestId('meeting-attach-transcript').textContent).toContain(
+            'actions.saveTranscript',
+        );
     });
 
     it('reports honestly when the best-effort summary leg produced nothing', async () => {
@@ -582,6 +640,53 @@ describe('MeetingDetailClient — summary generation', () => {
             envelopeEmitted: false,
         });
         await waitFor(() => expect(screen.queryByTestId('meeting-summary-generating')).toBeNull());
+    });
+
+    it('scrolls the Summary card into view when the transcript is submitted', async () => {
+        const pending = deferred<unknown>();
+        ingestMock.mockReturnValueOnce(pending.promise);
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        // jsdom has no layout, so `scrollIntoView` is absent entirely. Stubbing
+        // it on the summary node alone also proves WHICH element is scrolled to.
+        const scrollSpy = vi.fn();
+        screen.getByTestId('meeting-summary').scrollIntoView = scrollSpy;
+
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: 'Ada: hello.' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        // At SUBMIT time, not on completion: what the reader is carried to is
+        // the generating state, not a result that has already landed. The
+        // scroll runs once that state has committed, so the browser is not
+        // animating toward a position the same frame's growth invalidates.
+        await screen.findByTestId('meeting-summary-generating');
+        await waitFor(() =>
+            expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' }),
+        );
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+        pending.resolve({
+            meeting: mkMeeting({ hasTranscript: true, transcriptText: 'Ada: hello.' }),
+            memorySaved: false,
+            envelopeEmitted: false,
+        });
+        await waitFor(() => expect(screen.queryByTestId('meeting-summary-generating')).toBeNull());
+    });
+
+    it('does not scroll when the draft is empty — nothing was submitted', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        const scrollSpy = vi.fn();
+        screen.getByTestId('meeting-summary').scrollIntoView = scrollSpy;
+
+        fireEvent.change(screen.getByTestId('meeting-transcript-composer'), {
+            target: { value: '   ' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-attach-transcript'));
+
+        expect(scrollSpy).not.toHaveBeenCalled();
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.transcriptRequired');
     });
 
     it('falls back to the not-generated copy when no summary came back', async () => {

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -174,6 +174,20 @@ function renderWithEditOpen(
     return result;
 }
 
+/**
+ * Roster rows are addressed by their accessible name rather than a
+ * testid: `useTranslations` is mocked to echo the key, so the label the
+ * screen reader announces is the handle the spec uses — the two cannot
+ * drift apart. Order matches the roster.
+ */
+function participantNameInputs(): HTMLInputElement[] {
+    return screen.queryAllByLabelText('fields.participantName') as HTMLInputElement[];
+}
+
+function participantEmailInputs(): HTMLInputElement[] {
+    return screen.queryAllByLabelText('fields.participantEmail') as HTMLInputElement[];
+}
+
 describe('MeetingDetailClient — edit dialog', () => {
     it('keeps the form behind the header Edit button rather than in the page body', () => {
         render(<MeetingDetailClient meeting={mkMeeting()} />);
@@ -216,7 +230,7 @@ describe('MeetingDetailClient — edit dialog', () => {
         expect(picker.textContent).toContain('fields.workNone');
     });
 
-    it('seeds the roster textarea from the stored participants', () => {
+    it('seeds one editable row per stored participant', () => {
         renderWithEditOpen(
             mkMeeting({
                 participants: [
@@ -225,21 +239,44 @@ describe('MeetingDetailClient — edit dialog', () => {
                 ],
             }),
         );
-        // formatParticipants is the exact inverse of the capture form's parser.
-        expect((screen.getByTestId('meeting-edit-participants') as HTMLTextAreaElement).value).toBe(
-            'Ada Lovelace <ada@example.com>\nGrace Hopper',
+        expect(participantNameInputs().map((i) => i.value)).toEqual([
+            'Ada Lovelace',
+            'Grace Hopper',
+        ]);
+        // The address is its own field now, not `<>` syntax inside the name.
+        expect(participantEmailInputs().map((i) => i.value)).toEqual(['ada@example.com', '']);
+    });
+
+    it('adds a participant on a new row, leaving the existing roster alone', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        renderWithEditOpen(mkMeeting({ participants: [{ name: 'Ada Lovelace' }] }));
+
+        // The whole point of the editor: adding someone must not require
+        // retyping (or even touching) the people already on the list.
+        fireEvent.click(screen.getByTestId('meeting-edit-participant-add'));
+        const names = participantNameInputs();
+        fireEvent.change(names[names.length - 1], { target: { value: 'Alan Turing' } });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({
+                    participants: [{ name: 'Ada Lovelace' }, { name: 'Alan Turing' }],
+                }),
+            ),
         );
     });
 
     it('patches startedAt and participants — the two fields the UI could not edit before', async () => {
         updateMock.mockResolvedValueOnce(mkMeeting());
-        renderWithEditOpen();
+        renderWithEditOpen(mkMeeting({ participants: [{ name: 'Grace Hopper' }] }));
 
         fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
             target: { value: LOCAL_START },
         });
-        fireEvent.change(screen.getByTestId('meeting-edit-participants'), {
-            target: { value: 'Grace Hopper <grace@example.com>\nAlan Turing' },
+        fireEvent.change(participantEmailInputs()[0], {
+            target: { value: 'grace@example.com' },
         });
         fireEvent.click(screen.getByTestId('meeting-save'));
 
@@ -248,11 +285,25 @@ describe('MeetingDetailClient — edit dialog', () => {
                 'mtg-1',
                 expect.objectContaining({
                     startedAt: LOCAL_START_ISO,
-                    participants: [
-                        { name: 'Grace Hopper', email: 'grace@example.com' },
-                        { name: 'Alan Turing' },
-                    ],
+                    participants: [{ name: 'Grace Hopper', email: 'grace@example.com' }],
                 }),
+            ),
+        );
+    });
+
+    it('removes a participant through that row’s own control', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        renderWithEditOpen(
+            mkMeeting({ participants: [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }] }),
+        );
+
+        fireEvent.click(screen.getAllByTestId('meeting-edit-participant-remove')[0]);
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({ participants: [{ name: 'Grace Hopper' }] }),
             ),
         );
     });
@@ -261,9 +312,8 @@ describe('MeetingDetailClient — edit dialog', () => {
         updateMock.mockResolvedValueOnce(mkMeeting());
         renderWithEditOpen(mkMeeting({ participants: [{ name: 'Ada Lovelace' }] }));
 
-        fireEvent.change(screen.getByTestId('meeting-edit-participants'), {
-            target: { value: '   \n  ' },
-        });
+        fireEvent.click(screen.getByTestId('meeting-edit-participant-remove'));
+        expect(screen.getByTestId('meeting-edit-participants-empty')).toBeTruthy();
         fireEvent.click(screen.getByTestId('meeting-save'));
 
         await waitFor(() =>
@@ -272,6 +322,33 @@ describe('MeetingDetailClient — edit dialog', () => {
                 expect.objectContaining({ participants: [] }),
             ),
         );
+    });
+
+    it('drops a row left blank instead of refusing the save', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        renderWithEditOpen(mkMeeting({ participants: [{ name: 'Ada Lovelace' }] }));
+
+        // "Add participant" produces an empty row; abandoning it must not
+        // block the save or post a nameless participant.
+        fireEvent.click(screen.getByTestId('meeting-edit-participant-add'));
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith(
+                'mtg-1',
+                expect.objectContaining({ participants: [{ name: 'Ada Lovelace' }] }),
+            ),
+        );
+    });
+
+    it('refuses to save a malformed address, and says so', () => {
+        renderWithEditOpen(mkMeeting({ participants: [{ name: 'Ada Lovelace' }] }));
+
+        fireEvent.change(participantEmailInputs()[0], { target: { value: 'ada@' } });
+        fireEvent.click(screen.getByTestId('meeting-save'));
+
+        expect(updateMock).not.toHaveBeenCalled();
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.participantEmailInvalid');
     });
 
     it('refuses to save with an emptied start time (the API requires one)', () => {

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('next-intl', () => ({
     useTranslations: () => (key: string) => key,
@@ -164,17 +164,66 @@ describe('MeetingDetailClient — delete', () => {
     });
 });
 
-describe('MeetingDetailClient — edit panel', () => {
+/** Render, then open the edit dialog that holds the editable fields. */
+function renderWithEditOpen(
+    meeting: Meeting = mkMeeting(),
+    works: { id: string; name: string }[] = [],
+) {
+    const result = render(<MeetingDetailClient meeting={meeting} works={works} />);
+    fireEvent.click(screen.getByTestId('meeting-edit-open'));
+    return result;
+}
+
+describe('MeetingDetailClient — edit dialog', () => {
+    it('keeps the form behind the header Edit button rather than in the page body', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        expect(screen.queryByTestId('meeting-edit')).toBeNull();
+        expect(screen.queryByTestId('meeting-save')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('meeting-edit-open'));
+
+        expect(screen.getByTestId('meeting-edit')).toBeTruthy();
+        expect(screen.getByTestId('meeting-save')).toBeTruthy();
+    });
+
+    it('Cancel closes the dialog without patching', () => {
+        renderWithEditOpen();
+        fireEvent.change(screen.getByLabelText('fields.title'), { target: { value: 'Renamed' } });
+        fireEvent.click(screen.getByTestId('meeting-edit-cancel'));
+        expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('re-opening discards an abandoned draft', () => {
+        renderWithEditOpen();
+        const titleInput = () => screen.getByLabelText('fields.title') as HTMLInputElement;
+        fireEvent.change(titleInput(), { target: { value: 'Abandoned rename' } });
+        fireEvent.click(screen.getByTestId('meeting-edit-cancel'));
+
+        fireEvent.click(screen.getByTestId('meeting-edit-open'));
+        // Re-seeded from the canonical row, not left holding the draft.
+        expect(titleInput().value).toBe('Weekly roadmap review');
+    });
+
+    it('offers the Work picker, defaulting to the org-wide row, only when Works exist', () => {
+        renderWithEditOpen();
+        // Nothing to route to → no picker at all, rather than an empty one.
+        expect(screen.queryByTestId('meeting-edit-work')).toBeNull();
+
+        cleanup();
+        renderWithEditOpen(mkMeeting(), [{ id: 'work-1', name: 'Cats Directory' }]);
+        const picker = screen.getByTestId('meeting-edit-work');
+        // An org-wide meeting shows the "no Work" row as the current value.
+        expect(picker.textContent).toContain('fields.workNone');
+    });
+
     it('seeds the roster textarea from the stored participants', () => {
-        render(
-            <MeetingDetailClient
-                meeting={mkMeeting({
-                    participants: [
-                        { name: 'Ada Lovelace', email: 'ada@example.com' },
-                        { name: 'Grace Hopper' },
-                    ],
-                })}
-            />,
+        renderWithEditOpen(
+            mkMeeting({
+                participants: [
+                    { name: 'Ada Lovelace', email: 'ada@example.com' },
+                    { name: 'Grace Hopper' },
+                ],
+            }),
         );
         // formatParticipants is the exact inverse of the capture form's parser.
         expect((screen.getByTestId('meeting-edit-participants') as HTMLTextAreaElement).value).toBe(
@@ -184,7 +233,7 @@ describe('MeetingDetailClient — edit panel', () => {
 
     it('patches startedAt and participants — the two fields the UI could not edit before', async () => {
         updateMock.mockResolvedValueOnce(mkMeeting());
-        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        renderWithEditOpen();
 
         fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
             target: { value: LOCAL_START },
@@ -210,11 +259,7 @@ describe('MeetingDetailClient — edit panel', () => {
 
     it('an emptied roster patches an empty array rather than skipping the field', async () => {
         updateMock.mockResolvedValueOnce(mkMeeting());
-        render(
-            <MeetingDetailClient
-                meeting={mkMeeting({ participants: [{ name: 'Ada Lovelace' }] })}
-            />,
-        );
+        renderWithEditOpen(mkMeeting({ participants: [{ name: 'Ada Lovelace' }] }));
 
         fireEvent.change(screen.getByTestId('meeting-edit-participants'), {
             target: { value: '   \n  ' },
@@ -230,7 +275,7 @@ describe('MeetingDetailClient — edit panel', () => {
     });
 
     it('refuses to save with an emptied start time (the API requires one)', () => {
-        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        renderWithEditOpen();
         fireEvent.change(screen.getByTestId('meeting-edit-started-at'), { target: { value: '' } });
         fireEvent.click(screen.getByTestId('meeting-save'));
 
@@ -239,7 +284,7 @@ describe('MeetingDetailClient — edit panel', () => {
     });
 
     it('refuses to save a title that is only whitespace', () => {
-        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        renderWithEditOpen();
         fireEvent.change(screen.getByLabelText('fields.title'), { target: { value: '   ' } });
         fireEvent.click(screen.getByTestId('meeting-save'));
 
@@ -248,7 +293,7 @@ describe('MeetingDetailClient — edit panel', () => {
     });
 
     it('rejects an end time before the start time', () => {
-        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        renderWithEditOpen();
         fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
             target: { value: LOCAL_END },
         });
@@ -266,7 +311,7 @@ describe('MeetingDetailClient — edit panel', () => {
         // validating the new end against the PERSISTED start would too, but
         // validating a new *earlier* pair proves the draft is what counts.
         updateMock.mockResolvedValueOnce(mkMeeting());
-        render(<MeetingDetailClient meeting={mkMeeting({ endedAt: LOCAL_END_ISO })} />);
+        renderWithEditOpen(mkMeeting({ endedAt: LOCAL_END_ISO }));
 
         fireEvent.change(screen.getByTestId('meeting-edit-started-at'), {
             target: { value: '2026-05-24T07:00' },
@@ -290,11 +335,7 @@ describe('MeetingDetailClient — edit panel', () => {
 
     it('clears sourceUrl and workId with an explicit null so the API patches them', async () => {
         updateMock.mockResolvedValueOnce(mkMeeting());
-        render(
-            <MeetingDetailClient
-                meeting={mkMeeting({ sourceUrl: 'https://example.com/rec/1', workId: 'work-1' })}
-            />,
-        );
+        renderWithEditOpen(mkMeeting({ sourceUrl: 'https://example.com/rec/1', workId: 'work-1' }));
 
         fireEvent.change(screen.getByLabelText('fields.sourceUrl'), { target: { value: '  ' } });
         fireEvent.click(screen.getByTestId('meeting-save'));

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -426,6 +426,115 @@ describe('MeetingDetailClient — edit dialog', () => {
     });
 });
 
+describe('MeetingDetailClient — quick-add participant', () => {
+    /** Open the Details rail's inline add form and return its name input. */
+    function openQuickAdd(): HTMLInputElement {
+        fireEvent.click(screen.getByTestId('meeting-participant-quick-add-open'));
+        return screen.getByTestId('meeting-participant-quick-add-name') as HTMLInputElement;
+    }
+
+    it('appends to the stored roster instead of replacing it', async () => {
+        updateMock.mockResolvedValueOnce(
+            mkMeeting({ participants: [{ name: 'Ada Lovelace' }, { name: 'Alan Turing' }] }),
+        );
+        render(
+            <MeetingDetailClient
+                meeting={mkMeeting({ participants: [{ name: 'Ada Lovelace' }] })}
+            />,
+        );
+
+        fireEvent.change(openQuickAdd(), { target: { value: 'Alan Turing' } });
+        fireEvent.click(screen.getByTestId('meeting-participant-quick-add-submit'));
+
+        // Only `participants` is patched: a quick add must not carry some
+        // other field along with it.
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith('mtg-1', {
+                participants: [{ name: 'Ada Lovelace' }, { name: 'Alan Turing' }],
+            }),
+        );
+        expect(await screen.findByText('Alan Turing')).toBeTruthy();
+    });
+
+    it('closes and clears once the person has landed', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting({ participants: [{ name: 'Ada Lovelace' }] }));
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        fireEvent.change(openQuickAdd(), { target: { value: 'Ada Lovelace' } });
+        fireEvent.click(screen.getByTestId('meeting-participant-quick-add-submit'));
+
+        await waitFor(() =>
+            expect(screen.queryByTestId('meeting-participant-quick-add')).toBeNull(),
+        );
+        expect(screen.getByTestId('meeting-participant-quick-add-open')).toBeTruthy();
+    });
+
+    it('sends the address as the name when only an address is given', async () => {
+        updateMock.mockResolvedValueOnce(mkMeeting());
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        openQuickAdd();
+        fireEvent.change(screen.getByTestId('meeting-participant-quick-add-email'), {
+            target: { value: 'ada@example.com' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-participant-quick-add-submit'));
+
+        await waitFor(() =>
+            expect(updateMock).toHaveBeenCalledWith('mtg-1', {
+                participants: [{ name: 'ada@example.com', email: 'ada@example.com' }],
+            }),
+        );
+    });
+
+    it('refuses a malformed address and keeps what was typed', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+
+        fireEvent.change(openQuickAdd(), { target: { value: 'Ada' } });
+        fireEvent.change(screen.getByTestId('meeting-participant-quick-add-email'), {
+            target: { value: 'ada@' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-participant-quick-add-submit'));
+
+        expect(updateMock).not.toHaveBeenCalled();
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.participantEmailInvalid');
+        // The fix is one keystroke — the form must not throw the entry away.
+        const name = screen.getByTestId('meeting-participant-quick-add-name') as HTMLInputElement;
+        expect(name.value).toBe('Ada');
+    });
+
+    it('refuses someone already on the list', () => {
+        render(
+            <MeetingDetailClient
+                meeting={mkMeeting({
+                    participants: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+                })}
+            />,
+        );
+
+        openQuickAdd();
+        fireEvent.change(screen.getByTestId('meeting-participant-quick-add-email'), {
+            // Same person, different casing.
+            target: { value: 'ADA@example.com' },
+        });
+        fireEvent.click(screen.getByTestId('meeting-participant-quick-add-submit'));
+
+        expect(updateMock).not.toHaveBeenCalled();
+        expect(toastErrorMock).toHaveBeenCalledWith('errors.participantDuplicate');
+    });
+
+    it('cannot submit an empty form', () => {
+        render(<MeetingDetailClient meeting={mkMeeting()} />);
+        openQuickAdd();
+
+        const submit = screen.getByTestId(
+            'meeting-participant-quick-add-submit',
+        ) as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        fireEvent.click(submit);
+        expect(updateMock).not.toHaveBeenCalled();
+    });
+});
+
 /** A meeting whose transcript has already landed. */
 const STORED = 'Ada: the gate is green.';
 

--- a/apps/web/src/components/meetings/MeetingForm.tsx
+++ b/apps/web/src/components/meetings/MeetingForm.tsx
@@ -20,8 +20,11 @@ import {
     type MeetingSource,
 } from '@/lib/api/meetings.shared';
 import type { MeetingWorkOption } from './MeetingsList';
-import { localInputToIso } from './meeting-ui';
+import { localInputToIso, sourceIconMap } from './meeting-ui';
 import { createMeetingAction } from './actions';
+
+/** Stable across renders — the marks never depend on form state. */
+const SOURCE_ICONS = sourceIconMap(MEETING_CREATABLE_SOURCES);
 
 const sectionCard =
     'rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4';
@@ -210,9 +213,10 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                             value={source}
                             onValueChange={(v) => setSource(v as MeetingSource)}
                             data-testid="meeting-source-select"
+                            iconMap={SOURCE_ICONS}
                         >
                             {MEETING_CREATABLE_SOURCES.map((s) => (
-                                <option key={s} value={s}>
+                                <option key={s} value={s} data-icon={s}>
                                     {t(`sources.${s}`)}
                                 </option>
                             ))}

--- a/apps/web/src/components/meetings/MeetingForm.tsx
+++ b/apps/web/src/components/meetings/MeetingForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { ChevronLeft, Video } from 'lucide-react';
+import { ChevronLeft, Folder, Video } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Link, useRouter } from '@/i18n/navigation';
@@ -16,11 +16,15 @@ import {
     MEETING_SOURCE_URL_MAX_CHARS,
     MEETING_TITLE_MAX_CHARS,
     MEETING_TRANSCRIPT_MAX_CHARS,
-    parseParticipants,
     type MeetingSource,
 } from '@/lib/api/meetings.shared';
 import type { MeetingWorkOption } from './MeetingsList';
 import { localInputToIso, sourceIconMap } from './meeting-ui';
+import {
+    MeetingParticipantsEditor,
+    participantsFromRows,
+    type ParticipantRow,
+} from './MeetingParticipantsEditor';
 import { createMeetingAction } from './actions';
 
 /** Stable across renders — the marks never depend on form state. */
@@ -31,8 +35,11 @@ const sectionCard =
 
 const fieldLabel = 'block text-xs font-medium text-text dark:text-text-dark mb-2';
 
+// `text-xs` throughout, matching the detail page's edit dialog: one type
+// size across every control (Inputs, both pickers at `size="xs"`, the two
+// textareas) rather than `text-sm` fields above `text-xs` textareas.
 const dateInput = cn(
-    'w-full text-sm rounded-lg transition-colors outline-none px-4 py-2',
+    'w-full text-xs rounded-lg transition-colors outline-none px-4 py-2',
     'bg-card dark:bg-card-primary-dark',
     'border border-card-border dark:border-white/9',
     'text-text dark:text-text-dark',
@@ -66,7 +73,7 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
     const [workId, setWorkId] = useState('');
     const [sourceUrl, setSourceUrl] = useState('');
     const [externalId, setExternalId] = useState('');
-    const [participantsText, setParticipantsText] = useState('');
+    const [participantRows, setParticipantRows] = useState<ParticipantRow[]>([]);
     const [transcriptText, setTranscriptText] = useState('');
 
     const submit = () => {
@@ -99,7 +106,15 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
             endedIso = parsed;
         }
 
-        const participants = parseParticipants(participantsText);
+        // Malformed addresses are caught here rather than at the API, so the
+        // message names the typo instead of surfacing a 400 — same guard the
+        // detail page's edit dialog runs.
+        const { participants, invalidEmail } = participantsFromRows(participantRows);
+        if (invalidEmail) {
+            toast.error(t('errors.participantEmailInvalid'));
+            return;
+        }
+
         const trimmedTranscript = transcriptText.trim();
 
         startSubmit(async () => {
@@ -167,6 +182,7 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                     onChange={(e) => setTitle(e.target.value)}
                     maxLength={MEETING_TITLE_MAX_CHARS}
                     placeholder={t('fields.titlePlaceholder')}
+                    className="text-xs"
                 />
                 <div className="grid gap-4 @lg/main:grid-cols-2">
                     <div>
@@ -212,6 +228,7 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                         <Select
                             value={source}
                             onValueChange={(v) => setSource(v as MeetingSource)}
+                            size="xs"
                             data-testid="meeting-source-select"
                             iconMap={SOURCE_ICONS}
                         >
@@ -224,15 +241,27 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                     </div>
                     <div>
                         <label className={fieldLabel}>{t('fields.work')}</label>
+                        {/* `data-icon` on every option (the org-wide row
+                            included) keeps the folder in the trigger whatever
+                            is selected, rather than letting it appear and
+                            vanish with the choice — as on the edit dialog. */}
                         <Select
                             value={workId}
                             onValueChange={setWorkId}
                             placeholder={t('fields.workNone')}
+                            size="xs"
                             data-testid="meeting-work-select"
+                            iconMap={{
+                                work: (
+                                    <Folder className="h-3.5 w-3.5 text-text-muted dark:text-text-muted-dark" />
+                                ),
+                            }}
                         >
-                            <option value="">{t('fields.workNone')}</option>
+                            <option value="" data-icon="work">
+                                {t('fields.workNone')}
+                            </option>
                             {works.map((work) => (
-                                <option key={work.id} value={work.id}>
+                                <option key={work.id} value={work.id} data-icon="work">
                                     {work.name}
                                 </option>
                             ))}
@@ -248,6 +277,7 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                     onChange={(e) => setSourceUrl(e.target.value)}
                     maxLength={MEETING_SOURCE_URL_MAX_CHARS}
                     placeholder="https://example.com/recordings/123"
+                    className="text-xs"
                 />
                 <Input
                     label={t('fields.externalId')}
@@ -255,31 +285,23 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                     onChange={(e) => setExternalId(e.target.value)}
                     maxLength={MEETING_EXTERNAL_ID_MAX_CHARS}
                     helperText={t('fields.externalIdHint')}
+                    className="text-xs"
                 />
             </section>
 
-            {/* Roster */}
+            {/* Roster — rows, not `Name <email>` syntax in a textarea. The
+                capture form was the last surface still teaching that format;
+                it now authors the roster exactly the way the detail page's
+                edit dialog does, so there is one way to name a participant.
+                The editor carries its own label and count, so the section
+                needs no heading of its own. */}
             <section className={sectionCard}>
-                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
-                    {t('sections.participants')}
-                </h2>
-                <div>
-                    <label className={fieldLabel} htmlFor="meeting-participants">
-                        {t('fields.participants')}
-                    </label>
-                    <Textarea
-                        id="meeting-participants"
-                        data-testid="meeting-participants-input"
-                        value={participantsText}
-                        onChange={(e) => setParticipantsText(e.target.value)}
-                        rows={4}
-                        placeholder={'Ada Lovelace <ada@example.com>\nGrace Hopper'}
-                        className="font-mono text-xs"
-                    />
-                    <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
-                        {t('fields.participantsHint')}
-                    </p>
-                </div>
+                <MeetingParticipantsEditor
+                    label={t('fields.participants')}
+                    rows={participantRows}
+                    onChange={setParticipantRows}
+                    disabled={pending}
+                />
             </section>
 
             {/* Transcript */}
@@ -307,18 +329,21 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                 </div>
             </section>
 
-            <div className="flex items-center gap-2">
+            {/* Cancel then submit, secondary beside primary — the pairing the
+                edit dialog's footer uses, so the two forms end the same way. */}
+            <div className="flex items-center justify-end gap-2">
+                <Button href="/meetings" variant="secondary" size="sm">
+                    {t('actions.cancel')}
+                </Button>
                 <Button
                     onClick={submit}
                     loading={pending}
                     disabled={pending}
-                    size="md"
+                    variant="primary"
+                    size="sm"
                     data-testid="meeting-create-submit"
                 >
                     {t('actions.create')}
-                </Button>
-                <Button href="/meetings" variant="ghost" size="md">
-                    {t('actions.cancel')}
                 </Button>
             </div>
         </div>

--- a/apps/web/src/components/meetings/MeetingParticipantQuickAdd.tsx
+++ b/apps/web/src/components/meetings/MeetingParticipantQuickAdd.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils/cn';
+import {
+    MEETING_PARTICIPANT_EMAIL_MAX_CHARS,
+    MEETING_PARTICIPANT_NAME_MAX_CHARS,
+} from '@/lib/api/meetings.shared';
+
+/**
+ * Neutral focus for the two fields.
+ *
+ * `Input` focuses to the primary accent, which is the same blue as the
+ * dialog's Add button — the field then competed with the one control that
+ * should own the accent. The ring stays (focus has to be visible), it just
+ * takes a border-weight colour instead of the brand one.
+ */
+const NEUTRAL_FIELD = cn(
+    'text-xs',
+    'focus:border-border-secondary focus:ring-border/40',
+    'dark:focus:border-white/20 dark:focus:ring-white/10',
+);
+
+/**
+ * Meetings — add one person to the roster from the `/meetings/:id` Details
+ * rail.
+ *
+ * Naming somebody who was in the room is the roster edit that actually
+ * happens, and it used to cost the whole Edit dialog: open it, scroll past
+ * the title, times, link and Work picker, add a row, save every field back.
+ * This adds the one person without touching anything else on the record.
+ *
+ * It stays deliberately narrow. Renaming, correcting or removing someone
+ * still belongs to the dialog's row editor — this is the append case only,
+ * so there is one obvious place to do the fiddly work and one fast path
+ * for the common one.
+ *
+ * The form is a dialog rather than an inline panel: the rail is the page's
+ * narrow column, and two fields opened inside it pushed the provenance
+ * rows around every time somebody reached for the button.
+ */
+
+export function MeetingParticipantQuickAdd({
+    onAdd,
+    pending,
+    atCapacity,
+}: {
+    /** Resolves true when the person landed, so the form can clear itself. */
+    onAdd: (name: string, email: string) => Promise<boolean>;
+    pending: boolean;
+    atCapacity: boolean;
+}) {
+    const t = useTranslations('dashboard.meetingDetail');
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [email, setEmail] = useState('');
+
+    const close = () => {
+        // A request is already in flight for this roster; dismissing the
+        // form would leave the reader with no sign of what it did.
+        if (pending) return;
+        setOpen(false);
+        setName('');
+        setEmail('');
+    };
+
+    // Both fields blank is not an error, just nothing to add — the control
+    // is simply unavailable until there is something to send.
+    const hasSomething = name.trim().length > 0 || email.trim().length > 0;
+
+    const submit = async () => {
+        if (!hasSomething || pending) return;
+        const added = await onAdd(name, email);
+        // A refusal keeps the dialog open holding what was typed: the fix
+        // for a mistyped address is one keystroke, not a re-entry.
+        if (added) close();
+    };
+
+    const onFieldKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            void submit();
+        }
+    };
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setOpen(true)}
+                disabled={atCapacity}
+                data-testid="meeting-participant-quick-add-open"
+                className={cn(
+                    'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md border px-1.5 py-0.5',
+                    'text-[11px] font-medium transition-colors',
+                    'border-transparent text-text-muted dark:text-text-muted-dark',
+                    'hover:border-info/30 hover:bg-info/10 hover:text-info',
+                    'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-transparent disabled:hover:bg-transparent disabled:hover:text-text-muted',
+                )}
+            >
+                <Plus className="h-3 w-3 shrink-0" />
+                {t('fields.participantAdd')}
+            </button>
+
+            <Dialog open={open} onOpenChange={(next) => (next ? setOpen(true) : close())}>
+                <DialogContent className="max-w-sm">
+                    <DialogClose onClose={close} />
+                    <DialogHeader>
+                        <DialogTitle className="text-base font-semibold text-text dark:text-text-dark">
+                            {t('fields.participantAdd')}
+                        </DialogTitle>
+                    </DialogHeader>
+
+                    {/* The shared Input, at the same `text-xs` the edit
+                        dialog's fields use, so a participant is authored in
+                        the same field the rest of the record is — minus the
+                        accent, see NEUTRAL_FIELD. */}
+                    <div className="space-y-4" data-testid="meeting-participant-quick-add">
+                        <Input
+                            autoFocus
+                            label={t('fields.participantName')}
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            onKeyDown={onFieldKeyDown}
+                            disabled={pending}
+                            maxLength={MEETING_PARTICIPANT_NAME_MAX_CHARS}
+                            data-testid="meeting-participant-quick-add-name"
+                            className={NEUTRAL_FIELD}
+                        />
+                        <Input
+                            type="email"
+                            label={t('fields.participantEmail')}
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            onKeyDown={onFieldKeyDown}
+                            disabled={pending}
+                            maxLength={MEETING_PARTICIPANT_EMAIL_MAX_CHARS}
+                            placeholder="ada@example.com"
+                            data-testid="meeting-participant-quick-add-email"
+                            className={NEUTRAL_FIELD}
+                        />
+                    </div>
+
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            disabled={pending}
+                            onClick={close}
+                            data-testid="meeting-participant-quick-add-cancel"
+                        >
+                            {t('actions.cancel')}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="primary"
+                            size="sm"
+                            disabled={!hasSomething}
+                            loading={pending}
+                            onClick={submit}
+                            data-testid="meeting-participant-quick-add-submit"
+                        >
+                            {t('fields.participantAdd')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingParticipantsEditor.tsx
+++ b/apps/web/src/components/meetings/MeetingParticipantsEditor.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useRef } from 'react';
+import { Mail, Plus, User, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import {
+    MEETING_PARTICIPANTS_MAX,
+    MEETING_PARTICIPANT_EMAIL_MAX_CHARS,
+    MEETING_PARTICIPANT_NAME_MAX_CHARS,
+    isLikelyEmail,
+    type MeetingParticipant,
+} from '@/lib/api/meetings.shared';
+
+/**
+ * Meetings — the roster editor in the `/meetings/[id]` edit dialog.
+ *
+ * The roster used to be a raw textarea holding the whole list in
+ * `Name <email>` syntax, which put three avoidable traps in front of the
+ * user: a format to learn, no way to drop one person without finding and
+ * deleting their line, and a single stray Ctrl+A away from wiping the
+ * roster by accident. Here each participant is a row you can edit and
+ * remove on its own, and the two fields are labelled rather than encoded.
+ *
+ * What it does NOT change is the write: the meeting's roster is a
+ * `simple-json` column, so `PATCH` replaces the whole array either way
+ * (see `meetings.service.ts`). The rows are simply a better way to author
+ * that array.
+ */
+
+/**
+ * A row being edited. `key` is a render identity only — it is never
+ * persisted. Participants have no server-side id (they are not rows in a
+ * join table), so the array index cannot serve: removing the first of
+ * three would re-key the other two and React would carry the wrong text
+ * into the wrong input.
+ */
+export interface ParticipantRow {
+    key: string;
+    name: string;
+    email: string;
+}
+
+let rowSeq = 0;
+
+/** Fresh render identity. Monotonic per page load; never persisted. */
+export function newParticipantRow(name = '', email = ''): ParticipantRow {
+    rowSeq += 1;
+    return { key: `participant-${rowSeq}`, name, email };
+}
+
+/** Seed the editor from a stored roster. */
+export function participantRowsFrom(participants: MeetingParticipant[]): ParticipantRow[] {
+    return participants.map((p) => newParticipantRow(p.name, p.email ?? ''));
+}
+
+/**
+ * Collapse the rows back into the array `PATCH /meetings/:id` accepts.
+ *
+ * Wholly blank rows are dropped rather than rejected — an empty row is
+ * what "Add participant" produces, so leaving one unused must not block
+ * a save. A row with only an address takes the address as its name,
+ * matching what `parseParticipants` does with a bare e-mail line.
+ *
+ * Returns the first malformed address instead of throwing, so the caller
+ * can name it in the error it shows.
+ */
+export function participantsFromRows(rows: ParticipantRow[]): {
+    participants: MeetingParticipant[];
+    invalidEmail: string | null;
+} {
+    const participants: MeetingParticipant[] = [];
+
+    for (const row of rows) {
+        const name = row.name.trim();
+        const email = row.email.trim();
+        if (!name && !email) continue;
+        if (email && !isLikelyEmail(email)) return { participants: [], invalidEmail: email };
+
+        const entry: MeetingParticipant = {
+            name: (name || email).slice(0, MEETING_PARTICIPANT_NAME_MAX_CHARS),
+        };
+        if (email) entry.email = email.slice(0, MEETING_PARTICIPANT_EMAIL_MAX_CHARS);
+        participants.push(entry);
+    }
+
+    return { participants: participants.slice(0, MEETING_PARTICIPANTS_MAX), invalidEmail: null };
+}
+
+const rowInput = cn(
+    'w-full rounded-lg py-1.5 pl-7 pr-2 text-xs transition-colors outline-none',
+    'bg-card dark:bg-card-primary-dark',
+    'border border-card-border dark:border-white/9',
+    'text-text dark:text-text-dark placeholder-text-muted dark:placeholder-text-muted-dark',
+    'focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20',
+);
+
+const rowIcon =
+    'pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-muted dark:text-text-muted-dark';
+
+export function MeetingParticipantsEditor({
+    label,
+    rows,
+    onChange,
+    disabled = false,
+}: {
+    label: string;
+    rows: ParticipantRow[];
+    onChange: (rows: ParticipantRow[]) => void;
+    disabled?: boolean;
+}) {
+    const t = useTranslations('dashboard.meetingDetail');
+
+    /**
+     * Row to focus on the next render, consumed by the name input's ref
+     * callback. A ref rather than state: focusing is a one-shot DOM side
+     * effect, and routing it through state would re-render the list for
+     * something no pixel depends on.
+     */
+    const focusRowRef = useRef<string | null>(null);
+
+    const atCapacity = rows.length >= MEETING_PARTICIPANTS_MAX;
+
+    const addRow = () => {
+        if (atCapacity) return;
+        const row = newParticipantRow();
+        focusRowRef.current = row.key;
+        onChange([...rows, row]);
+    };
+
+    const removeRow = (key: string) => onChange(rows.filter((row) => row.key !== key));
+
+    const patchRow = (key: string, patch: Partial<Omit<ParticipantRow, 'key'>>) =>
+        onChange(rows.map((row) => (row.key === key ? { ...row, ...patch } : row)));
+
+    return (
+        <div data-testid="meeting-edit-participants">
+            <div className="mb-2 flex items-baseline justify-between gap-3">
+                <span className="text-xs font-medium text-text dark:text-text-dark">{label}</span>
+                {/* Pure numerals — nothing to translate, and the cap only
+                    becomes interesting as you approach it. */}
+                <span
+                    className={cn(
+                        'text-[11px] tabular-nums',
+                        atCapacity
+                            ? 'font-medium text-danger'
+                            : 'text-text-muted dark:text-text-muted-dark',
+                    )}
+                    data-testid="meeting-edit-participants-count"
+                >
+                    {rows.length}/{MEETING_PARTICIPANTS_MAX}
+                </span>
+            </div>
+
+            {rows.length > 0 ? (
+                <ul className="space-y-2">
+                    {rows.map((row) => (
+                        <li key={row.key} className="flex items-center gap-2">
+                            <div className="relative min-w-0 flex-1">
+                                <User className={rowIcon} aria-hidden="true" />
+                                <input
+                                    ref={(node) => {
+                                        if (node && focusRowRef.current === row.key) {
+                                            focusRowRef.current = null;
+                                            node.focus();
+                                        }
+                                    }}
+                                    value={row.name}
+                                    onChange={(e) => patchRow(row.key, { name: e.target.value })}
+                                    disabled={disabled}
+                                    maxLength={MEETING_PARTICIPANT_NAME_MAX_CHARS}
+                                    placeholder={t('fields.participantName')}
+                                    aria-label={t('fields.participantName')}
+                                    data-testid="meeting-edit-participant-name"
+                                    className={rowInput}
+                                />
+                            </div>
+                            <div className="relative min-w-0 flex-1">
+                                <Mail className={rowIcon} aria-hidden="true" />
+                                <input
+                                    type="email"
+                                    value={row.email}
+                                    onChange={(e) => patchRow(row.key, { email: e.target.value })}
+                                    disabled={disabled}
+                                    maxLength={MEETING_PARTICIPANT_EMAIL_MAX_CHARS}
+                                    placeholder={t('fields.participantEmail')}
+                                    aria-label={t('fields.participantEmail')}
+                                    data-testid="meeting-edit-participant-email"
+                                    className={cn(
+                                        rowInput,
+                                        // Flag the typo in place, but only once
+                                        // there is enough typed to be wrong.
+                                        row.email.trim() &&
+                                            !isLikelyEmail(row.email.trim()) &&
+                                            'border-danger/60 focus:border-danger',
+                                    )}
+                                />
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => removeRow(row.key)}
+                                disabled={disabled}
+                                aria-label={t('fields.participantRemove')}
+                                title={t('fields.participantRemove')}
+                                data-testid="meeting-edit-participant-remove"
+                                className={cn(
+                                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border transition-colors',
+                                    'border-transparent text-text-muted dark:text-text-muted-dark',
+                                    'hover:border-danger/30 hover:bg-danger/10 hover:text-danger',
+                                    'disabled:cursor-not-allowed disabled:opacity-50',
+                                )}
+                            >
+                                <X className="h-3.5 w-3.5" />
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p
+                    className="rounded-lg border border-dashed border-border/70 px-3 py-3 text-center text-xs text-text-muted dark:border-border-dark/70 dark:text-text-muted-dark"
+                    data-testid="meeting-edit-participants-empty"
+                >
+                    {t('fields.participantsEmpty')}
+                </p>
+            )}
+
+            <button
+                type="button"
+                onClick={addRow}
+                disabled={disabled || atCapacity}
+                data-testid="meeting-edit-participant-add"
+                className={cn(
+                    'mt-2 inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium transition-colors',
+                    'text-info hover:bg-info/10',
+                    'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+                )}
+            >
+                <Plus className="h-3.5 w-3.5" />
+                {t('fields.participantAdd')}
+            </button>
+        </div>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingSummary.tsx
+++ b/apps/web/src/components/meetings/MeetingSummary.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import type { ComponentPropsWithoutRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Meeting detail — the stored AI summary of `/meetings/:id`.
+ *
+ * The summary is written as markdown: the prompt asks for a few sentences
+ * of what was discussed and decided, then bullet action items. Rendered as
+ * preformatted text those bullets arrived as literal `-` and `**` on one
+ * flat block, so the part a reader actually scans for — the actions — had
+ * no shape at all.
+ *
+ * Typography is tuned DOWN from the prose defaults: a summary lives inside
+ * a card next to the transcript, so its headings stay near body size and
+ * the outer margins are stripped, leaving the card's own padding to set
+ * the frame.
+ */
+
+const summaryProse = cn(
+    'prose prose-sm max-w-none dark:prose-invert',
+    'text-sm leading-relaxed text-text dark:text-text-dark',
+    // The card's padding owns the outer edge; prose margins would double it.
+    '[&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
+    'prose-p:my-3 prose-p:text-inherit',
+    'prose-headings:mb-2 prose-headings:mt-4 prose-headings:font-semibold prose-headings:text-inherit',
+    // `###` is the section marker the summarizer is asked for, so h3 holds
+    // body size and separates by WEIGHT — a heading smaller than the text
+    // under it reads as a caption, not a section.
+    'prose-h1:text-base prose-h2:text-sm prose-h3:text-sm prose-h4:text-xs',
+    'prose-ul:my-3 prose-ol:my-3 prose-li:my-1 prose-li:text-inherit',
+    'marker:text-text-muted dark:marker:text-text-muted-dark',
+    'prose-strong:font-semibold prose-strong:text-inherit',
+    'prose-a:text-info prose-a:no-underline hover:prose-a:underline',
+    'prose-code:rounded prose-code:bg-black/5 prose-code:px-1 prose-code:py-0.5',
+    'prose-code:text-[11px] prose-code:font-normal dark:prose-code:bg-white/10',
+    "prose-code:before:content-[''] prose-code:after:content-['']",
+    'prose-pre:my-3 prose-pre:rounded-lg prose-pre:bg-surface prose-pre:text-[11px]',
+    'dark:prose-pre:bg-surface-dark',
+    'prose-blockquote:my-3 prose-blockquote:border-l-info/30 prose-blockquote:font-normal',
+    'prose-blockquote:not-italic prose-blockquote:text-text-secondary',
+    'dark:prose-blockquote:text-text-secondary-dark',
+    'prose-hr:my-4 prose-hr:border-border dark:prose-hr:border-border-dark',
+    'prose-table:my-3 prose-table:text-xs',
+    'prose-th:border prose-th:border-border prose-th:bg-surface-secondary/60 prose-th:px-2 prose-th:py-1',
+    'dark:prose-th:border-border-dark dark:prose-th:bg-white/5',
+    'prose-td:border prose-td:border-border prose-td:px-2 prose-td:py-1',
+    'dark:prose-td:border-border-dark',
+);
+
+const remarkPlugins = [remarkGfm];
+
+/** Wide tables scroll inside the card rather than stretching it. */
+function ScrollableTable(props: ComponentPropsWithoutRef<'table'>) {
+    return (
+        <div className="overflow-x-auto">
+            <table className="min-w-full" {...props} />
+        </div>
+    );
+}
+
+/**
+ * Security: the summary is model-written from a transcript a user pasted,
+ * so a link in it is attacker-influenced text. Anything that is not
+ * http(s) — `javascript:` above all — is defused rather than rendered,
+ * and what survives opens without handing the opener over.
+ */
+function SafeAnchor({ href, ...props }: ComponentPropsWithoutRef<'a'>) {
+    const safe = /^https?:/i.test(href ?? '');
+    if (!safe) return <span {...props} />;
+    return <a href={href} target="_blank" rel="noopener noreferrer" {...props} />;
+}
+
+const markdownComponents = {
+    table: ScrollableTable,
+    a: SafeAnchor,
+};
+
+export function MeetingSummary({ text }: { text: string }) {
+    return (
+        <div className={summaryProse} data-testid="meeting-summary-body">
+            <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
+                {text}
+            </ReactMarkdown>
+        </div>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingSummary.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingSummary.unit.spec.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { MeetingSummary } from './MeetingSummary';
+
+/**
+ * MeetingSummary — the stored AI summary on `/meetings/:id`.
+ *
+ * The summarizer prompt asks for a few sentences followed by bullet action
+ * items, so the stored text is markdown. It used to render as preformatted
+ * text, which put the `-` and `**` on screen verbatim. These specs pin that
+ * it is parsed, and that a link inside model-written text cannot smuggle a
+ * script URL onto the page.
+ */
+
+/** The shape the summarizer prompt asks for: a paragraph, then sections. */
+const SUMMARY = [
+    'The team agreed to ship the meetings surface this week.',
+    '',
+    '### Decisions',
+    '',
+    '- Ship behind a **flag** first',
+    '',
+    '### Action items',
+    '',
+    '- Ada to finish the transcript editor',
+    '- Grace to review the migration',
+].join('\n');
+
+describe('MeetingSummary', () => {
+    it('renders action items as a real list rather than literal dashes', () => {
+        render(<MeetingSummary text={SUMMARY} />);
+
+        const items = screen.getAllByRole('listitem');
+        expect(items.map((li) => li.textContent)).toEqual([
+            'Ship behind a flag first',
+            'Ada to finish the transcript editor',
+            'Grace to review the migration',
+        ]);
+        // The syntax itself must not survive into the rendered text.
+        expect(screen.getByTestId('meeting-summary-body').textContent).not.toContain('- Ada');
+    });
+
+    it('gives each section a heading of its own', () => {
+        render(<MeetingSummary text={SUMMARY} />);
+
+        // The summarizer is asked for `###`, so the sections it produces have
+        // to land as real headings a reader (and a screen reader) can scan.
+        expect(screen.getAllByRole('heading').map((h) => h.textContent)).toEqual([
+            'Decisions',
+            'Action items',
+        ]);
+    });
+
+    it('renders emphasis as markup, not asterisks', () => {
+        render(<MeetingSummary text={SUMMARY} />);
+
+        expect(screen.getByText('flag').tagName).toBe('STRONG');
+        expect(screen.getByTestId('meeting-summary-body').textContent).not.toContain('**');
+    });
+
+    it('keeps the prose in a paragraph so the card controls the rhythm', () => {
+        render(<MeetingSummary text={SUMMARY} />);
+
+        const body = screen.getByTestId('meeting-summary-body');
+        expect(body.querySelector('p')?.textContent).toBe(
+            'The team agreed to ship the meetings surface this week.',
+        );
+    });
+
+    it('opens an http link in a new tab without handing over the opener', () => {
+        render(<MeetingSummary text={'See [the notes](https://example.com/notes).'} />);
+
+        const link = screen.getByRole('link', { name: 'the notes' });
+        expect(link.getAttribute('href')).toBe('https://example.com/notes');
+        expect(link.getAttribute('rel')).toContain('noopener');
+        expect(link.getAttribute('target')).toBe('_blank');
+    });
+
+    it('defuses a script URL instead of rendering it as a link', () => {
+        // The summary is model-written from user-pasted text, so a link in it
+        // is attacker-influenced: the label survives, the protocol does not.
+        render(<MeetingSummary text={'[click me](javascript:alert(1))'} />);
+
+        expect(screen.queryByRole('link')).toBeNull();
+        expect(screen.getByText('click me')).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/meetings/MeetingSummaryGenerating.tsx
+++ b/apps/web/src/components/meetings/MeetingSummaryGenerating.tsx
@@ -3,29 +3,6 @@
 import { useTranslations } from 'next-intl';
 import { ShinyText } from '@/components/ui/ShinyText';
 
-/**
- * Meeting detail — the "the summary is being written" state of the
- * `/meetings/:id` Summary card.
- *
- * Attaching a transcript is a single opaque round trip: the API stores the
- * text, then runs the best-effort fan-out (AI summary → Memory observation →
- * activity envelope) and answers once. There is no percentage to report and
- * no stage to poll, so nothing here pretends otherwise — the panel says
- * "still working" with a shimmering stand-in for the paragraph that is
- * coming, and an indeterminate bar.
- *
- * The skeleton lines sit exactly where the summary paragraph will land, at
- * the same rhythm, so the finished text resolves into the shape the reader
- * has already been looking at rather than displacing it.
- *
- * Motion lives in CSS (`ms-summary-*` in `globals.css`) — no JS timers after
- * mount, and the whole panel goes still under `prefers-reduced-motion`.
- */
-
-/**
- * Widths of the stand-in lines, in the ragged pattern a short paragraph
- * actually makes — an even stack of equal bars reads as a table, not prose.
- */
 const SKELETON_LINES = ['100%', '94%', '82%', '58%'] as const;
 
 export function MeetingSummaryGenerating() {
@@ -64,17 +41,6 @@ export function MeetingSummaryGenerating() {
                         <span className="gp-shimmer" style={{ animationDelay: `${i * 0.18}s` }} />
                     </div>
                 ))}
-            </div>
-
-            <div
-                className="relative h-0.75 overflow-hidden rounded-full"
-                style={{ background: 'var(--gp-bar-track)' }}
-                aria-hidden
-            >
-                <div
-                    className="ms-summary-slide absolute inset-y-0 left-0 w-1/3 rounded-full"
-                    style={{ background: 'var(--gp-bar-fill)' }}
-                />
             </div>
         </div>
     );

--- a/apps/web/src/components/meetings/MeetingSummaryGenerating.tsx
+++ b/apps/web/src/components/meetings/MeetingSummaryGenerating.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { ShinyText } from '@/components/ui/ShinyText';
+
+/**
+ * Meeting detail — the "the summary is being written" state of the
+ * `/meetings/:id` Summary card.
+ *
+ * Attaching a transcript is a single opaque round trip: the API stores the
+ * text, then runs the best-effort fan-out (AI summary → Memory observation →
+ * activity envelope) and answers once. There is no percentage to report and
+ * no stage to poll, so nothing here pretends otherwise — the panel says
+ * "still working" with a shimmering stand-in for the paragraph that is
+ * coming, and an indeterminate bar.
+ *
+ * The skeleton lines sit exactly where the summary paragraph will land, at
+ * the same rhythm, so the finished text resolves into the shape the reader
+ * has already been looking at rather than displacing it.
+ *
+ * Motion lives in CSS (`ms-summary-*` in `globals.css`) — no JS timers after
+ * mount, and the whole panel goes still under `prefers-reduced-motion`.
+ */
+
+/**
+ * Widths of the stand-in lines, in the ragged pattern a short paragraph
+ * actually makes — an even stack of equal bars reads as a table, not prose.
+ */
+const SKELETON_LINES = ['100%', '94%', '82%', '58%'] as const;
+
+export function MeetingSummaryGenerating() {
+    const t = useTranslations('dashboard.meetingDetail');
+
+    return (
+        <div
+            // `status` + polite: the summary arriving is worth announcing,
+            // but never worth interrupting whatever the reader is doing.
+            role="status"
+            aria-live="polite"
+            data-testid="meeting-summary-generating"
+            className="ms-summary-generating space-y-4"
+        >
+            <div className="min-w-0">
+                <ShinyText
+                    text={t('summary.generating')}
+                    className="block text-sm font-medium"
+                    duration={2}
+                    stagger={0.04}
+                />
+                <p className="mt-1 text-[11px] text-text-muted dark:text-text-muted-dark">
+                    {t('summary.generatingHint')}
+                </p>
+            </div>
+
+            {/* Decorative: the label above already carries the state for
+                assistive tech, so the stand-in prose is hidden from it. */}
+            <div className="space-y-2.5" aria-hidden>
+                {SKELETON_LINES.map((width, i) => (
+                    <div
+                        key={width}
+                        className="ms-summary-line h-2.5"
+                        style={{ width, animationDelay: `${i * 0.18}s` }}
+                    >
+                        <span className="gp-shimmer" style={{ animationDelay: `${i * 0.18}s` }} />
+                    </div>
+                ))}
+            </div>
+
+            <div
+                className="relative h-0.75 overflow-hidden rounded-full"
+                style={{ background: 'var(--gp-bar-track)' }}
+                aria-hidden
+            >
+                <div
+                    className="ms-summary-slide absolute inset-y-0 left-0 w-1/3 rounded-full"
+                    style={{ background: 'var(--gp-bar-fill)' }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/meetings/MeetingsList.tsx
+++ b/apps/web/src/components/meetings/MeetingsList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Plus, Video } from 'lucide-react';
+import { ListFilter, Plus, Video } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Select } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
@@ -10,6 +10,23 @@ import { PageHeader } from '@/components/common/PageHeader';
 import { MEETING_SOURCES, type MeetingSource } from '@/lib/api/meetings.shared';
 import type { Meeting } from '@/lib/api/meetings';
 import { MeetingCard } from './MeetingCard';
+import { sourceIconMap } from './meeting-ui';
+
+/**
+ * The same marks the cards carry, plus a neutral one for "Any source" —
+ * without it the trigger would lose its icon (and shift) whenever the
+ * filter is cleared.
+ */
+const SOURCE_FILTER_ICONS = {
+    ...sourceIconMap(MEETING_SOURCES),
+    any: (
+        <ListFilter
+            aria-hidden="true"
+            strokeWidth={1.75}
+            className="h-3.5 w-3.5 shrink-0 text-text-muted dark:text-text-muted-dark"
+        />
+    ),
+};
 
 /** Minimal Work reference used by the "routed to" filter. */
 export interface MeetingWorkOption {
@@ -106,10 +123,13 @@ export function MeetingsList({
                         placeholder={t('filterBar.anySource')}
                         size="xs"
                         data-testid="meetings-source-filter"
+                        iconMap={SOURCE_FILTER_ICONS}
                     >
-                        <option value="">{t('filterBar.anySource')}</option>
+                        <option value="" data-icon="any">
+                            {t('filterBar.anySource')}
+                        </option>
                         {MEETING_SOURCES.map((source) => (
-                            <option key={source} value={source}>
+                            <option key={source} value={source} data-icon={source}>
                                 {t(`sources.${source}`)}
                             </option>
                         ))}

--- a/apps/web/src/components/meetings/index.ts
+++ b/apps/web/src/components/meetings/index.ts
@@ -13,4 +13,6 @@ export {
     formatDuration,
     isoToLocalInput,
     localInputToIso,
+    sourceIconMap,
 } from './meeting-ui';
+export { MeetingSourceIcon } from './meeting-source-icons';

--- a/apps/web/src/components/meetings/meeting-source-icons.tsx
+++ b/apps/web/src/components/meetings/meeting-source-icons.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { CircleDot, Download, PencilLine } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Meetings — the mark for each producing surface, so a meeting's origin
+ * is recognizable before its label is read. Used by the source badge
+ * (list cards + detail page) and by the source pickers (`/meetings/new`,
+ * the `/meetings` filter).
+ *
+ * Same approach (and same caveat) as `ai/dictation-provider-icons`: the
+ * vendor marks are STYLISED shapes in each vendor's signature colour,
+ * NOT the vendors' official trademarked logos, drawn as inlined
+ * theme-agnostic SVGs so a mid-tone badge with a white glyph reads
+ * correctly in light and dark mode without per-theme variants. They can
+ * be swapped for official SVGs later without touching a call site.
+ *
+ * `manual` and `import` are not vendors, so they get neutral lucide
+ * glyphs rather than an invented brand badge — inside the pill they ride
+ * `currentColor` and pick up the badge's own hue.
+ */
+
+interface GlyphProps {
+    /** Rendered pixel size (width === height). */
+    size?: number;
+}
+
+// Shared badge wrapper: a rounded square filled with `color`, `children`
+// is the white glyph drawn on top (coordinates in a 20×20 viewBox).
+function Badge({
+    color,
+    size = 12,
+    children,
+}: GlyphProps & { color: string; children: React.ReactNode }) {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            className="shrink-0"
+        >
+            <rect x="0" y="0" width="20" height="20" rx="5" fill={color} />
+            {children}
+        </svg>
+    );
+}
+
+// Zoom — brand blue; the video camera, body plus lens wedge.
+function ZoomIcon({ size }: GlyphProps) {
+    return (
+        <Badge color="#0B5CFF" size={size}>
+            <g fill="#FFFFFF">
+                <rect x="4.2" y="6.6" width="8" height="6.8" rx="1.8" />
+                <path d="M12.9 8.9 15.8 7v6l-2.9-1.9V8.9Z" />
+            </g>
+        </Badge>
+    );
+}
+
+// Google Meet — brand green; the same camera silhouette, but with the
+// clipped top-right corner the Meet mark is built from, so the two video
+// surfaces stay apart at badge size on colour AND shape.
+function GoogleMeetIcon({ size }: GlyphProps) {
+    return (
+        <Badge color="#00832D" size={size}>
+            <g fill="#FFFFFF">
+                <path d="M4.2 8.2a1.6 1.6 0 0 1 1.6-1.6h4.6l1.8 1.9v3.3l-1.8 1.6H5.8a1.6 1.6 0 0 1-1.6-1.6V8.2Z" />
+                <path d="M13 8.9 15.8 7v6L13 11.1V8.9Z" />
+            </g>
+        </Badge>
+    );
+}
+
+/** Neutral (non-vendor) marks — inherit `currentColor` unless tinted. */
+const NEUTRAL_ICONS = {
+    manual: PencilLine,
+    import: Download,
+} as const;
+
+/** An unrecognized source still gets a mark, just a neutral one. */
+const UNKNOWN_ICON = CircleDot;
+
+const BRAND_ICONS: Record<string, (props: GlyphProps) => React.ReactElement> = {
+    zoom: ZoomIcon,
+    'google-meet': GoogleMeetIcon,
+};
+
+/**
+ * The producing-surface mark on its own — always `aria-hidden`, since
+ * every call site renders the translated source name alongside it.
+ *
+ * `className` tints the neutral glyphs only; the vendor badges carry
+ * their own colour by definition.
+ */
+export function MeetingSourceIcon({
+    source,
+    size = 12,
+    className,
+}: {
+    source: string;
+    size?: number;
+    className?: string;
+}) {
+    const Brand = BRAND_ICONS[source];
+    if (Brand) {
+        return (
+            <span data-testid="meeting-source-icon" className="flex shrink-0 items-center">
+                <Brand size={size} />
+            </span>
+        );
+    }
+
+    const Glyph = NEUTRAL_ICONS[source as keyof typeof NEUTRAL_ICONS] ?? UNKNOWN_ICON;
+    return (
+        <Glyph
+            aria-hidden="true"
+            size={size}
+            strokeWidth={1.9}
+            className={cn('shrink-0', className)}
+            data-testid="meeting-source-icon"
+        />
+    );
+}

--- a/apps/web/src/components/meetings/meeting-source-icons.unit.spec.tsx
+++ b/apps/web/src/components/meetings/meeting-source-icons.unit.spec.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { MeetingSourceIcon } from './meeting-source-icons';
+import { SourceBadge, sourceIconMap } from './meeting-ui';
+import { MEETING_SOURCES } from '@/lib/api/meetings.shared';
+
+/**
+ * Meeting source marks — every producing surface must render one, and the
+ * vendor surfaces must be told apart by more than their label.
+ *
+ * The `Select` primitive only reserves the leading icon column when its
+ * `iconMap` has a hit for the option's `data-icon`, so a source missing
+ * from the map does not merely lose its mark — it pulls that row's label
+ * out of line with the rest of the list. Hence the completeness check.
+ */
+
+/** Fill colours of the badge plate, in document order. */
+function markFills(): string[] {
+    const icon = screen.getByTestId('meeting-source-icon');
+    return Array.from(icon.querySelectorAll('rect[fill], path[fill]')).map(
+        (node) => node.getAttribute('fill') ?? '',
+    );
+}
+
+describe('MeetingSourceIcon', () => {
+    it('renders a mark for every source the API can return', () => {
+        for (const source of MEETING_SOURCES) {
+            const { unmount } = render(<MeetingSourceIcon source={source} />);
+            expect(screen.getByTestId('meeting-source-icon'), source).toBeTruthy();
+            unmount();
+        }
+    });
+
+    it('falls back to a neutral mark for a source it has never seen', () => {
+        // The API's source set is closed today, but a new provider must not
+        // render a hole where the mark goes.
+        render(<MeetingSourceIcon source="teams" />);
+        expect(screen.getByTestId('meeting-source-icon')).toBeTruthy();
+    });
+
+    it('draws zoom and google-meet in their own brand colours', () => {
+        const { unmount } = render(<MeetingSourceIcon source="zoom" />);
+        const zoom = markFills();
+        unmount();
+
+        render(<MeetingSourceIcon source="google-meet" />);
+        const meet = markFills();
+
+        expect(zoom).toContain('#0B5CFF');
+        expect(meet).toContain('#00832D');
+        // Same silhouette family, but never the same plate — the two video
+        // surfaces have to be distinguishable at 12px without reading.
+        expect(zoom).not.toEqual(meet);
+    });
+
+    it('honours the requested size', () => {
+        render(<MeetingSourceIcon source="zoom" size={14} />);
+        const svg = screen.getByTestId('meeting-source-icon').querySelector('svg');
+        expect(svg?.getAttribute('width')).toBe('14');
+    });
+});
+
+describe('SourceBadge', () => {
+    it('shows the mark next to the translated label', () => {
+        render(<SourceBadge source="zoom" />);
+        const badge = screen.getByTestId('meeting-source-badge');
+        expect(badge.querySelector('[data-testid="meeting-source-icon"]')).toBeTruthy();
+        expect(badge.textContent).toContain('sources.zoom');
+    });
+
+    it('still labels an unknown source verbatim, with a mark', () => {
+        render(<SourceBadge source="teams" />);
+        const badge = screen.getByTestId('meeting-source-badge');
+        expect(badge.textContent).toContain('teams');
+        expect(badge.querySelector('[data-testid="meeting-source-icon"]')).toBeTruthy();
+    });
+});
+
+describe('sourceIconMap', () => {
+    it('covers every source the pickers list', () => {
+        const map = sourceIconMap(MEETING_SOURCES);
+        for (const source of MEETING_SOURCES) {
+            expect(map[source], `${source} has no icon`).toBeTruthy();
+        }
+    });
+});

--- a/apps/web/src/components/meetings/meeting-ui.tsx
+++ b/apps/web/src/components/meetings/meeting-ui.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
 import type { MeetingSource } from '@/lib/api/meetings.shared';
+import { MeetingSourceIcon } from './meeting-source-icons';
 
 /**
  * Meetings — shared presentational helpers for the surface (list card +
@@ -22,6 +24,27 @@ const UNKNOWN_SOURCE_STYLE =
 
 /** Sources the UI has a translated label for. */
 const KNOWN_SOURCES: readonly string[] = ['zoom', 'google-meet', 'manual', 'import'];
+
+/**
+ * Build the `iconMap` for a `<Select>` whose `<option>`s declare
+ * `data-icon={source}` — the picker then shows the same marks as the
+ * badges. A select row has no source color of its own, so the neutral
+ * (non-vendor) glyphs are tinted explicitly here; the vendor badges
+ * bring their own.
+ */
+export function sourceIconMap(sources: readonly string[]): Record<string, ReactNode> {
+    return Object.fromEntries(
+        sources.map((source) => [
+            source,
+            <MeetingSourceIcon
+                key={source}
+                source={source}
+                size={14}
+                className="text-text-muted dark:text-text-muted-dark"
+            />,
+        ]),
+    );
+}
 
 /**
  * Format an ISO timestamp for display. Locale/timezone formatting
@@ -106,11 +129,12 @@ export function SourceBadge({ source, className }: { source: string; className?:
         <span
             data-testid="meeting-source-badge"
             className={cn(
-                'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                'inline-flex shrink-0 items-center gap-1 rounded-full border py-0.5 pl-1.5 pr-2 text-[11px] font-medium',
                 SOURCE_STYLES[source] ?? UNKNOWN_SOURCE_STYLE,
                 className,
             )}
         >
+            <MeetingSourceIcon source={source} />
             {known ? t(`sources.${source as MeetingSource}`) : source}
         </span>
     );

--- a/apps/web/src/components/meetings/meetings-messages.unit.spec.ts
+++ b/apps/web/src/components/meetings/meetings-messages.unit.spec.ts
@@ -93,19 +93,20 @@ describe('Meetings messages — ICU syntax', () => {
     }
 
     it('the roster hint still shows the literal Name <email> format after escaping', () => {
+        // Only the CAPTURE form still teaches the syntax: `/meetings/[id]`
+        // edits its roster through a row editor now, so `meetingDetail` has
+        // no hint left to escape.
         const messages = JSON.parse(readFileSync(join(MESSAGES_DIR, 'en.json'), 'utf8'));
-        for (const namespace of ['meetingNew', 'meetingDetail']) {
-            const t = createTranslator({
-                locale: 'en',
-                messages,
-                namespace: `dashboard.${namespace}`,
-                onError: (error) => {
-                    throw error;
-                },
-            });
-            // The escape must survive as literal text — escaping it away
-            // would "fix" the error by deleting the thing the hint teaches.
-            expect(t('fields.participantsHint')).toContain('<email>');
-        }
+        const t = createTranslator({
+            locale: 'en',
+            messages,
+            namespace: 'dashboard.meetingNew',
+            onError: (error) => {
+                throw error;
+            },
+        });
+        // The escape must survive as literal text — escaping it away
+        // would "fix" the error by deleting the thing the hint teaches.
+        expect(t('fields.participantsHint')).toContain('<email>');
     });
 });

--- a/apps/web/src/components/meetings/meetings-messages.unit.spec.ts
+++ b/apps/web/src/components/meetings/meetings-messages.unit.spec.ts
@@ -92,21 +92,20 @@ describe('Meetings messages — ICU syntax', () => {
         });
     }
 
-    it('the roster hint still shows the literal Name <email> format after escaping', () => {
-        // Only the CAPTURE form still teaches the syntax: `/meetings/[id]`
-        // edits its roster through a row editor now, so `meetingDetail` has
-        // no hint left to escape.
-        const messages = JSON.parse(readFileSync(join(MESSAGES_DIR, 'en.json'), 'utf8'));
-        const t = createTranslator({
-            locale: 'en',
-            messages,
-            namespace: 'dashboard.meetingNew',
-            onError: (error) => {
-                throw error;
-            },
-        });
-        // The escape must survive as literal text — escaping it away
-        // would "fix" the error by deleting the thing the hint teaches.
-        expect(t('fields.participantsHint')).toContain('<email>');
+    it('no Meetings message teaches the `Name <email>` syntax any more', () => {
+        // Both roster surfaces author through the row editor now — the
+        // capture form was the last one still explaining the format — so
+        // there is no escaped angle bracket left to protect. The parse
+        // guard above stays: it is what catches the fault class if copy
+        // ever reintroduces one.
+        for (const locale of locales) {
+            const messages = JSON.parse(
+                readFileSync(join(MESSAGES_DIR, `${locale}.json`), 'utf8'),
+            ) as { dashboard: Record<string, Tree> };
+            expect(
+                'participantsHint' in (messages.dashboard.meetingNew as { fields: Tree }).fields,
+                `${locale}: the retired roster syntax hint is back`,
+            ).toBe(false);
+        }
     });
 });

--- a/apps/web/src/components/meetings/meetings-messages.unit.spec.ts
+++ b/apps/web/src/components/meetings/meetings-messages.unit.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { createTranslator } from 'next-intl';
+
+/**
+ * Meetings copy — ICU syntax guard across every locale.
+ *
+ * next-intl parses messages as ICU MessageFormat, where `<foo>` is a
+ * rich-text TAG, not literal text. An unmatched one raises
+ * `INVALID_MESSAGE: UNCLOSED_TAG` and next-intl then renders the message's
+ * own key path in the UI — so `fields.participantsHint` shipped reading
+ * "dashboard.meetingNew.fields.participantsHint" on screen rather than the
+ * hint, in all 21 locales, for as long as the roster hint has existed.
+ *
+ * The roster hint has to show the literal `Name <email>` format the parser
+ * accepts, so the angle bracket is escaped as `'<'`. This spec pins that:
+ * every message on the Meetings surface must survive a real
+ * `createTranslator` round trip.
+ *
+ * Only INVALID_MESSAGE (a SYNTAX fault, wrong in every environment) fails
+ * the spec. Missing-placeholder faults are a caller concern and depend on
+ * the values a component happens to pass, so they are ignored here.
+ */
+
+// Vitest's root is `apps/web` (see vitest.config.ts), so the bundle
+// directory resolves off the cwd rather than import.meta.url — which is
+// not a file: URL under the Vite transform.
+const MESSAGES_DIR = resolve(process.cwd(), 'messages');
+
+/** Every namespace the Meetings surface renders from. */
+const NAMESPACES = ['meetingsPage', 'meetingNew', 'meetingDetail'] as const;
+
+/** Placeholders used anywhere in the Meetings copy. */
+const VALUES = { title: 'A meeting', count: 2, from: 1, to: 10 };
+
+type Tree = { [key: string]: string | Tree };
+
+function leafKeys(node: Tree, prefix = ''): string[] {
+    return Object.entries(node).flatMap(([key, value]) =>
+        typeof value === 'string' ? [prefix + key] : leafKeys(value, `${prefix}${key}.`),
+    );
+}
+
+const locales = readdirSync(MESSAGES_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace('.json', ''))
+    .sort();
+
+describe('Meetings messages — ICU syntax', () => {
+    it('covers every locale bundled in the app', () => {
+        // A guard on the guard: if locales stop being discovered, the suite
+        // below would vacuously pass.
+        expect(locales.length).toBeGreaterThanOrEqual(21);
+        expect(locales).toContain('en');
+    });
+
+    for (const locale of locales) {
+        it(`${locale} — every Meetings message parses`, () => {
+            const messages = JSON.parse(
+                readFileSync(join(MESSAGES_DIR, `${locale}.json`), 'utf8'),
+            ) as { dashboard: Record<string, Tree> };
+
+            const invalid: string[] = [];
+
+            for (const namespace of NAMESPACES) {
+                const tree = messages.dashboard[namespace];
+                expect(tree, `${locale}: dashboard.${namespace} is missing`).toBeTruthy();
+
+                for (const key of leafKeys(tree)) {
+                    const t = createTranslator({
+                        locale,
+                        messages,
+                        namespace: `dashboard.${namespace}`,
+                        onError: (error) => {
+                            const text = String(error?.message ?? error);
+                            if (text.includes('INVALID_MESSAGE')) {
+                                invalid.push(`dashboard.${namespace}.${key}: ${text}`);
+                            }
+                        },
+                    });
+                    // next-intl types `t` against the literal key union;
+                    // this spec walks keys discovered at runtime.
+                    (t as unknown as (k: string, v?: Record<string, unknown>) => string)(
+                        key,
+                        VALUES,
+                    );
+                }
+            }
+
+            expect(invalid, `${locale} has invalid ICU messages`).toEqual([]);
+        });
+    }
+
+    it('the roster hint still shows the literal Name <email> format after escaping', () => {
+        const messages = JSON.parse(readFileSync(join(MESSAGES_DIR, 'en.json'), 'utf8'));
+        for (const namespace of ['meetingNew', 'meetingDetail']) {
+            const t = createTranslator({
+                locale: 'en',
+                messages,
+                namespace: `dashboard.${namespace}`,
+                onError: (error) => {
+                    throw error;
+                },
+            });
+            // The escape must survive as literal text — escaping it away
+            // would "fix" the error by deleting the thing the hint teaches.
+            expect(t('fields.participantsHint')).toContain('<email>');
+        }
+    });
+});

--- a/apps/web/src/lib/api/meetings.shared.ts
+++ b/apps/web/src/lib/api/meetings.shared.ts
@@ -64,6 +64,17 @@ export interface MeetingParticipant {
 }
 
 /**
+ * Loose e-mail shape check — one `@`, a dot in the domain, no spaces.
+ *
+ * Deliberately permissive: the API stores the address as an opaque
+ * string, so this only has to catch the typo the user can see (a
+ * missing `@`, a trailing comma), never adjudicate RFC 5322.
+ */
+export function isLikelyEmail(value: string): boolean {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+/**
  * Parse a human-typed roster into `MeetingParticipant[]`.
  *
  * One participant per line, in any of:
@@ -89,7 +100,7 @@ export function parseParticipants(raw: string): MeetingParticipant[] {
             const name = (angled[1].trim() || email).slice(0, MEETING_PARTICIPANT_NAME_MAX_CHARS);
             return { name, email };
         }
-        if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(line)) {
+        if (isLikelyEmail(line)) {
             const email = line.slice(0, MEETING_PARTICIPANT_EMAIL_MAX_CHARS);
             return { name: email.slice(0, MEETING_PARTICIPANT_NAME_MAX_CHARS), email };
         }

--- a/packages/agent/src/meetings/meetings.service.ts
+++ b/packages/agent/src/meetings/meetings.service.ts
@@ -29,6 +29,35 @@ export const MEETING_SUMMARY_INPUT_MAX_CHARS = 24_000;
 export const MEETING_SUMMARY_MAX_CHARS = 4_000;
 
 /**
+ * Summarizer instructions.
+ *
+ * The summary is stored as Markdown and rendered as Markdown on
+ * `/meetings/:id`, so the shape asked for here IS the shape a reader sees.
+ * It used to ask for a few sentences plus a flat bullet list, which
+ * flattened a decision, an owner and an aside into one undifferentiated
+ * run — the reader had to re-read the summary to find the part that
+ * concerned them.
+ *
+ * Sections are conditional on purpose: a heading followed by "none" is
+ * noise, and inviting the model to fill an empty section is inviting it to
+ * invent one.
+ */
+const MEETING_SUMMARY_SYSTEM_PROMPT = [
+    'You summarize meeting transcripts into Markdown for a meeting record.',
+    '',
+    'Structure:',
+    '- Open with one short paragraph (2-4 sentences) covering what the meeting was about and what came out of it. No heading above it.',
+    '- Then add only the sections the transcript actually supports, in this order, each a `###` heading followed by bullets: Discussion, Decisions, Action items, Open questions.',
+    '- Name the owner on an action item when the transcript does; write "Unassigned" when it does not.',
+    '',
+    'Rules:',
+    '- Omit any section you have nothing for. Never write a heading followed by "none" or "N/A".',
+    '- Plain Markdown only: paragraphs, `###` headings, `-` bullets, `**bold**` for emphasis. No title heading, no code fences, no tables.',
+    '- Never invent facts, owners, dates or decisions that are not in the transcript.',
+    '- Keep the whole summary under 400 words.',
+].join('\n');
+
+/**
  * Envelope kinds the meetings processor consumes (recordings → rows).
  *
  * One processor, one path: every provider that can hand the platform a
@@ -340,8 +369,7 @@ export class MeetingsService implements OnModuleInit {
                     messages: [
                         {
                             role: 'system',
-                            content:
-                                'You summarize meeting transcripts. Write a concise summary: 2-4 sentences of what was discussed and decided, then up to 5 bullet action items when present. Never invent facts that are not in the transcript.',
+                            content: MEETING_SUMMARY_SYSTEM_PROMPT,
                         },
                         {
                             role: 'user',
@@ -349,7 +377,11 @@ export class MeetingsService implements OnModuleInit {
                         },
                     ],
                     temperature: 0.2,
-                    maxTokens: 512,
+                    // Room for the opening paragraph plus the sections the
+                    // prompt asks for. The 400-word ceiling above keeps the
+                    // result well inside MEETING_SUMMARY_MAX_CHARS, so the
+                    // stored text is never a sentence cut in half.
+                    maxTokens: 900,
                 },
                 {
                     userId: meeting.userId,


### PR DESCRIPTION

<img width="1840" height="1729" alt="FireShot Capture 115 - New meeting - Ever Works -  localhost" src="https://github.com/user-attachments/assets/6e7b33de-2bb6-4c0a-8209-e230385420e6" />

<img width="1916" height="871" alt="Screenshot 2026-08-13 175236" src="https://github.com/user-attachments/assets/483d9029-edca-47a2-bc03-a0b7c90e0090" />


https://github.com/user-attachments/assets/213379eb-75a0-4795-9abb-5f18b2afb94b




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned meeting details with responsive sections and modal editing.
  - Edit meeting times, participants, and transcripts with validation and save/cancel states.
  - Add or remove participants directly from meeting details.
  - View formatted meeting summaries with progress feedback.
  - Delete meetings through an in-page confirmation dialog.
  - Added source icons for Zoom, Google Meet, imported, and manual meetings.
  - Improved meeting creation with participant email validation.

- **Localization**
  - Updated meeting workflows and validation messages across supported languages.

- **Accessibility**
  - Added reduced-motion support and accessible summary-generation status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->