### PR TITLE
feat(settings): Costs tab in Usage & Credits

### DIFF
--- a/apps/api/src/migrations/1785010000000-AddCostsDashboardIndexes.ts
+++ b/apps/api/src/migrations/1785010000000-AddCostsDashboardIndexes.ts
@@ -1,0 +1,82 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+/**
+ * Costs dashboard (Settings → Usage & Credits → Costs) — the covering
+ * indexes its five aggregations need.
+ *
+ * No columns, no tables: every number the Costs view shows is derived
+ * from rows that already exist (`plugin_usage_events.costCents` /
+ * `modelId` / `agentId`, `agent_runs.costCents`). What was missing was
+ * an access path:
+ *
+ *  - `plugin_usage_events` had `(userId, occurredAt)`, which narrows the
+ *    window but leaves the per-agent / per-model GROUP BY as a sort over
+ *    the whole window. Leading with the grouping column after `userId`
+ *    lets the planner walk the index in group order.
+ *  - `agent_runs` had NO user-keyed index at all — every one of
+ *    `listSessionsForUser`, the per-agent run counts and the top-runs
+ *    table was a full scan filtered on `userId`.
+ *
+ * Portable DDL via TypeORM's `TableIndex` API rather than raw
+ * `CREATE INDEX IF NOT EXISTS`, because production is Postgres while CI
+ * and the e2e stack run better-sqlite3 (mirrors 1784830000000).
+ *
+ * Idempotent in both directions: each index is created only when the
+ * table exists and the index does not, and dropped only when present, so
+ * a re-run on a partially-migrated database is a no-op rather than an
+ * abort.
+ */
+export class AddCostsDashboardIndexes1785010000000 implements MigrationInterface {
+    name = 'AddCostsDashboardIndexes1785010000000';
+
+    private static readonly INDEXES: ReadonlyArray<{
+        table: string;
+        name: string;
+        columnNames: string[];
+    }> = [
+        {
+            table: 'plugin_usage_events',
+            name: 'idx_plugin_usage_events_user_agent_occurred',
+            columnNames: ['userId', 'agentId', 'occurredAt'],
+        },
+        {
+            table: 'plugin_usage_events',
+            name: 'idx_plugin_usage_events_user_model_occurred',
+            columnNames: ['userId', 'modelId', 'occurredAt'],
+        },
+        {
+            table: 'agent_runs',
+            name: 'idx_agent_runs_user_created',
+            columnNames: ['userId', 'createdAt'],
+        },
+    ];
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const index of AddCostsDashboardIndexes1785010000000.INDEXES) {
+            if (!(await queryRunner.hasTable(index.table))) {
+                continue;
+            }
+            const table = await queryRunner.getTable(index.table);
+            if (table?.indices.some((existing) => existing.name === index.name)) {
+                continue;
+            }
+            await queryRunner.createIndex(
+                index.table,
+                new TableIndex({ name: index.name, columnNames: index.columnNames }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const index of AddCostsDashboardIndexes1785010000000.INDEXES) {
+            if (!(await queryRunner.hasTable(index.table))) {
+                continue;
+            }
+            const table = await queryRunner.getTable(index.table);
+            if (!table?.indices.some((existing) => existing.name === index.name)) {
+                continue;
+            }
+            await queryRunner.dropIndex(index.table, index.name);
+        }
+    }
+}

--- a/apps/api/src/migrations/1786910000000-AddCostsDashboardIndexes.ts
+++ b/apps/api/src/migrations/1786910000000-AddCostsDashboardIndexes.ts
@@ -26,8 +26,8 @@ import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
  * a re-run on a partially-migrated database is a no-op rather than an
  * abort.
  */
-export class AddCostsDashboardIndexes1785010000000 implements MigrationInterface {
-    name = 'AddCostsDashboardIndexes1785010000000';
+export class AddCostsDashboardIndexes1786910000000 implements MigrationInterface {
+    name = 'AddCostsDashboardIndexes1786910000000';
 
     private static readonly INDEXES: ReadonlyArray<{
         table: string;
@@ -52,7 +52,7 @@ export class AddCostsDashboardIndexes1785010000000 implements MigrationInterface
     ];
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        for (const index of AddCostsDashboardIndexes1785010000000.INDEXES) {
+        for (const index of AddCostsDashboardIndexes1786910000000.INDEXES) {
             if (!(await queryRunner.hasTable(index.table))) {
                 continue;
             }
@@ -68,7 +68,7 @@ export class AddCostsDashboardIndexes1785010000000 implements MigrationInterface
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        for (const index of AddCostsDashboardIndexes1785010000000.INDEXES) {
+        for (const index of AddCostsDashboardIndexes1786910000000.INDEXES) {
             if (!(await queryRunner.hasTable(index.table))) {
                 continue;
             }

--- a/apps/api/src/migrations/__tests__/AddCostsDashboardIndexes.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddCostsDashboardIndexes.spec.ts
@@ -1,5 +1,5 @@
 import { DataSource, Table } from 'typeorm';
-import { AddCostsDashboardIndexes1786910000000 } from './1786910000000-AddCostsDashboardIndexes';
+import { AddCostsDashboardIndexes1786910000000 } from '../1786910000000-AddCostsDashboardIndexes';
 
 /**
  * Executes the Costs-dashboard index migration against a real
@@ -15,6 +15,17 @@ import { AddCostsDashboardIndexes1786910000000 } from './1786910000000-AddCostsD
  *
  * better-sqlite3 is what CI and the e2e stack run, so a Postgres-only
  * construct in the migration would fail here.
+ *
+ * Lives in `__tests__/` (like every sibling migration spec) and NOT
+ * beside the migration: `nest build -b swc` emits `.spec.js` into `dist`
+ * as well, and the runtime migration glob is the FLAT
+ * `dist/migrations/*.js`. A spec compiled straight into that directory
+ * is loaded by `DataSource.initialize()` as if it were a migration,
+ * whose top-level `describe(...)` then throws `ReferenceError: describe
+ * is not defined` and crash-loops every API pod on boot. The nested
+ * directory keeps the compiled output at `dist/migrations/__tests__/`,
+ * one level below the glob. Pinned by
+ * `migrations-directory-contract.spec.ts`.
  */
 describe('AddCostsDashboardIndexes1786910000000', () => {
     let dataSource: DataSource;

--- a/apps/api/src/migrations/__tests__/migrations-directory-contract.spec.ts
+++ b/apps/api/src/migrations/__tests__/migrations-directory-contract.spec.ts
@@ -1,0 +1,54 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * `apps/api/src/migrations/` is not an ordinary source directory — it is
+ * the input to a RUNTIME glob.
+ *
+ * `packages/agent/src/database/database.config.ts` boots the API with
+ * `migrations: ['<cwd>/dist/migrations/*.js', '<cwd>/apps/api/dist/migrations/*.js']`
+ * and `migrationsRun: true` (prod/stage). The glob is FLAT and matches
+ * every `.js` file in that one directory, while `nest build -b swc`
+ * compiles the whole of `src` — spec files included — into `dist`.
+ *
+ * So any file dropped directly into `src/migrations/` is executed by
+ * `DataSource.initialize()` on every pod boot. For a Jest spec that
+ * means its top-level `describe(...)` runs outside Jest and throws
+ * `ReferenceError: describe is not defined`, TypeORM's
+ * `DirectoryExportedClassesLoader` propagates it, and the API
+ * crash-loops — invisibly, because Kubernetes rolls back to the old
+ * pods. That is the incident this file exists to prevent; migration
+ * specs therefore live one level down in `__tests__/`, whose compiled
+ * output (`dist/migrations/__tests__/*.js`) the glob cannot reach.
+ */
+describe('src/migrations directory contract', () => {
+    const MIGRATIONS_DIR = join(__dirname, '..');
+
+    /** Only files the runtime glob would actually pick up. */
+    const flatFiles = readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => entry.name);
+
+    it('contains no test file that the runtime migration glob would execute', () => {
+        const specs = flatFiles.filter((name) => /\.(spec|test)\.ts$/.test(name));
+
+        expect(specs).toEqual([]);
+    });
+
+    it('every flat file is a timestamped migration module, nothing else', () => {
+        const strays = flatFiles.filter((name) => !/^\d{13}-[A-Za-z0-9]+\.ts$/.test(name));
+
+        expect(strays).toEqual([]);
+    });
+
+    it('no flat migration file references Jest globals', () => {
+        // Belt and braces: a helper that merely IMPORTS a spec would be
+        // just as fatal, and the filename check above cannot see that.
+        const offenders = flatFiles.filter((name) => {
+            const source = readFileSync(join(MIGRATIONS_DIR, name), 'utf8');
+            return /^\s*(describe|it|test)\s*\(/m.test(source);
+        });
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/apps/api/src/migrations/costs-dashboard-indexes.migration.spec.ts
+++ b/apps/api/src/migrations/costs-dashboard-indexes.migration.spec.ts
@@ -1,5 +1,5 @@
 import { DataSource, Table } from 'typeorm';
-import { AddCostsDashboardIndexes1785010000000 } from './1785010000000-AddCostsDashboardIndexes';
+import { AddCostsDashboardIndexes1786910000000 } from './1786910000000-AddCostsDashboardIndexes';
 
 /**
  * Executes the Costs-dashboard index migration against a real
@@ -16,7 +16,7 @@ import { AddCostsDashboardIndexes1785010000000 } from './1785010000000-AddCostsD
  * better-sqlite3 is what CI and the e2e stack run, so a Postgres-only
  * construct in the migration would fail here.
  */
-describe('AddCostsDashboardIndexes1785010000000', () => {
+describe('AddCostsDashboardIndexes1786910000000', () => {
     let dataSource: DataSource;
 
     const EXPECTED = [
@@ -79,7 +79,7 @@ describe('AddCostsDashboardIndexes1785010000000', () => {
     it('creates all three indexes on the expected columns', async () => {
         await createTables();
         const runner = dataSource.createQueryRunner();
-        await new AddCostsDashboardIndexes1785010000000().up(runner);
+        await new AddCostsDashboardIndexes1786910000000().up(runner);
 
         const usageIndexes = await runner.getTable('plugin_usage_events');
         const runIndexes = await runner.getTable('agent_runs');
@@ -101,7 +101,7 @@ describe('AddCostsDashboardIndexes1785010000000', () => {
 
     it('is idempotent — a second `up` is a no-op, not a duplicate-name error', async () => {
         await createTables();
-        const migration = new AddCostsDashboardIndexes1785010000000();
+        const migration = new AddCostsDashboardIndexes1786910000000();
 
         const first = dataSource.createQueryRunner();
         await migration.up(first);
@@ -121,14 +121,14 @@ describe('AddCostsDashboardIndexes1785010000000', () => {
         // No `createTables()` — a fresh database mid-bootstrap.
         const runner = dataSource.createQueryRunner();
         await expect(
-            new AddCostsDashboardIndexes1785010000000().up(runner),
+            new AddCostsDashboardIndexes1786910000000().up(runner),
         ).resolves.toBeUndefined();
         await runner.release();
     });
 
     it('down removes exactly what up added, and tolerates a missing index', async () => {
         await createTables();
-        const migration = new AddCostsDashboardIndexes1785010000000();
+        const migration = new AddCostsDashboardIndexes1786910000000();
 
         const up = dataSource.createQueryRunner();
         await migration.up(up);

--- a/apps/api/src/migrations/costs-dashboard-indexes.migration.spec.ts
+++ b/apps/api/src/migrations/costs-dashboard-indexes.migration.spec.ts
@@ -1,0 +1,150 @@
+import { DataSource, Table } from 'typeorm';
+import { AddCostsDashboardIndexes1785010000000 } from './1785010000000-AddCostsDashboardIndexes';
+
+/**
+ * Executes the Costs-dashboard index migration against a real
+ * (in-memory) database rather than only compiling it.
+ *
+ * The failure this catches is the one that hurts in production: a
+ * migration that throws mid-run leaves the schema half-applied and, with
+ * `migrationsRun: true`, crash-loops every API pod on boot. The three
+ * cases below are exactly the states a real deployment can be in — the
+ * indexes absent, the indexes already present (re-run / partially
+ * applied), and the tables not yet created (fresh database whose table
+ * migrations run in a different order).
+ *
+ * better-sqlite3 is what CI and the e2e stack run, so a Postgres-only
+ * construct in the migration would fail here.
+ */
+describe('AddCostsDashboardIndexes1785010000000', () => {
+    let dataSource: DataSource;
+
+    const EXPECTED = [
+        ['plugin_usage_events', 'idx_plugin_usage_events_user_agent_occurred'],
+        ['plugin_usage_events', 'idx_plugin_usage_events_user_model_occurred'],
+        ['agent_runs', 'idx_agent_runs_user_created'],
+    ] as const;
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) {
+            await dataSource.destroy();
+        }
+    });
+
+    /** Minimal stand-ins carrying only the columns the indexes cover. */
+    async function createTables(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'plugin_usage_events',
+                columns: [
+                    { name: 'id', type: 'varchar', isPrimary: true },
+                    { name: 'userId', type: 'varchar' },
+                    { name: 'agentId', type: 'varchar', isNullable: true },
+                    { name: 'modelId', type: 'varchar', isNullable: true },
+                    { name: 'occurredAt', type: 'datetime' },
+                ],
+            }),
+        );
+        await runner.createTable(
+            new Table({
+                name: 'agent_runs',
+                columns: [
+                    { name: 'id', type: 'varchar', isPrimary: true },
+                    { name: 'userId', type: 'varchar' },
+                    { name: 'createdAt', type: 'datetime' },
+                ],
+            }),
+        );
+        await runner.release();
+    }
+
+    async function indexNames(table: string): Promise<string[]> {
+        const runner = dataSource.createQueryRunner();
+        const meta = await runner.getTable(table);
+        await runner.release();
+        return (meta?.indices ?? []).map((index) => index.name ?? '');
+    }
+
+    it('creates all three indexes on the expected columns', async () => {
+        await createTables();
+        const runner = dataSource.createQueryRunner();
+        await new AddCostsDashboardIndexes1785010000000().up(runner);
+
+        const usageIndexes = await runner.getTable('plugin_usage_events');
+        const runIndexes = await runner.getTable('agent_runs');
+        await runner.release();
+
+        for (const [table, name] of EXPECTED) {
+            await expect(indexNames(table)).resolves.toContain(name);
+        }
+        expect(
+            usageIndexes?.indices.find(
+                (index) => index.name === 'idx_plugin_usage_events_user_agent_occurred',
+            )?.columnNames,
+        ).toEqual(['userId', 'agentId', 'occurredAt']);
+        expect(
+            runIndexes?.indices.find((index) => index.name === 'idx_agent_runs_user_created')
+                ?.columnNames,
+        ).toEqual(['userId', 'createdAt']);
+    });
+
+    it('is idempotent — a second `up` is a no-op, not a duplicate-name error', async () => {
+        await createTables();
+        const migration = new AddCostsDashboardIndexes1785010000000();
+
+        const first = dataSource.createQueryRunner();
+        await migration.up(first);
+        await first.release();
+
+        const second = dataSource.createQueryRunner();
+        await expect(migration.up(second)).resolves.toBeUndefined();
+        await second.release();
+
+        const names = await indexNames('plugin_usage_events');
+        expect(
+            names.filter((name) => name === 'idx_plugin_usage_events_user_agent_occurred'),
+        ).toHaveLength(1);
+    });
+
+    it('skips tables that do not exist yet instead of aborting the run', async () => {
+        // No `createTables()` — a fresh database mid-bootstrap.
+        const runner = dataSource.createQueryRunner();
+        await expect(
+            new AddCostsDashboardIndexes1785010000000().up(runner),
+        ).resolves.toBeUndefined();
+        await runner.release();
+    });
+
+    it('down removes exactly what up added, and tolerates a missing index', async () => {
+        await createTables();
+        const migration = new AddCostsDashboardIndexes1785010000000();
+
+        const up = dataSource.createQueryRunner();
+        await migration.up(up);
+        await up.release();
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+
+        for (const [table, name] of EXPECTED) {
+            await expect(indexNames(table)).resolves.not.toContain(name);
+        }
+
+        // Reverting twice must not throw either.
+        const again = dataSource.createQueryRunner();
+        await expect(migration.down(again)).resolves.toBeUndefined();
+        await again.release();
+    });
+});

--- a/apps/api/src/subscriptions/costs.controller.spec.ts
+++ b/apps/api/src/subscriptions/costs.controller.spec.ts
@@ -1,0 +1,185 @@
+// Costs dashboard — unit spec for `GET /api/usage/costs/*`.
+//
+// Focus: owner-scoping (every service call keyed on the AUTHENTICATED
+// user, never a caller-supplied id), the DTO allow-list that keeps the
+// window vocabulary closed, and the 4xx mapping for the service's
+// stable-named error.
+//
+// Mirrors credits.controller.spec.ts: the agent barrels are stubbed so
+// the spec never drags in @ever-works/agent/database.
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    InvalidCostsWindowError: class InvalidCostsWindowError extends Error {
+        constructor(windowDays: unknown) {
+            super(`Invalid windowDays (expected one of 7, 30, 90): ${windowDays}`);
+            this.name = 'InvalidCostsWindowError';
+        }
+    },
+    COSTS_WINDOW_DAYS: [7, 30, 90],
+    COSTS_TOP_RUNS_MAX_LIMIT: 50,
+}));
+jest.mock('../auth', () => ({
+    AuthSessionGuard: class AuthSessionGuard {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { InvalidCostsWindowError } from '@ever-works/agent/subscriptions';
+import type { CostsSummaryService } from '@ever-works/agent/subscriptions';
+import { CostsController, CostsTopRunsQueryDto, CostsWindowQueryDto } from './costs.controller';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+const AUTH = { userId: 'user-1' } as AuthenticatedUser;
+const OTHER = { userId: 'user-2' } as AuthenticatedUser;
+
+function makeService(): jest.Mocked<CostsSummaryService> {
+    return {
+        getSummary: jest
+            .fn()
+            .mockResolvedValue({ windowDays: 30, from: 'F', to: 'T', totalCostCents: 0 }),
+        getDaily: jest
+            .fn()
+            .mockResolvedValue({ windowDays: 30, from: 'F', to: 'T', series: [], days: [] }),
+        getByAgent: jest.fn().mockResolvedValue({ windowDays: 30, from: 'F', to: 'T', rows: [] }),
+        getByModel: jest
+            .fn()
+            .mockResolvedValue({ windowDays: 30, from: 'F', to: 'T', totalCostCents: 0, rows: [] }),
+        getTopRuns: jest.fn().mockResolvedValue({ windowDays: 30, from: 'F', to: 'T', rows: [] }),
+    } as unknown as jest.Mocked<CostsSummaryService>;
+}
+
+async function validateDto<T extends object>(
+    Dto: new () => T,
+    payload: Record<string, unknown>,
+): Promise<string[]> {
+    const instance = plainToInstance(Dto, payload, { enableImplicitConversion: false });
+    const errors = await validate(instance, { whitelist: true, forbidNonWhitelisted: true });
+    return errors.map((error) => error.property);
+}
+
+describe('CostsController', () => {
+    let service: jest.Mocked<CostsSummaryService>;
+    let controller: CostsController;
+
+    beforeEach(() => {
+        service = makeService();
+        controller = new CostsController(service);
+    });
+
+    describe('owner scoping', () => {
+        it('keys every endpoint on the authenticated user', async () => {
+            await controller.summary(AUTH, { windowDays: 7 });
+            await controller.daily(AUTH, { windowDays: 7 });
+            await controller.byAgent(AUTH, { windowDays: 7 });
+            await controller.byModel(AUTH, { windowDays: 7 });
+            await controller.topRuns(AUTH, { windowDays: 7 });
+
+            expect(service.getSummary).toHaveBeenCalledWith('user-1', 7);
+            expect(service.getDaily).toHaveBeenCalledWith('user-1', 7);
+            expect(service.getByAgent).toHaveBeenCalledWith('user-1', 7);
+            expect(service.getByModel).toHaveBeenCalledWith('user-1', 7);
+            expect(service.getTopRuns).toHaveBeenCalledWith('user-1', 7, undefined);
+        });
+
+        it('cannot be pointed at another account — the id comes only from the token', async () => {
+            await controller.summary(OTHER, {});
+
+            expect(service.getSummary).toHaveBeenCalledWith('user-2', undefined);
+        });
+    });
+
+    describe('response shape', () => {
+        it('wraps the service payload with the house `status` envelope', async () => {
+            service.getSummary.mockResolvedValue({
+                windowDays: 30,
+                from: 'F',
+                to: 'T',
+                totalCostCents: 1200,
+                runsCount: 4,
+                avgPerRunCents: 300,
+            } as never);
+
+            await expect(controller.summary(AUTH, {})).resolves.toEqual({
+                status: 'success',
+                windowDays: 30,
+                from: 'F',
+                to: 'T',
+                totalCostCents: 1200,
+                runsCount: 4,
+                avgPerRunCents: 300,
+            });
+        });
+
+        it('forwards the top-runs limit through to the service', async () => {
+            await controller.topRuns(AUTH, { windowDays: 90, limit: 5 });
+
+            expect(service.getTopRuns).toHaveBeenCalledWith('user-1', 90, 5);
+        });
+    });
+
+    describe('error mapping', () => {
+        it('maps InvalidCostsWindowError to 400, never an unmapped 500', async () => {
+            service.getDaily.mockRejectedValue(new InvalidCostsWindowError(45));
+
+            await expect(controller.daily(AUTH, { windowDays: 45 })).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('lets an unexpected failure surface for the global filters', async () => {
+            const boom = new Error('database exploded');
+            service.getByModel.mockRejectedValue(boom);
+
+            await expect(controller.byModel(AUTH, {})).rejects.toBe(boom);
+        });
+    });
+
+    describe('CostsWindowQueryDto', () => {
+        it('accepts the 7/30/90 vocabulary as query strings', async () => {
+            for (const windowDays of ['7', '30', '90']) {
+                await expect(validateDto(CostsWindowQueryDto, { windowDays })).resolves.toEqual([]);
+            }
+        });
+
+        it('coerces the query string to a number before the allow-list check', async () => {
+            const dto = plainToInstance(CostsWindowQueryDto, { windowDays: '90' });
+            expect(dto.windowDays).toBe(90);
+        });
+
+        it('rejects any window outside the vocabulary', async () => {
+            for (const windowDays of ['1', '14', '31', '365', '-7', 'all', '7.5']) {
+                await expect(validateDto(CostsWindowQueryDto, { windowDays })).resolves.toEqual([
+                    'windowDays',
+                ]);
+            }
+        });
+
+        it('treats an omitted window as valid (the service picks the default)', async () => {
+            await expect(validateDto(CostsWindowQueryDto, {})).resolves.toEqual([]);
+        });
+
+        it('rejects unknown fields — forbidNonWhitelisted is on globally', async () => {
+            await expect(
+                validateDto(CostsWindowQueryDto, { windowDays: '7', userId: 'someone-else' }),
+            ).resolves.toEqual(['userId']);
+        });
+    });
+
+    describe('CostsTopRunsQueryDto', () => {
+        it('inherits the window rules and adds a bounded limit', async () => {
+            await expect(
+                validateDto(CostsTopRunsQueryDto, { windowDays: '30', limit: '20' }),
+            ).resolves.toEqual([]);
+            await expect(validateDto(CostsTopRunsQueryDto, { limit: '0' })).resolves.toEqual([
+                'limit',
+            ]);
+            await expect(validateDto(CostsTopRunsQueryDto, { limit: '51' })).resolves.toEqual([
+                'limit',
+            ]);
+            await expect(validateDto(CostsTopRunsQueryDto, { windowDays: '5' })).resolves.toEqual([
+                'windowDays',
+            ]);
+        });
+    });
+});

--- a/apps/api/src/subscriptions/costs.controller.ts
+++ b/apps/api/src/subscriptions/costs.controller.ts
@@ -1,0 +1,177 @@
+import {
+    BadRequestException,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { AuthSessionGuard, CurrentUser } from '@src/auth';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import {
+    COSTS_TOP_RUNS_MAX_LIMIT,
+    COSTS_WINDOW_DAYS,
+    CostsSummaryService,
+    InvalidCostsWindowError,
+    type CostsByAgent,
+    type CostsByModel,
+    type CostsDaily,
+    type CostsSummary,
+    type CostsTopRuns,
+} from '@ever-works/agent/subscriptions';
+
+/**
+ * Rolling window for every Costs panel. `windowDays` arrives as a query
+ * string, so `@Type(() => Number)` runs BEFORE `@IsIn` — without it the
+ * literal `'30'` never matches the numeric allow-list and every request
+ * 400s.
+ */
+export class CostsWindowQueryDto {
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @IsIn(COSTS_WINDOW_DAYS as unknown as number[], {
+        message: `windowDays must be one of ${COSTS_WINDOW_DAYS.join(', ')}`,
+    })
+    windowDays?: number;
+}
+
+/** Top-runs adds a bounded page size on top of the shared window. */
+export class CostsTopRunsQueryDto extends CostsWindowQueryDto {
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(COSTS_TOP_RUNS_MAX_LIMIT)
+    limit?: number;
+}
+
+/**
+ * Costs dashboard (Settings → Usage & Credits → Costs) — read-only,
+ * owner-scoped AI-spend aggregations.
+ *
+ * Every endpoint scopes to `@CurrentUser()` and NOTHING here accepts a
+ * user/org id: spend is the most sensitive read on the platform, and a
+ * caller-supplied scope param is exactly how a cross-account billing
+ * read happens. The sibling admin surface
+ * (`api/admin/usage`) stays the only cross-user view, behind
+ * `IsPlatformAdminGuard`.
+ *
+ * Sits beside `CreditsController` rather than in `budgets/` because it
+ * consumes `CostsSummaryService` from the agent's SubscriptionsModule,
+ * which this module already imports.
+ */
+@ApiTags('Usage')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/usage/costs')
+@UseGuards(AuthSessionGuard)
+export class CostsController {
+    constructor(private readonly costsSummaryService: CostsSummaryService) {}
+
+    @Get('summary')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Total AI spend, run count and average cost per run for a rolling window.',
+        description: 'windowDays accepts 7, 30 or 90 (default 30). Owner-scoped.',
+    })
+    @ApiResponse({ status: 200, description: 'Headline cost totals' })
+    @ApiResponse({ status: 400, description: 'Invalid windowDays' })
+    async summary(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CostsWindowQueryDto,
+    ): Promise<{ status: string } & CostsSummary> {
+        return this.run(() => this.costsSummaryService.getSummary(auth.userId, query.windowDays));
+    }
+
+    @Get('daily')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Daily spend for the window, stacked by Agent.',
+        description:
+            'Dense day axis (zero-spend days included) so the chart never collapses gaps. ' +
+            'Series beyond the top few Agents are folded into an "other" series; spend recorded ' +
+            'outside any Agent run is its own "unattributed" series.',
+    })
+    @ApiResponse({ status: 200, description: 'Stacked daily series' })
+    @ApiResponse({ status: 400, description: 'Invalid windowDays' })
+    async daily(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CostsWindowQueryDto,
+    ): Promise<{ status: string } & CostsDaily> {
+        return this.run(() => this.costsSummaryService.getDaily(auth.userId, query.windowDays));
+    }
+
+    @Get('by-agent')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Per-Agent spend, run count and average cost per run.',
+        description:
+            'No cache-hit column: the metering path does not record cached-read tokens, and a ' +
+            'derived percentage would be fabricated.',
+    })
+    @ApiResponse({ status: 200, description: 'Per-Agent rows, most expensive first' })
+    @ApiResponse({ status: 400, description: 'Invalid windowDays' })
+    async byAgent(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CostsWindowQueryDto,
+    ): Promise<{ status: string } & CostsByAgent> {
+        return this.run(() => this.costsSummaryService.getByAgent(auth.userId, query.windowDays));
+    }
+
+    @Get('by-model')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Per-model spend with each model share of the window total.',
+        description:
+            'A null modelId is honest, not missing data: search / screenshot / extractor calls ' +
+            'never go through a model.',
+    })
+    @ApiResponse({ status: 200, description: 'Per-model rows, most expensive first' })
+    @ApiResponse({ status: 400, description: 'Invalid windowDays' })
+    async byModel(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CostsWindowQueryDto,
+    ): Promise<{ status: string } & CostsByModel> {
+        return this.run(() => this.costsSummaryService.getByModel(auth.userId, query.windowDays));
+    }
+
+    @Get('top-runs')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'The window most expensive Agent runs.',
+        description:
+            'Only runs with settled cost are listed: agent_runs.costCents is NULL until run-cost ' +
+            `settlement stamps it, and NULL means "not attributable", not "free". limit defaults ` +
+            `to 20 and is capped at ${COSTS_TOP_RUNS_MAX_LIMIT}.`,
+    })
+    @ApiResponse({ status: 200, description: 'Top runs by cost, descending' })
+    @ApiResponse({ status: 400, description: 'Invalid windowDays or limit' })
+    async topRuns(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CostsTopRunsQueryDto,
+    ): Promise<{ status: string } & CostsTopRuns> {
+        return this.run(() =>
+            this.costsSummaryService.getTopRuns(auth.userId, query.windowDays, query.limit),
+        );
+    }
+
+    /**
+     * Defence-in-depth: the DTO allow-list already rejects a bad window,
+     * but the service's stable-named error must still map to a 4xx —
+     * never an unmapped 500 (billing PRD §6).
+     */
+    private async run<T>(load: () => Promise<T>): Promise<{ status: string } & T> {
+        try {
+            return { status: 'success', ...(await load()) };
+        } catch (error) {
+            if (error instanceof InvalidCostsWindowError) {
+                throw new BadRequestException(error.message);
+            }
+            throw error;
+        }
+    }
+}

--- a/apps/api/src/subscriptions/subscriptions.module.ts
+++ b/apps/api/src/subscriptions/subscriptions.module.ts
@@ -8,6 +8,7 @@ import { RUN_COST_SETTLER } from '@ever-works/agent/database';
 import { RUN_CREDITS_PRECHECK } from '@ever-works/agent/agents';
 import { SubscriptionsController } from './subscriptions.controller';
 import { CreditsController } from './credits.controller';
+import { CostsController } from './costs.controller';
 
 /**
  * Pricing Wave 9 M2 — @Global() for the same reason as the api-side
@@ -25,7 +26,10 @@ import { CreditsController } from './credits.controller';
     imports: [AuthModule, AgentSubscriptionsModule],
     // CreditsController (pricing Wave 9 M1) — read-only credits surface
     // beside the existing plan endpoints; consumed by the Wave 13 UI.
-    controllers: [SubscriptionsController, CreditsController],
+    // CostsController — the Costs dashboard aggregations
+    // (`GET /api/usage/costs/*`); reads the same metering rows as
+    // CreditsController's usage summary, on a rolling 7/30/90-day window.
+    controllers: [SubscriptionsController, CreditsController, CostsController],
     providers: [
         // Wave 9 M2 — metering → credits debit hook (run terminal writes)
         // + the dispatch gate's soft enforcement precheck. One service

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2731,6 +2731,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -3007,6 +3012,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2731,6 +2731,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -3007,6 +3012,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2731,6 +2731,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -3007,6 +3012,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3023,6 +3023,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "digest": {
@@ -3059,6 +3064,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2731,6 +2731,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -3007,6 +3012,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2731,6 +2731,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -3007,6 +3012,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2731,6 +2731,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -3007,6 +3012,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2663,6 +2663,11 @@
                 "export": {
                     "csv": "Export CSV",
                     "csvHint": "Download every usage event in {period} as a CSV file"
+                },
+                "tabs": {
+                    "label": "Usage views",
+                    "overview": "Overview",
+                    "costs": "Costs"
                 }
             },
             "fleet": {
@@ -2939,6 +2944,63 @@
                     "saveError": "Failed to save the digest settings",
                     "noOrg": "No active organization for this session, so there is no organization digest to configure. Create or switch to an organization first.",
                     "noAiProvider": "No AI provider is configured, so digests will arrive without the written summary. Every count is still computed and delivered."
+                }
+            },
+            "costs": {
+                "title": "Costs",
+                "subtitle": "Total AI spend for the selected window, and where it went — by day, agent, model and run.",
+                "loadError": "Some cost data could not be loaded. Refresh the page to try again.",
+                "loading": "Loading…",
+                "empty": "No spend in this window.",
+                "cacheHitNote": "Cache-hit rate is not shown: the metering path does not record cached-read tokens yet.",
+                "window": {
+                    "label": "Reporting window",
+                    "days": "{days}d"
+                },
+                "tiles": {
+                    "total": "Total spend",
+                    "runs": "Agent runs",
+                    "avgPerRun": "Average per run"
+                },
+                "panels": {
+                    "daily": "Spend per day, by agent",
+                    "byAgent": "By agent",
+                    "byModel": "By model",
+                    "topRuns": "Most expensive runs"
+                },
+                "series": {
+                    "other": "Other agents",
+                    "unattributed": "Unattributed",
+                    "unknownAgent": "Deleted agent",
+                    "noModel": "No model"
+                },
+                "byAgent": {
+                    "colAgent": "Agent",
+                    "colCost": "Cost",
+                    "colRuns": "Runs",
+                    "colAvg": "Avg / run"
+                },
+                "topRuns": {
+                    "colCost": "Cost",
+                    "colAgent": "Agent",
+                    "colTask": "Task",
+                    "colModel": "Model",
+                    "colStarted": "Started",
+                    "colStatus": "Status",
+                    "noTask": "{trigger} run",
+                    "runHint": "Run {runId}",
+                    "empty": "No runs with settled cost in this window.",
+                    "status": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled"
+                    }
+                },
+                "byModel": {
+                    "units": "{units} units",
+                    "total": "{total} across all models in this window"
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { creditsAPI } from '@/lib/api/credits';
+import { costsAPI } from '@/lib/api/costs';
 import { usageAPI, type AccountWideUsage } from '@/lib/api/usage';
 import {
     currentUsageMonth,
@@ -8,7 +9,19 @@ import {
     type UsageSummaryGrouped,
     type UsageSummaryTotals,
 } from '@/lib/api/credits.shared';
+import {
+    COSTS_DEFAULT_WINDOW_DAYS,
+    parseCostsWindowDays,
+    type CostsByAgent,
+    type CostsByModel,
+    type CostsDaily,
+    type CostsSummary,
+    type CostsTopRuns,
+} from '@/lib/api/costs.shared';
+import { parseUsageTab, USAGE_TAB_COSTS } from '@/lib/api/usage-tabs.shared';
 import { UsageCreditsSettings } from '@/components/settings/UsageCreditsSettings';
+import { UsageTabs } from '@/components/settings/usage/UsageTabs';
+import { CostsSettings } from '@/components/settings/costs/CostsSettings';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('metadata.pages');
@@ -31,9 +44,41 @@ interface UsageSettingsPageProps {
  * `parseUsagePeriod`, falling back to the current month), so a shared
  * link renders exactly the month it names; the client selector then
  * refetches through the `/api/credits/usage-summary` proxy.
+ *
+ * Costs tab — `?tab=costs` renders the Costs dashboard instead: total AI
+ * spend for a rolling 7/30/90-day window, daily spend stacked by Agent,
+ * per-Agent and per-model breakdowns and the most expensive runs. The
+ * two tabs fetch DISJOINT endpoint sets and only the active one is
+ * loaded, so adding this tab costs the Overview arm nothing.
  */
 export default async function UsageSettingsPage({ searchParams }: UsageSettingsPageProps) {
     const params = await searchParams;
+    const tab = parseUsageTab(params.tab);
+
+    if (tab === USAGE_TAB_COSTS) {
+        const windowDays = parseCostsWindowDays(params.windowDays) ?? COSTS_DEFAULT_WINDOW_DAYS;
+
+        // Same per-call `.catch(() => null)` posture as the Overview arm:
+        // one failing aggregation must degrade its own panel, not blank
+        // the page.
+        const [summary, daily, byAgent, byModel, topRuns] = await Promise.all([
+            costsAPI.summary({ windowDays }).catch((): CostsSummary | null => null),
+            costsAPI.daily({ windowDays }).catch((): CostsDaily | null => null),
+            costsAPI.byAgent({ windowDays }).catch((): CostsByAgent | null => null),
+            costsAPI.byModel({ windowDays }).catch((): CostsByModel | null => null),
+            costsAPI.topRuns({ windowDays }).catch((): CostsTopRuns | null => null),
+        ]);
+
+        return (
+            <UsageTabs active={USAGE_TAB_COSTS}>
+                <CostsSettings
+                    initialWindowDays={windowDays}
+                    initialSnapshot={{ summary, daily, byAgent, byModel, topRuns }}
+                />
+            </UsageTabs>
+        );
+    }
+
     const period = parseUsagePeriod(params.period) ?? currentUsageMonth();
 
     const [totals, byDay, byModel, byAgent, byWork, accountWide] = await Promise.all([
@@ -54,14 +99,16 @@ export default async function UsageSettingsPage({ searchParams }: UsageSettingsP
     ]);
 
     return (
-        <UsageCreditsSettings
-            initialPeriod={period}
-            initialTotals={totals}
-            initialByDay={byDay}
-            initialByModel={byModel}
-            initialByAgent={byAgent}
-            initialByWork={byWork}
-            accountWide={accountWide}
-        />
+        <UsageTabs active="overview">
+            <UsageCreditsSettings
+                initialPeriod={period}
+                initialTotals={totals}
+                initialByDay={byDay}
+                initialByModel={byModel}
+                initialByAgent={byAgent}
+                initialByWork={byWork}
+                accountWide={accountWide}
+            />
+        </UsageTabs>
     );
 }

--- a/apps/web/src/app/api/usage/costs/[section]/route.ts
+++ b/apps/web/src/app/api/usage/costs/[section]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { COSTS_SECTIONS, type CostsSection } from '@/lib/api/costs.shared';
+
+/**
+ * Costs dashboard — Next.js proxy for the owner-scoped cost
+ * aggregations, so the 7/30/90-day window picker can refetch every panel
+ * client-side. Forwards the auth cookie as a Bearer token.
+ *
+ * Mirrors `app/api/credits/usage-summary/route.ts`, with the section as
+ * a path segment instead of five near-identical route files.
+ */
+
+// Security: the section is interpolated into the upstream URL, so it is
+// matched against a closed allow-list rather than sanitized — an unknown
+// value is a 404 here and never reaches the internal API.
+const ALLOWED_SECTIONS = new Set<string>(COSTS_SECTIONS);
+
+// Security: allowlist of query parameters forwarded upstream, so
+// unknown/debug parameters (and anything that looks like a scope
+// override) are never passed through.
+const ALLOWED_PARAMS = new Set(['windowDays', 'limit']);
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ section: string }> },
+) {
+    const { section } = await params;
+    if (!ALLOWED_SECTIONS.has(section)) {
+        return NextResponse.json({ error: 'Unknown costs section' }, { status: 404 });
+    }
+
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstreamParams = new URLSearchParams();
+    request.nextUrl.searchParams.forEach((value, key) => {
+        if (ALLOWED_PARAMS.has(key)) {
+            upstreamParams.set(key, value);
+        }
+    });
+    const upstreamSearch = upstreamParams.size > 0 ? `?${upstreamParams.toString()}` : '';
+
+    const response = await fetch(
+        `${API_URL}/usage/costs/${section as CostsSection}${upstreamSearch}`,
+        { method: 'GET', headers, cache: 'no-store' },
+    );
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body) {
+        return NextResponse.json(
+            { error: 'Failed to load costs data' },
+            { status: response.status || 500 },
+        );
+    }
+
+    return NextResponse.json(body, { status: 200 });
+}

--- a/apps/web/src/components/settings/costs/CostsByModelList.tsx
+++ b/apps/web/src/components/settings/costs/CostsByModelList.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { formatCents } from '@/lib/api/credits.shared';
+import { formatSharePercent, shareBarWidth, type CostsByModelRow } from '@/lib/api/costs.shared';
+
+interface CostsByModelListProps {
+    rows: CostsByModelRow[];
+    /** Window total — the denominator every share is computed against. */
+    totalCostCents: number;
+    emptyLabel: string;
+    /** Localized label for rows whose capability never used a model. */
+    noModelLabel: string;
+    /** `(units) => localized string`, e.g. `1,204 units`. */
+    formatUnits: (units: number) => string;
+    /** `(total) => localized string` for the panel footer. */
+    formatTotal: (total: string) => string;
+}
+
+/**
+ * Per-model spend with a share bar (Costs tab).
+ *
+ * A list with CSS bars rather than a recharts chart: the panel needs the
+ * model id, the amount AND the share on one line, which a bar chart's
+ * category axis truncates. Model ids are long and arbitrary, so they get
+ * the full row width and the bar sits underneath.
+ */
+export function CostsByModelList({
+    rows,
+    totalCostCents,
+    emptyLabel,
+    noModelLabel,
+    formatUnits,
+    formatTotal,
+}: CostsByModelListProps) {
+    if (rows.length === 0) {
+        return (
+            <p
+                className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                data-testid="costs-by-model-empty"
+            >
+                {emptyLabel}
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <ul className="space-y-3" data-testid="costs-by-model-list">
+                {rows.map((row) => (
+                    <li
+                        key={row.modelId ?? '__none__'}
+                        data-testid="costs-by-model-row"
+                        className="space-y-1.5"
+                    >
+                        <div className="flex items-baseline justify-between gap-3">
+                            <span
+                                className="truncate text-sm text-text dark:text-text-dark"
+                                title={row.modelId ?? noModelLabel}
+                            >
+                                {row.modelId ?? noModelLabel}
+                            </span>
+                            <span className="shrink-0 text-sm font-medium text-text dark:text-text-dark tabular-nums">
+                                {formatCents(row.costCents)}
+                                <span className="ml-2 text-xs font-normal text-text-muted dark:text-text-muted-dark">
+                                    {formatSharePercent(row.sharePercent)}
+                                </span>
+                            </span>
+                        </div>
+                        <div
+                            className="h-1.5 w-full overflow-hidden rounded-full bg-surface-hover dark:bg-surface-hover-dark"
+                            role="presentation"
+                        >
+                            <div
+                                className="h-full rounded-full bg-primary"
+                                style={{ width: shareBarWidth(row.sharePercent) }}
+                            />
+                        </div>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark tabular-nums">
+                            {formatUnits(row.units)}
+                        </p>
+                    </li>
+                ))}
+            </ul>
+            {/* The denominator, stated: shares only add up against it. */}
+            <p
+                className="text-xs text-text-muted dark:text-text-muted-dark"
+                data-testid="costs-by-model-total"
+            >
+                {formatTotal(formatCents(totalCostCents))}
+            </p>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/costs/CostsDailyStackedChart.tsx
+++ b/apps/web/src/components/settings/costs/CostsDailyStackedChart.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Bar, BarChart, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { formatCents } from '@/lib/api/credits.shared';
+import {
+    costsSeriesColor,
+    formatCostsDayTick,
+    COSTS_OTHER_SERIES_KEY,
+    COSTS_UNATTRIBUTED_SERIES_KEY,
+    type CostsDailyBucket,
+    type CostsDailySeries,
+} from '@/lib/api/costs.shared';
+
+interface CostsDailyStackedChartProps {
+    series: CostsDailySeries[];
+    days: CostsDailyBucket[];
+    emptyLabel: string;
+    /** Localized copy for the two sentinel series keys. */
+    otherLabel: string;
+    unattributedLabel: string;
+    /** Localized fallback for an Agent whose row no longer resolves. */
+    unknownAgentLabel: string;
+}
+
+/**
+ * Daily spend, stacked by Agent (Costs tab).
+ *
+ * Same recharts building blocks as `UsageByDayChart` — the app's
+ * existing chart approach, so no new dependency — with one `<Bar>` per
+ * series sharing a `stackId`. Series order comes from the API (spend
+ * descending), so the biggest spender is the base of every stack and the
+ * legend reads top-down in the same order.
+ */
+export function CostsDailyStackedChart({
+    series,
+    days,
+    emptyLabel,
+    otherLabel,
+    unattributedLabel,
+    unknownAgentLabel,
+}: CostsDailyStackedChartProps) {
+    const labelFor = (entry: CostsDailySeries): string => {
+        if (entry.key === COSTS_OTHER_SERIES_KEY) {
+            return otherLabel;
+        }
+        if (entry.key === COSTS_UNATTRIBUTED_SERIES_KEY) {
+            return unattributedLabel;
+        }
+        return entry.label ?? unknownAgentLabel;
+    };
+
+    // A window with no spend still returns a dense day axis, so "no data"
+    // is the absence of SERIES, not the absence of days.
+    if (series.length === 0 || days.length === 0) {
+        return (
+            <p
+                className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                data-testid="costs-daily-chart-empty"
+            >
+                {emptyLabel}
+            </p>
+        );
+    }
+
+    // Recharts reads each series off a flat key on the row, so the
+    // per-day `costs` map is spread out here. Missing keys become 0 so a
+    // gap day does not break the stack.
+    const chartData = days.map((bucket) => {
+        const row: Record<string, number | string> = { day: formatCostsDayTick(bucket.day) };
+        for (const entry of series) {
+            row[entry.key] = bucket.costs[entry.key] ?? 0;
+        }
+        return row;
+    });
+
+    return (
+        <div className="h-64 w-full" data-testid="costs-daily-chart">
+            <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 0, right: 0, left: -10, bottom: 0 }}>
+                    <XAxis
+                        dataKey="day"
+                        tick={{ fontSize: 10 }}
+                        interval="preserveStartEnd"
+                        axisLine={false}
+                        tickLine={false}
+                    />
+                    <YAxis
+                        tick={{ fontSize: 10 }}
+                        width={36}
+                        axisLine={false}
+                        tickLine={false}
+                        tickFormatter={(value: number) => `$${(value / 100).toFixed(0)}`}
+                    />
+                    <Tooltip
+                        formatter={(value: number) => formatCents(value)}
+                        contentStyle={{
+                            background: 'rgba(15, 23, 42, 0.9)',
+                            border: '1px solid rgba(148, 163, 184, 0.2)',
+                            borderRadius: 6,
+                            fontSize: 12,
+                        }}
+                        labelStyle={{ color: '#cbd5e1' }}
+                        itemStyle={{ color: '#f1f5f9' }}
+                    />
+                    <Legend wrapperStyle={{ fontSize: 11 }} />
+                    {series.map((entry, index) => (
+                        <Bar
+                            key={entry.key}
+                            dataKey={entry.key}
+                            name={labelFor(entry)}
+                            stackId="cost"
+                            fill={costsSeriesColor(entry.key, index)}
+                            // Only the topmost segment gets a rounded cap;
+                            // rounding every segment leaves visible seams
+                            // through the stack.
+                            radius={index === series.length - 1 ? [2, 2, 0, 0] : undefined}
+                        />
+                    ))}
+                </BarChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/costs/CostsSettings.tsx
+++ b/apps/web/src/components/settings/costs/CostsSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlertCircle } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
@@ -92,16 +92,34 @@ export function CostsSettings({ initialWindowDays, initialSnapshot }: CostsSetti
     const [loading, setLoading] = useState(false);
     const [loadFailed, setLoadFailed] = useState(false);
 
+    /**
+     * Monotonic token for the in-flight window fetch.
+     *
+     * Five requests go out per window change and nothing cancels the
+     * previous batch, so clicking 7d then 90d races two batches whose
+     * completion order is not the click order. Without this guard the
+     * SLOWER batch wins and the page renders 7d numbers under a
+     * highlighted 90d button — silently wrong spend, which is the one
+     * thing this view must never show. Stale batches still populate the
+     * cache (their data is correct for THEIR window); they just may not
+     * touch what is on screen.
+     */
+    const latestRequest = useRef(0);
+
     const handleWindowChange = async (next: CostsWindowDays) => {
         if (next === windowDays) {
             return;
         }
+        const request = latestRequest.current + 1;
+        latestRequest.current = request;
+
         setWindowDays(next);
         setLoadFailed(false);
 
         const cached = cache[next];
         if (cached) {
             setSnapshot(cached);
+            setLoading(false);
             return;
         }
 
@@ -116,11 +134,19 @@ export function CostsSettings({ initialWindowDays, initialSnapshot }: CostsSetti
             ]);
             const fresh: CostsSnapshot = { summary, daily, byAgent, byModel, topRuns };
             setCache((current) => ({ ...current, [next]: fresh }));
+            if (latestRequest.current !== request) {
+                return;
+            }
             setSnapshot(fresh);
         } catch {
+            if (latestRequest.current !== request) {
+                return;
+            }
             setLoadFailed(true);
         } finally {
-            setLoading(false);
+            if (latestRequest.current === request) {
+                setLoading(false);
+            }
         }
     };
 

--- a/apps/web/src/components/settings/costs/CostsSettings.tsx
+++ b/apps/web/src/components/settings/costs/CostsSettings.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertCircle } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants';
+import { formatCents } from '@/lib/api/credits.shared';
+import {
+    buildCostsQuery,
+    COSTS_WINDOW_DAYS,
+    type CostsSnapshot,
+    type CostsSection,
+    type CostsWindowDays,
+} from '@/lib/api/costs.shared';
+import { CostsDailyStackedChart } from './CostsDailyStackedChart';
+import { CostsByModelList } from './CostsByModelList';
+
+interface CostsSettingsProps {
+    /** Window the server rendered the initial snapshot with. */
+    initialWindowDays: CostsWindowDays;
+    initialSnapshot: CostsSnapshot;
+}
+
+async function fetchCosts<T>(section: CostsSection, windowDays: CostsWindowDays): Promise<T> {
+    const response = await fetch(`/api/usage/costs/${section}${buildCostsQuery({ windowDays })}`, {
+        method: 'GET',
+        cache: 'no-store',
+    });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+    }
+    return (await response.json()) as T;
+}
+
+function StatTile({ label, value, testId }: { label: string; value: string; testId: string }) {
+    // Monochrome KPI tiles, matching the Overview tab's grid.
+    return (
+        <div
+            data-testid={testId}
+            className="rounded-lg border border-border dark:border-border-dark p-4"
+        >
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">{label}</p>
+            <p className="mt-1 text-xl font-semibold text-text dark:text-text-dark">{value}</p>
+        </div>
+    );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+    return (
+        <div className="rounded-lg border border-border dark:border-border-dark p-5 space-y-3">
+            <h3 className="text-sm font-semibold text-text dark:text-text-dark">{title}</h3>
+            {children}
+        </div>
+    );
+}
+
+/**
+ * Costs tab of Settings → Usage & Credits.
+ *
+ * Additive beside the Overview tab: the credits/period surface there is
+ * untouched, and this tab answers a different question — where the AI
+ * spend of the last 7/30/90 days actually went, per Agent, per model and
+ * per run.
+ *
+ * One window drives every panel, and each window's snapshot is cached so
+ * flipping back is instant (same pattern as `UsageCreditsSettings`).
+ */
+export function CostsSettings({ initialWindowDays, initialSnapshot }: CostsSettingsProps) {
+    const t = useTranslations('dashboard.settings.costs');
+
+    /**
+     * Run statuses that have localized copy. An unrecognized status (a
+     * future member of `AgentRunStatus`) falls back to its raw token
+     * rather than making next-intl throw on a missing key and taking the
+     * whole table down.
+     */
+    const runStatusLabel = (status: string): string =>
+        (['queued', 'running', 'completed', 'failed', 'cancelled'] as const).includes(
+            status as never,
+        )
+            ? t(`topRuns.status.${status}` as 'topRuns.status.completed')
+            : status;
+
+    const [windowDays, setWindowDays] = useState<CostsWindowDays>(initialWindowDays);
+    const [snapshot, setSnapshot] = useState<CostsSnapshot>(initialSnapshot);
+    const [cache, setCache] = useState<Record<number, CostsSnapshot>>({
+        [initialWindowDays]: initialSnapshot,
+    });
+    const [loading, setLoading] = useState(false);
+    const [loadFailed, setLoadFailed] = useState(false);
+
+    const handleWindowChange = async (next: CostsWindowDays) => {
+        if (next === windowDays) {
+            return;
+        }
+        setWindowDays(next);
+        setLoadFailed(false);
+
+        const cached = cache[next];
+        if (cached) {
+            setSnapshot(cached);
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const [summary, daily, byAgent, byModel, topRuns] = await Promise.all([
+                fetchCosts<CostsSnapshot['summary']>('summary', next),
+                fetchCosts<CostsSnapshot['daily']>('daily', next),
+                fetchCosts<CostsSnapshot['byAgent']>('by-agent', next),
+                fetchCosts<CostsSnapshot['byModel']>('by-model', next),
+                fetchCosts<CostsSnapshot['topRuns']>('top-runs', next),
+            ]);
+            const fresh: CostsSnapshot = { summary, daily, byAgent, byModel, topRuns };
+            setCache((current) => ({ ...current, [next]: fresh }));
+            setSnapshot(fresh);
+        } catch {
+            setLoadFailed(true);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const { summary, daily, byAgent, byModel, topRuns } = snapshot;
+    const dataUnavailable = !summary && !daily && !byAgent && !byModel && !topRuns;
+
+    return (
+        <div className="space-y-8" data-testid="costs-settings">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+                        {t('title')}
+                    </h2>
+                    <p className="text-text-muted dark:text-text-muted-dark text-sm">
+                        {t('subtitle')}
+                    </p>
+                </div>
+
+                <div
+                    role="group"
+                    aria-label={t('window.label')}
+                    className="flex flex-wrap items-center gap-2"
+                    data-testid="costs-window-bar"
+                >
+                    {COSTS_WINDOW_DAYS.map((days) => (
+                        <Button
+                            key={days}
+                            variant={windowDays === days ? 'primary' : 'secondary'}
+                            className={cn('text-xs px-3 py-1')}
+                            data-testid={`costs-window-${days}`}
+                            aria-pressed={windowDays === days}
+                            onClick={() => handleWindowChange(days)}
+                        >
+                            {t('window.days', { days })}
+                        </Button>
+                    ))}
+                </div>
+            </div>
+
+            {dataUnavailable || loadFailed ? (
+                <div
+                    data-testid="costs-load-error"
+                    className="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 p-4 text-sm text-text dark:text-text-dark"
+                >
+                    <AlertCircle className="w-4 h-4 shrink-0 text-warning" />
+                    {t('loadError')}
+                </div>
+            ) : null}
+
+            {/* ── Headline totals ─────────────────────────────────── */}
+            {summary ? (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3" data-testid="costs-tiles">
+                    <StatTile
+                        label={t('tiles.total')}
+                        value={formatCents(summary.totalCostCents)}
+                        testId="costs-tile-total"
+                    />
+                    <StatTile
+                        label={t('tiles.runs')}
+                        value={String(summary.runsCount)}
+                        testId="costs-tile-runs"
+                    />
+                    <StatTile
+                        label={t('tiles.avgPerRun')}
+                        value={formatCents(summary.avgPerRunCents)}
+                        testId="costs-tile-avg"
+                    />
+                </div>
+            ) : null}
+
+            {/* ── Daily spend, stacked by Agent ───────────────────── */}
+            <Panel title={t('panels.daily')}>
+                {loading ? (
+                    <p
+                        className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                        data-testid="costs-loading"
+                    >
+                        {t('loading')}
+                    </p>
+                ) : (
+                    <CostsDailyStackedChart
+                        series={daily?.series ?? []}
+                        days={daily?.days ?? []}
+                        emptyLabel={t('empty')}
+                        otherLabel={t('series.other')}
+                        unattributedLabel={t('series.unattributed')}
+                        unknownAgentLabel={t('series.unknownAgent')}
+                    />
+                )}
+            </Panel>
+
+            {/* ── By agent / by model ─────────────────────────────── */}
+            <div className="grid gap-4 @3xl/main:grid-cols-2">
+                <Panel title={t('panels.byAgent')}>
+                    {byAgent && byAgent.rows.length > 0 ? (
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm" data-testid="costs-by-agent-table">
+                                <thead>
+                                    <tr className="text-left text-xs text-text-muted dark:text-text-muted-dark border-b border-border dark:border-border-dark">
+                                        <th className="py-2 pr-4 font-medium">
+                                            {t('byAgent.colAgent')}
+                                        </th>
+                                        <th className="py-2 pr-4 font-medium text-right">
+                                            {t('byAgent.colCost')}
+                                        </th>
+                                        <th className="py-2 pr-4 font-medium text-right">
+                                            {t('byAgent.colRuns')}
+                                        </th>
+                                        <th className="py-2 font-medium text-right">
+                                            {t('byAgent.colAvg')}
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {byAgent.rows.map((row) => (
+                                        <tr
+                                            key={row.agentId ?? '__unattributed__'}
+                                            data-testid="costs-by-agent-row"
+                                            className="border-b border-border/60 dark:border-border-dark/60 last:border-0"
+                                        >
+                                            <td className="py-2 pr-4">
+                                                {row.agentId ? (
+                                                    <Link
+                                                        href={ROUTES.DASHBOARD_AGENT(row.agentId)}
+                                                        className="text-primary hover:underline"
+                                                    >
+                                                        {row.name ?? t('series.unknownAgent')}
+                                                    </Link>
+                                                ) : (
+                                                    <span className="text-text-muted dark:text-text-muted-dark">
+                                                        {t('series.unattributed')}
+                                                    </span>
+                                                )}
+                                            </td>
+                                            <td className="py-2 pr-4 text-right tabular-nums">
+                                                {formatCents(row.costCents)}
+                                            </td>
+                                            <td className="py-2 pr-4 text-right tabular-nums text-text-muted dark:text-text-muted-dark">
+                                                {row.runs}
+                                            </td>
+                                            <td className="py-2 text-right tabular-nums text-text-muted dark:text-text-muted-dark">
+                                                {formatCents(row.avgPerRunCents)}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    ) : (
+                        <p
+                            className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                            data-testid="costs-by-agent-empty"
+                        >
+                            {t('empty')}
+                        </p>
+                    )}
+                </Panel>
+
+                <Panel title={t('panels.byModel')}>
+                    <CostsByModelList
+                        rows={byModel?.rows ?? []}
+                        totalCostCents={byModel?.totalCostCents ?? 0}
+                        emptyLabel={t('empty')}
+                        noModelLabel={t('series.noModel')}
+                        formatUnits={(units) => t('byModel.units', { units })}
+                        formatTotal={(total) => t('byModel.total', { total })}
+                    />
+                </Panel>
+            </div>
+
+            {/* ── Most expensive runs ─────────────────────────────── */}
+            <Panel title={t('panels.topRuns')}>
+                {topRuns && topRuns.rows.length > 0 ? (
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm" data-testid="costs-top-runs-table">
+                            <thead>
+                                <tr className="text-left text-xs text-text-muted dark:text-text-muted-dark border-b border-border dark:border-border-dark">
+                                    <th className="py-2 pr-4 font-medium">
+                                        {t('topRuns.colCost')}
+                                    </th>
+                                    <th className="py-2 pr-4 font-medium">
+                                        {t('topRuns.colAgent')}
+                                    </th>
+                                    <th className="py-2 pr-4 font-medium">
+                                        {t('topRuns.colTask')}
+                                    </th>
+                                    <th className="py-2 pr-4 font-medium">
+                                        {t('topRuns.colModel')}
+                                    </th>
+                                    <th className="py-2 pr-4 font-medium">
+                                        {t('topRuns.colStarted')}
+                                    </th>
+                                    <th className="py-2 font-medium">{t('topRuns.colStatus')}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {topRuns.rows.map((row) => (
+                                    <tr
+                                        key={row.runId}
+                                        data-testid="costs-top-runs-row"
+                                        className="border-b border-border/60 dark:border-border-dark/60 last:border-0"
+                                    >
+                                        <td className="py-2 pr-4 font-medium tabular-nums">
+                                            {formatCents(row.costCents)}
+                                        </td>
+                                        <td className="py-2 pr-4">
+                                            <Link
+                                                href={ROUTES.DASHBOARD_AGENT_ACTIVITY(row.agentId)}
+                                                className="text-primary hover:underline"
+                                                title={t('topRuns.runHint', { runId: row.runId })}
+                                            >
+                                                {row.agentName ?? t('series.unknownAgent')}
+                                            </Link>
+                                        </td>
+                                        <td className="py-2 pr-4 max-w-[16rem] truncate">
+                                            {row.taskId ? (
+                                                <Link
+                                                    href={ROUTES.DASHBOARD_TASK(row.taskId)}
+                                                    className="text-primary hover:underline"
+                                                    title={row.taskTitle ?? row.taskId}
+                                                >
+                                                    {row.taskTitle ?? row.taskId}
+                                                </Link>
+                                            ) : (
+                                                <span className="text-text-muted dark:text-text-muted-dark">
+                                                    {t('topRuns.noTask', {
+                                                        trigger: row.triggerKind,
+                                                    })}
+                                                </span>
+                                            )}
+                                        </td>
+                                        <td className="py-2 pr-4 text-text-muted dark:text-text-muted-dark">
+                                            {row.modelId ?? t('series.noModel')}
+                                        </td>
+                                        <td className="py-2 pr-4 whitespace-nowrap text-text-muted dark:text-text-muted-dark">
+                                            {row.startedAt
+                                                ? new Date(row.startedAt).toLocaleString(
+                                                      undefined,
+                                                      {
+                                                          month: 'short',
+                                                          day: 'numeric',
+                                                          hour: '2-digit',
+                                                          minute: '2-digit',
+                                                      },
+                                                  )
+                                                : '—'}
+                                        </td>
+                                        <td
+                                            className={cn(
+                                                'py-2 whitespace-nowrap',
+                                                // Only failure gets colour: a run that
+                                                // burned money and produced nothing is
+                                                // the row a reader is scanning for.
+                                                row.status === 'failed'
+                                                    ? 'text-danger'
+                                                    : 'text-text-muted dark:text-text-muted-dark',
+                                            )}
+                                        >
+                                            {runStatusLabel(row.status)}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                ) : (
+                    <p
+                        className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                        data-testid="costs-top-runs-empty"
+                    >
+                        {t('topRuns.empty')}
+                    </p>
+                )}
+            </Panel>
+
+            {/*
+             * Stated, not hidden: the platform records no cached-read
+             * tokens, so a cache-hit column would be a fabricated number.
+             */}
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">{t('cacheHitNote')}</p>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/costs/CostsSettings.unit.spec.tsx
+++ b/apps/web/src/components/settings/costs/CostsSettings.unit.spec.tsx
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+        vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+// `@/i18n/navigation` pulls the next-intl routing config (and with it the
+// Next router) into a jsdom spec. The component only needs an anchor.
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ href, children, ...rest }: any) => (
+        <a href={typeof href === 'string' ? href : '#'} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+// recharts measures its container, which jsdom reports as 0×0 — the real
+// chart is exercised by the e2e suite. The stub keeps the series contract
+// observable (a `data-series` attribute) so the wiring is still asserted.
+vi.mock('recharts', () => {
+    const Passthrough = ({ children }: any) => <div>{children}</div>;
+    return {
+        ResponsiveContainer: Passthrough,
+        BarChart: ({ children }: any) => <div data-testid="recharts-barchart">{children}</div>,
+        Bar: ({ dataKey, name, stackId }: any) => (
+            <div
+                data-testid="recharts-bar"
+                data-key={dataKey}
+                data-name={name}
+                data-stack={stackId}
+            />
+        ),
+        XAxis: () => null,
+        YAxis: () => null,
+        Tooltip: () => null,
+        Legend: () => null,
+    };
+});
+
+import { CostsSettings } from './CostsSettings';
+import type { CostsSnapshot } from '@/lib/api/costs.shared';
+
+const EMPTY_SNAPSHOT: CostsSnapshot = {
+    summary: null,
+    daily: null,
+    byAgent: null,
+    byModel: null,
+    topRuns: null,
+};
+
+function snapshot(overrides: Partial<CostsSnapshot> = {}): CostsSnapshot {
+    return {
+        summary: {
+            status: 'success',
+            windowDays: 30,
+            from: '2026-07-16T00:00:00.000Z',
+            to: '2026-08-14T15:30:00.000Z',
+            totalCostCents: 12345,
+            runsCount: 9,
+            avgPerRunCents: 1372,
+        },
+        daily: {
+            status: 'success',
+            windowDays: 30,
+            from: '2026-07-16T00:00:00.000Z',
+            to: '2026-08-14T15:30:00.000Z',
+            series: [
+                { key: 'agent-1', label: 'Researcher', costCents: 10000 },
+                { key: 'unattributed', label: null, costCents: 2345 },
+            ],
+            days: [
+                { day: '2026-08-13', totalCostCents: 100, costs: { 'agent-1': 100 } },
+                { day: '2026-08-14', totalCostCents: 40, costs: { unattributed: 40 } },
+            ],
+        },
+        byAgent: {
+            status: 'success',
+            windowDays: 30,
+            from: '2026-07-16T00:00:00.000Z',
+            to: '2026-08-14T15:30:00.000Z',
+            rows: [
+                {
+                    agentId: 'agent-1',
+                    name: 'Researcher',
+                    costCents: 10000,
+                    runs: 8,
+                    avgPerRunCents: 1250,
+                },
+                {
+                    agentId: null,
+                    name: null,
+                    costCents: 2345,
+                    runs: 0,
+                    avgPerRunCents: 0,
+                },
+            ],
+        },
+        byModel: {
+            status: 'success',
+            windowDays: 30,
+            from: '2026-07-16T00:00:00.000Z',
+            to: '2026-08-14T15:30:00.000Z',
+            totalCostCents: 12345,
+            rows: [
+                { modelId: 'claude-opus-5', units: 900, costCents: 10000, sharePercent: 81 },
+                { modelId: null, units: 12, costCents: 2345, sharePercent: 19 },
+            ],
+        },
+        topRuns: {
+            status: 'success',
+            windowDays: 30,
+            from: '2026-07-16T00:00:00.000Z',
+            to: '2026-08-14T15:30:00.000Z',
+            rows: [
+                {
+                    runId: 'run-1',
+                    costCents: 5000,
+                    agentId: 'agent-1',
+                    agentName: 'Researcher',
+                    taskId: 'task-1',
+                    taskTitle: 'Refresh the catalog',
+                    modelId: 'claude-opus-5',
+                    status: 'completed',
+                    triggerKind: 'task',
+                    startedAt: '2026-08-13T09:00:00.000Z',
+                },
+                {
+                    runId: 'run-2',
+                    costCents: 900,
+                    agentId: 'agent-2',
+                    agentName: null,
+                    taskId: null,
+                    taskTitle: null,
+                    modelId: null,
+                    status: 'failed',
+                    triggerKind: 'heartbeat',
+                    startedAt: null,
+                },
+            ],
+        },
+        ...overrides,
+    };
+}
+
+describe('CostsSettings', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the headline tiles from the server snapshot', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        expect(screen.getByTestId('costs-tile-total')).toHaveTextContent('$123.45');
+        expect(screen.getByTestId('costs-tile-runs')).toHaveTextContent('9');
+        expect(screen.getByTestId('costs-tile-avg')).toHaveTextContent('$13.72');
+        expect(screen.queryByTestId('costs-load-error')).toBeNull();
+    });
+
+    it('stacks one chart series per API series, sharing a stack id', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        const bars = screen.getAllByTestId('recharts-bar');
+        expect(bars).toHaveLength(2);
+        expect(bars.map((bar) => bar.getAttribute('data-key'))).toEqual([
+            'agent-1',
+            'unattributed',
+        ]);
+        // Same stackId or the bars render side-by-side instead of stacked.
+        expect(new Set(bars.map((bar) => bar.getAttribute('data-stack')))).toEqual(
+            new Set(['cost']),
+        );
+        // The sentinel series gets localized copy, not a raw key.
+        expect(bars[1].getAttribute('data-name')).toBe('series.unattributed');
+    });
+
+    it('renders the per-agent table with runs and average, and no cache-hit column', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        const table = screen.getByTestId('costs-by-agent-table');
+        const headers = within(table)
+            .getAllByRole('columnheader')
+            .map((cell) => cell.textContent);
+        expect(headers).toEqual([
+            'byAgent.colAgent',
+            'byAgent.colCost',
+            'byAgent.colRuns',
+            'byAgent.colAvg',
+        ]);
+        expect(headers).not.toContain('byAgent.colCacheHit');
+
+        const rows = within(table).getAllByTestId('costs-by-agent-row');
+        expect(rows[0].textContent).toContain('Researcher');
+        expect(rows[0].textContent).toContain('$100.00');
+        expect(rows[0].textContent).toContain('$12.50');
+        // The unattributed row is labelled, never blank or a raw null.
+        expect(rows[1].textContent).toContain('series.unattributed');
+    });
+
+    it('links each agent and task row to its detail page', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        const topRuns = screen.getByTestId('costs-top-runs-table');
+        const links = within(topRuns).getAllByRole('link');
+        expect(links.map((link) => link.getAttribute('href'))).toEqual(
+            expect.arrayContaining(['/agents/agent-1/activity', '/tasks/task-1']),
+        );
+    });
+
+    it('labels a run with no task and no model honestly instead of leaving cells blank', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        const rows = within(screen.getByTestId('costs-top-runs-table')).getAllByTestId(
+            'costs-top-runs-row',
+        );
+        expect(rows[1].textContent).toContain('topRuns.noTask:{"trigger":"heartbeat"}');
+        expect(rows[1].textContent).toContain('series.noModel');
+        expect(rows[1].textContent).toContain('series.unknownAgent');
+    });
+
+    it('renders the by-model rows with share, units and the shared denominator', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        const rows = screen.getAllByTestId('costs-by-model-row');
+        expect(rows[0].textContent).toContain('claude-opus-5');
+        expect(rows[0].textContent).toContain('81%');
+        expect(rows[0].textContent).toContain('byModel.units:{"units":900}');
+        // A capability with no model is named, not rendered as `null`.
+        expect(rows[1].textContent).toContain('series.noModel');
+        // The window total the shares are computed against is stated.
+        expect(screen.getByTestId('costs-by-model-total')).toHaveTextContent(
+            'byModel.total:{"total":"$123.45"}',
+        );
+    });
+
+    it('renders each run status, colouring only the failed one', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+        const rows = within(screen.getByTestId('costs-top-runs-table')).getAllByTestId(
+            'costs-top-runs-row',
+        );
+        expect(rows[0].textContent).toContain('topRuns.status.completed');
+        expect(rows[1].textContent).toContain('topRuns.status.failed');
+        expect(rows[1].querySelector('.text-danger')).not.toBeNull();
+        expect(rows[0].querySelector('.text-danger')).toBeNull();
+    });
+
+    it('shows the load-error banner when every panel failed server-side', () => {
+        render(<CostsSettings initialWindowDays={30} initialSnapshot={EMPTY_SNAPSHOT} />);
+
+        expect(screen.getByTestId('costs-load-error')).toBeInTheDocument();
+        expect(screen.getByTestId('costs-daily-chart-empty')).toBeInTheDocument();
+        expect(screen.getByTestId('costs-top-runs-empty')).toBeInTheDocument();
+    });
+
+    describe('window picker', () => {
+        it('refetches every panel through the proxy with the new window', async () => {
+            const fetchMock = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({ status: 'success', rows: [], series: [], days: [] }),
+            });
+            vi.stubGlobal('fetch', fetchMock);
+
+            render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+            await userEvent.click(screen.getByTestId('costs-window-7'));
+
+            await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+            expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+                '/api/usage/costs/summary?windowDays=7',
+                '/api/usage/costs/daily?windowDays=7',
+                '/api/usage/costs/by-agent?windowDays=7',
+                '/api/usage/costs/by-model?windowDays=7',
+                '/api/usage/costs/top-runs?windowDays=7',
+            ]);
+        });
+
+        it('serves a window it has already loaded from cache without refetching', async () => {
+            const fetchMock = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({ status: 'success', rows: [], series: [], days: [] }),
+            });
+            vi.stubGlobal('fetch', fetchMock);
+
+            render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+            await userEvent.click(screen.getByTestId('costs-window-7'));
+            await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+
+            // Back to the server-rendered window — already cached.
+            await userEvent.click(screen.getByTestId('costs-window-30'));
+            expect(fetchMock).toHaveBeenCalledTimes(5);
+            expect(screen.getByTestId('costs-tile-total')).toHaveTextContent('$123.45');
+        });
+
+        it('surfaces a failed refetch instead of silently keeping stale numbers', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+            render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+            await userEvent.click(screen.getByTestId('costs-window-90'));
+
+            expect(await screen.findByTestId('costs-load-error')).toBeInTheDocument();
+        });
+
+        it('marks the active window for assistive tech', async () => {
+            render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+            expect(screen.getByTestId('costs-window-30')).toHaveAttribute('aria-pressed', 'true');
+            expect(screen.getByTestId('costs-window-7')).toHaveAttribute('aria-pressed', 'false');
+        });
+    });
+});

--- a/apps/web/src/components/settings/costs/CostsSettings.unit.spec.tsx
+++ b/apps/web/src/components/settings/costs/CostsSettings.unit.spec.tsx
@@ -302,6 +302,71 @@ describe('CostsSettings', () => {
             expect(await screen.findByTestId('costs-load-error')).toBeInTheDocument();
         });
 
+        it('ignores a slow batch for a window the user has already moved off', async () => {
+            // Five requests go out per window change and nothing cancels
+            // the previous batch. Resolving them out of click order is
+            // exactly the production case (a 7d batch on a heavy account
+            // finishing after the 90d batch); the LAST click must win, or
+            // the page shows one window's spend under another window's
+            // highlighted button.
+            const pending = new Map<string, ((value: unknown) => void)[]>();
+            const respond = (windowDays: string, totalCostCents: number) => {
+                for (const resolve of pending.get(windowDays) ?? []) {
+                    resolve({
+                        ok: true,
+                        json: async () => ({
+                            status: 'success',
+                            windowDays: Number(windowDays),
+                            from: 'F',
+                            to: 'T',
+                            totalCostCents,
+                            runsCount: 1,
+                            avgPerRunCents: totalCostCents,
+                            series: [],
+                            days: [],
+                            rows: [],
+                        }),
+                    });
+                }
+                pending.set(windowDays, []);
+            };
+
+            vi.stubGlobal(
+                'fetch',
+                vi.fn((url: string) => {
+                    const windowDays =
+                        new URLSearchParams(url.split('?')[1] ?? '').get('windowDays') ?? '';
+                    return new Promise((resolve) => {
+                        pending.set(windowDays, [...(pending.get(windowDays) ?? []), resolve]);
+                    });
+                }),
+            );
+
+            render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
+
+            await userEvent.click(screen.getByTestId('costs-window-7'));
+            await waitFor(() => expect(pending.get('7')).toHaveLength(5));
+            await userEvent.click(screen.getByTestId('costs-window-90'));
+            await waitFor(() => expect(pending.get('90')).toHaveLength(5));
+
+            // 90d (the current selection) lands first, 7d (abandoned) after.
+            respond('90', 9000);
+            await waitFor(() =>
+                expect(screen.getByTestId('costs-tile-total')).toHaveTextContent('$90.00'),
+            );
+            respond('7', 700);
+
+            await waitFor(() =>
+                expect(screen.getByTestId('costs-window-90')).toHaveAttribute(
+                    'aria-pressed',
+                    'true',
+                ),
+            );
+            // The abandoned batch must not repaint the tiles.
+            expect(screen.getByTestId('costs-tile-total')).toHaveTextContent('$90.00');
+            expect(screen.queryByTestId('costs-load-error')).toBeNull();
+        });
+
         it('marks the active window for assistive tech', async () => {
             render(<CostsSettings initialWindowDays={30} initialSnapshot={snapshot()} />);
 

--- a/apps/web/src/components/settings/usage/UsageTabs.tsx
+++ b/apps/web/src/components/settings/usage/UsageTabs.tsx
@@ -1,0 +1,66 @@
+import { getTranslations } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import { ROUTES } from '@/lib/constants';
+import { USAGE_TAB_COSTS, USAGE_TAB_OVERVIEW, type UsageTab } from '@/lib/api/usage-tabs.shared';
+
+interface UsageTabsProps {
+    active: UsageTab;
+    children: React.ReactNode;
+}
+
+/**
+ * Settings → Usage & Credits tab bar.
+ *
+ * Server component with plain links rather than client-side state: each
+ * tab fetches a DIFFERENT set of endpoints, so a link means the page
+ * only ever loads the panels it is about to render, and a `?tab=costs`
+ * URL is shareable and server-rendered.
+ *
+ * The Overview tab is the default arm and its subtree is unchanged — the
+ * existing page is wrapped, not rewritten.
+ */
+export async function UsageTabs({ active, children }: UsageTabsProps) {
+    const t = await getTranslations('dashboard.settings.usage.tabs');
+
+    const tabs: { id: UsageTab; label: string; href: string }[] = [
+        {
+            id: USAGE_TAB_OVERVIEW,
+            label: t('overview'),
+            href: ROUTES.DASHBOARD_USAGE,
+        },
+        {
+            id: USAGE_TAB_COSTS,
+            label: t('costs'),
+            href: `${ROUTES.DASHBOARD_USAGE}?tab=${USAGE_TAB_COSTS}`,
+        },
+    ];
+
+    return (
+        <div className="space-y-6">
+            <nav
+                aria-label={t('label')}
+                data-testid="usage-tabs"
+                className="flex items-center gap-1 border-b border-border dark:border-border-dark"
+            >
+                {tabs.map((tab) => (
+                    <Link
+                        key={tab.id}
+                        href={tab.href}
+                        data-testid={`usage-tab-${tab.id}`}
+                        aria-current={tab.id === active ? 'page' : undefined}
+                        className={cn(
+                            '-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors',
+                            tab.id === active
+                                ? 'border-primary text-text dark:text-text-dark'
+                                : 'border-transparent text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark',
+                        )}
+                    >
+                        {tab.label}
+                    </Link>
+                ))}
+            </nav>
+            {children}
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/usage/UsageTabs.tsx
+++ b/apps/web/src/components/settings/usage/UsageTabs.tsx
@@ -32,7 +32,10 @@ export async function UsageTabs({ active, children }: UsageTabsProps) {
         {
             id: USAGE_TAB_COSTS,
             label: t('costs'),
-            href: `${ROUTES.DASHBOARD_USAGE}?tab=${USAGE_TAB_COSTS}`,
+            // The deep link lives in ROUTES beside every other settings
+            // destination — re-interpolating it here would give the
+            // constant no caller and let the two drift apart.
+            href: ROUTES.DASHBOARD_USAGE_COSTS,
         },
     ];
 

--- a/apps/web/src/lib/api/costs.shared.ts
+++ b/apps/web/src/lib/api/costs.shared.ts
@@ -1,0 +1,207 @@
+/**
+ * Costs dashboard — client-safe wire types + pure helpers for the
+ * Settings → Usage & Credits → Costs tab.
+ *
+ * Mirrors `apps/api/src/subscriptions/costs.controller.ts`; kept apart
+ * from `costs.ts` (which is `server-only`) so `'use client'` components
+ * can import types and helpers without pulling the server guard into the
+ * client bundle — same split as `credits.shared.ts`.
+ */
+
+// ── Window vocabulary ───────────────────────────────────────────────
+
+/**
+ * The rolling windows the Costs tab offers. Pinned to the API's
+ * `COSTS_WINDOW_DAYS`: the DTO rejects anything else, so a value added
+ * here without the API moving first would 400 every request.
+ */
+export const COSTS_WINDOW_DAYS = [7, 30, 90] as const;
+export type CostsWindowDays = (typeof COSTS_WINDOW_DAYS)[number];
+
+export const COSTS_DEFAULT_WINDOW_DAYS: CostsWindowDays = 30;
+
+/** Series keys that are not an Agent id (mirrors the API sentinels). */
+export const COSTS_UNATTRIBUTED_SERIES_KEY = 'unattributed';
+export const COSTS_OTHER_SERIES_KEY = 'other';
+
+/** The sections of the Costs API, used by the proxy route's allow-list. */
+export const COSTS_SECTIONS = ['summary', 'daily', 'by-agent', 'by-model', 'top-runs'] as const;
+export type CostsSection = (typeof COSTS_SECTIONS)[number];
+
+// ── Wire types ──────────────────────────────────────────────────────
+
+interface CostsWindowEcho {
+    status: string;
+    windowDays: CostsWindowDays;
+    from: string;
+    to: string;
+}
+
+export interface CostsSummary extends CostsWindowEcho {
+    totalCostCents: number;
+    runsCount: number;
+    avgPerRunCents: number;
+}
+
+export interface CostsDailySeries {
+    key: string;
+    /** Agent name; null for the sentinel series (localized by the UI). */
+    label: string | null;
+    costCents: number;
+}
+
+export interface CostsDailyBucket {
+    day: string;
+    totalCostCents: number;
+    costs: Record<string, number>;
+}
+
+export interface CostsDaily extends CostsWindowEcho {
+    series: CostsDailySeries[];
+    days: CostsDailyBucket[];
+}
+
+export interface CostsByAgentRow {
+    agentId: string | null;
+    name: string | null;
+    costCents: number;
+    runs: number;
+    avgPerRunCents: number;
+}
+
+export interface CostsByAgent extends CostsWindowEcho {
+    rows: CostsByAgentRow[];
+}
+
+export interface CostsByModelRow {
+    modelId: string | null;
+    units: number;
+    costCents: number;
+    sharePercent: number;
+}
+
+export interface CostsByModel extends CostsWindowEcho {
+    totalCostCents: number;
+    rows: CostsByModelRow[];
+}
+
+export interface CostsTopRunRow {
+    runId: string;
+    costCents: number;
+    agentId: string;
+    agentName: string | null;
+    taskId: string | null;
+    taskTitle: string | null;
+    modelId: string | null;
+    status: string;
+    triggerKind: string;
+    startedAt: string | null;
+}
+
+export interface CostsTopRuns extends CostsWindowEcho {
+    rows: CostsTopRunRow[];
+}
+
+/** Everything the Costs tab renders for ONE window. */
+export interface CostsSnapshot {
+    summary: CostsSummary | null;
+    daily: CostsDaily | null;
+    byAgent: CostsByAgent | null;
+    byModel: CostsByModel | null;
+    topRuns: CostsTopRuns | null;
+}
+
+// ── Pure helpers (unit-tested in costs.shared.unit.spec.ts) ─────────
+
+/** Runtime guard for anything a URL param or a `<select>` yields. */
+export function isCostsWindowDays(value: unknown): value is CostsWindowDays {
+    return typeof value === 'number' && (COSTS_WINDOW_DAYS as readonly number[]).includes(value);
+}
+
+/**
+ * Normalize an untrusted value (URL param, storage) to a window.
+ * Returns `undefined` rather than throwing so callers can fall back to
+ * their own default — a bad `?windowDays=` must never blank the page.
+ */
+export function parseCostsWindowDays(value: unknown): CostsWindowDays | undefined {
+    if (Array.isArray(value)) {
+        return parseCostsWindowDays(value[0]);
+    }
+    if (typeof value === 'number') {
+        return isCostsWindowDays(value) ? value : undefined;
+    }
+    if (typeof value !== 'string' || value.trim() === '') {
+        return undefined;
+    }
+    // `Number('')` is 0 and `Number(' 7 ')` is 7 — the empty check above
+    // handles the first, and the allow-list handles everything else.
+    const parsed = Number(value);
+    return isCostsWindowDays(parsed) ? parsed : undefined;
+}
+
+/** Build the `/usage/costs/<section>` query string (omits defaults). */
+export function buildCostsQuery(
+    params: { windowDays?: CostsWindowDays; limit?: number } = {},
+): string {
+    const search = new URLSearchParams();
+    if (params.windowDays) {
+        search.set('windowDays', String(params.windowDays));
+    }
+    if (params.limit) {
+        search.set('limit', String(params.limit));
+    }
+    const qs = search.toString();
+    return qs ? `?${qs}` : '';
+}
+
+/**
+ * `sharePercent` → a bar width clamped into 0..100.
+ *
+ * A single model always renders a FULL bar (its share is 100), and a
+ * rounding artifact just above 100 can never overflow its track.
+ */
+export function shareBarWidth(sharePercent: number): string {
+    if (!Number.isFinite(sharePercent) || sharePercent <= 0) {
+        return '0%';
+    }
+    return `${Math.min(100, sharePercent)}%`;
+}
+
+/** `12.5` → `12.5%`; whole numbers drop the decimal. */
+export function formatSharePercent(sharePercent: number): string {
+    if (!Number.isFinite(sharePercent)) {
+        return '0%';
+    }
+    const rounded = Math.round(sharePercent * 10) / 10;
+    return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}%`;
+}
+
+/** `2026-08-14` → `08-14` for a dense chart axis. */
+export function formatCostsDayTick(day: string): string {
+    return /^\d{4}-\d{2}-\d{2}$/.test(day) ? day.slice(5) : day;
+}
+
+/**
+ * Deterministic series colour. Keyed by INDEX, not by a hash of the id:
+ * the series array is already ordered by spend, so the biggest spender
+ * keeps the same colour between windows, and two adjacent stack segments
+ * can never collide the way hashed colours occasionally do.
+ */
+const COSTS_SERIES_COLORS = [
+    '#3b82f6',
+    '#8b5cf6',
+    '#14b8a6',
+    '#f59e0b',
+    '#ec4899',
+    '#22c55e',
+] as const;
+
+/** Muted grey for the folded / unattributed buckets, never a hue. */
+export const COSTS_SENTINEL_SERIES_COLOR = '#94a3b8';
+
+export function costsSeriesColor(key: string, index: number): string {
+    if (key === COSTS_OTHER_SERIES_KEY || key === COSTS_UNATTRIBUTED_SERIES_KEY) {
+        return COSTS_SENTINEL_SERIES_COLOR;
+    }
+    return COSTS_SERIES_COLORS[index % COSTS_SERIES_COLORS.length];
+}

--- a/apps/web/src/lib/api/costs.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/costs.shared.unit.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildCostsQuery,
+    costsSeriesColor,
+    COSTS_OTHER_SERIES_KEY,
+    COSTS_SECTIONS,
+    COSTS_SENTINEL_SERIES_COLOR,
+    COSTS_UNATTRIBUTED_SERIES_KEY,
+    COSTS_WINDOW_DAYS,
+    formatCostsDayTick,
+    formatSharePercent,
+    isCostsWindowDays,
+    parseCostsWindowDays,
+    shareBarWidth,
+} from './costs.shared';
+
+describe('costs window vocabulary', () => {
+    it('matches the API allow-list exactly — anything else 400s', () => {
+        expect(COSTS_WINDOW_DAYS).toEqual([7, 30, 90]);
+    });
+
+    it('pins the proxy route section allow-list to the API paths', () => {
+        expect(COSTS_SECTIONS).toEqual(['summary', 'daily', 'by-agent', 'by-model', 'top-runs']);
+    });
+
+    it('isCostsWindowDays accepts only the numeric members', () => {
+        expect(isCostsWindowDays(7)).toBe(true);
+        expect(isCostsWindowDays(90)).toBe(true);
+        expect(isCostsWindowDays(31)).toBe(false);
+        // A numeric STRING is not a window — the caller must parse first.
+        expect(isCostsWindowDays('7')).toBe(false);
+        expect(isCostsWindowDays(null)).toBe(false);
+    });
+});
+
+describe('parseCostsWindowDays', () => {
+    it('accepts the vocabulary as numbers and as query strings', () => {
+        expect(parseCostsWindowDays(30)).toBe(30);
+        expect(parseCostsWindowDays('90')).toBe(90);
+        expect(parseCostsWindowDays(' 7 ')).toBe(7);
+    });
+
+    it('takes the first value of a repeated query parameter', () => {
+        expect(parseCostsWindowDays(['7', '30'])).toBe(7);
+    });
+
+    it('returns undefined for anything else so callers can default', () => {
+        for (const bad of ['', '  ', 'all', '31', '-7', 'NaN', null, undefined, {}, []]) {
+            expect(parseCostsWindowDays(bad)).toBeUndefined();
+        }
+    });
+
+    it('does not let the empty string coerce to 0 and then to a window', () => {
+        // `Number('')` is 0, which is falsy but still a number — the guard
+        // has to reject it explicitly.
+        expect(parseCostsWindowDays('')).toBeUndefined();
+    });
+});
+
+describe('buildCostsQuery', () => {
+    it('omits everything that was not supplied', () => {
+        expect(buildCostsQuery()).toBe('');
+        expect(buildCostsQuery({})).toBe('');
+    });
+
+    it('serializes the window and the limit', () => {
+        expect(buildCostsQuery({ windowDays: 90 })).toBe('?windowDays=90');
+        expect(buildCostsQuery({ windowDays: 7, limit: 5 })).toBe('?windowDays=7&limit=5');
+    });
+});
+
+describe('shareBarWidth', () => {
+    it('maps a share to a percentage width', () => {
+        expect(shareBarWidth(42.5)).toBe('42.5%');
+        expect(shareBarWidth(100)).toBe('100%');
+    });
+
+    it('clamps above 100 so a rounding artifact cannot overflow the track', () => {
+        expect(shareBarWidth(100.4)).toBe('100%');
+    });
+
+    it('collapses non-positive and non-finite shares to zero width', () => {
+        expect(shareBarWidth(0)).toBe('0%');
+        expect(shareBarWidth(-5)).toBe('0%');
+        expect(shareBarWidth(Number.NaN)).toBe('0%');
+    });
+});
+
+describe('formatSharePercent', () => {
+    it('drops the decimal on whole numbers and keeps one otherwise', () => {
+        expect(formatSharePercent(25)).toBe('25%');
+        expect(formatSharePercent(33.3)).toBe('33.3%');
+        expect(formatSharePercent(33.34)).toBe('33.3%');
+    });
+
+    it('never renders NaN%', () => {
+        expect(formatSharePercent(Number.NaN)).toBe('0%');
+    });
+});
+
+describe('formatCostsDayTick', () => {
+    it('trims the year off an ISO day', () => {
+        expect(formatCostsDayTick('2026-08-14')).toBe('08-14');
+    });
+
+    it('passes anything unexpected through untouched', () => {
+        expect(formatCostsDayTick('week 32')).toBe('week 32');
+    });
+});
+
+describe('costsSeriesColor', () => {
+    it('gives the sentinel series a neutral grey, never a hue', () => {
+        expect(costsSeriesColor(COSTS_OTHER_SERIES_KEY, 0)).toBe(COSTS_SENTINEL_SERIES_COLOR);
+        expect(costsSeriesColor(COSTS_UNATTRIBUTED_SERIES_KEY, 3)).toBe(
+            COSTS_SENTINEL_SERIES_COLOR,
+        );
+    });
+
+    it('is stable per index so the top spender keeps its colour', () => {
+        expect(costsSeriesColor('agent-a', 0)).toBe(costsSeriesColor('agent-b', 0));
+        expect(costsSeriesColor('agent-a', 0)).not.toBe(costsSeriesColor('agent-a', 1));
+    });
+
+    it('wraps around rather than returning undefined past the palette', () => {
+        expect(costsSeriesColor('agent-a', 99)).toMatch(/^#[0-9a-f]{6}$/i);
+    });
+});

--- a/apps/web/src/lib/api/costs.ts
+++ b/apps/web/src/lib/api/costs.ts
@@ -1,0 +1,59 @@
+import 'server-only';
+import { serverFetch } from './server-api';
+import {
+    buildCostsQuery,
+    type CostsByAgent,
+    type CostsByModel,
+    type CostsDaily,
+    type CostsSummary,
+    type CostsTopRuns,
+    type CostsWindowDays,
+} from './costs.shared';
+
+export type { CostsByAgent, CostsByModel, CostsDaily, CostsSummary, CostsTopRuns, CostsWindowDays };
+
+/**
+ * Costs dashboard — server-side wrappers over `GET /api/usage/costs/*`.
+ *
+ * Endpoints deliberately do NOT start with `/api`: serverFetch prepends
+ * `API_URL`, which is normalized to end in `/api` (see the
+ * double-prefix regression specs beside the other lib/api wrappers).
+ */
+export const costsAPI = {
+    /** Headline total + run count + average cost per run. */
+    async summary(params: { windowDays?: CostsWindowDays } = {}): Promise<CostsSummary> {
+        return serverFetch<CostsSummary>(`/usage/costs/summary${buildCostsQuery(params)}`, {
+            method: 'GET',
+        });
+    },
+
+    /** Daily spend for the window, stacked by Agent. */
+    async daily(params: { windowDays?: CostsWindowDays } = {}): Promise<CostsDaily> {
+        return serverFetch<CostsDaily>(`/usage/costs/daily${buildCostsQuery(params)}`, {
+            method: 'GET',
+        });
+    },
+
+    /** Per-Agent spend, run count and average cost per run. */
+    async byAgent(params: { windowDays?: CostsWindowDays } = {}): Promise<CostsByAgent> {
+        return serverFetch<CostsByAgent>(`/usage/costs/by-agent${buildCostsQuery(params)}`, {
+            method: 'GET',
+        });
+    },
+
+    /** Per-model spend with each model's share of the window total. */
+    async byModel(params: { windowDays?: CostsWindowDays } = {}): Promise<CostsByModel> {
+        return serverFetch<CostsByModel>(`/usage/costs/by-model${buildCostsQuery(params)}`, {
+            method: 'GET',
+        });
+    },
+
+    /** The window's most expensive runs. */
+    async topRuns(
+        params: { windowDays?: CostsWindowDays; limit?: number } = {},
+    ): Promise<CostsTopRuns> {
+        return serverFetch<CostsTopRuns>(`/usage/costs/top-runs${buildCostsQuery(params)}`, {
+            method: 'GET',
+        });
+    },
+};

--- a/apps/web/src/lib/api/usage-tabs.shared.ts
+++ b/apps/web/src/lib/api/usage-tabs.shared.ts
@@ -1,0 +1,28 @@
+/**
+ * Settings → Usage & Credits tab vocabulary.
+ *
+ * Its own file rather than a constant inside the page: the tab bar (a
+ * server component), the page's `?tab=` parsing and the unit spec all
+ * need it, and `costs.shared.ts` is about the costs WIRE format, not the
+ * page's navigation.
+ */
+
+export const USAGE_TAB_OVERVIEW = 'overview';
+export const USAGE_TAB_COSTS = 'costs';
+
+export const USAGE_TABS = [USAGE_TAB_OVERVIEW, USAGE_TAB_COSTS] as const;
+export type UsageTab = (typeof USAGE_TABS)[number];
+
+/**
+ * Normalize an untrusted `?tab=` value. Falls back to Overview rather
+ * than throwing or 404ing, so a stale or hand-edited link still renders
+ * the page it names in spirit.
+ */
+export function parseUsageTab(value: unknown): UsageTab {
+    if (Array.isArray(value)) {
+        return parseUsageTab(value[0]);
+    }
+    return typeof value === 'string' && (USAGE_TABS as readonly string[]).includes(value)
+        ? (value as UsageTab)
+        : USAGE_TAB_OVERVIEW;
+}

--- a/apps/web/src/lib/api/usage-tabs.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/usage-tabs.shared.unit.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+    parseUsageTab,
+    USAGE_TAB_COSTS,
+    USAGE_TAB_OVERVIEW,
+    USAGE_TABS,
+} from './usage-tabs.shared';
+
+describe('parseUsageTab', () => {
+    it('accepts the two known tabs', () => {
+        expect(parseUsageTab('overview')).toBe(USAGE_TAB_OVERVIEW);
+        expect(parseUsageTab('costs')).toBe(USAGE_TAB_COSTS);
+    });
+
+    it('falls back to Overview for anything else — a bad ?tab= never 404s', () => {
+        for (const bad of [undefined, null, '', 'Costs', 'billing', 42, {}]) {
+            expect(parseUsageTab(bad)).toBe(USAGE_TAB_OVERVIEW);
+        }
+    });
+
+    it('takes the first value of a repeated query parameter', () => {
+        expect(parseUsageTab(['costs', 'overview'])).toBe(USAGE_TAB_COSTS);
+    });
+
+    it('keeps Overview first so it stays the default arm', () => {
+        expect(USAGE_TABS[0]).toBe(USAGE_TAB_OVERVIEW);
+    });
+});

--- a/apps/web/src/lib/api/usage-tabs.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/usage-tabs.shared.unit.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ROUTES } from '@/lib/constants';
 import {
     parseUsageTab,
     USAGE_TAB_COSTS,
@@ -24,5 +25,16 @@ describe('parseUsageTab', () => {
 
     it('keeps Overview first so it stays the default arm', () => {
         expect(USAGE_TABS[0]).toBe(USAGE_TAB_OVERVIEW);
+    });
+
+    it('round-trips the ROUTES deep link the tab bar navigates to', () => {
+        // The tab bar links to ROUTES.DASHBOARD_USAGE_COSTS and the page
+        // resolves the arm with parseUsageTab. If the constant's `?tab=`
+        // value ever drifts from the vocabulary the link silently lands
+        // back on Overview, which reads as "the Costs tab is broken".
+        const query = new URLSearchParams(ROUTES.DASHBOARD_USAGE_COSTS.split('?')[1] ?? '');
+
+        expect(ROUTES.DASHBOARD_USAGE_COSTS.split('?')[0]).toBe(ROUTES.DASHBOARD_USAGE);
+        expect(parseUsageTab(query.get('tab'))).toBe(USAGE_TAB_COSTS);
     });
 });

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -200,6 +200,9 @@ export const ROUTES = {
     // Payment-method management (billing PRD §3.3, audit B10 + B25).
     DASHBOARD_SETTINGS_PAYMENT_METHOD: '/settings/billing/payment-method',
     DASHBOARD_USAGE: '/settings/usage',
+    // Costs dashboard — a tab of the Usage & Credits page, not its own
+    // route, so the settings nav keeps ONE entry for the whole surface.
+    DASHBOARD_USAGE_COSTS: '/settings/usage?tab=costs',
     // Dynamic plugin settings routes
     DASHBOARD_SETTINGS_PLUGIN_CATEGORY: (category: string) => `/settings/plugins/${category}`,
     // Profile (alias of settings — `/profile` redirects to `/settings`)

--- a/docs/internal/feat-costs-notes.md
+++ b/docs/internal/feat-costs-notes.md
@@ -1,0 +1,182 @@
+# Costs dashboard — implementation notes
+
+Branch: `session/feat-costs`. Surface: **Settings → Usage & Credits → Costs**
+(`/settings/usage?tab=costs`).
+
+## What shipped
+
+A Costs tab beside the existing Usage & Credits overview, answering "where did
+the AI spend of the last 7 / 30 / 90 days actually go":
+
+- headline tiles — total spend, agent runs, average cost per run;
+- daily spend, **stacked by Agent** (dense day axis, top 6 agents + `other` +
+  `unattributed`);
+- per-Agent table — cost, runs, average per run;
+- per-model list — cost, share bar, units, and the window denominator;
+- most-expensive-runs table — cost, agent, task, model, started, status.
+
+Everything additive. The Overview tab's component tree, endpoints and testids
+are untouched, and it stays the default arm of the page.
+
+## What the code already had (and the brief assumed it did not)
+
+The brief planned for two things that turned out to be present on `develop`
+already. Both plans were dropped in favour of the existing implementation:
+
+| Brief assumption                                                                           | Reality                                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "Model id per call may not be recorded — add `modelId` capture at the usage-emission seam" | `plugin_usage_events.modelId` already exists and `AiFacadeService` already stamps `response.model` on **every** `pluginUsageService.record(...)` call site. No emission change was needed, so none was made. |
+| "Add by-model / by-agent aggregations"                                                     | Wave 13 already shipped `PluginUsageRepository.getSpendByModelForUser` / `getSpendByAgentForUser` behind `GET /api/credits/usage-summary?groupBy=`. Those are reused rather than duplicated.                 |
+
+What was genuinely missing, and is what this branch adds: the **rolling
+7/30/90-day window** (the existing period grammar is `YYYY-MM | 7d | 30d`), the
+**daily × agent** cross-tab, **run counts and per-run averages**, and the
+**top-runs** view.
+
+## Cache-hit rate: deliberately omitted, not forgotten
+
+The brief said to compute cache-hit % "if present in run-log metadata, else omit
+and note a follow-up (do NOT fake it)". It is **not** present:
+
+- `PluginUsageService.record` persists `metadata: { operation, promptTokens,
+completionTokens }` — no cached-read component;
+- `packages/plugin`'s `TokenUsage` is `{ promptTokens, completionTokens,
+totalTokens }`; nothing on the dispatch path carries
+  `cache_read_input_tokens`;
+- the only code in the repo that sees the field is
+  `packages/plugins/claude-managed-agent`, which surfaces it as pipeline
+  `metrics` that are never persisted;
+- `WorkRunsSummary` in `agent-run.repository.ts` documents the identical finding
+  for its token rollup.
+
+So the column is absent from the API and the UI, and the UI states why
+(`dashboard.settings.costs.cacheHitNote`). See the follow-ups below.
+
+## Data model
+
+**No new entities and no new columns.** Three covering indexes only:
+
+| Table                 | Index                                                                       | Serves                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `plugin_usage_events` | `idx_plugin_usage_events_user_agent_occurred (userId, agentId, occurredAt)` | per-agent rollups, daily × agent                                                                                     |
+| `plugin_usage_events` | `idx_plugin_usage_events_user_model_occurred (userId, modelId, occurredAt)` | per-model rollup                                                                                                     |
+| `agent_runs`          | `idx_agent_runs_user_created (userId, createdAt)`                           | run counts, top-runs — `agent_runs` had **no** user-keyed index at all, so `listSessionsForUser` was a full scan too |
+
+Migration: `apps/api/src/migrations/1785010000000-AddCostsDashboardIndexes.ts`
+(portable `TableIndex` DDL, idempotent in both directions, skips tables that do
+not exist yet). Matching `@Index()` declarations were added to
+`plugin-usage-event.entity.ts` and `agent-run.entity.ts`.
+
+## Endpoints
+
+All owner-scoped via `@CurrentUser()`; **no endpoint accepts a user or org id**.
+`windowDays` ∈ `{7, 30, 90}` (default 30), enforced by a class-validator
+allow-list and re-checked in the service (`InvalidCostsWindowError` → 400).
+
+| Method | Path                        | Returns                                             |
+| ------ | --------------------------- | --------------------------------------------------- |
+| GET    | `/api/usage/costs/summary`  | `totalCostCents`, `runsCount`, `avgPerRunCents`     |
+| GET    | `/api/usage/costs/daily`    | `series[]` (agent + sentinels) and a dense `days[]` |
+| GET    | `/api/usage/costs/by-agent` | `rows[]` — cost, runs, avg per run                  |
+| GET    | `/api/usage/costs/by-model` | `totalCostCents` + `rows[]` with `sharePercent`     |
+| GET    | `/api/usage/costs/top-runs` | `rows[]` (`limit` default 20, max 50)               |
+
+Controller: `apps/api/src/subscriptions/costs.controller.ts`, registered on the
+api-side `SubscriptionsModule` beside `CreditsController`.
+
+Service: `packages/agent/src/subscriptions/credits/costs-summary.service.ts`,
+exported from `@ever-works/agent/subscriptions` (barrel + module pin spec
+updated).
+
+### Semantics worth knowing
+
+- **Window** is half-open `[from, to)`; `from` is snapped to UTC midnight so the
+  first bar is a whole day, `to` is "now" so the newest events are included. A
+  `7d` window is today plus the six whole days before it — seven bars, not eight.
+- **`unattributed`** is real spend with `agentId IS NULL` (the Work-generator
+  flow, ad-hoc facade calls). It gets its own series/row; it is never folded
+  into an agent's numbers or dropped.
+- **`other`** is the folded tail past the top 6 agents. Folding preserves the
+  day totals.
+- **Top runs excludes `costCents IS NULL`**: NULL means run-cost settlement has
+  not stamped the run, i.e. "unknown", not "free". Ties break on `id` so paging
+  is deterministic.
+- **Dominant model per run** = the model accounting for the most spend in that
+  run (units break ties), resolved in one grouped query for the whole page.
+- **`sharePercent`** is computed against the sum of the returned rows, not a
+  separately-queried total, so the shares always add up.
+
+## UI
+
+- Route: `/settings/usage?tab=costs` (`ROUTES.DASHBOARD_USAGE_COSTS`). The tab
+  bar is a server component with plain links, so each tab loads only its own
+  endpoints and a `?tab=costs` link is shareable and server-rendered.
+- Page: `apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx` — branches
+  on `parseUsageTab`; the Overview arm is byte-for-byte the previous behaviour.
+- Components: `apps/web/src/components/settings/costs/` (`CostsSettings`,
+  `CostsDailyStackedChart`, `CostsByModelList`) and
+  `apps/web/src/components/settings/usage/UsageTabs.tsx`.
+- Charting uses **recharts**, already a dependency (same primitives as
+  `UsageByDayChart`). No new dependency was added.
+- Client refetch goes through `apps/web/src/app/api/usage/costs/[section]/route.ts`,
+  which allow-lists both the section and the query parameters.
+- i18n: `dashboard.settings.usage.tabs.*` and `dashboard.settings.costs.*`, added
+  to all 21 locale files with the English string copied verbatim (no machine
+  translation).
+
+## Tests
+
+```bash
+# Aggregation semantics + window edges (mocked repositories)
+cd packages/agent && npx jest --testPathPattern='costs-summary'
+
+# The same aggregations executed against in-memory better-sqlite3 over seeded
+# rows: half-open window edges, NULL-agent bucket, top-runs ordering + ties
+cd packages/agent && npx jest --testPathPattern='costs-aggregations'
+
+# Barrel + module provider/export pins (updated for CostsSummaryService)
+cd packages/agent && npx jest --testPathPattern='subscriptions.module'
+
+# Controller owner-scoping, DTO allow-list, 400 mapping
+cd apps/api && npx jest --testPathPattern='costs.controller'
+
+# Migration applied + reverted against a real database, twice each
+cd apps/api && npx jest --testPathPattern='costs-dashboard-indexes'
+
+# Wire helpers, tab parsing, and the rendered panels + window picker
+cd apps/web && npx vitest run src/lib/api/costs.shared.unit.spec.ts \
+  src/lib/api/usage-tabs.shared.unit.spec.ts src/components/settings/costs
+```
+
+Build / type-check:
+
+```bash
+npx turbo build --filter=@ever-works/agent --filter=@ever-works/contracts
+cd apps/api && npx tsc --noEmit -p tsconfig.json
+cd apps/web && npx tsc --noEmit
+```
+
+## Known follow-ups
+
+1. **Cache-hit rate.** Needs `cache_read_input_tokens` carried end to end:
+   widen `packages/plugin`'s `TokenUsage`, have `AiOperations` / the provider
+   plugins report it, persist it on `plugin_usage_events` (a new nullable
+   `cachedInputTokens` column), and only then add the column. Historic rows will
+   read as unknown, not 0.
+2. **Work column on top-runs.** `AgentRun.workId` is available but was left off
+   the wire on purpose: the row would carry an id the UI has no name for. Add it
+   together with `getWorkNames` resolution.
+3. **`limit` on top-runs has no UI control yet** — the API and the server wrapper
+   support it; the tab always requests the default 20.
+4. **sqlite day bucketing.** Daily buckets are computed in JS from the round-tripped
+   `occurredAt` (the existing `getDailySpendForUser` does the same) because
+   `date_trunc`/`to_char` are Postgres-only. On better-sqlite3 the driver reads a
+   timestamp back in the process timezone, so a midnight-UTC event can land in the
+   previous day's bucket on a non-UTC runner. Production is Postgres; the
+   integration spec works around it by asserting day relationships rather than
+   absolute day strings. A shared portable day-bucket helper would fix both
+   call sites at once.
+5. **No e2e spec yet.** The Playwright journey
+   (`apps/web/e2e/flow-billing-usage-ui-journey.spec.ts`) still covers only the
+   Overview tab; a Costs arm (tab switch → panels mount → window toggle) is cheap
+   to add once this lands.

--- a/docs/internal/feat-costs-notes.md
+++ b/docs/internal/feat-costs-notes.md
@@ -62,7 +62,7 @@ So the column is absent from the API and the UI, and the UI states why
 | `plugin_usage_events` | `idx_plugin_usage_events_user_model_occurred (userId, modelId, occurredAt)` | per-model rollup                                                                                                     |
 | `agent_runs`          | `idx_agent_runs_user_created (userId, createdAt)`                           | run counts, top-runs — `agent_runs` had **no** user-keyed index at all, so `listSessionsForUser` was a full scan too |
 
-Migration: `apps/api/src/migrations/1785010000000-AddCostsDashboardIndexes.ts`
+Migration: `apps/api/src/migrations/1786910000000-AddCostsDashboardIndexes.ts`
 (portable `TableIndex` DDL, idempotent in both directions, skips tables that do
 not exist yet). Matching `@Index()` declarations were added to
 `plugin-usage-event.entity.ts` and `agent-run.entity.ts`.

--- a/docs/internal/feat-costs-notes.md
+++ b/docs/internal/feat-costs-notes.md
@@ -140,8 +140,10 @@ cd packages/agent && npx jest --testPathPattern='subscriptions.module'
 # Controller owner-scoping, DTO allow-list, 400 mapping
 cd apps/api && npx jest --testPathPattern='costs.controller'
 
-# Migration applied + reverted against a real database, twice each
-cd apps/api && npx jest --testPathPattern='costs-dashboard-indexes'
+# Migration applied + reverted against a real database, twice each, plus the
+# guard that keeps migration specs OUT of the flat `dist/migrations/*.js`
+# runtime glob (a spec compiled into it crash-loops the API on boot).
+cd apps/api && npx jest --testPathPattern='migrations/__tests__'
 
 # Wire helpers, tab parsing, and the rendered panels + window picker
 cd apps/web && npx vitest run src/lib/api/costs.shared.unit.spec.ts \

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -1348,6 +1348,73 @@ export class AgentRunRepository {
             totalTokensLast24h: num('totalTokensLast24h'),
         };
     }
+
+    /**
+     * Costs dashboard — how many runs each Agent started for one user
+     * inside the window, as ONE grouped scan.
+     *
+     * `createdAt` (not `startedAt`) is the window column deliberately:
+     * it matches `PluginUsageRepository.getUsageCountsForUser`'s
+     * `agentRuns` count, so the Costs "runs" column and the Usage &
+     * Credits "Agent runs" tile can never disagree for the same window,
+     * and a run that was queued but never picked up still counts.
+     *
+     * Backed by `idx_agent_runs_user_created`.
+     */
+    async countRunsByAgentForUser(
+        userId: string,
+        from: Date,
+        to: Date,
+    ): Promise<AgentRunCountRow[]> {
+        const rows = await this.repository
+            .createQueryBuilder('run')
+            .select('run.agentId', 'agentId')
+            .addSelect('COUNT(run.id)', 'runs')
+            .where('run.userId = :userId', { userId })
+            .andWhere('run.createdAt >= :from', { from })
+            .andWhere('run.createdAt < :to', { to })
+            .groupBy('run.agentId')
+            .getRawMany<{ agentId: string; runs: string }>();
+
+        return rows.map((row) => ({ agentId: row.agentId, runs: Number(row.runs ?? 0) }));
+    }
+
+    /**
+     * Costs dashboard — the most expensive runs of one user inside the
+     * window, newest-cost-first.
+     *
+     * Only runs with a SETTLED cost are returned (`costCents > 0`):
+     * `costCents` is NULL until run-cost settlement stamps it, and a
+     * NULL means "not attributable", not "free" — listing those in a
+     * table whose whole purpose is cost would be dishonest.
+     *
+     * `id` breaks ties so paging/ordering is deterministic across calls
+     * (the same reason `findPageForUserExport` adds it).
+     */
+    async findTopByCostForUser(
+        userId: string,
+        from: Date,
+        to: Date,
+        limit = 20,
+    ): Promise<AgentRun[]> {
+        const take = Math.min(Math.max(limit, 1), 100);
+        return this.repository
+            .createQueryBuilder('run')
+            .where('run.userId = :userId', { userId })
+            .andWhere('run.createdAt >= :from', { from })
+            .andWhere('run.createdAt < :to', { to })
+            .andWhere('run.costCents > 0')
+            .orderBy('run.costCents', 'DESC')
+            .addOrderBy('run.id', 'ASC')
+            .take(take)
+            .getMany();
+    }
+}
+
+/** Costs dashboard — one Agent's run count inside an aggregation window. */
+export interface AgentRunCountRow {
+    agentId: string;
+    runs: number;
 }
 
 /**

--- a/packages/agent/src/database/repositories/costs-aggregations.integration.spec.ts
+++ b/packages/agent/src/database/repositories/costs-aggregations.integration.spec.ts
@@ -1,0 +1,308 @@
+import { DataSource } from 'typeorm';
+import { AgentRun } from '@src/entities/agent-run.entity';
+import { PluginUsageCapability, PluginUsageEvent } from '@src/entities/plugin-usage-event.entity';
+import { ENTITIES } from '../_entities-inventory';
+import { AgentRunRepository } from './agent-run.repository';
+import { PluginUsageRepository } from './plugin-usage.repository';
+
+/**
+ * The Costs dashboard aggregations, executed against a real (in-memory)
+ * database rather than a mocked query builder.
+ *
+ * The unit spec beside `CostsSummaryService` mocks these repositories
+ * wholesale, so no SQL is ever generated there and nothing can catch a
+ * window that is inclusive on the wrong end, a GROUP BY that drops the
+ * NULL bucket, or an ORDER BY that ties non-deterministically. Those are
+ * exactly the defects that make a spend report quietly wrong, so they
+ * are pinned here over seeded rows.
+ *
+ * Driver note: better-sqlite3 is what CI and the e2e stack run, so a
+ * Postgres-only construct (`to_char`, `date_trunc`) would fail here —
+ * which is the point. Cross-driver identifier quoting is separately
+ * pinned by `credit-ledger.period-totals-sql.integration.spec.ts`.
+ */
+describe('Costs aggregations over seeded rows (integration)', () => {
+    let dataSource: DataSource;
+    let usage: PluginUsageRepository;
+    let runs: AgentRunRepository;
+
+    const USER = '11111111-1111-4111-8111-111111111111';
+    const OTHER_USER = '22222222-2222-4222-8222-222222222222';
+    const AGENT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const AGENT_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const WORK = '33333333-3333-4333-8333-333333333333';
+
+    const FROM = new Date('2026-08-08T00:00:00.000Z');
+    const TO = new Date('2026-08-15T00:00:00.000Z');
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            // The whole inventory, not a hand-picked subset:
+            // `PluginUsageEvent` declares `@ManyToOne` to `User` and
+            // `Work`, whose own relation graphs reach most of the schema,
+            // so TypeORM's metadata builder refuses any partial list. The
+            // e2e stack boots the same inventory on this driver, so this
+            // is also a cheap guard that the two new indexes are portable.
+            entities: ENTITIES,
+            synchronize: true,
+            logging: false,
+        });
+        await dataSource.initialize();
+        // Referential integrity is switched off deliberately, and AFTER
+        // initialize because TypeORM's better-sqlite3 driver turns it on
+        // itself during connection setup (so `prepareDatabase` is too
+        // early). These are AGGREGATION specs: none of the queries under
+        // test joins to `users` / `works` / `agents`, so seeding a valid
+        // parent graph for every fixture row would add a large amount of
+        // unrelated setup whose breakage would read as a costs bug. The
+        // FKs themselves are created by the migrations and exercised by
+        // the e2e stack.
+        await dataSource.query('PRAGMA foreign_keys = OFF');
+        usage = new PluginUsageRepository(dataSource.getRepository(PluginUsageEvent));
+        runs = new AgentRunRepository(dataSource.getRepository(AgentRun));
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    beforeEach(async () => {
+        await dataSource.getRepository(PluginUsageEvent).clear();
+        await dataSource.getRepository(AgentRun).clear();
+    });
+
+    function seedEvent(overrides: Partial<PluginUsageEvent>): Promise<PluginUsageEvent> {
+        const repository = dataSource.getRepository(PluginUsageEvent);
+        return repository.save(
+            repository.create({
+                userId: USER,
+                workId: WORK,
+                pluginId: 'anthropic',
+                capability: PluginUsageCapability.AI,
+                units: 1,
+                costCents: 0,
+                currency: 'usd',
+                occurredAt: new Date('2026-08-10T12:00:00.000Z'),
+                ...overrides,
+            } as Partial<PluginUsageEvent>),
+        );
+    }
+
+    function seedRun(overrides: Partial<AgentRun>): Promise<AgentRun> {
+        const repository = dataSource.getRepository(AgentRun);
+        return repository.save(
+            repository.create({
+                userId: USER,
+                agentId: AGENT_A,
+                triggerKind: 'task',
+                status: 'completed',
+                gateAttempts: 0,
+                persistent: false,
+                awaitingInput: false,
+                interruptRequested: false,
+                createdAt: new Date('2026-08-10T12:00:00.000Z'),
+                ...overrides,
+            } as Partial<AgentRun>),
+        );
+    }
+
+    describe('getDailySpendByAgentForUser', () => {
+        // Day-level assertions use midday timestamps and compare days to
+        // each OTHER rather than to hard-coded strings. The better-sqlite3
+        // driver round-trips a timestamp through a string and reads it back
+        // in the process timezone, so a midnight-UTC event lands in the
+        // previous day's bucket on a runner east of Greenwich. That is a
+        // driver artifact (production is Postgres) and pinning absolute
+        // day strings would make this suite pass or fail by geography.
+        const midday = (date: string) => new Date(`${date}T12:00:00.000Z`);
+
+        it('merges same-day events per agent and keeps the null-agent bucket', async () => {
+            await seedEvent({
+                agentId: AGENT_A,
+                costCents: 100,
+                occurredAt: new Date('2026-08-10T09:00:00.000Z'),
+            });
+            await seedEvent({
+                agentId: AGENT_A,
+                costCents: 50,
+                occurredAt: new Date('2026-08-10T15:00:00.000Z'),
+            });
+            await seedEvent({ agentId: AGENT_B, costCents: 7, occurredAt: midday('2026-08-10') });
+            await seedEvent({ agentId: null, costCents: 3, occurredAt: midday('2026-08-11') });
+
+            const buckets = await usage.getDailySpendByAgentForUser(USER, FROM, TO);
+
+            // Three buckets, not four: the two AGENT_A events share a day.
+            expect(buckets).toHaveLength(3);
+            const [firstDay, secondDay] = [...new Set(buckets.map((b) => b.day))];
+            expect(buckets).toEqual(
+                expect.arrayContaining([
+                    { day: firstDay, agentId: AGENT_A, costCents: 150 },
+                    { day: firstDay, agentId: AGENT_B, costCents: 7 },
+                    // Unattributed spend keeps its own bucket instead of
+                    // being folded into an agent's or dropped.
+                    { day: secondDay, agentId: null, costCents: 3 },
+                ]),
+            );
+            expect(secondDay).not.toBe(firstDay);
+        });
+
+        it('honours the half-open window and excludes other users', async () => {
+            // One tick before `from` — excluded.
+            await seedEvent({
+                agentId: AGENT_A,
+                costCents: 111,
+                occurredAt: new Date(FROM.getTime() - 1),
+            });
+            // Exactly `to` — excluded; the window is [from, to).
+            await seedEvent({ agentId: AGENT_A, costCents: 222, occurredAt: TO });
+            // Exactly `from` — INCLUDED.
+            await seedEvent({ agentId: AGENT_A, costCents: 5, occurredAt: FROM });
+            await seedEvent({
+                agentId: AGENT_A,
+                costCents: 999,
+                userId: OTHER_USER,
+                occurredAt: midday('2026-08-10'),
+            });
+
+            const buckets = await usage.getDailySpendByAgentForUser(USER, FROM, TO);
+
+            expect(buckets).toHaveLength(1);
+            expect(buckets[0]).toMatchObject({ agentId: AGENT_A, costCents: 5 });
+        });
+
+        it('returns days in ascending order', async () => {
+            for (const day of ['2026-08-13', '2026-08-09', '2026-08-11']) {
+                await seedEvent({ agentId: AGENT_A, costCents: 1, occurredAt: midday(day) });
+            }
+
+            const buckets = await usage.getDailySpendByAgentForUser(USER, FROM, TO);
+            const days = buckets.map((b) => b.day);
+
+            expect(days).toHaveLength(3);
+            expect(days).toEqual([...days].sort());
+        });
+    });
+
+    describe('getDominantModelByRun', () => {
+        const RUN_1 = '44444444-4444-4444-8444-444444444441';
+        const RUN_2 = '44444444-4444-4444-8444-444444444442';
+
+        it('picks the model that accounts for the most spend in each run', async () => {
+            await seedEvent({ runId: RUN_1, modelId: 'cheap-model', costCents: 10 });
+            await seedEvent({ runId: RUN_1, modelId: 'cheap-model', costCents: 10 });
+            await seedEvent({ runId: RUN_1, modelId: 'expensive-model', costCents: 90 });
+            await seedEvent({ runId: RUN_2, modelId: 'only-model', costCents: 5 });
+
+            const models = await usage.getDominantModelByRun([RUN_1, RUN_2]);
+
+            expect(models.get(RUN_1)).toBe('expensive-model');
+            expect(models.get(RUN_2)).toBe('only-model');
+        });
+
+        it('omits runs whose events carry no model id rather than inventing one', async () => {
+            await seedEvent({ runId: RUN_1, modelId: null, costCents: 40 });
+
+            const models = await usage.getDominantModelByRun([RUN_1, RUN_2]);
+
+            expect(models.has(RUN_1)).toBe(false);
+            expect(models.size).toBe(0);
+        });
+
+        it('short-circuits on an empty id list instead of emitting `IN ()`', async () => {
+            await expect(usage.getDominantModelByRun([])).resolves.toEqual(new Map());
+        });
+    });
+
+    describe('countRunsByAgentForUser', () => {
+        it('counts every run in the window regardless of status', async () => {
+            await seedRun({ agentId: AGENT_A, status: 'completed' });
+            await seedRun({ agentId: AGENT_A, status: 'failed' });
+            // Queued-and-never-dispatched still consumed an attempt.
+            await seedRun({ agentId: AGENT_A, status: 'queued' });
+            await seedRun({ agentId: AGENT_B, status: 'completed' });
+
+            const counts = await runs.countRunsByAgentForUser(USER, FROM, TO);
+
+            expect(counts).toEqual(
+                expect.arrayContaining([
+                    { agentId: AGENT_A, runs: 3 },
+                    { agentId: AGENT_B, runs: 1 },
+                ]),
+            );
+            expect(counts).toHaveLength(2);
+        });
+
+        it('honours the half-open window and excludes other users', async () => {
+            await seedRun({ createdAt: new Date('2026-08-07T23:59:59.999Z') });
+            await seedRun({ createdAt: TO });
+            await seedRun({ createdAt: FROM });
+            await seedRun({ userId: OTHER_USER });
+
+            const counts = await runs.countRunsByAgentForUser(USER, FROM, TO);
+
+            expect(counts).toEqual([{ agentId: AGENT_A, runs: 1 }]);
+        });
+    });
+
+    describe('findTopByCostForUser', () => {
+        it('orders by cost descending and applies the limit', async () => {
+            await seedRun({ costCents: 10 });
+            await seedRun({ costCents: 900 });
+            await seedRun({ costCents: 300 });
+
+            const top = await runs.findTopByCostForUser(USER, FROM, TO, 2);
+
+            expect(top.map((run) => run.costCents)).toEqual([900, 300]);
+        });
+
+        it('excludes unsettled runs — NULL costCents means "unknown", not "free"', async () => {
+            await seedRun({ costCents: null });
+            await seedRun({ costCents: 0 });
+            await seedRun({ costCents: 1 });
+
+            const top = await runs.findTopByCostForUser(USER, FROM, TO, 20);
+
+            expect(top).toHaveLength(1);
+            expect(top[0].costCents).toBe(1);
+        });
+
+        it('breaks cost ties deterministically by id so paging is stable', async () => {
+            const ids = [
+                '55555555-5555-4555-8555-555555555553',
+                '55555555-5555-4555-8555-555555555551',
+                '55555555-5555-4555-8555-555555555552',
+            ];
+            for (const id of ids) {
+                await seedRun({ id, costCents: 100 });
+            }
+
+            const first = await runs.findTopByCostForUser(USER, FROM, TO, 20);
+            const second = await runs.findTopByCostForUser(USER, FROM, TO, 20);
+
+            expect(first.map((run) => run.id)).toEqual([...ids].sort());
+            expect(second.map((run) => run.id)).toEqual(first.map((run) => run.id));
+        });
+
+        it('honours the half-open window and never leaks another user run', async () => {
+            await seedRun({ costCents: 500, createdAt: TO });
+            await seedRun({ costCents: 600, userId: OTHER_USER });
+            await seedRun({ costCents: 700, createdAt: FROM });
+
+            const top = await runs.findTopByCostForUser(USER, FROM, TO, 20);
+
+            expect(top.map((run) => run.costCents)).toEqual([700]);
+        });
+
+        it('clamps a caller-supplied limit into 1..100', async () => {
+            for (let i = 0; i < 3; i += 1) {
+                await seedRun({ costCents: 10 + i });
+            }
+
+            await expect(runs.findTopByCostForUser(USER, FROM, TO, 0)).resolves.toHaveLength(1);
+            await expect(runs.findTopByCostForUser(USER, FROM, TO, 1000)).resolves.toHaveLength(3);
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/plugin-usage.repository.ts
+++ b/packages/agent/src/database/repositories/plugin-usage.repository.ts
@@ -19,6 +19,16 @@ export type DailySpendBucket = {
     costCents: number;
 };
 
+/**
+ * Costs dashboard — one (day, agent) cell of the stacked daily chart.
+ * `agentId` is `null` for usage recorded outside an Agent run.
+ */
+export type DailyAgentSpendBucket = {
+    day: string;
+    agentId: string | null;
+    costCents: number;
+};
+
 export type CrossUserSpendRow = {
     userId: string;
     workId: string;
@@ -401,6 +411,103 @@ export class PluginUsageRepository {
     }
 
     /**
+     * Costs dashboard — the stacked daily chart's input: one row per
+     * (day, agent) with non-zero events for this user in the window.
+     *
+     * Bucketed in JS, not SQL, for the same reason as
+     * {@link getDailySpendForUser}: `to_char`/`date_trunc` are
+     * PostgreSQL-only and the CI + e2e stacks run better-sqlite3. The
+     * scan is narrowed by the `(userId, occurredAt)` index and projects
+     * three columns only, so a 90-day window of a heavy account reads
+     * three ints/dates per event rather than whole rows.
+     *
+     * `agentId` is `null` for usage that never ran inside an Agent (the
+     * Work-generator flow, ad-hoc facade calls) — surfaced honestly as
+     * its own bucket, never dropped.
+     */
+    async getDailySpendByAgentForUser(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<DailyAgentSpendBucket[]> {
+        const rows = await this.repository
+            .createQueryBuilder('e')
+            .select('e.occurredAt', 'occurredAt')
+            .addSelect('e.agentId', 'agentId')
+            .addSelect('e.costCents', 'costCents')
+            .where('e.userId = :userId', { userId })
+            .andWhere('e.occurredAt >= :start', { start: periodStart })
+            .andWhere('e.occurredAt < :end', { end: periodEnd })
+            .getRawMany<{ occurredAt: Date | string; agentId: string | null; costCents: number }>();
+
+        // Composite map key: the day and the agent id can never collide
+        // because the day segment is a fixed-width `YYYY-MM-DD`.
+        const byDayAgent = new Map<string, number>();
+        for (const row of rows) {
+            const occurredAt =
+                row.occurredAt instanceof Date ? row.occurredAt : new Date(row.occurredAt);
+            const day = occurredAt.toISOString().slice(0, 10);
+            const key = `${day} ${row.agentId ?? ''}`;
+            byDayAgent.set(key, (byDayAgent.get(key) ?? 0) + Number(row.costCents ?? 0));
+        }
+
+        return Array.from(byDayAgent.entries())
+            .map(([key, costCents]) => {
+                const [day, agentId] = key.split(' ');
+                return { day, agentId: agentId === '' ? null : agentId, costCents };
+            })
+            .sort((a, b) => a.day.localeCompare(b.day));
+    }
+
+    /**
+     * Costs dashboard — the dominant model of each run in `runIds`, for
+     * the top-runs table's "model" column.
+     *
+     * ONE grouped query over `(runId, modelId)` rather than a lookup per
+     * run: a run can call several models (escalation, a cheap
+     * summarizer), so "the model" is defined as the one that accounts
+     * for the most spend, with the highest unit count breaking a tie.
+     * Runs whose events carry no model id (or that predate per-run
+     * tagging) are simply absent from the map.
+     */
+    async getDominantModelByRun(runIds: string[]): Promise<Map<string, string>> {
+        if (runIds.length === 0) {
+            return new Map();
+        }
+        const rows = await this.repository
+            .createQueryBuilder('e')
+            .select('e.runId', 'runId')
+            .addSelect('e.modelId', 'modelId')
+            .addSelect('COALESCE(SUM(e.costCents), 0)', 'costCents')
+            .addSelect('COALESCE(SUM(e.units), 0)', 'units')
+            .where('e.runId IN (:...runIds)', { runIds })
+            .andWhere('e.modelId IS NOT NULL')
+            .groupBy('e.runId')
+            .addGroupBy('e.modelId')
+            .getRawMany<{
+                runId: string;
+                modelId: string;
+                costCents: string;
+                units: string;
+            }>();
+
+        const best = new Map<string, { modelId: string; costCents: number; units: number }>();
+        for (const row of rows) {
+            const costCents = Number(row.costCents ?? 0);
+            const units = Number(row.units ?? 0);
+            const current = best.get(row.runId);
+            if (
+                !current ||
+                costCents > current.costCents ||
+                (costCents === current.costCents && units > current.units)
+            ) {
+                best.set(row.runId, { modelId: row.modelId, costCents, units });
+            }
+        }
+        return new Map(Array.from(best.entries()).map(([runId, v]) => [runId, v.modelId]));
+    }
+
+    /**
      * Wave 13 — display-name resolution for grouped rows: ONE `IN`
      * query per entity type (never per row). Unknown/deleted ids are
      * simply absent from the map; callers label them honestly.
@@ -426,6 +533,23 @@ export class PluginUsageRepository {
             select: ['id', 'name'],
         });
         return new Map(works.map((w) => [w.id, w.name]));
+    }
+
+    /**
+     * Costs dashboard — Task titles for the top-runs table (one `IN`
+     * query, never per row). Sibling of `getAgentNames`/`getWorkNames`;
+     * lives here because this repository already reaches `Task` through
+     * `repository.manager` for the §4.2 counts.
+     */
+    async getTaskTitles(ids: string[]): Promise<Map<string, string>> {
+        if (ids.length === 0) {
+            return new Map();
+        }
+        const tasks = await this.repository.manager.find(Task, {
+            where: { id: In(ids) },
+            select: ['id', 'title'],
+        });
+        return new Map(tasks.map((task) => [task.id, task.title]));
     }
 
     /**

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -46,6 +46,12 @@ export type AgentRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'ca
 // Run orchestration (Wave 4 M1) — cheap per-Work concurrency counts +
 // Sessions-view grouping both scan (workId, status).
 @Index('idx_agent_runs_work_status', ['workId', 'status'])
+// Costs dashboard — the account-wide "runs per Agent" and "top runs by
+// cost" aggregations both scan one user's runs inside a date window.
+// Before this index the only user-keyed access path was a full scan;
+// `listSessionsForUser` filters on the same leading column.
+// Migration: `AddCostsDashboardIndexes1785010000000`.
+@Index('idx_agent_runs_user_created', ['userId', 'createdAt'])
 export class AgentRun {
     @PrimaryGeneratedColumn('uuid')
     id: string;

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -50,7 +50,7 @@ export type AgentRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'ca
 // cost" aggregations both scan one user's runs inside a date window.
 // Before this index the only user-keyed access path was a full scan;
 // `listSessionsForUser` filters on the same leading column.
-// Migration: `AddCostsDashboardIndexes1785010000000`.
+// Migration: `AddCostsDashboardIndexes1786910000000`.
 @Index('idx_agent_runs_user_created', ['userId', 'createdAt'])
 export class AgentRun {
     @PrimaryGeneratedColumn('uuid')

--- a/packages/agent/src/entities/plugin-usage-event.entity.ts
+++ b/packages/agent/src/entities/plugin-usage-event.entity.ts
@@ -48,6 +48,13 @@ export enum PluginUsageCapability {
 // `AddRunIdToPluginUsageEvents1783600000000` adds the column + index.
 // No FK to `agent_runs` — run deletion must NOT cascade-drop audit rows.
 @Index('idx_plugin_usage_events_run_occurred', ['runId', 'occurredAt'])
+// Costs dashboard — the per-agent and per-model account-wide rollups
+// group one user's events inside a date window. `(userId, occurredAt)`
+// above narrows the window; leading with the grouping column lets the
+// planner satisfy the GROUP BY from the index instead of sorting the
+// window. Migration: `AddCostsDashboardIndexes1785010000000`.
+@Index('idx_plugin_usage_events_user_agent_occurred', ['userId', 'agentId', 'occurredAt'])
+@Index('idx_plugin_usage_events_user_model_occurred', ['userId', 'modelId', 'occurredAt'])
 @Entity({ name: 'plugin_usage_events' })
 export class PluginUsageEvent {
     @PrimaryGeneratedColumn('uuid')

--- a/packages/agent/src/entities/plugin-usage-event.entity.ts
+++ b/packages/agent/src/entities/plugin-usage-event.entity.ts
@@ -52,7 +52,7 @@ export enum PluginUsageCapability {
 // group one user's events inside a date window. `(userId, occurredAt)`
 // above narrows the window; leading with the grouping column lets the
 // planner satisfy the GROUP BY from the index instead of sorting the
-// window. Migration: `AddCostsDashboardIndexes1785010000000`.
+// window. Migration: `AddCostsDashboardIndexes1786910000000`.
 @Index('idx_plugin_usage_events_user_agent_occurred', ['userId', 'agentId', 'occurredAt'])
 @Index('idx_plugin_usage_events_user_model_occurred', ['userId', 'modelId', 'occurredAt'])
 @Entity({ name: 'plugin_usage_events' })

--- a/packages/agent/src/subscriptions/credits/costs-summary.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/costs-summary.service.spec.ts
@@ -1,0 +1,431 @@
+import type { AgentRunRepository } from '@src/database/repositories/agent-run.repository';
+import type { PluginUsageRepository } from '@src/database/repositories/plugin-usage.repository';
+import type { AgentRun } from '@src/entities/agent-run.entity';
+import {
+    COSTS_DAILY_MAX_SERIES,
+    COSTS_OTHER_SERIES_KEY,
+    COSTS_TOP_RUNS_MAX_LIMIT,
+    COSTS_UNATTRIBUTED_SERIES_KEY,
+    CostsSummaryService,
+    InvalidCostsWindowError,
+    resolveCostsWindow,
+} from './costs-summary.service';
+
+const USER = 'user-1';
+
+/** 2026-08-14T15:30:00Z — mid-day so the "snap to UTC midnight" rule bites. */
+const NOW = new Date('2026-08-14T15:30:00.000Z');
+
+function pluginUsageRepositoryMock(): jest.Mocked<PluginUsageRepository> {
+    return {
+        getTotalSpendCentsForUser: jest.fn().mockResolvedValue(0),
+        getUsageCountsForUser: jest
+            .fn()
+            .mockResolvedValue({ tasksCompleted: 0, worksActive: 0, agentRuns: 0 }),
+        getDailySpendByAgentForUser: jest.fn().mockResolvedValue([]),
+        getSpendByAgentForUser: jest.fn().mockResolvedValue([]),
+        getSpendByModelForUser: jest.fn().mockResolvedValue([]),
+        getAgentNames: jest.fn().mockResolvedValue(new Map()),
+        getTaskTitles: jest.fn().mockResolvedValue(new Map()),
+        getDominantModelByRun: jest.fn().mockResolvedValue(new Map()),
+    } as unknown as jest.Mocked<PluginUsageRepository>;
+}
+
+function agentRunRepositoryMock(): jest.Mocked<AgentRunRepository> {
+    return {
+        countRunsByAgentForUser: jest.fn().mockResolvedValue([]),
+        findTopByCostForUser: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<AgentRunRepository>;
+}
+
+function run(overrides: Partial<AgentRun> = {}): AgentRun {
+    return {
+        id: 'run-1',
+        agentId: 'agent-1',
+        userId: USER,
+        triggerKind: 'task',
+        status: 'completed',
+        costCents: 500,
+        startedAt: new Date('2026-08-13T09:00:00.000Z'),
+        taskId: null,
+        workId: null,
+        ...overrides,
+    } as unknown as AgentRun;
+}
+
+describe('resolveCostsWindow', () => {
+    it('defaults to 30 days when no window is supplied', () => {
+        expect(resolveCostsWindow(undefined, NOW).windowDays).toBe(30);
+    });
+
+    it('rejects anything outside the 7/30/90 vocabulary', () => {
+        for (const bad of [0, 1, 14, 31, 60, 365, -7, 7.5]) {
+            expect(() => resolveCostsWindow(bad, NOW)).toThrow(InvalidCostsWindowError);
+        }
+    });
+
+    it('snaps `from` to UTC midnight and ends the window at "now"', () => {
+        const window = resolveCostsWindow(7, NOW);
+        expect(window.from.toISOString()).toBe('2026-08-08T00:00:00.000Z');
+        expect(window.to.toISOString()).toBe(NOW.toISOString());
+    });
+
+    it('a 7d window spans exactly 7 whole days including today', () => {
+        // The off-by-one that would make a "7d" chart render 8 bars.
+        const { from, to } = resolveCostsWindow(7, NOW);
+        const wholeDaysElapsed = Math.floor(
+            (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000),
+        );
+        expect(wholeDaysElapsed).toBe(6); // 6 whole days + the partial current day
+        expect(from.toISOString().slice(0, 10)).toBe('2026-08-08');
+        expect(to.toISOString().slice(0, 10)).toBe('2026-08-14');
+    });
+
+    it('scales the start date with the window length', () => {
+        expect(resolveCostsWindow(30, NOW).from.toISOString().slice(0, 10)).toBe('2026-07-16');
+        expect(resolveCostsWindow(90, NOW).from.toISOString().slice(0, 10)).toBe('2026-05-17');
+    });
+});
+
+describe('CostsSummaryService', () => {
+    let usage: jest.Mocked<PluginUsageRepository>;
+    let runs: jest.Mocked<AgentRunRepository>;
+    let service: CostsSummaryService;
+
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(NOW);
+        usage = pluginUsageRepositoryMock();
+        runs = agentRunRepositoryMock();
+        service = new CostsSummaryService(usage, runs);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('getSummary', () => {
+        it('divides total spend by the run count', async () => {
+            usage.getTotalSpendCentsForUser.mockResolvedValue(1234);
+            usage.getUsageCountsForUser.mockResolvedValue({
+                tasksCompleted: 3,
+                worksActive: 2,
+                agentRuns: 4,
+            });
+
+            const summary = await service.getSummary(USER, 7);
+
+            expect(summary.totalCostCents).toBe(1234);
+            expect(summary.runsCount).toBe(4);
+            expect(summary.avgPerRunCents).toBe(309); // 1234 / 4 = 308.5 → 309
+            expect(summary.windowDays).toBe(7);
+            expect(summary.from).toBe('2026-08-08T00:00:00.000Z');
+        });
+
+        it('reports a zero average rather than NaN when there were no runs', async () => {
+            usage.getTotalSpendCentsForUser.mockResolvedValue(900);
+
+            const summary = await service.getSummary(USER);
+
+            expect(summary.runsCount).toBe(0);
+            expect(summary.avgPerRunCents).toBe(0);
+        });
+
+        it('scopes every read to the caller and the resolved window', async () => {
+            await service.getSummary(USER, 90);
+
+            const [userId, from, to] = usage.getTotalSpendCentsForUser.mock.calls[0];
+            expect(userId).toBe(USER);
+            expect(from.toISOString()).toBe('2026-05-17T00:00:00.000Z');
+            expect(to.toISOString()).toBe(NOW.toISOString());
+        });
+
+        it('propagates a bad window as InvalidCostsWindowError', async () => {
+            await expect(service.getSummary(USER, 45)).rejects.toBeInstanceOf(
+                InvalidCostsWindowError,
+            );
+            expect(usage.getTotalSpendCentsForUser).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getDaily', () => {
+        it('emits a dense day axis so zero-spend days keep their slot', async () => {
+            usage.getDailySpendByAgentForUser.mockResolvedValue([
+                { day: '2026-08-08', agentId: 'a1', costCents: 100 },
+                { day: '2026-08-14', agentId: 'a1', costCents: 50 },
+            ]);
+
+            const daily = await service.getDaily(USER, 7);
+
+            expect(daily.days).toHaveLength(7);
+            expect(daily.days.map((d) => d.day)).toEqual([
+                '2026-08-08',
+                '2026-08-09',
+                '2026-08-10',
+                '2026-08-11',
+                '2026-08-12',
+                '2026-08-13',
+                '2026-08-14',
+            ]);
+            expect(daily.days[0]).toEqual({
+                day: '2026-08-08',
+                totalCostCents: 100,
+                costs: { a1: 100 },
+            });
+            expect(daily.days[3]).toEqual({
+                day: '2026-08-11',
+                totalCostCents: 0,
+                costs: {},
+            });
+        });
+
+        it('sums several agents into one day total', async () => {
+            usage.getDailySpendByAgentForUser.mockResolvedValue([
+                { day: '2026-08-14', agentId: 'a1', costCents: 100 },
+                { day: '2026-08-14', agentId: 'a2', costCents: 25 },
+            ]);
+
+            const daily = await service.getDaily(USER, 7);
+            const today = daily.days.find((d) => d.day === '2026-08-14');
+
+            expect(today?.totalCostCents).toBe(125);
+            expect(today?.costs).toEqual({ a1: 100, a2: 25 });
+        });
+
+        it('gives unattributed spend its own series instead of dropping it', async () => {
+            usage.getDailySpendByAgentForUser.mockResolvedValue([
+                { day: '2026-08-14', agentId: null, costCents: 70 },
+            ]);
+
+            const daily = await service.getDaily(USER, 7);
+
+            expect(daily.series).toEqual([
+                { key: COSTS_UNATTRIBUTED_SERIES_KEY, label: null, costCents: 70 },
+            ]);
+            expect(daily.days.at(-1)?.costs).toEqual({ [COSTS_UNATTRIBUTED_SERIES_KEY]: 70 });
+        });
+
+        it('folds the tail past the series cap into one "other" series', async () => {
+            const agents = Array.from({ length: COSTS_DAILY_MAX_SERIES + 3 }, (_, i) => ({
+                day: '2026-08-14',
+                // Descending cost so the fold boundary is unambiguous.
+                agentId: `agent-${i}`,
+                costCents: 1000 - i,
+            }));
+            usage.getDailySpendByAgentForUser.mockResolvedValue(agents);
+            usage.getAgentNames.mockResolvedValue(
+                new Map(agents.map((a) => [a.agentId, `Agent ${a.agentId}`])),
+            );
+
+            const daily = await service.getDaily(USER, 7);
+
+            expect(daily.series).toHaveLength(COSTS_DAILY_MAX_SERIES + 1);
+            const other = daily.series.at(-1);
+            expect(other?.key).toBe(COSTS_OTHER_SERIES_KEY);
+            // The three folded agents: 1000-6, 1000-7, 1000-8.
+            expect(other?.costCents).toBe(994 + 993 + 992);
+            // Folding must not lose money: the day total still matches.
+            expect(daily.days.at(-1)?.totalCostCents).toBe(
+                agents.reduce((sum, a) => sum + a.costCents, 0),
+            );
+        });
+
+        it('orders series by window spend and resolves Agent names', async () => {
+            usage.getDailySpendByAgentForUser.mockResolvedValue([
+                { day: '2026-08-13', agentId: 'small', costCents: 10 },
+                { day: '2026-08-14', agentId: 'big', costCents: 900 },
+                { day: '2026-08-14', agentId: 'small', costCents: 5 },
+            ]);
+            usage.getAgentNames.mockResolvedValue(new Map([['big', 'Researcher']]));
+
+            const daily = await service.getDaily(USER, 7);
+
+            expect(daily.series.map((s) => s.key)).toEqual(['big', 'small']);
+            expect(daily.series[0]).toEqual({ key: 'big', label: 'Researcher', costCents: 900 });
+            // A deleted Agent keeps its series with an honest null label.
+            expect(daily.series[1].label).toBeNull();
+            expect(daily.series[1].costCents).toBe(15);
+        });
+    });
+
+    describe('getByAgent', () => {
+        it('joins spend to run counts and computes the per-run average', async () => {
+            usage.getSpendByAgentForUser.mockResolvedValue([
+                { key: 'a1', units: 900, costCents: 1000 },
+                { key: 'a2', units: 100, costCents: 300 },
+            ]);
+            runs.countRunsByAgentForUser.mockResolvedValue([
+                { agentId: 'a1', runs: 4 },
+                { agentId: 'a2', runs: 3 },
+            ]);
+            usage.getAgentNames.mockResolvedValue(new Map([['a1', 'Researcher']]));
+
+            const byAgent = await service.getByAgent(USER, 30);
+
+            expect(byAgent.rows[0]).toEqual({
+                agentId: 'a1',
+                name: 'Researcher',
+                costCents: 1000,
+                runs: 4,
+                avgPerRunCents: 250,
+            });
+            // Deleted Agent → honest null name, never a fabricated label.
+            expect(byAgent.rows[1].name).toBeNull();
+            expect(byAgent.rows[1].avgPerRunCents).toBe(100);
+        });
+
+        it('keeps the unattributed row at zero runs rather than borrowing a count', async () => {
+            usage.getSpendByAgentForUser.mockResolvedValue([
+                { key: null, units: 5, costCents: 80 },
+            ]);
+            runs.countRunsByAgentForUser.mockResolvedValue([{ agentId: 'a1', runs: 9 }]);
+
+            const byAgent = await service.getByAgent(USER, 30);
+
+            expect(byAgent.rows[0]).toEqual({
+                agentId: null,
+                name: null,
+                costCents: 80,
+                runs: 0,
+                avgPerRunCents: 0,
+            });
+        });
+
+        it('shows an Agent that ran but recorded no metered spend as zero, not missing', async () => {
+            usage.getSpendByAgentForUser.mockResolvedValue([{ key: 'a1', units: 0, costCents: 0 }]);
+            runs.countRunsByAgentForUser.mockResolvedValue([{ agentId: 'a1', runs: 2 }]);
+
+            const byAgent = await service.getByAgent(USER, 7);
+
+            expect(byAgent.rows[0].runs).toBe(2);
+            expect(byAgent.rows[0].avgPerRunCents).toBe(0);
+        });
+
+        it('exposes no cache-hit field — the metering path records no cached tokens', async () => {
+            usage.getSpendByAgentForUser.mockResolvedValue([
+                { key: 'a1', units: 10, costCents: 100 },
+            ]);
+
+            const byAgent = await service.getByAgent(USER, 7);
+
+            expect(Object.keys(byAgent.rows[0]).sort()).toEqual([
+                'agentId',
+                'avgPerRunCents',
+                'costCents',
+                'name',
+                'runs',
+            ]);
+        });
+    });
+
+    describe('getByModel', () => {
+        it('computes each share against the sum of the returned rows', async () => {
+            usage.getSpendByModelForUser.mockResolvedValue([
+                { key: 'claude-opus-5', units: 900, costCents: 750 },
+                { key: 'gpt-5-mini', units: 400, costCents: 250 },
+            ]);
+
+            const byModel = await service.getByModel(USER, 30);
+
+            expect(byModel.totalCostCents).toBe(1000);
+            expect(byModel.rows.map((r) => r.sharePercent)).toEqual([75, 25]);
+            expect(byModel.rows[0].modelId).toBe('claude-opus-5');
+        });
+
+        it('rounds shares to one decimal and never emits NaN on an empty window', async () => {
+            usage.getSpendByModelForUser.mockResolvedValue([
+                { key: 'a', units: 1, costCents: 1 },
+                { key: 'b', units: 1, costCents: 2 },
+            ]);
+            expect((await service.getByModel(USER, 7)).rows.map((r) => r.sharePercent)).toEqual([
+                33.3, 66.7,
+            ]);
+
+            usage.getSpendByModelForUser.mockResolvedValue([{ key: 'a', units: 0, costCents: 0 }]);
+            const zero = await service.getByModel(USER, 7);
+            expect(zero.totalCostCents).toBe(0);
+            expect(zero.rows[0].sharePercent).toBe(0);
+        });
+
+        it('keeps the null-model bucket — search/screenshot calls have no model', async () => {
+            usage.getSpendByModelForUser.mockResolvedValue([
+                { key: null, units: 12, costCents: 40 },
+                { key: 'gpt-5', units: 3, costCents: 60 },
+            ]);
+
+            const byModel = await service.getByModel(USER, 7);
+
+            expect(byModel.rows.map((r) => r.modelId)).toEqual([null, 'gpt-5']);
+            expect(byModel.rows[0].sharePercent).toBe(40);
+        });
+    });
+
+    describe('getTopRuns', () => {
+        it('enriches each run with its Agent, Task and dominant model', async () => {
+            runs.findTopByCostForUser.mockResolvedValue([
+                run({ id: 'r1', agentId: 'a1', taskId: 't1', workId: 'w1', costCents: 900 }),
+                run({ id: 'r2', agentId: 'a2', taskId: null, costCents: 400 }),
+            ]);
+            usage.getAgentNames.mockResolvedValue(
+                new Map([
+                    ['a1', 'Researcher'],
+                    ['a2', 'Writer'],
+                ]),
+            );
+            usage.getTaskTitles.mockResolvedValue(new Map([['t1', 'Refresh the catalog']]));
+            usage.getDominantModelByRun.mockResolvedValue(new Map([['r1', 'claude-opus-5']]));
+
+            const top = await service.getTopRuns(USER, 30);
+
+            expect(top.rows[0]).toEqual({
+                runId: 'r1',
+                costCents: 900,
+                agentId: 'a1',
+                agentName: 'Researcher',
+                taskId: 't1',
+                taskTitle: 'Refresh the catalog',
+                modelId: 'claude-opus-5',
+                status: 'completed',
+                triggerKind: 'task',
+                startedAt: '2026-08-13T09:00:00.000Z',
+            });
+            // A run whose events carry no model id stays listed, unlabelled.
+            expect(top.rows[1].modelId).toBeNull();
+            expect(top.rows[1].taskTitle).toBeNull();
+        });
+
+        it('resolves names with ONE batched lookup per dimension, never per row', async () => {
+            runs.findTopByCostForUser.mockResolvedValue([
+                run({ id: 'r1', agentId: 'a1', taskId: 't1' }),
+                run({ id: 'r2', agentId: 'a1', taskId: 't2' }),
+                run({ id: 'r3', agentId: 'a2', taskId: null }),
+            ]);
+
+            await service.getTopRuns(USER, 30);
+
+            expect(usage.getAgentNames).toHaveBeenCalledTimes(1);
+            // Deduplicated: `a1` appears twice in the rows, once in the query.
+            expect(usage.getAgentNames).toHaveBeenCalledWith(['a1', 'a2']);
+            expect(usage.getTaskTitles).toHaveBeenCalledWith(['t1', 't2']);
+            expect(usage.getDominantModelByRun).toHaveBeenCalledWith(['r1', 'r2', 'r3']);
+        });
+
+        it('clamps the limit into 1..max and falls back to the default on junk', async () => {
+            await service.getTopRuns(USER, 30, 999);
+            expect(runs.findTopByCostForUser.mock.calls[0][3]).toBe(COSTS_TOP_RUNS_MAX_LIMIT);
+
+            await service.getTopRuns(USER, 30, 0);
+            expect(runs.findTopByCostForUser.mock.calls[1][3]).toBe(20);
+
+            await service.getTopRuns(USER, 30, Number.NaN);
+            expect(runs.findTopByCostForUser.mock.calls[2][3]).toBe(20);
+        });
+
+        it('does not query names at all for an empty window', async () => {
+            const top = await service.getTopRuns(USER, 7);
+
+            expect(top.rows).toEqual([]);
+            expect(usage.getAgentNames).toHaveBeenCalledWith([]);
+            expect(usage.getTaskTitles).toHaveBeenCalledWith([]);
+        });
+    });
+});

--- a/packages/agent/src/subscriptions/credits/costs-summary.service.ts
+++ b/packages/agent/src/subscriptions/credits/costs-summary.service.ts
@@ -1,0 +1,472 @@
+import { Injectable } from '@nestjs/common';
+import { AgentRunRepository } from '@src/database/repositories/agent-run.repository';
+import { PluginUsageRepository } from '@src/database/repositories/plugin-usage.repository';
+import type { AgentRun } from '@src/entities/agent-run.entity';
+
+/**
+ * Costs dashboard — the rolling windows the Costs view offers.
+ *
+ * Deliberately NOT the Usage & Credits page's `YYYY-MM | 7d | 30d`
+ * period vocabulary: Costs answers "what has this account been burning
+ * lately", which is a rolling question, and it needs a 90-day arm the
+ * calendar-month grammar has no way to express. The two selectors stay
+ * independent so neither page's contract has to move.
+ */
+export const COSTS_WINDOW_DAYS = [7, 30, 90] as const;
+export type CostsWindowDays = (typeof COSTS_WINDOW_DAYS)[number];
+
+/** Default window when the caller sends none. */
+export const COSTS_DEFAULT_WINDOW_DAYS: CostsWindowDays = 30;
+
+/** Default / maximum rows the top-runs table returns. */
+export const COSTS_TOP_RUNS_DEFAULT_LIMIT = 20;
+export const COSTS_TOP_RUNS_MAX_LIMIT = 50;
+
+/**
+ * How many Agent series the stacked daily chart keeps separate before
+ * folding the tail into {@link COSTS_OTHER_SERIES_KEY}. Beyond this the
+ * stack stops being readable and the legend stops fitting.
+ */
+export const COSTS_DAILY_MAX_SERIES = 6;
+
+/**
+ * Series keys for the two buckets that are not an Agent id. Both are
+ * safe sentinels: every real key is a UUID, so neither can collide.
+ *
+ * - `unattributed` — real spend that never ran inside an Agent (the
+ *   Work-generator flow, ad-hoc facade calls). Shown, never dropped.
+ * - `other`        — the folded tail of the per-Agent series.
+ */
+export const COSTS_UNATTRIBUTED_SERIES_KEY = 'unattributed';
+export const COSTS_OTHER_SERIES_KEY = 'other';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Stable-named error so the API boundary maps a bad window to a 400
+ * (never an unmapped 500) — sibling of `InvalidUsagePeriodError`.
+ */
+export class InvalidCostsWindowError extends Error {
+    constructor(windowDays: unknown) {
+        super(
+            `Invalid windowDays (expected one of ${COSTS_WINDOW_DAYS.join(', ')}): ${windowDays}`,
+        );
+        this.name = 'InvalidCostsWindowError';
+    }
+}
+
+/** Resolved half-open `[from, to)` aggregation window. */
+export interface CostsWindow {
+    windowDays: CostsWindowDays;
+    from: Date;
+    to: Date;
+}
+
+/**
+ * Pure, exported for unit tests + the API DTO layer: resolve a window
+ * length to a half-open `[from, to)` range ending "now".
+ *
+ * `from` is snapped to UTC midnight so the daily chart's first bucket is
+ * a WHOLE day rather than a partial one whose bar is short for reasons
+ * that have nothing to do with spend. `to` stays "now" so the newest
+ * events are included the moment they land.
+ */
+export function resolveCostsWindow(windowDays?: number, now: Date = new Date()): CostsWindow {
+    const requested = windowDays ?? COSTS_DEFAULT_WINDOW_DAYS;
+    if (!(COSTS_WINDOW_DAYS as readonly number[]).includes(requested)) {
+        throw new InvalidCostsWindowError(windowDays);
+    }
+    const days = requested as CostsWindowDays;
+    // `days - 1` because the current (partial) day is one of them: a 7d
+    // window is "today plus the six whole days before it", not "today
+    // plus seven", which would render eight buckets.
+    const startOfToday = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    return {
+        windowDays: days,
+        from: new Date(startOfToday - (days - 1) * DAY_MS),
+        to: now,
+    };
+}
+
+/** Every Costs payload echoes the window it was computed over. */
+interface CostsWindowEcho {
+    windowDays: CostsWindowDays;
+    from: string;
+    to: string;
+}
+
+/** Headline numbers for the window. */
+export interface CostsSummary extends CostsWindowEcho {
+    /** Metered spend in the window (`plugin_usage_events.costCents`). */
+    totalCostCents: number;
+    /** Agent runs created in the window (settled or not). */
+    runsCount: number;
+    /** `totalCostCents / runsCount`, rounded; 0 when there were no runs. */
+    avgPerRunCents: number;
+}
+
+/** One series of the stacked daily chart. */
+export interface CostsDailySeries {
+    /** Agent id, or one of the two sentinel keys. */
+    key: string;
+    /** Agent name; null for the sentinel series (the UI localizes those). */
+    label: string | null;
+    /** Series total across the whole window — drives the legend order. */
+    costCents: number;
+}
+
+/** One day of the stacked daily chart (dense — zero days included). */
+export interface CostsDailyBucket {
+    /** `YYYY-MM-DD`, UTC. */
+    day: string;
+    totalCostCents: number;
+    /** Cents per series key. Keys absent from a day simply had no spend. */
+    costs: Record<string, number>;
+}
+
+export interface CostsDaily extends CostsWindowEcho {
+    series: CostsDailySeries[];
+    days: CostsDailyBucket[];
+}
+
+/** One row of the per-Agent breakdown table. */
+export interface CostsByAgentRow {
+    /** Null for spend recorded outside any Agent run. */
+    agentId: string | null;
+    /** Agent name; null when unattributed or the Agent was deleted. */
+    name: string | null;
+    costCents: number;
+    /** Runs this Agent started in the window (0 for the unattributed row). */
+    runs: number;
+    /** `costCents / runs`, rounded; 0 when `runs` is 0. */
+    avgPerRunCents: number;
+}
+
+export interface CostsByAgent extends CostsWindowEcho {
+    rows: CostsByAgentRow[];
+}
+
+/** One row of the per-model breakdown. */
+export interface CostsByModelRow {
+    /** Null for capabilities that never go through a model (search, …). */
+    modelId: string | null;
+    units: number;
+    costCents: number;
+    /** Share of the window's total spend, 0–100, one decimal place. */
+    sharePercent: number;
+}
+
+export interface CostsByModel extends CostsWindowEcho {
+    totalCostCents: number;
+    rows: CostsByModelRow[];
+}
+
+/** One row of the top-runs table. */
+export interface CostsTopRunRow {
+    runId: string;
+    costCents: number;
+    agentId: string;
+    agentName: string | null;
+    taskId: string | null;
+    taskTitle: string | null;
+    // Deliberately no `workId`: the row would carry an id the UI has no
+    // name for and therefore cannot render, and a wire field with no
+    // consumer is the kind of half-wiring that rots. Add it together
+    // with the Work-name resolution when a Work column is wanted.
+    /** The run's dominant model; null when its events carry no model id. */
+    modelId: string | null;
+    /** Terminal state — a failed run that still cost money matters. */
+    status: string;
+    /** `heartbeat | manual | task | chat | event` — labels a task-less run. */
+    triggerKind: string;
+    /** ISO timestamp, or null on a run that never started. */
+    startedAt: string | null;
+}
+
+export interface CostsTopRuns extends CostsWindowEcho {
+    rows: CostsTopRunRow[];
+}
+
+/**
+ * Costs dashboard — owner-scoped AI-spend aggregations behind
+ * `GET /api/usage/costs/*`.
+ *
+ * Reads ONLY, and derives everything from rows that already exist:
+ * `plugin_usage_events` is the per-call metering source of truth and
+ * `agent_runs.costCents` is its per-run rollup (stamped by
+ * `RunCostSettlementService` on every terminal transition). Nothing here
+ * writes, and nothing here re-derives a cost the settlement path already
+ * computed.
+ *
+ * Every panel is a bounded number of grouped queries — one per
+ * dimension, plus at most one `IN` name-resolution query — never a
+ * lookup per row.
+ *
+ * ## Cache-hit rate is deliberately absent
+ *
+ * The per-agent table has no cache-hit column because the platform does
+ * not record one. `PluginUsageService.record` stores
+ * `{ promptTokens, completionTokens }` in `metadata`; nothing on the
+ * dispatch path reports `cache_read_input_tokens` (the one plugin that
+ * receives it — `claude-managed-agent` — surfaces it as pipeline metrics
+ * that are never persisted). `WorkRunsSummary` documents the same
+ * finding for its token rollup. Deriving a percentage from data that
+ * does not exist would be a fabricated number, so the column is omitted
+ * until the emission seam carries the field; see
+ * `docs/internal/feat-costs-notes.md` for the follow-up.
+ */
+@Injectable()
+export class CostsSummaryService {
+    constructor(
+        private readonly pluginUsageRepository: PluginUsageRepository,
+        private readonly agentRunRepository: AgentRunRepository,
+    ) {}
+
+    /** Headline total + run count + average cost per run. */
+    async getSummary(userId: string, windowDays?: number): Promise<CostsSummary> {
+        const window = resolveCostsWindow(windowDays);
+        const [totalCostCents, counts] = await Promise.all([
+            this.pluginUsageRepository.getTotalSpendCentsForUser(userId, window.from, window.to),
+            this.pluginUsageRepository.getUsageCountsForUser(userId, window.from, window.to),
+        ]);
+
+        return {
+            ...echo(window),
+            totalCostCents,
+            runsCount: counts.agentRuns,
+            avgPerRunCents: perRun(totalCostCents, counts.agentRuns),
+        };
+    }
+
+    /** Daily spend, stacked by Agent, dense across the whole window. */
+    async getDaily(userId: string, windowDays?: number): Promise<CostsDaily> {
+        const window = resolveCostsWindow(windowDays);
+        const buckets = await this.pluginUsageRepository.getDailySpendByAgentForUser(
+            userId,
+            window.from,
+            window.to,
+        );
+
+        // Window totals per Agent decide which series survive the fold.
+        const totalsByAgent = new Map<string | null, number>();
+        for (const bucket of buckets) {
+            totalsByAgent.set(
+                bucket.agentId,
+                (totalsByAgent.get(bucket.agentId) ?? 0) + bucket.costCents,
+            );
+        }
+
+        const agentIds = Array.from(totalsByAgent.keys()).filter((id): id is string => id !== null);
+        const names = await this.pluginUsageRepository.getAgentNames(agentIds);
+
+        const ranked = agentIds
+            .map((agentId) => ({ agentId, costCents: totalsByAgent.get(agentId) ?? 0 }))
+            // Cost first, id second: without the tie-break two agents on
+            // equal spend could swap places between two identical calls.
+            .sort((a, b) => b.costCents - a.costCents || a.agentId.localeCompare(b.agentId));
+
+        const keptIds = new Set(ranked.slice(0, COSTS_DAILY_MAX_SERIES).map((r) => r.agentId));
+        const foldedIds = ranked.slice(COSTS_DAILY_MAX_SERIES);
+
+        const seriesKeyFor = (agentId: string | null): string => {
+            if (agentId === null) {
+                return COSTS_UNATTRIBUTED_SERIES_KEY;
+            }
+            return keptIds.has(agentId) ? agentId : COSTS_OTHER_SERIES_KEY;
+        };
+
+        const series: CostsDailySeries[] = ranked
+            .filter((row) => keptIds.has(row.agentId))
+            .map((row) => ({
+                key: row.agentId,
+                label: names.get(row.agentId) ?? null,
+                costCents: row.costCents,
+            }));
+        if (foldedIds.length > 0) {
+            series.push({
+                key: COSTS_OTHER_SERIES_KEY,
+                label: null,
+                costCents: foldedIds.reduce((sum, row) => sum + row.costCents, 0),
+            });
+        }
+        if (totalsByAgent.has(null)) {
+            series.push({
+                key: COSTS_UNATTRIBUTED_SERIES_KEY,
+                label: null,
+                costCents: totalsByAgent.get(null) ?? 0,
+            });
+        }
+
+        // Dense day axis: a gap day must render as an empty slot, not
+        // vanish and make two non-adjacent days look adjacent.
+        const days = new Map<string, CostsDailyBucket>();
+        for (const day of enumerateDays(window)) {
+            days.set(day, { day, totalCostCents: 0, costs: {} });
+        }
+        for (const bucket of buckets) {
+            const target = days.get(bucket.day);
+            if (!target) {
+                // Defensive: an event exactly on the `to` boundary cannot
+                // occur (half-open window), so this is unreachable in
+                // practice — dropping it silently would be the bug.
+                continue;
+            }
+            const key = seriesKeyFor(bucket.agentId);
+            target.costs[key] = (target.costs[key] ?? 0) + bucket.costCents;
+            target.totalCostCents += bucket.costCents;
+        }
+
+        return { ...echo(window), series, days: Array.from(days.values()) };
+    }
+
+    /** Per-Agent spend, run count and average cost per run. */
+    async getByAgent(userId: string, windowDays?: number): Promise<CostsByAgent> {
+        const window = resolveCostsWindow(windowDays);
+        const [spendRows, runCounts] = await Promise.all([
+            this.pluginUsageRepository.getSpendByAgentForUser(userId, window.from, window.to),
+            this.agentRunRepository.countRunsByAgentForUser(userId, window.from, window.to),
+        ]);
+
+        const runsByAgent = new Map(runCounts.map((row) => [row.agentId, row.runs]));
+        const names = await this.pluginUsageRepository.getAgentNames(
+            spendRows.map((row) => row.key).filter((key): key is string => key !== null),
+        );
+
+        const rows: CostsByAgentRow[] = spendRows.map((row) => {
+            // The unattributed bucket has no runs BY DEFINITION — its
+            // events are the ones with no run behind them — so its
+            // average stays 0 rather than dividing by an unrelated count.
+            const runs = row.key === null ? 0 : (runsByAgent.get(row.key) ?? 0);
+            return {
+                agentId: row.key,
+                name: row.key === null ? null : (names.get(row.key) ?? null),
+                costCents: row.costCents,
+                runs,
+                avgPerRunCents: perRun(row.costCents, runs),
+            };
+        });
+
+        return { ...echo(window), rows };
+    }
+
+    /** Per-model spend with each model's share of the window total. */
+    async getByModel(userId: string, windowDays?: number): Promise<CostsByModel> {
+        const window = resolveCostsWindow(windowDays);
+        const rows = await this.pluginUsageRepository.getSpendByModelForUser(
+            userId,
+            window.from,
+            window.to,
+        );
+
+        // Share is computed against the SUM OF THESE ROWS, not against a
+        // separately-queried total: the two queries could straddle a new
+        // event and produce shares that do not add up to 100%.
+        const totalCostCents = rows.reduce((sum, row) => sum + row.costCents, 0);
+
+        return {
+            ...echo(window),
+            totalCostCents,
+            rows: rows.map((row) => ({
+                modelId: row.key,
+                units: row.units,
+                costCents: row.costCents,
+                sharePercent: sharePercent(row.costCents, totalCostCents),
+            })),
+        };
+    }
+
+    /** The window's most expensive runs, with their Agent/Task/model. */
+    async getTopRuns(
+        userId: string,
+        windowDays?: number,
+        limit: number = COSTS_TOP_RUNS_DEFAULT_LIMIT,
+    ): Promise<CostsTopRuns> {
+        const window = resolveCostsWindow(windowDays);
+        const take = clampLimit(limit);
+        const runs = await this.agentRunRepository.findTopByCostForUser(
+            userId,
+            window.from,
+            window.to,
+            take,
+        );
+
+        const [agentNames, taskTitles, models] = await Promise.all([
+            this.pluginUsageRepository.getAgentNames(unique(runs.map((run) => run.agentId))),
+            this.pluginUsageRepository.getTaskTitles(
+                unique(runs.map((run) => run.taskId).filter((id): id is string => !!id)),
+            ),
+            this.pluginUsageRepository.getDominantModelByRun(runs.map((run) => run.id)),
+        ]);
+
+        return {
+            ...echo(window),
+            rows: runs.map((run) => this.toTopRunRow(run, agentNames, taskTitles, models)),
+        };
+    }
+
+    private toTopRunRow(
+        run: AgentRun,
+        agentNames: Map<string, string>,
+        taskTitles: Map<string, string>,
+        models: Map<string, string>,
+    ): CostsTopRunRow {
+        return {
+            runId: run.id,
+            costCents: run.costCents ?? 0,
+            agentId: run.agentId,
+            agentName: agentNames.get(run.agentId) ?? null,
+            taskId: run.taskId ?? null,
+            taskTitle: run.taskId ? (taskTitles.get(run.taskId) ?? null) : null,
+            modelId: models.get(run.id) ?? null,
+            status: run.status,
+            triggerKind: run.triggerKind,
+            startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
+        };
+    }
+}
+
+function echo(window: CostsWindow): CostsWindowEcho {
+    return {
+        windowDays: window.windowDays,
+        from: window.from.toISOString(),
+        to: window.to.toISOString(),
+    };
+}
+
+/** Integer-cent average; 0 runs means 0, never NaN or Infinity. */
+function perRun(totalCostCents: number, runs: number): number {
+    return runs > 0 ? Math.round(totalCostCents / runs) : 0;
+}
+
+/** Share as a percentage with one decimal; 0 total means 0, never NaN. */
+function sharePercent(costCents: number, totalCostCents: number): number {
+    if (totalCostCents <= 0) {
+        return 0;
+    }
+    return Math.round((costCents / totalCostCents) * 1000) / 10;
+}
+
+function clampLimit(limit: number): number {
+    if (!Number.isFinite(limit) || limit < 1) {
+        return COSTS_TOP_RUNS_DEFAULT_LIMIT;
+    }
+    return Math.min(Math.floor(limit), COSTS_TOP_RUNS_MAX_LIMIT);
+}
+
+function unique(values: string[]): string[] {
+    return Array.from(new Set(values));
+}
+
+/** Every UTC `YYYY-MM-DD` the window touches, ascending. */
+function enumerateDays(window: CostsWindow): string[] {
+    const days: string[] = [];
+    const last = Date.UTC(
+        window.to.getUTCFullYear(),
+        window.to.getUTCMonth(),
+        window.to.getUTCDate(),
+    );
+    for (let cursor = window.from.getTime(); cursor <= last; cursor += DAY_MS) {
+        days.push(new Date(cursor).toISOString().slice(0, 10));
+    }
+    return days;
+}

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -19,3 +19,5 @@ export * from './credits/entitlements.service';
 export * from './credits/run-cost-settlement.service';
 // Account-wide usage aggregations for the Billing/Usage pages (Wave 13)
 export * from './credits/usage-summary.service';
+// Costs dashboard aggregations (Settings → Usage & Credits → Costs)
+export * from './credits/costs-summary.service';

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -1,4 +1,5 @@
 import * as subscriptionsBarrel from './index';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
 import { SubscriptionsModule } from './subscriptions.module';
 import { SubscriptionService } from './subscription.service';
 import { UsageLedgerService } from './usage-ledger.service';
@@ -37,6 +38,18 @@ import {
     USAGE_SUMMARY_GROUP_BYS,
     UsageSummaryService,
 } from './credits/usage-summary.service';
+import {
+    COSTS_DAILY_MAX_SERIES,
+    COSTS_DEFAULT_WINDOW_DAYS,
+    COSTS_OTHER_SERIES_KEY,
+    COSTS_TOP_RUNS_DEFAULT_LIMIT,
+    COSTS_TOP_RUNS_MAX_LIMIT,
+    COSTS_UNATTRIBUTED_SERIES_KEY,
+    COSTS_WINDOW_DAYS,
+    CostsSummaryService,
+    InvalidCostsWindowError,
+    resolveCostsWindow,
+} from './credits/costs-summary.service';
 
 /**
  * Pins the public `@ever-works/agent/subscriptions` barrel surface and the
@@ -86,6 +99,17 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.resolveUsageSummaryWindow).toBe(resolveUsageSummaryWindow);
             expect(subscriptionsBarrel.InvalidUsagePeriodError).toBe(InvalidUsagePeriodError);
             expect(subscriptionsBarrel.USAGE_SUMMARY_GROUP_BYS).toBe(USAGE_SUMMARY_GROUP_BYS);
+        });
+
+        it('re-exports the costs-dashboard surface', () => {
+            expect(subscriptionsBarrel.CostsSummaryService).toBe(CostsSummaryService);
+            expect(subscriptionsBarrel.resolveCostsWindow).toBe(resolveCostsWindow);
+            expect(subscriptionsBarrel.InvalidCostsWindowError).toBe(InvalidCostsWindowError);
+            expect(subscriptionsBarrel.COSTS_WINDOW_DAYS).toBe(COSTS_WINDOW_DAYS);
+            // The window vocabulary is a wire contract: the API DTO
+            // validates against it and the web selector renders it.
+            expect(COSTS_WINDOW_DAYS).toEqual([7, 30, 90]);
+            expect(COSTS_DEFAULT_WINDOW_DAYS).toBe(30);
         });
 
         it('re-exports the account-wide CSV export column contract (B29)', () => {
@@ -194,6 +218,17 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'USAGE_SUMMARY_GROUP_BYS',
                     // Account-wide usage CSV export (B29)
                     'USAGE_EXPORT_COLUMNS',
+                    // Costs dashboard aggregations
+                    'CostsSummaryService',
+                    'resolveCostsWindow',
+                    'InvalidCostsWindowError',
+                    'COSTS_WINDOW_DAYS',
+                    'COSTS_DEFAULT_WINDOW_DAYS',
+                    'COSTS_TOP_RUNS_DEFAULT_LIMIT',
+                    'COSTS_TOP_RUNS_MAX_LIMIT',
+                    'COSTS_DAILY_MAX_SERIES',
+                    'COSTS_UNATTRIBUTED_SERIES_KEY',
+                    'COSTS_OTHER_SERIES_KEY',
                 ].sort(),
             );
         });
@@ -227,6 +262,21 @@ describe('SubscriptionsModule + barrel re-exports', () => {
         it('declares + exports UsageSummaryService (Wave 13 — consumed by apps/api CreditsController)', () => {
             expect(getMeta('providers')).toContain(UsageSummaryService);
             expect(getMeta('exports')).toContain(UsageSummaryService);
+        });
+
+        it('declares + exports CostsSummaryService (consumed by apps/api CostsController)', () => {
+            expect(getMeta('providers')).toContain(CostsSummaryService);
+            expect(getMeta('exports')).toContain(CostsSummaryService);
+        });
+
+        it('provides AgentRunRepository locally so CostsSummaryService can resolve it', () => {
+            // AgentRunRepository is owned by AgentsModule, not the
+            // DatabaseModule repository inventory — without this local
+            // provider CostsSummaryService fails to instantiate at boot.
+            expect(getMeta('providers')).toContain(AgentRunRepository);
+            // Module-local on purpose: exporting it would hand consumers a
+            // second AgentRunRepository instance beside AgentsModule's.
+            expect(getMeta('exports')).not.toContain(AgentRunRepository);
         });
 
         it('binds the abstract BillingProvider token through a config-driven factory', () => {

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -1,5 +1,8 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '@src/database/database.module';
+import { AgentRun } from '@src/entities/agent-run.entity';
+import { AgentRunRepository } from '@src/database/repositories/agent-run.repository';
 import { NotificationsModule } from '@src/notifications/notifications.module';
 import { SubscriptionService } from './subscription.service';
 import { UsageLedgerService } from './usage-ledger.service';
@@ -13,6 +16,7 @@ import { CreditLedgerService } from './credits/credit-ledger.service';
 import { EntitlementsService } from './credits/entitlements.service';
 import { RunCostSettlementService } from './credits/run-cost-settlement.service';
 import { UsageSummaryService } from './credits/usage-summary.service';
+import { CostsSummaryService } from './credits/costs-summary.service';
 
 @Module({
     imports: [
@@ -20,6 +24,15 @@ import { UsageSummaryService } from './credits/usage-summary.service';
         // Wave 9 M2 — RunCostSettlementService emits the balance-exhausted
         // notification through the existing NotificationService.
         NotificationsModule,
+        // Costs dashboard — `AgentRunRepository` is not in the
+        // `_repository-inventory` DatabaseModule exports (it is owned by
+        // AgentsModule), so it is provided locally here. Same pattern,
+        // and same reason, as `TerminalTranscriptModule`: importing
+        // AgentsModule for two read-only aggregations would drag the
+        // whole agent runtime into this module's graph. The local
+        // instance never writes a terminal transition, so it never
+        // exercises the RUN_COST_SETTLER hook.
+        TypeOrmModule.forFeature([AgentRun]),
     ],
     providers: [
         SubscriptionService,
@@ -35,6 +48,11 @@ import { UsageSummaryService } from './credits/usage-summary.service';
         // Account-wide usage aggregations behind
         // `GET /api/credits/usage-summary` (Wave 13 Billing/Usage UI).
         UsageSummaryService,
+        // Costs dashboard — the `GET /api/usage/costs/*` aggregations
+        // (spend by day/agent/model + top runs). Read-only; derived from
+        // the same metering rows the usage summary reads.
+        AgentRunRepository,
+        CostsSummaryService,
         // The money path (billing PRD B5) — checkout, webhook, invoices,
         // auto-recharge. Additive beside the read-only credits surface.
         BillingService,
@@ -71,6 +89,7 @@ import { UsageSummaryService } from './credits/usage-summary.service';
         EntitlementsService,
         RunCostSettlementService,
         UsageSummaryService,
+        CostsSummaryService,
         BillingService,
         AutoRechargeService,
         PlanSubscriptionService,


### PR DESCRIPTION
## What

A **Costs** tab beside the existing Usage & Credits overview: headline tiles (total spend / agent runs / average per run), a daily bar chart stacked by agent, per-agent and per-model breakdowns, and a most-expensive-runs table — all driven by one 7/30/90-day window picker. Strictly additive: Overview stays the default arm with its component tree, endpoints and testids untouched.

## Exploration corrected two of the brief's assumptions

1. *"Model id may not be recorded — add capture at the usage-emission seam."* **False.** `plugin_usage_events.modelId` already exists and `AiFacadeService` already stamps `response.model` at every record call site. No emission change was needed, so none was made.
2. *"Add by-model / by-agent aggregations."* Already shipped in Wave 13 behind `GET /api/credits/usage-summary?groupBy=`. Reused rather than duplicated.

What was genuinely missing — and is what this branch adds — is the rolling 7/30/90-day window (the existing grammar has no 90d arm), the daily×agent cross-tab, run counts with per-run averages, and top-runs.

## Cache-hit % is deliberately omitted

Per the brief's "do not fake it" rule. Verified absent end to end: `PluginUsageService.record` persists only operation and prompt/completion tokens, `packages/plugin`'s `TokenUsage` has no cached-read field, and the only code that ever sees `cache_read_input_tokens` is the claude-managed-agent plugin, which surfaces it as pipeline metrics that are never persisted. The codebase already documents this same finding in `WorkRunsSummary`. The UI says why rather than showing a zero. The follow-up path is spelled out in the notes: widen `TokenUsage`, report it from providers, persist a nullable `cachedInputTokens`, and make historic rows read as unknown rather than 0.

Part of the Agent Workbench program (Feature O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)