### PR TITLE
fix(uptime): the retry and vantage-point control never ran on a transport failure

### DIFF
--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -151,14 +151,24 @@ jobs:
           probe_once() {
             local url="$1"
             : > "${BODY}"; : > "${ERRF}"
+            # 🛑 `|| CURL_RC=$?` is load-bearing, not defensive style.
+            # GitHub runs `run:` steps under `bash -e`, and the `set -uo
+            # pipefail` above ADDS flags — it does not clear `-e`. With this
+            # assignment unchecked, a curl timeout (exit 28) terminated the
+            # whole STEP right here: before the 3-attempt retry below, and
+            # before the control-target check that says "vantage point
+            # suspect". Both safety nets were dead code for every transport
+            # failure, so one blip on one target reported as a hard failure
+            # with no verdict. Observed twice on demo.ever.works while all
+            # seven production surfaces answered 200.
+            CURL_RC=0
             W="$(curl -sS -L \
                   --connect-timeout 8 \
                   --max-time 20 \
                   -A "${PROBE_UA}" \
                   -o "${BODY}" \
                   -w '%{http_code} %{time_namelookup} %{time_connect} %{time_appconnect} %{time_starttransfer} %{time_total} %{size_download}' \
-                  "${url}" 2>"${ERRF}")"
-            CURL_RC=$?
+                  "${url}" 2>"${ERRF}")" || CURL_RC=$?
             if [ -z "${W}" ]; then
               W="000 0.000000 0.000000 0.000000 0.000000 0.000000 0"
             fi


### PR DESCRIPTION
Follow-up to [#2107](https://github.com/ever-works/ever-works/pull/2107). Taking over an abandoned lane — session `4952730c` claimed this file on 2026-08-16 07:20 and has been idle ~42h against a 60-minute staleness threshold. Real state verified before touching it: merged, running on schedule, raising false alarms.

## Symptom (seen twice)

The monitor reports **failure** while all seven production surfaces answer **HTTP 200**. One target (`demo.ever.works`) hits a 20s curl timeout, and the step dies with `exit 28` — no verdict, no retry, no control note. Both times `demo.ever.works` answered **200 in ~0.74s** from another vantage point moments later.

A monitor that cries wolf is worse than no monitor: it trains everyone to ignore it, and the next alarm is the real one.

## Root cause — not what it looks like

My first reading was "one timeout aborts the step". That's the symptom, not the cause.

**GitHub runs `run:` steps under `bash -e`.** The script's `set -uo pipefail` *adds* `-u` and `pipefail`; it does **not** clear `-e`. So this:

```bash
W="$(curl ...)"
CURL_RC=$?
```

kills the step the instant curl returns non-zero. Which means:

- the **3-attempt, 15s-spaced retry has never executed** for a transport failure (timeout, DNS, TLS). Only marker-mismatch / unexpected-HTTP failures — where curl itself exits 0 — could ever reach it.
- the **control-target check** (`VANTAGE POINT SUSPECT`), the thing that tells you whether to trust the verdict at all, was equally unreachable.
- `CURL_RC=$?` could only ever read `0`.

Both of the workflow's safety nets were dead code for its most common failure mode.

## Fix

Make the assignment *checked* — `|| CURL_RC=$?` — which is `-e`-safe whether or not `-e` is set.

Reproduced both behaviours in a local `bash -e` harness:

| | result |
|---|---|
| unchecked (shipped) | step exits **28**, never reaches the retry |
| checked (this PR) | retry reached with `rc=28`, step exits **0** |

## Not changed

The `gh issue create` / `gh issue view` calls in the reporting step are also unchecked, but failing loudly there is defensible — if the alert issue can't be written, silence would be worse. Left alone deliberately rather than swept up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uptime monitoring resilience when connection checks encounter transport errors.
  * Monitoring now continues through retry and location checks, ensuring failures are classified and reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->