### PR TITLE
fix(works): pass workId so managed-storage Works can resolve the platform token

### DIFF
--- a/packages/agent/src/works-config/__tests__/works-config-repository-sync.service.spec.ts
+++ b/packages/agent/src/works-config/__tests__/works-config-repository-sync.service.spec.ts
@@ -6,6 +6,15 @@ jest.mock('@src/generators/data-generator/data-repository', () => ({
 }));
 
 describe('WorksConfigRepositorySyncService', () => {
+    // `workId` appears in every facade options object below on purpose. Without
+    // it, GitFacade.resolveToken cannot reach its managed-storage short-circuit
+    // — whose first line is `if (!options.workId) return null` — so it falls
+    // through to a per-user credential lookup and demands a personal GitHub
+    // account that a managed-storage user does not have by design.
+    //
+    // These assertions previously pinned the shape WITHOUT workId, i.e. exactly
+    // the shape that made Work creation fail on production for every user on
+    // managed "Ever Works Git" storage.
     const work = {
         id: 'dir-1',
         gitProvider: 'github',
@@ -96,11 +105,11 @@ describe('WorksConfigRepositorySyncService', () => {
         expect(gitFacade.pull).toHaveBeenCalledWith(
             '/tmp/data-repo',
             { name: 'User One', email: 'user@example.com' },
-            { userId: 'user-1', providerId: 'github' },
+            { userId: 'user-1', providerId: 'github', workId: 'dir-1' },
         );
         expect(gitFacade.push).toHaveBeenCalledWith(
             { dir: '/tmp/data-repo' },
-            { userId: 'user-1', providerId: 'github' },
+            { userId: 'user-1', providerId: 'github', workId: 'dir-1' },
         );
         expect(gitFacade.pull.mock.invocationCallOrder[0]).toBeLessThan(
             gitFacade.push.mock.invocationCallOrder[0],
@@ -129,12 +138,12 @@ describe('WorksConfigRepositorySyncService', () => {
         expect(gitFacade.push).toHaveBeenNthCalledWith(
             1,
             { dir: '/tmp/data-repo' },
-            { userId: 'user-1', providerId: 'github' },
+            { userId: 'user-1', providerId: 'github', workId: 'dir-1' },
         );
         expect(gitFacade.push).toHaveBeenNthCalledWith(
             2,
             { dir: '/tmp/data-repo', force: true },
-            { userId: 'user-1', providerId: 'github' },
+            { userId: 'user-1', providerId: 'github', workId: 'dir-1' },
         );
     });
 

--- a/packages/agent/src/works-config/services/works-config-repository-sync.service.ts
+++ b/packages/agent/src/works-config/services/works-config-repository-sync.service.ts
@@ -27,6 +27,26 @@ export class WorksConfigRepositorySyncService {
         private readonly eventEmitter?: EventEmitter2,
     ) {}
 
+    /**
+     * Every git-facade call here passes `workId`, and that is load-bearing.
+     *
+     * `GitFacade.resolveToken` short-circuits to the platform PAT via
+     * `tryResolveEverWorksGitPlatformToken`, whose FIRST line is
+     * `if (!options.workId) return null`. It needs the id to look the Work up
+     * and check `storageProvider === ever-works-git`.
+     *
+     * These calls used to pass only `{ userId, providerId }`. So for a Work on
+     * managed storage the short-circuit could never fire, the facade fell
+     * through to the per-user credential lookup, and sync died with
+     *
+     *     NoGitCredentialsError: No connected account found for user <id>
+     *     with provider github
+     *
+     * which the API surfaced as `400 Repository not found`. A user on managed
+     * storage has no personal GitHub connection BY DESIGN — that is the whole
+     * point of the option — so Work creation failed for every such user while
+     * the repo lived in the platform org they were never asked to connect to.
+     */
     async syncWork(options: WorksConfigRepositorySyncOptions): Promise<void> {
         const work = await this.workRepository.findById(options.workId);
         if (!work?.user) {
@@ -43,7 +63,7 @@ export class WorksConfigRepositorySyncService {
         try {
             const dest = await this.gitFacade.cloneOrPull(
                 { owner, repo, committer },
-                { userId: options.userId, providerId: work.gitProvider },
+                { userId: options.userId, providerId: work.gitProvider, workId: work.id },
             );
             const dataRepository = await DataRepository.create(dest);
 
@@ -69,8 +89,9 @@ export class WorksConfigRepositorySyncService {
             await this.gitFacade.pull(dest, committer, {
                 userId: options.userId,
                 providerId: work.gitProvider,
+                workId: work.id,
             });
-            await this.pushSyncedConfig(dest, options.userId, work.gitProvider);
+            await this.pushSyncedConfig(dest, options.userId, work.gitProvider, work.id);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -90,9 +111,14 @@ export class WorksConfigRepositorySyncService {
         }
     }
 
-    private async pushSyncedConfig(dir: string, userId: string, providerId: string): Promise<void> {
+    private async pushSyncedConfig(
+        dir: string,
+        userId: string,
+        providerId: string,
+        workId: string,
+    ): Promise<void> {
         try {
-            await this.gitFacade.push({ dir }, { userId, providerId });
+            await this.gitFacade.push({ dir }, { userId, providerId, workId });
         } catch (error) {
             if (!this.isNonFastForwardPushError(error)) {
                 throw error;
@@ -105,7 +131,7 @@ export class WorksConfigRepositorySyncService {
             this.logger.warn(
                 `.works/works.yml sync push was rejected as non-fast-forward for ${dir}; force pushing (remote history will be overwritten)`,
             );
-            await this.gitFacade.push({ dir, force: true }, { userId, providerId });
+            await this.gitFacade.push({ dir, force: true }, { userId, providerId, workId });
         }
     }
 

--- a/packages/agent/src/works-config/services/works-config-repository-sync.workid.spec.ts
+++ b/packages/agent/src/works-config/services/works-config-repository-sync.workid.spec.ts
@@ -1,0 +1,111 @@
+import { WorksConfigRepositorySyncService } from './works-config-repository-sync.service';
+
+/**
+ * Guard: every git-facade call from the config sync must carry `workId`.
+ *
+ * `GitFacade.resolveToken` short-circuits to the platform PAT via
+ * `tryResolveEverWorksGitPlatformToken`, whose first line is
+ * `if (!options.workId) return null`. Without the id it cannot look the Work up
+ * to see that `storageProvider === 'ever-works-git'`, so the short-circuit
+ * never fires and the facade falls through to a per-user credential lookup.
+ *
+ * That is exactly what broke Work creation on production for managed storage:
+ *
+ *     NoGitCredentialsError: No connected account found for user <id>
+ *     with provider github
+ *     -> API surfaced 400 "Repository not found"
+ *
+ * A user on managed storage has no personal GitHub connection BY DESIGN, so
+ * this failed for every such user while the repo sat in the platform org.
+ *
+ * This asserts on the OPTIONS OBJECT handed to the facade rather than on the
+ * outcome, because the outcome depends on a real token: a test that mocked the
+ * facade to succeed would pass whether or not `workId` was threaded through —
+ * which is precisely how the omission survived. The facade is mocked here only
+ * to record its arguments.
+ */
+describe('WorksConfigRepositorySyncService — workId reaches the git facade', () => {
+    const WORK_ID = 'work-123';
+    const USER_ID = 'user-456';
+
+    /** Calls that resolve a token and therefore need `workId`. */
+    const TOKEN_RESOLVING_CALLS = ['cloneOrPull', 'pull', 'push'] as const;
+
+    function build() {
+        const calls: Record<string, unknown[][]> = {};
+        const record =
+            (name: string) =>
+            (...args: unknown[]) => {
+                (calls[name] ||= []).push(args);
+                if (name === 'cloneOrPull') return Promise.resolve('/tmp/repo');
+                if (name === 'getStatus') return Promise.resolve([{ path: '.works/works.yml' }]);
+                return Promise.resolve(undefined);
+            };
+
+        const gitFacade = {
+            cloneOrPull: jest.fn(record('cloneOrPull')),
+            getStatus: jest.fn(record('getStatus')),
+            addAll: jest.fn(record('addAll')),
+            commit: jest.fn(record('commit')),
+            pull: jest.fn(record('pull')),
+            push: jest.fn(record('push')),
+        };
+
+        const work = {
+            id: WORK_ID,
+            gitProvider: 'github',
+            storageProvider: 'ever-works-git',
+            user: { id: USER_ID },
+            getRepoOwner: () => 'ever-works-cloud',
+            getDataRepo: () => 'probe-data',
+            resolveCommitter: () => ({ name: 'x', email: 'x@example.com' }),
+        };
+
+        // Constructor order is (workRepository, gitFacade, projection, writer,
+        // eventEmitter?). Getting projection/writer the wrong way round makes
+        // the flow throw before it reaches `push`, which reads as "push was
+        // never called" rather than as a wiring mistake — worth naming.
+        const service = new WorksConfigRepositorySyncService(
+            { findById: jest.fn().mockResolvedValue(work) } as never,
+            gitFacade as never,
+            { buildWriteRequest: jest.fn().mockResolvedValue({}) } as never,
+            { writeToDataRepository: jest.fn().mockResolvedValue(undefined) } as never,
+            undefined as never,
+        );
+
+        return { service, gitFacade, calls };
+    }
+
+    it('passes workId on every call that resolves a token', async () => {
+        const { service, calls } = build();
+
+        await service
+            .syncWork({ workId: WORK_ID, userId: USER_ID, reason: 'test' } as never)
+            .catch(() => undefined);
+
+        for (const name of TOKEN_RESOLVING_CALLS) {
+            const invocations = calls[name] || [];
+
+            // Control: the call must actually have happened, otherwise "no
+            // missing workId" would be vacuously true.
+            // jest expect() takes no message arg; the failure names the call via the loop.
+            expect({ call: name, invocations: invocations.length }).toEqual({
+                call: name,
+                invocations: invocations.length,
+            });
+            expect(invocations.length).toBeGreaterThan(0);
+
+            for (const args of invocations) {
+                const opts = args.find(
+                    (a) => a && typeof a === 'object' && 'providerId' in (a as object),
+                ) as { workId?: string } | undefined;
+
+                expect(opts).toBeDefined();
+                expect({ call: name, workId: opts!.workId }).toEqual({
+                    call: name,
+                    workId: WORK_ID,
+                });
+            }
+        }
+    });
+});


### PR DESCRIPTION
**Work creation still fails on production for every user on managed "Ever Works Git" storage**, even
after the creation gate was corrected in #2028. Found by driving the real UI on `app.ever.works`.

## Observed

```
[WorksConfigRepositorySyncService] Failed to sync .works/works.yml for
  ever-works-cloud/k8s-db-operators-live-verify-data:
  No connected account found for user 56d22941-… with provider github
[WorkLifecycleService] Error syncing work from data repository
web: 400 "Repository not found. Please verify the repository exists and try again."
```

No Work persisted (`getWorks: 0 works for user`), and **no toast** — the user is left on a filled form
with no signal. It fails closed (neither repo exists in the org afterwards), but it fails.

## Root cause — the mechanism was there, starved of one field

`GitFacade.resolveToken` already short-circuits to the platform PAT via
`tryResolveEverWorksGitPlatformToken`, whose **first line** is:

```ts
if (!options.workId) return null;
```

It needs the id to load the Work and check `storageProvider === 'ever-works-git'`.

This service **has** the Work — it loads it on the first line of `syncWork` — but called the facade
with only `{ userId, providerId }`. So for managed storage the short-circuit could never fire, the
facade fell through to a per-user credential lookup, and demanded a personal GitHub connection that a
managed-storage user **does not have by design** — that being the entire point of the option. Meanwhile
the repository sits in the platform org the user was never asked to connect to.

Threaded `workId` through all five facade calls (`cloneOrPull`, `pull`, and both `push` paths via
`pushSyncedConfig`). **Zero call sites remain without it.**

## Test

Asserts on the **options object** handed to the facade, not the outcome. The outcome depends on a real
token, so a test that mocked the facade to succeed would pass whether or not `workId` was threaded
through — precisely how the omission survived. Includes a control that the calls actually happened, so
"no missing `workId`" cannot be vacuously true.

**Verified both ways.** Removing `workId` again fails with `"workId": "work-123"` vs
`"workId": undefined`; with the fix it passes.

## Note for the next reader

Getting the constructor's `projection`/`writer` arguments the wrong way round makes the flow throw
before it reaches `push`, which reads as *"push was never called"* rather than as a wiring mistake. I
hit that while writing the spec; it documents the real order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)