### PR TITLE
fix(e2e): finish the EW-025 fallout — two more specs pinned the leaked token

### DIFF
--- a/apps/web/e2e/flow-email-addresses-deep.spec.ts
+++ b/apps/web/e2e/flow-email-addresses-deep.spec.ts
@@ -28,9 +28,9 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *     from the OWNER, distinct from sec-pin's cross-user 404);
  *   · providerSettings rotation persists and leaves the verification state
  *     untouched; an empty `{}` PATCH is a safe no-op;
- *   · DISABLE does NOT invalidate the verification token (the sharp contrast
- *     with DELETE, which sec-pin proves DOES kill the token) — and a confirm
- *     can still flip `verified` while the row is disabled;
+ *   · DISABLE drops the row from the active pool (its non-revocation of the
+ *     outstanding token is no longer assertable — EW-025 removed the token from
+ *     every response, so the confirm link cannot be followed from a test);
  *   · the disable→enable round-trip restores the active pool + clears
  *     `disabledAt`;
  *   · `defaultForReplies` is NON-exclusive (two coexisting defaults — no
@@ -46,8 +46,9 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *
  * ── PROBED CONTRACTS (live sqlite stack, http://127.0.0.1:3100, keyless) ──
  *   POST /api/email/addresses → 201 { address:{ … 15 fields incl.
- *     verified:false, verificationToken, verificationTokenExpiresAt(~now+24h),
- *     defaultForReplies, disabledAt:null } }.
+ *     verified:false, defaultForReplies, disabledAt:null }. NOTE: EW-025 strips
+ *     `verificationToken` AND `verificationTokenExpiresAt` from every response —
+ *     returning them let a caller verify an address they do not own.
  *     · address local-part >320 chars → 400 ['address must be shorter than or
  *       equal to 320 characters', …]; pluginId >128 → 400 ['pluginId must be
  *       shorter than or equal to 128 characters'].
@@ -56,14 +57,17 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *       should not exist']; { disabled:'yes' } → 400 ['disabled must be a
  *       boolean value']; { defaultForReplies:'x' } → 400.
  *     · own non-existent id (zero-UUID) → 404 'Email address not found'.
- *     · { providerSettings:{…} } rotates settings, leaves verified/token
- *       intact; {} is a 200 no-op (no field changes).
+ *     · { providerSettings:{…} } rotates settings and leaves `verified` false;
+ *       {} is a 200 no-op (no field changes). The token survives too, but that
+ *       is a server-side invariant — EW-025 makes it unobservable here.
  *     · { defaultForReplies:true } on two rows → BOTH stay true (non-exclusive).
  *     · { disabled:true } stamps disabledAt + drops the row from the active
  *       list; { disabled:false } clears disabledAt + restores it.
- *   GET /api/email/verify/:token (PUBLIC) → always 200 { verified:bool }:
- *     · a DISABLED address's still-issued token confirms verified:true (disable
- *       ≠ token revocation), even though the row stays out of the active list.
+ *   GET /api/email/verify/:token (PUBLIC) → always 200 { verified:bool }.
+ *     ⚠️ EW-025: the token is no longer returned by any API response, so the
+ *     POSITIVE confirm path is not reachable from e2e — verification mail goes
+ *     via the provider plugin, not the MailHog sink either. Disable-≠-revocation
+ *     is therefore recorded as a coverage gap in the test body, not asserted.
  *   GET /api/email/addresses?direction=<x> → 200 always; an unknown value
  *     (`both`, `sideways`) returns a filtered/empty list, NOT a 400 — the
  *     query filter is permissive (contrast the strict create-body enum).
@@ -84,8 +88,10 @@ interface EmailAddress {
     pluginId: string;
     providerSettings: Record<string, unknown>;
     verified: boolean;
-    verificationToken: string | null;
-    verificationTokenExpiresAt: string | null;
+    /** EW-025: never sent over the API — optional so tests can assert ABSENCE. */
+    verificationToken?: never;
+    /** EW-025: stripped too — publishing it reveals how long a guess stays useful. */
+    verificationTokenExpiresAt?: never;
     defaultForReplies: boolean;
     disabledAt: string | null;
 }
@@ -232,7 +238,10 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        expect(addr.verificationToken).toBeTruthy();
+        // EW-025: the verification token no longer crosses the API boundary —
+        // returning it let a caller verify an address they do not own. Assert
+        // its ABSENCE, which is the security contract, instead of its presence.
+        expect(addr.verificationToken).toBeUndefined();
 
         const res = await patch(request, user.access_token, addr.id, {
             providerSettings: { apiKey: 'rotated-key', region: 'eu' },
@@ -240,10 +249,11 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
         expect(res.status()).toBe(200);
         const updated = ((await res.json()) as { address: EmailAddress }).address;
         expect(updated.providerSettings).toEqual({ apiKey: 'rotated-key', region: 'eu' });
-        // Rotating credentials is orthogonal to verification — the outstanding
-        // confirmation token and the unverified flag both survive untouched.
+        // Rotating credentials is orthogonal to verification: the unverified
+        // flag survives untouched. (The token survives too, but that is now a
+        // server-side invariant — it is deliberately not observable here.)
         expect(updated.verified).toBe(false);
-        expect(updated.verificationToken).toBe(addr.verificationToken);
+        expect(updated.verificationToken).toBeUndefined();
     });
 
     test('an empty PATCH body is a safe 200 no-op', async ({ request }) => {
@@ -269,8 +279,9 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        const token = addr.verificationToken as string;
-        expect(token).toBeTruthy();
+        // EW-025 — the token is no longer returned by the API, so this test can
+        // no longer follow the confirmation link itself. See the note below.
+        expect(addr.verificationToken).toBeUndefined();
 
         // Retire the row. sec-pin proves DELETE kills the outstanding token;
         // disable is a softer state — the confirmation link must STILL work.
@@ -285,11 +296,22 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
             (await listAddresses(request, user.access_token)).some((x) => x.id === addr.id),
         ).toBe(false);
 
-        // …yet its still-issued confirmation link confirms it (disable is not
-        // token revocation; verified is set even while the row is disabled).
-        const confirm = await request.get(`${API_BASE}/api/email/verify/${token}`);
-        expect(confirm.status()).toBe(200);
-        expect(((await confirm.json()) as { verified: boolean }).verified).toBe(true);
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The claim in this test's NAME — that disabling does not revoke the
+        // outstanding token, so the emailed link still works — is no longer
+        // checkable from here, and both reasons are by design:
+        //
+        //   1. EW-025 removed the token from every API response, so the test
+        //      cannot read it back and follow the link. That is the fix.
+        //   2. Verification mail goes out through the PROVIDER PLUGIN
+        //      (`triggerVerification` -> `emailFacade.verifyAddress`), not
+        //      SMTP, so it never reaches the MailHog sink the e2e stack runs
+        //      and cannot be read from there either.
+        //
+        // What survives here is the observable half: the row leaves the active
+        // pool and stays unverified. Restoring the rest needs a loopback email
+        // provider for CI or a test-only token hook — see the same note in
+        // flow-agent-inbox-messaging.spec.ts.
     });
 
     test('disable→enable round-trip restores the address to the active pool', async ({
@@ -462,20 +484,27 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
 
-        // The TTL stamp is the precondition the confirm flow checks: a token
-        // whose expiry is already past returns { verified:false } (service
-        // email.service.ts L211). On this build the expiry is always future,
-        // so a same-build confirm succeeds — proving the non-expired branch.
-        expect(addr.verificationTokenExpiresAt).toBeTruthy();
-        const expiresAt = new Date(addr.verificationTokenExpiresAt as string).getTime();
-        const DAY = 24 * 60 * 60 * 1000;
-        expect(expiresAt).toBeGreaterThan(before);
-        expect(expiresAt).toBeLessThanOrEqual(before + DAY + 5 * 60 * 1000);
+        // EW-025 strips BOTH the token and its expiry at the API boundary. The
+        // expiry goes too on purpose: publishing it tells an attacker exactly
+        // how long a guessed token stays useful.
+        //
+        // So the TTL is now a server-side invariant. What this test can still
+        // pin is that neither field leaks — which is the security half, and the
+        // half a regression would most plausibly break by adding a field back
+        // to the projection.
+        expect(addr.verificationTokenExpiresAt).toBeUndefined();
+        expect(addr.verificationToken).toBeUndefined();
+        // `before` is kept deliberately: it documents that this test used to
+        // bound the stamp within ~24h, so anyone restoring that coverage knows
+        // what it asserted.
+        expect(before).toBeLessThanOrEqual(Date.now());
 
-        // A not-yet-expired token confirms — the live, exercisable half of the
-        // TTL contract (the expired half needs a past stamp no API will accept).
-        const confirm = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(confirm.status()).toBe(200);
-        expect(((await confirm.json()) as { verified: boolean }).verified).toBe(true);
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The 24h TTL and the not-yet-expired confirm branch (email.service.ts
+        // rejects a past `verificationTokenExpiresAt`) are no longer reachable
+        // from an e2e test: the stamp is not readable and the token needed to
+        // exercise the confirm path is not either. Covering it again needs a
+        // unit test over `confirmVerification`, or a loopback email provider
+        // for CI. Recorded rather than silently dropped.
     });
 });

--- a/apps/web/e2e/sec-pin-email-agent-ownership.spec.ts
+++ b/apps/web/e2e/sec-pin-email-agent-ownership.spec.ts
@@ -47,19 +47,21 @@ import { createAgentViaAPI } from './helpers/agents-tasks';
  *     · ?direction=inbound|outbound returns only matching-direction rows;
  *       the unfiltered list is the superset.
  *   POST /api/email/addresses
- *     · 201 {address:{ verificationToken: 32-char base64url,
- *       verificationTokenExpiresAt: ~now+24h, verified:false }}.
+ *     · 201 {address:{ verified:false }}. EW-025: `verificationToken` and
+ *       `verificationTokenExpiresAt` are STRIPPED from every response — the
+ *       token is 32-char base64url with a ~24h TTL server-side, but neither is
+ *       observable, so the pins here assert their ABSENCE.
  *     · invalid email → 400 'address must be an email'; bad direction →
  *       400 'direction must be one of the following values: outbound,
  *       inbound, both'; unknown property → 400; missing providerSettings
  *       → 400 'providerSettings must be an object'.
- *   DELETE /api/email/addresses/:id → 204; afterwards the row's
- *     verification token confirms {verified:false} (deleting an address
- *     invalidates its outstanding confirmation link).
- *   GET /api/email/verify/:token (PUBLIC, throttled 10/min/IP — this
- *     file spends ≤4 hits/run) → always 200 with EXACTLY {verified:bool}:
- *     first click of a good token → true, the SAME token again → false
- *     (single-use), bogus → false. No address data in either body.
+ *   DELETE /api/email/addresses/:id → 204. (That deleting an address also
+ *     invalidates its outstanding confirmation link is still true server-side
+ *     but no longer assertable here — EW-025 removed the token.)
+ *   GET /api/email/verify/:token (PUBLIC, throttled 10/min/IP) → always 200
+ *     with EXACTLY {verified:bool} and no address data. A token matching
+ *     nothing → false. The good-token and single-use branches need a real
+ *     token, which EW-025 no longer exposes — recorded as gaps in the bodies.
  *   Anon (no bearer): POST/PATCH/DELETE /api/email/addresses[...] and
  *     POST /api/email/addresses/:id/verify → 401.
  *
@@ -78,8 +80,10 @@ interface EmailAddress {
     direction: 'outbound' | 'inbound' | 'both';
     pluginId: string;
     verified: boolean;
-    verificationToken: string | null;
-    verificationTokenExpiresAt: string | null;
+    /** EW-025: never sent over the API — optional so tests can assert ABSENCE. */
+    verificationToken?: never;
+    /** EW-025: stripped too — its value reveals how long a guess stays useful. */
+    verificationTokenExpiresAt?: never;
     defaultForReplies: boolean;
     disabledAt: string | null;
 }
@@ -330,22 +334,31 @@ test.describe('Email security pins — agent ownership, address scoping, verific
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        expect(addr.verificationToken).toBeTruthy();
 
-        // First click-through confirms…
-        const first = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(first.status()).toBe(200);
-        const firstBody = (await first.json()) as Record<string, unknown>;
-        expect(firstBody.verified).toBe(true);
-        // …and the public response leaks nothing beyond the boolean.
-        expect(Object.keys(firstBody)).toEqual(['verified']);
+        // EW-025 — the STRONGER pin, and the one this file should lead with:
+        // the token never crosses the API boundary at all. A single-use token
+        // that an attacker can read from a 201 body is not much of a defence;
+        // the fix removed the exposure, so assert the exposure is gone.
+        expect(addr.verificationToken).toBeUndefined();
 
-        // The SAME link replayed must be dead (token consumed on confirm).
-        const replay = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(replay.status()).toBe(200);
-        const replayBody = (await replay.json()) as Record<string, unknown>;
-        expect(replayBody.verified).toBe(false);
-        expect(Object.keys(replayBody)).toEqual(['verified']);
+        // Still assertable without a real token: the PUBLIC confirm endpoint is
+        // not an existence oracle. An unknown token answers 200 with exactly
+        // one key and no detail — the property that stops it being used to
+        // enumerate addresses or distinguish "wrong" from "already used".
+        const bogus = await request.get(`${API_BASE}/api/email/verify/${'z'.repeat(32)}`);
+        expect(bogus.status()).toBe(200);
+        const bogusBody = (await bogus.json()) as Record<string, unknown>;
+        expect(bogusBody.verified).toBe(false);
+        expect(Object.keys(bogusBody)).toEqual(['verified']);
+
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // Single-use (a confirmed link cannot be replayed) is a real invariant
+        // and is NO LONGER reachable from an e2e test: reaching it requires a
+        // valid token, which EW-025 removed from every response, and the
+        // emailed copy goes via the provider plugin rather than the MailHog
+        // sink the e2e stack runs. It needs unit coverage over
+        // `EmailService.confirmVerification` (which nulls the token on success)
+        // — not deletion. Recorded so the property is not quietly lost.
     });
 
     test('fresh addresses carry a time-boxed, high-entropy verification token', async ({
@@ -358,17 +371,30 @@ test.describe('Email security pins — agent ownership, address scoping, verific
 
         for (const addr of [addr1, addr2]) {
             expect(addr.verified).toBe(false);
-            // 24 bytes of randomness, base64url → exactly 32 url-safe chars.
-            expect(addr.verificationToken).toMatch(/^[A-Za-z0-9_-]{32}$/);
-            // EW-711 #44: the token is stamped with a TTL at issuance —
-            // present, in the future, and no further out than ~24h.
-            expect(addr.verificationTokenExpiresAt).toBeTruthy();
-            const expiresAt = new Date(addr.verificationTokenExpiresAt as string).getTime();
-            expect(expiresAt).toBeGreaterThan(before);
-            expect(expiresAt).toBeLessThanOrEqual(before + DAY_MS + TTL_SLACK_MS);
+            // EW-025 — neither the token NOR its expiry may cross the API
+            // boundary. The expiry is stripped too, on purpose: publishing it
+            // tells an attacker exactly how long a guessed token stays useful.
+            expect(addr.verificationToken).toBeUndefined();
+            expect(addr.verificationTokenExpiresAt).toBeUndefined();
         }
-        // Tokens are unique per address — no shared/global confirmation link.
-        expect(addr1.verificationToken).not.toBe(addr2.verificationToken);
+        // `before` is retained deliberately — it documents that this test used
+        // to bound the TTL stamp, so whoever restores that coverage knows what
+        // was asserted.
+        expect(before).toBeLessThanOrEqual(Date.now());
+
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // Three invariants were pinned here and are now unobservable, because
+        // the values they inspect are no longer returned:
+        //   · 24 bytes of randomness → exactly 32 url-safe base64 chars,
+        //     i.e. /^[A-Za-z0-9_-]{32}$/
+        //   · a TTL stamped at issuance, in the future and no further out than
+        //     DAY_MS + TTL_SLACK_MS (EW-711 #44) — the constants are kept below
+        //     so the exact bound survives for whoever rewrites this as a unit test
+        //   · tokens unique per address — no shared/global confirmation link
+        // All three are properties of the ISSUER, so they belong in a unit test
+        // over the token-minting path rather than in an API-contract spec. They
+        // are listed here rather than dropped so the loss is visible.
+        expect(DAY_MS + TTL_SLACK_MS).toBe(24 * 60 * 60 * 1000 + 5 * 60 * 1000);
     });
 
     test('deleting an address invalidates its outstanding verification link', async ({
@@ -376,8 +402,9 @@ test.describe('Email security pins — agent ownership, address scoping, verific
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        const token = addr.verificationToken as string;
-        expect(token).toBeTruthy();
+        // EW-025 — the token is not returned, so this test can no longer hold
+        // the link it wants to prove dead. See the recorded gap below.
+        expect(addr.verificationToken).toBeUndefined();
 
         const del = await request.delete(`${API_BASE}/api/email/addresses/${addr.id}`, {
             headers: authedHeaders(user.access_token),
@@ -386,9 +413,16 @@ test.describe('Email security pins — agent ownership, address scoping, verific
         const remaining = await listAddresses(request, user.access_token);
         expect(remaining.some((x) => x.id === addr.id)).toBe(false);
 
-        // The already-issued confirmation link must now be dead — a leaked
-        // email for a retired address can never flip anything to verified.
-        const verify = await request.get(`${API_BASE}/api/email/verify/${token}`);
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The property this test is named for — a leaked email for a RETIRED
+        // address can never flip anything to verified — needs the deleted row's
+        // token, which EW-025 no longer returns. It belongs in a unit test over
+        // `EmailAddressRepository.delete` / `confirmVerification` now.
+        //
+        // What remains assertable is the half that does not need the token: the
+        // row is gone from the caller's list, and the public confirm endpoint
+        // stays a non-oracle for a token that matches nothing.
+        const verify = await request.get(`${API_BASE}/api/email/verify/${'y'.repeat(32)}`);
         expect(verify.status()).toBe(200);
         expect(((await verify.json()) as { verified: boolean }).verified).toBe(false);
     });


### PR DESCRIPTION
EW-025 strips `verificationToken` and `verificationTokenExpiresAt` from every API response, because returning them let a caller **verify an address they do not own**. I repaired one spec for that and missed two:

| Spec | `verificationToken` refs |
|---|---|
| `flow-email-addresses-deep` | 9 |
| `sec-pin-email-agent-ownership` | 12 |

Both still asserted the token was **present** and then used it to hit `/api/email/verify/:token`. **Five tests red on stage as a direct result of my own fix.**

**A half-finished CI run hid them.** The previous stage E2E lost **16 of 33 jobs** to the runner-comms incident, and both specs sat inside the lost shards — which is also why I reported "real failures 12 → 2" when the complete run says **12 → 10**.

## Absence is the stronger contract, not a weakening

Every presence assertion becomes an absence assertion. A single-use token an attacker can read out of a 201 body is not much of a defence — EW-025 removed the exposure, so the pins now assert **the exposure is gone**.

**What stayed assertable was kept:**
- PATCH rotating `providerSettings` still leaves `verified` false
- disable still drops the row from the active pool
- the public confirm endpoint is still **not an existence oracle** — a token matching nothing answers `200` with exactly `{verified:false}` and no detail. That needs no real token, so it survives intact.

**Four properties are no longer reachable from e2e** and are recorded at the call site rather than silently dropped, each needing unit coverage instead:

| Property | Belongs in |
|---|---|
| single-use (a confirmed link cannot be replayed) | `confirmVerification` |
| 32-char base64url entropy · ~24h TTL · per-address uniqueness | the token issuer |
| delete invalidates an outstanding link | repository delete |

`DAY_MS`/`TTL_SLACK_MS` are deliberately retained and pinned so the exact bound survives for whoever writes those tests.

Headers, both `EmailAddress` interfaces and the summary bullets are updated too, so neither file documents a contract it no longer tests.

## Verification

`tsc --noEmit`: **0 errors**. Root prettier: clean. No `toBeTruthy` / `toMatch` / `verify/${token}` uses remain in either spec.

🛑 **ESLint gives no signal on `apps/web/e2e/**`** — I added a deliberately unused variable and it reported nothing. So "eslint was quiet" is not evidence for these files, and I did not treat it as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email address API behavior so verification tokens and expiry timestamps are no longer exposed in responses.
  * Adjusted security and address-management checks to validate the updated response data.
  * Preserved verification-state checks during provider rotation and address disabling.
  * Documented coverage gaps for token confirmation, replay prevention, expiration, and invalidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->