### PR TITLE
fix(tasks): dispatch the Task's own agent when no assignee rows exist (EW-054)

### DIFF
--- a/apps/web/src/components/tasks/TasksKanbanView.tsx
+++ b/apps/web/src/components/tasks/TasksKanbanView.tsx
@@ -622,7 +622,18 @@ export function TasksKanbanView({ tasks: initialTasks }: { tasks: Task[] }) {
                 // still ends in a running agent.
                 if (to === 'in_progress') {
                     const candidates = await listTaskRunCandidatesAction(taskId).catch(() => []);
-                    if (!candidates.some((agent) => agent.source === 'assignee')) {
+                    // 'assignee' = a task_assignees row; 'task' = the Task's own
+                    // agentId column, which is what the detail page's Agent
+                    // picker writes. Both dispatch server-side (the transition
+                    // falls back to task.agentId when there are no assignee
+                    // rows), so both mean "this Task already has its agent" —
+                    // checking only 'assignee' opened the picker on top of every
+                    // detail-page-assigned Task, asking the user to re-choose an
+                    // agent they had already chosen.
+                    const hasAgent = candidates.some(
+                        (agent) => agent.source === 'assignee' || agent.source === 'task',
+                    );
+                    if (!hasAgent) {
                         setPickerTaskId(taskId);
                     }
                 }

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -412,3 +412,75 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         });
     });
 });
+
+describe('TaskTransitionService — owner-column agent fallback (kanban/detail-page assign)', () => {
+    let tasks: any;
+    let blocks: any;
+    let approvers: any;
+    let assignees: any;
+    let runs: any;
+    let dispatcher: any;
+
+    beforeEach(() => {
+        tasks = { casUpdateStatus: jest.fn().mockResolvedValue(true), findById: jest.fn() };
+        blocks = { findByTaskId: jest.fn().mockResolvedValue([]) };
+        approvers = { allApproved: jest.fn().mockResolvedValue(true) };
+        assignees = { findAgentAssignees: jest.fn().mockResolvedValue([]) };
+        runs = {
+            createQueued: jest.fn().mockResolvedValue({ id: 'r1' }),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+    });
+
+    const makeSvc = () =>
+        new TaskTransitionService(tasks, blocks, approvers, assignees, runs, dispatcher);
+
+    it('dispatches the Task OWN agent (task.agentId) when there are no assignee rows', async () => {
+        // The Task detail page assigns an Agent by writing task.agentId — it
+        // creates NO task_assignees row. Pre-fix, fanOutAgentExecutions
+        // returned at `agentAssignees.length === 0`, so moving such a Task to
+        // In Progress dispatched nothing, silently: the primary human flow.
+        const svc = makeSvc();
+        const task = makeTask({ status: TaskStatus.TODO, agentId: 'agent-9' } as Partial<Task>);
+        tasks.findById.mockResolvedValueOnce({
+            ...task,
+            status: TaskStatus.IN_PROGRESS,
+        });
+        assignees.findAgentAssignees.mockResolvedValueOnce([]);
+
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+
+        expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+        const call = dispatcher.enqueue.mock.calls[0][0];
+        expect(call.taskId).toBe('t1');
+        // The dedup key carries the agent id — proves WHICH agent dispatched.
+        expect(call.dedupKey).toContain('agent-9');
+    });
+
+    it('assignee rows take precedence — the owner column does not double-dispatch', async () => {
+        // When explicit assignee rows exist they are the fan-out set, exactly
+        // as before this fix; task.agentId must not add a duplicate run.
+        const svc = makeSvc();
+        const task = makeTask({ status: TaskStatus.TODO, agentId: 'agent-9' } as Partial<Task>);
+        tasks.findById.mockResolvedValueOnce({
+            ...task,
+            status: TaskStatus.IN_PROGRESS,
+        });
+        assignees.findAgentAssignees.mockResolvedValueOnce([
+            { assigneeId: 'agent-a' },
+            { assigneeId: 'agent-b' },
+        ]);
+
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+
+        expect(dispatcher.enqueue).toHaveBeenCalledTimes(2);
+        const keys = dispatcher.enqueue.mock.calls.map((c: any[]) => c[0].dedupKey).join('|');
+        expect(keys).toContain('agent-a');
+        expect(keys).toContain('agent-b');
+        expect(keys).not.toContain('agent-9');
+    });
+});

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -292,8 +292,23 @@ export class TaskTransitionService {
     private async fanOutAgentExecutions(task: Task): Promise<void> {
         if (!this.dispatcher || !this.assignees) return;
         const agentAssignees = await this.assignees.findAgentAssignees(task.id);
-        if (agentAssignees.length === 0) return;
         const generation = (task.recurrenceOccurredCount ?? 0) + 1;
+
+        // No task_assignees rows does NOT mean no agent. The Task detail page
+        // assigns an Agent by writing `task.agentId` (the owner column, indexed
+        // as idx_tasks_agent) without creating an assignee row — and the
+        // run-candidates API already models it as its own source ('task',
+        // tasks.service.ts). This fan-out only iterated assignee rows, so the
+        // PRIMARY human flow — pick an Agent on the detail page, move the Task
+        // to In Progress — dispatched nothing, silently: the card moved and no
+        // run ever started. Fall back to the Task's own agent, mirroring the
+        // candidates API's precedence (assignee rows first, owner column next).
+        if (agentAssignees.length === 0) {
+            if (task.agentId) {
+                await this.dispatchAgentRun(task, task.agentId, { generation });
+            }
+            return;
+        }
         for (const assignee of agentAssignees) {
             await this.dispatchAgentRun(task, assignee.assigneeId, { generation });
         }


### PR DESCRIPTION
**The primary human flow was broken end to end**: assign an Agent on the Task detail page (writes `task.agentId`, creates no `task_assignees` row), move the Task to In Progress — nothing runs. Silently: the card moves, no run starts, no error, no log.

Two consumers, one blind spot — and the run-candidates API already modelled the owner column correctly as source `'task'`; both consumers just ignored it:

| Consumer | Bug | Fix |
|---|---|---|
| `fanOutAgentExecutions` | iterated `task_assignees` only, returned at `length===0` | falls back to `task.agentId` |
| Kanban drag check | accepted only `source==='assignee'` → opened the picker on already-assigned Tasks | accepts `'assignee' \|\| 'task'` |

Precedence mirrors the candidates API: assignee rows win when present; the owner column never double-dispatches (pinned by test).

**Test proven against pre-fix code**: reverting the server change fails exactly the new fallback test (1 failed / 20 passed). The pre-existing "no assignees → no fan-out" test stays green because its fixture has no `agentId` either.

Found by the code-reading pass (prediction proved 9/9, independently refuted-and-survived), confirmed mechanism corrected by the refuter — part of the vetted-predictions batch.

Verified: agent suite 21/21 · agent build TSC 0 issues · web tsc 0 · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks assigned directly to an agent now automatically dispatch to that agent when no explicit assignee rows are present.
  * Moving a task to “In Progress” keeps the agent picker closed when an agent is already assigned.

* **Bug Fixes**
  * Prevented duplicate dispatches when explicit assignees are configured.
  * Preserved existing assignee-row behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->