### PR TITLE
fix(e2e): repair four stale specs behind the red stage suite (EW-038)

### DIFF
--- a/apps/web/e2e/agent-lifecycle-status.spec.ts
+++ b/apps/web/e2e/agent-lifecycle-status.spec.ts
@@ -150,9 +150,26 @@ test.describe('Agent lifecycle — status state machine', () => {
         // --- The /agents catalog card also carries the live status badge. ---
         // AgentCard renders an i18n status label ("Draft"/"Active"/"Paused").
         await page.goto('/agents', { waitUntil: 'domcontentloaded' });
-        const card = page
-            .locator('a', { has: page.getByRole('heading', { name, level: 3 }) })
-            .first();
+
+        // The card's <Link> is a full-bleed OVERLAY anchor — `absolute inset-0`
+        // with NO children (AgentCard.tsx:61-65). The card's text is a SIBLING
+        // of that anchor, not a descendant. So the old locator here,
+        //
+        //     page.locator('a', { has: getByRole('heading', { name, level: 3 }) })
+        //
+        // could never match, and failed with "element(s) not found" whether or
+        // not the card rendered — which reads exactly like a missing card.
+        //
+        // The card root became an overlay in commit 1a5e0144 (2026-08-09,
+        // PR #1994): "a button nested in an anchor is invalid markup and
+        // swallows keyboard activation". Deliberate a11y fix, no user-visible
+        // change. This spec predates it (last touched 2026-07-21), which is why
+        // it went red without anything breaking for users.
+        //
+        // Anchor to the href — the one thing that identifies THIS agent's card
+        // unambiguously — then step up to the card root that holds both the
+        // anchor and the content.
+        const card = page.locator(`a[href$="/agents/${agent.id}"]`).locator('xpath=..');
         await expect(card).toBeVisible({ timeout: 30_000 });
         // The paused card shows the "Paused" badge (i18n label) and not "Draft".
         await expect(card.getByText(/^Paused$/i)).toBeVisible({ timeout: 30_000 });

--- a/apps/web/e2e/flow-agent-inbox-messaging.spec.ts
+++ b/apps/web/e2e/flow-agent-inbox-messaging.spec.ts
@@ -59,16 +59,21 @@ import { createAgentViaAPI } from './helpers/agents-tasks';
  *
  *   POST /api/email/addresses { address, direction:'outbound'|'inbound',
  *                               pluginId, providerSettings, defaultForReplies? }
- *        → 201 { address:{ id, verified:false, verificationToken, disabledAt:null,
- *          defaultForReplies, … } }. The reply-from address lifecycle:
+ *        → 201 { address:{ id, verified:false, disabledAt:null,
+ *          defaultForReplies, … } }. NOTE: `verificationToken` is deliberately
+ *          ABSENT (EW-025) — returning it let a caller verify an address they
+ *          do not own without ever receiving the email. It is stripped on read
+ *          as well as on create. The reply-from address lifecycle:
  *          · GET  /api/email/addresses?direction=outbound → only ACTIVE rows
  *          · PATCH /api/email/addresses/:id { defaultForReplies|disabled }
  *            → 200 { address } (disabled stamps `disabledAt`, drops it from
  *            the active list — i.e. retiring a reply address)
  *          · POST /api/email/addresses/:id/verify → 500 (no provider key);
- *          · GET  /api/email/verify/:token (PUBLIC) → { verified:true } good
- *            token, { verified:false } bogus — the address-confirmation
- *            click-through that makes an address eligible to reply from.
+ *          · GET  /api/email/verify/:token (PUBLIC) → { verified:false } for a
+ *            bogus token. The POSITIVE path is not reachable from e2e: the
+ *            token is no longer returned (EW-025) and the mail goes via the
+ *            provider plugin, not the MailHog SMTP sink. See the note in the
+ *            lifecycle test.
  *        Cross-user: PATCH/DELETE/verify on another user's address → 404.
  *
  *   Auth: every authenticated route 401s without a bearer.
@@ -118,7 +123,8 @@ interface EmailAddress {
     direction: 'outbound' | 'inbound' | 'both';
     pluginId: string;
     verified: boolean;
-    verificationToken: string | null;
+    /** EW-025: never sent over the API — kept optional so tests can assert its ABSENCE. */
+    verificationToken?: never;
     defaultForReplies: boolean;
     disabledAt: string | null;
 }
@@ -402,7 +408,27 @@ test.describe('Agent inbox + messaging', () => {
 
         const addr = await createOutboundAddress(request, token);
         expect(addr.verified).toBe(false);
-        expect(addr.verificationToken, 'a fresh address carries a verification token').toBeTruthy();
+        // EW-025 — this used to assert the token was PRESENT
+        // (`expect(addr.verificationToken).toBeTruthy()`), i.e. it pinned a
+        // vulnerability rather than a feature.
+        //
+        // Ownership of an address is proven by receiving the emailed link, so
+        // returning the token in the creation response removed the only proof
+        // the flow has. Reproduced end to end before the fix:
+        //
+        //   1. POST an address the caller does NOT control -> 201, token in JSON
+        //   2. GET /api/email/verify/<token>  (unauthenticated) -> {"verified":true}
+        //   3. read back -> that address is now `verified`
+        //
+        // No mail was ever sent, and a verified address can then be used as an
+        // outbound sender. `toPublicEmailAddress` now strips the token at the
+        // controller boundary, so this asserts the token is ABSENT — which
+        // makes this test a regression guard for the hole instead of a pin on it.
+        expect(
+            addr.verificationToken,
+            'the verification token must never cross the API boundary — returning it lets a caller ' +
+                'verify an address they do not own without receiving the email',
+        ).toBeUndefined();
         expect(addr.disabledAt).toBeNull();
 
         // It is in the ACTIVE outbound pool (candidate reply-from address).
@@ -424,25 +450,45 @@ test.describe('Agent inbox + messaging', () => {
         ).toBe(true);
 
         // PUBLIC verify click-through: a bogus token is rejected (verified:false),
-        // the real token confirms it (verified:true) — both 200, never throwing.
+        // returning 200 rather than throwing.
         const bad = await request.get(`${API_BASE}/api/email/verify/${uniq('bogus')}`);
         expect(bad.status()).toBe(200);
         expect((await bad.json()).verified).toBe(false);
 
-        const good = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(good.status()).toBe(200);
-        expect((await good.json()).verified).toBe(true);
-
-        // After confirmation the address reports verified + consumes the token.
-        const afterVerify = (
+        // The address stays unverified until someone actually follows the
+        // emailed link — which is the entire point of EW-025.
+        const stillUnverified = (
             (await (
                 await request.get(`${API_BASE}/api/email/addresses?direction=outbound`, {
                     headers: authedHeaders(token),
                 })
             ).json()) as { addresses: EmailAddress[] }
         ).addresses.find((x) => x.id === addr.id);
-        expect(afterVerify?.verified).toBe(true);
-        expect(afterVerify?.verificationToken ?? null).toBeNull();
+        expect(stillUnverified?.verified).toBe(false);
+        // The list endpoint must not leak the token either — EW-025 strips it
+        // on read as well as on create, so a caller cannot harvest it later.
+        expect(stillUnverified?.verificationToken ?? undefined).toBeUndefined();
+
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The POSITIVE click-through (`GET /api/email/verify/<real token>` ->
+        // verified:true) is no longer reachable from an e2e test, and both
+        // reasons are by design:
+        //
+        //   1. EW-025 removed the token from every API response, so the test
+        //      cannot read it back. That is the fix, not an oversight.
+        //   2. The email goes out through the PROVIDER PLUGIN —
+        //      `triggerVerification` -> `emailFacade.verifyAddress` -> the
+        //      `postmark` plugin, seeded here with `apiKey: 'ci-fake-key'` —
+        //      not through SMTP. So it never reaches the MailHog sink the
+        //      e2e stack runs (`helpers/mailhog.ts`), and cannot be read from
+        //      there either. I checked; that was the obvious fix and it does
+        //      not work.
+        //
+        // Restoring this coverage needs one of: a fake/loopback email provider
+        // plugin for CI that writes to MailHog, or a test-only hook to fetch
+        // the token. Both are real work and neither belongs in this commit.
+        // Asserting `verified` stays false at least pins that the address is
+        // NOT self-verifiable without the email.
 
         // Retire the address: disabling stamps `disabledAt` and removes it from
         // the active reply pool (findActiveByUser filters disabled rows out).

--- a/apps/web/e2e/flow-agents-list-pagination-sort.spec.ts
+++ b/apps/web/e2e/flow-agents-list-pagination-sort.spec.ts
@@ -447,7 +447,7 @@ test.describe('GET /api/agents — filters', () => {
         expect((await listRaw(request, u.access_token, '?status=bogus')).status()).toBe(400);
     });
 
-    test('archived agents are excluded from the default list and ?status=archived is always empty', async ({
+    test('archived agents are excluded by default but returned when explicitly requested', async ({
         request,
     }) => {
         const u = await freshUser(request);
@@ -461,11 +461,24 @@ test.describe('GET /api/agents — filters', () => {
         expect(def.meta.total).toBe(2); // archived one dropped
         expect(def.data.map((r) => r.id)).not.toContain(ids[0]);
 
-        // `archived` is a valid enum (200) but the repo filters `status != archived`
-        // BEFORE applying the status filter → the intersection is always empty.
+        // `?status=archived` RETURNS the archived rows. `AgentRepository
+        // .findByUserIdScoped` computes `wantsArchived` and SKIPS the blanket
+        // `status != archived` predicate when the caller asks for them
+        // explicitly, then ANDs `status = archived`.
+        //
+        // This used to expect an empty list, describing the two predicates as
+        // contradicting each other. That contradiction is exactly what the
+        // carve-out was added to FIX — the repository's own comment notes that
+        // without it "the archived view is always empty" — and
+        // `app/[locale]/(dashboard)/agents/archived/page.tsx` renders
+        // `agentsAPI.list({ status: 'archived' })`, so the old expectation
+        // described a state in which that tab could never show anything.
         const arch = await list(request, u.access_token, '?status=archived');
-        expect(arch.meta.total).toBe(0);
-        expect(arch.data).toEqual([]);
+        expect(arch.meta.total).toBe(1);
+        // Identify the row, not just the count — a bare count would also pass
+        // if the wrong agent came back.
+        expect(arch.data.map((r) => r.id)).toEqual([ids[0]]);
+        expect(arch.data[0].status).toBe('archived');
     });
 
     test('?search matches on the agent name and total reflects only the matches', async ({

--- a/apps/web/e2e/flow-agents-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-agents-ui-journey.spec.ts
@@ -132,8 +132,18 @@ test.describe('Agents catalog UI — prompt-first surface', () => {
 
         await page.goto('/en/agents', { waitUntil: 'domcontentloaded' });
         // Scope to the card's own anchor (href ends at /agents/:id) so status
-        // and scope labels can't be satisfied by a neighbouring agent's card.
-        const card = page.locator(`a[href$="/agents/${agent.id}"]`).first();
+        // and scope labels can't be satisfied by a neighbouring agent's card —
+        // then step UP to the card root.
+        //
+        // The anchor is a full-bleed overlay (`absolute inset-0`, no children,
+        // AgentCard.tsx:61-65), so the name/status/scope text is a SIBLING of
+        // it, not a descendant. Searching inside the anchor — which is what
+        // `card.getByText(...)` did while `card` was the anchor itself — can
+        // never find them. Changed by commit 1a5e0144 (2026-08-09, PR #1994) to
+        // stop nesting a button inside an anchor; deliberate, no user-visible
+        // change. The `..` keeps the per-agent scoping the original comment
+        // wanted while looking at the subtree that actually holds the text.
+        const card = page.locator(`a[href$="/agents/${agent.id}"]`).first().locator('xpath=..');
         await expect(card).toBeVisible({ timeout: 30_000 });
         await expect(card.getByText(agent.name)).toBeVisible();
         await expect(card.getByText('Draft', { exact: true })).toBeVisible();


### PR DESCRIPTION
Stage E2E has been red since at least 2026-08-11. Triaging every failure found **not one user-visible defect** — all four specs assert contracts that shipped code deliberately changed, or that this session's own security fix removed.

## 1 + 2. `agent-lifecycle-status` and `flow-agents-ui-journey` — one cause

`AgentCard`'s `<Link>` is a full-bleed **overlay** anchor — `absolute inset-0`, zero children (`AgentCard.tsx:61-65`). The card's text is a **sibling** of it. Both specs searched *inside* the anchor:

```ts
locator('a', { has: getByRole('heading', { level: 3 }) })   // never matches
locator(`a[href$="/agents/${id}"]`).getByText(name)         // never matches
```

so they failed with `element(s) not found` **whether or not the card rendered** — which reads exactly like a missing card. Both now anchor on the href (the one thing identifying *this* agent's card) and step up to the card root.

**Cause:** commit `1a5e0144` (2026-08-09, PR #1994) switched the card root from a wrapping `<Link>` to an overlay anchor because *"a button nested in an anchor is invalid markup and swallows keyboard activation"* — a deliberate a11y fix, and *"callers that pass no actions render identically."* Both specs predate it; E2E went red ~08-11. The dates line up.

> I had previously recorded the **opposite** — that the selector was correct, so the card must not have rendered. That was wrong: I saw `<Link` at line 61 and `<h3>` at line 78 and inferred containment without checking the `<Link>` closed at 65. Line proximity is not containment.

## 3. `flow-agents-list-pagination-sort` — the archived carve-out

Asserted `?status=archived` is *"always empty"*. `findByUserIdScoped` skips the blanket `status != archived` predicate when archived is explicitly requested, and `/agents/archived` renders `agentsAPI.list({ status: 'archived' })`. The old expectation described a state where **that tab could never show anything**. Now asserts the row *is* returned, identified by id and status rather than by count.

## 4. `flow-agent-inbox-messaging` — broken by my own EW-025 fix

```ts
expect(addr.verificationToken, 'a fresh address carries a verification token').toBeTruthy();
```

EW-025 strips that token from every API response, because returning it let a caller verify an address they **do not own** without receiving the email. **The spec was pinning the vulnerability**, and my fix turned it red — I shipped EW-025 without updating it.

It now asserts the token is **absent** on create *and* on list, turning the spec into a regression guard for the hole.

The **positive** verify click-through is recorded as a deliberate coverage gap, with both reasons at the call site:
1. the token is no longer readable from the API — that is the fix, not an oversight;
2. the mail goes via the provider plugin (`postmark`, `ci-fake-key`), not SMTP, so it never reaches the MailHog sink the e2e stack runs.

I checked MailHog first — it was the obvious fix and it does not work. Restoring the coverage needs a loopback email provider for CI or a test-only token hook; neither belongs here. The spec's header doc and `EmailAddress` interface are updated so the file no longer documents the pre-EW-025 contract.

## Verification

`tsc --noEmit` on `apps/web`: **0 errors** against a 0 baseline — and a deliberately-introduced type error in one of these specs **was** caught, proving the e2e files are genuinely inside that typecheck rather than silently excluded.

Related: [#2048](https://github.com/ever-works/ever-works/pull/2048) (same archived carve-out in a sibling spec), [#2049](https://github.com/ever-works/ever-works/pull/2049) (RTL spec tested a URL scheme the app does not use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for agent lifecycle and catalog details.
  * Updated verification checks to confirm tokens remain protected and addresses stay unverified until valid confirmation.
  * Added coverage ensuring archived-agent filtering returns the correct results.
  * Strengthened checks for agent names, statuses, and scopes displayed in catalog cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->