### PR TITLE
fix(auth): a session the API rejects must sign the user out, not 500 every page (EW-059)

### DIFF
--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -33,7 +33,24 @@ async function clearAuthCookieOnUnauthorized(error: unknown): Promise<boolean> {
         console.warn(
             'Auth session rejected by API; clearing auth cookie. Verify web/API AUTH_SECRET values and session storage if this happens after login.',
         );
-        await removeAuthAccessCookies();
+        // Best-effort. These helpers are `cache()`d and run during Server
+        // Component RENDER, where Next.js refuses cookie mutation and throws
+        // "Cookies can only be modified in a Server Action or Route Handler."
+        // That throw used to escape from inside this catch handler and take
+        // the whole render down: a session the API rejects turned EVERY
+        // authenticated page — and /login itself — into a hard 500, leaving
+        // the user with no way back in through the UI. Reporting the session
+        // as unauthenticated is the part that matters; the redirect to login
+        // follows, and the stale cookie is cleared by the next Server Action
+        // or route handler (login POST, /logout) where the write is legal.
+        try {
+            await removeAuthAccessCookies();
+        } catch (clearError) {
+            console.warn(
+                'Could not clear the auth cookie from this context (expected during a Server Component render); treating the session as unauthenticated anyway.',
+                clearError,
+            );
+        }
         return true;
     }
     return false;

--- a/apps/web/src/lib/auth/index.unit.spec.ts
+++ b/apps/web/src/lib/auth/index.unit.spec.ts
@@ -109,3 +109,70 @@ describe('getAuthFromAPI', () => {
         expect(removeAuthAccessCookiesMock).toHaveBeenCalledTimes(1);
     });
 });
+
+/**
+ * Regression — the auth-401-during-render 500, found live on app.ever.works:
+ * a session the API rejected turned EVERY authenticated page, and /login
+ * itself, into a hard 500 with no way back in through the UI.
+ *
+ * These helpers are cache()d and run during Server Component RENDER, where
+ * Next.js refuses cookie mutation and throws "Cookies can only be modified in
+ * a Server Action or Route Handler." That throw came from INSIDE the 401 catch
+ * handler, so it escaped and killed the render instead of degrading to
+ * "not signed in".
+ */
+describe('401 while the cookie cannot be cleared (Server Component render)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const renderContextError = () =>
+        new Error('Cookies can only be modified in a Server Action or Route Handler.');
+
+    const rejectedSession = {
+        isAuthenticated: true,
+        isExpired: false,
+        isOpaqueToken: true,
+        token: 'opaque-session-token',
+    };
+
+    it('getAuthFromCookie reports no session instead of throwing', async () => {
+        const { ApiResponseError } = await import('../api/server-api');
+        getAuthFromRequestMock.mockResolvedValue(rejectedSession);
+        getProfileMock.mockRejectedValue(new ApiResponseError('unauthorized', 401));
+        removeAuthAccessCookiesMock.mockRejectedValue(renderContextError());
+
+        const { getAuthFromCookie } = await importAuthModule();
+
+        // Pre-fix this REJECTED with the render-context error, which is what
+        // produced the 500 on every authenticated page.
+        await expect(getAuthFromCookie()).resolves.toBeNull();
+        expect(removeAuthAccessCookiesMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('getAuthFromAPI reports no session instead of throwing', async () => {
+        const { ApiResponseError } = await import('../api/server-api');
+        getAuthFromRequestMock.mockResolvedValue(rejectedSession);
+        getFreshProfileMock.mockRejectedValue(new ApiResponseError('unauthorized', 401));
+        removeAuthAccessCookiesMock.mockRejectedValue(renderContextError());
+
+        const { getAuthFromAPI } = await importAuthModule();
+
+        await expect(getAuthFromAPI()).resolves.toBeNull();
+    });
+
+    it('control: a NON-401 failure still propagates — this must not swallow real errors', async () => {
+        getAuthFromRequestMock.mockResolvedValue(rejectedSession);
+        getProfileMock.mockRejectedValue(new Error('upstream exploded'));
+
+        const { getAuthFromCookie } = await importAuthModule();
+
+        await expect(getAuthFromCookie()).rejects.toThrow('upstream exploded');
+        expect(removeAuthAccessCookiesMock).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Found live on production, by browsing it

Every authenticated page on `app.ever.works` returns **HTTP 500** — `/skills`, `/tasks`, `/agents`, `/goals`, `/works`, `/activity`, `/missions`, `/ideas`, `/settings` — **and so does `/login`**, so there is no way back in through the UI.

Controls that localised it: anonymous requests are fine (307 → login), all pods have been Running 34h with **zero restarts**, and Gauzy production is unaffected. Not a bad deploy — a code path.

## The chain, from the web pods' own logs

```
API Error: { message: 'Unauthorized', statusCode: 401 }
⨯ Error: Cookies can only be modified in a Server Action or Route Handler.
  digest: '3774326816'
```

`getAuthFromCookie`/`getAuthFromAPI` are `cache()`d helpers that run during Server Component **render**. On a 401, `clearAuthCookieOnUnauthorized` tries to delete the auth cookie — Next.js refuses cookie mutation during render and throws. The throw originates **inside the catch handler**, so nothing catches it: it escapes as a Server Components render error and takes the page down.

Intent: *clear the bad cookie, report no session.* Effect: **a hard lockout for any user whose token the API stops accepting — which is every user, eventually.**

## The fix

The clear becomes best-effort. Reporting the session as unauthenticated is the part that matters; the redirect to login follows, and the stale cookie gets cleared by the next Server Action or route handler (login POST, `/logout`) where the write is legal. **A non-401 failure still propagates untouched** — pinned by a control test.

Verified: 6/6 spec, the two new cases **proven to fail against pre-fix code** (2 failed / 4 passed; the 4 pre-existing tests are unaffected either way) · web tsc 0 · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired or invalid authentication cookies so failed cleanup no longer interrupts page rendering.
  * Authentication failures continue to be handled as unauthenticated when cookie removal is unavailable.
  * Other authentication errors continue to surface normally.

* **Tests**
  * Added regression coverage for authentication failures during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->