### PR TITLE
cascade(develop→stage): finish the EW-025 spec fallout

### DIFF
--- a/apps/web/e2e/flow-email-addresses-deep.spec.ts
+++ b/apps/web/e2e/flow-email-addresses-deep.spec.ts
@@ -28,9 +28,9 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *     from the OWNER, distinct from sec-pin's cross-user 404);
  *   · providerSettings rotation persists and leaves the verification state
  *     untouched; an empty `{}` PATCH is a safe no-op;
- *   · DISABLE does NOT invalidate the verification token (the sharp contrast
- *     with DELETE, which sec-pin proves DOES kill the token) — and a confirm
- *     can still flip `verified` while the row is disabled;
+ *   · DISABLE drops the row from the active pool (its non-revocation of the
+ *     outstanding token is no longer assertable — EW-025 removed the token from
+ *     every response, so the confirm link cannot be followed from a test);
  *   · the disable→enable round-trip restores the active pool + clears
  *     `disabledAt`;
  *   · `defaultForReplies` is NON-exclusive (two coexisting defaults — no
@@ -46,8 +46,9 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *
  * ── PROBED CONTRACTS (live sqlite stack, http://127.0.0.1:3100, keyless) ──
  *   POST /api/email/addresses → 201 { address:{ … 15 fields incl.
- *     verified:false, verificationToken, verificationTokenExpiresAt(~now+24h),
- *     defaultForReplies, disabledAt:null } }.
+ *     verified:false, defaultForReplies, disabledAt:null }. NOTE: EW-025 strips
+ *     `verificationToken` AND `verificationTokenExpiresAt` from every response —
+ *     returning them let a caller verify an address they do not own.
  *     · address local-part >320 chars → 400 ['address must be shorter than or
  *       equal to 320 characters', …]; pluginId >128 → 400 ['pluginId must be
  *       shorter than or equal to 128 characters'].
@@ -56,14 +57,17 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *       should not exist']; { disabled:'yes' } → 400 ['disabled must be a
  *       boolean value']; { defaultForReplies:'x' } → 400.
  *     · own non-existent id (zero-UUID) → 404 'Email address not found'.
- *     · { providerSettings:{…} } rotates settings, leaves verified/token
- *       intact; {} is a 200 no-op (no field changes).
+ *     · { providerSettings:{…} } rotates settings and leaves `verified` false;
+ *       {} is a 200 no-op (no field changes). The token survives too, but that
+ *       is a server-side invariant — EW-025 makes it unobservable here.
  *     · { defaultForReplies:true } on two rows → BOTH stay true (non-exclusive).
  *     · { disabled:true } stamps disabledAt + drops the row from the active
  *       list; { disabled:false } clears disabledAt + restores it.
- *   GET /api/email/verify/:token (PUBLIC) → always 200 { verified:bool }:
- *     · a DISABLED address's still-issued token confirms verified:true (disable
- *       ≠ token revocation), even though the row stays out of the active list.
+ *   GET /api/email/verify/:token (PUBLIC) → always 200 { verified:bool }.
+ *     ⚠️ EW-025: the token is no longer returned by any API response, so the
+ *     POSITIVE confirm path is not reachable from e2e — verification mail goes
+ *     via the provider plugin, not the MailHog sink either. Disable-≠-revocation
+ *     is therefore recorded as a coverage gap in the test body, not asserted.
  *   GET /api/email/addresses?direction=<x> → 200 always; an unknown value
  *     (`both`, `sideways`) returns a filtered/empty list, NOT a 400 — the
  *     query filter is permissive (contrast the strict create-body enum).
@@ -84,8 +88,10 @@ interface EmailAddress {
     pluginId: string;
     providerSettings: Record<string, unknown>;
     verified: boolean;
-    verificationToken: string | null;
-    verificationTokenExpiresAt: string | null;
+    /** EW-025: never sent over the API — optional so tests can assert ABSENCE. */
+    verificationToken?: never;
+    /** EW-025: stripped too — publishing it reveals how long a guess stays useful. */
+    verificationTokenExpiresAt?: never;
     defaultForReplies: boolean;
     disabledAt: string | null;
 }
@@ -232,7 +238,10 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        expect(addr.verificationToken).toBeTruthy();
+        // EW-025: the verification token no longer crosses the API boundary —
+        // returning it let a caller verify an address they do not own. Assert
+        // its ABSENCE, which is the security contract, instead of its presence.
+        expect(addr.verificationToken).toBeUndefined();
 
         const res = await patch(request, user.access_token, addr.id, {
             providerSettings: { apiKey: 'rotated-key', region: 'eu' },
@@ -240,10 +249,11 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
         expect(res.status()).toBe(200);
         const updated = ((await res.json()) as { address: EmailAddress }).address;
         expect(updated.providerSettings).toEqual({ apiKey: 'rotated-key', region: 'eu' });
-        // Rotating credentials is orthogonal to verification — the outstanding
-        // confirmation token and the unverified flag both survive untouched.
+        // Rotating credentials is orthogonal to verification: the unverified
+        // flag survives untouched. (The token survives too, but that is now a
+        // server-side invariant — it is deliberately not observable here.)
         expect(updated.verified).toBe(false);
-        expect(updated.verificationToken).toBe(addr.verificationToken);
+        expect(updated.verificationToken).toBeUndefined();
     });
 
     test('an empty PATCH body is a safe 200 no-op', async ({ request }) => {
@@ -269,8 +279,9 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        const token = addr.verificationToken as string;
-        expect(token).toBeTruthy();
+        // EW-025 — the token is no longer returned by the API, so this test can
+        // no longer follow the confirmation link itself. See the note below.
+        expect(addr.verificationToken).toBeUndefined();
 
         // Retire the row. sec-pin proves DELETE kills the outstanding token;
         // disable is a softer state — the confirmation link must STILL work.
@@ -285,11 +296,22 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
             (await listAddresses(request, user.access_token)).some((x) => x.id === addr.id),
         ).toBe(false);
 
-        // …yet its still-issued confirmation link confirms it (disable is not
-        // token revocation; verified is set even while the row is disabled).
-        const confirm = await request.get(`${API_BASE}/api/email/verify/${token}`);
-        expect(confirm.status()).toBe(200);
-        expect(((await confirm.json()) as { verified: boolean }).verified).toBe(true);
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The claim in this test's NAME — that disabling does not revoke the
+        // outstanding token, so the emailed link still works — is no longer
+        // checkable from here, and both reasons are by design:
+        //
+        //   1. EW-025 removed the token from every API response, so the test
+        //      cannot read it back and follow the link. That is the fix.
+        //   2. Verification mail goes out through the PROVIDER PLUGIN
+        //      (`triggerVerification` -> `emailFacade.verifyAddress`), not
+        //      SMTP, so it never reaches the MailHog sink the e2e stack runs
+        //      and cannot be read from there either.
+        //
+        // What survives here is the observable half: the row leaves the active
+        // pool and stays unverified. Restoring the rest needs a loopback email
+        // provider for CI or a test-only token hook — see the same note in
+        // flow-agent-inbox-messaging.spec.ts.
     });
 
     test('disable→enable round-trip restores the address to the active pool', async ({
@@ -462,20 +484,27 @@ test.describe('Email addresses — deep PATCH + lifecycle-edge contracts', () =>
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
 
-        // The TTL stamp is the precondition the confirm flow checks: a token
-        // whose expiry is already past returns { verified:false } (service
-        // email.service.ts L211). On this build the expiry is always future,
-        // so a same-build confirm succeeds — proving the non-expired branch.
-        expect(addr.verificationTokenExpiresAt).toBeTruthy();
-        const expiresAt = new Date(addr.verificationTokenExpiresAt as string).getTime();
-        const DAY = 24 * 60 * 60 * 1000;
-        expect(expiresAt).toBeGreaterThan(before);
-        expect(expiresAt).toBeLessThanOrEqual(before + DAY + 5 * 60 * 1000);
+        // EW-025 strips BOTH the token and its expiry at the API boundary. The
+        // expiry goes too on purpose: publishing it tells an attacker exactly
+        // how long a guessed token stays useful.
+        //
+        // So the TTL is now a server-side invariant. What this test can still
+        // pin is that neither field leaks — which is the security half, and the
+        // half a regression would most plausibly break by adding a field back
+        // to the projection.
+        expect(addr.verificationTokenExpiresAt).toBeUndefined();
+        expect(addr.verificationToken).toBeUndefined();
+        // `before` is kept deliberately: it documents that this test used to
+        // bound the stamp within ~24h, so anyone restoring that coverage knows
+        // what it asserted.
+        expect(before).toBeLessThanOrEqual(Date.now());
 
-        // A not-yet-expired token confirms — the live, exercisable half of the
-        // TTL contract (the expired half needs a past stamp no API will accept).
-        const confirm = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(confirm.status()).toBe(200);
-        expect(((await confirm.json()) as { verified: boolean }).verified).toBe(true);
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The 24h TTL and the not-yet-expired confirm branch (email.service.ts
+        // rejects a past `verificationTokenExpiresAt`) are no longer reachable
+        // from an e2e test: the stamp is not readable and the token needed to
+        // exercise the confirm path is not either. Covering it again needs a
+        // unit test over `confirmVerification`, or a loopback email provider
+        // for CI. Recorded rather than silently dropped.
     });
 });

--- a/apps/web/e2e/flow-idea-build-lifecycle.spec.ts
+++ b/apps/web/e2e/flow-idea-build-lifecycle.spec.ts
@@ -627,7 +627,15 @@ test.describe('Idea build lifecycle (seeded user UI)', () => {
         // must be driven by opening the trigger and clicking the option row,
         // then submitting the native GET form. Narrowing to "Accepted" keeps
         // the terminal Idea visible and confirms the filter surface works.
-        const statusTrigger = page.locator('form button[aria-haspopup="listbox"]');
+        // Since a350801a (2026-07-29) the chat composer's voice-provider picker
+        // (data-testid="chat-dictation-provider") is a SECOND
+        // form>button[aria-haspopup=listbox] on this page — and the chat panel
+        // mounts before page content, so the bare selector strict-mode-failed
+        // (first attempt clicked the wrong trigger, retry surfaced the
+        // 2-element violation). Exclude it explicitly.
+        const statusTrigger = page.locator(
+            'form button[aria-haspopup="listbox"]:not([data-testid="chat-dictation-provider"])',
+        );
         await expect(statusTrigger).toBeVisible({ timeout: 30_000 });
 
         const applyStatus = async (label: string) => {

--- a/apps/web/e2e/flow-idea-to-work-accept.spec.ts
+++ b/apps/web/e2e/flow-idea-to-work-accept.spec.ts
@@ -281,20 +281,29 @@ test.describe('Idea → Work accept flow (fresh API user)', () => {
         //      completion) owns the QUEUED → ACCEPTED finalization, not the
         //      user-facing endpoint ──
         const work = await createWorkViaAPI(request, token, { name: `AfterBuild Work ${s}` });
+        // PR #1997 (3e98d5bf): accept on a QUEUED Idea now returns 200 — the
+        // provenance link is recorded regardless of status. The STATUS stays
+        // build-pipeline-owned: it remains `queued` and `acceptedWorkId` stays
+        // null, because the PENDING/ACCEPTED-gated transition no-ops. (The
+        // pre-#1997 assertion here expected 404 and was red from 2026-08-09.)
         const acceptQueued = await request.post(
             `${API_BASE}/api/me/work-proposals/${queuedIdeaId}/accept`,
             { headers: authedHeaders(token), data: { workId: work.id } },
         );
-        expect(acceptQueued.status()).toBe(404);
-        expect(String((await acceptQueued.json()).message)).toMatch(
-            /not found or already finalized/i,
-        );
+        expect(acceptQueued.status()).toBe(200);
+        expect(((await acceptQueued.json()) as { ok: boolean }).ok).toBe(true);
 
-        // ── 3. The QUEUED Idea still has NO acceptedWorkId (the rejected
-        //      accept didn't leak a half-finalized state) ───────────────────
+        // ── 3. The QUEUED Idea's lifecycle state is untouched: still queued,
+        //      still NO acceptedWorkId — only the provenance link was added ──
         const afterReject = await readIdea(request, token, queuedIdeaId);
         expect(afterReject.status).toBe('queued');
         expect(afterReject.acceptedWorkId).toBeNull();
+        const queuedLinks = await request.get(
+            `${API_BASE}/api/me/work-proposals/${queuedIdeaId}/works`,
+            { headers: authedHeaders(token) },
+        );
+        expect(queuedLinks.status()).toBe(200);
+        expect(JSON.stringify(await queuedLinks.json())).toContain(work.id);
 
         // ── 4. Cross-check the inverse guard: an ACCEPTED Idea cannot be
         //      re-queued via /build (allowed: pending, failed) ───────────────
@@ -362,19 +371,30 @@ test.describe('Idea → Work accept flow (fresh API user)', () => {
         );
         expect(reDismiss.status()).toBe(404);
 
-        // ── 3. Accept a DISMISSED Idea → 404 (DISMISSED is terminal — accept
-        //      is valid only from PENDING / ACCEPTED) ─────────────────────────
+        // ── 3. Accept a DISMISSED Idea → 200, provenance recorded, STATUS
+        //      untouched. PR #1997 (3e98d5bf): the accept endpoint records the
+        //      Idea↔Work link regardless of status and reports success — the
+        //      link, not the status, is what "this Idea produced a Work"
+        //      means. The status transition is still PENDING/ACCEPTED-gated,
+        //      so DISMISSED stays terminal. (Pre-#1997 this was a 404; the
+        //      old assertion was red from 2026-08-09 until now.) ─────────────
         const work = await createWorkViaAPI(request, token, { name: `Dismiss Work ${s}` });
         const acceptDismissed = await request.post(
             `${API_BASE}/api/me/work-proposals/${dismissId}/accept`,
             { headers: authedHeaders(token), data: { workId: work.id } },
         );
-        expect(acceptDismissed.status()).toBe(404);
-        expect(String((await acceptDismissed.json()).message)).toMatch(
-            /not found or already finalized/i,
-        );
-        // Still dismissed — the rejected accept didn't mutate it.
+        expect(acceptDismissed.status()).toBe(200);
+        expect(((await acceptDismissed.json()) as { ok: boolean }).ok).toBe(true);
+        // Still dismissed — the accept records provenance without resurrecting
+        // the Idea's lifecycle state.
         expect((await readIdea(request, token, dismissId)).status).toBe('dismissed');
+        // And the link is observable.
+        const dismissedLinks = await request.get(
+            `${API_BASE}/api/me/work-proposals/${dismissId}/works`,
+            { headers: authedHeaders(token) },
+        );
+        expect(dismissedLinks.status()).toBe(200);
+        expect(JSON.stringify(await dismissedLinks.json())).toContain(work.id);
 
         // ── 4. The inverse: dismiss an ACCEPTED Idea → 404 (not pending) ────
         const acceptFirstId = await createIdea(

--- a/apps/web/e2e/flow-mission-idea-build-executor-chain.spec.ts
+++ b/apps/web/e2e/flow-mission-idea-build-executor-chain.spec.ts
@@ -440,13 +440,26 @@ test.describe('build-executor trigger — QUEUED commit + provenance divergence'
         expect(BUILD_OK_OR_DISABLED).toContain(build.status());
         expect((await getIdea(request, token, idea.id)).status).toBe('queued');
 
-        // accept is PENDING/ACCEPTED-only → a QUEUED Idea is "already finalized".
+        // PR #1997 (3e98d5bf): accept RECORDS THE PROVENANCE LINK regardless of
+        // status and reports success — the link, not the status, is what "this
+        // Idea produced a Work" means. The STATUS transition stays governed by
+        // fromStatuses exactly as before, so a QUEUED Idea remains queued (the
+        // build pipeline still owns QUEUED → ACCEPTED). This assertion used to
+        // expect the pre-#1997 404 and was red from 2026-08-09 until now.
         const accept = await request.post(`${API_BASE}/api/me/work-proposals/${idea.id}/accept`, {
             headers: authedHeaders(token),
             data: { workId: work.id },
         });
-        expect(accept.status()).toBe(404);
-        expect(msgOf(await accept.json())).toMatch(/not found or already finalized/i);
+        expect(accept.status()).toBe(200);
+        expect(((await accept.json()) as { ok: boolean }).ok).toBe(true);
+        // Status untouched by the accept — still owned by the build pipeline.
+        expect((await getIdea(request, token, idea.id)).status).toBe('queued');
+        // The provenance link is the observable outcome.
+        const links = await request.get(`${API_BASE}/api/me/work-proposals/${idea.id}/works`, {
+            headers: authedHeaders(token),
+        });
+        expect(links.status()).toBe(200);
+        expect(JSON.stringify(await links.json())).toContain(work.id);
 
         // dismiss is PENDING-only → a QUEUED Idea is "not pending".
         const dismiss = await request.patch(

--- a/apps/web/e2e/flow-onboarding-wizard-catalog-work-chain.spec.ts
+++ b/apps/web/e2e/flow-onboarding-wizard-catalog-work-chain.spec.ts
@@ -223,6 +223,11 @@ function expectDefaultState(env: StateEnvelope): void {
         storage: { choice: 'ever-works-git' },
         db: { choice: 'ever-works-db' },
         deploy: { choice: 'ever-works' },
+        // A8 (786b7157, 2026-07-28) added the desktop bucket to the canonical
+        // default. This exact `toEqual` was red from that commit until now —
+        // an exact-equality pin on a growing object needs updating whenever
+        // the canonical default grows.
+        desktop: { choice: 'cloud' },
         skippedSteps: [],
         pluginsReviewed: false,
     });

--- a/apps/web/e2e/profile.spec.ts
+++ b/apps/web/e2e/profile.spec.ts
@@ -13,7 +13,7 @@ test.describe('Profile — UI', () => {
         await page.goto('/en/settings', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
         const value = await usernameInput.inputValue();
         expect(value.length, 'username should be pre-populated').toBeGreaterThan(0);

--- a/apps/web/e2e/sec-pin-email-agent-ownership.spec.ts
+++ b/apps/web/e2e/sec-pin-email-agent-ownership.spec.ts
@@ -47,19 +47,21 @@ import { createAgentViaAPI } from './helpers/agents-tasks';
  *     · ?direction=inbound|outbound returns only matching-direction rows;
  *       the unfiltered list is the superset.
  *   POST /api/email/addresses
- *     · 201 {address:{ verificationToken: 32-char base64url,
- *       verificationTokenExpiresAt: ~now+24h, verified:false }}.
+ *     · 201 {address:{ verified:false }}. EW-025: `verificationToken` and
+ *       `verificationTokenExpiresAt` are STRIPPED from every response — the
+ *       token is 32-char base64url with a ~24h TTL server-side, but neither is
+ *       observable, so the pins here assert their ABSENCE.
  *     · invalid email → 400 'address must be an email'; bad direction →
  *       400 'direction must be one of the following values: outbound,
  *       inbound, both'; unknown property → 400; missing providerSettings
  *       → 400 'providerSettings must be an object'.
- *   DELETE /api/email/addresses/:id → 204; afterwards the row's
- *     verification token confirms {verified:false} (deleting an address
- *     invalidates its outstanding confirmation link).
- *   GET /api/email/verify/:token (PUBLIC, throttled 10/min/IP — this
- *     file spends ≤4 hits/run) → always 200 with EXACTLY {verified:bool}:
- *     first click of a good token → true, the SAME token again → false
- *     (single-use), bogus → false. No address data in either body.
+ *   DELETE /api/email/addresses/:id → 204. (That deleting an address also
+ *     invalidates its outstanding confirmation link is still true server-side
+ *     but no longer assertable here — EW-025 removed the token.)
+ *   GET /api/email/verify/:token (PUBLIC, throttled 10/min/IP) → always 200
+ *     with EXACTLY {verified:bool} and no address data. A token matching
+ *     nothing → false. The good-token and single-use branches need a real
+ *     token, which EW-025 no longer exposes — recorded as gaps in the bodies.
  *   Anon (no bearer): POST/PATCH/DELETE /api/email/addresses[...] and
  *     POST /api/email/addresses/:id/verify → 401.
  *
@@ -78,8 +80,10 @@ interface EmailAddress {
     direction: 'outbound' | 'inbound' | 'both';
     pluginId: string;
     verified: boolean;
-    verificationToken: string | null;
-    verificationTokenExpiresAt: string | null;
+    /** EW-025: never sent over the API — optional so tests can assert ABSENCE. */
+    verificationToken?: never;
+    /** EW-025: stripped too — its value reveals how long a guess stays useful. */
+    verificationTokenExpiresAt?: never;
     defaultForReplies: boolean;
     disabledAt: string | null;
 }
@@ -330,22 +334,31 @@ test.describe('Email security pins — agent ownership, address scoping, verific
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        expect(addr.verificationToken).toBeTruthy();
 
-        // First click-through confirms…
-        const first = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(first.status()).toBe(200);
-        const firstBody = (await first.json()) as Record<string, unknown>;
-        expect(firstBody.verified).toBe(true);
-        // …and the public response leaks nothing beyond the boolean.
-        expect(Object.keys(firstBody)).toEqual(['verified']);
+        // EW-025 — the STRONGER pin, and the one this file should lead with:
+        // the token never crosses the API boundary at all. A single-use token
+        // that an attacker can read from a 201 body is not much of a defence;
+        // the fix removed the exposure, so assert the exposure is gone.
+        expect(addr.verificationToken).toBeUndefined();
 
-        // The SAME link replayed must be dead (token consumed on confirm).
-        const replay = await request.get(`${API_BASE}/api/email/verify/${addr.verificationToken}`);
-        expect(replay.status()).toBe(200);
-        const replayBody = (await replay.json()) as Record<string, unknown>;
-        expect(replayBody.verified).toBe(false);
-        expect(Object.keys(replayBody)).toEqual(['verified']);
+        // Still assertable without a real token: the PUBLIC confirm endpoint is
+        // not an existence oracle. An unknown token answers 200 with exactly
+        // one key and no detail — the property that stops it being used to
+        // enumerate addresses or distinguish "wrong" from "already used".
+        const bogus = await request.get(`${API_BASE}/api/email/verify/${'z'.repeat(32)}`);
+        expect(bogus.status()).toBe(200);
+        const bogusBody = (await bogus.json()) as Record<string, unknown>;
+        expect(bogusBody.verified).toBe(false);
+        expect(Object.keys(bogusBody)).toEqual(['verified']);
+
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // Single-use (a confirmed link cannot be replayed) is a real invariant
+        // and is NO LONGER reachable from an e2e test: reaching it requires a
+        // valid token, which EW-025 removed from every response, and the
+        // emailed copy goes via the provider plugin rather than the MailHog
+        // sink the e2e stack runs. It needs unit coverage over
+        // `EmailService.confirmVerification` (which nulls the token on success)
+        // — not deletion. Recorded so the property is not quietly lost.
     });
 
     test('fresh addresses carry a time-boxed, high-entropy verification token', async ({
@@ -358,17 +371,30 @@ test.describe('Email security pins — agent ownership, address scoping, verific
 
         for (const addr of [addr1, addr2]) {
             expect(addr.verified).toBe(false);
-            // 24 bytes of randomness, base64url → exactly 32 url-safe chars.
-            expect(addr.verificationToken).toMatch(/^[A-Za-z0-9_-]{32}$/);
-            // EW-711 #44: the token is stamped with a TTL at issuance —
-            // present, in the future, and no further out than ~24h.
-            expect(addr.verificationTokenExpiresAt).toBeTruthy();
-            const expiresAt = new Date(addr.verificationTokenExpiresAt as string).getTime();
-            expect(expiresAt).toBeGreaterThan(before);
-            expect(expiresAt).toBeLessThanOrEqual(before + DAY_MS + TTL_SLACK_MS);
+            // EW-025 — neither the token NOR its expiry may cross the API
+            // boundary. The expiry is stripped too, on purpose: publishing it
+            // tells an attacker exactly how long a guessed token stays useful.
+            expect(addr.verificationToken).toBeUndefined();
+            expect(addr.verificationTokenExpiresAt).toBeUndefined();
         }
-        // Tokens are unique per address — no shared/global confirmation link.
-        expect(addr1.verificationToken).not.toBe(addr2.verificationToken);
+        // `before` is retained deliberately — it documents that this test used
+        // to bound the TTL stamp, so whoever restores that coverage knows what
+        // was asserted.
+        expect(before).toBeLessThanOrEqual(Date.now());
+
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // Three invariants were pinned here and are now unobservable, because
+        // the values they inspect are no longer returned:
+        //   · 24 bytes of randomness → exactly 32 url-safe base64 chars,
+        //     i.e. /^[A-Za-z0-9_-]{32}$/
+        //   · a TTL stamped at issuance, in the future and no further out than
+        //     DAY_MS + TTL_SLACK_MS (EW-711 #44) — the constants are kept below
+        //     so the exact bound survives for whoever rewrites this as a unit test
+        //   · tokens unique per address — no shared/global confirmation link
+        // All three are properties of the ISSUER, so they belong in a unit test
+        // over the token-minting path rather than in an API-contract spec. They
+        // are listed here rather than dropped so the loss is visible.
+        expect(DAY_MS + TTL_SLACK_MS).toBe(24 * 60 * 60 * 1000 + 5 * 60 * 1000);
     });
 
     test('deleting an address invalidates its outstanding verification link', async ({
@@ -376,8 +402,9 @@ test.describe('Email security pins — agent ownership, address scoping, verific
     }) => {
         const user = await registerUserViaAPI(request);
         const addr = await createAddress(request, user.access_token);
-        const token = addr.verificationToken as string;
-        expect(token).toBeTruthy();
+        // EW-025 — the token is not returned, so this test can no longer hold
+        // the link it wants to prove dead. See the recorded gap below.
+        expect(addr.verificationToken).toBeUndefined();
 
         const del = await request.delete(`${API_BASE}/api/email/addresses/${addr.id}`, {
             headers: authedHeaders(user.access_token),
@@ -386,9 +413,16 @@ test.describe('Email security pins — agent ownership, address scoping, verific
         const remaining = await listAddresses(request, user.access_token);
         expect(remaining.some((x) => x.id === addr.id)).toBe(false);
 
-        // The already-issued confirmation link must now be dead — a leaked
-        // email for a retired address can never flip anything to verified.
-        const verify = await request.get(`${API_BASE}/api/email/verify/${token}`);
+        // ── COVERAGE GAP, deliberate and recorded ────────────────────────────
+        // The property this test is named for — a leaked email for a RETIRED
+        // address can never flip anything to verified — needs the deleted row's
+        // token, which EW-025 no longer returns. It belongs in a unit test over
+        // `EmailAddressRepository.delete` / `confirmVerification` now.
+        //
+        // What remains assertable is the half that does not need the token: the
+        // row is gone from the caller's list, and the public confirm endpoint
+        // stays a non-oracle for a token that matches nothing.
+        const verify = await request.get(`${API_BASE}/api/email/verify/${'y'.repeat(32)}`);
         expect(verify.status()).toBe(200);
         expect(((await verify.json()) as { verified: boolean }).verified).toBe(false);
     });

--- a/apps/web/e2e/security-settings.spec.ts
+++ b/apps/web/e2e/security-settings.spec.ts
@@ -17,7 +17,14 @@ test.describe('Security — UI', () => {
         const count = await pwInputs.count();
         expect(count, 'expect at least 3 password inputs').toBeGreaterThanOrEqual(3);
 
-        const submit = page.locator('button[type="submit"]').first();
+        // The page's ONLY button[type="submit"] is the AI chat composer's send
+        // button (mounted before page content in the shell, disabled while the
+        // composer is empty since 8d251a90) — the real update control renders
+        // type="button". Target it by its accessible name, scoped to the page
+        // content, so the chat panel can never be the match.
+        const submit = page
+            .locator('#main-content')
+            .getByRole('button', { name: /update password/i });
         await expect(submit).toBeVisible({ timeout: 10_000 });
     });
 
@@ -27,7 +34,14 @@ test.describe('Security — UI', () => {
         await page.goto('/en/settings/security', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const submit = page.locator('button[type="submit"]').first();
+        // The page's ONLY button[type="submit"] is the AI chat composer's send
+        // button (mounted before page content in the shell, disabled while the
+        // composer is empty since 8d251a90) — the real update control renders
+        // type="button". Target it by its accessible name, scoped to the page
+        // content, so the chat panel can never be the match.
+        const submit = page
+            .locator('#main-content')
+            .getByRole('button', { name: /update password/i });
         await submit.click();
         await page.waitForTimeout(800);
 

--- a/apps/web/e2e/settings-profile-ui.spec.ts
+++ b/apps/web/e2e/settings-profile-ui.spec.ts
@@ -14,7 +14,7 @@ test.describe('Settings — profile UI update', () => {
     test('username field is pre-populated', async ({ page }) => {
         await page.goto('/en/settings', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 15_000 });
         const value = await usernameInput.inputValue();
         expect(value.length).toBeGreaterThan(0);
@@ -26,7 +26,7 @@ test.describe('Settings — profile UI update', () => {
         await page.goto('/en/settings', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
 
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         if (!(await usernameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
             test.skip(true, 'username input not visible on /settings');
         }
@@ -47,7 +47,7 @@ test.describe('Settings — profile UI update', () => {
         await page.waitForTimeout(2_500);
         await page.reload({ waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
-        const reloaded = page.locator('input').first();
+        const reloaded = page.locator('#main-content input').first();
         const persistedValue = await reloaded.inputValue();
         // The save may have failed (e.g. validation, rate-limit). We
         // accept either: (a) the new value persists, or (b) the old

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -35,7 +35,7 @@ test.describe('Settings navigation', () => {
         await expect(page).toHaveURL(/\/settings/);
 
         // Profile form should have username input
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
     });
 
@@ -88,7 +88,7 @@ test.describe('Profile settings', () => {
         await page.goto('/en/settings');
 
         // Username input should have a value (the current user's username)
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
         await expect(usernameInput).not.toHaveValue('');
     });

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -102,11 +102,15 @@ test.describe('Complete user journey', () => {
         }
 
         // The previously separate "Create Manually" flow was merged into
-        // the unified WorkAICreator (new-work-client.tsx:405-426). The shared
-        // ui/Input wrapper drops the `name` prop between JSX and the rendered
-        // `<input>` (verified against the failing-run aria-snapshot — the
-        // textbox is present but `input[name="name"]` returns 0). Target by
-        // accessible role + label instead.
+        // the unified WorkAICreator (new-work-client.tsx:405-426). Target by
+        // accessible role + label — robust against the shell's chat composer,
+        // which mounts BEFORE page content and owns the page's first bare
+        // input/textarea.
+        //
+        // (An earlier version of this comment claimed ui/Input drops the
+        // `name` prop; that is STALE — input.tsx spreads {...props} onto the
+        // real <input>, so name comes through. The 0-match aria-snapshot that
+        // suggested it came from the wrong element being inspected.)
         const dirSlug = `journey-${suffix}`;
         const nameInput = page.getByRole('textbox', { name: /Work Name/i });
         await expect(nameInput).toBeVisible({ timeout: 30_000 });
@@ -137,7 +141,7 @@ test.describe('Complete user journey', () => {
         await expect(page).toHaveURL(/\/settings/);
 
         // Verify username is shown
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
 
         // ---- Step 5: Visit security settings ----

--- a/apps/web/e2e/work-create-ui-journey.spec.ts
+++ b/apps/web/e2e/work-create-ui-journey.spec.ts
@@ -98,7 +98,13 @@ test.describe('Work create — full UI wizard', () => {
         await nameInput.fill(name);
 
         // AI prompt (<Textarea name="prompt">) — required by the submit handler.
-        const promptField = page.locator('textarea[name="prompt"], textarea').first();
+        // The bare-`textarea` fallback resolved to the AI chat composer's
+        // unnamed <textarea> (mounted before page content in the shell), so the
+        // wizard's prompt stayed empty and handleGenerate exited at its
+        // promptRequired guard. The wizard's field DOES carry name="prompt"
+        // (WorkAICreator passes it through ui/textarea's {...props} spread), so
+        // select it alone.
+        const promptField = page.locator('textarea[name="prompt"]');
         if (await promptField.isVisible({ timeout: 5_000 }).catch(() => false)) {
             await promptField.fill(`e2e ui description ${name}`);
         }
@@ -126,7 +132,13 @@ test.describe('Work create — full UI wizard', () => {
             await expect(
                 page,
                 'a failed git-less submit must NOT bounce the user to the empty composer',
-            ).not.toHaveURL(/\/new(\?|$)/);
+                // (?<!works) — the wizard's own URL is /en/works/new?mode=manual,
+                // which the bare /\/new(\?|$)/ ALSO matched, so the assertion could
+                // never pass even when the product correctly stayed put. The
+                // lookbehind keeps catching the real bounce target (/en/new) while
+                // letting the stay-put URL through. Verified:
+                //   old: stay-put=true  bounce=true   new: stay-put=false bounce=true
+            ).not.toHaveURL(/(?<!works)\/new(\?|$)/);
 
             await expect(
                 page.locator('input[name="name"]'),


### PR DESCRIPTION
One commit — [#2062](https://github.com/ever-works/ever-works/pull/2062).

Repairs the last two specs still asserting that `verificationToken` crosses the API boundary. EW-025 strips it (returning it let a caller verify an address they do not own), so `flow-email-addresses-deep` (9 refs) and `sec-pin-email-agent-ownership` (12 refs) were red on stage **because of my own fix**.

Every presence assertion becomes an **absence** assertion — the stronger contract. What stayed assertable was kept, notably that the public confirm endpoint is not an existence oracle (a token matching nothing returns exactly `{verified:false}`, which needs no real token). Four properties that genuinely cannot be reached from e2e any more are recorded at the call site with where their unit tests belong, rather than dropped.

**Expected effect on the next stage run:** real failures should fall from **10** to about **5**. The last complete run (`6c5f1042`) had 10 real failures and 0 infrastructure losses — the first clean measurement since the repairs began, and the one that corrected my earlier "12 → 2" (which was measured on a run that lost 16 of 33 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)