### PR TITLE
cascade: develop → stage — unbreak the main image build

### DIFF
--- a/apps/api/src/email/email-address.projection.ts
+++ b/apps/api/src/email/email-address.projection.ts
@@ -1,4 +1,4 @@
-import type { TenantEmailAddress } from '@ever-works/agent';
+import type { TenantEmailAddress } from '@ever-works/agent/entities';
 
 /**
  * The shape of a tenant email address as it may leave the server.


### PR DESCRIPTION
Corrects the import that is currently failing the `main` image build (`@ever-works/agent` → `@ever-works/agent/entities`). Verified with the workspace built, the way the Docker build does it: `email-address.projection` no longer appears in the API build output.