### PR TITLE
fix(goals): a blank Target value must not become a target of 0 (EW-044)

### DIFF
--- a/apps/web/src/components/goals/GoalForm.tsx
+++ b/apps/web/src/components/goals/GoalForm.tsx
@@ -84,8 +84,19 @@ export function GoalForm() {
             toast.error(t('errors.metricSourceRequired'));
             return;
         }
-        const target = Number(targetValue);
-        if (!Number.isFinite(target)) {
+        // `Number('')` is 0, NOT NaN — so checking only `Number.isFinite` let an
+        // EMPTY Target value through as a real target of 0. Combined with the
+        // default comparator `gte`, that creates a Goal meaning "reach at least
+        // 0", which every possible metric value already satisfies: the Goal is
+        // vacuous and reports success on its first evaluation. Verified on
+        // production — submitting the form with Target value blank produced
+        // `targetValue = 0, comparator = gte` with no error shown.
+        //
+        // The empty case must be rejected explicitly, before the conversion.
+        // `Number(' ')` is 0 too, hence the trim.
+        const rawTarget = targetValue.trim();
+        const target = Number(rawTarget);
+        if (rawTarget.length === 0 || !Number.isFinite(target)) {
             toast.error(t('errors.targetInvalid'));
             return;
         }

--- a/apps/web/src/components/goals/goal-target-validation.unit.spec.ts
+++ b/apps/web/src/components/goals/goal-target-validation.unit.spec.ts
@@ -27,52 +27,52 @@ import { describe, it, expect } from 'vitest';
 
 /** The guard as it now stands in GoalForm.handleSubmit. */
 function targetValueIsAcceptable(raw: string): boolean {
-	const trimmed = raw.trim();
-	const n = Number(trimmed);
-	return trimmed.length > 0 && Number.isFinite(n);
+    const trimmed = raw.trim();
+    const n = Number(trimmed);
+    return trimmed.length > 0 && Number.isFinite(n);
 }
 
 /** The guard as it was — kept so the regression is demonstrable, not asserted. */
 function legacyGuard(raw: string): boolean {
-	return Number.isFinite(Number(raw));
+    return Number.isFinite(Number(raw));
 }
 
 describe('Goal target value validation', () => {
-	it('control: the legacy guard really did accept an empty string', () => {
-		// If this ever fails, the bug this spec exists for was never real and the
-		// rest of the file is theatre. Pinning it makes the regression concrete.
-		expect(legacyGuard('')).toBe(true);
-		expect(Number('')).toBe(0);
-		expect(Number('   ')).toBe(0);
-	});
+    it('control: the legacy guard really did accept an empty string', () => {
+        // If this ever fails, the bug this spec exists for was never real and the
+        // rest of the file is theatre. Pinning it makes the regression concrete.
+        expect(legacyGuard('')).toBe(true);
+        expect(Number('')).toBe(0);
+        expect(Number('   ')).toBe(0);
+    });
 
-	it.each([
-		['', 'empty'],
-		['   ', 'whitespace only'],
-		['abc', 'not a number'],
-		['NaN', 'literal NaN'],
-		['Infinity', 'infinite'],
-		['-Infinity', 'negative infinite'],
-	])('rejects %j (%s)', (raw) => {
-		expect(targetValueIsAcceptable(raw)).toBe(false);
-	});
+    it.each([
+        ['', 'empty'],
+        ['   ', 'whitespace only'],
+        ['abc', 'not a number'],
+        ['NaN', 'literal NaN'],
+        ['Infinity', 'infinite'],
+        ['-Infinity', 'negative infinite'],
+    ])('rejects %j (%s)', (raw) => {
+        expect(targetValueIsAcceptable(raw)).toBe(false);
+    });
 
-	it.each([
-		['1000', 'a plain integer'],
-		['0', 'an EXPLICIT zero — a deliberate target of 0 is still legitimate'],
-		['0.5', 'a fraction'],
-		['-25', 'a negative target, e.g. shrinking a cost'],
-		[' 42 ', 'padded but valid'],
-	])('accepts %j (%s)', (raw) => {
-		expect(targetValueIsAcceptable(raw)).toBe(true);
-	});
+    it.each([
+        ['1000', 'a plain integer'],
+        ['0', 'an EXPLICIT zero — a deliberate target of 0 is still legitimate'],
+        ['0.5', 'a fraction'],
+        ['-25', 'a negative target, e.g. shrinking a cost'],
+        [' 42 ', 'padded but valid'],
+    ])('accepts %j (%s)', (raw) => {
+        expect(targetValueIsAcceptable(raw)).toBe(true);
+    });
 
-	it('distinguishes an explicit 0 from a blank field — the whole point of the fix', () => {
-		// The old guard could not tell these apart; that is what made the bug
-		// invisible. A user who genuinely wants a target of 0 must still be able
-		// to say so, so the fix must not simply reject falsy numbers.
-		expect(targetValueIsAcceptable('0')).toBe(true);
-		expect(targetValueIsAcceptable('')).toBe(false);
-		expect(legacyGuard('0')).toBe(legacyGuard('')); // both true — indistinguishable
-	});
+    it('distinguishes an explicit 0 from a blank field — the whole point of the fix', () => {
+        // The old guard could not tell these apart; that is what made the bug
+        // invisible. A user who genuinely wants a target of 0 must still be able
+        // to say so, so the fix must not simply reject falsy numbers.
+        expect(targetValueIsAcceptable('0')).toBe(true);
+        expect(targetValueIsAcceptable('')).toBe(false);
+        expect(legacyGuard('0')).toBe(legacyGuard('')); // both true — indistinguishable
+    });
 });

--- a/apps/web/src/components/goals/goal-target-validation.unit.spec.ts
+++ b/apps/web/src/components/goals/goal-target-validation.unit.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * EW-044 — a blank Target value must not become a target of 0.
+ *
+ * `GoalForm` validated the field with:
+ *
+ *     const target = Number(targetValue);
+ *     if (!Number.isFinite(target)) { toast.error(…); return; }
+ *
+ * `Number('')` is **0**, not `NaN`, so an empty field sailed straight through
+ * and was persisted as a real target. Combined with the default comparator
+ * `gte`, the resulting Goal means *"reach at least 0"* — satisfied by every
+ * possible metric value, so it is vacuous and reports success on its first
+ * evaluation.
+ *
+ * Confirmed on production before the fix: submitting with Target value blank
+ * created goal `0c2db0bf-049b-4abd-af18-f2902ca26c38` with
+ * `targetValue = 0, comparator = gte`, and no error was shown to the user.
+ *
+ * This pins the PREDICATE rather than the component. The bug is entirely in the
+ * accept/reject decision — rendering a form and firing a toast adds mocks
+ * without adding evidence, and the empty-string case is exactly what a
+ * component test with a `fireEvent.change(…, '')` would be least likely to
+ * cover convincingly.
+ */
+
+/** The guard as it now stands in GoalForm.handleSubmit. */
+function targetValueIsAcceptable(raw: string): boolean {
+	const trimmed = raw.trim();
+	const n = Number(trimmed);
+	return trimmed.length > 0 && Number.isFinite(n);
+}
+
+/** The guard as it was — kept so the regression is demonstrable, not asserted. */
+function legacyGuard(raw: string): boolean {
+	return Number.isFinite(Number(raw));
+}
+
+describe('Goal target value validation', () => {
+	it('control: the legacy guard really did accept an empty string', () => {
+		// If this ever fails, the bug this spec exists for was never real and the
+		// rest of the file is theatre. Pinning it makes the regression concrete.
+		expect(legacyGuard('')).toBe(true);
+		expect(Number('')).toBe(0);
+		expect(Number('   ')).toBe(0);
+	});
+
+	it.each([
+		['', 'empty'],
+		['   ', 'whitespace only'],
+		['abc', 'not a number'],
+		['NaN', 'literal NaN'],
+		['Infinity', 'infinite'],
+		['-Infinity', 'negative infinite'],
+	])('rejects %j (%s)', (raw) => {
+		expect(targetValueIsAcceptable(raw)).toBe(false);
+	});
+
+	it.each([
+		['1000', 'a plain integer'],
+		['0', 'an EXPLICIT zero — a deliberate target of 0 is still legitimate'],
+		['0.5', 'a fraction'],
+		['-25', 'a negative target, e.g. shrinking a cost'],
+		[' 42 ', 'padded but valid'],
+	])('accepts %j (%s)', (raw) => {
+		expect(targetValueIsAcceptable(raw)).toBe(true);
+	});
+
+	it('distinguishes an explicit 0 from a blank field — the whole point of the fix', () => {
+		// The old guard could not tell these apart; that is what made the bug
+		// invisible. A user who genuinely wants a target of 0 must still be able
+		// to say so, so the fix must not simply reject falsy numbers.
+		expect(targetValueIsAcceptable('0')).toBe(true);
+		expect(targetValueIsAcceptable('')).toBe(false);
+		expect(legacyGuard('0')).toBe(legacyGuard('')); // both true — indistinguishable
+	});
+});


### PR DESCRIPTION
## The bug

`GoalForm` validated Target value with:

```ts
const target = Number(targetValue);
if (!Number.isFinite(target)) { toast.error(t('errors.targetInvalid')); return; }
```

**`Number('')` is `0`, not `NaN`.** So the guard catches `'abc'` and sails straight past an empty field, persisting 0 as a real target.

Combined with the default comparator `gte`, the resulting Goal means **"reach at least 0"** — satisfied by every possible metric value. The Goal is vacuous, reports success on its first evaluation, and the user is never told anything went wrong.

## Confirmed on production

Submitted the form with Target value blank:

```
goal 0c2db0bf-049b-4abd-af18-f2902ca26c38
targetValue = 0 | comparator = gte | window = month | status = draft
```

No error, no warning — straight to the detail page.

## The fix

Reject empty/whitespace-only input explicitly, before the conversion (`Number(' ')` is 0 too, hence the trim).

**An explicit `'0'` is still accepted.** A deliberate target of zero is legitimate — "keep failures at 0" is a perfectly good Goal — so the fix must not simply reject falsy numbers, which is the obvious wrong way to patch this.

## Tests

Pin the **predicate**, not the component: the bug lives entirely in the accept/reject decision, and rendering a form to fire a toast would add mocks without adding evidence.

Two of the 13 cases matter most:
- a **control** asserting the *legacy* guard really did accept `''` — so the regression is demonstrated rather than asserted;
- a case proving the old guard **could not distinguish an explicit `'0'` from a blank field**, which is exactly what made this invisible.

`tsc --noEmit`: 0 errors. Prettier: clean. 13/13 pass.

Found by a code-reading pass that predicted it from `GoalForm.tsx:87-91`, then confirmed in the browser against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Goal targets now reject blank, whitespace-only, nonnumeric, and non-finite values.
  - Explicit zero, negative values, fractions, and numbers with surrounding spaces remain supported.
  - Blank goal targets can no longer be submitted as zero.

- **Tests**
  - Added regression coverage for valid and invalid goal target inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->