### PR TITLE
fix(activity): CSV export must honour the `search` filter (EW-049)

### DIFF
--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -164,6 +164,7 @@ export class ActivityLogController {
     @ApiQuery({ name: 'status', required: false })
     @ApiQuery({ name: 'dateFrom', required: false })
     @ApiQuery({ name: 'dateTo', required: false })
+    @ApiQuery({ name: 'search', required: false })
     @ApiResponse({ status: 200, description: 'CSV file download' })
     async exportCsv(
         @CurrentUser() auth: AuthenticatedUser,
@@ -173,6 +174,17 @@ export class ActivityLogController {
         @Query('status') status?: string,
         @Query('dateFrom') dateFrom?: string,
         @Query('dateTo') dateTo?: string,
+        // The Activity page sends `search` alongside the other filters, but this
+        // handler never declared it, so Nest dropped it and the export returned
+        // the user's ENTIRE log while the screen showed a filtered view. Verified
+        // on production: `?search=deployment` and `?search=zzz-cannot-match-zzz`
+        // both returned byte-identical CSV to the unfiltered request.
+        //
+        // Nothing below the controller needed changing — `ActivityLogQueryOptions`
+        // already declares `search`, and `findByUserIdForExport` shares
+        // `findByUserIdWithLimit` with the list query, which applies it. The
+        // filter existed on every layer except the one that reads the URL.
+        @Query('search') search?: string,
     ) {
         await this.reconcileActivities(auth.userId);
 
@@ -183,6 +195,7 @@ export class ActivityLogController {
             status: status as ActivityStatus,
             dateFrom: dateFrom ? new Date(dateFrom) : undefined,
             dateTo: dateTo ? new Date(dateTo) : undefined,
+            search,
         });
 
         res.setHeader('Content-Type', 'text/csv');


### PR DESCRIPTION
The Activity page sends `search` with its other filters, but the export handler never declared it — so Nest dropped it silently. **A user filtering the screen and clicking Export downloads their entire activity log**, and the file disagrees with the view that produced it.

## Verified on production

| Request | Rows | Bytes |
|---|---|---|
| `/export` | 16 | 2122 |
| `/export?search=deployment` | 16 | 2122 |
| `/export?search=zzz-cannot-match-zzz` | **16** | **2122** |

The impossible search is the control: a term that *cannot* match anything returns byte-identical output, so the parameter is **ignored**, not merely unselective.

## Three lines, because every other layer already worked

- `ActivityLogQueryOptions` already declares `search?: string`
- `findByUserIdForExport` and `findByUserId` both delegate to the same private `findByUserIdWithLimit`, which applies the search predicate

**The filter existed on every layer except the one that reads the URL.** So this adds the `@Query('search')` param, the matching `@ApiQuery` doc, and passes it through — no service or repository change.

## Verification note

`pnpm --filter "ever-works-api..." build` exits **0** (802 files compiled).

Worth recording: the plain `--filter ever-works-api` build fails locally on unbuilt workspace deps (`@ever-works/trigger-tasks`, `monitoring`, `github-storage-plugin`), and grepping that failing output for `error TS` returns **0** — which looks exactly like success. That is the REG-001 trap. The `...` suffix builds the dependency graph; check the exit code, not a match count.

Predicted by a code-reading pass, then confirmed in the browser against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity log CSV exports now respect the search filter applied in the interface.
  * Exported results can be narrowed using the search query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->