### PR TITLE
test(e2e): stop three specs asserting the defects #2106/#2108/#2093 fixed

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -55,8 +55,25 @@ test.describe('Registration', () => {
         await expect(page).not.toHaveURL(/\/register/);
     });
 
-    test('should show error for mismatched passwords', async ({ page }) => {
+    // ── Registration validation errors ──────────────────────────────────
+    //
+    // These two used to assert `locator('.bg-danger/10')` — the single error
+    // BANNER above the form. #2106 (EW-073…EW-076) deliberately removed that
+    // banner for validation problems and keys each error to the field it
+    // belongs to, rendered by `ui/input` as `<p class="… text-danger">`. The
+    // banner still exists, but only for `errors.general` (e.g. terms not
+    // accepted), so the old locator can never match a password problem again.
+    //
+    // Asserting the MESSAGE rather than the class is deliberate: the class is
+    // styling and will drift, the sentence is the thing the user must actually
+    // be told. Each test checks the message is absent BEFORE submitting, so a
+    // locator that silently matches nothing cannot pass by accident.
+
+    test('should show a field-level error for mismatched passwords', async ({ page }) => {
         await page.goto('/en/register');
+
+        const mismatch = page.getByText('Passwords do not match');
+        await expect(mismatch).toBeHidden(); // control: not shown before submit
 
         await page.locator('input[name="name"]').fill('Test User');
         await page.locator('input[name="email"]').fill('mismatch@test.local');
@@ -66,13 +83,16 @@ test.describe('Registration', () => {
 
         await page.locator('button[type="submit"]').click();
 
-        // Should show password mismatch error (stays on register page)
         await expect(page).toHaveURL(/\/register/);
-        await expect(page.locator('.bg-danger\\/10')).toBeVisible();
+        await expect(mismatch).toBeVisible();
     });
 
-    test('should show error for short password', async ({ page }) => {
+    test('should show a field-level error for short password', async ({ page }) => {
         await page.goto('/en/register');
+
+        // EW-073: the hint now states the rule the server actually enforces.
+        const tooShort = page.getByText('Password must be at least 8 characters');
+        await expect(tooShort).toBeHidden(); // control: not shown before submit
 
         await page.locator('input[name="name"]').fill('Test User');
         await page.locator('input[name="email"]').fill('short@test.local');
@@ -82,9 +102,8 @@ test.describe('Registration', () => {
 
         await page.locator('button[type="submit"]').click();
 
-        // Should show password too short error
         await expect(page).toHaveURL(/\/register/);
-        await expect(page.locator('.bg-danger\\/10')).toBeVisible();
+        await expect(tooShort).toBeVisible();
     });
 
     test('should have link to login page', async ({ page }) => {

--- a/apps/web/e2e/flow-email-verification-deep.spec.ts
+++ b/apps/web/e2e/flow-email-verification-deep.spec.ts
@@ -57,7 +57,16 @@ import {
  *        already-verified actor (svc short-circuit)      -> 400 { message:'Email already verified' }
  *        (asserted as a REAL 400 when MailHog delivers a token; else the cross-account /
  *        no-gate contract is asserted instead — never a fictional success).
- *   POST /api/auth/resend-verification                   -> 404 (does not exist).
+ *   POST /api/auth/resend-verification { email }         -> 200, @Public() (EW-070, #2108).
+ *        ANTI-ENUMERATION: unknown address, already-verified address and deactivated
+ *        account all return the SAME status and byte-identical body
+ *        ('If an account exists for that address and still needs verification, a
+ *        verification email has been sent'), with a throwaway bcrypt on every branch so
+ *        timing does not leak what the body hides. Throttled (5/60s by default) —
+ *        without that it is a mail cannon aimed at any address an attacker names.
+ *        A malformed address is still a 400 (@IsEmail on the DTO).
+ *        (Previously documented here as '-> 404 (does not exist)', which was the EW-070
+ *        DEFECT: a user whose verification mail never arrived was locked out for good.)
  *
  *   POST /api/auth/verify-email { token }                -> 200 + fresh session on a valid token
  *        bad/unknown token   -> 400 { message:'Invalid verification token' }
@@ -404,17 +413,58 @@ test.describe('Flow: email-verification deep (oracle / send / web-route)', () =>
         }
     });
 
-    test('send-verification is auth-gated (401), resend-verification does not exist (404), and send is NON-throttled (4x 200)', async ({
+    test('send-verification is auth-gated (401); resend-verification is PUBLIC, non-enumerating (200) — EW-070', async ({
         request,
     }) => {
         // Unauthenticated => 401 (AuthSessionGuard).
         const anon = await request.post(`${API_BASE}/api/auth/send-verification`);
         expect(anon.status()).toBe(401);
-        // resend-verification is NOT a real route.
-        const wrongPath = await request.post(`${API_BASE}/api/auth/resend-verification`);
-        expect(wrongPath.status()).toBe(404);
 
-        const u = await registerUserViaAPI(request);
+        // ── EW-070 ────────────────────────────────────────────────────────
+        // This assertion used to read `expect(wrongPath.status()).toBe(404)`
+        // — it PINNED the defect: a user whose verification mail never arrived
+        // was permanently locked out because no signed-out resend existed.
+        // #2108 added the endpoint, so 404 is now the wrong answer and this
+        // test was failing for the best possible reason.
+        //
+        // The contract that matters is anti-enumeration: an address with no
+        // account and an address that genuinely needs verification must be
+        // INDISTINGUISHABLE — same status, same byte-identical body.
+        const RESEND = `${API_BASE}/api/auth/resend-verification`;
+        const CONSTANT_BODY =
+            'If an account exists for that address and still needs verification, a verification email has been sent';
+
+        // (a) an address that certainly has no account
+        const unknown = await request.post(RESEND, {
+            data: { email: `no-such-user-${Date.now()}@test.local` },
+        });
+        expect(unknown.status(), 'unknown address must not 404/401 — the route is @Public()').toBe(
+            200,
+        );
+        expect((await unknown.json()).message).toBe(CONSTANT_BODY);
+
+        // (b) a real, freshly-registered (therefore unverified) account
+        const known = await registerUserViaAPI(request);
+        const existing = await request.post(RESEND, { data: { email: known.email } });
+        expect(existing.status()).toBe(200);
+
+        // (c) the oracle check — the two responses must be identical. If these
+        // ever diverge, the endpoint has become an account-existence probe.
+        expect(
+            (await existing.json()).message,
+            'known and unknown addresses must return the SAME body',
+        ).toBe(CONSTANT_BODY);
+
+        // A malformed address is still rejected by the DTO (@IsEmail) — the
+        // anti-enumeration guarantee is about real addresses, not about
+        // accepting garbage.
+        const malformed = await request.post(RESEND, { data: { email: 'not-an-email' } });
+        expect(malformed.status()).toBe(400);
+
+        // Reuse the account registered above rather than creating a second
+        // one — this suite is load-sensitive and registration is its most
+        // expensive step.
+        const u = known;
 
         // send-verification carries NO @Throttle, so four rapid authed calls all return 200 with
         // the documented envelope (an unverified actor each time regenerates a verification token).

--- a/apps/web/e2e/flow-goals-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-goals-ui-journey.spec.ts
@@ -352,6 +352,13 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         });
         await expect(page.getByRole('link', { name: 'Back to Goals' })).toBeVisible();
 
+        // The autonomy layer (#2093) turned this page into a tab strip —
+        // Definition of Done | Progress log | Sessions | Orchestrator | Results
+        // — and it opens on 'dod'. The Progress/Details/Outcome sections still
+        // exist under exactly these names, but they are inside the 'progress'
+        // panel, so the tab has to be opened before they render at all.
+        await page.getByRole('tab', { name: 'Progress log' }).click();
+
         // Section scaffold.
         await expect(page.getByRole('heading', { name: 'Progress' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
@@ -485,6 +492,12 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         await expect(page.getByRole('heading', { name: goal.title, level: 1 })).toBeVisible({
             timeout: 30_000,
         });
+        // The outcome override lives in the 'progress' panel, and #2093 made
+        // this page open on 'dod' — without this click the trigger below is
+        // not in the DOM at all and the test fails looking like a missing
+        // control rather than an unopened tab.
+        await page.getByRole('tab', { name: 'Progress log' }).click();
+
         // The only listbox trigger INSIDE the page content is the outcome
         // override. Scoped to #main-content because since a350801a the chat
         // composer carries a second listbox trigger (the voice-provider


### PR DESCRIPTION
The `develop → stage` cascade ([#2109](https://github.com/ever-works/ever-works/pull/2109)) took the stage E2E from **11 failing specs to 13**. Diffing the failing **sets** rather than the counts showed all three new failures are specs that **pin behaviour those PRs deliberately changed** — the gate was correctly noticing the fixes landed.

No product code changes here. All three were tests.

| spec | what it asserted | why that is now wrong |
|---|---|---|
| `auth.spec.ts` (2 tests) | `locator('.bg-danger/10')` — the single error **banner** | **#2106 (EW-073…076)** keys validation errors to their field instead. That *is* the EW-074 fix: the old banner named a field the form did not have. |
| `flow-email-verification-deep.spec.ts` | test literally named *"resend-verification **does not exist (404)**"* | It pinned the **EW-070 defect** — a user whose verification mail never arrived was locked out permanently. **#2108** added the endpoint. |
| `flow-goals-ui-journey.spec.ts` (2 tests) | `heading 'Progress'` and the outcome `Select` on `/goals/:id` | **#2093** made the page a tab strip opening on `dod`. Both still exist under exactly those names — inside the `progress` panel. |

### What changed

- **auth**: asserts the **message** (`Passwords do not match`, `Password must be at least 8 characters`) rather than a CSS class — the class is styling and drifts, the sentence is what the user must be told. Each test also asserts the message is **absent before submit**, so a locator that silently matches nothing cannot pass by accident. The `.bg-danger/10` assertion *elsewhere* in that file is deliberately untouched: the banner still exists for `errors.general`, and that test passes.
- **verification**: asserts the contract that actually matters — `@Public()` 200, and an **unknown address vs a real unverified one returning byte-identical bodies**, so the endpoint cannot become an account-existence oracle. A malformed address is still a 400. Also fixes the file's pinned-contract docblock, which still documented `-> 404 (does not exist)`.
- **goals**: opens the `Progress log` tab first. Without it the failure reads as a *missing control* rather than an unopened tab.

### Note on the remaining red

This does **not** make the stage E2E green — it has been red since **2026-08-11** for pre-existing reasons. Those remain, including a product-side 500 traced to a **TOCTOU race in organization slug allocation** (`allocateUsername` is a read-then-return loop that reserves nothing, and `organization.service.ts` does not use `isUniqueConstraintError`, so the unique violation surfaces as a 500 instead of a retry or a 409).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registration validation messaging to show clear field-level errors for password mismatches and passwords shorter than eight characters.
  * Improved email verification resend behavior with consistent responses that protect account privacy, while still rejecting malformed email addresses.
  * Updated goals page interactions to correctly display progress details and outcome controls through the Progress log tab.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->