### PR TITLE
fix(auth): a signed-out path to a new verification email, and reset failures told apart (EW-070, EW-082)

### DIFF
--- a/apps/api/src/auth/controllers/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth.controller.spec.ts
@@ -10,8 +10,11 @@ jest.mock('@ever-works/agent/services', () => ({
     ZeroFrictionFunnelService: class ZeroFrictionFunnelService {},
 }));
 
+import 'reflect-metadata';
 import { BadRequestException } from '@nestjs/common';
+import { THROTTLER_LIMIT, THROTTLER_TTL } from '@nestjs/throttler/dist/throttler.constants';
 import { AuthController } from './auth.controller';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 import type { AuthService } from '../services/auth.service';
 import type { AnonymousAuthService } from '../services/anonymous-auth.service';
 import type { ClaimAccountService } from '../services/claim-account.service';
@@ -31,6 +34,7 @@ describe('AuthController', () => {
             | 'getUserProfile'
             | 'updateUserProfile'
             | 'verifyEmail'
+            | 'resendVerificationEmail'
             | 'forgotPassword'
             | 'getUserByPasswordResetToken'
             | 'consumePasswordResetToken'
@@ -75,6 +79,7 @@ describe('AuthController', () => {
             getUserProfile: jest.fn(),
             updateUserProfile: jest.fn(),
             verifyEmail: jest.fn(),
+            resendVerificationEmail: jest.fn(),
             forgotPassword: jest.fn(),
             getUserByPasswordResetToken: jest.fn(),
             consumePasswordResetToken: jest.fn().mockResolvedValue(undefined),
@@ -763,6 +768,56 @@ describe('AuthController', () => {
                 'Invalid or expired token',
             );
             expect(authProvider.issueSession).not.toHaveBeenCalled();
+        });
+    });
+
+    // EW-070 — the signed-out resend route. The two properties that make this
+    // route safe (it is reachable WITHOUT a session, and it cannot be turned
+    // into a mail cannon) live in decorator metadata, so they are asserted
+    // here rather than left to a code reading.
+    describe('resendVerification (POST /api/auth/resend-verification)', () => {
+        it('forwards the full dto to authService.resendVerificationEmail', async () => {
+            authService.resendVerificationEmail.mockResolvedValue({ message: 'ok' } as any);
+
+            const dto: any = {
+                email: 'a@b.co',
+                emailVerificationCallbackUrl: 'https://app/v',
+            };
+            const result = await controller.resendVerification(dto);
+
+            expect(authService.resendVerificationEmail).toHaveBeenCalledWith(dto);
+            expect(result).toEqual({ message: 'ok' });
+        });
+
+        it('is @Public() — the whole point is that it works WITHOUT a session', () => {
+            // An unverified user cannot log in (login answers 403), so a
+            // session-guarded resend is unreachable exactly when it is needed.
+            const meta = Reflect.getMetadata(
+                IS_PUBLIC_KEY,
+                AuthController.prototype.resendVerification,
+            );
+            expect(meta).toBe(true);
+        });
+
+        it('is @Throttle()d on the `long` tier so it cannot be used as a mail cannon', () => {
+            const handler = AuthController.prototype.resendVerification;
+
+            // Keyed on `long`, not `default`. A `default`-keyed override binds
+            // to no configured throttler (the tiers are short/medium/long — see
+            // throttler.config.ts) and is silently ignored, leaving only the
+            // loose 1000/min global cap. That trap is why this asserts the tier
+            // NAME and not merely "some throttle exists".
+            const limit = Reflect.getMetadata(THROTTLER_LIMIT + 'long', handler);
+            const ttl = Reflect.getMetadata(THROTTLER_TTL + 'long', handler);
+
+            expect(limit).toBeDefined();
+            expect(Number(limit)).toBe(5);
+            expect(Number(ttl)).toBe(60_000);
+
+            // The inert key carries nothing — if someone "fixes" this route by
+            // moving the override to `default`, the cap silently disappears and
+            // the assertion above starts failing.
+            expect(Reflect.getMetadata(THROTTLER_LIMIT + 'default', handler)).toBeUndefined();
         });
     });
 

--- a/apps/api/src/auth/controllers/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth.controller.ts
@@ -29,7 +29,12 @@ import { CaptchaVerifierService } from '../services/captcha-verifier.service';
 import { ZeroFrictionFunnelService } from '@ever-works/agent/services';
 import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import { RegisterDto, LoginDto, UpdatePasswordDto, ClaimAccountDto } from '../dto/auth.dto';
-import { VerifyEmailDto, ForgotPasswordDto, ResetPasswordDto } from '../dto/email-verification.dto';
+import {
+    VerifyEmailDto,
+    ForgotPasswordDto,
+    ResetPasswordDto,
+    ResendVerificationDto,
+} from '../dto/email-verification.dto';
 import { RequestMagicLinkDto, RedeemMagicLinkDto } from '../dto/magic-link.dto';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { CreateAnonymousDto } from '../dto/anonymous.dto';
@@ -552,6 +557,46 @@ export class AuthController {
     @ApiResponse({ status: 200, description: 'Verification email sent' })
     async sendVerification(@Request() req) {
         return this.authService.sendVerificationEmail(req.user.userId);
+    }
+
+    /**
+     * EW-070 — the signed-out way back in.
+     *
+     * `send-verification` above requires a session, and an unverified account
+     * cannot get one (login answers 403). Without a public counterpart, a
+     * user whose verification mail was lost is locked out permanently. This
+     * is that counterpart.
+     *
+     * The response is deliberately uninformative: identical 200 body whether
+     * the address is unknown, already verified, deactivated, or was really
+     * just mailed. See `AuthService.resendVerificationEmail` for the full
+     * property list.
+     */
+    @Public()
+    // Security: this route causes mail to be sent to an attacker-chosen
+    // address, so it needs the tightest cap in the file. Keyed on the
+    // configured `long` tier — a `default`-keyed override binds to no real
+    // throttler and is silently ignored, leaving only the loose 1000/min
+    // global cap (the same trap documented on register/forgot-password).
+    // Env-tunable so the e2e suite, which drives every spec from one source
+    // IP, can raise it — mirroring REGISTER_THROTTLE_LIMIT.
+    @Throttle({
+        long: {
+            limit: Number(process.env.RESEND_VERIFICATION_THROTTLE_LIMIT ?? 5),
+            ttl: Number(process.env.RESEND_VERIFICATION_THROTTLE_TTL_MS ?? 60_000),
+        },
+    })
+    @Post('resend-verification')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Resend verification email (public)',
+        description:
+            'Request a fresh email-verification link without being signed in. Always returns the same 200 body regardless of whether the address exists, is already verified, or was mailed.',
+    })
+    @ApiResponse({ status: 200, description: 'Verification email sent if applicable' })
+    @ApiResponse({ status: 429, description: 'Too many requests' })
+    async resendVerification(@Body() resendVerificationDto: ResendVerificationDto) {
+        return this.authService.resendVerificationEmail(resendVerificationDto);
     }
 
     @Public()

--- a/apps/api/src/auth/dto/email-verification.dto.ts
+++ b/apps/api/src/auth/dto/email-verification.dto.ts
@@ -8,6 +8,14 @@ export class VerifyEmailDto {
     token: string;
 }
 
+/**
+ * EW-070 — body of the SIGNED-OUT verification resend.
+ *
+ * The class existed since the first auth commit but nothing ever imported it:
+ * there was no public resend route, so a user whose verification mail never
+ * arrived had no way back in (login 403s, and the authenticated
+ * `POST /auth/send-verification` needs the session they cannot get).
+ */
 export class ResendVerificationDto {
     @ApiProperty({
         description: 'Email address to resend verification to',
@@ -16,6 +24,14 @@ export class ResendVerificationDto {
     @IsEmail()
     @IsNotEmpty()
     email: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Callback URL the verification link should point at. Host-validated against ALLOWED_CALLBACK_HOSTS; anything else falls back to the platform default.',
+    })
+    @IsString()
+    @IsOptional()
+    emailVerificationCallbackUrl?: string;
 }
 
 export class ForgotPasswordDto {

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -483,6 +483,203 @@ describe('AuthService', () => {
         });
     });
 
+    // EW-070 — the signed-out resend. Before this existed, an unverified user
+    // whose verification mail never arrived was locked out permanently: login
+    // answers 403, and the only resend route required the session the 403 was
+    // withholding.
+    describe('resendVerificationEmail', () => {
+        const MESSAGE = AuthService.RESEND_VERIFICATION_MESSAGE;
+
+        it('THE anti-enumeration assertion: byte-identical response for a known and an unknown address', async () => {
+            // Unknown address.
+            userRepo.findByEmail.mockResolvedValueOnce(null);
+            const unknown = await service.resendVerificationEmail({
+                email: 'nobody@x.test',
+            } as any);
+
+            // Known, unverified address — this branch really does send mail.
+            userRepo.findByEmail.mockResolvedValueOnce({
+                id: 'u-1',
+                emailVerified: false,
+                isActive: true,
+            } as any);
+            userRepo.findById.mockResolvedValue({
+                id: 'u-1',
+                emailVerified: false,
+            } as any);
+            userRepo.update.mockResolvedValue({} as any);
+            const known = await service.resendVerificationEmail({ email: 'real@x.test' } as any);
+
+            // Same keys, same values — and byte-for-byte the same serialization,
+            // which is what a caller on the wire actually compares.
+            expect(known).toEqual(unknown);
+            expect(JSON.stringify(known)).toBe(JSON.stringify(unknown));
+            expect(Object.keys(known)).toEqual(Object.keys(unknown));
+            expect(known.message).toBe(MESSAGE);
+
+            // ...and the branches really WERE different underneath, otherwise
+            // this test would pass just as happily against a stub that never
+            // sends anything.
+            expect(emitter.emit).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns the same body for an ALREADY VERIFIED address, and sends nothing', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-2',
+                emailVerified: true,
+                isActive: true,
+            } as any);
+
+            const result = await service.resendVerificationEmail({
+                email: 'done@x.test',
+            } as any);
+
+            expect(result).toEqual({ message: MESSAGE });
+            // Resending to a verified address is pointless, and answering
+            // differently would turn this route into a verification-state oracle.
+            expect(emitter.emit).not.toHaveBeenCalled();
+            expect(userRepo.update).not.toHaveBeenCalled();
+        });
+
+        it('returns the same body for a DEACTIVATED account, and sends nothing', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-3',
+                emailVerified: false,
+                isActive: false,
+            } as any);
+
+            const result = await service.resendVerificationEmail({
+                email: 'suspended@x.test',
+            } as any);
+
+            expect(result).toEqual({ message: MESSAGE });
+            expect(emitter.emit).not.toHaveBeenCalled();
+        });
+
+        it('reuses the EXISTING verification-token machinery — no second token format', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-1',
+                emailVerified: false,
+                isActive: true,
+            } as any);
+            userRepo.findById.mockResolvedValue({ id: 'u-1', emailVerified: false } as any);
+            userRepo.update.mockResolvedValue({} as any);
+
+            await service.resendVerificationEmail({ email: 'real@x.test' } as any);
+
+            // Same event as registration's first send...
+            expect(emitter.emit).toHaveBeenCalledWith(
+                UserCreatedEvent.EVENT_NAME,
+                expect.any(UserCreatedEvent),
+            );
+            const event = emitter.emit.mock.calls[0][1] as UserCreatedEvent;
+
+            // ...same 32-byte raw token in the link (64 hex chars)...
+            expect(event.confirmationToken).toMatch(/^[0-9a-f]{64}$/);
+
+            // ...same H-01 sha256-at-rest storage in the SAME column...
+            const updateInput = userRepo.update.mock.calls[0][1];
+            expect(updateInput.emailVerificationToken).toBe(
+                createHash('sha256').update(event.confirmationToken, 'utf8').digest('hex'),
+            );
+
+            // ...and the same 24h expiry.
+            const expires = updateInput.emailVerificationExpires as Date;
+            expect(expires.getTime() - Date.now()).toBeGreaterThan(23 * 60 * 60 * 1000);
+            expect(expires.getTime() - Date.now()).toBeLessThan(25 * 60 * 60 * 1000);
+        });
+
+        it('never leaks the token in the response body (C-01)', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-1',
+                emailVerified: false,
+                isActive: true,
+            } as any);
+            userRepo.findById.mockResolvedValue({ id: 'u-1', emailVerified: false } as any);
+            userRepo.update.mockResolvedValue({} as any);
+
+            const result = await service.resendVerificationEmail({ email: 'real@x.test' } as any);
+            const event = emitter.emit.mock.calls[0][1] as UserCreatedEvent;
+
+            expect(JSON.stringify(result)).not.toContain(event.confirmationToken);
+            expect(Object.keys(result)).toEqual(['message']);
+        });
+
+        it('inherits the C-04 callback-host allow-list — an attacker host falls back to the platform default', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-1',
+                emailVerified: false,
+                isActive: true,
+            } as any);
+            userRepo.findById.mockResolvedValue({ id: 'u-1', emailVerified: false } as any);
+            userRepo.update.mockResolvedValue({} as any);
+
+            await service.resendVerificationEmail({
+                email: 'real@x.test',
+                emailVerificationCallbackUrl: 'https://attacker.example/steal',
+            } as any);
+
+            const event = emitter.emit.mock.calls[0][1] as UserCreatedEvent;
+            expect(event.confirmationUrl).toBe(
+                `https://app.test/api/auth/verify-email?token=${event.confirmationToken}`,
+            );
+        });
+
+        it('honours an ALLOWED callback host', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-1',
+                emailVerified: false,
+                isActive: true,
+            } as any);
+            userRepo.findById.mockResolvedValue({ id: 'u-1', emailVerified: false } as any);
+            userRepo.update.mockResolvedValue({} as any);
+
+            await service.resendVerificationEmail({
+                email: 'real@x.test',
+                emailVerificationCallbackUrl: 'https://x.test/verify',
+            } as any);
+
+            const event = emitter.emit.mock.calls[0][1] as UserCreatedEvent;
+            expect(event.confirmationUrl).toBe(
+                `https://x.test/verify?token=${event.confirmationToken}`,
+            );
+        });
+
+        it('a DOWNSTREAM FAILURE still returns the identical body — a 500 here would itself be an oracle', async () => {
+            userRepo.findByEmail.mockResolvedValue({
+                id: 'u-1',
+                emailVerified: false,
+                isActive: true,
+            } as any);
+            // sendVerificationEmail re-reads the user and throws if it is gone.
+            userRepo.findById.mockResolvedValue(null);
+
+            const result = await service.resendVerificationEmail({
+                email: 'real@x.test',
+            } as any);
+
+            expect(result).toEqual({ message: MESSAGE });
+            expect(emitter.emit).not.toHaveBeenCalled();
+        });
+
+        it('runs the timing-equalization hash on the no-user branch too (H-03)', async () => {
+            userRepo.findByEmail.mockResolvedValue(null);
+            const bcryptSpy = jest.spyOn(bcrypt, 'hash').mockResolvedValue('dummy' as never);
+            bcryptSpy.mockClear();
+
+            await service.resendVerificationEmail({ email: 'no@one.test' } as any);
+
+            // Without this, the no-user branch returns in microseconds while the
+            // user-exists branch does a DB write plus an email dispatch — and
+            // wall-clock leaks exactly what the identical body hides.
+            expect(bcryptSpy).toHaveBeenCalledTimes(1);
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const { getBcryptCost } = require('../providers/bcrypt-cost');
+            expect(bcryptSpy.mock.calls[0][1]).toBe(getBcryptCost());
+            bcryptSpy.mockRestore();
+        });
+    });
+
     describe('forgotPassword', () => {
         it('returns generic message and skips emit when email unknown', async () => {
             userRepo.findByEmail.mockResolvedValue(null);

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -31,13 +31,22 @@ import {
     UserForgotPasswordEvent,
     UserMagicLinkRequestedEvent,
 } from '../../events';
-import { ForgotPasswordDto } from '../dto/email-verification.dto';
+import { ForgotPasswordDto, ResendVerificationDto } from '../dto/email-verification.dto';
 import { RequestMagicLinkDto } from '../dto/magic-link.dto';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import type { SocialAuthUser } from '../types/social-auth.types';
 
 @Injectable()
 export class AuthService {
+    /**
+     * EW-070 — the single body `resendVerificationEmail` answers with, on
+     * every branch. Held as a constant so the anti-enumeration test can
+     * assert the known-address and unknown-address responses are the same
+     * string rather than two independently-drifting literals.
+     */
+    static readonly RESEND_VERIFICATION_MESSAGE =
+        'If an account exists for that address and still needs verification, a verification email has been sent';
+
     private readonly logger = new Logger(AuthService.name);
 
     private webAppUrl: string;
@@ -342,6 +351,71 @@ export class AuthService {
         );
 
         return updatedUser;
+    }
+
+    /**
+     * EW-070 — signed-out resend of the email-verification link.
+     *
+     * Until this existed there was no way back in for a user whose
+     * verification mail never arrived: `login` answers 403 for an unverified
+     * address, and the only resend route (`POST /auth/send-verification`)
+     * sits behind `AuthSessionGuard` — it needs the session the 403 is
+     * withholding. That is a permanent lockout reachable by nothing worse
+     * than a slow mail server.
+     *
+     * Security properties, mirroring `forgotPassword` below:
+     *  - ANTI-ENUMERATION. Every outcome — unknown address, already-verified
+     *    address, deactivated account, unverified account that really was
+     *    mailed, downstream mailer failure — returns HTTP 200 with the
+     *    byte-identical body `RESEND_VERIFICATION_MESSAGE`. Nothing in the
+     *    response distinguishes them, so this endpoint cannot be used to
+     *    test whether an address has an account here.
+     *  - TIMING. The same throwaway bcrypt runs on every branch (see H-03 on
+     *    `forgotPassword`) so wall-clock does not leak what the body hides.
+     *  - ONE TOKEN FORMAT. The mail itself is issued by the existing
+     *    `sendVerificationEmail`, so this shares the 32-byte token, the
+     *    sha256-at-rest storage (H-01), the 24h expiry, the callback-host
+     *    allow-list (C-04) and the `UserCreatedEvent` mail path. No second
+     *    token format is introduced.
+     *
+     * Rate limiting lives on the controller (`@Throttle`) — without it this
+     * is a mail cannon aimed at any address an attacker names.
+     */
+    async resendVerificationEmail(resendVerificationDto: ResendVerificationDto) {
+        // Same expensive work on every branch before any branch-specific
+        // behaviour, so timing cannot separate "account exists and is
+        // unverified" from the three silent branches below.
+        await this.randomHashedPassword().catch(() => undefined);
+
+        const user = await this.userRepository.findByEmail(resendVerificationDto.email);
+
+        // Three silent branches, one shared body:
+        //  - no account for this address,
+        //  - the address is already verified (resending would be pointless
+        //    and lets an attacker probe verification state),
+        //  - the account is deactivated (do not mail it; a suspension must
+        //    not become a mail-cannon trigger).
+        const shouldSend = Boolean(user) && !user!.emailVerified && user!.isActive !== false;
+
+        if (shouldSend) {
+            try {
+                await this.sendVerificationEmail(
+                    user!.id,
+                    resendVerificationDto.emailVerificationCallbackUrl,
+                );
+            } catch (error) {
+                // A downstream failure must NOT change the response — a 500
+                // here where an unknown address gets a 200 is itself an
+                // enumeration oracle. Log for operators, answer identically.
+                this.logger.error(
+                    `Failed to resend verification email for user ${user!.id}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+
+        return { message: AuthService.RESEND_VERIFICATION_MESSAGE };
     }
 
     async forgotPassword(forgotPasswordDto: ForgotPasswordDto) {

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -134,6 +134,35 @@
                 "link": "إنشاء حساب"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "إعادة تعيين كلمة المرور",
             "subtitle": "أدخل كلمة المرور الجديدة أدناه",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "فشل في إعادة تعيين كلمة المرور. يرجى المحاولة مرة أخرى أو طلب رابط إعادة تعيين جديد.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "رابط إعادة تعيين غير صالح",
                 "invalidLink": "رابط إعادة تعيين غير صالح",
                 "missingTokenMessage": "رابط إعادة تعيين كلمة المرور غير صالح أو غير كامل. يرجى طلب إعادة تعيين جديدة.",
@@ -7727,6 +7760,7 @@
             "signIn": "تسجيل الدخول",
             "createAccount": "إنشاء حساب",
             "forgotPassword": "نسيت كلمة المرور",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "إعادة تعيين كلمة المرور",
             "authError": "خطأ في المصادقة",
             "dashboard": "لوحة التحكم",
@@ -7768,6 +7802,7 @@
             "unsupportedProvider": "مزود غير مدعوم",
             "providerConnectFailed": "فشل في ربط المزود",
             "forgotPasswordFailed": "فشل في إرسال بريد إعادة تعيين كلمة المرور",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "فشل في إعادة تعيين كلمة المرور",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -134,6 +134,35 @@
                 "link": "Регистрация"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Сменете паролата си",
             "subtitle": "Въведете новата парола по-долу",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Неуспешна смяна на парола. Моля, опитайте отново или поискайте нова връзка за нова парола.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Невалидна връзка за нова парола",
                 "invalidLink": "Невалидна връзка за нова парола",
                 "missingTokenMessage": "Връзката за нова парола е невалидна или непълна. Моля, поискайте нова смяна на парола.",
@@ -7727,6 +7760,7 @@
             "signIn": "Вход",
             "createAccount": "Създай акаунт",
             "forgotPassword": "Забравена парола",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Нова парола",
             "authError": "Грешка при автентикация",
             "dashboard": "Табло",
@@ -7768,6 +7802,7 @@
             "unsupportedProvider": "Неподдържан доставчик",
             "providerConnectFailed": "Свързването с доставчика неуспешно",
             "forgotPasswordFailed": "Неуспешно изпращане на имейл за нова парола",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Неуспешно нулиране на парола",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -134,6 +134,35 @@
                 "link": "Registrieren"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Passwort zurücksetzen",
             "subtitle": "Geben Sie Ihr neues Passwort unten ein",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Passwort konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut oder fordern Sie einen neuen Reset-Link an.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Ungültiger Reset-Link",
                 "invalidLink": "Ungültiger Reset-Link",
                 "missingTokenMessage": "Der Passwort-Reset-Link ist ungültig oder unvollständig. Bitte fordern Sie einen neuen Passwort-Reset an.",
@@ -7727,6 +7760,7 @@
             "signIn": "Anmelden",
             "createAccount": "Konto erstellen",
             "forgotPassword": "Passwort vergessen",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Passwort zurücksetzen",
             "authError": "Authentifizierungsfehler",
             "dashboard": "Dashboard",
@@ -7768,6 +7802,7 @@
             "unsupportedProvider": "Nicht unterstützter Anbieter",
             "providerConnectFailed": "Verbindung zum Anbieter fehlgeschlagen",
             "forgotPasswordFailed": "Passwort-Reset-E-Mail konnte nicht gesendet werden",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Passwort konnte nicht zurückgesetzt werden",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -134,6 +134,35 @@
                 "link": "Sign up"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Reset your password",
             "subtitle": "Enter your new password below",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Failed to reset password. Please try again or request a new reset link.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Invalid reset link",
                 "invalidLink": "Invalid Reset Link",
                 "missingTokenMessage": "The password reset link is invalid or incomplete. Please request a new password reset.",
@@ -7733,6 +7766,7 @@
             "signIn": "Sign In",
             "createAccount": "Create Account",
             "forgotPassword": "Forgot Password",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Reset Password",
             "authError": "Authentication Error",
             "dashboard": "Dashboard",
@@ -7774,6 +7808,7 @@
             "unsupportedProvider": "Unsupported provider",
             "providerConnectFailed": "Failed to connect provider",
             "forgotPasswordFailed": "Failed to send password reset email",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Failed to reset password",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -134,6 +134,35 @@
                 "link": "Regístrate"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Restablece tu contraseña",
             "subtitle": "Ingresa tu nueva contraseña a continuación",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Error al restablecer la contraseña. Inténtalo de nuevo o solicita un nuevo enlace de restablecimiento.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Enlace de restablecimiento inválido",
                 "invalidLink": "Enlace de Restablecimiento Inválido",
                 "missingTokenMessage": "El enlace de restablecimiento de contraseña es inválido o incompleto. Solicita un nuevo restablecimiento de contraseña.",
@@ -7727,6 +7760,7 @@
             "signIn": "Iniciar sesión",
             "createAccount": "Crear cuenta",
             "forgotPassword": "Olvidé mi contraseña",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Restablecer contraseña",
             "authError": "Error de autenticación",
             "dashboard": "Panel",
@@ -7768,6 +7802,7 @@
             "unsupportedProvider": "Proveedor no compatible",
             "providerConnectFailed": "Fallo al conectar proveedor",
             "forgotPasswordFailed": "Fallo al enviar correo de restablecimiento de contraseña",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Fallo al restablecer contraseña",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -134,6 +134,35 @@
                 "link": "S'inscrire"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Réinitialiser votre mot de passe",
             "subtitle": "Saisissez votre nouveau mot de passe ci-dessous",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Échec de la réinitialisation du mot de passe. Veuillez réessayer ou demander un nouveau lien de réinitialisation.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Lien de réinitialisation invalide",
                 "invalidLink": "Lien de réinitialisation invalide",
                 "missingTokenMessage": "Le lien de réinitialisation du mot de passe est invalide ou incomplet. Veuillez demander une nouvelle réinitialisation du mot de passe.",
@@ -7727,6 +7760,7 @@
             "signIn": "Se connecter",
             "createAccount": "Créer un compte",
             "forgotPassword": "Mot de passe oublié",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Réinitialiser le mot de passe",
             "authError": "Erreur d'authentification",
             "dashboard": "Tableau de bord",
@@ -7768,6 +7802,7 @@
             "unsupportedProvider": "Fournisseur non pris en charge",
             "providerConnectFailed": "Échec de la connexion du fournisseur",
             "forgotPasswordFailed": "Échec de l'envoi de l'e-mail de réinitialisation du mot de passe",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Échec de la réinitialisation du mot de passe",
             "magicLinkFailed": "Échec de l'envoi du lien magique",
             "magicLinkInvalid": "Lien magique invalide ou expiré"

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -134,6 +134,35 @@
                 "link": "הירשם"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "אפס את הסיסמה שלך",
             "subtitle": "הזן את הסיסמה החדשה למטה",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "נכשל לאפס סיסמה. נסה שוב או בקש קישור איפוס חדש.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "קישור איפוס לא תקין",
                 "invalidLink": "קישור איפוס לא תקין",
                 "missingTokenMessage": "קישור איפוס הסיסמה לא תקין או חלקי. בקש איפוס סיסמה חדש.",
@@ -7727,6 +7760,7 @@
             "signIn": "התחבר",
             "createAccount": "צור חשבון",
             "forgotPassword": "שכחת סיסמה",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "אפס סיסמה",
             "authError": "שגיאת אימות",
             "dashboard": "לוח בקרה",
@@ -7768,6 +7802,7 @@
             "unsupportedProvider": "ספק לא נתמך",
             "providerConnectFailed": "נכשל בחיבור לספק",
             "forgotPasswordFailed": "נכשל בשליחת דוא\"ל איפוס סיסמה",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "נכשל באיפוס סיסמה",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -134,6 +134,35 @@
                 "link": "साइन अप"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "अपना पासवर्ड रीसेट करें",
             "subtitle": "नीचे अपना नया पासवर्ड दर्ज करें",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "पासवर्ड रीसेट करने में विफल। कृपया पुनः प्रयास करें या नया रीसेट लिंक अनुरोध करें।",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "अमान्य रीसेट लिंक",
                 "invalidLink": "अमान्य रीसेट लिंक",
                 "missingTokenMessage": "पासवर्ड रीसेट लिंक अमान्य या अपूर्ण है। कृपया नया पासवर्ड रीसेट अनुरोध करें।",
@@ -7728,6 +7761,7 @@
             "signIn": "साइन इन करें",
             "createAccount": "खाता बनाएं",
             "forgotPassword": "पासवर्ड भूल गए",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "पासवर्ड रीसेट करें",
             "authError": "प्रमाणीकरण त्रुटि",
             "dashboard": "डैशबोर्ड",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "असमर्थित प्रदाता",
             "providerConnectFailed": "प्रदाता से कनेक्ट करने में विफल",
             "forgotPasswordFailed": "पासवर्ड रीसेट ईमेल भेजने में विफल",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "पासवर्ड रीसेट करने में विफल",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -134,6 +134,35 @@
                 "link": "Daftar"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Reset kata sandi Anda",
             "subtitle": "Masukkan kata sandi baru di bawah ini",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Gagal mereset kata sandi. Harap coba lagi atau minta tautan reset baru.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Tautan reset tidak valid",
                 "invalidLink": "Tautan Reset Tidak Valid",
                 "missingTokenMessage": "Tautan reset kata sandi tidak valid atau tidak lengkap. Harap minta reset kata sandi baru.",
@@ -7728,6 +7761,7 @@
             "signIn": "Masuk",
             "createAccount": "Buat Akun",
             "forgotPassword": "Lupa Kata Sandi",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Atur Ulang Kata Sandi",
             "authError": "Kesalahan Autentikasi",
             "dashboard": "Dasbor",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Penyedia tidak didukung",
             "providerConnectFailed": "Gagal menghubungkan penyedia",
             "forgotPasswordFailed": "Gagal mengirim email atur ulang kata sandi",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Gagal mengatur ulang kata sandi",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -134,6 +134,35 @@
                 "link": "Iscriviti"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Resetta la tua password",
             "subtitle": "Inserisci la tua nuova password qui sotto",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Impossibile resettare la password. Riprova o richiedi un nuovo link di reset.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Link di reset non valido",
                 "invalidLink": "Link di Reset Non Valido",
                 "missingTokenMessage": "Il link di reset password non è valido o incompleto. Richiedi un nuovo reset password.",
@@ -7728,6 +7761,7 @@
             "signIn": "Accedi",
             "createAccount": "Crea account",
             "forgotPassword": "Password dimenticata",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Reimposta password",
             "authError": "Errore di autenticazione",
             "dashboard": "Dashboard",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Provider non supportato",
             "providerConnectFailed": "Connessione provider fallita",
             "forgotPasswordFailed": "Impossibile inviare email di reset password",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Impossibile resettare la password",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -134,6 +134,35 @@
                 "link": "サインアップ"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "パスワードをリセット",
             "subtitle": "新しいパスワードを以下に入力",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "パスワードのリセットに失敗しました。もう一度お試しください、または新しいリセットリンクをリクエストしてください。",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "無効なリセットリンク",
                 "invalidLink": "無効なリセットリンク",
                 "missingTokenMessage": "パスワードリセットリンクが無効または不完全です。新しいパスワードリセットをリクエストしてください。",
@@ -7728,6 +7761,7 @@
             "signIn": "サインイン",
             "createAccount": "アカウント作成",
             "forgotPassword": "パスワードをお忘れですか",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "パスワードをリセット",
             "authError": "認証エラー",
             "dashboard": "ダッシュボード",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "サポートされていないプロバイダー",
             "providerConnectFailed": "プロバイダーの接続に失敗しました",
             "forgotPasswordFailed": "パスワードリセットメールの送信に失敗しました",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "パスワードのリセットに失敗しました",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -134,6 +134,35 @@
                 "link": "회원가입"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "비밀번호 재설정",
             "subtitle": "아래에 새 비밀번호 입력",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "비밀번호 재설정 실패. 다시 시도하거나 새 재설정 링크를 요청해 주세요.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "잘못된 재설정 링크",
                 "invalidLink": "잘못된 재설정 링크",
                 "missingTokenMessage": "비밀번호 재설정 링크가 유효하지 않거나 불완전합니다. 새 비밀번호 재설정을 요청해 주세요.",
@@ -7728,6 +7761,7 @@
             "signIn": "로그인",
             "createAccount": "계정 생성",
             "forgotPassword": "비밀번호 찾기",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "비밀번호 재설정",
             "authError": "인증 오류",
             "dashboard": "대시보드",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "지원되지 않는 공급자",
             "providerConnectFailed": "공급자 연결 실패",
             "forgotPasswordFailed": "비밀번호 재설정 이메일 발송 실패",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "비밀번호 재설정 실패",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -134,6 +134,35 @@
                 "link": "Registreren"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Reset uw wachtwoord",
             "subtitle": "Voer uw nieuwe wachtwoord hieronder in",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Kon wachtwoord niet resetten. Probeer het opnieuw of vraag een nieuwe resetlink aan.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Ongeldige resetlink",
                 "invalidLink": "Ongeldige Resetlink",
                 "missingTokenMessage": "De wachtwoordresetlink is ongeldig of onvolledig. Vraag een nieuwe wachtwoordreset aan.",
@@ -7728,6 +7761,7 @@
             "signIn": "Inloggen",
             "createAccount": "Account aanmaken",
             "forgotPassword": "Wachtwoord vergeten",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Wachtwoord resetten",
             "authError": "Authenticatiefout",
             "dashboard": "Dashboard",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Niet-ondersteunde provider",
             "providerConnectFailed": "Verbinding met provider mislukt",
             "forgotPasswordFailed": "Verzenden van wachtwoordreset-e-mail mislukt",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Wachtwoord resetten mislukt",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -134,6 +134,35 @@
                 "link": "Zarejestruj się"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Zresetuj swoje hasło",
             "subtitle": "Wprowadź nowe hasło poniżej",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Nie udało się zresetować hasła. Spróbuj ponownie lub zażądaj nowego linku resetowania.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Nieprawidłowy link resetowania",
                 "invalidLink": "Nieprawidłowy link resetowania",
                 "missingTokenMessage": "Link resetowania hasła jest nieprawidłowy lub niekompletny. Zażądaj nowego resetowania hasła.",
@@ -7728,6 +7761,7 @@
             "signIn": "Zaloguj się",
             "createAccount": "Utwórz konto",
             "forgotPassword": "Zapomniałem hasła",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Zresetuj hasło",
             "authError": "Błąd uwierzytelniania",
             "dashboard": "Pulpit",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Nieobsługiwany dostawca",
             "providerConnectFailed": "Nie udało się połączyć dostawcy",
             "forgotPasswordFailed": "Nie udało się wysłać e-maila do resetowania hasła",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Nie udało się zresetować hasła",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -134,6 +134,35 @@
                 "link": "Cadastrar"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Redefinir sua senha",
             "subtitle": "Digite sua nova senha abaixo",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Falha ao redefinir senha. Tente novamente ou solicite um novo link de redefinição.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Link de redefinição inválido",
                 "invalidLink": "Link de Redefinição Inválido",
                 "missingTokenMessage": "O link de redefinição de senha é inválido ou incompleto. Solicite uma nova redefinição de senha.",
@@ -7728,6 +7761,7 @@
             "signIn": "Entrar",
             "createAccount": "Criar Conta",
             "forgotPassword": "Esqueceu a Senha",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Redefinir Senha",
             "authError": "Erro de Autenticação",
             "dashboard": "Painel",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Provedor não suportado",
             "providerConnectFailed": "Falha ao conectar provedor",
             "forgotPasswordFailed": "Falha ao enviar e-mail de redefinição de senha",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Falha ao redefinir senha",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -134,6 +134,35 @@
                 "link": "Зарегистрироваться"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Сбросить пароль",
             "subtitle": "Введите новый пароль ниже",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Не удалось сбросить пароль. Пожалуйста, попробуйте снова или запросите новую ссылку.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Недействительная ссылка сброса",
                 "invalidLink": "Недействительная ссылка для сброса",
                 "missingTokenMessage": "Ссылка для сброса пароля недействительна или неполна. Пожалуйста, запросите новый сброс пароля.",
@@ -7728,6 +7761,7 @@
             "signIn": "Войти",
             "createAccount": "Создать аккаунт",
             "forgotPassword": "Забыли пароль?",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Сбросить пароль",
             "authError": "Ошибка аутентификации",
             "dashboard": "Панель управления",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Неподдерживаемый провайдер",
             "providerConnectFailed": "Не удалось подключить провайдер",
             "forgotPasswordFailed": "Не удалось отправить email для сброса пароля",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Не удалось сбросить пароль",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -134,6 +134,35 @@
                 "link": "สมัครสมาชิก"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "รีเซ็ตรหัสผ่านของคุณ",
             "subtitle": "ป้อนรหัสผ่านใหม่ด้านล่าง",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "ไม่สามารถรีเซ็ตรหัสผ่านได้ กรุณาลองอีกครั้งหรือขอ ลิงก์รีเซ็ตใหม่",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "ลิงก์รีเซ็ตไม่ถูกต้อง",
                 "invalidLink": "ลิงก์รีเซ็ตไม่ถูกต้อง",
                 "missingTokenMessage": "ลิงก์รีเซ็ตรหัสผ่านไม่ถูกต้องหรือไม่สมบูรณ์ กรุณาขอรีเซ็ตรหัสผ่านใหม่",
@@ -7728,6 +7761,7 @@
             "signIn": "เข้าสู่ระบบ",
             "createAccount": "สร้างบัญชี",
             "forgotPassword": "ลืมรหัสผ่าน",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "ตั้งรหัสผ่านใหม่",
             "authError": "ข้อผิดพลาดการรับรองตัวตน",
             "dashboard": "แดชบอร์ด",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "ผู้ให้บริการที่ไม่รองรับ",
             "providerConnectFailed": "เชื่อมต่อผู้ให้บริการล้มเหลว",
             "forgotPasswordFailed": "ส่งอีเมลตั้งรหัสผ่านใหม่ล้มเหลว",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "ตั้งรหัสผ่านใหม่ล้มเหลว",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -134,6 +134,35 @@
                 "link": "Kayıt Ol"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Şifrenizi sıfırlayın",
             "subtitle": "Yeni şifrenizi aşağıya girin",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Şifre sıfırlanamadı. Lütfen tekrar deneyin veya yeni bir sıfırlama bağlantısı isteyin.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Geçersiz sıfırlama bağlantısı",
                 "invalidLink": "Geçersiz Sıfırlama Bağlantısı",
                 "missingTokenMessage": "Şifre sıfırlama bağlantısı geçersiz veya eksik. Lütfen yeni bir şifre sıfırlama isteyin.",
@@ -7728,6 +7761,7 @@
             "signIn": "Oturum Aç",
             "createAccount": "Hesap Oluştur",
             "forgotPassword": "Şifremi Unuttum",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Şifreyi Sıfırla",
             "authError": "Kimlik Doğrulama Hatası",
             "dashboard": "Panel",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Desteklenmeyen sağlayıcı",
             "providerConnectFailed": "Sağlayıcıya bağlanma başarısız",
             "forgotPasswordFailed": "Şifre sıfırlama e-postası gönderilemedi",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Şifre sıfırlanamadı",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -134,6 +134,35 @@
                 "link": "Зареєструватися"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Скинути пароль",
             "subtitle": "Введіть новий пароль нижче",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Не вдалося скинути пароль. Спробуйте знову або запросіть нове посилання.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Недійсне посилання скидання",
                 "invalidLink": "Недійсне посилання для скидання",
                 "missingTokenMessage": "Посилання для скидання пароля недійсне або неповне. Запросіть нове скидання пароля.",
@@ -7728,6 +7761,7 @@
             "signIn": "Увійти",
             "createAccount": "Створити обліковий запис",
             "forgotPassword": "Забули пароль?",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Скинути пароль",
             "authError": "Помилка автентифікації",
             "dashboard": "Панель приладів",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Непідтримуваний постачальник",
             "providerConnectFailed": "Не вдалося підключити постачальника",
             "forgotPasswordFailed": "Не вдалося надіслати email для скидання пароля",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Не вдалося скинути пароль",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -134,6 +134,35 @@
                 "link": "Đăng ký"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "Đặt lại mật khẩu của bạn",
             "subtitle": "Nhập mật khẩu mới bên dưới",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "Không thể đặt lại mật khẩu. Vui lòng thử lại hoặc yêu cầu liên kết đặt lại mới.",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "Liên kết đặt lại không hợp lệ",
                 "invalidLink": "Liên kết Đặt lại Không hợp lệ",
                 "missingTokenMessage": "Liên kết đặt lại mật khẩu không hợp lệ hoặc không đầy đủ. Vui lòng yêu cầu đặt lại mật khẩu mới.",
@@ -7728,6 +7761,7 @@
             "signIn": "Đăng nhập",
             "createAccount": "Tạo Tài khoản",
             "forgotPassword": "Quên Mật khẩu",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "Đặt lại Mật khẩu",
             "authError": "Lỗi Xác thực",
             "dashboard": "Bảng điều khiển",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "Nhà cung cấp không được hỗ trợ",
             "providerConnectFailed": "Kết nối nhà cung cấp thất bại",
             "forgotPasswordFailed": "Gửi email đặt lại mật khẩu thất bại",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "Đặt lại mật khẩu thất bại",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -134,6 +134,35 @@
                 "link": "注册"
             }
         },
+        "resendVerification": {
+            "title": "Resend verification email",
+            "subtitle": "Enter your email address and we'll send a fresh verification link",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "placeholder": "Enter your email"
+                },
+                "submit": "Send verification email",
+                "submitting": "Sending..."
+            },
+            "successTitle": "Check your email",
+            "successSubtitle": "If that address still needs verifying, a new link is on its way",
+            "success": {
+                "title": "Verification link sent — if the account needs one",
+                "message": "If an account exists for {email} and is not yet verified, we have sent a new verification link there. Nothing arrives if the address is not registered or is already verified, so double-check it for typos.",
+                "checkSpam": "If you don't see the email, check your spam folder.",
+                "linkExpiry": "Verification links are valid for 24 hours."
+            },
+            "errors": {
+                "failed": "Failed to send verification email. Please try again."
+            },
+            "alreadyVerified": "Already verified?",
+            "backToLogin": "Back to login",
+            "noAccount": {
+                "text": "Don't have an account?",
+                "link": "Sign up"
+            }
+        },
         "resetPassword": {
             "title": "重置您的密码",
             "subtitle": "在下面输入您的新密码",
@@ -168,6 +197,10 @@
             },
             "errors": {
                 "failed": "重置密码失败。请重试或请求新的重置链接。",
+                "expiredToken": "This password reset link has expired. Reset links are valid for one hour — request a new one to continue.",
+                "invalidToken": "This password reset link is no longer valid. It may have already been used, or a newer link may have replaced it. Request a new one to continue.",
+                "rateLimited": "Too many attempts in a short time. Wait about a minute and try again — your reset link has not been used up.",
+                "upstream": "Something went wrong on our end, not with your link. Wait a moment and try again; if your new password already works, sign in with it instead.",
                 "noToken": "无效的重置链接",
                 "invalidLink": "无效的重置链接",
                 "missingTokenMessage": "密码重置链接无效或不完整。请请求新的密码重置。",
@@ -7728,6 +7761,7 @@
             "signIn": "登录",
             "createAccount": "创建账户",
             "forgotPassword": "忘记密码",
+            "resendVerification": "Resend Verification Email",
             "resetPassword": "重置密码",
             "authError": "认证错误",
             "dashboard": "仪表板",
@@ -7769,6 +7803,7 @@
             "unsupportedProvider": "不支持的提供商",
             "providerConnectFailed": "连接提供商失败",
             "forgotPasswordFailed": "发送密码重置邮件失败",
+            "resendVerificationFailed": "Failed to send verification email",
             "resetPasswordFailed": "重置密码失败",
             "magicLinkFailed": "Failed to send magic link",
             "magicLinkInvalid": "Invalid or expired magic link"

--- a/apps/web/src/app/[locale]/(auth)/auth/error/auth-error-content.tsx
+++ b/apps/web/src/app/[locale]/(auth)/auth/error/auth-error-content.tsx
@@ -5,7 +5,7 @@ import { AuthLayout } from '@/components/layout/AuthLayout';
 import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { Button } from '@/components/ui/button';
-import { ROUTES } from '@/lib/constants';
+import { ROUTES, SUPPORT_EMAIL } from '@/lib/constants';
 import { Link } from '@/i18n/navigation';
 
 function AuthErrorContent() {
@@ -190,7 +190,18 @@ function AuthErrorContent() {
 
         if (errorType === 'email_not_verified') {
             buttons.push(
-                <Button key="resend" href="/" size="lg" className="animate-fade-in">
+                // EW-070: this was `href="/"`. A button labelled "Resend
+                // Verification Email" that navigates to the home page and
+                // resends nothing is worse than no button — it is the only
+                // offer made to someone who cannot sign in, and taking it
+                // leaves them exactly where they were. It now points at the
+                // page that actually calls the public resend endpoint.
+                <Button
+                    key="resend"
+                    href={ROUTES.AUTH_RESEND_VERIFICATION}
+                    size="lg"
+                    className="animate-fade-in"
+                >
                     {t('actions.resendVerification')}
                 </Button>,
             );
@@ -198,7 +209,17 @@ function AuthErrorContent() {
 
         if (errorType === 'account_locked') {
             buttons.push(
-                <Button key="support" href="/support" size="lg" className="animate-fade-in">
+                // `/support` has no route anywhere in the app — and because
+                // unknown routes here answer HTTP 200 with a generic page
+                // rather than a 404, the dead link never announced itself. A
+                // locked-out user needs a destination that exists, so this
+                // opens a mail composer to the configured support address.
+                <Button
+                    key="support"
+                    href={`mailto:${SUPPORT_EMAIL}`}
+                    size="lg"
+                    className="animate-fade-in"
+                >
                     {t('actions.contactSupport')}
                 </Button>,
             );
@@ -219,7 +240,15 @@ function AuthErrorContent() {
 
         if (errorType?.startsWith('verify_email_')) {
             buttons.push(
-                <Button key="resend-verification" href="/" size="lg" className="animate-fade-in">
+                // EW-070: same dead `href="/"` as above, on the branch reached
+                // when a verification link is missing/invalid/expired — the
+                // exact situation a resend is meant to resolve.
+                <Button
+                    key="resend-verification"
+                    href={ROUTES.AUTH_RESEND_VERIFICATION}
+                    size="lg"
+                    className="animate-fade-in"
+                >
                     {t('actions.resendVerification')}
                 </Button>,
             );

--- a/apps/web/src/app/[locale]/(auth)/resend-verification/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/resend-verification/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import ResendVerificationForm from './resend-verification-form';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('metadata.pages');
+    return { title: t('resendVerification') };
+}
+
+/**
+ * EW-070 — the signed-out route back in.
+ *
+ * A user whose verification email never arrived had no path at all: login
+ * answers 403 for an unverified address, the only resend action requires the
+ * session that 403 withholds, and the two "Resend Verification Email" buttons
+ * on /auth/error pointed at `/`. This page is what those buttons now point at.
+ */
+export default function ResendVerificationPage() {
+    return <ResendVerificationForm />;
+}

--- a/apps/web/src/app/[locale]/(auth)/resend-verification/resend-verification-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/resend-verification/resend-verification-form.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Link } from '@/i18n/navigation';
+import { AuthLayout } from '@/components/layout/AuthLayout';
+import { useTranslations } from 'next-intl';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants';
+import { requestVerificationEmail } from '@/app/actions/auth';
+
+/**
+ * EW-070 — signed-out verification resend.
+ *
+ * Deliberately shaped like forgot-password, for the same reason: the API
+ * answers with ONE body whether the address is unknown, already verified, or
+ * genuinely mailed. So this renders ONE success branch and the copy hedges
+ * exactly as far as the server does. Rendering two branches — or wording this
+ * as a flat "Email sent" — would either leak account existence or repeat the
+ * EW-071 defect of claiming something the server never promised.
+ */
+export default function ResendVerificationForm() {
+    const [isPending, startTransition] = useTransition();
+    const t = useTranslations('auth.resendVerification');
+    const [email, setEmail] = useState('');
+    const [submittedEmail, setSubmittedEmail] = useState('');
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError('');
+
+        startTransition(() => {
+            void (async () => {
+                const response = await requestVerificationEmail(email);
+                if (!response.success) {
+                    setError(response.error || t('errors.failed'));
+                    return;
+                }
+
+                // Pin the address that was actually submitted so the
+                // confirmation cannot drift if the field is edited afterwards.
+                setSubmittedEmail(email);
+                setSuccess(true);
+            })();
+        });
+    };
+
+    if (success) {
+        return (
+            <AuthLayout title={t('successTitle')} subtitle={t('successSubtitle')}>
+                <div className="space-y-6">
+                    <div className="bg-success/10 border border-success/20 rounded-lg p-6">
+                        <div className="flex items-start gap-3">
+                            <div className="w-8 h-8 bg-success/20 rounded-lg flex items-center justify-center shrink-0">
+                                <svg
+                                    className="w-5 h-5 text-success"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                                    />
+                                </svg>
+                            </div>
+                            <div>
+                                <h3 className="font-medium text-text dark:text-text-dark mb-1">
+                                    {t('success.title')}
+                                </h3>
+                                <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                                    {t('success.message', { email: submittedEmail })}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="text-center space-y-2">
+                        <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                            {t('success.checkSpam')}
+                        </p>
+                        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                            {t('success.linkExpiry')}
+                        </p>
+                        <div className="pt-2">
+                            <Link
+                                href={ROUTES.AUTH_LOGIN}
+                                className="text-primary hover:text-primary-hover font-medium transition-colors"
+                            >
+                                {t('backToLogin')}
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </AuthLayout>
+        );
+    }
+
+    return (
+        <AuthLayout title={t('title')} subtitle={t('subtitle')}>
+            <form onSubmit={handleSubmit} className="space-y-6">
+                {error && (
+                    <div className="bg-danger/10 border border-danger/20 text-danger px-4 py-3 rounded-lg text-sm">
+                        {error}
+                    </div>
+                )}
+
+                <Input
+                    type="email"
+                    label={t('form.email.label')}
+                    name="email"
+                    placeholder={t('form.email.placeholder')}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    disabled={isPending}
+                />
+
+                <Button type="submit" disabled={isPending || !email} loading={isPending} fullWidth>
+                    {isPending ? t('form.submitting') : t('form.submit')}
+                </Button>
+
+                <div className="text-center space-y-4">
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                        {t('alreadyVerified')}{' '}
+                        <Link
+                            href={ROUTES.AUTH_LOGIN}
+                            className="text-primary hover:text-primary-hover font-medium transition-colors"
+                        >
+                            {t('backToLogin')}
+                        </Link>
+                    </p>
+
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                        {t('noAccount.text')}{' '}
+                        <Link
+                            href={ROUTES.AUTH_REGISTER}
+                            className="text-primary hover:text-primary-hover font-medium transition-colors"
+                        >
+                            {t('noAccount.link')}
+                        </Link>
+                    </p>
+                </div>
+            </form>
+        </AuthLayout>
+    );
+}

--- a/apps/web/src/app/[locale]/(auth)/reset-password/reset-password-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/reset-password/reset-password-form.tsx
@@ -25,6 +25,12 @@ function ResetPasswordContent() {
         confirmPassword?: string;
         general?: string;
     }>({});
+    // EW-082: when the submit failed because the LINK is dead (expired, or
+    // already used) rather than because the request hiccuped, "try again"
+    // cannot work — only a fresh link can. Track that so the form can offer the
+    // one action that helps, instead of leaving the user to re-press a button
+    // that will fail identically forever.
+    const [linkIsDead, setLinkIsDead] = useState(false);
     const [success] = useState(false);
 
     // If no token, show error message instead of redirecting
@@ -82,6 +88,7 @@ function ResetPasswordContent() {
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setErrors({});
+        setLinkIsDead(false);
 
         // Validate passwords match
         if (formData.password !== formData.confirmPassword) {
@@ -104,7 +111,13 @@ function ResetPasswordContent() {
             void (async () => {
                 const response = await resetPasswordAction(token!, formData.password);
                 if (!response.success) {
+                    // EW-082: `response.error` is now the specific string for
+                    // whichever failure actually happened — expired link, a
+                    // no-longer-valid link, throttled, or a server-side problem
+                    // — instead of one "Failed to reset password" for all four.
+                    // See `classifyResetPasswordError`.
                     setErrors({ general: response.error || t('errors.failed') });
+                    setLinkIsDead(Boolean(response.linkIsDead));
                     return;
                 }
             })();
@@ -157,8 +170,19 @@ function ResetPasswordContent() {
         <AuthLayout title={t('title')} subtitle={t('subtitle')}>
             <form onSubmit={handleSubmit} className="space-y-6">
                 {errors.general && (
-                    <div className="bg-danger/10 border border-danger/20 text-danger px-4 py-3 rounded-lg text-sm">
-                        {errors.general}
+                    <div className="bg-danger/10 border border-danger/20 text-danger px-4 py-3 rounded-lg text-sm space-y-3">
+                        <p>{errors.general}</p>
+
+                        {/* EW-082: a dead link cannot be retried into working.
+                            Surface the only action that resolves it, right
+                            where the failure is reported — the message above
+                            tells the user to request a new link, so make that
+                            clickable instead of making them go find the page. */}
+                        {linkIsDead && (
+                            <Button href={ROUTES.AUTH_FORGOT_PASSWORD} size="sm">
+                                {t('errors.requestNewLink')}
+                            </Button>
+                        )}
                     </div>
                 )}
 

--- a/apps/web/src/app/actions/auth-resend-verification.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-resend-verification.unit.spec.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * EW-070 — the signed-out resend action, and EW-082 — the reset-password
+ * failure messages it sits next to.
+ *
+ * What matters here is that `requestVerificationEmail` posts to the PUBLIC
+ * endpoint (not the session-guarded one an unverified user can never reach)
+ * and that it does not invent a distinction the server refuses to make.
+ */
+
+const { resendVerificationMock, resetPasswordMock, getTranslationsMock } = vi.hoisted(() => ({
+    resendVerificationMock: vi.fn(),
+    resetPasswordMock: vi.fn(),
+    getTranslationsMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+    setOAuthStateCookie: vi.fn(),
+    removeAuthAccessCookies: vi.fn(),
+    setAuthCookies: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+    authAPI: {
+        resendVerification: resendVerificationMock,
+        resetPassword: resetPasswordMock,
+        getOAuthAuthUrl: vi.fn(),
+        login: vi.fn(),
+        register: vi.fn(),
+        logout: vi.fn(),
+    },
+}));
+
+vi.mock('next-intl/server', () => ({
+    // Namespaced translator: returns `${namespace}.${key}` so assertions can
+    // prove WHICH message key was chosen, which is the whole point of EW-082.
+    getTranslations: (namespace?: string) =>
+        Promise.resolve((key: string) => (namespace ? `${namespace}.${key}` : key)),
+    getLocale: async () => 'en',
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    redirect: vi.fn(),
+}));
+
+/** Mirrors `ApiResponseError` (message + statusCode) without importing 'server-only'. */
+function apiError(message: string, statusCode: number): Error {
+    const err = new Error(message) as Error & { statusCode: number };
+    err.statusCode = statusCode;
+    return err;
+}
+
+describe('requestVerificationEmail — EW-070 signed-out resend', () => {
+    beforeEach(() => {
+        resendVerificationMock.mockReset();
+        getTranslationsMock.mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+        vi.restoreAllMocks();
+    });
+
+    it('posts to the PUBLIC resend endpoint, not the session-guarded one', async () => {
+        resendVerificationMock.mockResolvedValue({ message: 'ok' });
+        const { requestVerificationEmail } = await import('./auth');
+
+        const result = await requestVerificationEmail('user@example.com');
+
+        // `authAPI.sendVerification` is the authenticated route and is
+        // unreachable for the users this feature exists for — assert we did
+        // NOT go there by asserting we went here, with the email in the body.
+        expect(resendVerificationMock).toHaveBeenCalledTimes(1);
+        expect(resendVerificationMock.mock.calls[0][0]).toMatchObject({
+            email: 'user@example.com',
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('sends a verification callback URL so the emailed link lands on the verify route', async () => {
+        resendVerificationMock.mockResolvedValue({ message: 'ok' });
+        const { requestVerificationEmail } = await import('./auth');
+
+        await requestVerificationEmail('user@example.com');
+
+        const body = resendVerificationMock.mock.calls[0][0];
+        expect(body.emailVerificationCallbackUrl).toContain('/api/auth/verify-email');
+    });
+
+    it('rejects a malformed address before touching the API', async () => {
+        const { requestVerificationEmail } = await import('./auth');
+
+        const result = await requestVerificationEmail('not-an-email');
+
+        expect(result.success).toBe(false);
+        expect(resendVerificationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns a generic translated failure and never forwards the raw upstream message', async () => {
+        resendVerificationMock.mockRejectedValue(
+            apiError('ECONNREFUSED 10.42.0.7:3000 postgres pool exhausted', 500),
+        );
+        const { requestVerificationEmail } = await import('./auth');
+
+        const result = await requestVerificationEmail('user@example.com');
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('api.errors.resendVerificationFailed');
+        // Infra detail must not reach the browser.
+        expect(result.error).not.toContain('ECONNREFUSED');
+        expect(result.error).not.toContain('postgres');
+    });
+
+    it('does not branch on the response body — the server returns one body for every outcome', async () => {
+        // Unknown address and real address get the same API body by design.
+        // Whatever comes back, the action reports the same success shape, so
+        // the UI cannot leak account existence.
+        resendVerificationMock.mockResolvedValue({ message: 'anything at all' });
+        const { requestVerificationEmail } = await import('./auth');
+
+        const a = await requestVerificationEmail('unknown@example.com');
+        const b = await requestVerificationEmail('known@example.com');
+
+        expect(a).toEqual(b);
+        expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+});
+
+describe('resetPassword — EW-082 distinguishes the failure modes', () => {
+    beforeEach(() => {
+        resetPasswordMock.mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+        vi.restoreAllMocks();
+    });
+
+    const VALID_PASSWORD = 'newsecret1';
+
+    it('an EXPIRED link gets the expired message and offers a new link', async () => {
+        resetPasswordMock.mockRejectedValue(apiError('Reset token expired', 400));
+        const { resetPassword } = await import('./auth');
+
+        const result = await resetPassword('tok', VALID_PASSWORD);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('auth.resetPassword.errors.expiredToken');
+        expect(result.linkIsDead).toBe(true);
+    });
+
+    it('an ALREADY-USED / invalid link gets the invalid message and offers a new link', async () => {
+        resetPasswordMock.mockRejectedValue(apiError('Invalid reset token', 400));
+        const { resetPassword } = await import('./auth');
+
+        const result = await resetPassword('tok', VALID_PASSWORD);
+
+        expect(result.error).toBe('auth.resetPassword.errors.invalidToken');
+        expect(result.linkIsDead).toBe(true);
+    });
+
+    it('a THROTTLED submit does NOT tell the user their link is dead', async () => {
+        resetPasswordMock.mockRejectedValue(apiError('ThrottlerException: Too Many Requests', 429));
+        const { resetPassword } = await import('./auth');
+
+        const result = await resetPassword('tok', VALID_PASSWORD);
+
+        expect(result.error).toBe('auth.resetPassword.errors.rateLimited');
+        // The token was never consumed — sending this user off to request a
+        // new link would be wrong advice, and lands them in the same throttle.
+        expect(result.linkIsDead).toBe(false);
+    });
+
+    it('an UPSTREAM failure says try again, and does not blame the link', async () => {
+        resetPasswordMock.mockRejectedValue(apiError('Internal server error', 500));
+        const { resetPassword } = await import('./auth');
+
+        const result = await resetPassword('tok', VALID_PASSWORD);
+
+        expect(result.error).toBe('auth.resetPassword.errors.upstream');
+        expect(result.linkIsDead).toBe(false);
+    });
+
+    it('the four failures produce four DIFFERENT messages — the old behaviour was one for all', async () => {
+        const { resetPassword } = await import('./auth');
+
+        const messages: string[] = [];
+        for (const err of [
+            apiError('Reset token expired', 400),
+            apiError('Invalid reset token', 400),
+            apiError('ThrottlerException', 429),
+            apiError('Internal server error', 500),
+        ]) {
+            resetPasswordMock.mockRejectedValueOnce(err);
+            const r = await resetPassword('tok', VALID_PASSWORD);
+            messages.push(String(r.error));
+        }
+
+        expect(new Set(messages).size).toBe(4);
+    });
+});

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -9,6 +9,7 @@ import { redirect } from '@/i18n/navigation';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { isValidRedirectUrl } from '@/lib/utils';
 import { getRedirectUrl } from '@/lib/auth/redirect';
+import { classifyResetPasswordError, resetLinkIsDead } from '@/lib/auth/reset-password-error';
 import { OAuthProvider } from '@/lib/api/enums';
 
 // Security: `isValidRedirectUrl` only validates URL *syntax* — it accepts any
@@ -313,6 +314,58 @@ export async function connectProvider(providerId: OAuthProvider) {
     }
 }
 
+// =====================
+// Email verification
+// =====================
+
+/**
+ * EW-070 — request a fresh verification email while SIGNED OUT.
+ *
+ * The authenticated sibling lives in `actions/settings.ts` and calls
+ * `getAuthFromCookie()` first, so it is useless to the people who need it
+ * most: an unverified account cannot log in (the API answers 403), which means
+ * it can never obtain the session that action requires. Combined with the two
+ * "Resend Verification Email" buttons on /auth/error being `href="/"`, a user
+ * whose verification mail was lost had no path back at all.
+ *
+ * The API answers 200 with one fixed message for every outcome — unknown
+ * address, already verified, deactivated, or genuinely mailed — so this action
+ * deliberately does NOT inspect the body. There is nothing in it to inspect,
+ * and inventing a distinction here would undo the anti-enumeration property
+ * the server is careful to hold.
+ */
+export async function requestVerificationEmail(email: string) {
+    const t = await getTranslations('validation.auth');
+
+    const emailSchema = z.string().email(t('email.invalid'));
+    const validation = emailSchema.safeParse(email);
+    if (!validation.success) {
+        return {
+            success: false,
+            error: validation.error.errors[0].message,
+        };
+    }
+
+    try {
+        await authAPI.resendVerification({
+            email: validation.data,
+            emailVerificationCallbackUrl: withAppUrl(ROUTES.API_AUTH_VERIFY_EMAIL),
+        });
+
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        const errorT = await getTranslations('api.errors');
+
+        // Security: return a generic translated message; never forward the raw
+        // upstream `error.message` to the client (it can leak infra detail).
+        return {
+            success: false,
+            error: errorT('resendVerificationFailed'),
+        };
+    }
+}
+
 // =================
 // Password Reset
 // =================
@@ -383,13 +436,27 @@ export async function resetPassword(token: string, newPassword: string) {
         });
     } catch (error) {
         console.error(error);
-        const errorT = await getTranslations('api.errors');
+        const tReset = await getTranslations('auth.resetPassword.errors');
 
-        // Security: return a generic translated message; never forward the raw
-        // upstream `error.message` to the client (it can leak infra detail).
+        // EW-082: every rejection here used to collapse into one string,
+        // "Failed to reset password" — which leaves the user unable to tell
+        // "your link is dead, get a new one" apart from "the server hiccuped,
+        // press the button again". Those need opposite responses, and guessing
+        // wrong costs an already locked-out user another round trip through
+        // their inbox.
+        //
+        // Security: still no raw upstream `error.message` reaches the client —
+        // every branch returns a translated constant. The classification reads
+        // the upstream error; it never forwards it.
+        const reason = classifyResetPasswordError(error);
+
         return {
             success: false,
-            error: errorT('resetPasswordFailed'),
+            error: tReset(reason),
+            // Lets the form offer "Request a new link" for exactly the two
+            // reasons where a new link is the fix, and stay quiet otherwise.
+            reason,
+            linkIsDead: resetLinkIsDead(reason),
         };
     }
 

--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -66,6 +66,19 @@ export interface VerifyEmailDto {
     token: string;
 }
 
+/**
+ * EW-070 — body of the SIGNED-OUT verification resend.
+ *
+ * Distinct from `sendVerification()` below, which posts to the
+ * session-guarded `/auth/send-verification`. An unverified account cannot
+ * obtain a session (login answers 403), so that route is unreachable exactly
+ * when a resend is needed.
+ */
+export interface ResendVerificationDto {
+    email: string;
+    emailVerificationCallbackUrl?: string;
+}
+
 export interface ForgotPasswordDto {
     email: string;
     resetPasswordCallbackUrl?: string;
@@ -255,6 +268,20 @@ export const authAPI = {
         return serverMutation<MessageResponse>({
             endpoint: '/auth/send-verification',
             data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * EW-070 — public resend. Always resolves with the same message whether or
+     * not the address has an account here, so callers must not branch on the
+     * body: there is nothing in it to branch on.
+     */
+    resendVerification: async (data: ResendVerificationDto) => {
+        return serverMutation<MessageResponse>({
+            endpoint: '/auth/resend-verification',
+            data,
             method: 'POST',
             wrapInData: false,
         });

--- a/apps/web/src/lib/auth/reset-password-error.ts
+++ b/apps/web/src/lib/auth/reset-password-error.ts
@@ -1,0 +1,69 @@
+/**
+ * EW-082 — telling the reset-password failures apart.
+ *
+ * Lives in its own module rather than beside the action that uses it because
+ * `app/actions/auth.ts` carries `'use server'`, and a server-action file may
+ * only export async functions — a plain exported helper there would break the
+ * build, and an unexported one could not be unit-tested directly.
+ */
+
+/** Message keys under `auth.resetPassword.errors` that `resetPassword` returns. */
+export type ResetPasswordFailureReason =
+    | 'expiredToken'
+    | 'invalidToken'
+    | 'rateLimited'
+    | 'upstream'
+    | 'failed';
+
+/**
+ * Which reset-password failure is this?
+ *
+ * The API distinguishes them; the UI threw the distinction away and rendered
+ * one flat "Failed to reset password" for all of them. What the server
+ * actually emits (apps/api auth.service.ts / auth.controller.ts):
+ *
+ *   - `400 Reset token expired` — the row is still there, the hour is up.
+ *   - `400 Invalid reset token` — no row matches the hash. This is ALSO what an
+ *     already-consumed token produces, because `consumePasswordResetToken`
+ *     clears the column on success. The API genuinely cannot tell "already
+ *     used" from "never valid", so neither can we — which is why the copy for
+ *     this branch says the link "may have already been used" instead of
+ *     claiming a precision the server does not have.
+ *   - `429` — the 5/min throttle on the route. The token was never touched.
+ *   - anything else (5xx, an unreachable API, a parse failure) — the link is
+ *     probably fine, the platform is not. "Wait and try again" is right here
+ *     and wrong for the two dead-link cases above.
+ *
+ * Matched on status AND on the words that carry the meaning, in the same shape
+ * as `isEmailNotVerifiedError` in the actions module, so an unrelated future
+ * 400 on this route cannot start telling people their link expired. Anything
+ * unrecognised falls through to the original generic string: a new upstream
+ * failure is reported vaguely, never wrongly.
+ */
+export function classifyResetPasswordError(error: unknown): ResetPasswordFailureReason {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    const statusCode = (error as { statusCode?: number } | null)?.statusCode;
+
+    if (statusCode === 429) return 'rateLimited';
+
+    if (statusCode === undefined || statusCode === 400) {
+        if (/expired/i.test(message)) return 'expiredToken';
+        if (/invalid.*token|token.*invalid/i.test(message)) return 'invalidToken';
+    }
+
+    if (typeof statusCode === 'number' && statusCode >= 500) return 'upstream';
+
+    return 'failed';
+}
+
+/**
+ * Is this the kind of failure where retrying the same link can never work?
+ *
+ * Only a fresh link fixes an expired or no-longer-valid one; the form uses
+ * this to decide whether to offer "Request a new reset link" alongside the
+ * message, instead of leaving the user to re-press a button that will fail
+ * identically forever.
+ */
+export function resetLinkIsDead(reason: ResetPasswordFailureReason): boolean {
+    return reason === 'expiredToken' || reason === 'invalidToken';
+}

--- a/apps/web/src/lib/auth/reset-password-error.unit.spec.ts
+++ b/apps/web/src/lib/auth/reset-password-error.unit.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+    classifyResetPasswordError,
+    resetLinkIsDead,
+    type ResetPasswordFailureReason,
+} from './reset-password-error';
+
+/**
+ * EW-082 — every reset-password submit failure used to render one bare
+ * "Failed to reset password", whether the link had expired, had already been
+ * used, or the API had simply fallen over. Those three need opposite
+ * responses from the user, so the classification is pinned here.
+ *
+ * The inputs below are the errors `serverFetch` actually constructs from what
+ * the API actually sends (`ApiResponseError` carries `message` + `statusCode`,
+ * and apps/api throws `BadRequestException('Reset token expired')` /
+ * `BadRequestException('Invalid reset token')`).
+ */
+
+/** Mirrors `ApiResponseError` from lib/api/server-api without importing 'server-only'. */
+function apiError(message: string, statusCode: number): Error {
+    const err = new Error(message) as Error & { statusCode: number };
+    err.statusCode = statusCode;
+    return err;
+}
+
+describe('classifyResetPasswordError', () => {
+    it('an EXPIRED token is reported as expired, not as a generic failure', () => {
+        expect(classifyResetPasswordError(apiError('Reset token expired', 400))).toBe(
+            'expiredToken',
+        );
+    });
+
+    it('an INVALID / already-consumed token is reported as invalid', () => {
+        // The API clears the token column on a successful reset, so a second
+        // submit of the same link produces exactly this error. "Already used"
+        // and "never valid" are indistinguishable upstream — hence one branch.
+        expect(classifyResetPasswordError(apiError('Invalid reset token', 400))).toBe(
+            'invalidToken',
+        );
+    });
+
+    it('a THROTTLED submit (429) is reported as rate-limited, not as a dead link', () => {
+        // Critical distinction: a 429 never reached the service, so the token
+        // is untouched and waiting a minute really does fix it. Telling this
+        // user their link is dead would send them to request a new one for no
+        // reason — and straight back into the same throttle.
+        expect(classifyResetPasswordError(apiError('ThrottlerException', 429))).toBe('rateLimited');
+    });
+
+    it('a SERVER error is reported as upstream, not as a dead link', () => {
+        expect(classifyResetPasswordError(apiError('Internal server error', 500))).toBe('upstream');
+        expect(classifyResetPasswordError(apiError('Bad gateway', 502))).toBe('upstream');
+    });
+
+    it('an unrecognised 400 falls back to the generic message rather than guessing', () => {
+        // Reported vaguely, never wrongly: a future 400 on this route must not
+        // start claiming the link expired.
+        expect(classifyResetPasswordError(apiError('Password must be at least 8 chars', 400))).toBe(
+            'failed',
+        );
+    });
+
+    it('does not mistake an unrelated message for a token error', () => {
+        expect(classifyResetPasswordError(apiError('Account suspended', 403))).toBe('failed');
+    });
+
+    it('handles a bare Error with no statusCode (network / fetch failure)', () => {
+        // No status at all: still classify on wording, since `serverFetch` can
+        // surface the API's message without a status in some failure paths.
+        expect(classifyResetPasswordError(new Error('Reset token expired'))).toBe('expiredToken');
+        expect(classifyResetPasswordError(new Error('fetch failed'))).toBe('failed');
+    });
+
+    it('handles null / undefined / non-Error throws without crashing', () => {
+        expect(classifyResetPasswordError(null)).toBe('failed');
+        expect(classifyResetPasswordError(undefined)).toBe('failed');
+        expect(classifyResetPasswordError('some string')).toBe('failed');
+    });
+
+    it('the four distinguishable failures really are four DIFFERENT answers', () => {
+        // The defect was that all of these collapsed into one string. This
+        // asserts the collapse cannot come back: if someone reverts the
+        // classifier to a constant, the Set shrinks and this fails.
+        const reasons = [
+            classifyResetPasswordError(apiError('Reset token expired', 400)),
+            classifyResetPasswordError(apiError('Invalid reset token', 400)),
+            classifyResetPasswordError(apiError('ThrottlerException', 429)),
+            classifyResetPasswordError(apiError('Internal server error', 500)),
+        ];
+        expect(new Set(reasons).size).toBe(4);
+    });
+});
+
+describe('resetLinkIsDead', () => {
+    it('is true for exactly the reasons a NEW link fixes', () => {
+        expect(resetLinkIsDead('expiredToken')).toBe(true);
+        expect(resetLinkIsDead('invalidToken')).toBe(true);
+    });
+
+    it('is false where retrying the SAME link is the right advice', () => {
+        // Offering "request a new link" here would be actively misleading —
+        // the link is fine.
+        expect(resetLinkIsDead('rateLimited')).toBe(false);
+        expect(resetLinkIsDead('upstream')).toBe(false);
+        expect(resetLinkIsDead('failed')).toBe(false);
+    });
+
+    it('covers every declared reason', () => {
+        const all: ResetPasswordFailureReason[] = [
+            'expiredToken',
+            'invalidToken',
+            'rateLimited',
+            'upstream',
+            'failed',
+        ];
+        expect(all.filter(resetLinkIsDead)).toEqual(['expiredToken', 'invalidToken']);
+    });
+});

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -10,6 +10,20 @@ export const COMPANY_OWNER_WEBSITE =
     'https://ever.works';
 
 /**
+ * Where "Contact Support" actually goes.
+ *
+ * The auth error page linked to `/support`, which has no route in this app —
+ * and unknown routes here answer HTTP 200 with a generic page rather than a
+ * 404, so the dead link looked fine to anyone checking it by status code. The
+ * one person guaranteed to click it is someone locked out of their account,
+ * for whom a page that silently goes nowhere is the end of the road.
+ *
+ * Env-overridable so a self-hosted operator can point it at their own desk.
+ */
+export const SUPPORT_EMAIL =
+    process.env.NEXT_PUBLIC_SUPPORT_EMAIL || process.env.SUPPORT_EMAIL || 'ever@ever.co';
+
+/**
  * Locales written right-to-left.
  *
  * `<html dir>` was never set, so Arabic and Hebrew rendered left-to-right —
@@ -229,6 +243,12 @@ export const ROUTES = {
     AUTH_EMAIL_CONFIRMATION: '/email-confirmation',
     AUTH_RESET_PASSWORD: '/reset-password',
     AUTH_FORGOT_PASSWORD: '/forgot-password',
+    // EW-070 — the signed-out way back in for a user whose verification email
+    // never arrived. Reached while UNAUTHENTICATED and unverifiable (login
+    // answers 403 for an unverified address), so it MUST be in PUBLIC_ROUTES.
+    // The two "Resend Verification Email" buttons on /auth/error point here;
+    // they used to point at `/`, which resent nothing.
+    AUTH_RESEND_VERIFICATION: '/resend-verification',
     // Magic-link token-landing page. Reached while still UNAUTHENTICATED
     // (the redeem happens client-side after the page renders), so it must
     // be in PUBLIC_ROUTES — otherwise the proxy auth gate bounces it to
@@ -268,6 +288,10 @@ export const PUBLIC_ROUTES = [
     ROUTES.AUTH_EMAIL_CONFIRMATION,
     ROUTES.AUTH_RESET_PASSWORD,
     ROUTES.AUTH_FORGOT_PASSWORD,
+    // EW-070 — must render for signed-out users; an unverified account cannot
+    // get a session, so gating this page would recreate the lockout it exists
+    // to break.
+    ROUTES.AUTH_RESEND_VERIFICATION,
     // Token-landing page — must render for unauthenticated users so the
     // client-side redeem can set the session cookie (mirrors the other
     // token-landing pages above).


### PR DESCRIPTION
## EW-070 — there was no way back in

A user whose verification email never arrived was locked out **permanently**, and every exit was a dead end:

| Exit | What it actually did |
|---|---|
| Sign in | `403` — unverified addresses cannot get a session |
| Resend action (`app/actions/settings.ts:14`) | calls `getAuthFromCookie()` — needs the session the 403 withholds |
| "Resend Verification Email" ×2 (`auth-error-content.tsx:193`, `:222`) | `href="/"` — navigates home, resends nothing |
| "Contact Support" | `/support` — **no route exists**; unknown routes here answer HTTP 200 with a generic page, so the dead link never announced itself |

And `grep` confirmed no public resend endpoint anywhere in `apps/api/src/auth`. So this builds one.

### `POST /api/auth/resend-verification` — `@Public()`

- **Anti-enumeration.** Unknown address, already-verified address, deactivated account, an account that really was mailed, *and a downstream mailer failure* all return `200` with the **byte-identical** body. The mailer failure is the subtle one: a 500 there, where an unknown address gets a 200, is itself an oracle — so it is caught, logged server-side, and answered identically.
- **Timing.** The same throwaway bcrypt runs on every branch (H-03), so wall-clock does not leak what the body hides.
- **Rate limited.** `@Throttle` keyed on the **`long`** tier. A `default`-keyed override binds to no configured throttler and is silently ignored, leaving only the loose 1000/min global cap — so the test asserts the tier *name*, not merely that a throttle exists. Env-tunable (`RESEND_VERIFICATION_THROTTLE_LIMIT`), mirroring `REGISTER_THROTTLE_LIMIT`, so the single-source-IP e2e suite can raise it.
- **One token format.** The mail is issued by the existing `sendVerificationEmail` — same 32-byte token, same sha256 at-rest storage (H-01), same 24h expiry, same C-04 callback-host allow-list, same `UserCreatedEvent` path. No second token format.

Then the dead buttons are wired to a real signed-out page (`/resend-verification`, in `PUBLIC_ROUTES`) that calls it, and Contact Support opens a composer to a configurable `SUPPORT_EMAIL` instead of a route that does not exist.

Page copy follows the honest pattern **EW-071** established next door: the server returns ONE body for unknown / already-verified / actually-sent, so the page renders ONE success branch and says *"If an account exists for {email} and is not yet verified…"* rather than claiming an email was sent. It names the two failure modes the user can act on — a typo, or an already-verified address — because those are the only ones the server permits us to mention.

## EW-082 — one bare "Failed" for four different problems

Every rejection collapsed into `api.errors.resetPasswordFailed` ("Failed to reset password"), leaving the user unable to tell *"your link is dead, get a new one"* from *"the server hiccuped, press the button again"*. Those need opposite responses, and guessing wrong costs an already locked-out person another round trip through their inbox.

| Upstream | Now reported as | Offers a new link? |
|---|---|---|
| `400 Reset token expired` | expired — links last 1 hour | yes |
| `400 Invalid reset token` | no longer valid, **may** have already been used | yes |
| `429` | throttled — *your link has not been used up* | **no** |
| 5xx / unreachable | our end, not your link | **no** |

Two judgement calls worth flagging:

- **`invalidToken` deliberately hedges.** `consumePasswordResetToken` clears the column on success, so an already-used token and a garbage token are the *same* 400 upstream. The copy says the link "may have already been used" rather than inventing a precision the server does not have.
- **429 must NOT claim the link is dead.** The request never reached the service, so the token is untouched — telling this user to request a new link sends them off for no reason, and straight back into the same throttle.

Matched on status **and** the words that carry the meaning, in the same shape as the existing `isEmailNotVerifiedError`, so an unrelated future 400 cannot start claiming an expiry; anything unrecognised keeps the old generic string. **A new upstream failure is reported vaguely, never wrongly.** No raw upstream message reaches the client on any branch — every one returns a translated constant.

English text added to all 21 locale files (established pattern); `{email}` interpolation asserted present.

## Verification — every fix carries a control proven to fail

| Control | Result |
|---|---|
| Broke anti-enumeration (leaked `"No unverified account found"` on the no-user branch) | byte-identical test **+2 others went RED**; restored → 9/9 green |
| Collapsed the classifier to `return 'failed'` (the original defect) | **11 tests went RED** across both suites; restored → 22/22 green |
| Probed the message-key checker with a non-existent key | reported `MISSING` — so its clean run means something |

- `api jest src/auth` — **536/536** pass · `web vitest` — **108/108** pass
- `api tsc` **131**, `web tsc` **36** — both *identical* to the pre-change baseline measured on a clean tree; **none in any file touched here**
- `prettier --check` clean; `eslint` clean on every changed web file
- All **27** referenced message keys resolve in **all 21** locales
- Route file confirmed **present on disk** — not inferred from a 200 (this app soft-404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
