### PR TITLE
fix(settings): actually read the fleetEnabled prop the layout passes (EW-056)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -42,91 +42,106 @@ interface StaticTab {
     href: string;
 }
 
-export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutClientProps) {
+export function SettingsLayoutClient({
+    children,
+    settingsMenu,
+    // Default true per the prop's contract above: the flag exists to turn
+    // Fleet OFF, never to require callers to opt in. (This prop was declared
+    // and passed by the server layout but never destructured, so FLEET_ENABLED
+    // had no effect on the nav — the tab rendered unconditionally.)
+    fleetEnabled = true,
+}: SettingsLayoutClientProps) {
     const pathname = usePathname();
     const t = useTranslations('dashboard.settings');
 
     const baseSettingsPath = '/settings';
 
-    // Static tabs that are always visible
+    // Static tabs — always visible except `fleet`, which honours FLEET_ENABLED
+    // (filtered at the end of this memo).
     const staticTabs: StaticTab[] = useMemo(
-        () => [
-            { id: 'profile', label: t('tabs.profile'), icon: User, href: baseSettingsPath },
-            {
-                id: 'organization',
-                label: t('tabs.organization'),
-                icon: Building2,
-                href: `${baseSettingsPath}/organization`,
-            },
-            {
-                id: 'security',
-                label: t('tabs.security'),
-                icon: Lock,
-                href: `${baseSettingsPath}/security`,
-            },
-            {
-                id: 'api-keys',
-                label: t('tabs.apiKeys'),
-                icon: Key,
-                href: `${baseSettingsPath}/api-keys`,
-            },
-            {
-                id: 'data',
-                label: t('tabs.data'),
-                icon: HardDrive,
-                href: `${baseSettingsPath}/data`,
-            },
-            {
-                id: 'github-app',
-                label: t('tabs.githubApp'),
-                icon: Github,
-                href: `${baseSettingsPath}/github-app`,
-            },
-            {
-                id: 'work-agent',
-                label: t('tabs.workAgent'),
-                icon: Bot,
-                href: `${baseSettingsPath}/work-agent`,
-            },
-            // Fleet sits directly ABOVE Job Runtime by design: Fleet is
-            // WHERE work can run; Job Runtime stays HOW work is dispatched.
-            {
-                id: 'fleet',
-                label: t('tabs.fleet'),
-                icon: Server,
-                href: `${baseSettingsPath}/fleet`,
-            },
-            {
-                id: 'job-runtime',
-                label: t('tabs.jobRuntime'),
-                icon: Cpu,
-                href: `${baseSettingsPath}/job-runtime`,
-            },
-            // Digest briefings — the personal cadence AND the org-scoped
-            // one live on one page, since they are two records of the
-            // same thing rather than two features.
-            {
-                id: 'digest',
-                label: t('tabs.digest'),
-                icon: Newspaper,
-                href: `${baseSettingsPath}/digest`,
-            },
-            // Wave 13 — Billing + Usage & Credits (billing/usage PRD §2):
-            // also reachable from the settings shell like api-keys/security.
-            {
-                id: 'billing',
-                label: t('tabs.billing'),
-                icon: CreditCard,
-                href: `${baseSettingsPath}/billing`,
-            },
-            {
-                id: 'usage',
-                label: t('tabs.usageCredits'),
-                icon: BarChart3,
-                href: `${baseSettingsPath}/usage`,
-            },
-        ],
-        [t],
+        () =>
+            [
+                { id: 'profile', label: t('tabs.profile'), icon: User, href: baseSettingsPath },
+                {
+                    id: 'organization',
+                    label: t('tabs.organization'),
+                    icon: Building2,
+                    href: `${baseSettingsPath}/organization`,
+                },
+                {
+                    id: 'security',
+                    label: t('tabs.security'),
+                    icon: Lock,
+                    href: `${baseSettingsPath}/security`,
+                },
+                {
+                    id: 'api-keys',
+                    label: t('tabs.apiKeys'),
+                    icon: Key,
+                    href: `${baseSettingsPath}/api-keys`,
+                },
+                {
+                    id: 'data',
+                    label: t('tabs.data'),
+                    icon: HardDrive,
+                    href: `${baseSettingsPath}/data`,
+                },
+                {
+                    id: 'github-app',
+                    label: t('tabs.githubApp'),
+                    icon: Github,
+                    href: `${baseSettingsPath}/github-app`,
+                },
+                {
+                    id: 'work-agent',
+                    label: t('tabs.workAgent'),
+                    icon: Bot,
+                    href: `${baseSettingsPath}/work-agent`,
+                },
+                // Fleet sits directly ABOVE Job Runtime by design: Fleet is
+                // WHERE work can run; Job Runtime stays HOW work is dispatched.
+                {
+                    id: 'fleet',
+                    label: t('tabs.fleet'),
+                    icon: Server,
+                    href: `${baseSettingsPath}/fleet`,
+                },
+                {
+                    id: 'job-runtime',
+                    label: t('tabs.jobRuntime'),
+                    icon: Cpu,
+                    href: `${baseSettingsPath}/job-runtime`,
+                },
+                // Digest briefings — the personal cadence AND the org-scoped
+                // one live on one page, since they are two records of the
+                // same thing rather than two features.
+                {
+                    id: 'digest',
+                    label: t('tabs.digest'),
+                    icon: Newspaper,
+                    href: `${baseSettingsPath}/digest`,
+                },
+                // Wave 13 — Billing + Usage & Credits (billing/usage PRD §2):
+                // also reachable from the settings shell like api-keys/security.
+                {
+                    id: 'billing',
+                    label: t('tabs.billing'),
+                    icon: CreditCard,
+                    href: `${baseSettingsPath}/billing`,
+                },
+                {
+                    id: 'usage',
+                    label: t('tabs.usageCredits'),
+                    icon: BarChart3,
+                    href: `${baseSettingsPath}/usage`,
+                },
+                // The fleet tab is declared unconditionally above (keeping the
+                // "Fleet sits directly ABOVE Job Runtime" ordering comment true)
+                // and filtered here when the operator has turned Fleet off — the
+                // same FLEET_ENABLED switch the API and the Fleet page enforce, so
+                // a disabled deployment has no entry point and no route.
+            ].filter((tab) => tab.id !== 'fleet' || fleetEnabled),
+        [t, fleetEnabled],
     );
 
     // Danger zone tab (always at bottom)

--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.unit.spec.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.unit.spec.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('@/i18n/navigation', () => ({
+    usePathname: () => '/settings',
+}));
+vi.mock('next/link', () => ({
+    default: ({ href, children, ...rest }: any) => (
+        <a href={typeof href === 'string' ? href : ''} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('@/lib/utils/plugin-category-icons', () => ({
+    getCategoryIcon: () => () => null,
+}));
+
+import { SettingsLayoutClient } from './settings-layout-client';
+
+/**
+ * The `fleetEnabled` prop must actually WIRE THROUGH to the nav.
+ *
+ * The prop was declared (with a docstring), and the server layout passed
+ * `fleetEnabled={isFleetEnabled()}` — but the client component never
+ * destructured it, so FLEET_ENABLED had no effect and the fleet tab rendered
+ * unconditionally. A test on the filter predicate alone would not have caught
+ * that: the defect was the unread prop, not the logic. So this RENDERS the
+ * component and asserts on the emitted nav.
+ */
+describe('SettingsLayoutClient — fleetEnabled wiring', () => {
+    const renderNav = (props: { fleetEnabled?: boolean } = {}) =>
+        render(
+            <SettingsLayoutClient settingsMenu={null} {...props}>
+                <div data-testid="page-body" />
+            </SettingsLayoutClient>,
+        );
+
+    const fleetLink = () =>
+        [...document.querySelectorAll('a')].find((a) =>
+            (a.getAttribute('href') || '').endsWith('/settings/fleet'),
+        );
+
+    it('control: a neighbouring tab renders in every variant, so absence below is meaningful', () => {
+        renderNav({ fleetEnabled: false });
+        // Job Runtime sits directly below Fleet by design — if IT were missing
+        // too, "no fleet tab" would mean the nav failed to render at all.
+        const jobRuntime = [...document.querySelectorAll('a')].find((a) =>
+            (a.getAttribute('href') || '').endsWith('/settings/job-runtime'),
+        );
+        expect(jobRuntime).toBeTruthy();
+        expect(screen.getByTestId('page-body')).toBeInTheDocument();
+    });
+
+    it('renders the fleet tab by default (prop omitted) — the documented contract', () => {
+        renderNav();
+        expect(fleetLink()).toBeTruthy();
+    });
+
+    it('renders the fleet tab when explicitly enabled', () => {
+        renderNav({ fleetEnabled: true });
+        expect(fleetLink()).toBeTruthy();
+    });
+
+    it('hides the fleet tab when the operator has turned Fleet off', () => {
+        // Pre-fix this failed: the prop was never read, so the tab rendered
+        // regardless — a disabled deployment kept a nav entry to a dead route.
+        renderNav({ fleetEnabled: false });
+        expect(fleetLink()).toBeUndefined();
+    });
+});


### PR DESCRIPTION
The client nav declared `fleetEnabled?: boolean` with a docstring, and the server layout passed `fleetEnabled={isFleetEnabled()}` — but the destructuring read only `{ children, settingsMenu }`. The prop was never consumed, so the Fleet tab rendered unconditionally: on a `FLEET_ENABLED=off` deployment, a nav entry pointing at a feature the API and the Fleet page both refuse.

**Additive fix, default preserved**: destructure `fleetEnabled = true` (the flag turns Fleet *off*, never requires opt-in) and filter the tab out of `staticTabs` when false. The tab stays declared in place so the "Fleet sits directly ABOVE Job Runtime" ordering comment stays true; memo deps gain `fleetEnabled`.

**The spec is a render test on purpose** — the defect was an *unread prop*, which a predicate-only test could never catch. Proven against pre-fix behaviour (simulating the ignored prop fails exactly the hides-when-off case, 1/4), with a control asserting the neighbouring Job Runtime tab still renders in the disabled variant — so "no fleet tab" can't be satisfied by the nav failing to render entirely.

Verified: 4/4 spec · web tsc 0 · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)