### PR TITLE
fix(e2e): drive the RTL locale by cookie, not URL prefix (EW-038)

### DIFF
--- a/apps/web/e2e/internationalization-rtl.spec.ts
+++ b/apps/web/e2e/internationalization-rtl.spec.ts
@@ -3,41 +3,92 @@ import { test, expect } from '@playwright/test';
 /**
  * RTL locale support.
  *
- * This spec used to pass while RTL was **entirely unimplemented**. It asserted
+ * ── Why this spec drives the locale by COOKIE, not by URL ──────────────────
+ *
+ * `apps/web/src/i18n/routing.ts` sets `localePrefix: 'never'`, and says why:
+ * "the locale belongs in user state, not in the URL … next-intl persists the
+ * locale in the `NEXT_LOCALE` cookie … internally without ever surfacing the
+ * segment to the browser."
+ *
+ * So `/ar/login` is not an Arabic page — it is a **redirect**. Verified against
+ * production:
+ *
+ *     GET /ar/login  -> 307  https://app.ever.works/login
+ *     GET /he/login  -> 307  https://app.ever.works/login
+ *     GET /es/login  -> 307  https://app.ever.works/login   ← a SHIPPED locale
+ *     GET /fr/login  -> 307  https://app.ever.works/login   ← also shipped
+ *
+ * Every prefixed path redirects, including locales that certainly exist. This
+ * spec used to `page.goto('/ar/login')` and assert `dir === 'rtl'`, so it was
+ * asserting against the **English default page** and could never pass for any
+ * locale. Its escape hatch only fired on a 404 — but these are 307 → 200, so it
+ * did not skip either. That is two of the red shards on stage E2E.
+ *
+ * Driving the cookie instead reflects how the app actually works, and RTL is
+ * genuinely implemented. Verified on production:
+ *
+ *     Cookie: NEXT_LOCALE=ar  ->  <html lang="ar" dir="rtl">
+ *     Cookie: NEXT_LOCALE=he  ->  <html lang="he" dir="rtl">
+ *     Cookie: NEXT_LOCALE=en  ->  <html lang="en" dir="ltr">
+ *
+ * ── Why the assertions are strict ─────────────────────────────────────────
+ *
+ * This spec once passed while RTL was **entirely unimplemented**. It asserted
  *
  *     expect(dir).not.toBe('ltr')
  *
  * and `document.documentElement.dir` returns the EMPTY STRING when the
  * attribute is absent. `'' !== 'ltr'`, so a page with no `dir` at all satisfied
- * it. Verified live on app-dev.ever.works with the locale switched to Arabic:
- * `lang="ar"` and 530 Arabic characters rendered, but no element in the entire
- * document carried a `dir` attribute and the computed direction from `<main>`
- * up to `<html>` was `ltr` at every level.
- *
- * "Not ltr" is not the contract. The contract is `rtl`, so that is what this
- * asserts now — an unset or `auto` value fails, which is the only way this test
- * can notice the thing it exists to notice.
- *
- * `fa` and `ur` are probed too but are not shipped locales; they skip cleanly
- * on 404 rather than failing.
+ * it. "Not ltr" is not the contract; `rtl` is. An unset or `auto` value must
+ * fail, which is the only way this test can notice the thing it exists to
+ * notice.
  */
 
-const RTL_LOCALES = ['ar', 'he', 'fa', 'ur'];
+/** Shipped RTL locales. `fa`/`ur` are deliberately excluded — see below. */
+const RTL_LOCALES = ['ar', 'he'];
+
+/**
+ * Set the locale the way the application does, then load the unprefixed path.
+ * `baseURL` may be absent in some configs, so derive the cookie domain from the
+ * URL actually being used rather than assuming localhost.
+ */
+async function gotoWithLocale(
+    page: import('@playwright/test').Page,
+    baseURL: string | undefined,
+    locale: string,
+    path: string,
+) {
+    const base = baseURL || 'http://localhost:3000';
+    await page.context().addCookies([
+        {
+            name: 'NEXT_LOCALE',
+            value: locale,
+            url: base,
+        },
+    ]);
+    return page.goto(`${base}${path}`, { waitUntil: 'domcontentloaded' });
+}
 
 test.describe('RTL locales — <html dir> is set when locale is RTL', () => {
     for (const loc of RTL_LOCALES) {
-        test(`/${loc}/login carries dir="rtl" on <html>`, async ({ page, baseURL }) => {
-            const res = await page.goto(`${baseURL || 'http://localhost:3000'}/${loc}/login`, {
-                waitUntil: 'domcontentloaded',
-            });
-            if (!res || res.status() === 404) {
-                test.skip(true, `${loc} locale not exposed`);
-            }
+        test(`NEXT_LOCALE=${loc} renders /login with dir="rtl"`, async ({ page, baseURL }) => {
+            const res = await gotoWithLocale(page, baseURL, loc, '/login');
+
             expect(res!.status()).toBeLessThan(500);
+
+            // Control: the locale must actually have been applied. Without this,
+            // a silent fallback to English would make the dir assertion below
+            // fail for a reason that has nothing to do with RTL support, and the
+            // failure message would send the reader hunting in the wrong place.
+            const lang = await page.evaluate(() => document.documentElement.lang);
+            expect(lang, `locale did not apply — <html lang="${lang}">, expected "${loc}"`).toBe(
+                loc,
+            );
+
             const dir = await page.evaluate(() => document.documentElement.dir);
             expect(
                 dir,
-                `<html dir="${dir}"> for ${loc} locale — an unset or 'auto' dir is what let this ` +
+                `<html dir="${dir}"> for ${loc} — an unset or 'auto' dir is what let this ` +
                     `spec pass while RTL was unimplemented, so only 'rtl' counts`,
             ).toBe('rtl');
 
@@ -50,37 +101,26 @@ test.describe('RTL locales — <html dir> is set when locale is RTL', () => {
     }
 });
 
-test.describe('LTR baseline — /en stays dir="ltr"', () => {
-    test('/en/login carries dir="ltr" (or empty/unset)', async ({ page, baseURL }) => {
-        await page.goto(`${baseURL || 'http://localhost:3000'}/en/login`, {
-            waitUntil: 'domcontentloaded',
-        });
+test.describe('LTR baseline — English stays dir="ltr"', () => {
+    test('NEXT_LOCALE=en renders /login with dir="ltr" (or unset)', async ({ page, baseURL }) => {
+        await gotoWithLocale(page, baseURL, 'en', '/login');
         const dir = await page.evaluate(() => document.documentElement.dir);
         // Default LTR is fine to leave unset; explicit ltr is fine too.
-        // What's NOT acceptable is `rtl` for English.
+        // What is NOT acceptable is `rtl` for English.
         expect(dir).not.toBe('rtl');
     });
 });
 
 test.describe('Mixed-locale layout — switching locales does not break the page', () => {
-    test('navigating from /en to /ar and back keeps the page non-blank', async ({
-        page,
-        baseURL,
-    }) => {
-        await page.goto(`${baseURL || 'http://localhost:3000'}/en/login`, {
-            waitUntil: 'domcontentloaded',
-        });
-        await page.waitForTimeout(800);
-        const arRes = await page.goto(`${baseURL || 'http://localhost:3000'}/ar/login`, {
-            waitUntil: 'domcontentloaded',
-        });
-        if (!arRes || arRes.status() === 404) {
-            test.skip(true, 'ar locale not exposed');
-        }
-        await page.waitForTimeout(800);
-        await page.goto(`${baseURL || 'http://localhost:3000'}/en/login`, {
-            waitUntil: 'domcontentloaded',
-        });
+    test('switching en → ar → en keeps the page non-blank', async ({ page, baseURL }) => {
+        await gotoWithLocale(page, baseURL, 'en', '/login');
+        await gotoWithLocale(page, baseURL, 'ar', '/login');
+
+        // Control: prove the flip actually happened, so "non-blank after
+        // switching back" is a statement about a real locale change.
+        expect(await page.evaluate(() => document.documentElement.lang)).toBe('ar');
+
+        await gotoWithLocale(page, baseURL, 'en', '/login');
         const body = await page
             .locator('body')
             .innerText()
@@ -90,3 +130,15 @@ test.describe('Mixed-locale layout — switching locales does not break the page
         );
     });
 });
+
+/**
+ * `fa` and `ur` were probed by the previous version of this spec "and skip
+ * cleanly on 404 if not shipped". With `localePrefix: 'never'` there is no 404
+ * to skip on — an unsupported locale in `NEXT_LOCALE` silently falls back to
+ * the default, so such a test would fail on the `lang` control above rather
+ * than skipping. They are therefore left out entirely: a test that cannot
+ * distinguish "not shipped" from "broken" is worse than no test.
+ *
+ * If `fa`/`ur` are ever added to `LOCALES`, add them to `RTL_LOCALES` above and
+ * they are covered with no other change.
+ */


### PR DESCRIPTION
Two more of the specs failing on stage E2E. **The tests were wrong; RTL itself works.**

## The spec tested a URL scheme the app does not use

It navigated to `/${locale}/login` and asserted `<html dir="rtl">`. But `i18n/routing.ts` sets `localePrefix: 'never'` — *"the locale belongs in user state, not in the URL … next-intl persists the locale in the `NEXT_LOCALE` cookie … without ever surfacing the segment to the browser."*

A prefixed path is therefore a **redirect**, not a localised page. Verified against production:

```
GET /ar/login  -> 307  https://app.ever.works/login
GET /he/login  -> 307  https://app.ever.works/login
GET /es/login  -> 307  https://app.ever.works/login   ← a SHIPPED locale
GET /fr/login  -> 307  https://app.ever.works/login   ← also shipped
```

Every prefixed path redirects — including locales that certainly exist — so the spec was asserting against the **English default page** and could never pass for any locale. Its escape hatch only fired on a 404, and these are 307 → 200, so it did not skip either.

## RTL is implemented and correct

Verified on production with the cookie the app actually uses:

| Cookie | `<html>` |
|---|---|
| `NEXT_LOCALE=ar` | `lang="ar" dir="rtl"` ✅ |
| `NEXT_LOCALE=he` | `lang="he" dir="rtl"` ✅ |
| `NEXT_LOCALE=en` | `lang="en" dir="ltr"` ✅ |

## Changes

- Drive the locale via `NEXT_LOCALE` and load the unprefixed path.
- **Add a `lang` control to every case.** Without it, a silent fallback to English would fail the `dir` assertion for a reason unrelated to RTL, sending the reader hunting in the wrong place.
- **Drop `fa`/`ur`.** They were probed on the promise that they "skip cleanly on 404 if not shipped" — but with `localePrefix: 'never'` there is no 404 to skip on, and an unsupported `NEXT_LOCALE` silently falls back to the default, so those cases would fail the `lang` control rather than skip. A test that cannot distinguish *not shipped* from *broken* is worse than no test. Neither is in `LOCALES`; `ar` and `he` both are, and both are in `RTL_LOCALES`.

The strict `toBe('rtl')` assertions are unchanged — `dir` returns the empty string when unset, which is how the original `not.toBe('ltr')` passed while RTL was entirely unimplemented.

Part of [EW-038](https://github.com/ever-works/ever-works/pull/2048): stage E2E has been red since at least 2026-08-11, which makes every `stage → main` promotion a judgement call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internationalization coverage for right-to-left languages.
  * Added validation for Arabic and Hebrew language settings and text direction.
  * Improved locale switching and English baseline checks.
  * Removed coverage for unsupported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->