### PR TITLE
fix(e2e): archived agents ARE returned when explicitly requested (EW-038)

### DIFF
--- a/apps/web/e2e/agents-list-filter.spec.ts
+++ b/apps/web/e2e/agents-list-filter.spec.ts
@@ -50,11 +50,27 @@ test.describe('Agents — list filtering', () => {
         expect(active.data.length).toBe(1);
         expect(active.data[0].status).toBe('active');
 
-        // Archived agents stay out of list queries even when explicitly requested.
+        // Archived agents are hidden from list queries BY DEFAULT, but are
+        // returned when explicitly requested — `AgentRepository
+        // .findByUserIdScoped` has a deliberate carve-out for exactly this,
+        // and `/agents/archived/page.tsx` depends on it: it renders
+        // `agentsAPI.list({ status: 'archived' })`.
+        //
+        // This assertion used to expect an empty list ("archived agents stay
+        // out of list queries even when explicitly requested"), which is the
+        // behaviour the carve-out was added to FIX — the repository's own
+        // comment notes that without it "the archived view is always empty".
+        // So the spec was pinning a state in which the Archived tab could
+        // never show anything, and failed against the shipped code.
+        //
+        // The default-exclusion half is covered by the sibling test above,
+        // 'default list excludes archived agents'.
         const archived = await (
             await request.get(`${API_BASE}/api/agents?status=archived`, { headers })
         ).json();
-        expect(archived.data.length).toBe(0);
+        expect(archived.data.length).toBe(1);
+        expect(archived.data[0].status).toBe('archived');
+        expect(archived.data[0].name).toBe('Gamma Archived');
     });
 
     test('?search matches on agent name', async ({ request }) => {


### PR DESCRIPTION
One of the specs failing on stage E2E. **The test was wrong, not the product** — and the behaviour it pinned would break a shipped feature.

## The contradiction

`agents-list-filter.spec.ts` asserted:

```ts
// Archived agents stay out of list queries even when explicitly requested.
const archived = await request.get(`${API_BASE}/api/agents?status=archived`);
expect(archived.data.length).toBe(0);
```

`AgentRepository.findByUserIdScoped` says the opposite, deliberately:

```ts
// Archived Agents are hidden from every catalog surface by
// default — EXCEPT when the caller explicitly asks for them
// (`?status=archived`), which is what the `/agents/archived`
// tab does. Without this carve-out the two predicates
// contradict each other and the archived view is always empty.
```

And `app/[locale]/(dashboard)/agents/archived/page.tsx:26` depends on it: it renders `agentsAPI.list({ status: 'archived', limit: 50 })`.

So the spec pinned a state in which **the Archived tab could never show anything**, and failed against the very code that makes that tab work.

## The fix

Assert the archived agent **is** returned, identified by name and status rather than count alone — a bare `length === 1` would also pass if the wrong agent came back. The default-exclusion half stays covered by the sibling test `default list excludes archived agents`, which is untouched.

## How I got here

Found while promoting EW-028 to production. The `stage → main` gate went red, so I checked whether my change caused it: it did not — the stage commit immediately before my merge (`1a7b506b`) already failed with **6 red shards**, and runs on 2026-08-11 failed too.

Two hypotheses of mine died on the way, both worth recording so nobody re-runs them:

- *"Exact-count assertions rot as a shared tenant accumulates agents."* These specs do assert `meta.total).toBe(2)`, which is real fragility — but `seedAgents` registers a fresh user per test, and the other failure is a missing DOM element, not a wrong count.
- *"`seedAgents` throws because registration is broken."* `registerUserViaAPI` genuinely throws on a failed registration, and registration is what EW-001/EW-008 broke — so it was worth checking. Seeding succeeded; the test reached a page assertion.

**Still open on the sibling failure** (`agent-lifecycle-status.spec.ts:156`): the selector is *correct* — `AgentCard.tsx:61` renders `<Link>` wrapping an `<h3>` at line 78, exactly what the spec targets — so the agent's card genuinely did not render. I checked whether paused agents are excluded from the list like archived ones; **they are not** (the repository excludes only `ARCHIVED`), so that explanation is ruled out. Unresolved, and not addressed here.

⚠️ The wider issue is [EW-038](https://github.com/ever-works/ever-works): a permanently-red E2E suite means `promotion-gate.yml` blocks every production promotion on a judgement call, so the pressure is to bypass it reflexively — and the one time it catches something real, nobody will believe it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)