### PR TITLE
fix(test): convert the last settle() race, and make a can-never-fail assertion real (EW-063)

### DIFF
--- a/packages/agent/src/services/__tests__/webhook-delivery.service.spec.ts
+++ b/packages/agent/src/services/__tests__/webhook-delivery.service.spec.ts
@@ -301,22 +301,37 @@ describe('WebhookDeliveryService.deliver', () => {
         expect(client.post).not.toHaveBeenCalled();
     });
 
-    it('records a non-zero durationMs on successful delivery', async () => {
-        const client: WebhookHttpClient = {
-            post: jest.fn().mockImplementation(async () => {
-                await new Promise((resolve) => setTimeout(resolve, 5));
-                return { status: 200 };
-            }),
-        };
-        const svc = new WebhookDeliveryService(client);
-        const result = await svc.deliver({
-            url: 'https://hooks.example.com/p',
-            secret: 's',
-            event: 'x',
-            payload: {},
-        });
-        expect(result.ok).toBe(true);
-        expect(typeof result.durationMs).toBe('number');
-        expect(result.durationMs!).toBeGreaterThanOrEqual(0);
+    it('records the measured durationMs on successful delivery', async () => {
+        // This asserted `durationMs >= 0` under the title "records a non-zero
+        // durationMs" — satisfied by 0, and by any number at all, so it could
+        // not fail and did not check what it claimed. The weakening was not
+        // careless: the service measures with Date.now(), whose granularity is
+        // ~15ms on Windows, so the old 5ms mocked sleep genuinely could measure
+        // 0 and a `> 0` assertion would flake.
+        //
+        // So drive the clock instead of racing it. Deterministic on any machine
+        // under any load, and it pins the actual arithmetic (end - start)
+        // rather than settling for "is a number".
+        const nowSpy = jest.spyOn(Date, 'now');
+        const ticks = [1_000, 1_042];
+        let tick = 0;
+        nowSpy.mockImplementation(() => ticks[Math.min(tick++, ticks.length - 1)]);
+
+        try {
+            const client: WebhookHttpClient = {
+                post: jest.fn().mockImplementation(async () => ({ status: 200 })),
+            };
+            const svc = new WebhookDeliveryService(client);
+            const result = await svc.deliver({
+                url: 'https://hooks.example.com/p',
+                secret: 's',
+                event: 'x',
+                payload: {},
+            });
+            expect(result.ok).toBe(true);
+            expect(result.durationMs).toBe(42);
+        } finally {
+            nowSpy.mockRestore();
+        }
     });
 });

--- a/packages/plugins/job-runtime-node/src/__tests__/node-job-runtime.plugin.spec.ts
+++ b/packages/plugins/job-runtime-node/src/__tests__/node-job-runtime.plugin.spec.ts
@@ -298,12 +298,20 @@ describe('NodeWorkerHostFactory', () => {
 		});
 
 		await host.start();
-		await settle();
+		// Poll for the three backoffs rather than betting 250ms of wall clock on
+		// them — the same reasoning the `until` docblock above already spells
+		// out. This was the last remaining `settle()` call site: the fix was
+		// introduced for this exact failure mode and never applied here, so the
+		// assertions below could see one or two delays on a loaded runner and
+		// fail with no code change.
+		await until(() => expect(delays.length).toBeGreaterThanOrEqual(3));
 
 		expect(calls).toBeGreaterThanOrEqual(3);
 		// Doubling from the base delay — not a hot loop against a dead endpoint.
 		expect(delays.slice(0, 3)).toEqual([1_000, 2_000, 4_000]);
 		// And the stop requested from INSIDE the loop actually took effect.
+		// Checked after the poll above, so this reads a settled loop rather than
+		// a count that simply has not grown yet.
 		expect(delays.length).toBeLessThan(10);
 	});
 


### PR DESCRIPTION
From a systematic hunt over the 18 remaining specs that use fixed waits, run after two CI-load flakes blocked the pipeline within an hour.

The hunt classified every timed wait **by the assertion that follows it** — a wait expecting something to *happen* is a race; a wait expecting something *not* to happen is correct as a fixed sleep, since absence has no state to converge on. **Result: one genuine race in 18 specs, zero rejected on independent re-check.** The suite is in better shape than two flakes in an hour suggested.

## 1. The last `settle()` call site

`node-job-runtime.plugin.spec.ts:301` — a fixed 250ms sleep followed by assertions that three lease attempts **happened**. Under load the loop may finish one or two, leaving `delays.slice(0,3)` as `[1000]` and failing with no code change.

As with the watcher flake, **the file already knew**: its `until()` helper exists for exactly this, with a docblock recording a **7026ms overrun** on a saturated runner. The fix was written for this failure mode and never applied here. The `delays.length < 10` bound is now checked *after* the poll, so it reads a settled loop rather than a count that hasn't grown yet.

## 2. A test that could not fail

`webhook-delivery.service.spec.ts` — titled *"records a **non-zero** durationMs"*, asserting `durationMs >= 0`. Zero satisfies that, and so does every number.

The weakening wasn't careless: the service measures with `Date.now()`, ~15ms granularity on Windows, so the old 5ms mocked sleep really could measure 0 and `> 0` would flake. So the fix **drives the clock instead of racing it** — `Date.now` stubbed to 1000 then 1042, asserting `durationMs === 42` exactly. Deterministic under any load, and it pins the arithmetic rather than settling for "is a number".

## Both proven able to fail

Shrinking `until()`'s timeout to 1ms fails 3 tests including this one. Making the stubbed clock return the same value twice fails the webhook test — **which the old `>= 0` assertion would have passed**. Restoring each returns 21/21 and 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved webhook delivery timing tests with deterministic duration validation.
  * Updated job retry backoff tests to reliably account for variable timer scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->