### PR TITLE
fix(ci): give the MCP caller-identity bootstrap its own hook timeout (EW-038)

### DIFF
--- a/apps/mcp/test/caller-identity.e2e.spec.ts
+++ b/apps/mcp/test/caller-identity.e2e.spec.ts
@@ -163,7 +163,32 @@ describe('caller identity reaches the upstream API (HTTP transport)', () => {
 		app = await NestFactory.create(AppModule, { logger: false });
 		await app.listen(0, '127.0.0.1');
 		baseUrl = await app.getUrl();
-	});
+		// Per-hook timeout, deliberately larger than the 30 s global in
+		// vitest.config.ts.
+		//
+		// This hook is not a unit-spec cold import — it boots a whole Nest
+		// application: dynamic import of `@nestjs/core` + `app.module.js`,
+		// `NestFactory.create` (provider graph, plugin discovery, OpenAPI spec
+		// parsing from SPEC_FIXTURE), then a real listen. Locally that is ~5 s;
+		// under the concurrent turbo test load on a self-hosted runner it drifts
+		// past 30 s often enough to flake CI.
+		//
+		// The cost is not a slow test, it is an UNRELIABLE SIGNAL: on 2026-08-13
+		// the SAME commit (005a3e17) reported `lint-and-test` PASS on the push
+		// run and FAIL on the pull_request run, with this hook the only failure —
+		// so "is this branch green?" came down to which run you happened to read.
+		//
+		// Raising the number is the right fix HERE, unlike the usual case: there
+		// is nothing to poll for. The hook awaits one bounded bootstrap, so a
+		// genuine hang still fails — just later — while ordinary CI-load slowness
+		// stops producing a red build. Applied per-hook so the 30 s global still
+		// makes a hang anywhere else fail fast.
+		//
+		// vitest.config.ts already made this same trade once (5 s -> 30 s, "CI-load
+		// resilience … cold `await import()` … under the concurrent turbo test
+		// load"). This hook simply does much more work than the specs that
+		// motivated it.
+	}, 120_000);
 
 	afterAll(async () => {
 		await app?.close();


### PR DESCRIPTION
`lint-and-test` has been flaking on `ever-works-mcp`:

```
test/caller-identity.e2e.spec.ts > caller identity reaches the upstream API
Error: Hook timed out in 30000ms
```

**It is not a hang.** The hook boots a whole Nest application — dynamic import of `@nestjs/core` + `app.module.js`, `NestFactory.create` (provider graph, plugin discovery, OpenAPI spec parsing from `SPEC_FIXTURE`), then a real `listen`. Locally that takes **5.3 s**; under the concurrent turbo test load on a self-hosted runner it drifts past the 30 s global.

## The cost is an unreliable signal, not a slow test

On 2026-08-13 the **same commit** (`005a3e17`) reported `lint-and-test` **PASS** on the `push` run and **FAIL** on the `pull_request` run, with this hook the only failure. So *"is this branch green?"* came down to which of two identical runs you happened to read — and `gh pr checks` shows whichever landed last.

It also blocked [#2050](https://github.com/ever-works/ever-works/pull/2050), whose diff touches only `apps/web/e2e` — files `lint-and-test` never runs.

## Why raising the number is right *here*

Normally bumping a timeout relocates a flake rather than fixing it, and I said exactly that earlier in this sweep. It does not apply to this hook: **there is nothing to poll for.** It awaits one bounded bootstrap. A genuine hang still fails — just later — while ordinary CI-load slowness stops producing a red build.

Applied **per-hook** (120 s) rather than globally, so the 30 s in `vitest.config.ts` still makes a hang anywhere else fail fast.

That config already made this same trade once — 5 s → 30 s, *"CI-load resilience … cold `await import()` … under the concurrent turbo test load"*. This hook simply does much more work than the specs that motivated it.

**Blast radius checked:** `grep -rln NestFactory.create apps/mcp/test` returns this file only, so no sibling spec carries the same risk.

**Verified:** 4/4 pass locally in ~5 s with the change applied.

Part of EW-038 — the last genuinely *flaky* item, as distinct from the five specs that had simply drifted from the product ([#2048](https://github.com/ever-works/ever-works/pull/2048), [#2049](https://github.com/ever-works/ever-works/pull/2049), [#2050](https://github.com/ever-works/ever-works/pull/2050)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the setup timeout for caller identity end-to-end tests to improve reliability during slower initialization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->