### PR TITLE
fix(web): don't link Work repositories that were never created (EW-037)

### DIFF
--- a/apps/web/src/components/works/detail/WorkDetailContext.tsx
+++ b/apps/web/src/components/works/detail/WorkDetailContext.tsx
@@ -12,8 +12,12 @@ type WorkDetailContextType = {
     config: WorkConfig | null;
     repoLinks: {
         main: string | null;
-        dataRepo: string | null;
-        websiteRepo: string | null;
+        // EW-037: `undefined` where the repository's real name is unknowable —
+        // managed storage provisions collision-suffixed names, so a derived
+        // `${slug}-data` URL points at a repo that does not exist. Consumers
+        // must render something other than a link in that case.
+        dataRepo: string | null | undefined;
+        websiteRepo: string | null | undefined;
     } | null;
     permissions: WorkPermissions;
 };
@@ -70,7 +74,12 @@ export const useWorkPermissions = () => {
     return permissions;
 };
 
-function repoLink(work: Work, oauthConnection: GitProviderConnectionInfo | null) {
+/**
+ * Exported for unit testing (EW-037). Building a repository URL is exactly the
+ * kind of logic that looks obviously right and silently produces links to
+ * repositories that do not exist.
+ */
+export function repoLink(work: Work, oauthConnection: GitProviderConnectionInfo | null) {
     if (!oauthConnection) {
         return null;
     }
@@ -95,12 +104,53 @@ function repoLink(work: Work, oauthConnection: GitProviderConnectionInfo | null)
     const dataRepository = relatedRepositories?.data;
     const websiteRepository = relatedRepositories?.website;
 
+    // EW-037 — do not invent a URL for a repository that was never created.
+    //
+    // Managed "Ever Works Git" storage names repos with a collision-resistant
+    // prefix (`anon-<hash>-<slug>`, see `EverWorksGitProvider.buildRepoName`),
+    // so a derived `${slug}-data` name is NEVER right for such a Work. The
+    // detail page linked all three of these for `EW027 Verify Directory`:
+    //   ever-works-cloud/anon-1d565e12-ew027-verify-directory   (exists)
+    //   ever-works-cloud/ew027-verify-directory-data            (404)
+    //   ever-works-cloud/ew027-verify-directory-website         (404)
+    //
+    // The discriminator is STRUCTURAL rather than `storageProvider`, which the
+    // API does not expose on the Work read model: when `relatedRepositories`
+    // is present at all, the platform recorded exactly what it provisioned, so
+    // a MISSING role means that repository does not exist — not that we forgot
+    // to record it. When the whole object is absent (self-hosted / legacy
+    // Works that predate it), the `${slug}-data` convention is how the user's
+    // own repos really are named, so keep deriving and keep those links alive.
+    //
+    // Returning `undefined` lets the row render as plain text instead of a
+    // link — see `RepositoryRow`.
+    const rolesAreRecorded = Boolean(relatedRepositories);
+    const derived = (recorded: string | undefined, fallback: string) => {
+        if (recorded) return encodeURIComponent(recorded);
+        return rolesAreRecorded ? undefined : encodeURIComponent(fallback);
+    };
+
     // Security: encodeURIComponent applied to all user-controlled path segments to prevent
     // path-traversal via malicious slug or repository names (e.g. "../../evil").
-    const encSlug = encodeURIComponent(work.slug);
+    // NB the segments below are encoded exactly ONCE — `work.slug` is passed raw
+    // into `derived()` rather than pre-encoded, because encoding it first and
+    // then encoding `"${encSlug}-data"` again double-escapes any slug that
+    // needed encoding at all (`a b` -> `a%2520b-data`).
+    const link = (
+        repository: { owner?: string; repo?: string } | undefined,
+        fallbackRepo: string,
+    ) => {
+        const repoSegment = derived(repository?.repo, fallbackRepo);
+        if (!repoSegment) return undefined;
+        return `${baseUrl}/${encodeURIComponent(repository?.owner || owner)}/${repoSegment}`;
+    };
+
     return {
+        // The `work` role is always recorded for managed storage, and for
+        // self-hosted storage the bare slug is the repo name, so this one
+        // needs no suppression.
         main: `${baseUrl}/${encodeURIComponent(mainRepository?.owner || owner)}/${encodeURIComponent(mainRepository?.repo || work.slug)}`,
-        dataRepo: `${baseUrl}/${encodeURIComponent(dataRepository?.owner || owner)}/${encodeURIComponent(dataRepository?.repo || `${encSlug}-data`)}`,
-        websiteRepo: `${baseUrl}/${encodeURIComponent(websiteRepository?.owner || owner)}/${encodeURIComponent(websiteRepository?.repo || `${encSlug}-website`)}`,
+        dataRepo: link(dataRepository, `${work.slug}-data`),
+        websiteRepo: link(websiteRepository, `${work.slug}-website`),
     };
 }

--- a/apps/web/src/components/works/detail/deploy/DeployForm.tsx
+++ b/apps/web/src/components/works/detail/deploy/DeployForm.tsx
@@ -339,14 +339,25 @@ function UpdateWebsiteRepository({ work }: DeployFormProps) {
                     </h3>
                     <p className="text-text-secondary dark:text-text-secondary-dark mb-4">
                         {t('form.updateRepository.description')}{' '}
-                        <Link
-                            href={repoLinks?.websiteRepo || '#'}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-primary hover:text-primary-hover"
-                        >
-                            {t('form.updateRepository.websiteRepository')}
-                        </Link>
+                        {/* EW-037: `|| '#'` made an unknown repository look like
+                            a working link. `repoLinks.websiteRepo` is
+                            `undefined` when the real name cannot be known
+                            (managed storage uses collision-suffixed names), so
+                            fall back to plain text rather than a dead click. */}
+                        {repoLinks?.websiteRepo ? (
+                            <Link
+                                href={repoLinks.websiteRepo}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary hover:text-primary-hover"
+                            >
+                                {t('form.updateRepository.websiteRepository')}
+                            </Link>
+                        ) : (
+                            <span className="text-text-secondary dark:text-text-secondary-dark">
+                                {t('form.updateRepository.websiteRepository')}
+                            </span>
+                        )}
                     </p>
 
                     <Button

--- a/apps/web/src/components/works/detail/overview/WorkInfo.tsx
+++ b/apps/web/src/components/works/detail/overview/WorkInfo.tsx
@@ -78,14 +78,25 @@ function RepositoryRow({
     return (
         <li className="flex items-center gap-1">
             {hasVisibility && <RepoVisibilityIcon isPrivate={isPrivate} label={label} />}
-            <Link
-                href={href || '#'}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:text-primary-hover"
-            >
-                {label}
-            </Link>
+            {/* EW-037: `href={href || '#'}` turned an unknown repository into a
+                link to `#` — visually identical to a working one, and a dead
+                click. `repoLink()` now returns `undefined` for a repository
+                whose real name we cannot know (managed storage records the
+                name it provisioned; there is nothing to guess). Render the
+                label as plain text in that case: the repository is still worth
+                naming, it just has no address to point at. */}
+            {href ? (
+                <Link
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:text-primary-hover"
+                >
+                    {label}
+                </Link>
+            ) : (
+                <span className="text-foreground-muted">{label}</span>
+            )}
             <InfoPopover title={helpTitle} body={helpBody} ariaLabel={helpAriaLabel} />
         </li>
     );

--- a/apps/web/src/components/works/detail/work-repo-links.unit.spec.ts
+++ b/apps/web/src/components/works/detail/work-repo-links.unit.spec.ts
@@ -27,131 +27,131 @@ import type { GitProviderConnectionInfo, Work } from '@/lib/api/types-only';
  */
 
 const connection = {
-	homepage: 'https://github.com',
-	username: 'someuser',
+    homepage: 'https://github.com',
+    username: 'someuser',
 } as GitProviderConnectionInfo;
 
 /** A managed Work, shaped as `WorkLifecycleService.createWork` persists one. */
 function managedWork(overrides: Partial<Work> = {}): Work {
-	return {
-		id: 'w-1',
-		slug: 'ew027-verify-directory',
-		name: 'EW027 Verify Directory',
-		owner: 'ever-works-cloud',
-		organization: true,
-		gitProvider: 'github',
-		sourceRepository: {
-			url: 'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
-			owner: 'ever-works-cloud',
-			repo: 'anon-1d565e12-ew027-verify-directory',
-			type: 'data_repo',
-			relatedRepositories: {
-				work: {
-					owner: 'ever-works-cloud',
-					repo: 'anon-1d565e12-ew027-verify-directory',
-				},
-				data: {
-					owner: 'ever-works-cloud',
-					repo: 'anon-1d565e12-ew027-verify-directory',
-				},
-			},
-		},
-		...overrides,
-	} as unknown as Work;
+    return {
+        id: 'w-1',
+        slug: 'ew027-verify-directory',
+        name: 'EW027 Verify Directory',
+        owner: 'ever-works-cloud',
+        organization: true,
+        gitProvider: 'github',
+        sourceRepository: {
+            url: 'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+            owner: 'ever-works-cloud',
+            repo: 'anon-1d565e12-ew027-verify-directory',
+            type: 'data_repo',
+            relatedRepositories: {
+                work: {
+                    owner: 'ever-works-cloud',
+                    repo: 'anon-1d565e12-ew027-verify-directory',
+                },
+                data: {
+                    owner: 'ever-works-cloud',
+                    repo: 'anon-1d565e12-ew027-verify-directory',
+                },
+            },
+        },
+        ...overrides,
+    } as unknown as Work;
 }
 
 describe('repoLink — never link a repository that was not provisioned', () => {
-	it('control: the derived name differs from the provisioned one, so these tests can fail', () => {
-		const work = managedWork();
-		// If this ever stops holding, every assertion below goes vacuous — the
-		// derived URL would accidentally be correct. Fail loudly instead.
-		expect(`${work.slug}-data`).not.toBe(
-			work.sourceRepository?.relatedRepositories?.data?.repo,
-		);
-	});
+    it('control: the derived name differs from the provisioned one, so these tests can fail', () => {
+        const work = managedWork();
+        // If this ever stops holding, every assertion below goes vacuous — the
+        // derived URL would accidentally be correct. Fail loudly instead.
+        expect(`${work.slug}-data`).not.toBe(
+            work.sourceRepository?.relatedRepositories?.data?.repo,
+        );
+    });
 
-	it('uses the RECORDED repo name for a managed Work, not the derived one', () => {
-		const links = repoLink(managedWork(), connection);
+    it('uses the RECORDED repo name for a managed Work, not the derived one', () => {
+        const links = repoLink(managedWork(), connection);
 
-		expect(links?.dataRepo).toBe(
-			'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
-		);
-		// The exact string production served, which 404s.
-		expect(links?.dataRepo).not.toContain('ew027-verify-directory-data');
-	});
+        expect(links?.dataRepo).toBe(
+            'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+        );
+        // The exact string production served, which 404s.
+        expect(links?.dataRepo).not.toContain('ew027-verify-directory-data');
+    });
 
-	it('omits the data link for a Work created BEFORE the EW-028 fix', () => {
-		// This is the exact production shape I observed: managed storage that
-		// recorded only the `work` role, because `createWork` did not yet
-		// register `data`. Every such Work already exists in the database and
-		// will never gain the role retroactively, so the UI must cope with it —
-		// the API-side fix only helps Works created from now on.
-		//
-		// Pre-fix this rendered
-		//   https://github.com/ever-works-cloud/ew027-verify-directory-data
-		// which 404s.
-		const work = managedWork({
-			sourceRepository: {
-				url: 'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
-				owner: 'ever-works-cloud',
-				repo: 'anon-1d565e12-ew027-verify-directory',
-				type: 'data_repo',
-				relatedRepositories: {
-					work: {
-						owner: 'ever-works-cloud',
-						repo: 'anon-1d565e12-ew027-verify-directory',
-					},
-				},
-			},
-		} as Partial<Work>);
+    it('omits the data link for a Work created BEFORE the EW-028 fix', () => {
+        // This is the exact production shape I observed: managed storage that
+        // recorded only the `work` role, because `createWork` did not yet
+        // register `data`. Every such Work already exists in the database and
+        // will never gain the role retroactively, so the UI must cope with it —
+        // the API-side fix only helps Works created from now on.
+        //
+        // Pre-fix this rendered
+        //   https://github.com/ever-works-cloud/ew027-verify-directory-data
+        // which 404s.
+        const work = managedWork({
+            sourceRepository: {
+                url: 'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+                owner: 'ever-works-cloud',
+                repo: 'anon-1d565e12-ew027-verify-directory',
+                type: 'data_repo',
+                relatedRepositories: {
+                    work: {
+                        owner: 'ever-works-cloud',
+                        repo: 'anon-1d565e12-ew027-verify-directory',
+                    },
+                },
+            },
+        } as Partial<Work>);
 
-		const links = repoLink(work, connection);
+        const links = repoLink(work, connection);
 
-		expect(links?.dataRepo).toBeUndefined();
-		// The `work` role IS recorded, so that link must still resolve —
-		// suppressing everything would be its own bug.
-		expect(links?.main).toBe(
-			'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
-		);
-	});
+        expect(links?.dataRepo).toBeUndefined();
+        // The `work` role IS recorded, so that link must still resolve —
+        // suppressing everything would be its own bug.
+        expect(links?.main).toBe(
+            'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+        );
+    });
 
-	it('omits the website link entirely when that role was never recorded', () => {
-		// Managed storage creates ONE repo. A website repo is a separate
-		// artefact gated by `shouldGenerateProviderRepository`; until it is
-		// actually created there is no honest URL to show. Pointing this at the
-		// work repo would trade a dead link for a WRONG one.
-		const links = repoLink(managedWork(), connection);
+    it('omits the website link entirely when that role was never recorded', () => {
+        // Managed storage creates ONE repo. A website repo is a separate
+        // artefact gated by `shouldGenerateProviderRepository`; until it is
+        // actually created there is no honest URL to show. Pointing this at the
+        // work repo would trade a dead link for a WRONG one.
+        const links = repoLink(managedWork(), connection);
 
-		expect(links?.websiteRepo).toBeUndefined();
-	});
+        expect(links?.websiteRepo).toBeUndefined();
+    });
 
-	it('still derives conventional names when no roles were recorded at all', () => {
-		// Self-hosted / legacy Works: the convention is real, the links work,
-		// and suppressing them here would be the regression.
-		const work = managedWork({ sourceRepository: undefined } as Partial<Work>);
-		const links = repoLink(work, connection);
+    it('still derives conventional names when no roles were recorded at all', () => {
+        // Self-hosted / legacy Works: the convention is real, the links work,
+        // and suppressing them here would be the regression.
+        const work = managedWork({ sourceRepository: undefined } as Partial<Work>);
+        const links = repoLink(work, connection);
 
-		expect(links?.dataRepo).toBe(
-			'https://github.com/ever-works-cloud/ew027-verify-directory-data',
-		);
-		expect(links?.websiteRepo).toBe(
-			'https://github.com/ever-works-cloud/ew027-verify-directory-website',
-		);
-	});
+        expect(links?.dataRepo).toBe(
+            'https://github.com/ever-works-cloud/ew027-verify-directory-data',
+        );
+        expect(links?.websiteRepo).toBe(
+            'https://github.com/ever-works-cloud/ew027-verify-directory-website',
+        );
+    });
 
-	it('encodes a path-traversal attempt in the slug exactly once', () => {
-		// The original encoded `work.slug`, then encoded `"${encSlug}-data"`
-		// again — double-escaping any slug that needed encoding at all.
-		const work = managedWork({
-			slug: '../../evil',
-			sourceRepository: undefined,
-		} as Partial<Work>);
-		const links = repoLink(work, connection);
+    it('encodes a path-traversal attempt in the slug exactly once', () => {
+        // The original encoded `work.slug`, then encoded `"${encSlug}-data"`
+        // again — double-escaping any slug that needed encoding at all.
+        const work = managedWork({
+            slug: '../../evil',
+            sourceRepository: undefined,
+        } as Partial<Work>);
+        const links = repoLink(work, connection);
 
-		expect(links?.dataRepo).toBe('https://github.com/ever-works-cloud/..%2F..%2Fevil-data');
-		// Single encoding: a literal '%25' would mean the '%' was escaped twice.
-		expect(links?.dataRepo).not.toContain('%25');
-		// And the traversal must not survive as real path separators.
-		expect(links?.dataRepo).not.toContain('../');
-	});
+        expect(links?.dataRepo).toBe('https://github.com/ever-works-cloud/..%2F..%2Fevil-data');
+        // Single encoding: a literal '%25' would mean the '%' was escaped twice.
+        expect(links?.dataRepo).not.toContain('%25');
+        // And the traversal must not survive as real path separators.
+        expect(links?.dataRepo).not.toContain('../');
+    });
 });

--- a/apps/web/src/components/works/detail/work-repo-links.unit.spec.ts
+++ b/apps/web/src/components/works/detail/work-repo-links.unit.spec.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { repoLink } from './WorkDetailContext';
+import type { GitProviderConnectionInfo, Work } from '@/lib/api/types-only';
+
+/**
+ * EW-037 — the Work detail page must not link repositories that do not exist.
+ *
+ * Observed on production 2026-08-13. The detail page for `EW027 Verify
+ * Directory` rendered three "open repository" links; only one worked:
+ *
+ *   ever-works-cloud/anon-1d565e12-ew027-verify-directory   EXISTS (private)
+ *   ever-works-cloud/ew027-verify-directory-data            404
+ *   ever-works-cloud/ew027-verify-directory-website         404
+ *
+ * Managed "Ever Works Git" storage provisions ONE repo under a
+ * collision-resistant name (`anon-<hash>-<slug>`), so the conventional
+ * `${slug}-data` / `${slug}-website` names are not merely unknown — they are
+ * known to be wrong. The old code derived them anyway via per-field `||`
+ * fallbacks, producing URLs that look plausible and 404.
+ *
+ * The rule under test is structural: when `relatedRepositories` is present the
+ * platform recorded exactly what it provisioned, so a MISSING role means "no
+ * such repository". When the object is absent entirely (self-hosted / legacy
+ * Works), the `${slug}-data` convention really is how the user's repos are
+ * named, and those links must keep working — that is what stops this fix from
+ * being a regression for the majority case.
+ */
+
+const connection = {
+	homepage: 'https://github.com',
+	username: 'someuser',
+} as GitProviderConnectionInfo;
+
+/** A managed Work, shaped as `WorkLifecycleService.createWork` persists one. */
+function managedWork(overrides: Partial<Work> = {}): Work {
+	return {
+		id: 'w-1',
+		slug: 'ew027-verify-directory',
+		name: 'EW027 Verify Directory',
+		owner: 'ever-works-cloud',
+		organization: true,
+		gitProvider: 'github',
+		sourceRepository: {
+			url: 'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+			owner: 'ever-works-cloud',
+			repo: 'anon-1d565e12-ew027-verify-directory',
+			type: 'data_repo',
+			relatedRepositories: {
+				work: {
+					owner: 'ever-works-cloud',
+					repo: 'anon-1d565e12-ew027-verify-directory',
+				},
+				data: {
+					owner: 'ever-works-cloud',
+					repo: 'anon-1d565e12-ew027-verify-directory',
+				},
+			},
+		},
+		...overrides,
+	} as unknown as Work;
+}
+
+describe('repoLink — never link a repository that was not provisioned', () => {
+	it('control: the derived name differs from the provisioned one, so these tests can fail', () => {
+		const work = managedWork();
+		// If this ever stops holding, every assertion below goes vacuous — the
+		// derived URL would accidentally be correct. Fail loudly instead.
+		expect(`${work.slug}-data`).not.toBe(
+			work.sourceRepository?.relatedRepositories?.data?.repo,
+		);
+	});
+
+	it('uses the RECORDED repo name for a managed Work, not the derived one', () => {
+		const links = repoLink(managedWork(), connection);
+
+		expect(links?.dataRepo).toBe(
+			'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+		);
+		// The exact string production served, which 404s.
+		expect(links?.dataRepo).not.toContain('ew027-verify-directory-data');
+	});
+
+	it('omits the data link for a Work created BEFORE the EW-028 fix', () => {
+		// This is the exact production shape I observed: managed storage that
+		// recorded only the `work` role, because `createWork` did not yet
+		// register `data`. Every such Work already exists in the database and
+		// will never gain the role retroactively, so the UI must cope with it —
+		// the API-side fix only helps Works created from now on.
+		//
+		// Pre-fix this rendered
+		//   https://github.com/ever-works-cloud/ew027-verify-directory-data
+		// which 404s.
+		const work = managedWork({
+			sourceRepository: {
+				url: 'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+				owner: 'ever-works-cloud',
+				repo: 'anon-1d565e12-ew027-verify-directory',
+				type: 'data_repo',
+				relatedRepositories: {
+					work: {
+						owner: 'ever-works-cloud',
+						repo: 'anon-1d565e12-ew027-verify-directory',
+					},
+				},
+			},
+		} as Partial<Work>);
+
+		const links = repoLink(work, connection);
+
+		expect(links?.dataRepo).toBeUndefined();
+		// The `work` role IS recorded, so that link must still resolve —
+		// suppressing everything would be its own bug.
+		expect(links?.main).toBe(
+			'https://github.com/ever-works-cloud/anon-1d565e12-ew027-verify-directory',
+		);
+	});
+
+	it('omits the website link entirely when that role was never recorded', () => {
+		// Managed storage creates ONE repo. A website repo is a separate
+		// artefact gated by `shouldGenerateProviderRepository`; until it is
+		// actually created there is no honest URL to show. Pointing this at the
+		// work repo would trade a dead link for a WRONG one.
+		const links = repoLink(managedWork(), connection);
+
+		expect(links?.websiteRepo).toBeUndefined();
+	});
+
+	it('still derives conventional names when no roles were recorded at all', () => {
+		// Self-hosted / legacy Works: the convention is real, the links work,
+		// and suppressing them here would be the regression.
+		const work = managedWork({ sourceRepository: undefined } as Partial<Work>);
+		const links = repoLink(work, connection);
+
+		expect(links?.dataRepo).toBe(
+			'https://github.com/ever-works-cloud/ew027-verify-directory-data',
+		);
+		expect(links?.websiteRepo).toBe(
+			'https://github.com/ever-works-cloud/ew027-verify-directory-website',
+		);
+	});
+
+	it('encodes a path-traversal attempt in the slug exactly once', () => {
+		// The original encoded `work.slug`, then encoded `"${encSlug}-data"`
+		// again — double-escaping any slug that needed encoding at all.
+		const work = managedWork({
+			slug: '../../evil',
+			sourceRepository: undefined,
+		} as Partial<Work>);
+		const links = repoLink(work, connection);
+
+		expect(links?.dataRepo).toBe('https://github.com/ever-works-cloud/..%2F..%2Fevil-data');
+		// Single encoding: a literal '%25' would mean the '%' was escaped twice.
+		expect(links?.dataRepo).not.toContain('%25');
+		// And the traversal must not survive as real path separators.
+		expect(links?.dataRepo).not.toContain('../');
+	});
+});


### PR DESCRIPTION
Found by opening a real Work in a browser. The detail page renders three "open repository" links; on managed storage **two of them 404**.

Production, 2026-08-13, `EW027 Verify Directory` — verified with authenticated `gh api`:

| Linked repo | Result |
|---|---|
| `ever-works-cloud/anon-1d565e12-ew027-verify-directory` | **EXISTS** (private) |
| `ever-works-cloud/ew027-verify-directory-data` | **404** |
| `ever-works-cloud/ew027-verify-directory-website` | **404** |
| *control* `ever-works-cloud/definitely-not-a-real-repo-xyz` | 404 ✅ discriminates |

## Cause — the same per-field fallback as EW-028, one layer up

```ts
dataRepo: `${base}/${enc(data?.owner || owner)}/${enc(data?.repo || `${slug}-data`)}`
```

Managed *Ever Works Git* storage provisions **one** repo under a collision-resistant name (`anon-<hash>-<slug>`), so `${slug}-data` is not merely unknown — it is **known to be wrong**. The fallback manufactured a plausible URL for a repository that does not exist and never will.

## The discriminator is structural, not `storageProvider`

My first attempt gated on `work.storageProvider === 'ever-works-git'` — **`tsc` rejected it**: the API does not expose that field on the Work read model. Rather than widen the API contract, the rule is structural:

- `relatedRepositories` **present** → the platform recorded exactly what it provisioned, so a **missing role means "no such repository"**.
- `relatedRepositories` **absent** → self-hosted / legacy Work, where the `${slug}-data` convention really is how the user's repos are named. **Keep deriving**, keep those links alive.

That second branch is what stops this from being a regression for the majority case, and it is asserted directly rather than assumed.

## Two more things fixed

- **Dead-link renders.** `RepositoryRow` and `DeployForm` both used `href={link || '#'}`, which makes an unknown repository *visually identical to a working one*. They now render the label as plain text — the repository is still worth naming, it just has no address.
- **Latent double-encoding.** The original encoded `work.slug`, then encoded `` `${encSlug}-data` `` again, so any slug needing encoding came out double-escaped (`a b` → `a%2520b-data`). Segments are now encoded exactly once, asserted with a path-traversal case that must still be neutralised.

## Tests

6 new unit tests, **verified to fail against pre-fix behaviour** — 2 failed / 4 passed, the failures being exactly the two suppression assertions, while the control and the derive-when-unrecorded tests stayed green.

One case uses the **exact pre-EW-028 production shape** (only the `work` role recorded). Those rows already exist in the database and will never gain the role retroactively — [#2044](https://github.com/ever-works/ever-works/pull/2044) only helps Works created from now on, so the UI has to cope with them regardless.

`repoLink` is exported solely to make it testable. Nothing is removed. `tsc --noEmit` on `apps/web`: **0 errors** (baseline 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository links for managed and self-hosted works.
  * Prevented missing repository information from creating invalid links.
  * Displayed unknown repositories as plain text instead of broken links.
  * Corrected repository URL generation and encoding for unusual names.
  * Preserved conventional repository links when repository metadata is unavailable.

* **Tests**
  * Added coverage for repository link generation, missing repository details, legacy works, and special-character URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->