### PR TITLE
fix(auth): signup's Terms and Privacy links both 404'd (EW-065)

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import { Link } from '@/i18n/navigation';
+import { COMPANY_OWNER_WEBSITE } from '@/lib/constants';
 import { AuthLayout } from '@/components/layout/AuthLayout';
 import { useTranslations } from 'next-intl';
 import { SocialLoginButtons } from '@/components/auth/social-login';
@@ -48,6 +49,20 @@ export default function RegisterForm({
     // Nothing to pin an acceptance to means nothing truthful to record, so the
     // form refuses rather than registering silently.
     const termsUnavailable = termsDocuments.length === 0;
+
+    /**
+     * Where to send someone who wants to READ what they are accepting.
+     *
+     * Resolved from the documents this form was handed, so the link and the
+     * recorded acceptance can never disagree. `url` is a site-relative path on
+     * the company website (e.g. `/tos`), so it is resolved against
+     * COMPANY_OWNER_WEBSITE. Falls back to that same path convention when a
+     * document omits `url` — never to the old in-app paths, which have no pages.
+     */
+    const legalHref = (kind: 'tos' | 'privacy') => {
+        const doc = termsDocuments.find((d) => d.documentId.startsWith(`${kind}:`));
+        return new URL(doc?.url || `/${kind}`, COMPANY_OWNER_WEBSITE).toString();
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -185,13 +200,37 @@ export default function RegisterForm({
                         className="ml-2 text-xs text-text-secondary dark:text-text-secondary-dark"
                     >
                         {t('form.terms.text')}{' '}
-                        <Link href="/terms" className="text-primary hover:text-primary-hover">
+                        {/*
+                         * Both hrefs come from the SAME documents whose acceptance
+                         * this form records, so the page a user reads can never
+                         * drift from the version they are agreeing to.
+                         *
+                         * They used to be hardcoded `/terms` and `/privacy`, and
+                         * BOTH 404'd: those paths are declared public in
+                         * constants.ts but no page exists behind them, so the
+                         * signup told users they were agreeing to documents it
+                         * then failed to show. The corpus has always carried the
+                         * real locations — `/tos` and `/privacy` on the marketing
+                         * site — which is also why `/terms` was never going to
+                         * work: it is simply not the path.
+                         */}
+                        <a
+                            href={legalHref('tos')}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary hover:text-primary-hover"
+                        >
                             {t('form.terms.termsLink')}
-                        </Link>{' '}
+                        </a>{' '}
                         {t('form.terms.and')}{' '}
-                        <Link href="/privacy" className="text-primary hover:text-primary-hover">
+                        <a
+                            href={legalHref('privacy')}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary hover:text-primary-hover"
+                        >
                             {t('form.terms.privacyLink')}
-                        </Link>
+                        </a>
                     </label>
                 </div>
 


### PR DESCRIPTION
Found by opening the registration page as a user.

The consent line says you agree to the **Terms of Service** and **Privacy Policy** — and linked to `/terms` and `/privacy`, **both of which render the 404 page**. The signup asserted an agreement and then failed to show either document, while the required checkbox beside it records that acceptance server-side against a published corpus.

`/terms` was never going to work: **it is not the path.** The corpus the form *already receives* has carried the real locations all along — the live API returns:

| documentId | version | title | url |
|---|---|---|---|
| `tos:ever-works` | 1.0.2 | Terms of Service | `/tos` |
| `privacy:ever-works` | 1.0.2 | Privacy Policy | `/privacy` |

Both resolve on the company website to real documents — verified 200 with body content and the titles *"Terms of Service - Ever Works"* / *"Privacy Policy - Ever Works"*, not the 404 shell.

**Fix**: derive both hrefs from those same documents via `legalHref()`, resolved against `COMPANY_OWNER_WEBSITE`. The page a user reads can no longer drift from the version whose acceptance is recorded — a hardcoded path could, and did. Falls back to the same convention if a document omits `url`, never to the in-app paths that have no pages.

**Scope, stated rather than silently dropped**: `/about`, `/contact` and `/help` are also declared public in `constants.ts` and also 404. They are not linked from signup, so they are not in this change — they need content, which is yours to write. Recorded in the register.

Verified: web tsc 0 · prettier clean · derivation asserted against both the live corpus shape and the empty-document fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registration terms and privacy links to use the provided legal documents.
  * Added fallback links when external legal pages are unavailable.
  * Legal documents now open securely in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->