### PR TITLE
fix(auth): social sign-up walked past the required consent checkbox (EW-069)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -200,7 +200,8 @@
                     "text": "أوافق على",
                     "termsLink": "شروط الخدمة",
                     "and": "و",
-                    "privacyLink": "سياسة الخصوصية"
+                    "privacyLink": "سياسة الخصوصية",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "إنشاء الحساب",
                 "submitting": "جاري إنشاء الحساب..."

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -200,7 +200,8 @@
                     "text": "Съгласен съм с",
                     "termsLink": "Условия за ползване",
                     "and": "и",
-                    "privacyLink": "Политика за поверителност"
+                    "privacyLink": "Политика за поверителност",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Създай акаунт",
                 "submitting": "Създаване на акаунт..."

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -200,7 +200,8 @@
                     "text": "Ich stimme den",
                     "termsLink": "Nutzungsbedingungen",
                     "and": "und",
-                    "privacyLink": "Datenschutzerklärung"
+                    "privacyLink": "Datenschutzerklärung",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Konto erstellen",
                 "submitting": "Erstelle Konto…"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -200,7 +200,8 @@
                     "text": "I agree to the",
                     "termsLink": "Terms of Service",
                     "and": "and",
-                    "privacyLink": "Privacy Policy"
+                    "privacyLink": "Privacy Policy",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Create account",
                 "submitting": "Creating account..."

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -200,7 +200,8 @@
                     "text": "Acepto los",
                     "termsLink": "Términos de Servicio",
                     "and": "y",
-                    "privacyLink": "Política de Privacidad"
+                    "privacyLink": "Política de Privacidad",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Crear cuenta",
                 "submitting": "Creando cuenta..."

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -200,7 +200,8 @@
                     "text": "J'accepte les",
                     "termsLink": "Conditions d'utilisation",
                     "and": "et",
-                    "privacyLink": "Politique de confidentialité"
+                    "privacyLink": "Politique de confidentialité",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Créer un compte",
                 "submitting": "Création du compte en cours..."

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -200,7 +200,8 @@
                     "text": "אני מסכים ל",
                     "termsLink": "תנאי השירות",
                     "and": "ו",
-                    "privacyLink": "מדיניות הפרטיות"
+                    "privacyLink": "מדיניות הפרטיות",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "צור חשבון",
                 "submitting": "יוצר חשבון..."

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -200,7 +200,8 @@
                     "text": "मैं सहमत हूं",
                     "termsLink": "सेवा की शर्तें",
                     "and": "और",
-                    "privacyLink": "गोपनीयता नीति"
+                    "privacyLink": "गोपनीयता नीति",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "खाता बनाएं",
                 "submitting": "खाता बनाया जा रहा है..."

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -200,7 +200,8 @@
                     "text": "Saya setuju dengan",
                     "termsLink": "Syarat Layanan",
                     "and": "dan",
-                    "privacyLink": "Kebijakan Privasi"
+                    "privacyLink": "Kebijakan Privasi",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Buat Akun",
                 "submitting": "Membuat akun..."

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -200,7 +200,8 @@
                     "text": "Accetto i",
                     "termsLink": "Termini di Servizio",
                     "and": "e",
-                    "privacyLink": "Informativa sulla privacy"
+                    "privacyLink": "Informativa sulla privacy",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Crea account",
                 "submitting": "Creazione account in corso..."

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -200,7 +200,8 @@
                     "text": "私は以下のことに同意します：",
                     "termsLink": "利用規約",
                     "and": "および",
-                    "privacyLink": "プライバシーポリシー"
+                    "privacyLink": "プライバシーポリシー",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "アカウントを作成",
                 "submitting": "アカウント作成中..."

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -200,7 +200,8 @@
                     "text": "다음에 동의합니다:",
                     "termsLink": "이용 약관",
                     "and": "및",
-                    "privacyLink": "개인정보 처리방침"
+                    "privacyLink": "개인정보 처리방침",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "계정 생성",
                 "submitting": "계정 생성 중..."

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -200,7 +200,8 @@
                     "text": "Ik ga akkoord met de",
                     "termsLink": "Gebruiksvoorwaarden",
                     "and": "en",
-                    "privacyLink": "Privacybeleid"
+                    "privacyLink": "Privacybeleid",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Account Aanmaken",
                 "submitting": "Aan het aanmaken van account..."

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -200,7 +200,8 @@
                     "text": "Zgadzam się na",
                     "termsLink": "Regulamin",
                     "and": "i",
-                    "privacyLink": "Politykę prywatności"
+                    "privacyLink": "Politykę prywatności",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Utwórz konto",
                 "submitting": "Tworzenie konta..."

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -200,7 +200,8 @@
                     "text": "Eu concordo com os",
                     "termsLink": "Termos de Serviço",
                     "and": "e",
-                    "privacyLink": "Política de Privacidade"
+                    "privacyLink": "Política de Privacidade",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Criar conta",
                 "submitting": "Criando conta..."

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -200,7 +200,8 @@
                     "text": "Я согласен с",
                     "termsLink": "Условиями использования",
                     "and": "и",
-                    "privacyLink": "Политикой конфиденциальности"
+                    "privacyLink": "Политикой конфиденциальности",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Создать аккаунт",
                 "submitting": "Создание аккаунта..."

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -200,7 +200,8 @@
                     "text": "ฉันยอมรับ",
                     "termsLink": "เงื่อนไขการให้บริการ",
                     "and": "และ",
-                    "privacyLink": "นโยบายความเป็นส่วนตัว"
+                    "privacyLink": "นโยบายความเป็นส่วนตัว",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "สร้างบัญชี",
                 "submitting": "กำลังสร้างบัญชี..."

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -200,7 +200,8 @@
                     "text": "Şartları kabul ediyorum: ",
                     "termsLink": "Hizmet Şartları",
                     "and": "ve",
-                    "privacyLink": "Gizlilik Politikası"
+                    "privacyLink": "Gizlilik Politikası",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Hesap Oluştur",
                 "submitting": "Hesap oluşturuluyor..."

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -200,7 +200,8 @@
                     "text": "Я погоджуюся з",
                     "termsLink": "Умовами використання",
                     "and": "та",
-                    "privacyLink": "Політикою конфіденційності"
+                    "privacyLink": "Політикою конфіденційності",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Створити обліковий запис",
                 "submitting": "Створення облікового запису..."

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -200,7 +200,8 @@
                     "text": "Tôi đồng ý với",
                     "termsLink": "Điều khoản Dịch vụ",
                     "and": "và",
-                    "privacyLink": "Chính sách Bảo mật"
+                    "privacyLink": "Chính sách Bảo mật",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "Tạo tài khoản",
                 "submitting": "Đang tạo tài khoản..."

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -200,7 +200,8 @@
                     "text": "我同意",
                     "termsLink": "服务条款",
                     "and": "和",
-                    "privacyLink": "隐私政策"
+                    "privacyLink": "隐私政策",
+                    "required": "Please accept the Terms of Service and Privacy Policy first"
                 },
                 "submit": "创建帐户",
                 "submitting": "正在创建帐户..."

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -219,7 +219,20 @@ export default function RegisterForm({
                             </div>
                         </div>
 
-                        <SocialLoginButtons providers={availableSocialProviders} />
+                        {/*
+                         * Gated on the SAME condition as Create account. These
+                         * buttons sit inside this form but are type="button",
+                         * so they never triggered the required checkbox's
+                         * validation and never reached handleSubmit — a click
+                         * created a real account with consent unticked, and
+                         * with the documents unloaded even though the email
+                         * path refuses in that state.
+                         */}
+                        <SocialLoginButtons
+                            providers={availableSocialProviders}
+                            disabled={!formData.acceptedTerms || termsUnavailable}
+                            disabledReason={t('form.terms.required')}
+                        />
                     </>
                 )}
 

--- a/apps/web/src/components/auth/social-login-consent-gate.unit.spec.tsx
+++ b/apps/web/src/components/auth/social-login-consent-gate.unit.spec.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+vi.mock('@/app/actions/auth', () => ({ connectProvider: vi.fn() }));
+// `Button` reaches @/i18n/navigation, whose next-intl client entry does not
+// resolve under vitest's ESM loader — the same stub the other component specs
+// use. Nothing about the gate's behaviour is mocked.
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+    useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { SocialLoginButtons } from './social-login';
+import { OAuthProvider } from '@/lib/api/enums';
+
+/**
+ * Registration presents a `required` consent checkbox and disables Create
+ * account until the legal documents load — but the social buttons sit inside
+ * that same form as `type="button"`, so a click never ran HTML5 constraint
+ * validation and never reached the submit handler. An account was created with
+ * the box unticked, and the only call to `termsAcceptanceService.record()`
+ * lives on the email/password branch, so nothing was recorded either.
+ *
+ * This pins the gate itself. It is deliberately a RENDER test: the defect was a
+ * path that skipped a precondition, which a predicate test cannot observe.
+ */
+describe('SocialLoginButtons — consent gate', () => {
+    const providers = [OAuthProvider.GOOGLE, OAuthProvider.GITHUB];
+    const buttons = () => screen.getAllByRole('button');
+
+    it('control: the providers really do render when nothing blocks them', () => {
+        // Without this, "all buttons disabled" below could be satisfied by the
+        // component rendering no buttons at all.
+        render(<SocialLoginButtons providers={providers} />);
+        expect(buttons().length).toBe(providers.length);
+        expect(buttons().every((b) => !b.hasAttribute('disabled'))).toBe(true);
+    });
+
+    it('disables every provider while the page precondition is unmet', () => {
+        render(<SocialLoginButtons providers={providers} disabled disabledReason="accept terms" />);
+        expect(buttons().length).toBe(providers.length);
+        for (const b of buttons()) {
+            expect(b).toBeDisabled();
+            expect(b.getAttribute('aria-disabled')).toBe('true');
+        }
+    });
+
+    it('explains itself rather than being mysteriously inert', () => {
+        render(<SocialLoginButtons providers={providers} disabled disabledReason="accept terms" />);
+        expect(buttons()[0].getAttribute('title')).toBe('accept terms');
+    });
+
+    it('leaves the login page untouched — disabled defaults to false', () => {
+        // The login page has no consent precondition and passes no flag; it must
+        // keep working exactly as before.
+        render(<SocialLoginButtons providers={providers} />);
+        for (const b of buttons()) {
+            expect(b).not.toBeDisabled();
+            expect(b.getAttribute('title')).toBeNull();
+        }
+    });
+});

--- a/apps/web/src/components/auth/social-login.tsx
+++ b/apps/web/src/components/auth/social-login.tsx
@@ -17,9 +17,28 @@ const providerIcons: Record<OAuthProvider, ComponentType<{ className?: string }>
 
 interface SocialLoginButtonsProps {
     providers: OAuthProvider[];
+    /**
+     * Block the providers when the surrounding page has a precondition the
+     * buttons would otherwise walk straight past.
+     *
+     * Registration needs this: its consent checkbox is `required`, but these
+     * are `type="button"` inside that form, so clicking one never runs HTML5
+     * constraint validation and never reaches the submit handler. An account
+     * was created with the box unticked.
+     *
+     * Optional and defaulting to false so the login page — which has no such
+     * precondition — is unchanged.
+     */
+    disabled?: boolean;
+    /** Shown when `disabled`, so the buttons are not mysteriously inert. */
+    disabledReason?: string;
 }
 
-export function SocialLoginButtons({ providers }: SocialLoginButtonsProps) {
+export function SocialLoginButtons({
+    providers,
+    disabled = false,
+    disabledReason,
+}: SocialLoginButtonsProps) {
     const t = useTranslations('auth.login');
     const [isPending, startTransition] = useTransition();
     const isSingleProvider = providers.length === 1;
@@ -58,7 +77,9 @@ export function SocialLoginButtons({ providers }: SocialLoginButtonsProps) {
                         key={provider}
                         type="button"
                         onClick={() => handleConnectProvider(provider)}
-                        disabled={isPending}
+                        disabled={isPending || disabled}
+                        title={disabled ? disabledReason : undefined}
+                        aria-disabled={isPending || disabled}
                         variant="secondary"
                         className="h-10 gap-2 text-sm"
                     >


### PR DESCRIPTION
The registration page presents consent as **mandatory** — a `required` checkbox, and Create account disabled until the legal documents load. The Google/GitHub buttons sit **inside that same form** but are `type="button"`, so a click never runs HTML5 constraint validation and never reaches `handleSubmit`. **A real account was created with the box unticked.**

It compounds: `termsAcceptanceService.record()` has **exactly one call site** in the whole API — the email/password branch — while the OAuth callback creates the user via `validateSocialUser`. So a social signup produced an account with **no acceptance row at all**, in a product that otherwise resolves a versioned document corpus and records digests.

The asymmetry also made a code comment false: when the corpus fails to load, the email path refuses (*"registration is blocked"*) — while the social buttons still created accounts in exactly that state.

**Fix**: gate the buttons on the same condition as Create account, with a title explaining why they are inert. The prop is optional and defaults false, so the login page's two call sites are untouched.

**Scope, stated rather than implied**: this closes the *bypass* — no account can be created from this page without the box ticked. It does **not** make the OAuth path *record* the acceptance; that needs the claims threaded through OAuth state and consumed in the callback, which is an API change rather than a form fix. Recorded as the remaining half.

Verified: 4/4 — including a control asserting the buttons render **enabled** when nothing blocks them (else "all disabled" would pass on an empty render), and one pinning the login page unaffected. Removing the gate fails exactly the disabled test · tsc 0 · prettier clean · i18n key in all 21 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)