### PR TITLE
fix(auth): an unverified address is not a credential failure (EW-014)

### DIFF
--- a/apps/api/src/auth/providers/auth-provider.service.spec.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.spec.ts
@@ -986,6 +986,42 @@ describe('AuthProviderService', () => {
             delete process.env.LOGIN_LOCKOUT_DURATION_MS;
         });
 
+        // EW-014 — an unverified address is not a credential failure.
+        //
+        // `requireEmailVerification` is on by default, so signInEmail ALSO
+        // throws for an unverified account. Counting that meant a user typing
+        // their own CORRECT password locked themselves out after five tries,
+        // and the helpful "please verify your email" message was then replaced
+        // by the lockout one — a brand-new account is exactly where this lands.
+        it('does NOT count an unverified-email rejection toward the lockout', async () => {
+            const ctx = createService();
+            const row = installCounterFake(ctx, 0);
+            ctx.auth.api.signInEmail.mockRejectedValue(new Error('Email not verified'));
+
+            await expect(
+                ctx.service.signInEmail('a@b.co', 'correct-password', new Headers()),
+            ).rejects.toThrow(/Email not verified/);
+
+            expect(ctx.userRepository.increment).not.toHaveBeenCalled();
+            expect(row.failedLoginAttempts).toBe(0);
+        });
+
+        // Control: the discriminator must stay NARROW. If it ever matched
+        // broadly it would stop counting real credential failures and quietly
+        // disable the lockout — the opposite defect, and a security one.
+        it('control: a genuine credential failure STILL counts', async () => {
+            const ctx = createService();
+            const row = installCounterFake(ctx, 0);
+            ctx.auth.api.signInEmail.mockRejectedValue(new Error('Invalid credentials'));
+
+            await expect(ctx.service.signInEmail('a@b.co', 'wrong', new Headers())).rejects.toThrow(
+                /Invalid credentials/,
+            );
+
+            expect(ctx.userRepository.increment).toHaveBeenCalled();
+            expect(row.failedLoginAttempts).toBe(1);
+        });
+
         it('atomically increments failedLoginAttempts on a failed signInEmail', async () => {
             const { service, userRepository } = setupSignInEmailFailure();
 

--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -129,7 +129,19 @@ export class AuthProviderService extends AuthProvider {
                 },
             });
         } catch (err) {
-            if (existingUser) {
+            // Lockout counts CREDENTIAL failures. `requireEmailVerification` is
+            // on by default (auth-runtime.instance.ts), so signInEmail also
+            // throws for an unverified address — and counting that meant a user
+            // typing their own CORRECT password locked themselves out after
+            // five tries, at which point the helpful "please verify your email"
+            // message was replaced by the lockout one and they had no idea what
+            // to fix. A brand-new account is exactly where this lands.
+            //
+            // Skipping the increment is safe in either ordering: if Better Auth
+            // checks verification BEFORE the password, every attempt returns the
+            // same rejection and no password information leaks; if it checks
+            // after, reaching this error means the credentials were right.
+            if (existingUser && !isEmailNotVerifiedRejection(err)) {
                 await this.recordFailedLogin(existingUser);
             }
             throw err;
@@ -529,4 +541,22 @@ export class AuthProviderService extends AuthProvider {
         await this.authSyncService.syncCredentialPassword(userId, newHash);
         await this.userRepository.update(userId, { password: newHash });
     }
+}
+
+/**
+ * Does this rejection mean "the address is not confirmed" rather than "the
+ * credentials were wrong"?
+ *
+ * Mirrors the web side's `isEmailNotVerifiedError` (apps/web/src/app/actions/
+ * auth.ts) deliberately: both sides key on the two words that carry the
+ * meaning, tolerant of case and wording drift, because Better Auth does not
+ * expose a stable code for this on the thrown value.
+ *
+ * Kept narrow on purpose. If it ever matched too broadly it would stop counting
+ * real credential failures toward the lockout, so it must match the verification
+ * wording and nothing else.
+ */
+function isEmailNotVerifiedRejection(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    return /email.*not.*verif/i.test(message);
 }


### PR DESCRIPTION
Found earlier in this effort, left open, and **re-found independently** by the auth-flow audit — so here is the fix.

`requireEmailVerification` is on by default, so `signInEmail` throws for an unverified account as well as for a wrong password. The catch treated **every** throw as a failed-login event — so a user typing their **own correct password** incremented the lockout counter. Five tries and the account locks for 15 minutes.

The experience is worse than the mechanics suggest, because the messages degrade in the wrong direction:

1. first attempts → *"Please verify your email address before signing in"* (correct, actionable)
2. after five → *"Account temporarily locked due to too many failed login attempts"*

The one instruction that would have helped is **replaced** by one implying they got their own password wrong. A brand-new account is exactly where this lands — and the "Resend Verification Email" affordance is itself broken (recorded separately), so there is no way out.

**Fix**: skip the increment for the unverified rejection. Safe in either ordering — if verification is checked *before* the password, every attempt returns the same rejection and no password information leaks; if *after*, reaching that error means the credentials were right.

The discriminator mirrors the web side's existing `isEmailNotVerifiedError` rather than inventing a second convention, and is deliberately **narrow**: matching too broadly would stop counting real credential failures and quietly disable the lockout — the opposite defect, and a security one.

Verified: 8/8, including a **narrowness control** asserting a genuine `Invalid credentials` throw still increments. Reverting the fix fails exactly the unverified test (1 failed / 7 passed) while the control keeps passing · API tsc unchanged at its 5 pre-existing errors (identical on clean develop) · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)