### PR TITLE
fix(auth): a locked-out account was told its password was wrong (EW-072)

### DIFF
--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -64,6 +64,20 @@ function isEmailNotVerifiedError(error: unknown): boolean {
     return statusCode === undefined || statusCode === 403;
 }
 
+/**
+ * Does this rejection mean "the account is in a lockout window"?
+ *
+ * Matched on the wording the API actually emits (auth-provider.service.ts
+ * `buildLockoutMessage`: "Account temporarily locked due to too many failed
+ * login attempts, try again in N minutes"). Kept narrow, on the words that
+ * carry the meaning, so an unrelated future rejection cannot start claiming a
+ * lockout — the same discipline as the sibling above.
+ */
+function isAccountLockedError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    return /account .*lock|temporarily locked/i.test(message);
+}
+
 export async function login(identifier: string, password: string, redirectUrl: string | null) {
     const t = await getTranslations('validation.auth');
     // `validation.auth` has no key for an unverified email; the message already
@@ -109,6 +123,19 @@ export async function login(identifier: string, password: string, redirectUrl: s
             message = t('account.suspended');
         } else if (isEmailNotVerifiedError(error)) {
             message = tAuthError('emailNotVerified');
+        } else if (isAccountLockedError(error)) {
+            // Same defect the comment above describes, still open for the
+            // lockout case: the API sends a precise, actionable message —
+            // "Account temporarily locked …, try again in N minutes" — and it
+            // fell through to "Invalid email or password". The credentials may
+            // well be RIGHT, and the suggested fix ("Forgot password?") cannot
+            // clear a time-based lock. Pass the server's own wording through so
+            // the countdown survives; the generic locked string is the fallback
+            // if the API ever stops including it.
+            message =
+                error instanceof Error && error.message
+                    ? error.message
+                    : tAuthError('accountLocked');
         }
 
         return {


### PR DESCRIPTION
The same defect the comment in this file already describes — still open for the lockout case.

The API sends a precise, actionable rejection: *"Account temporarily locked due to too many failed login attempts, try again in N minutes"*. The web action mapped `suspended` and `email not verified` to their own messages, and let **everything else** fall through to *"Invalid email or password"*.

So a locked-out user is told the one thing that isn't true. Their credentials may be perfectly correct — the account is in a time window. And the message steers them to **"Forgot password?"**, which cannot clear a lockout: the same wrong-next-step this file's own comment calls out for the unverified case.

It compounds with [EW-014](https://github.com/ever-works/ever-works/pull/2097): before that fix, an unverified user's *correct* password drove the counter, so the sequence was *"please verify your email"* → *"invalid email or password"* — the useful instruction replaced by a false one.

**Fix**: surface the server's own wording so the "try again in N minutes" countdown reaches the user, falling back to the existing `auth.error.accountLocked` string if the API ever stops including it.

The matcher is deliberately narrow **and proven so** — it fires on both real lockout strings and rejects *"Invalid email or password"*, *"Email not verified"* and *"User account is suspended"*. A broad match would have this branch swallowing ordinary credential failures and telling users they're locked out when they aren't.

Verified: tsc 0 · prettier clean · matcher discrimination asserted across 5 cases (2 match / 3 reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error handling for temporarily locked accounts.
  * Displays the server-provided lockout message when available, with a translated fallback otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->