### PR TITLE
fix(e2e): repair the last 8 red specs — shell-selector drift + two stale contracts (EW-038)

### DIFF
--- a/apps/web/e2e/flow-idea-build-lifecycle.spec.ts
+++ b/apps/web/e2e/flow-idea-build-lifecycle.spec.ts
@@ -627,7 +627,15 @@ test.describe('Idea build lifecycle (seeded user UI)', () => {
         // must be driven by opening the trigger and clicking the option row,
         // then submitting the native GET form. Narrowing to "Accepted" keeps
         // the terminal Idea visible and confirms the filter surface works.
-        const statusTrigger = page.locator('form button[aria-haspopup="listbox"]');
+        // Since a350801a (2026-07-29) the chat composer's voice-provider picker
+        // (data-testid="chat-dictation-provider") is a SECOND
+        // form>button[aria-haspopup=listbox] on this page — and the chat panel
+        // mounts before page content, so the bare selector strict-mode-failed
+        // (first attempt clicked the wrong trigger, retry surfaced the
+        // 2-element violation). Exclude it explicitly.
+        const statusTrigger = page.locator(
+            'form button[aria-haspopup="listbox"]:not([data-testid="chat-dictation-provider"])',
+        );
         await expect(statusTrigger).toBeVisible({ timeout: 30_000 });
 
         const applyStatus = async (label: string) => {

--- a/apps/web/e2e/flow-idea-to-work-accept.spec.ts
+++ b/apps/web/e2e/flow-idea-to-work-accept.spec.ts
@@ -281,20 +281,29 @@ test.describe('Idea → Work accept flow (fresh API user)', () => {
         //      completion) owns the QUEUED → ACCEPTED finalization, not the
         //      user-facing endpoint ──
         const work = await createWorkViaAPI(request, token, { name: `AfterBuild Work ${s}` });
+        // PR #1997 (3e98d5bf): accept on a QUEUED Idea now returns 200 — the
+        // provenance link is recorded regardless of status. The STATUS stays
+        // build-pipeline-owned: it remains `queued` and `acceptedWorkId` stays
+        // null, because the PENDING/ACCEPTED-gated transition no-ops. (The
+        // pre-#1997 assertion here expected 404 and was red from 2026-08-09.)
         const acceptQueued = await request.post(
             `${API_BASE}/api/me/work-proposals/${queuedIdeaId}/accept`,
             { headers: authedHeaders(token), data: { workId: work.id } },
         );
-        expect(acceptQueued.status()).toBe(404);
-        expect(String((await acceptQueued.json()).message)).toMatch(
-            /not found or already finalized/i,
-        );
+        expect(acceptQueued.status()).toBe(200);
+        expect(((await acceptQueued.json()) as { ok: boolean }).ok).toBe(true);
 
-        // ── 3. The QUEUED Idea still has NO acceptedWorkId (the rejected
-        //      accept didn't leak a half-finalized state) ───────────────────
+        // ── 3. The QUEUED Idea's lifecycle state is untouched: still queued,
+        //      still NO acceptedWorkId — only the provenance link was added ──
         const afterReject = await readIdea(request, token, queuedIdeaId);
         expect(afterReject.status).toBe('queued');
         expect(afterReject.acceptedWorkId).toBeNull();
+        const queuedLinks = await request.get(
+            `${API_BASE}/api/me/work-proposals/${queuedIdeaId}/works`,
+            { headers: authedHeaders(token) },
+        );
+        expect(queuedLinks.status()).toBe(200);
+        expect(JSON.stringify(await queuedLinks.json())).toContain(work.id);
 
         // ── 4. Cross-check the inverse guard: an ACCEPTED Idea cannot be
         //      re-queued via /build (allowed: pending, failed) ───────────────
@@ -362,19 +371,30 @@ test.describe('Idea → Work accept flow (fresh API user)', () => {
         );
         expect(reDismiss.status()).toBe(404);
 
-        // ── 3. Accept a DISMISSED Idea → 404 (DISMISSED is terminal — accept
-        //      is valid only from PENDING / ACCEPTED) ─────────────────────────
+        // ── 3. Accept a DISMISSED Idea → 200, provenance recorded, STATUS
+        //      untouched. PR #1997 (3e98d5bf): the accept endpoint records the
+        //      Idea↔Work link regardless of status and reports success — the
+        //      link, not the status, is what "this Idea produced a Work"
+        //      means. The status transition is still PENDING/ACCEPTED-gated,
+        //      so DISMISSED stays terminal. (Pre-#1997 this was a 404; the
+        //      old assertion was red from 2026-08-09 until now.) ─────────────
         const work = await createWorkViaAPI(request, token, { name: `Dismiss Work ${s}` });
         const acceptDismissed = await request.post(
             `${API_BASE}/api/me/work-proposals/${dismissId}/accept`,
             { headers: authedHeaders(token), data: { workId: work.id } },
         );
-        expect(acceptDismissed.status()).toBe(404);
-        expect(String((await acceptDismissed.json()).message)).toMatch(
-            /not found or already finalized/i,
-        );
-        // Still dismissed — the rejected accept didn't mutate it.
+        expect(acceptDismissed.status()).toBe(200);
+        expect(((await acceptDismissed.json()) as { ok: boolean }).ok).toBe(true);
+        // Still dismissed — the accept records provenance without resurrecting
+        // the Idea's lifecycle state.
         expect((await readIdea(request, token, dismissId)).status).toBe('dismissed');
+        // And the link is observable.
+        const dismissedLinks = await request.get(
+            `${API_BASE}/api/me/work-proposals/${dismissId}/works`,
+            { headers: authedHeaders(token) },
+        );
+        expect(dismissedLinks.status()).toBe(200);
+        expect(JSON.stringify(await dismissedLinks.json())).toContain(work.id);
 
         // ── 4. The inverse: dismiss an ACCEPTED Idea → 404 (not pending) ────
         const acceptFirstId = await createIdea(

--- a/apps/web/e2e/flow-mission-idea-build-executor-chain.spec.ts
+++ b/apps/web/e2e/flow-mission-idea-build-executor-chain.spec.ts
@@ -440,13 +440,26 @@ test.describe('build-executor trigger — QUEUED commit + provenance divergence'
         expect(BUILD_OK_OR_DISABLED).toContain(build.status());
         expect((await getIdea(request, token, idea.id)).status).toBe('queued');
 
-        // accept is PENDING/ACCEPTED-only → a QUEUED Idea is "already finalized".
+        // PR #1997 (3e98d5bf): accept RECORDS THE PROVENANCE LINK regardless of
+        // status and reports success — the link, not the status, is what "this
+        // Idea produced a Work" means. The STATUS transition stays governed by
+        // fromStatuses exactly as before, so a QUEUED Idea remains queued (the
+        // build pipeline still owns QUEUED → ACCEPTED). This assertion used to
+        // expect the pre-#1997 404 and was red from 2026-08-09 until now.
         const accept = await request.post(`${API_BASE}/api/me/work-proposals/${idea.id}/accept`, {
             headers: authedHeaders(token),
             data: { workId: work.id },
         });
-        expect(accept.status()).toBe(404);
-        expect(msgOf(await accept.json())).toMatch(/not found or already finalized/i);
+        expect(accept.status()).toBe(200);
+        expect(((await accept.json()) as { ok: boolean }).ok).toBe(true);
+        // Status untouched by the accept — still owned by the build pipeline.
+        expect((await getIdea(request, token, idea.id)).status).toBe('queued');
+        // The provenance link is the observable outcome.
+        const links = await request.get(`${API_BASE}/api/me/work-proposals/${idea.id}/works`, {
+            headers: authedHeaders(token),
+        });
+        expect(links.status()).toBe(200);
+        expect(JSON.stringify(await links.json())).toContain(work.id);
 
         // dismiss is PENDING-only → a QUEUED Idea is "not pending".
         const dismiss = await request.patch(

--- a/apps/web/e2e/flow-onboarding-wizard-catalog-work-chain.spec.ts
+++ b/apps/web/e2e/flow-onboarding-wizard-catalog-work-chain.spec.ts
@@ -223,6 +223,11 @@ function expectDefaultState(env: StateEnvelope): void {
         storage: { choice: 'ever-works-git' },
         db: { choice: 'ever-works-db' },
         deploy: { choice: 'ever-works' },
+        // A8 (786b7157, 2026-07-28) added the desktop bucket to the canonical
+        // default. This exact `toEqual` was red from that commit until now —
+        // an exact-equality pin on a growing object needs updating whenever
+        // the canonical default grows.
+        desktop: { choice: 'cloud' },
         skippedSteps: [],
         pluginsReviewed: false,
     });

--- a/apps/web/e2e/profile.spec.ts
+++ b/apps/web/e2e/profile.spec.ts
@@ -13,7 +13,7 @@ test.describe('Profile — UI', () => {
         await page.goto('/en/settings', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
         const value = await usernameInput.inputValue();
         expect(value.length, 'username should be pre-populated').toBeGreaterThan(0);

--- a/apps/web/e2e/security-settings.spec.ts
+++ b/apps/web/e2e/security-settings.spec.ts
@@ -17,7 +17,14 @@ test.describe('Security — UI', () => {
         const count = await pwInputs.count();
         expect(count, 'expect at least 3 password inputs').toBeGreaterThanOrEqual(3);
 
-        const submit = page.locator('button[type="submit"]').first();
+        // The page's ONLY button[type="submit"] is the AI chat composer's send
+        // button (mounted before page content in the shell, disabled while the
+        // composer is empty since 8d251a90) — the real update control renders
+        // type="button". Target it by its accessible name, scoped to the page
+        // content, so the chat panel can never be the match.
+        const submit = page
+            .locator('#main-content')
+            .getByRole('button', { name: /update password/i });
         await expect(submit).toBeVisible({ timeout: 10_000 });
     });
 
@@ -27,7 +34,14 @@ test.describe('Security — UI', () => {
         await page.goto('/en/settings/security', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const submit = page.locator('button[type="submit"]').first();
+        // The page's ONLY button[type="submit"] is the AI chat composer's send
+        // button (mounted before page content in the shell, disabled while the
+        // composer is empty since 8d251a90) — the real update control renders
+        // type="button". Target it by its accessible name, scoped to the page
+        // content, so the chat panel can never be the match.
+        const submit = page
+            .locator('#main-content')
+            .getByRole('button', { name: /update password/i });
         await submit.click();
         await page.waitForTimeout(800);
 

--- a/apps/web/e2e/settings-profile-ui.spec.ts
+++ b/apps/web/e2e/settings-profile-ui.spec.ts
@@ -14,7 +14,7 @@ test.describe('Settings — profile UI update', () => {
     test('username field is pre-populated', async ({ page }) => {
         await page.goto('/en/settings', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 15_000 });
         const value = await usernameInput.inputValue();
         expect(value.length).toBeGreaterThan(0);
@@ -26,7 +26,7 @@ test.describe('Settings — profile UI update', () => {
         await page.goto('/en/settings', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
 
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         if (!(await usernameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
             test.skip(true, 'username input not visible on /settings');
         }
@@ -47,7 +47,7 @@ test.describe('Settings — profile UI update', () => {
         await page.waitForTimeout(2_500);
         await page.reload({ waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
-        const reloaded = page.locator('input').first();
+        const reloaded = page.locator('#main-content input').first();
         const persistedValue = await reloaded.inputValue();
         // The save may have failed (e.g. validation, rate-limit). We
         // accept either: (a) the new value persists, or (b) the old

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -35,7 +35,7 @@ test.describe('Settings navigation', () => {
         await expect(page).toHaveURL(/\/settings/);
 
         // Profile form should have username input
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
     });
 
@@ -88,7 +88,7 @@ test.describe('Profile settings', () => {
         await page.goto('/en/settings');
 
         // Username input should have a value (the current user's username)
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
         await expect(usernameInput).not.toHaveValue('');
     });

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -102,11 +102,15 @@ test.describe('Complete user journey', () => {
         }
 
         // The previously separate "Create Manually" flow was merged into
-        // the unified WorkAICreator (new-work-client.tsx:405-426). The shared
-        // ui/Input wrapper drops the `name` prop between JSX and the rendered
-        // `<input>` (verified against the failing-run aria-snapshot — the
-        // textbox is present but `input[name="name"]` returns 0). Target by
-        // accessible role + label instead.
+        // the unified WorkAICreator (new-work-client.tsx:405-426). Target by
+        // accessible role + label — robust against the shell's chat composer,
+        // which mounts BEFORE page content and owns the page's first bare
+        // input/textarea.
+        //
+        // (An earlier version of this comment claimed ui/Input drops the
+        // `name` prop; that is STALE — input.tsx spreads {...props} onto the
+        // real <input>, so name comes through. The 0-match aria-snapshot that
+        // suggested it came from the wrong element being inspected.)
         const dirSlug = `journey-${suffix}`;
         const nameInput = page.getByRole('textbox', { name: /Work Name/i });
         await expect(nameInput).toBeVisible({ timeout: 30_000 });
@@ -137,7 +141,7 @@ test.describe('Complete user journey', () => {
         await expect(page).toHaveURL(/\/settings/);
 
         // Verify username is shown
-        const usernameInput = page.locator('input').first();
+        const usernameInput = page.locator('#main-content input').first();
         await expect(usernameInput).toBeVisible({ timeout: 10_000 });
 
         // ---- Step 5: Visit security settings ----

--- a/apps/web/e2e/work-create-ui-journey.spec.ts
+++ b/apps/web/e2e/work-create-ui-journey.spec.ts
@@ -98,7 +98,13 @@ test.describe('Work create — full UI wizard', () => {
         await nameInput.fill(name);
 
         // AI prompt (<Textarea name="prompt">) — required by the submit handler.
-        const promptField = page.locator('textarea[name="prompt"], textarea').first();
+        // The bare-`textarea` fallback resolved to the AI chat composer's
+        // unnamed <textarea> (mounted before page content in the shell), so the
+        // wizard's prompt stayed empty and handleGenerate exited at its
+        // promptRequired guard. The wizard's field DOES carry name="prompt"
+        // (WorkAICreator passes it through ui/textarea's {...props} spread), so
+        // select it alone.
+        const promptField = page.locator('textarea[name="prompt"]');
         if (await promptField.isVisible({ timeout: 5_000 }).catch(() => false)) {
             await promptField.fill(`e2e ui description ${name}`);
         }
@@ -126,7 +132,13 @@ test.describe('Work create — full UI wizard', () => {
             await expect(
                 page,
                 'a failed git-less submit must NOT bounce the user to the empty composer',
-            ).not.toHaveURL(/\/new(\?|$)/);
+                // (?<!works) — the wizard's own URL is /en/works/new?mode=manual,
+                // which the bare /\/new(\?|$)/ ALSO matched, so the assertion could
+                // never pass even when the product correctly stayed put. The
+                // lookbehind keeps catching the real bounce target (/en/new) while
+                // letting the stay-put URL through. Verified:
+                //   old: stay-put=true  bounce=true   new: stay-put=false bounce=true
+            ).not.toHaveURL(/(?<!works)\/new(\?|$)/);
 
             await expect(
                 page.locator('input[name="name"]'),


### PR DESCRIPTION
Root-caused by a 12-agent triage pass, every claim file:line-proved and independently refuted. **None of the 8 is a product defect.**

## One commit broke 5 specs

`8d251a90` (chat attachments) added a permanently-hidden `<input type=file>` to the chat composer — which the shell mounts **before** page content on every authenticated page. Every `page.locator('input').first()` has grabbed it since 2026-07-28. And the chat send button became the page's only `button[type=submit]`, disabled-when-empty — so `security-settings` waited forever on it (and before that commit, **passed for the wrong reason**: the click no-oped into the chat).

Fix: scope to `#main-content`, target real controls by accessible name.

## Two stale contracts

- `work-create`: guard regex matched the wizard's own URL — **could never pass** (discrimination verified before applying the lookbehind fix); bare-`textarea` filled the chat composer instead of the wizard prompt.
- `onboarding`: exact-equality pin missing the `desktop` bucket A8 added.
- `accept` specs: PR #1997 deliberately made accept record provenance regardless of status and return 200; specs encoded the pre-#1997 404. Updated **and strengthened** — status untouched, `acceptedWorkId` null, link asserted via `GET /:id/works`.
- `idea-build-lifecycle`: strict-mode violation from the voice-provider picker; excluded by testid.

## Env-flag theory refuted (recorded so nobody re-tries it)

Setting `EVER_WORKS_IDEA_BUILD_EXECUTOR_ENABLED` in CI would fix nothing and a live executor would **break** the stays-queued assertions.

With this + #2062 (already cascading), every triaged red on stage E2E has a fix merged. Expected next complete stage run: **~0 real failures** — for the first time since 2026-08-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Idea acceptance behavior so queued and dismissed Ideas can be accepted successfully while preserving their lifecycle status and provenance details.
  * Improved automated coverage for onboarding defaults, profile settings, security settings, and work creation flows.
  * Prevented UI tests from selecting unrelated inputs, buttons, text areas, or listboxes when multiple matching elements are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->