### PR TITLE
fix(web): signup states the rules it enforces (EW-073/074/075/076)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "الاسم الكامل",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "عنوان البريد الإلكتروني",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "كلمة المرور",
                     "placeholder": "إنشاء كلمة مرور قوية",
-                    "hint": "يجب أن تكون 8 أحرف على الأقل"
+                    "hint": "يجب أن تكون 8 أحرف على الأقل مع حرف صغير ورقم/رمز خاص"
                 },
                 "confirmPassword": {
                     "label": "تأكيد كلمة المرور",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "كلمات المرور غير متطابقة",
                 "passwordTooShort": "يجب أن تكون كلمة المرور 8 أحرف على الأقل",
                 "generic": "حدث خطأ. يرجى المحاولة مرة أخرى.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7908,6 +7914,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Пълно име",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Имейл адрес",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Парола",
                     "placeholder": "Създайте силна парола",
-                    "hint": "Трябва да е поне 8 символа"
+                    "hint": "Трябва да е поне 8 символа с малка буква и число/специален символ"
                 },
                 "confirmPassword": {
                     "label": "Потвърдете паролата",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Паролите не съвпадат",
                 "passwordTooShort": "Паролата трябва да е поне 8 символа",
                 "generic": "Грешка. Моля, опитайте отново.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7908,6 +7914,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Vollständiger Name",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "E-Mail-Adresse",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Passwort",
                     "placeholder": "Erstellen Sie ein starkes Passwort",
-                    "hint": "Mindestens 8 Zeichen"
+                    "hint": "Mindestens 8 Zeichen mit Kleinbuchstaben und Zahl/Sonderzeichen"
                 },
                 "confirmPassword": {
                     "label": "Passwort bestätigen",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Passwörter stimmen nicht überein",
                 "passwordTooShort": "Passwort muss mindestens 8 Zeichen haben",
                 "generic": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7908,6 +7914,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Full name",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Email address",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Password",
                     "placeholder": "Create a strong password",
-                    "hint": "Must be at least 8 characters"
+                    "hint": "Must be at least 8 characters with lowercase and number/special character"
                 },
                 "confirmPassword": {
                     "label": "Confirm password",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Passwords do not match",
                 "passwordTooShort": "Password must be at least 8 characters",
                 "generic": "An error occurred. Please try again.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7914,6 +7920,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Nombre completo",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Dirección de email",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Contraseña",
                     "placeholder": "Crea una contraseña segura",
-                    "hint": "Debe tener al menos 8 caracteres"
+                    "hint": "Debe tener al menos 8 caracteres con minúscula y número/carácter especial"
                 },
                 "confirmPassword": {
                     "label": "Confirmar contraseña",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Las contraseñas no coinciden",
                 "passwordTooShort": "La contraseña debe tener al menos 8 caracteres",
                 "generic": "Ocurrió un error. Inténtalo de nuevo.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7908,6 +7914,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Nom complet",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Adresse e-mail",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Mot de passe",
                     "placeholder": "Créez un mot de passe fort",
-                    "hint": "Doit comporter au moins 8 caractères"
+                    "hint": "Doit comporter au moins 8 caractères avec une minuscule et un chiffre/caractère spécial"
                 },
                 "confirmPassword": {
                     "label": "Confirmer le mot de passe",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Les mots de passe ne correspondent pas",
                 "passwordTooShort": "Le mot de passe doit comporter au moins 8 caractères",
                 "generic": "Une erreur s'est produite. Veuillez réessayer.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7908,6 +7914,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "שם מלא",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "כתובת אימייל",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "סיסמה",
                     "placeholder": "צור סיסמה חזקה",
-                    "hint": "חייב להיות לפחות 8 תווים"
+                    "hint": "חייב להיות לפחות 8 תווים עם אותיות קטנות ומספר/תו מיוחד"
                 },
                 "confirmPassword": {
                     "label": "אשר סיסמה",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "סיסמאות לא תואמות",
                 "passwordTooShort": "סיסמה חייבת להיות לפחות 8 תווים",
                 "generic": "אירעה שגיאה. נסה שוב.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7908,6 +7914,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "पूरा नाम",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "ईमेल पता",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "पासवर्ड",
                     "placeholder": "एक मजबूत पासवर्ड बनाएं",
-                    "hint": "कम से कम 8 अक्षरों का होना चाहिए"
+                    "hint": "कम से कम 8 अक्षरों का होना चाहिए जिसमें लोअरकेस और संख्या/विशेष चिह्न शामिल हो"
                 },
                 "confirmPassword": {
                     "label": "पासवर्ड确认 करें",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "पासवर्ड मेल नहीं खाते",
                 "passwordTooShort": "पासवर्ड कम से कम 8 अक्षरों का होना चाहिए",
                 "generic": "एक त्रुटि हुई। कृपया पुनः प्रयास करें।",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Nama lengkap",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Alamat email",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Kata sandi",
                     "placeholder": "Buat kata sandi yang kuat",
-                    "hint": "Harus minimal 8 karakter"
+                    "hint": "Harus minimal 8 karakter dengan huruf kecil dan angka/karakter khusus"
                 },
                 "confirmPassword": {
                     "label": "Konfirmasi kata sandi",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Kata sandi tidak cocok",
                 "passwordTooShort": "Kata sandi harus minimal 8 karakter",
                 "generic": "Terjadi kesalahan. Harap coba lagi.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Nome completo",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Indirizzo email",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Password",
                     "placeholder": "Crea una password forte",
-                    "hint": "Deve essere di almeno 8 caratteri"
+                    "hint": "Deve essere di almeno 8 caratteri con minuscole e numero/carattere speciale"
                 },
                 "confirmPassword": {
                     "label": "Conferma password",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Le password non corrispondono",
                 "passwordTooShort": "La password deve essere di almeno 8 caratteri",
                 "generic": "Si è verificato un errore. Riprova.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "フルネーム",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "メールアドレス",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "パスワード",
                     "placeholder": "強力なパスワードを作成",
-                    "hint": "最低8文字必要です"
+                    "hint": "最低8文字で、小文字と数字/特殊文字を含む必要があります"
                 },
                 "confirmPassword": {
                     "label": "パスワードを確認",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "パスワードが一致しません",
                 "passwordTooShort": "パスワードは最低8文字必要です",
                 "generic": "エラーが発生しました。もう一度お試しください。",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "전체 이름",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "이메일 주소",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "비밀번호",
                     "placeholder": "강력한 비밀번호 생성",
-                    "hint": "최소 8자 이상이어야 합니다"
+                    "hint": "최소 8자 이상, 소문자 및 숫자/특수문자 포함"
                 },
                 "confirmPassword": {
                     "label": "비밀번호 확인",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "비밀번호가 일치하지 않습니다",
                 "passwordTooShort": "비밀번호는 최소 8자여야 합니다",
                 "generic": "오류가 발생했습니다. 다시 시도해 주세요.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Volledige naam",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "E-mailadres",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Wachtwoord",
                     "placeholder": "Maak een sterk wachtwoord",
-                    "hint": "Moet minimaal 8 tekens bevatten"
+                    "hint": "Moet minimaal 8 tekens bevatten met kleine letter en cijfer/special teken"
                 },
                 "confirmPassword": {
                     "label": "Bevestig wachtwoord",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Wachtwoorden komen niet overeen",
                 "passwordTooShort": "Wachtwoord moet minimaal 8 tekens bevatten",
                 "generic": "Er is een fout opgetreden. Probeer het opnieuw.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Imię i nazwisko",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Adres e-mail",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Hasło",
                     "placeholder": "Utwórz silne hasło",
-                    "hint": "Musi mieć co najmniej 8 znaków"
+                    "hint": "Musi mieć co najmniej 8 znaków, w tym małą literę i cyfrę/znak specjalny"
                 },
                 "confirmPassword": {
                     "label": "Potwierdź hasło",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Hasła nie pasują",
                 "passwordTooShort": "Hasło musi mieć co najmniej 8 znaków",
                 "generic": "Wystąpił błąd. Spróbuj ponownie.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Nome completo",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Endereço de e-mail",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Senha",
                     "placeholder": "Crie uma senha forte",
-                    "hint": "Deve ter pelo menos 8 caracteres"
+                    "hint": "Deve ter pelo menos 8 caracteres com minúscula e número/caractere especial"
                 },
                 "confirmPassword": {
                     "label": "Confirmar senha",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Senhas não coincidem",
                 "passwordTooShort": "Senha deve ter pelo menos 8 caracteres",
                 "generic": "Ocorreu um erro. Tente novamente.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Полное имя",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Адрес email",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Пароль",
                     "placeholder": "Создайте надёжный пароль",
-                    "hint": "Должен содержать минимум 8 символов"
+                    "hint": "Должен содержать минимум 8 символов, включая строчные буквы и цифру/спецсимвол"
                 },
                 "confirmPassword": {
                     "label": "Подтвердите пароль",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Пароли не совпадают",
                 "passwordTooShort": "Пароль должен содержать минимум 8 символов",
                 "generic": "Произошла ошибка. Пожалуйста, попробуйте снова.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "ชื่อเต็ม",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "ที่อยู่อีเมล",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "รหัสผ่าน",
                     "placeholder": "สร้างรหัสผ่านที่แข็งแกร่ง",
-                    "hint": "ต้องมีอย่างน้อย 8 ตัวอักษร"
+                    "hint": "ต้องมีอย่างน้อย 8 ตัวอักษร พร้อมตัวพิมพ์เล็กและตัวเลข/อักขระพิเศษ"
                 },
                 "confirmPassword": {
                     "label": "ยืนยันรหัสผ่าน",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "รหัสผ่านไม่ตรงกัน",
                 "passwordTooShort": "รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร",
                 "generic": "เกิดข้อผิดพลาด กรุณาลองอีกครั้ง",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Tam ad",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "E-posta adresi",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Şifre",
                     "placeholder": "Güçlü bir şifre oluşturun",
-                    "hint": "En az 8 karakter olmalıdır"
+                    "hint": "En az 8 karakter, küçük harf ve rakam/özel karakter içermelidir"
                 },
                 "confirmPassword": {
                     "label": "Şifreyi onaylayın",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Şifreler eşleşmiyor",
                 "passwordTooShort": "Şifre en az 8 karakter olmalıdır",
                 "generic": "Bir hata oluştu. Lütfen tekrar deneyin.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Повне ім'я",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Адреса електронної пошти",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Пароль",
                     "placeholder": "Створіть надійний пароль",
-                    "hint": "Має бути щонайменше 8 символів"
+                    "hint": "Має бути щонайменше 8 символів з маленькою літерою та цифрою/спеціальним символом"
                 },
                 "confirmPassword": {
                     "label": "Підтвердити пароль",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Паролі не співпадають",
                 "passwordTooShort": "Пароль має бути щонайменше 8 символів",
                 "generic": "Сталася помилка. Спробуйте знову.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "Họ và tên",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "Địa chỉ email",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "Mật khẩu",
                     "placeholder": "Tạo mật khẩu mạnh",
-                    "hint": "Phải có ít nhất 8 ký tự"
+                    "hint": "Phải có ít nhất 8 ký tự với chữ thường và số/ký tự đặc biệt"
                 },
                 "confirmPassword": {
                     "label": "Xác nhận mật khẩu",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "Mật khẩu không khớp",
                 "passwordTooShort": "Mật khẩu phải có ít nhất 8 ký tự",
                 "generic": "Đã xảy ra lỗi. Vui lòng thử lại.",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -181,7 +181,8 @@
             "form": {
                 "name": {
                     "label": "全名",
-                    "placeholder": "John Doe"
+                    "placeholder": "John Doe",
+                    "hint": "Must be at least {length} characters"
                 },
                 "email": {
                     "label": "电子邮件地址",
@@ -190,7 +191,7 @@
                 "password": {
                     "label": "密码",
                     "placeholder": "创建强密码",
-                    "hint": "至少 8 个字符"
+                    "hint": "至少 8 个字符，包含小写字母、数字/特殊字符"
                 },
                 "confirmPassword": {
                     "label": "确认密码",
@@ -219,7 +220,12 @@
                 "passwordsDoNotMatch": "密码不匹配",
                 "passwordTooShort": "密码至少 8 个字符",
                 "generic": "发生错误。请重试。",
-                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue."
+                "termsNotAccepted": "Please accept the Terms of Service and Privacy Policy to continue.",
+                "termsUnavailable": {
+                    "title": "Terms could not be loaded",
+                    "message": "We could not load the Terms of Service and Privacy Policy you need to accept, so account creation is paused. Please try again in a moment.",
+                    "retry": "Try again"
+                }
             }
         }
     },
@@ -7909,6 +7915,9 @@
             },
             "terms": {
                 "required": "You must accept the Terms of Service and Privacy Policy to create an account."
+            },
+            "name": {
+                "minLength": "Full name must be at least {length} characters"
             }
         }
     },

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { Link } from '@/i18n/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import { COMPANY_OWNER_WEBSITE } from '@/lib/constants';
 import { AuthLayout } from '@/components/layout/AuthLayout';
 import { useTranslations } from 'next-intl';
 import { SocialLoginButtons } from '@/components/auth/social-login';
 import { register as registerAction } from '@/app/actions/auth';
+import { PASSWORD_RULES, VALIDATION_RULES } from '@/app/actions/validation';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants';
@@ -29,7 +30,14 @@ export default function RegisterForm({
     termsDocuments,
 }: RegisterFormProps) {
     const t = useTranslations('auth.register');
+    // The rules this form has to state are already written, and already
+    // translated into all 21 locales, under `validation.auth` — they are the
+    // very strings the server action returns when it rejects. Reusing them
+    // keeps the message a user reads BEFORE submit identical to the one they
+    // would otherwise have read after.
+    const tv = useTranslations('validation.auth');
     const [isPending, startTransition] = useTransition();
+    const router = useRouter();
 
     const [formData, setFormData] = useState({
         name: '',
@@ -44,11 +52,61 @@ export default function RegisterForm({
         acceptedTerms: false,
     });
 
-    const [error, setError] = useState('');
+    /**
+     * Errors keyed by the field they belong to.
+     *
+     * This used to be a single `error` string rendered as a banner above the
+     * form. Every rule the server enforced and the page did not — lowercase,
+     * number-or-special, no leading dot, the name minimum — arrived as that
+     * banner, detached from the input that caused it, after a round trip. The
+     * sibling reset-password form already keys its errors by field; this
+     * matches it.
+     */
+    const [errors, setErrors] = useState<{
+        name?: string;
+        password?: string;
+        confirmPassword?: string;
+        general?: string;
+    }>({});
 
     // Nothing to pin an acceptance to means nothing truthful to record, so the
     // form refuses rather than registering silently.
     const termsUnavailable = termsDocuments.length === 0;
+
+    // EW-075: that refusal was correct and completely silent. With the corpus
+    // unloaded the checkbox, Create account and every social button went
+    // disabled, nothing said why, and there was no way forward short of
+    // reloading the page by hand — a signup that looks broken rather than
+    // temporarily unavailable. `router.refresh()` re-runs the server component
+    // that fetches the corpus, so a transient upstream failure is retryable in
+    // place; a persistent one at least explains itself.
+    const [isRetrying, startRetry] = useTransition();
+    const retryTerms = () => startRetry(() => router.refresh());
+
+    /**
+     * The password rules the server action will apply, in the order it applies
+     * them, each paired with the message it would have returned.
+     *
+     * The regexes are imported rather than restated: the whole defect class
+     * here (EW-073, EW-076) is a client that disagrees with the server about
+     * what a valid password is, and a second copy of `/[\d\W_]/` in this file
+     * would be the next instance of it.
+     */
+    const passwordError = (password: string): string | undefined => {
+        if (password.length < PASSWORD_RULES.MIN_LENGTH) {
+            return t('errors.passwordTooShort');
+        }
+        if (!PASSWORD_RULES.LOWERCASE.test(password)) {
+            return tv('password.lowercase');
+        }
+        if (!PASSWORD_RULES.NUMBER_OR_SPECIAL.test(password)) {
+            return tv('password.numberOrSpecial');
+        }
+        if (!PASSWORD_RULES.NOT_STARTING_WITH_DOT_OR_NEWLINE.test(password)) {
+            return tv('password.cannotStartWith');
+        }
+        return undefined;
+    };
 
     /**
      * Where to send someone who wants to READ what they are accepting.
@@ -66,21 +124,37 @@ export default function RegisterForm({
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        setError('');
+        setErrors({});
 
-        // Validation
-        if (formData.password !== formData.confirmPassword) {
-            setError(t('errors.passwordsDoNotMatch'));
+        // EW-074: the minimum was enforced but never shown. A two-character
+        // entry was accepted by the page, posted, and came back as "Username
+        // must contain at least 3 characters" — a rule about a field this form
+        // does not display. It is checked here now, against the same constant
+        // the action uses, and reported against the field actually filled in.
+        if (formData.name.trim().length < VALIDATION_RULES.USERNAME_MIN_LENGTH) {
+            setErrors({
+                name: tv('name.minLength', { length: VALIDATION_RULES.USERNAME_MIN_LENGTH }),
+            });
             return;
         }
 
-        if (formData.password.length < 8) {
-            setError(t('errors.passwordTooShort'));
+        if (formData.password !== formData.confirmPassword) {
+            setErrors({ confirmPassword: t('errors.passwordsDoNotMatch') });
+            return;
+        }
+
+        // EW-073: only the length was checked here, so a 10-character
+        // ALL-UPPERCASE password satisfied every rule the page stated and every
+        // rule the page enforced, and was still rejected by the action. All
+        // four rules run now, and the failing one is named against the field.
+        const invalidPassword = passwordError(formData.password);
+        if (invalidPassword) {
+            setErrors({ password: invalidPassword });
             return;
         }
 
         if (!formData.acceptedTerms || termsUnavailable) {
-            setError(t('errors.termsNotAccepted'));
+            setErrors({ general: t('errors.termsNotAccepted') });
             return;
         }
 
@@ -101,7 +175,7 @@ export default function RegisterForm({
             );
 
             if (response && !response.success) {
-                setError(response.error || t('errors.generic'));
+                setErrors({ general: response.error || t('errors.generic') });
             }
         });
     };
@@ -116,9 +190,41 @@ export default function RegisterForm({
         >
             <ThemeToggle variant="fixed" />
             <form onSubmit={handleSubmit} className="space-y-4">
-                {error && (
+                {errors.general && (
                     <div className="bg-danger/10 border border-danger/20 text-danger px-4 py-3 rounded-lg text-sm">
-                        {error}
+                        {errors.general}
+                    </div>
+                )}
+
+                {/*
+                 * EW-075: say why the form is inert, and offer the way out.
+                 * Without this the page is a set of disabled controls with no
+                 * explanation — indistinguishable from a broken build, and with
+                 * nothing to click that would ever change it.
+                 */}
+                {termsUnavailable && (
+                    <div
+                        role="alert"
+                        className="bg-warning/10 border border-warning/20 px-4 py-3 rounded-lg text-sm space-y-3"
+                    >
+                        <div>
+                            <p className="font-medium text-text dark:text-text-dark">
+                                {t('errors.termsUnavailable.title')}
+                            </p>
+                            <p className="mt-1 text-text-secondary dark:text-text-secondary-dark">
+                                {t('errors.termsUnavailable.message')}
+                            </p>
+                        </div>
+
+                        <Button
+                            type="button"
+                            onClick={retryTerms}
+                            loading={isRetrying}
+                            disabled={isRetrying}
+                            size="sm"
+                        >
+                            {t('errors.termsUnavailable.retry')}
+                        </Button>
                     </div>
                 )}
 
@@ -129,7 +235,17 @@ export default function RegisterForm({
                         name="name"
                         placeholder={t('form.name.placeholder')}
                         value={formData.name}
-                        onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                        onChange={(e) => {
+                            setFormData({ ...formData, name: e.target.value });
+                            setErrors((prev) => ({ ...prev, name: undefined }));
+                        }}
+                        error={errors.name}
+                        // EW-074: the 3-character minimum was undisclosed. It is
+                        // the API's `@MinLength(3)` on `username`, so it is
+                        // stated from the same constant the checks read.
+                        helperText={t('form.name.hint', {
+                            length: VALIDATION_RULES.USERNAME_MIN_LENGTH,
+                        })}
                         required
                         disabled={isPending}
                         className="text-sm shadow-sm"
@@ -153,7 +269,16 @@ export default function RegisterForm({
                         label={t('form.password.label')}
                         placeholder={t('form.password.placeholder')}
                         value={formData.password}
-                        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                        onChange={(e) => {
+                            setFormData({ ...formData, password: e.target.value });
+                            setErrors((prev) => ({ ...prev, password: undefined }));
+                        }}
+                        error={errors.password}
+                        // EW-073: this said only "Must be at least 8
+                        // characters" while three further rules were being
+                        // enforced. It now carries the sibling reset flow's
+                        // wording, which already states all of them and is
+                        // already translated into all 21 locales.
                         helperText={t('form.password.hint')}
                         required
                         disabled={isPending}
@@ -166,9 +291,11 @@ export default function RegisterForm({
                         label={t('form.confirmPassword.label')}
                         placeholder={t('form.confirmPassword.placeholder')}
                         value={formData.confirmPassword}
-                        onChange={(e) =>
-                            setFormData({ ...formData, confirmPassword: e.target.value })
-                        }
+                        onChange={(e) => {
+                            setFormData({ ...formData, confirmPassword: e.target.value });
+                            setErrors((prev) => ({ ...prev, confirmPassword: undefined }));
+                        }}
+                        error={errors.confirmPassword}
                         required
                         disabled={isPending}
                         className="text-sm shadow-sm"

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.unit.spec.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.unit.spec.tsx
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import en from '../../../../../messages/en.json';
+
+/**
+ * Signup form — EW-073, EW-074, EW-075.
+ *
+ * All three defects are the same shape: a rule the server enforces that the
+ * page neither states nor checks, so the only way to discover it is to fill the
+ * form in, submit, and read a banner that names something you cannot see. These
+ * are deliberately RENDER tests — the defect lives in what reaches the screen
+ * and in whether `register` is called at all, neither of which a predicate test
+ * can observe.
+ *
+ * The translation mock resolves real strings out of `messages/en.json` rather
+ * than echoing the key back. That matters twice over: a key that does not exist
+ * fails loudly here instead of silently rendering its own name, and assertions
+ * can be made against the words a user actually reads ("Full name", not
+ * "Username").
+ */
+
+const { registerActionMock, refreshMock } = vi.hoisted(() => ({
+    registerActionMock: vi.fn(),
+    refreshMock: vi.fn(),
+}));
+
+/** Walks a dotted path and applies next-intl's `{placeholder}` substitution. */
+function translate(path: string, values?: Record<string, unknown>): string {
+    const value = path.split('.').reduce<unknown>((node, key) => {
+        if (node && typeof node === 'object' && key in node) {
+            return (node as Record<string, unknown>)[key];
+        }
+        throw new Error(`missing message key: ${path}`);
+    }, en as unknown);
+
+    if (typeof value !== 'string') throw new Error(`message key is not a string: ${path}`);
+
+    return values
+        ? value.replace(/\{(\w+)\}/g, (match, name) =>
+              name in values ? String(values[name]) : match,
+          )
+        : value;
+}
+
+vi.mock('next-intl', () => ({
+    useTranslations: (namespace: string) => (key: string, values?: Record<string, unknown>) =>
+        translate(`${namespace}.${key}`, values),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+    useRouter: () => ({ push: vi.fn(), refresh: refreshMock }),
+}));
+
+vi.mock('@/app/actions/auth', () => ({
+    register: registerActionMock,
+    connectProvider: vi.fn(),
+}));
+
+vi.mock('@/components/theme-toggle', () => ({ ThemeToggle: () => null }));
+
+import RegisterForm from './register-form';
+import type { TermsAcceptanceDocument } from '@/lib/api/types-only';
+
+const TERMS: TermsAcceptanceDocument[] = [
+    {
+        documentId: 'tos:default',
+        version: '2026-01-01',
+        sha256: 'a'.repeat(64),
+        locale: 'en',
+        url: '/tos',
+    } as TermsAcceptanceDocument,
+    {
+        documentId: 'privacy:default',
+        version: '2026-01-01',
+        sha256: 'b'.repeat(64),
+        locale: 'en',
+        url: '/privacy',
+    } as TermsAcceptanceDocument,
+];
+
+/** Fills every field and ticks consent, then submits. */
+function fillAndSubmit({ name = 'Jane Doe', password = 'lowercase1' } = {}) {
+    fireEvent.change(screen.getByLabelText(en.auth.register.form.name.label), {
+        target: { value: name },
+    });
+    fireEvent.change(screen.getByLabelText(en.auth.register.form.email.label), {
+        target: { value: 'jane@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(en.auth.register.form.password.label), {
+        target: { value: password },
+    });
+    fireEvent.change(screen.getByLabelText(en.auth.register.form.confirmPassword.label), {
+        target: { value: password },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    // Submit the FORM, not the button: React 19 attaches its form-action
+    // handling to the submit event and calls `new FormData(event.target)`,
+    // which throws in jsdom when the target is the button element.
+    const form = screen
+        .getByRole('button', { name: en.auth.register.form.submit })
+        .closest('form') as HTMLFormElement;
+    fireEvent.submit(form);
+}
+
+function renderForm(termsDocuments: TermsAcceptanceDocument[] = TERMS) {
+    return render(<RegisterForm availableSocialProviders={[]} termsDocuments={termsDocuments} />);
+}
+
+beforeEach(() => {
+    registerActionMock.mockReset();
+    registerActionMock.mockResolvedValue({ success: true });
+    refreshMock.mockReset();
+});
+
+describe('signup — the stated password rules match the enforced ones (EW-073)', () => {
+    it('control: a password satisfying every rule reaches the register action', async () => {
+        // Without this, "the action was not called" below could be satisfied by
+        // the form being broken in some way that has nothing to do with the
+        // password.
+        renderForm();
+        fillAndSubmit({ password: 'lowercase1' });
+
+        await waitFor(() => expect(registerActionMock).toHaveBeenCalledTimes(1));
+        expect(registerActionMock.mock.calls[0][2]).toBe('lowercase1');
+    });
+
+    it('the hint states every rule the server applies, not just the length', () => {
+        renderForm();
+
+        const hint = en.auth.register.form.password.hint;
+        expect(screen.getByText(hint)).toBeTruthy();
+
+        // The three rules that were enforced in silence. Asserted on the text
+        // the user sees, so a hint that regresses to length-only fails here.
+        expect(hint).toMatch(/lowercase/i);
+        expect(hint).toMatch(/number|special/i);
+        expect(hint).toMatch(/8/);
+    });
+
+    it('an all-uppercase 10-character password is refused with the rule it broke', async () => {
+        // The reported case: passes the on-screen length rule, passes the only
+        // check the page ran, and is rejected by `actions/auth.ts` for want of
+        // a lowercase letter.
+        renderForm();
+        fillAndSubmit({ password: 'PASSWORD12' });
+
+        expect(await screen.findByText(en.validation.auth.password.lowercase)).toBeTruthy();
+        expect(registerActionMock).not.toHaveBeenCalled();
+    });
+
+    it('a password with no number or special character is refused before submit', async () => {
+        renderForm();
+        fillAndSubmit({ password: 'onlyletters' });
+
+        expect(await screen.findByText(en.validation.auth.password.numberOrSpecial)).toBeTruthy();
+        expect(registerActionMock).not.toHaveBeenCalled();
+    });
+
+    it('a password starting with a dot is refused before submit', async () => {
+        renderForm();
+        fillAndSubmit({ password: '.lowercase1' });
+
+        expect(await screen.findByText(en.validation.auth.password.cannotStartWith)).toBeTruthy();
+        expect(registerActionMock).not.toHaveBeenCalled();
+    });
+
+    it('the too-short message still fires, and only for a short password', async () => {
+        renderForm();
+        fillAndSubmit({ password: 'short1' });
+
+        expect(await screen.findByText(en.auth.register.errors.passwordTooShort)).toBeTruthy();
+        expect(registerActionMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('signup — the client never rejects what the API accepts (EW-076)', () => {
+    it('accepts a password whose only special character is an underscore', async () => {
+        // `abcdefg_` satisfies the API's `/^(?=.*[a-z])(?=.*[\d\W_]).{8,}$/`.
+        // The old web rule `/(\d|\W)/` did not match `_`, so the form told the
+        // user their password lacked a number or special character while the
+        // server would have taken it.
+        renderForm();
+        fillAndSubmit({ password: 'abcdefg_' });
+
+        await waitFor(() => expect(registerActionMock).toHaveBeenCalledTimes(1));
+        expect(screen.queryByText(en.validation.auth.password.numberOrSpecial)).toBeNull();
+    });
+});
+
+describe('signup — the name field names itself (EW-074)', () => {
+    it('states its minimum next to the field', () => {
+        renderForm();
+
+        expect(
+            screen.getByText(translate('auth.register.form.name.hint', { length: 3 })),
+        ).toBeTruthy();
+    });
+
+    it('rejects a two-character name before submit, naming the field on screen', async () => {
+        renderForm();
+        fillAndSubmit({ name: '山田' });
+
+        const message = await screen.findByText(
+            translate('validation.auth.name.minLength', { length: 3 }),
+        );
+
+        // The message must describe the field the form actually shows.
+        expect(message.textContent).toMatch(/full name/i);
+        expect(message.textContent).not.toMatch(/username/i);
+        expect(registerActionMock).not.toHaveBeenCalled();
+    });
+
+    it('the old message that named a non-existent field is no longer what signup uses', () => {
+        // `validation.auth.username.minLength` still exists — the profile
+        // settings form edits a real username and is right to use it. What
+        // must not happen is signup reaching for it again.
+        expect(en.validation.auth.username.minLength).toMatch(/username/i);
+        expect(en.validation.auth.name.minLength).not.toMatch(/username/i);
+    });
+
+    it('a three-character name is accepted', async () => {
+        renderForm();
+        fillAndSubmit({ name: '山田家' });
+
+        await waitFor(() => expect(registerActionMock).toHaveBeenCalledTimes(1));
+        expect(registerActionMock.mock.calls[0][0]).toBe('山田家');
+    });
+
+    it('padding with spaces does not fake the minimum', async () => {
+        // The counterpart to the rule above: the check is on the trimmed
+        // length, and `register`'s schema trims too, so the two agree rather
+        // than the client being the stricter of the pair.
+        renderForm();
+        fillAndSubmit({ name: '  山田  ' });
+
+        expect(
+            await screen.findByText(translate('validation.auth.name.minLength', { length: 3 })),
+        ).toBeTruthy();
+        expect(registerActionMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('signup — an unloadable legal corpus explains itself (EW-075)', () => {
+    it('control: with the documents loaded, no failure notice is shown', () => {
+        renderForm();
+        expect(screen.queryByRole('alert')).toBeNull();
+        expect(
+            (
+                screen.getByRole('button', {
+                    name: en.auth.register.form.submit,
+                }) as HTMLButtonElement
+            ).disabled,
+        ).toBe(false);
+    });
+
+    it('says why the form is inert instead of being silently disabled', () => {
+        renderForm([]);
+
+        const alert = screen.getByRole('alert');
+        expect(alert.textContent).toContain(en.auth.register.errors.termsUnavailable.title);
+        expect(alert.textContent).toContain(en.auth.register.errors.termsUnavailable.message);
+
+        // The submit stays blocked — the explanation is added, the guard is not
+        // traded away for it.
+        expect(
+            (
+                screen.getByRole('button', {
+                    name: en.auth.register.form.submit,
+                }) as HTMLButtonElement
+            ).disabled,
+        ).toBe(true);
+    });
+
+    it('offers a retry that re-runs the server component which loads the corpus', () => {
+        renderForm([]);
+
+        fireEvent.click(
+            screen.getByRole('button', { name: en.auth.register.errors.termsUnavailable.retry }),
+        );
+
+        expect(refreshMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/src/app/actions/auth-register.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-register.unit.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `register` — the server side of EW-073, EW-074 and EW-076.
+ *
+ * The signup form now states and checks these rules before submit, but the
+ * action is where they are actually enforced, and a client-side check is only
+ * ever a convenience. This file pins the enforcement itself:
+ *
+ *   - EW-076: `abcdefg_` must be ACCEPTED. The old `/(\d|\W)/` rejected it
+ *     while the API's `[\d\W_]` accepts it, so the web layer refused a password
+ *     the server would have taken.
+ *   - EW-074: a too-short name must fail with a message that names the field
+ *     the form displays, not `username`.
+ *   - EW-073: the three rules the hint used to omit must still reject.
+ *
+ * `getTranslations` echoes its key, so each branch is identified by the key it
+ * returns rather than by prose that may later be re-worded.
+ */
+
+const { registerMock, setAuthCookiesMock, redirectMock } = vi.hoisted(() => ({
+    registerMock: vi.fn(),
+    setAuthCookiesMock: vi.fn(),
+    redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+    setAuthCookies: setAuthCookiesMock,
+    setOAuthStateCookie: vi.fn(),
+    removeAuthAccessCookies: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+    authAPI: {
+        register: registerMock,
+        login: vi.fn(),
+        logout: vi.fn(),
+        getOAuthAuthUrl: vi.fn(),
+    },
+}));
+
+vi.mock('next-intl/server', () => ({
+    getTranslations: async () => (key: string) => key,
+    getLocale: async () => 'en',
+}));
+
+vi.mock('@/i18n/navigation', () => ({ redirect: redirectMock }));
+
+/** One valid claim — the terms plumbing is not what this file is testing. */
+const TERMS = [
+    {
+        documentId: 'tos:default',
+        version: '2026-01-01',
+        sha256: 'a'.repeat(64),
+        locale: 'en',
+    },
+];
+
+async function callRegister(name: string, password: string) {
+    const { register } = await import('./auth');
+    return register(name, 'jane@example.com', password, TERMS);
+}
+
+beforeEach(() => {
+    registerMock.mockReset();
+    registerMock.mockResolvedValue({ access_token: 'token' });
+    setAuthCookiesMock.mockReset();
+    redirectMock.mockReset();
+});
+
+afterEach(() => {
+    vi.resetModules();
+});
+
+describe('register — the client never rejects what the API accepts (EW-076)', () => {
+    it('accepts a password whose only special character is an underscore', async () => {
+        await callRegister('Jane Doe', 'abcdefg_');
+
+        expect(registerMock).toHaveBeenCalledTimes(1);
+        expect(registerMock.mock.calls[0][0].password).toBe('abcdefg_');
+    });
+
+    it('control: a password with genuinely nothing but letters is still refused', async () => {
+        // Proves the rule was reconciled with the API, not deleted. Without
+        // this, the test above would pass just as well against no check at all.
+        const result = await callRegister('Jane Doe', 'abcdefghi');
+
+        expect(result).toEqual({ success: false, error: 'password.numberOrSpecial' });
+        expect(registerMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('register — the password rules the hint used to omit (EW-073)', () => {
+    it('refuses a 10-character all-uppercase password for want of a lowercase letter', async () => {
+        const result = await callRegister('Jane Doe', 'PASSWORD12');
+
+        expect(result).toEqual({ success: false, error: 'password.lowercase' });
+        expect(registerMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses a password starting with a dot', async () => {
+        const result = await callRegister('Jane Doe', '.lowercase1');
+
+        expect(result).toEqual({ success: false, error: 'password.cannotStartWith' });
+        expect(registerMock).not.toHaveBeenCalled();
+    });
+
+    it('refuses a password under 8 characters', async () => {
+        const result = await callRegister('Jane Doe', 'short1');
+
+        expect(result).toEqual({ success: false, error: 'password.minLength' });
+        expect(registerMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('register — the rejection names the field the form shows (EW-074)', () => {
+    it('reports a short name with the name key, not the username key', async () => {
+        const result = await callRegister('山田', 'lowercase1');
+
+        expect(result).toEqual({ success: false, error: 'name.minLength' });
+        expect(result).not.toEqual({ success: false, error: 'username.minLength' });
+        expect(registerMock).not.toHaveBeenCalled();
+    });
+
+    it('control: a long-enough name gets past the check entirely', async () => {
+        await callRegister('山田家', 'lowercase1');
+
+        expect(registerMock).toHaveBeenCalledTimes(1);
+        expect(registerMock.mock.calls[0][0].username).toBe('山田家');
+    });
+
+    it('counts the trimmed length, matching the form, and posts the trimmed value', async () => {
+        // The form checks `name.trim().length`. If this schema counted the raw
+        // string the client would be the stricter of the two — the same defect
+        // as EW-076, in a different field.
+        const padded = await callRegister('  山田  ', 'lowercase1');
+        expect(padded).toEqual({ success: false, error: 'name.minLength' });
+        expect(registerMock).not.toHaveBeenCalled();
+
+        await callRegister('  山田家  ', 'lowercase1');
+        expect(registerMock).toHaveBeenCalledTimes(1);
+        expect(registerMock.mock.calls[0][0].username).toBe('山田家');
+    });
+});

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod';
 import { removeAuthAccessCookies, setOAuthStateCookie, setAuthCookies } from '@/lib/auth';
 import { ALLOWED_REDIRECT_URLS, ROUTES, withAppUrl } from '@/lib/constants';
-import { VALIDATION_RULES } from './validation';
+import { PASSWORD_RULES, VALIDATION_RULES } from './validation';
 import { authAPI, AuthResponse, type TermsAcceptanceClaim } from '@/lib/api';
 import { redirect } from '@/i18n/navigation';
 import { getLocale, getTranslations } from 'next-intl/server';
@@ -193,19 +193,44 @@ export async function register(
     });
 
     const registerSchema = z.object({
+        // EW-074: this value is posted as `username`, but the ONLY place a
+        // person ever sees it is the signup field labelled "Full name" — that
+        // form has no username field at all. It used to fail with
+        // `username.minLength` ("Username must contain at least 3 characters"),
+        // naming a field the form does not have, which reads as a bug in the
+        // page rather than as something the user can act on. `name.minLength`
+        // names what is actually on screen. The rule itself is unchanged, and
+        // the form now states it beside the field and checks it before submit.
+        //
+        // The 3-character floor is the API's (`RegisterDto.username`,
+        // `@MinLength(3)` in apps/api/src/auth/dto/auth.dto.ts), and it does
+        // exclude ordinary two-character CJK names — 山田 is a real full name —
+        // in an app that ships ja/ko/zh. That is a genuine defect, but it
+        // cannot be fixed from this file: lowering the web minimum alone would
+        // only move the rejection from an instant client-side message to an
+        // opaque 400 from the API. It has to change in the DTO first (and in
+        // the `dto.spec.ts` cases that pin it), so it is deliberately left at 3
+        // here rather than split the client and the server apart.
+        //
+        // `.trim()` so the client and this schema agree on what "3 characters"
+        // means. The form checks the trimmed length — `"  ab  "` is a
+        // two-character name however it is padded — and without the same
+        // treatment here the client would be the stricter of the two, which is
+        // the exact failure mode EW-076 is about, only in the other field.
         username: z
             .string()
+            .trim()
             .min(
                 VALIDATION_RULES.USERNAME_MIN_LENGTH,
-                t('username.minLength', { length: VALIDATION_RULES.USERNAME_MIN_LENGTH }),
+                t('name.minLength', { length: VALIDATION_RULES.USERNAME_MIN_LENGTH }),
             ),
         email: z.string().email(t('email.invalid')),
         password: z
             .string()
-            .min(8, t('password.minLength', { length: 8 }))
-            .regex(/[a-z]/, t('password.lowercase'))
-            .regex(/(\d|\W)/, t('password.numberOrSpecial'))
-            .regex(/^[^.\n]/, t('password.cannotStartWith')),
+            .min(PASSWORD_RULES.MIN_LENGTH, t('password.minLength', { length: 8 }))
+            .regex(PASSWORD_RULES.LOWERCASE, t('password.lowercase'))
+            .regex(PASSWORD_RULES.NUMBER_OR_SPECIAL, t('password.numberOrSpecial'))
+            .regex(PASSWORD_RULES.NOT_STARTING_WITH_DOT_OR_NEWLINE, t('password.cannotStartWith')),
         terms: z.array(termsClaimSchema).min(1, t('terms.required')),
     });
 
@@ -360,12 +385,15 @@ export async function resetPassword(token: string, newPassword: string) {
     // Validation
     const resetSchema = z.object({
         token: z.string().min(1, 'Token is required'),
+        // Same shared rules as `register` above. EW-076's underscore gap was
+        // copy-pasted into this schema too, so a password the API accepts was
+        // rejected here as well.
         password: z
             .string()
-            .min(8, t('password.minLength', { length: 8 }))
-            .regex(/[a-z]/, t('password.lowercase'))
-            .regex(/(\d|\W)/, t('password.numberOrSpecial'))
-            .regex(/^[^.\n]/, t('password.cannotStartWith')),
+            .min(PASSWORD_RULES.MIN_LENGTH, t('password.minLength', { length: 8 }))
+            .regex(PASSWORD_RULES.LOWERCASE, t('password.lowercase'))
+            .regex(PASSWORD_RULES.NUMBER_OR_SPECIAL, t('password.numberOrSpecial'))
+            .regex(PASSWORD_RULES.NOT_STARTING_WITH_DOT_OR_NEWLINE, t('password.cannotStartWith')),
     });
 
     const validation = resetSchema.safeParse({ token, password: newPassword });

--- a/apps/web/src/app/actions/validation.ts
+++ b/apps/web/src/app/actions/validation.ts
@@ -3,3 +3,29 @@ export const VALIDATION_RULES = {
     PASSWORD_MIN_LENGTH: 6,
     USERNAME_MIN_LENGTH: 3,
 } as const;
+
+/**
+ * The password rules the server actions in this folder actually enforce.
+ *
+ * They live here, next to `VALIDATION_RULES`, for one reason: the signup form
+ * has to show them next to the field BEFORE submit, and a second hand-written
+ * copy of the same four regexes inside the client component is a drift bug
+ * waiting to happen. Both sides import these.
+ *
+ * `NUMBER_OR_SPECIAL` deserves its own note (EW-076). The web side used to
+ * spell it `/(\d|\W)/`. `\W` is `[^A-Za-z0-9_]` — it excludes the underscore.
+ * The API's `RegisterDto` (apps/api/src/auth/dto/auth.dto.ts) spells the same
+ * rule `/^(?=.*[a-z])(?=.*[\d\W_]).{8,}$/`, and `[\d\W_]` *includes* it. So
+ * `abcdefg_` was a password the API would have accepted and the web layer
+ * rejected before it ever got there. The class below is the API's, verbatim,
+ * so the client can never reject what the server would take.
+ *
+ * None of these carry the `g` flag: `RegExp.prototype.test` is stateless
+ * without it, so these constants are safe to share across calls.
+ */
+export const PASSWORD_RULES = {
+    MIN_LENGTH: 8,
+    LOWERCASE: /[a-z]/,
+    NUMBER_OR_SPECIAL: /[\d\W_]/,
+    NOT_STARTING_WITH_DOT_OR_NEWLINE: /^[^.\n]/,
+} as const;

--- a/apps/web/src/app/actions/validation.unit.spec.ts
+++ b/apps/web/src/app/actions/validation.unit.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { PASSWORD_RULES } from './validation';
+
+/**
+ * EW-076 — the web password rules must never reject a password the API accepts.
+ *
+ * The API's contract is one regex, in `RegisterDto.password`
+ * (apps/api/src/auth/dto/auth.dto.ts):
+ *
+ *     /^(?=.*[a-z])(?=.*[\d\W_]).{8,}$/
+ *
+ * The web side spelled the same rule as three separate checks, and one of them
+ * disagreed: `/(\d|\W)/` where the API says `[\d\W_]`. `\W` is `[^A-Za-z0-9_]`,
+ * so it excludes exactly one character the API includes — the underscore. A
+ * password like `abcdefg_` was therefore accepted by the API and rejected by
+ * the web layer before it ever got there, with a message ("must contain at
+ * least one number or special character") that flatly contradicts the server.
+ *
+ * This spec is a differential test, not a restatement of the fix: it runs the
+ * API's own regex and the web's rules over the same corpus and asserts the web
+ * is never the stricter of the two. Copying `[\d\W_]` into an assertion would
+ * pass no matter which way either side drifted.
+ */
+
+// Verbatim from apps/api/src/auth/dto/auth.dto.ts (RegisterDto.password).
+// Kept as a literal on purpose: this is the contract under test, so it must be
+// readable here without chasing an import across the workspace boundary.
+const API_PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[\d\W_]).{8,}$/;
+
+/** The web layer's verdict, assembled from the shared rules the app enforces. */
+function webAccepts(password: string): boolean {
+    return (
+        password.length >= PASSWORD_RULES.MIN_LENGTH &&
+        PASSWORD_RULES.LOWERCASE.test(password) &&
+        PASSWORD_RULES.NUMBER_OR_SPECIAL.test(password)
+    );
+}
+
+/**
+ * Passwords spanning every way the two spellings could disagree: underscore
+ * only, digit only, punctuation only, whitespace, unicode, and the plain
+ * letters-only case both sides must reject.
+ */
+const CORPUS = [
+    'abcdefg_', // underscore is the ONLY "special" — the EW-076 case
+    '_abcdefgh', // leading underscore
+    'ab_cd_efg', // underscores in the middle
+    'password_', // realistic
+    'abcdefgh1', // digit
+    'abcdefgh!', // punctuation
+    'abcdefgh ', // whitespace (\W)
+    'abcdefgh€', // non-ASCII symbol (\W)
+    'abcdefghi', // letters only — both must reject
+    'ABCDEFGH1', // no lowercase — both must reject
+    'abc_def', // 7 chars — both must reject on length
+    'абвгдеёж1', // non-Latin lowercase + digit
+];
+
+describe('PASSWORD_RULES vs the API contract (EW-076)', () => {
+    it.each(CORPUS)('web never rejects what the API accepts: %j', (password) => {
+        if (API_PASSWORD_REGEX.test(password)) {
+            expect(webAccepts(password)).toBe(true);
+        }
+    });
+
+    it('control: the corpus really does contain passwords the API accepts', () => {
+        // Without this, the assertion above is vacuously true if every sample
+        // happens to fail the API regex — the check would look green while
+        // testing nothing at all.
+        const accepted = CORPUS.filter((p) => API_PASSWORD_REGEX.test(p));
+        expect(accepted.length).toBeGreaterThan(5);
+        expect(accepted).toContain('abcdefg_');
+    });
+
+    it('control: the corpus really does contain passwords the API rejects', () => {
+        // And the mirror — proves the API regex is discriminating here rather
+        // than accepting everything handed to it.
+        //
+        // `абвгдеёж1` is in this list because the API's `(?=.*[a-z])` is ASCII
+        // only, so an all-Cyrillic password has no "lowercase letter" as far as
+        // it is concerned. That is arguably its own defect in an app shipping
+        // 21 locales, but it is the API's rule and `PASSWORD_RULES.LOWERCASE`
+        // is `/[a-z]/` too — the two agree, which is all this file is about.
+        expect(CORPUS.filter((p) => !API_PASSWORD_REGEX.test(p))).toEqual([
+            'abcdefghi',
+            'ABCDEFGH1',
+            'abc_def',
+            'абвгдеёж1',
+        ]);
+    });
+
+    it('the underscore counts as a special character, as it does on the API', () => {
+        // The single character the old `/(\d|\W)/` got wrong, pinned directly.
+        expect(PASSWORD_RULES.NUMBER_OR_SPECIAL.test('_')).toBe(true);
+        expect(/(\d|\W)/.test('_')).toBe(false); // the old spelling, for contrast
+    });
+
+    it('still rejects a password with neither a number nor a special character', () => {
+        // The rule must not have been widened into uselessness to make the
+        // underscore pass — `[\d\W_]` matches no plain letter.
+        expect(PASSWORD_RULES.NUMBER_OR_SPECIAL.test('abcdefghi')).toBe(false);
+        expect(webAccepts('abcdefghi')).toBe(false);
+    });
+
+    it('the rules are stateless — no `g` flag carrying lastIndex between calls', () => {
+        // A `g`-flagged shared regex returns alternating true/false across
+        // calls; these constants are module-level and reused per keystroke.
+        for (const rule of Object.values(PASSWORD_RULES)) {
+            if (rule instanceof RegExp) expect(rule.global).toBe(false);
+        }
+        expect(PASSWORD_RULES.LOWERCASE.test('abc')).toBe(true);
+        expect(PASSWORD_RULES.LOWERCASE.test('abc')).toBe(true);
+    });
+});


### PR DESCRIPTION
## The defect class

Four findings on the signup form, all the same shape: **a rule the server enforces that the page neither states nor checks.** The only way to discover any of them was to fill the form in, submit, and read a banner naming something you cannot see on screen.

| | Before | After |
|---|---|---|
| **EW-073** | Hint: *"Must be at least 8 characters"*. Also enforced: lowercase, number-or-special, no leading dot. `PASSWORD12` passed every on-screen rule and every check the page ran, then was rejected by the server. | Hint states all of them; all four rules run client-side and the failing one is shown against the field. |
| **EW-074** | Field labelled **"Full name"**, rejected with *"**Username** must contain at least 3 characters"* — a field this form does not have — and the minimum was never displayed. | `validation.auth.name.minLength` names the field on screen. Minimum shown beside the input and checked before submit. |
| **EW-076** | Web: `/(\d|\W)/`. API `RegisterDto`: `[\d\W_]`. `\W` excludes the underscore, so **`abcdefg_` was accepted by the API and rejected by the web layer before it got there.** | One shared constant, spelled the API's way, imported by both the client and the action. |
| **EW-075** | Corpus fails to load → checkbox, *Create account* and every social button disabled, **no message, no way forward** but a manual reload. | Explains itself and offers a retry that re-runs the server component. The guard itself is unchanged — submit stays blocked. |

## What changed

- **`apps/web/src/app/actions/validation.ts`** — new `PASSWORD_RULES` holding the four rules in one place. The client has to show these before submit, and a second hand-written copy of the same regexes inside the component is exactly how EW-076 happened in the first place.
- **`apps/web/src/app/actions/auth.ts`** — `register` and `resetPassword` use the shared rules (both had the underscore gap). `register`'s name error moves to `name.minLength`, and its schema gains `.trim()` so it counts the same characters the form counts.
- **`register-form.tsx`** — errors keyed by field instead of one banner, matching the sibling reset-password form; inline password + name checks; terms-unavailable notice with retry.
- **21 locale files** — the password hint takes **each locale's own** `auth.resetPassword.form.password.helperText`, which already says all three rules, so this is a real translation in all 21 rather than English pushed into 20. New keys (`name.hint`, `name.minLength`, `errors.termsUnavailable.*`) carry English everywhere, per the existing convention.

## On the CJK minimum

The 3-character floor **does** exclude ordinary two-character CJK names — 山田 is a real full name — in an app shipping `ja`/`ko`/`zh`. It is deliberately **left at 3** here. The floor is the API's own `@MinLength(3)` on `RegisterDto.username`; lowering it on the web alone would not admit 山田, it would only move the rejection from an instant client-side message to an opaque 400. Changing it needs the DTO and the `dto.spec.ts` cases that pin it, which is outside this group. The message and the rule are at least truthful and visible now, and the constraint is documented at the schema.

## Verification

`apps/web`: **180 files / 1854 tests pass**, `tsc --noEmit` clean, eslint clean on all 6 touched files (confirmed via `--format json` that the globs actually matched — bracketed route dirs silently match nothing otherwise), prettier clean.

**Every fix was proven by breaking it.** Each was reverted one at a time and the suite re-run:

| Deliberate break | Result |
|---|---|
| baseline | 40 passed, exit 0 |
| `NUMBER_OR_SPECIAL` back to `/(\d\|\W)/` | **7 failed** |
| password hint back to length-only | **1 failed** |
| inline password checks removed | **3 failed** |
| terms-unavailable notice + retry removed | **2 failed** |
| signup back to the `username.minLength` message | **4 failed** |
| name minimum no longer checked pre-submit | **1 failed** |
| action stops trimming (client stricter than server) | **1 failed** |
| restored | 40 passed, exit 0 |

The EW-076 spec is a **differential** test rather than a restatement of the fix: it runs the API's own regex and the web rules over one corpus and asserts the web is never the stricter of the two, with controls proving the corpus contains passwords the API both accepts and rejects. It caught a real surprise while being written — the API's `(?=.*[a-z])` is ASCII-only, so an all-Cyrillic password has no "lowercase letter" as far as it is concerned. `PASSWORD_RULES.LOWERCASE` is `/[a-z]/` too, so the two agree; noted in the spec as its own (out-of-scope) finding.

The form specs mock `next-intl` by resolving **real strings out of `messages/en.json`** rather than echoing keys back, so a key that does not exist fails loudly instead of rendering its own name, and assertions read against the words a user actually sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
