### PR TITLE
cascade(develop→stage): 4 fixes + 2 docs pages

### DIFF
--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -164,6 +164,7 @@ export class ActivityLogController {
     @ApiQuery({ name: 'status', required: false })
     @ApiQuery({ name: 'dateFrom', required: false })
     @ApiQuery({ name: 'dateTo', required: false })
+    @ApiQuery({ name: 'search', required: false })
     @ApiResponse({ status: 200, description: 'CSV file download' })
     async exportCsv(
         @CurrentUser() auth: AuthenticatedUser,
@@ -173,6 +174,17 @@ export class ActivityLogController {
         @Query('status') status?: string,
         @Query('dateFrom') dateFrom?: string,
         @Query('dateTo') dateTo?: string,
+        // The Activity page sends `search` alongside the other filters, but this
+        // handler never declared it, so Nest dropped it and the export returned
+        // the user's ENTIRE log while the screen showed a filtered view. Verified
+        // on production: `?search=deployment` and `?search=zzz-cannot-match-zzz`
+        // both returned byte-identical CSV to the unfiltered request.
+        //
+        // Nothing below the controller needed changing — `ActivityLogQueryOptions`
+        // already declares `search`, and `findByUserIdForExport` shares
+        // `findByUserIdWithLimit` with the list query, which applies it. The
+        // filter existed on every layer except the one that reads the URL.
+        @Query('search') search?: string,
     ) {
         await this.reconcileActivities(auth.userId);
 
@@ -183,6 +195,7 @@ export class ActivityLogController {
             status: status as ActivityStatus,
             dateFrom: dateFrom ? new Date(dateFrom) : undefined,
             dateTo: dateTo ? new Date(dateTo) : undefined,
+            search,
         });
 
         res.setHeader('Content-Type', 'text/csv');

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
 				'features/settings-map',
 				'features/missions',
 				'features/ideas',
+				'features/goals',
 				'features/agents',
 				'features/agents-catalog',
 				'features/skills-catalog',

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -97,6 +97,7 @@ const sidebars: SidebarsConfig = {
 				'features/works-config',
 				'features/work-import',
 				'features/work-members',
+				'features/teams',
 				'features/comparisons',
 				'features/advanced-prompts',
 				'features/git-operations',

--- a/apps/web/src/components/goals/GoalForm.tsx
+++ b/apps/web/src/components/goals/GoalForm.tsx
@@ -84,8 +84,19 @@ export function GoalForm() {
             toast.error(t('errors.metricSourceRequired'));
             return;
         }
-        const target = Number(targetValue);
-        if (!Number.isFinite(target)) {
+        // `Number('')` is 0, NOT NaN — so checking only `Number.isFinite` let an
+        // EMPTY Target value through as a real target of 0. Combined with the
+        // default comparator `gte`, that creates a Goal meaning "reach at least
+        // 0", which every possible metric value already satisfies: the Goal is
+        // vacuous and reports success on its first evaluation. Verified on
+        // production — submitting the form with Target value blank produced
+        // `targetValue = 0, comparator = gte` with no error shown.
+        //
+        // The empty case must be rejected explicitly, before the conversion.
+        // `Number(' ')` is 0 too, hence the trim.
+        const rawTarget = targetValue.trim();
+        const target = Number(rawTarget);
+        if (rawTarget.length === 0 || !Number.isFinite(target)) {
             toast.error(t('errors.targetInvalid'));
             return;
         }

--- a/apps/web/src/components/goals/goal-target-validation.unit.spec.ts
+++ b/apps/web/src/components/goals/goal-target-validation.unit.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * EW-044 — a blank Target value must not become a target of 0.
+ *
+ * `GoalForm` validated the field with:
+ *
+ *     const target = Number(targetValue);
+ *     if (!Number.isFinite(target)) { toast.error(…); return; }
+ *
+ * `Number('')` is **0**, not `NaN`, so an empty field sailed straight through
+ * and was persisted as a real target. Combined with the default comparator
+ * `gte`, the resulting Goal means *"reach at least 0"* — satisfied by every
+ * possible metric value, so it is vacuous and reports success on its first
+ * evaluation.
+ *
+ * Confirmed on production before the fix: submitting with Target value blank
+ * created goal `0c2db0bf-049b-4abd-af18-f2902ca26c38` with
+ * `targetValue = 0, comparator = gte`, and no error was shown to the user.
+ *
+ * This pins the PREDICATE rather than the component. The bug is entirely in the
+ * accept/reject decision — rendering a form and firing a toast adds mocks
+ * without adding evidence, and the empty-string case is exactly what a
+ * component test with a `fireEvent.change(…, '')` would be least likely to
+ * cover convincingly.
+ */
+
+/** The guard as it now stands in GoalForm.handleSubmit. */
+function targetValueIsAcceptable(raw: string): boolean {
+    const trimmed = raw.trim();
+    const n = Number(trimmed);
+    return trimmed.length > 0 && Number.isFinite(n);
+}
+
+/** The guard as it was — kept so the regression is demonstrable, not asserted. */
+function legacyGuard(raw: string): boolean {
+    return Number.isFinite(Number(raw));
+}
+
+describe('Goal target value validation', () => {
+    it('control: the legacy guard really did accept an empty string', () => {
+        // If this ever fails, the bug this spec exists for was never real and the
+        // rest of the file is theatre. Pinning it makes the regression concrete.
+        expect(legacyGuard('')).toBe(true);
+        expect(Number('')).toBe(0);
+        expect(Number('   ')).toBe(0);
+    });
+
+    it.each([
+        ['', 'empty'],
+        ['   ', 'whitespace only'],
+        ['abc', 'not a number'],
+        ['NaN', 'literal NaN'],
+        ['Infinity', 'infinite'],
+        ['-Infinity', 'negative infinite'],
+    ])('rejects %j (%s)', (raw) => {
+        expect(targetValueIsAcceptable(raw)).toBe(false);
+    });
+
+    it.each([
+        ['1000', 'a plain integer'],
+        ['0', 'an EXPLICIT zero — a deliberate target of 0 is still legitimate'],
+        ['0.5', 'a fraction'],
+        ['-25', 'a negative target, e.g. shrinking a cost'],
+        [' 42 ', 'padded but valid'],
+    ])('accepts %j (%s)', (raw) => {
+        expect(targetValueIsAcceptable(raw)).toBe(true);
+    });
+
+    it('distinguishes an explicit 0 from a blank field — the whole point of the fix', () => {
+        // The old guard could not tell these apart; that is what made the bug
+        // invisible. A user who genuinely wants a target of 0 must still be able
+        // to say so, so the fix must not simply reject falsy numbers.
+        expect(targetValueIsAcceptable('0')).toBe(true);
+        expect(targetValueIsAcceptable('')).toBe(false);
+        expect(legacyGuard('0')).toBe(legacyGuard('')); // both true — indistinguishable
+    });
+});

--- a/apps/web/src/components/tasks/NewTaskForm.tsx
+++ b/apps/web/src/components/tasks/NewTaskForm.tsx
@@ -56,12 +56,40 @@ const PRIORITY_OPTIONS: ReadonlyArray<{
  * non-alphanumerics) collapse to a single hyphen, with no leading or
  * trailing hyphens. So "Redesign onboarding flow" → "redesign-onboarding-flow".
  */
+/**
+ * The API caps each label at 80 characters (`@MaxLength(80, { each: true })`
+ * on both the create and update DTOs), while the Title input allows 200. Since
+ * the Labels field mirrors the slugified title until the user edits it, ANY
+ * title longer than 80 characters derived an over-length label and made the
+ * Task uncreatable — with no hint that the *label* was the problem, because the
+ * server action surfaces the rejection as a generic
+ * "An error occurred in the Server Components render" alert.
+ *
+ * Verified on production before the fix: an 88-character title produced an
+ * 88-character label, Create stayed on /tasks/new, and no row was written.
+ *
+ * Truncating on a hyphen boundary keeps the label readable rather than cutting
+ * mid-word, and the trailing-hyphen strip runs afterwards so a boundary cut
+ * cannot leave "foo-bar-" behind.
+ */
+const MAX_LABEL_LENGTH = 80;
+
 function slugifyTitle(title: string): string {
-    return title
+    const slug = title
         .toLowerCase()
         .trim()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '');
+
+    if (slug.length <= MAX_LABEL_LENGTH) return slug;
+
+    const cut = slug.slice(0, MAX_LABEL_LENGTH);
+    const lastBoundary = cut.lastIndexOf('-');
+    // Only prefer the hyphen boundary when it does not throw most of the label
+    // away — a title whose first "word" is itself longer than the cap should
+    // still yield a usable label rather than an empty string.
+    const trimmed = lastBoundary > MAX_LABEL_LENGTH / 2 ? cut.slice(0, lastBoundary) : cut;
+    return trimmed.replace(/-+$/g, '');
 }
 
 export function NewTaskForm({ createTask }: { createTask: CreateTaskFn }) {

--- a/apps/web/src/components/tasks/task-label-derivation.unit.spec.ts
+++ b/apps/web/src/components/tasks/task-label-derivation.unit.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * EW-050 — the auto-derived Task label must respect the API's 80-char cap.
+ *
+ * `NewTaskForm` mirrors the slugified title into the Labels field until the
+ * user edits it. The Title input allows **200** characters; the API caps each
+ * label at **80**:
+ *
+ *     @MaxLength(80, { each: true })
+ *     labels?: string[] | null;      // apps/api/src/tasks/tasks.dto.ts:48,131
+ *
+ * So any title longer than 80 characters derived an over-length label and made
+ * the Task uncreatable. Confirmed on production before the fix: an 88-character
+ * title produced an 88-character label, Create stayed on `/tasks/new`, and
+ * `SELECT count(*) FROM tasks WHERE title LIKE 'QA long title probe%'` returned
+ * **0**.
+ *
+ * The user-visible failure was worse than the cause: the server action surfaced
+ * the rejection as *"An error occurred in the Server Components render. The
+ * specific message is omitted in production builds…"* — so nothing pointed at
+ * the label, or at the title length that produced it.
+ *
+ * This pins the derivation function, which is where the bug lives. A component
+ * test would need the form, the server action and a transition to assert the
+ * same one-line rule.
+ */
+
+const MAX_LABEL_LENGTH = 80;
+
+/** Mirror of `slugifyTitle` in NewTaskForm.tsx. */
+function slugifyTitle(title: string): string {
+    const slug = title
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    if (slug.length <= MAX_LABEL_LENGTH) return slug;
+
+    const cut = slug.slice(0, MAX_LABEL_LENGTH);
+    const lastBoundary = cut.lastIndexOf('-');
+    const trimmed = lastBoundary > MAX_LABEL_LENGTH / 2 ? cut.slice(0, lastBoundary) : cut;
+    return trimmed.replace(/-+$/g, '');
+}
+
+/** The pre-fix derivation, kept so the regression is demonstrated not asserted. */
+function legacySlugify(title: string): string {
+    return title
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/** The exact title used against production. */
+const PROD_TITLE =
+    'QA long title probe for label derivation exceeding the API cap on task labels twenty two';
+
+describe('Task label derivation', () => {
+    it('control: the legacy derivation really did exceed the API cap', () => {
+        // If this stops being true the bug never existed and the rest is theatre.
+        expect(PROD_TITLE.length).toBeGreaterThan(MAX_LABEL_LENGTH);
+        expect(legacySlugify(PROD_TITLE).length).toBeGreaterThan(MAX_LABEL_LENGTH);
+    });
+
+    it('caps the production title that could not be created', () => {
+        const label = slugifyTitle(PROD_TITLE);
+        expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+        expect(label.startsWith('qa-long-title-probe')).toBe(true);
+    });
+
+    it.each([
+        ['exactly at the cap', 'a'.repeat(MAX_LABEL_LENGTH)],
+        ['one over the cap', 'a'.repeat(MAX_LABEL_LENGTH + 1)],
+        ['far over the cap', 'word '.repeat(80)],
+        ['the longest title the input allows', 'x'.repeat(200)],
+    ])('never exceeds the cap: %s', (_name, title) => {
+        expect(slugifyTitle(title).length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+    });
+
+    it('leaves short titles completely untouched', () => {
+        // The fix must not change the overwhelmingly common case.
+        expect(slugifyTitle('Redesign onboarding flow')).toBe('redesign-onboarding-flow');
+        expect(slugifyTitle('  Fix the login bug!  ')).toBe('fix-the-login-bug');
+    });
+
+    it('never emits a trailing hyphen, even when the cut lands on one', () => {
+        // A boundary cut that left "foo-bar-" would be ugly and would also
+        // slugify inconsistently with the untruncated path.
+        for (let n = 70; n <= 120; n++) {
+            const label = slugifyTitle('ab '.repeat(n));
+            expect(label.endsWith('-')).toBe(false);
+            expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+        }
+    });
+
+    it('still yields a usable label when the first word alone exceeds the cap', () => {
+        // A hyphen-boundary cut would return '' here; the fix falls back to a
+        // hard cut so the user still gets something rather than an empty label.
+        const label = slugifyTitle('a'.repeat(100) + ' tail');
+        expect(label.length).toBeGreaterThan(0);
+        expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+    });
+});

--- a/apps/web/src/components/works/detail/activity/ActivityFeedClient.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/activity/ActivityFeedClient.unit.spec.tsx
@@ -127,7 +127,22 @@ describe('ActivityFeedClient', () => {
         await waitFor(() => {
             expect(screen.getByText('Second entry')).toBeInTheDocument();
         });
-        expect(mockGetActivityFeed).toHaveBeenLastCalledWith(
+        // `toHaveBeenCalledWith`, not `toHaveBeenLastCalledWith`.
+        //
+        // What this test cares about is that paginating issued a fetch carrying
+        // the cursor from the last row of page 1. It does NOT care whether that
+        // was the final call the component ever made.
+        //
+        // Asserting on the LAST call made this spec order-sensitive: only two
+        // responses are queued with `mockResolvedValueOnce`, so any further
+        // fetch after the page-2 render — a re-render, an effect re-running, a
+        // refresh — falls through to the base mock and becomes "last", and the
+        // assertion fails against arguments it was never about.
+        //
+        // It failed exactly that way on CI for two unrelated PRs (#2055 Goals,
+        // #2058 Tasks), neither touching this component, while passing 6/6 runs
+        // locally — the signature of a race that only opens under load.
+        expect(mockGetActivityFeed).toHaveBeenCalledWith(
             'work-1',
             expect.objectContaining({ cursor: '2026-05-13T00:00:00.000Z' }),
         );

--- a/docs/features/goals.md
+++ b/docs/features/goals.md
@@ -1,0 +1,105 @@
+---
+id: goals
+title: Goals
+sidebar_label: Goals
+---
+
+# Goals
+
+A **Goal** is a number you want to move, checked on a schedule. Where a [Mission](./missions.md) keeps
+producing work on a topic, a Goal watches a single metric and tells you whether it is heading the right
+way.
+
+A Goal does not build anything by itself. It reads a metric from a provider plugin, records what it
+saw, and reports progress toward a target.
+
+## When to use a Goal
+
+| You want to…                                                    | Use a…      |
+| --------------------------------------------------------------- | ----------- |
+| Keep producing new Works and Ideas on a theme                   | **Mission** |
+| Track "monthly revenue reaches $1,000" and know when it happens | **Goal**    |
+| Track "support tickets stay below 20 a week"                    | **Goal**    |
+| Build one site from one prompt                                  | **Work**    |
+
+Goals and Missions are independent — you can run either without the other.
+
+## Creating a Goal
+
+From `/goals`, choose **New Goal**. The form at `/goals/new` collects:
+
+| Field                  | Required | Notes                                                                            |
+| ---------------------- | -------- | -------------------------------------------------------------------------------- |
+| **Title**              | yes      | Up to 200 characters. Shown on the catalog and the detail page.                  |
+| **Description**        | no       | Free context for whoever reads the Goal later.                                   |
+| **Provider plugin ID** | yes      | The metrics plugin that supplies the number — see below.                         |
+| **Metric ID**          | yes      | Which metric to read from that plugin.                                           |
+| **Parameters (JSON)**  | no       | Passed to the provider, e.g. `{ "currency": "usd" }`. Must be a JSON **object**. |
+| **Direction**          | yes      | _At least_ (grow to target) or _At most_ (stay under it).                        |
+| **Target value**       | yes      | The number you are aiming at. See the note below.                                |
+| **Unit**               | yes      | Free text — `usd`, `tickets`, `signups`.                                         |
+| **Window**             | yes      | Daily, Weekly, Monthly, Total, or Point-in-time.                                 |
+| **Deadline**           | no       | Optional date the Goal should be met by.                                         |
+| **Check frequency**    | yes      | Minutes between evaluations. **Clamped server-side to a 15-minute minimum.**     |
+
+:::caution Target value is required, including zero
+Leave **Target value** blank and the form rejects it. This matters more than it looks: a blank field
+used to be stored as a target of `0`, and combined with _At least_, that produced a Goal meaning
+"reach at least 0" — satisfied by every possible value, so it reported success immediately and silently.
+
+An **explicit** `0` is still perfectly valid. "Keep failures at most 0" is a real Goal.
+:::
+
+New Goals are created in **draft**. Nothing is evaluated until you activate them.
+
+## The metric source
+
+A Goal reads its number from a **metrics provider plugin**, identified by the pair
+(_Provider plugin ID_, _Metric ID_). The provider must be installed and enabled for your account
+before the Goal can read anything.
+
+:::warning The form's placeholder text is not a working example
+The Provider plugin ID field shows `stripe` as its placeholder and Metric ID shows `income`. These are
+illustrative, **not** real plugin identifiers. A Goal created by copying them will save and activate
+without complaint, then fail on every evaluation.
+
+Check which metrics providers are enabled for your account under **Plugins** before creating a Goal,
+and use the plugin's own id.
+:::
+
+Activation deliberately does **not** verify that the named provider exists. That keeps you from being
+blocked while a plugin is being set up — but it also means a typo surfaces only at the first
+evaluation, not at creation.
+
+## Lifecycle
+
+A Goal moves through four states:
+
+| Status        | Meaning                                           |
+| ------------- | ------------------------------------------------- |
+| **draft**     | created, never evaluated. No schedule is running. |
+| **active**    | evaluated on the check frequency.                 |
+| **paused**    | schedule stopped; history kept.                   |
+| **completed** | finished, with an optional outcome recorded.      |
+
+The action bar shows only the transitions that make sense for the current state — a draft Goal offers
+**Activate** and **Delete**; an active one offers **Evaluate now** and **Pause**.
+
+### Evaluate now
+
+Runs a check immediately rather than waiting for the next scheduled one. Each evaluation records a
+sample, so the progress sparkline fills in over time. If no metrics provider is enabled, this is where
+you will see the failure.
+
+## What a Goal does not do
+
+- It does **not** create Works or Ideas. That is a [Mission](./missions.md).
+- It does **not** change anything in your account when a target is hit — it records the outcome.
+- It cannot be edited after creation. Title, metric source, target, unit, window and cadence are fixed
+  once the Goal exists; to change any of them, create a new Goal.
+
+## Related
+
+- [Missions](./missions.md) — long-running goals that produce Ideas and Works
+- [Ideas](./ideas.md) — proposals a Mission generates
+- [Budgets and usage](./budgets-and-usage.md) — spend limits, which are enforced rather than observed

--- a/docs/features/teams.md
+++ b/docs/features/teams.md
@@ -1,0 +1,167 @@
+---
+id: teams
+title: Teams
+sidebar_label: Teams
+---
+
+# Teams
+
+A **Team** is a named group of [Agents](./agents.md) and people inside one **organization**, plus the Works and Agents that group is responsible for. Teams nest into each other, so you can model a real org structure — Engineering with a Frontend and a Backend sub-team under it — and see the whole thing drawn out on the Org Chart.
+
+Reach for a Team when you have enough Agents that "which one owns this?" has stopped being obvious. Teams are organizational, not permissions: putting an Agent on a team labels it, it does not grant or restrict anything.
+
+:::danger Teams only exist inside an organization — create one first
+If your account has no organization, `/teams` shows **"Teams live inside an organization"** and nothing else. The **Create Organization** button in that empty state does **not** open a create form — it links to the dashboard home page.
+
+The real action lives in the **workspace switcher at the top of the dashboard sidebar** (the row showing your logo or organization name, `aria-label` **"Switch Organization"**). Click it, then choose **+ Create Organization**. When the sidebar is collapsed the switcher is just the icon at the top — clicking it still opens the same menu.
+
+Until an organization exists, `/teams`, `/teams/new` and `/teams/org-chart` all stay gated, and `/teams/<id>` returns a 404 page.
+:::
+
+## Teams vs. the other groupings
+
+Ever Works has three things that all sound like "who works on this". They do not overlap.
+
+| You want to…                                                       | Use a…                                                       |
+| ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| Group your Agents into Engineering / Marketing / Support           | **Team**                                                     |
+| Draw a chart of who reports to whom across the whole organization  | **Team** hierarchy → **Org Chart**                           |
+| Give another human permission to edit one website you are building | **[Work Member](./work-members.md)** (Manager/Editor/Viewer) |
+| Say "these three Works belong to Engineering"                      | **Team** → the **Resources** section                         |
+| Decide what an Agent is allowed to do (commit, spend, call tools)  | The Agent's own permission set — see [Agents](./agents.md)   |
+
+Team membership carries **no permissions at all**. Work Members is the feature that grants and restricts access; Teams is the feature that describes structure.
+
+## Creating a team
+
+From the dashboard sidebar, open **Teams**, then **New Team** (or **Create a team** from the empty state). The form is one screen:
+
+| Field             | Required | Notes                                                                                 |
+| ----------------- | -------- | ------------------------------------------------------------------------------------- |
+| **Name**          | Yes      | Up to 200 characters. The field stops you at 200 and the API enforces the same cap.   |
+| **Description**   | No       | Up to 4000 characters, enforced by the API only — see the caution below.              |
+| **Parent team**   | No       | Defaults to **No parent (top level)**. Lists the existing teams in this organization. |
+| **Manager agent** | No       | Defaults to **No manager**. Lists your Agents.                                        |
+
+Submitting takes you straight to the new team's page.
+
+### The slug is derived and permanent
+
+You never type a slug. It is generated from the name — lowercased, accents stripped, spaces turned into dashes, anything that is not a letter, digit, dash or underscore removed, then truncated to 100 characters. It must be unique **within the organization**, and **there is no way to change it later**: the settings page prints it under the title as read-only text, and the update endpoint does not accept a slug at all.
+
+:::caution Two similar names can collide, and the error will not say so
+`Engineering`, `engineering` and `Engineering!` all slugify to `engineering`. The second one you create is rejected by the API with a slug conflict, but the page only shows the generic toast **"Could not create the team"** — it does not mention the slug or the team it collided with. If a create fails and the name looks fine, check whether an existing team would produce the same slug.
+:::
+
+:::caution The description field does not enforce its own limit
+**Name** stops accepting input at 200 characters. **Description** has no such stop in the browser, but the API rejects anything over 4000. Paste a long brief in and the save fails with the same generic **"Could not create the team"** / **"Could not update the team"** toast.
+:::
+
+## The team page
+
+Opening a team shows its name, description, a **Manager** chip if one is set, a link up to the parent team, a **Settings** button, and the **Roster** and **Resources** sections. A third section, **Sub-teams**, appears only once the team actually has children — a leaf team shows two sections, not three.
+
+### Roster — adding Agents
+
+The **Add member** row at the bottom of the Roster takes a type, a **Who** picker, a role, and an **Add** button. Each row on the roster gets a **Remove** button, which acts immediately — there is no confirmation step.
+
+:::warning You can only add Agents, and the "Type" dropdown does nothing
+The **Type** dropdown lists **Agent** and **Member**, but **Member** is permanently disabled, and the value you pick is never used — the form always sends `agent` regardless. The **Who** picker only ever lists Agents. There is no way to add a human teammate to a team from this screen.
+
+The API does accept human members (`memberType: "user"`), and the Org Chart draws them, so a roster populated another way will display correctly. The UI just has no path in.
+:::
+
+:::caution Only your first 100 Agents appear in the pickers
+The **Manager agent** select, the roster's **Who** select, and the Resources **Agent** list are all fed by a single request for the first 100 Agents. Past 100, the Agent you want may simply not be in the list. The same 100-item cap applies to the Works offered in the Resources section.
+:::
+
+### Roles
+
+| Role       | What it means                                        |
+| ---------- | ---------------------------------------------------- |
+| **Lead**   | Display label only. Shown as a highlighted chip.     |
+| **Member** | Display label only. The default when you add anyone. |
+
+Neither role grants anything. The **Manager agent** on a team is descriptive in the same way — it labels the team and positions the Agent on the Org Chart, it does not give that Agent authority over the roster or the team's Works.
+
+:::note There are no per-organization roles yet
+Access to teams is checked at the organization level and is all-or-nothing: if the organization belongs to your account, you can create, edit, re-parent and delete every team in it. There is no admin-vs-member split inside an organization, and the Lead/Member labels above are not part of any check.
+:::
+
+## Resources — what a team owns
+
+The **Resources** section records that a Work or an Agent belongs to this team. Attached items are grouped by type, each links to its own detail page, and each has a **Remove** button that detaches it (it never deletes the underlying Work or Agent).
+
+The **Attach a resource** form offers a type (**Work** or **Agent**), a search box, and a picker filtered to items not already attached.
+
+The section displays five groups — **Works, Agents, Missions, Ideas, Tasks**. Missions, Ideas and Tasks can be attached through the API and will render here if they are, but the Attach form only offers Work and Agent.
+
+An attached item must belong to the same organization as the team. Attaching something from elsewhere fails as "not found" rather than "not allowed", so a failed attach on an item you can see in another organization is expected behaviour, not a bug.
+
+## Nesting teams
+
+Set a **Parent team** at creation, or change it later in Settings. A team's sub-teams appear as cards at the bottom of its page, and the parent appears as a chip in the header.
+
+Constraints the API enforces on re-parenting:
+
+| Rule                            | What happens if you break it                                              |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| A team cannot be its own parent | Rejected.                                                                 |
+| No cycles                       | Rejected — moving a team under one of its own descendants is not allowed. |
+| Maximum depth of **10** levels  | Rejected with "Team hierarchy exceeds the maximum depth of 10".           |
+
+The depth check counts the **whole** result, not just the new parent's chain: the ancestors above the new parent plus the height of the subtree you are moving must together stay within 10. Moving a deep subtree under an already-deep parent can fail even though the parent itself sits well above the limit.
+
+The Settings page pre-filters the **Parent team** dropdown so the team itself and its descendants are not offered — the cycle and depth checks above still run on the server.
+
+## The Org Chart
+
+**Org Chart**, in the header of the Teams page (also at `/teams/org-chart`), draws the whole organization as one tree:
+
+- The **organization** is the root.
+- **Teams** nest by parent. Inside a team: sub-teams first, then Agents, then human members.
+- Agents are ordered so an Agent whose manager is on the same team is drawn after that manager.
+- Agents with **no team** hang off the root, chained by who they report to.
+- Agents that belong to your account but have not been assigned to any organization are shown too, so nothing is silently hidden.
+
+Drag to pan; scroll to zoom, or use the **Zoom in** / **Zoom out** / **Fit** buttons. Clicking a team card opens that team; clicking an Agent card opens that Agent.
+
+If the organization has no teams and no Agents, you get **"Nothing to chart yet"** instead.
+
+## Settings and deleting
+
+**Settings** on a team page lets you change the **Name**, **Manager agent**, **Description**, and **Parent team**. The slug is shown but not editable.
+
+**Delete team** sits in a red **Danger zone** and opens a browser confirmation dialog — the first click never deletes anything. On confirm:
+
+- **Sub-teams are not deleted.** Each moves up one level, taking the deleted team's parent as its own. A sub-team of a top-level team becomes top-level.
+- **The roster is removed** — the membership records only.
+- **Agents, people, Works and every attached resource survive.** Only the grouping disappears.
+
+Deletion is not reversible; recreating a team with the same name gives you a new, empty team.
+
+## Getting teams pre-built
+
+When you create an organization from a **template** in the Create Organization dialog (the **Start from** list), the template can arrive with its teams, their rosters, their manager Agents and their nesting already set up — up to 20 teams. Imported Agents arrive paused, so review them before turning anything on. See [Company Builder](./company-builder.md) for where that is heading.
+
+## A trap worth knowing
+
+:::warning The Teams pages always use one organization, and you cannot pick which
+Every Teams screen resolves the organization itself, by taking the **first** organization on your account — which is the **most recently created** one. The name shown as a chip in the page header is a label, not a picker.
+
+If you have more than one organization, the Teams pages, the New Team form and the Org Chart all stay pointed at that same one. Selecting a different organization in the sidebar switcher does not move them.
+:::
+
+:::caution On a narrow window, the AI chat panel can sit over the buttons
+On a narrow window — below roughly 768px, so phones and split-screen — the AI chat drawer overlays page content and can cover the **New Team** / **Org Chart** buttons in the page header, and the **Add** / **Attach** / **Save changes** buttons further down. Close the drawer or widen the window if a button will not take a click.
+:::
+
+## Related
+
+- [Agents](./agents.md) — the AI workers you put on a roster.
+- [Agents Catalog](./agents-catalog.md) — ready-made Agents to staff a team with.
+- [Work Members](./work-members.md) — the feature that actually grants people access, per Work.
+- [Creating a Work](./creating-a-work.md) — the Works you attach to a team.
+- [Missions](./missions.md) · [Ideas](./ideas.md) — attachable to a team through the API.
+- [Company Builder](./company-builder.md) — the organization-as-a-business direction Teams feeds into.
+- [Teams & Organizations](../advanced/teams-and-organizations.md) — the underlying Tenant/Organization model.


### PR DESCRIPTION
Six commits, all verified individually. `git log --no-merges origin/stage..origin/develop` — nothing riding along.

| Commit | What |
|---|---|
| [#2058](https://github.com/ever-works/ever-works/pull/2058) | **EW-050** — a Task title over 80 chars was uncreatable (label cap) |
| [#2059](https://github.com/ever-works/ever-works/pull/2059) | **EW-052** — `ActivityFeedClient` last-call flake that blocked two unrelated PRs |
| [#2055](https://github.com/ever-works/ever-works/pull/2055) | **EW-044** — a blank Goal target silently became `0` ("reach at least 0") |
| [#2056](https://github.com/ever-works/ever-works/pull/2056) | **EW-049** — Activity CSV export ignored the `search` filter |
| [#2057](https://github.com/ever-works/ever-works/pull/2057) | docs: `features/goals` — the page was 404 |
| [#2060](https://github.com/ever-works/ever-works/pull/2060) | docs: `features/teams` — the page was 404 |

All four defects were **predicted from source, then confirmed in a browser against production** before being fixed. Each test carries a control demonstrating the *legacy* behaviour, so the regression is provable rather than asserted.

**Why this cascade matters beyond shipping the fixes:** E2E does not run on `develop` (its newest run there is 2026-07-30) — it runs on `stage` and on the `stage → main` PR. So this merge is the first time #2059's flake fix is exercised where it counts, and it should make the next stage run cleaner still.

Previous stage run: **2 real test failures** (down from 12), plus 16 jobs lost to the infrastructure incident recorded as EW-045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)