### PR TITLE
fix(csp): allow the Cloudflare Web Analytics beacon on the app (EW-033)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -55,7 +55,7 @@ const CSP = [
     "media-src 'self' https:",
     "font-src 'self' data:",
     "style-src 'self' 'unsafe-inline'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com https://challenges.cloudflare.com",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com https://challenges.cloudflare.com https://static.cloudflareinsights.com",
     // EW-617 — Cloudflare Turnstile widget script + challenge iframe. Keep in
     // lock-step with proxy.ts's buildCsp() (its byte-twin).
     "frame-src 'self' https://challenges.cloudflare.com",

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -90,7 +90,7 @@ function buildCsp(): string {
         "media-src 'self' https:",
         "font-src 'self' data:",
         "style-src 'self' 'unsafe-inline'",
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com https://challenges.cloudflare.com",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com https://challenges.cloudflare.com https://static.cloudflareinsights.com",
         // EW-617 — Cloudflare Turnstile widget script + challenge iframe. Keep
         // in lock-step with next.config.ts's CSP array (its byte-twin).
         "frame-src 'self' https://challenges.cloudflare.com",


### PR DESCRIPTION
Every page load on `app.ever.works` logs a CSP violation:

```
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/…'
violates the following CSP directive: "script-src 'self' 'unsafe-inline'
'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com
https://challenges.cloudflare.com"
```

The beacon is injected by the **Cloudflare proxy** because Web Analytics is enabled on the zone. It can never be self-hosted, so the CSP can never satisfy it without naming the host. Net effect: **analytics the owner switched on has been silently dead**, and every visitor gets a console error.

This does not add a new third-party vendor — it realigns the CSP with a setting that is already on. `script-src` already permits PostHog (us + eu) and `challenges.cloudflare.com`.

**Applied to both copies.** The identical string lives in `apps/web/next.config.ts` (headers()) *and* `apps/web/src/proxy.ts`. Changing one and not the other would leave the two paths serving different policies — the kind of drift nobody notices until a header differs by route.

`apps/web/e2e/csp-strict.spec.ts` only rejects a literal `*` in `script-src`; it does not pin the host list, so it stays green and still guards what it exists to guard.

⚠️ **`font-src` is deliberately untouched.** The demo site shows 24 blocked `fonts.gstatic.com` requests per page, which looks like the same class of bug and is not: `next/font` self-hosts, and **zero elements** use that font. Widening `font-src` would ship 24 cross-origin fetches for an unused font and hide a broken build behind a green console. Tracked separately as EW-034.

Matching fix for the generated-site template: [directory-web-template#1010](https://github.com/ever-works/directory-web-template/pull/1010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)