### PR TITLE
fix(plugins): cancel keeps the enable-for-works default; failures are no longer silent (EW-055)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6537,6 +6537,7 @@
             "disableWarning": "Disabling this plugin will also disable it in all your works",
             "cannotDisableSystem": "System plugins cannot be disabled",
             "disableFailed": "Failed to disable plugin",
+            "enableFailed": "Failed to enable plugin",
             "autoEnableForWorks": "Also enable for all works",
             "autoEnableForWorksDescription": "This plugin will be automatically active in all your works. You can still disable it per Work.",
             "confirmDisable": "Confirm Disable",

--- a/apps/web/src/lib/hooks/use-plugin-toggle.ts
+++ b/apps/web/src/lib/hooks/use-plugin-toggle.ts
@@ -2,6 +2,8 @@
 
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 import { enablePlugin, disablePlugin } from '@/app/actions/plugins';
 
 interface UsePluginToggleOptions {
@@ -12,6 +14,7 @@ interface UsePluginToggleOptions {
 
 export function usePluginToggle({ pluginId, enabled, visibility }: UsePluginToggleOptions) {
     const router = useRouter();
+    const t = useTranslations('dashboard.plugins');
     const [isPending, startTransition] = useTransition();
     const [optimisticEnabled, setOptimisticEnabled] = useState(enabled);
     const [showDisableWarning, setShowDisableWarning] = useState(false);
@@ -41,7 +44,12 @@ export function usePluginToggle({ pluginId, enabled, visibility }: UsePluginTogg
                         throw new Error(result.error);
                     }
                 } catch (error) {
+                    // A failed enable used to roll the switch back with NO message —
+                    // to the user, indistinguishable from the switch never moving.
                     setOptimisticEnabled(false);
+                    toast.error(
+                        error instanceof Error && error.message ? error.message : t('enableFailed'),
+                    );
                 }
             });
             return;
@@ -65,14 +73,22 @@ export function usePluginToggle({ pluginId, enabled, visibility }: UsePluginTogg
                     throw new Error(result.error);
                 }
             } catch (error) {
+                // Same silent rollback on the disable path.
                 setOptimisticEnabled(true);
+                toast.error(
+                    error instanceof Error && error.message ? error.message : t('disableFailed'),
+                );
             }
         });
     };
 
     const handleCancelEnable = () => {
         setShowEnablePanel(false);
-        setAutoEnableForDirs(false);
+        // Cancelling is declining THIS enable, not unsetting the default for
+        // every future one: this used to set false and nothing ever reset it,
+        // so one dismissed dialog silently flipped every later enable to
+        // works-disabled for the rest of the session. Restore the default.
+        setAutoEnableForDirs(true);
     };
 
     const handleCancelDisable = () => {


### PR DESCRIPTION
Two defects in `usePluginToggle`, both proved by the code-reading pass and independently verified:

**1. One dismissed dialog silently changed every later enable.** `handleCancelEnable` set `autoEnableForDirs(false)` and nothing ever reset it — so after a single Cancel/ESC/overlay click, every subsequent plugin enable in the session skipped the user's works with no indication why. Cancel now restores the default: declining *this* enable is not unsetting the default for every future one.

**2. Failures were invisible.** Both catch blocks rolled the optimistic switch back with no message — a failed enable/disable was indistinguishable from the switch never moving. Now toasts the server's own error when present, else the i18n fallback (`disableFailed` existed; adds the missing `enableFailed` sibling).

Verified: tsc 0 · prettier clean · per-edit count checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)