### PR TITLE
fix(templates): first inbound links for the three orphaned template browsers (EW-058, part 2)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -951,7 +951,8 @@
                 "allTemplates": "كل القوالب",
                 "yourTemplates": "قوالبك",
                 "yourTemplatesEmpty": "الوكلاء الذي تنشئهم ستظهر هنا كقوابل لإعادة الاستخدام.",
-                "openInWizard": "افتح في المعالج"
+                "openInWizard": "افتح في المعالج",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1145,7 +1146,8 @@
                     "showing": "عرض {from}-{to} من {total}",
                     "previous": "السابق",
                     "next": "التالي"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "إنشاء مهمة جديدة",
@@ -1428,7 +1430,8 @@
                 "filter": {
                     "scope": "النطاق",
                     "all": "الكل"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "التعليمات",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -951,7 +951,8 @@
                 "allTemplates": "Всички шаблони",
                 "yourTemplates": "Твоите шаблони",
                 "yourTemplatesEmpty": "Агентите, които създадеш, ще се появят тук като шаблони за многократна употреба.",
-                "openInWizard": "Отвори в помощник"
+                "openInWizard": "Отвори в помощник",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1145,7 +1146,8 @@
                     "showing": "Показване на {from}-{to} от {total}",
                     "previous": "Предишна",
                     "next": "Следваща"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Създай нова Задача",
@@ -1428,7 +1430,8 @@
                 "filter": {
                     "scope": "Обхват",
                     "all": "Всички"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Инструкции",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -951,7 +951,8 @@
                 "allTemplates": "Alle Vorlagen",
                 "yourTemplates": "Ihre Vorlagen",
                 "yourTemplatesEmpty": "Von Ihnen erstellte Agenten erscheinen hier als wiederverwendbare Vorlagen.",
-                "openInWizard": "Assistent öffnen"
+                "openInWizard": "Assistent öffnen",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1145,7 +1146,8 @@
                     "showing": "{from}–{to} von {total} angezeigt",
                     "previous": "Zurück",
                     "next": "Weiter"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Neue Aufgabe erstellen",
@@ -1428,7 +1430,8 @@
                 "filter": {
                     "scope": "Bereich",
                     "all": "Alle"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Anweisungen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1036,7 +1036,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1205,7 +1206,8 @@
                     "showing": "Showing {from}-{to} of {total}",
                     "previous": "Previous",
                     "next": "Next"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Create a new Task",
@@ -1480,7 +1482,8 @@
                 "filter": {
                     "scope": "Scope",
                     "all": "All"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "backToSkills": "Back to Skills",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -951,7 +951,8 @@
                 "allTemplates": "Todas las plantillas",
                 "yourTemplates": "Tus plantillas",
                 "yourTemplatesEmpty": "Los Agentes que creas aparecerán aquí como plantillas reutilizables.",
-                "openInWizard": "Abrir en el asistente"
+                "openInWizard": "Abrir en el asistente",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1145,7 +1146,8 @@
                     "showing": "Mostrando {from}-{to} de {total}",
                     "previous": "Anterior",
                     "next": "Siguiente"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Crear una nueva Tarea",
@@ -1428,7 +1430,8 @@
                 "filter": {
                     "scope": "Ámbito",
                     "all": "Todos"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Instrucciones",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -951,7 +951,8 @@
                 "allTemplates": "Tous les modèles",
                 "yourTemplates": "Vos modèles",
                 "yourTemplatesEmpty": "Les Agents que vous créez apparaîtront ici comme modèles réutilisables.",
-                "openInWizard": "Ouvrir dans l'assistant"
+                "openInWizard": "Ouvrir dans l'assistant",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1145,7 +1146,8 @@
                     "showing": "Affichage de {from}-{to} sur {total}",
                     "previous": "Précédent",
                     "next": "Suivant"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Créer une nouvelle Tâche",
@@ -1428,7 +1430,8 @@
                 "filter": {
                     "scope": "Étendue",
                     "all": "Tous"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Instructions",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -951,7 +951,8 @@
                 "allTemplates": "כל התבניות",
                 "yourTemplates": "התבניות שלך",
                 "yourTemplatesEmpty": "הסוכנים שאתה יוצר יופיעו כאן כתבניות חוזרות.",
-                "openInWizard": "פתח באשף"
+                "openInWizard": "פתח באשף",
+                "browsePage": "Open the full template browser"
             },
             "settings": {
                 "identity": {
@@ -1145,7 +1146,8 @@
                     "showing": "מציג {from}-{to} מתוך {total}",
                     "previous": "הקודם",
                     "next": "הבא"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "צור משימה חדשה",
@@ -1428,7 +1430,8 @@
                 "filter": {
                     "scope": "היקף",
                     "all": "הכל"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "הוראות",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "{from}-{to} / {total} दिखाए जा रहे हैं",
                     "previous": "पिछला",
                     "next": "अगला"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "एक नया कार्य बनाएं",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "स्कोप",
                     "all": "सभी"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "निर्देश",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Menampilkan {from}-{to} dari {total}",
                     "previous": "Sebelumnya",
                     "next": "Berikutnya"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Buat Tugas baru",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Cakupan",
                     "all": "Semua"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Petunjuk",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Visualizzazione di {from}-{to} su {total}",
                     "previous": "Precedente",
                     "next": "Successivo"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Crea un nuovo Task",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Ambito",
                     "all": "Tutti"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Istruzioni",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "{from}〜{to} / {total}件を表示",
                     "previous": "前へ",
                     "next": "次へ"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "新しいタスクを作成",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "スコープ",
                     "all": "すべて"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "指示",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "{total}개 중 {from}-{to} 표시",
                     "previous": "이전",
                     "next": "다음"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "새 작업 생성",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "범위",
                     "all": "전체"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "지시사항",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "{from}-{to} van {total} weergegeven",
                     "previous": "Vorige",
                     "next": "Volgende"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Maak een nieuwe Taak",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Scope",
                     "all": "Alle"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Instructies",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Wyświetlanie {from}-{to} z {total}",
                     "previous": "Poprzednia",
                     "next": "Następna"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Utwórz nowe Zadanie",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Zasięg",
                     "all": "Wszystkie"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Instrukcje",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Exibindo {from}-{to} de {total}",
                     "previous": "Anterior",
                     "next": "Próximo"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Criar uma nova Tarefa",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Escopo",
                     "all": "Todos"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Instruções",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Показано {from}–{to} из {total}",
                     "previous": "Назад",
                     "next": "Вперёд"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Создать новую задачу",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Область действия",
                     "all": "Все"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Инструкции",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "แสดง {from}-{to} จาก {total}",
                     "previous": "ก่อนหน้า",
                     "next": "ถัดไป"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "สร้างงานใหม่",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "ขอบเขต",
                     "all": "ทั้งหมด"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "คำแนะนำ",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "{total} içinden {from}-{to} gösteriliyor",
                     "previous": "Önceki",
                     "next": "Sonraki"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Yeni Görev Oluştur",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Kapsam",
                     "all": "Tümü"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Talimatlar",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Показано {from}–{to} з {total}",
                     "previous": "Назад",
                     "next": "Вперед"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Створити нове завдання",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Обсяг дій",
                     "all": "Усі"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Інструкції",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "Hiển thị {from}-{to} trong {total}",
                     "previous": "Trước",
                     "next": "Tiếp theo"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "Tạo Task mới",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "Phạm vi",
                     "all": "Tất cả"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "Hướng dẫn",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -996,7 +996,8 @@
                 "allTemplates": "All templates",
                 "yourTemplates": "Your templates",
                 "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
-                "openInWizard": "Open in wizard"
+                "openInWizard": "Open in wizard",
+                "browsePage": "Open the full template browser"
             },
             "pageTabs": {
                 "agents": "Agents",
@@ -1114,7 +1115,8 @@
                     "showing": "显示第 {from}-{to} 条，共 {total} 条",
                     "previous": "上一页",
                     "next": "下一页"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "newDialog": {
                 "title": "创建新任务",
@@ -1350,7 +1352,8 @@
                 "filter": {
                     "scope": "范围",
                     "all": "全部"
-                }
+                },
+                "browseTemplates": "Browse templates"
             },
             "detail": {
                 "instructions": "指令",

--- a/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
@@ -85,14 +85,27 @@ export default async function SkillsPage({
                 subtitle={t('subtitle')}
                 tone="success"
                 actions={
-                    <Button
-                        href={ROUTES.DASHBOARD_SKILL_NEW}
-                        size="sm"
-                        className="gap-1.5 shrink-0"
-                    >
-                        <Plus className="w-3.5 h-3.5" aria-hidden="true" />
-                        {t('list.newSkill')}
-                    </Button>
+                    <>
+                        {/* EW-058: first inbound link to the orphaned
+                            /skills/templates browser (route existed, nothing
+                            linked to it). */}
+                        <Button
+                            href={ROUTES.DASHBOARD_SKILL_TEMPLATES}
+                            variant="secondary"
+                            size="sm"
+                            className="gap-1.5 shrink-0"
+                        >
+                            {t('list.browseTemplates')}
+                        </Button>
+                        <Button
+                            href={ROUTES.DASHBOARD_SKILL_NEW}
+                            size="sm"
+                            className="gap-1.5 shrink-0"
+                        >
+                            <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                            {t('list.newSkill')}
+                        </Button>
+                    </>
                 }
             />
             <SkillsPageClient

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
@@ -100,10 +100,27 @@ export default async function TasksPage({ searchParams }: { searchParams: TasksS
                 subtitle={t('subtitle')}
                 tone="task"
                 actions={
-                    <Button href={ROUTES.DASHBOARD_TASK_NEW} size="sm" className="gap-1.5 shrink-0">
-                        <Plus className="w-3.5 h-3.5" />
-                        {t('list.newTask')}
-                    </Button>
+                    <>
+                        {/* EW-058: first inbound link to the orphaned
+                            /tasks/templates browser (route existed, nothing
+                            linked to it). */}
+                        <Button
+                            href={ROUTES.DASHBOARD_TASK_TEMPLATES}
+                            variant="secondary"
+                            size="sm"
+                            className="gap-1.5 shrink-0"
+                        >
+                            {t('list.browseTemplates')}
+                        </Button>
+                        <Button
+                            href={ROUTES.DASHBOARD_TASK_NEW}
+                            size="sm"
+                            className="gap-1.5 shrink-0"
+                        >
+                            <Plus className="w-3.5 h-3.5" />
+                            {t('list.newTask')}
+                        </Button>
+                    </>
                 }
             />
             <form className="mb-4 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end">

--- a/apps/web/src/components/agents/AgentTemplateChips.tsx
+++ b/apps/web/src/components/agents/AgentTemplateChips.tsx
@@ -164,6 +164,19 @@ export function AgentTemplateChips({
                         emptyHint={t('catalog.yourTemplatesEmpty')}
                         onPick={pickAndCollapse}
                     />
+                    {/* EW-058: /agents/templates was an orphan route — defined
+                        in ROUTES, linked from nowhere in the product. This is
+                        its first inbound link; the inline catalog above stays
+                        the quick path, the dedicated page is the full browser. */}
+                    <div className="pt-1">
+                        <Button
+                            href={ROUTES.DASHBOARD_AGENT_TEMPLATES}
+                            variant="secondary"
+                            size="sm"
+                        >
+                            {t('catalog.browsePage')}
+                        </Button>
+                    </div>
                 </div>
             )}
         </div>


### PR DESCRIPTION
Completes EW-058 with [#2069](https://github.com/ever-works/ever-works/pull/2069): `/agents/templates`, `/tasks/templates` and `/skills/templates` all shipped with route constants defined and **zero inbound links** — three complete browser pages reachable only by typing the URL.

- **/skills** + **/tasks**: a secondary *Browse templates* button in each page header beside the New button
- **/agents**: a footer link inside the expanded template catalog — the inline View All stays the quick path, the dedicated page is the full browser

i18n keys added to all 21 locale files (English text so every locale renders).

Verified: web tsc 0 · prettier clean · keys resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)