### PR TITLE
fix(email): import TenantEmailAddress from @ever-works/agent/entities — unbreaks the main build

### DIFF
--- a/apps/api/src/email/email-address.projection.ts
+++ b/apps/api/src/email/email-address.projection.ts
@@ -1,4 +1,4 @@
-import type { TenantEmailAddress } from '@ever-works/agent';
+import type { TenantEmailAddress } from '@ever-works/agent/entities';
 
 /**
  * The shape of a tenant email address as it may leave the server.


### PR DESCRIPTION
**`main`'s image build is failing right now** and this is my fault. `email-address.projection.ts`
(added in #2037) imported `TenantEmailAddress` from the bare package:

```
src/email/email-address.projection.ts:1:41 - error TS2307:
Cannot find module '@ever-works/agent'
```

The rest of `apps/api` uses the subpath — `email.service.ts`, in the same directory, imports the same
type from `@ever-works/agent/entities`. Corrected to match.

## How I missed it

Locally `tsc` reported **899 errors on my branch and 899 on develop**, and I read that equality as
"adds nothing". It doesn't: **my file didn't exist in the baseline**, so its error was new while some
other file's error happened to differ. *Comparing totals is not comparing sets.*

The deeper trap: locally the workspace packages are unbuilt, so `@ever-works/agent` is missing for
**every** importer — which makes a genuinely-wrong import path indistinguishable from ambient noise. In
Docker, turbo builds the dependencies first, the 898 ambient errors vanish, and only the real mistake
is left standing.

## Verified the way the image build does it

```
pnpm --filter @ever-works/agent build     -> exit 0, "TSC Found 0 issues"
pnpm --filter ever-works-api build        -> email-address.projection NO LONGER appears
```

The only remaining `TS2307`s name eight **other** workspace packages
(`@ever-works/monitoring`, `@ever-works/trigger-tasks`, `@ever-works/email-templates`, …) that turbo
builds via `--filter=ever-works-api...` — i.e. exactly the ambient set, with mine no longer among it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)