### PR TITLE
fix(activity): board view must not silently cap at 100 of its requested 500 (EW-057)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
@@ -170,15 +170,35 @@ export function ActivityClient({ initialActivities, totalActivities }: ActivityC
             const currentRequestId = ++kanbanRequestIdRef.current;
             setKanbanLoading(true);
             try {
-                const response = await getActivityLog({
-                    actionType: filters.actionType || undefined,
-                    status: filters.status || undefined,
-                    search: filters.search || undefined,
-                    limit: KANBAN_LIMIT,
-                    offset: 0,
-                });
-                if (currentRequestId === kanbanRequestIdRef.current && response.success) {
-                    setKanbanActivities(response.activities);
+                // The API clamps `limit` to 100 (`Math.min(limit, 100)`, a
+                // documented two-layer contract) — so a single request for
+                // KANBAN_LIMIT rows silently came back with 100, and the
+                // board's per-column counts contradicted the summary cards
+                // rendered directly above it. Page in API-max chunks instead,
+                // stopping early when the server says there is no more.
+                const PAGE = 100;
+                const collected: typeof kanbanActivities = [];
+                for (let offset = 0; offset < KANBAN_LIMIT; offset += PAGE) {
+                    const response = await getActivityLog({
+                        actionType: filters.actionType || undefined,
+                        status: filters.status || undefined,
+                        search: filters.search || undefined,
+                        limit: PAGE,
+                        offset,
+                    });
+                    // A newer request superseded this one mid-pagination —
+                    // stop fetching AND stop touching state.
+                    if (currentRequestId !== kanbanRequestIdRef.current) return;
+                    if (!response.success) break;
+                    collected.push(...response.activities);
+                    // Server said we have everything (short page, or reached
+                    // the reported total).
+                    if (response.activities.length < PAGE || collected.length >= response.total) {
+                        break;
+                    }
+                }
+                if (currentRequestId === kanbanRequestIdRef.current) {
+                    setKanbanActivities(collected);
                 }
             } catch (error) {
                 if (currentRequestId === kanbanRequestIdRef.current) {


### PR DESCRIPTION
The Board view asked for `KANBAN_LIMIT = 500` rows in one call; the API clamps `limit` to 100 (`Math.min(limit, 100)`, a documented two-layer contract). The clamp is silent — so with >100 matching entries, the board's five column counts summed to **exactly 100** while the summary cards **directly above** showed the true totals. Two contradictory numbers on one screen, plus a newest-100 bias hiding older pending/failed items from their columns.

**Fix respects the API contract instead of fighting it**: sequential pages of 100 up to the limit, stopping early on a short page or when the collected count reaches the server-reported `total`. The stale-request guard now also runs **between pages** — a superseding request aborts the loop before the next fetch and never touches state.

Found by the code-reading pass (client request + server clamp both proved) and independently verified.

Verified: web tsc 0 · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)