### PR TITLE
fix(test): stop ActivityFeedClient asserting on the LAST call (EW-052)

### DIFF
--- a/apps/web/src/components/works/detail/activity/ActivityFeedClient.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/activity/ActivityFeedClient.unit.spec.tsx
@@ -127,7 +127,22 @@ describe('ActivityFeedClient', () => {
         await waitFor(() => {
             expect(screen.getByText('Second entry')).toBeInTheDocument();
         });
-        expect(mockGetActivityFeed).toHaveBeenLastCalledWith(
+        // `toHaveBeenCalledWith`, not `toHaveBeenLastCalledWith`.
+        //
+        // What this test cares about is that paginating issued a fetch carrying
+        // the cursor from the last row of page 1. It does NOT care whether that
+        // was the final call the component ever made.
+        //
+        // Asserting on the LAST call made this spec order-sensitive: only two
+        // responses are queued with `mockResolvedValueOnce`, so any further
+        // fetch after the page-2 render — a re-render, an effect re-running, a
+        // refresh — falls through to the base mock and becomes "last", and the
+        // assertion fails against arguments it was never about.
+        //
+        // It failed exactly that way on CI for two unrelated PRs (#2055 Goals,
+        // #2058 Tasks), neither touching this component, while passing 6/6 runs
+        // locally — the signature of a race that only opens under load.
+        expect(mockGetActivityFeed).toHaveBeenCalledWith(
             'work-1',
             expect.objectContaining({ cursor: '2026-05-13T00:00:00.000Z' }),
         );


### PR DESCRIPTION
`toHaveBeenLastCalledWith` → `toHaveBeenCalledWith` for the pagination cursor.

## Why it flakes

The test cares that paginating issued a fetch carrying the cursor from the last row of page 1. It does **not** care whether that was the final call the component ever made — but asserting on the *last* call made it depend on exactly that.

Only two responses are queued via `mockResolvedValueOnce`, so any further fetch after the page-2 render (a re-render, an effect re-running, a refresh) falls through to the base mock and becomes "last". The assertion then compares against arguments it was never about.

## Evidence it is a real blocker, not a one-off

It failed on CI for **two unrelated PRs** — [#2055](https://github.com/ever-works/ever-works/pull/2055) (Goals validation) and [#2058](https://github.com/ever-works/ever-works/pull/2058) (Tasks label cap) — neither touching this component or anything it renders:

```
AssertionError: expected last "vi.fn()" call to have been called with
  [ 'work-1', ObjectContaining{…} ]
```

Meanwhile it passed **6/6** consecutive local runs. A race that only opens under CI load.

## The control that matters

Relaxing `Last` genuinely weakens an assertion, so I verified it is not now a tautology: substituting a deliberately wrong cursor still **fails** the test (1 failed / 7). Without that check, this change could have quietly turned a real assertion into one that passes on any call with the right shape.

## Scope

Deliberately narrow — this is the one assertion with evidence of flaking. Five other `toHaveBeenLastCalledWith` uses exist in `apps/web`; changing them speculatively would weaken passing tests for no demonstrated reason.

Part of [EW-038](https://github.com/ever-works/ever-works/pull/2053) — the third distinct flake class this session, after the MCP hook timeout and 16 runner-comms losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved pagination test reliability by checking that the expected request was made without depending on request order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->