### PR TITLE
fix(e2e): repair the final four red shards — three shadowing repeats + two contract drifts (EW-038)

### DIFF
--- a/apps/web/e2e/flow-agent-inbox-messaging.spec.ts
+++ b/apps/web/e2e/flow-agent-inbox-messaging.spec.ts
@@ -665,9 +665,19 @@ test.describe('Agent inbox + messaging', () => {
             // settle enabled (CI-grade timeout, matching the rest of this
             // file) before clicking — never weaken the "Send is clickable"
             // contract, just give hydration room to land.
-            const sendBtn = page
+            // Scoped to #main-content: the global AI chat drawer's submit
+            // button ALSO has accessible name exactly "Send"
+            // (ChatInput aria-label = dashboard.aiChat.sendButton), mounts
+            // BEFORE page content in DOM order, stays in the ARIA tree while
+            // visually closed (opacity-0, not display:none), and is
+            // disabled={!canSend} — permanently disabled with an empty chat
+            // composer. The page-wide `.first()` therefore resolved to THAT
+            // button and `toBeEnabled` timed out on every run since this test
+            // was written. The inbox composer's real Send is fine.
+            const main = page.locator('#main-content');
+            const sendBtn = main
                 .getByRole('button', { name: 'Send', exact: true })
-                .or(page.getByRole('button', { name: /Send/i }))
+                .or(main.getByRole('button', { name: /Send/i }))
                 .first();
             await expect(sendBtn).toBeEnabled({ timeout: 30_000 });
             await sendBtn.click();
@@ -680,10 +690,13 @@ test.describe('Agent inbox + messaging', () => {
             // forwards raw backend error messages (e.g. the 404 "no outbound email
             // address" text) to the client — its catch block now returns the static
             // "Send failed — please try again." string, so match that too.
-            const errorBanner = page.getByText(
+            // Same #main-content scoping: the /error/i alternation is broad
+            // enough to match chat-drawer text, which sits outside the page
+            // content but inside the page-wide locator's reach.
+            const errorBanner = main.getByText(
                 /no outbound email address|From address not found|requires bodyText|Send failed|error/i,
             );
-            const successBanner = page.getByText(/Sent ✓/i);
+            const successBanner = main.getByText(/Sent ✓/i);
             const banner = errorBanner.or(successBanner).first();
             // The outcome banner is the ideal proof, but under CI hydration the server-
             // action result can fail to paint a banner even though the composer rendered

--- a/apps/web/e2e/flow-fleet-enrollment-contract.spec.ts
+++ b/apps/web/e2e/flow-fleet-enrollment-contract.spec.ts
@@ -22,8 +22,10 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *     (a replay is 401, not a second node);
  *   - every invalid credential path is ONE undifferentiated 401 — the
  *     response must never say which check failed;
- *   - the heartbeat secret is minted at enroll, and a DISABLED node
- *     stops being able to report (drain actually drains).
+ *   - the heartbeat secret is minted at enroll, and a DISABLED node's
+ *     beat is still accepted but can never re-enable it (c98337eb:
+ *     drain drains LEASING, not observability — a drained node that
+ *     goes dark would be indistinguishable from a crashed one).
  */
 
 const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
@@ -247,10 +249,19 @@ test.describe('the enrollment protocol, end to end', () => {
         expect(drained.status()).toBe(200);
         expect((await drained.json()).status).toBe('disabled');
 
+        // c98337eb (A29, pause/drain): drain drains LEASING, not observability.
+        // The old contract 401'd a disabled node's heartbeat; the new one
+        // accepts it (200) but keeps the status sticky — a drained node that
+        // goes dark is indistinguishable from a crashed one, so the beat stays
+        // welcome while the node stays out of the lease pool. The invariant
+        // worth pinning is that the beat must never RE-ENABLE the node.
         const after = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
             data: { nodeId, secret },
         });
-        expect(after.status(), 'a drained node must not be able to report').toBe(401);
+        expect(after.status(), 'a drained node may still report (observability)').toBe(200);
+        const beat = await after.json();
+        expect(beat.ok).toBe(true);
+        expect(beat.node.status, 'a beat must never re-enable a drained node').toBe('disabled');
     });
 });
 
@@ -271,7 +282,10 @@ test.describe('PATCH / DELETE /api/fleet/nodes/:id', () => {
             data: {},
         });
         expect(empty.status()).toBe(400);
-        expect(errText(await empty.json())).toContain('Provide name and/or disabled');
+        // The full message has grown twice as PATCH gained fields (72940460
+        // added capabilities, c98337eb added paused). Pin the stable prefix,
+        // not the whole enumeration — the 400-on-empty-body is the contract.
+        expect(errText(await empty.json())).toContain('Provide name');
     });
 
     test('authz: stranger 404, unknown 404, malformed 400, anon 401; delete is 204', async ({

--- a/apps/web/e2e/flow-goals-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-goals-ui-journey.spec.ts
@@ -485,8 +485,13 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         await expect(page.getByRole('heading', { name: goal.title, level: 1 })).toBeVisible({
             timeout: 30_000,
         });
-        // The only listbox trigger on the detail page is the outcome override.
-        const trigger = page.locator('button[aria-haspopup="listbox"]');
+        // The only listbox trigger INSIDE the page content is the outcome
+        // override. Scoped to #main-content because since a350801a the chat
+        // composer carries a second listbox trigger (the voice-provider
+        // picker, data-testid="chat-dictation-provider") which mounts outside
+        // #main-content but stays in the DOM while the panel is closed — the
+        // unscoped locator resolved to 2+ buttons and strict mode threw.
+        const trigger = page.locator('#main-content button[aria-haspopup="listbox"]');
         const achieved = page.getByRole('option', { name: 'Achieved' });
         // Post-condition of OPENING: the option row is on screen. The dropdown
         // is rendered by client state, so a trigger click before hydration is

--- a/apps/web/e2e/flow-onboarding-wizard.spec.ts
+++ b/apps/web/e2e/flow-onboarding-wizard.spec.ts
@@ -83,12 +83,13 @@ interface CatalogResponse {
 /**
  * Mirror of `computeStepList` in useOnboardingFlow.ts. Base flow is always
  * welcome → ai-choice → storage-choice → db-choice → deploy-choice →
- * plugins-catalog → create-work (7 steps). Per-provider config steps are
- * inserted ONLY for a non-default choice in the ai/storage/deploy buckets.
- * The db bucket adds a bare db-choice step with NO config sub-step (even for
- * the non-default `custom` choice — its connection details are entered on the
- * Deploy page after creation, not in the wizard). With all defaults that is
- * exactly 7 steps; with all BYOK + a self-hosted deploy it is 10.
+ * desktop-choice → profile → communication → plugins-catalog → create-work
+ * (10 steps). Per-provider config steps are inserted ONLY for a non-default
+ * choice in the ai/storage/deploy buckets. The db bucket adds a bare
+ * db-choice step with NO config sub-step (even for the non-default `custom`
+ * choice — its connection details are entered on the Deploy page after
+ * creation, not in the wizard). With all defaults that is exactly 10 steps;
+ * with all BYOK + a self-hosted deploy it is 13.
  */
 function computeStepIds(state: Pick<WizardStateV2, 'ai' | 'storage' | 'deploy'>): string[] {
     const ids: string[] = ['welcome', 'ai-choice'];
@@ -100,6 +101,12 @@ function computeStepIds(state: Pick<WizardStateV2, 'ai' | 'storage' | 'deploy'>)
     if (state.deploy.choice === 'vercel' || state.deploy.choice === 'k8s') {
         ids.push(`deploy-config:${state.deploy.choice}`);
     }
+    // A8 (786b7157) added the UNCONDITIONAL `desktop-choice` step between the
+    // deploy config and profile. This mirror was synced to Wave 11 and never
+    // resynced for A8, which made the Help drawer's derived x/N badge one
+    // greater than every assertion below — the class of drift the lockstep
+    // comment warns about, happening anyway.
+    ids.push('desktop-choice');
     // Wave 11 added two always-shown, always-skippable steps between the
     // provider choices and the catalog: `profile` ("what do you do" — roles +
     // team size) and `communication` (connect chat workspaces). Mirrors
@@ -162,7 +169,7 @@ test.describe('Onboarding wizard — catalog-driven multi-step flow', () => {
         expect(pristine.state.skippedSteps).toEqual([]);
         expect(pristine.state.pluginsReviewed).toBe(false);
 
-        // With all defaults the wizard renders exactly the 7 base steps —
+        // With all defaults the wizard renders exactly the 10 base steps —
         // no config sub-steps because every ai/storage/deploy bucket is the
         // Ever Works default, and db-choice is always a bare step.
         expect(computeStepIds(pristine.state)).toEqual([
@@ -171,6 +178,7 @@ test.describe('Onboarding wizard — catalog-driven multi-step flow', () => {
             'storage-choice',
             'db-choice',
             'deploy-choice',
+            'desktop-choice',
             'profile',
             'communication',
             'plugins-catalog',
@@ -217,10 +225,10 @@ test.describe('Onboarding wizard — catalog-driven multi-step flow', () => {
         expect(afterAi.state.deploy.choice).toBe('ever-works');
 
         // The derived step list now includes an ai-config step → 10 steps
-        // (the 9 base steps + the inserted ai-config sub-step).
+        // (the 10 base steps + the inserted ai-config sub-step).
         const stepsAfterAi = computeStepIds(afterAi.state);
         expect(stepsAfterAi).toContain(`ai-config:${byokAi}`);
-        expect(stepsAfterAi).toHaveLength(10);
+        expect(stepsAfterAi).toHaveLength(11);
 
         // Step — pick a non-default storage + deploy that each add a config
         // sub-step, advance lastStep, and skip the plugins step.
@@ -253,6 +261,7 @@ test.describe('Onboarding wizard — catalog-driven multi-step flow', () => {
             'db-choice',
             'deploy-choice',
             'deploy-config:vercel',
+            'desktop-choice',
             'profile',
             'communication',
             'plugins-catalog',
@@ -408,10 +417,10 @@ test.describe('Onboarding wizard — dismiss + complete lifecycle', () => {
         // Badge label maths: currentStep = min(lastStep + 1, totalSteps),
         // totalSteps = derived step count. All defaults → 9 steps (welcome,
         // ai-choice, storage-choice, db-choice, deploy-choice, profile,
-        // communication, plugins-catalog, create-work), lastStep 4 → "5/9".
+        // communication, plugins-catalog, create-work), lastStep 4 → "5/10".
         const totalSteps = computeStepIds(after.state).length;
         const currentStep = Math.min(after.state.lastStep + 1, totalSteps);
-        expect(totalSteps).toBe(9);
+        expect(totalSteps).toBe(10);
         expect(currentStep).toBe(5);
     });
 

--- a/apps/web/e2e/flow-settings-data-management-ui.spec.ts
+++ b/apps/web/e2e/flow-settings-data-management-ui.spec.ts
@@ -427,7 +427,11 @@ test.describe('flow: data-management UI — the import card + auth gate (export 
         }).toPass({ timeout: 20_000 });
 
         // The hidden file input only accepts .json (the restore contract).
-        const fileInput = page.locator('input[type="file"]');
+        // Scoped to #main-content: since 8d251a90 the chat composer mounts a
+        // SECOND hidden input[type=file] (its attachment picker) on every
+        // dashboard page, outside the page content — the page-wide locator
+        // counted 2 and this assertion failed on every run.
+        const fileInput = page.locator('#main-content input[type="file"]');
         await expect(fileInput, 'a file input is mounted').toHaveCount(1);
         await expect(fileInput, 'file input is .json-scoped').toHaveAttribute('accept', '.json');
 
@@ -489,8 +493,10 @@ test.describe('flow: data-management UI — the import card + auth gate (export 
         }).toPass({ timeout: 20_000 });
 
         // Set the hidden file input to the export bytes (named .json so the
-        // client's extension guard passes).
-        const fileInput = page.locator('input[type="file"]');
+        // client's extension guard passes). #main-content scoping for the same
+        // reason as Flow 10 — the chat composer's attachment input would make
+        // setInputFiles a strict-mode violation.
+        const fileInput = page.locator('#main-content input[type="file"]');
         await fileInput.setInputFiles({
             name: `account-export-${stamp}.json`,
             mimeType: 'application/json',


### PR DESCRIPTION
The last 9 failing tests on stage E2E, triaged by a parallel pass with adversarial refutation. **All five files: TEST_IS_WRONG. Zero product defects.**

## The chat-composer shadowing pattern, three more times

| Spec | Shadow element |
|---|---|
| `flow-agent-inbox-messaging` :580/:672 | the drawer's **Send** button — accessible name exactly "Send", `disabled={!canSend}` forever with an empty composer; `toBeEnabled` timed out on **every recorded run** |
| `flow-goals-ui-journey` :477 | the voice-provider **listbox trigger** (a350801a) — strict mode threw on 2 matches |
| `flow-settings-data-management-ui` :407/:455 | the chat **attachment `input[type=file]`** (8d251a90) — `toHaveCount(1)` saw 2 |

All fixed with the established `#main-content` scoping — the composer mounts outside it. That makes **four** distinct chat-composer shadow elements found this session (hidden file input, unnamed textarea, disabled submit, listbox trigger), all one pattern.

## Contract drift, two files

- **onboarding-wizard**: the spec's `computeStepList` mirror missed A8's unconditional `desktop-choice` step — same root cause as the already-fixed sibling. Mirror + four pins bumped in lockstep, docstring refreshed.
- **fleet-enrollment**: pinned the pre-c98337eb contract. Drain now drains **leasing, not observability** — a disabled node's beat answers 200 with status sticky. The pin becomes the new invariant: *a beat must never re-enable a drained node*. The empty-PATCH 400 message pin is loosened to the stable prefix (it grew twice as PATCH gained fields).

## Why this matters

Stage E2E trajectory across complete runs: **12 → 10 → 4 → (this should be 0)**. If the next stage run lands clean, [#2046](https://github.com/ever-works/ever-works/pull/2046) promotes to production through a genuinely green gate — the first since 2026-08-11.

Verified: web tsc 0 · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)