### PR TITLE
cascade: stage → main — unbreak the image build

### DIFF
--- a/apps/api/src/email/email-address.projection.ts
+++ b/apps/api/src/email/email-address.projection.ts
@@ -1,4 +1,4 @@
-import type { TenantEmailAddress } from '@ever-works/agent';
+import type { TenantEmailAddress } from '@ever-works/agent/entities';
 
 /**
  * The shape of a tenant email address as it may leave the server.


### PR DESCRIPTION
Restores the `main` image build, which my #2037 broke with a wrong import path (`@ever-works/agent` instead of `@ever-works/agent/entities`).

Until this lands, the two P0 fixes cascaded earlier (email-token leak, managed-Git Work creation) cannot deploy — the API and MCP images fail to build, so production is still serving `0f54028`.

Verified with the workspace built, mirroring Docker: `pnpm --filter @ever-works/agent build` (exit 0) then `pnpm --filter ever-works-api build` — `email-address.projection` no longer appears; the only remaining TS2307s are the eight sibling workspace packages turbo builds via `--filter=ever-works-api...`.