### PR TITLE
cascade: develop → stage (auth honesty, org-slug race 500, E2E specs, uptime monitor)

### DIFF
--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -151,14 +151,24 @@ jobs:
           probe_once() {
             local url="$1"
             : > "${BODY}"; : > "${ERRF}"
+            # 🛑 `|| CURL_RC=$?` is load-bearing, not defensive style.
+            # GitHub runs `run:` steps under `bash -e`, and the `set -uo
+            # pipefail` above ADDS flags — it does not clear `-e`. With this
+            # assignment unchecked, a curl timeout (exit 28) terminated the
+            # whole STEP right here: before the 3-attempt retry below, and
+            # before the control-target check that says "vantage point
+            # suspect". Both safety nets were dead code for every transport
+            # failure, so one blip on one target reported as a hard failure
+            # with no verdict. Observed twice on demo.ever.works while all
+            # seven production surfaces answered 200.
+            CURL_RC=0
             W="$(curl -sS -L \
                   --connect-timeout 8 \
                   --max-time 20 \
                   -A "${PROBE_UA}" \
                   -o "${BODY}" \
                   -w '%{http_code} %{time_namelookup} %{time_connect} %{time_appconnect} %{time_starttransfer} %{time_total} %{size_download}' \
-                  "${url}" 2>"${ERRF}")"
-            CURL_RC=$?
+                  "${url}" 2>"${ERRF}")" || CURL_RC=$?
             if [ -z "${W}" ]; then
               W="000 0.000000 0.000000 0.000000 0.000000 0.000000 0"
             fi

--- a/apps/api/src/organizations/__tests__/organization.service.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization.service.spec.ts
@@ -8,6 +8,7 @@ jest.mock('@ever-works/contracts/api', () => ({
 }));
 
 import { ConflictException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
 import { OrganizationService } from '../organization.service';
 
 /**
@@ -26,8 +27,17 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
         orgCountByTenant?: number;
         tenantId?: string;
         existingLinkedOrg?: (Org & { linkedWorkId?: string | null }) | null;
+        /**
+         * Make the organizations INSERT lose a slug race this many times
+         * before succeeding. Defaults to 0, so every existing test is
+         * unaffected.
+         */
+        slugRaceLosses?: number;
+        /** Throw this from the organizations INSERT instead of succeeding. */
+        saveError?: Error;
     }) {
         const queryLog: QueryRecord[] = [];
+        let remainingRaceLosses = opts.slugRaceLosses ?? 0;
 
         const userRepository = {
             findById: jest.fn().mockResolvedValue(opts.user ?? null),
@@ -61,12 +71,37 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
                 if (target === 'organizations') {
                     return {
                         create: jest.fn((data) => ({ ...data, id: 'o-new' })),
-                        save: jest.fn(async (org) => ({
-                            ...org,
-                            id: 'o-new',
-                            createdAt: new Date('2026-01-01'),
-                            updatedAt: new Date('2026-01-01'),
-                        })),
+                        save: jest.fn(async (org) => {
+                            if (opts.saveError) {
+                                throw opts.saveError;
+                            }
+                            if (remainingRaceLosses > 0) {
+                                remainingRaceLosses -= 1;
+                                // What Postgres actually returns when a
+                                // concurrent INSERT already took the slug:
+                                // SQLSTATE 23505. Constructed as a REAL
+                                // QueryFailedError because that is what
+                                // `isUniqueConstraintError` narrows on — a
+                                // hand-rolled `{ code: '23505' }` would slip
+                                // past the guard and prove nothing.
+                                throw new QueryFailedError(
+                                    'INSERT INTO "organizations" ...',
+                                    [],
+                                    Object.assign(
+                                        new Error(
+                                            'duplicate key value violates unique constraint "UQ_organizations_slug"',
+                                        ),
+                                        { code: '23505' },
+                                    ) as never,
+                                );
+                            }
+                            return {
+                                ...org,
+                                id: 'o-new',
+                                createdAt: new Date('2026-01-01'),
+                                updatedAt: new Date('2026-01-01'),
+                            };
+                        }),
                     };
                 }
                 if (target === 'users') {
@@ -132,6 +167,67 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
             await expect(service.createOrganization('u-1', 'x'.repeat(201))).rejects.toBeInstanceOf(
                 ConflictException,
             );
+        });
+
+        // ── Slug race (the intermittent 500 in flow-idempotency-concurrency) ──
+        //
+        // `allocateUsername` reserves nothing, so between "this slug is free"
+        // and the INSERT another request can take it. The UNIQUE index on
+        // `organizations.slug` then rejects the loser, and that violation used
+        // to reach the client as HTTP 500.
+
+        it('re-allocates and still succeeds when a concurrent create steals the slug', async () => {
+            const { service, usernameAllocator } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+                slugRaceLosses: 1,
+            });
+
+            // No throw: losing a race is not the caller's problem. The slug is
+            // DERIVED from the name, so the right answer is the next free one
+            // and a normal success — exactly what they'd have got a second later.
+            const org = await service.createOrganization('u-1', 'Acme Inc.');
+
+            expect(org.id).toBe('o-new');
+            // Allocated twice: the retry asks again, so attempt 2 sees the
+            // winner's row and picks a different candidate.
+            expect(usernameAllocator.allocateUsername).toHaveBeenCalledTimes(2);
+        });
+
+        it('gives up after repeated slug races rather than retrying forever', async () => {
+            const { service, usernameAllocator } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+                slugRaceLosses: 99,
+            });
+
+            // Bounded at 4 attempts. Losing four consecutive races is not
+            // concurrency any more, so the error surfaces instead of the
+            // request hanging in a retry loop.
+            await expect(service.createOrganization('u-1', 'Acme Inc.')).rejects.toBeInstanceOf(
+                QueryFailedError,
+            );
+            expect(usernameAllocator.allocateUsername).toHaveBeenCalledTimes(4);
+        });
+
+        it('does NOT retry an error that is not a unique-constraint violation', async () => {
+            const { service, usernameAllocator } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+                // A NOT-NULL violation is a bug, not a lost race. Retrying it
+                // would repeat the same failure three more times, turn one log
+                // line into four, and delay the real error reaching anyone.
+                saveError: new QueryFailedError(
+                    'INSERT INTO "organizations" ...',
+                    [],
+                    Object.assign(new Error('null value in column "displayName"'), {
+                        code: '23502',
+                    }) as never,
+                ),
+            });
+
+            await expect(service.createOrganization('u-1', 'Acme Inc.')).rejects.toBeInstanceOf(
+                QueryFailedError,
+            );
+            // Allocated exactly once — the error propagated on the first attempt.
+            expect(usernameAllocator.allocateUsername).toHaveBeenCalledTimes(1);
         });
 
         it('lazy-creates Tenant, allocates slug, inserts Org, runs backfill', async () => {

--- a/apps/api/src/organizations/organization.service.ts
+++ b/apps/api/src/organizations/organization.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import { isUniqueConstraintError } from '@ever-works/agent/utils';
 import type {
     Organization,
     OrganizationRegistrationProvider,
@@ -500,76 +501,142 @@ export class OrganizationService {
         const tenant = await this.tenantBootstrap.ensureTenant(userId);
 
         const slugBase = slugOverride?.trim() || trimmedName;
-        const slug = await this.usernameAllocator.allocateUsername(slugBase);
 
-        return this.dataSource.transaction(async (manager) => {
-            // Use the manager's repository so the INSERT lands in the
-            // same transaction as the backfill UPDATEs below.
-            //
-            // `extra` fields are layered on top of the base shape so
-            // Phase 6 callers (which pass nothing) keep producing
-            // `{ tenantId, slug, displayName }` exactly as before. The
-            // entity's column defaults handle the unspecified columns
-            // (registrationStatus defaults to `'draft'`).
-            // PR-6 — vision is optional at creation; empty/whitespace
-            // collapses to null so we never stamp `visionUpdatedAt`
-            // for a blank field the modal submitted untouched.
-            const vision = this.normalizeVision(extra?.vision);
-            const org = manager.getRepository<Organization>('organizations').create({
-                tenantId: tenant.id,
-                slug,
-                displayName: trimmedName,
-                legalName: extra?.legalName ?? null,
-                countryCode: extra?.countryCode ?? null,
-                registrationProvider: extra?.registrationProvider ?? null,
-                registrationStatus: extra?.registrationStatus ?? 'draft',
-                linkedWorkId: extra?.linkedWorkId ?? null,
-                vision,
-                visionUpdatedAt: vision !== null ? new Date() : null,
-            });
-            const saved = await manager.getRepository<Organization>('organizations').save(org);
+        // 🛑 `allocateUsername` RESERVES NOTHING. It loops until it finds a
+        // candidate that does not currently collide and hands it back; the
+        // INSERT happens afterwards, in the transaction below. Between those
+        // two moments another request can take the same slug — and it does:
+        // two people registering a company with the same name at the same
+        // moment both get told `acme` is free, and the second INSERT hits the
+        // UNIQUE index on `organizations.slug`.
+        //
+        // That violation used to escape as a raw `QueryFailedError`, which
+        // Nest renders as **HTTP 500**. `organization.service.ts` was not among
+        // the files using `isUniqueConstraintError`, even though that helper's
+        // own docblock describes precisely this case. The e2e
+        // `flow-idempotency-concurrency-matrix` caught it intermittently, and
+        // `user.entity.ts:305` had already noted that "the DB UNIQUE constraint
+        // will catch any race" — it does; nothing was catching the catch.
+        //
+        // Retry rather than 409: the slug is DERIVED, not chosen. The caller
+        // asked for an organization named "Acme", not for the string `acme`,
+        // so losing the race should yield `acme-2` and a 201 — the same result
+        // they would have got a second later. A 409 would be us reporting our
+        // own race back to a user who did nothing wrong.
+        return this.withSlugCollisionRetry(slugBase, (slug) =>
+            this.dataSource.transaction(async (manager) => {
+                // Use the manager's repository so the INSERT lands in the
+                // same transaction as the backfill UPDATEs below.
+                //
+                // `extra` fields are layered on top of the base shape so
+                // Phase 6 callers (which pass nothing) keep producing
+                // `{ tenantId, slug, displayName }` exactly as before. The
+                // entity's column defaults handle the unspecified columns
+                // (registrationStatus defaults to `'draft'`).
+                // PR-6 — vision is optional at creation; empty/whitespace
+                // collapses to null so we never stamp `visionUpdatedAt`
+                // for a blank field the modal submitted untouched.
+                const vision = this.normalizeVision(extra?.vision);
+                const org = manager.getRepository<Organization>('organizations').create({
+                    tenantId: tenant.id,
+                    slug,
+                    displayName: trimmedName,
+                    legalName: extra?.legalName ?? null,
+                    countryCode: extra?.countryCode ?? null,
+                    registrationProvider: extra?.registrationProvider ?? null,
+                    registrationStatus: extra?.registrationStatus ?? 'draft',
+                    linkedWorkId: extra?.linkedWorkId ?? null,
+                    vision,
+                    visionUpdatedAt: vision !== null ? new Date() : null,
+                });
+                const saved = await manager.getRepository<Organization>('organizations').save(org);
 
-            // Step (d): pin the new Org as the user's last-seen scope
-            // so the next login lands on it. Only do this if the user
-            // hasn't already explicitly picked another Org as their
-            // landing scope (defensive — shouldn't be possible on first
-            // Org, but cheap to check).
-            const currentUser = await manager
-                .getRepository('users')
-                .findOne({ where: { id: userId } });
-            if (currentUser && currentUser.lastScopeOrganizationId === null) {
-                await manager
+                // Step (d): pin the new Org as the user's last-seen scope
+                // so the next login lands on it. Only do this if the user
+                // hasn't already explicitly picked another Org as their
+                // landing scope (defensive — shouldn't be possible on first
+                // Org, but cheap to check).
+                const currentUser = await manager
                     .getRepository('users')
-                    .update(userId, { lastScopeOrganizationId: saved.id });
+                    .findOne({ where: { id: userId } });
+                if (currentUser && currentUser.lastScopeOrganizationId === null) {
+                    await manager
+                        .getRepository('users')
+                        .update(userId, { lastScopeOrganizationId: saved.id });
+                }
+
+                // Step (e): unconditional tenantId backfill. Walks every
+                // user-owned table and stamps `tenantId = tenant.id` on
+                // rows where it's still NULL. Idempotent — re-running this
+                // is a no-op once all rows have tenantId set.
+                const allTables = [...TIER_A_BACKFILL_TABLES, ...TIER_B_BACKFILL_TABLES];
+                // Emit driver-correct positional placeholders. Postgres uses `$1/$2`;
+                // better-sqlite3 (the e2e in-memory driver) uses `?`. The previously
+                // hard-coded `$1/$2` raw query threw `RangeError: Too many parameter
+                // values were provided` under sqlite, which 500'd the whole
+                // create-Organization transaction. Behaviour on Postgres is unchanged.
+                const isPostgres = manager.connection?.options?.type === 'postgres';
+                for (const { table, userColumn } of allTables) {
+                    // Security: validate interpolated identifiers (defense-in-depth).
+                    this.assertSafeSqlIdentifier(table);
+                    this.assertSafeSqlIdentifier(userColumn);
+                    const sql = isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1 WHERE "${userColumn}" = $2 AND "tenantId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ? WHERE "${userColumn}" = ? AND "tenantId" IS NULL`;
+                    await manager.query(sql, [tenant.id, userId]);
+                }
+
+                this.logger.log(
+                    `Created Organization ${saved.id} (slug=${saved.slug}) for user ${userId}; tenantId backfilled across ${allTables.length} tables`,
+                );
+
+                return saved;
+            }),
+        );
+    }
+
+    /**
+     * Allocate a slug, run `create`, and re-allocate if the UNIQUE index says
+     * somebody else took it first.
+     *
+     * The allocator is a read-then-return loop with no reservation, so its
+     * answer is only ever "free a moment ago". The DB index is the actual
+     * arbiter. Losing that race is normal under concurrency, not exceptional —
+     * so it is retried, and only a run of consecutive losses is an error.
+     *
+     * The whole transaction is retried, not just the INSERT: it rolls back as a
+     * unit, so a failed attempt leaves nothing behind and the next attempt
+     * starts clean. `allocateUsername` is called fresh each time, so attempt 2
+     * sees the winner's row and picks the next free suffix.
+     */
+    private async withSlugCollisionRetry<T>(
+        slugBase: string,
+        create: (slug: string) => Promise<T>,
+    ): Promise<T> {
+        // 4 attempts covers concurrency far past anything this endpoint sees;
+        // a caller that loses four consecutive races is not racing, something
+        // else is wrong and a 409 is the honest answer.
+        const MAX_ATTEMPTS = 4;
+
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            const slug = await this.usernameAllocator.allocateUsername(slugBase);
+            try {
+                return await create(slug);
+            } catch (error) {
+                if (!isUniqueConstraintError(error) || attempt === MAX_ATTEMPTS) {
+                    throw error;
+                }
+                // Deliberately `warn`, not `error`: this is the system working.
+                // It is logged because a SUSTAINED rate of these means the
+                // allocator is being outrun and is worth knowing about.
+                this.logger.warn(
+                    `Organization slug race on "${slug}" (attempt ${attempt}/${MAX_ATTEMPTS}) — re-allocating`,
+                );
             }
+        }
 
-            // Step (e): unconditional tenantId backfill. Walks every
-            // user-owned table and stamps `tenantId = tenant.id` on
-            // rows where it's still NULL. Idempotent — re-running this
-            // is a no-op once all rows have tenantId set.
-            const allTables = [...TIER_A_BACKFILL_TABLES, ...TIER_B_BACKFILL_TABLES];
-            // Emit driver-correct positional placeholders. Postgres uses `$1/$2`;
-            // better-sqlite3 (the e2e in-memory driver) uses `?`. The previously
-            // hard-coded `$1/$2` raw query threw `RangeError: Too many parameter
-            // values were provided` under sqlite, which 500'd the whole
-            // create-Organization transaction. Behaviour on Postgres is unchanged.
-            const isPostgres = manager.connection?.options?.type === 'postgres';
-            for (const { table, userColumn } of allTables) {
-                // Security: validate interpolated identifiers (defense-in-depth).
-                this.assertSafeSqlIdentifier(table);
-                this.assertSafeSqlIdentifier(userColumn);
-                const sql = isPostgres
-                    ? `UPDATE "${table}" SET "tenantId" = $1 WHERE "${userColumn}" = $2 AND "tenantId" IS NULL`
-                    : `UPDATE "${table}" SET "tenantId" = ? WHERE "${userColumn}" = ? AND "tenantId" IS NULL`;
-                await manager.query(sql, [tenant.id, userId]);
-            }
-
-            this.logger.log(
-                `Created Organization ${saved.id} (slug=${saved.slug}) for user ${userId}; tenantId backfilled across ${allTables.length} tables`,
-            );
-
-            return saved;
-        });
+        // Unreachable: the final attempt either returns or rethrows above.
+        throw new ConflictException('Could not allocate a unique organization slug');
     }
 
     /**

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -55,8 +55,25 @@ test.describe('Registration', () => {
         await expect(page).not.toHaveURL(/\/register/);
     });
 
-    test('should show error for mismatched passwords', async ({ page }) => {
+    // ── Registration validation errors ──────────────────────────────────
+    //
+    // These two used to assert `locator('.bg-danger/10')` — the single error
+    // BANNER above the form. #2106 (EW-073…EW-076) deliberately removed that
+    // banner for validation problems and keys each error to the field it
+    // belongs to, rendered by `ui/input` as `<p class="… text-danger">`. The
+    // banner still exists, but only for `errors.general` (e.g. terms not
+    // accepted), so the old locator can never match a password problem again.
+    //
+    // Asserting the MESSAGE rather than the class is deliberate: the class is
+    // styling and will drift, the sentence is the thing the user must actually
+    // be told. Each test checks the message is absent BEFORE submitting, so a
+    // locator that silently matches nothing cannot pass by accident.
+
+    test('should show a field-level error for mismatched passwords', async ({ page }) => {
         await page.goto('/en/register');
+
+        const mismatch = page.getByText('Passwords do not match');
+        await expect(mismatch).toBeHidden(); // control: not shown before submit
 
         await page.locator('input[name="name"]').fill('Test User');
         await page.locator('input[name="email"]').fill('mismatch@test.local');
@@ -66,13 +83,16 @@ test.describe('Registration', () => {
 
         await page.locator('button[type="submit"]').click();
 
-        // Should show password mismatch error (stays on register page)
         await expect(page).toHaveURL(/\/register/);
-        await expect(page.locator('.bg-danger\\/10')).toBeVisible();
+        await expect(mismatch).toBeVisible();
     });
 
-    test('should show error for short password', async ({ page }) => {
+    test('should show a field-level error for short password', async ({ page }) => {
         await page.goto('/en/register');
+
+        // EW-073: the hint now states the rule the server actually enforces.
+        const tooShort = page.getByText('Password must be at least 8 characters');
+        await expect(tooShort).toBeHidden(); // control: not shown before submit
 
         await page.locator('input[name="name"]').fill('Test User');
         await page.locator('input[name="email"]').fill('short@test.local');
@@ -82,9 +102,8 @@ test.describe('Registration', () => {
 
         await page.locator('button[type="submit"]').click();
 
-        // Should show password too short error
         await expect(page).toHaveURL(/\/register/);
-        await expect(page.locator('.bg-danger\\/10')).toBeVisible();
+        await expect(tooShort).toBeVisible();
     });
 
     test('should have link to login page', async ({ page }) => {

--- a/apps/web/e2e/flow-agents-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-agents-ui-journey.spec.ts
@@ -15,7 +15,14 @@ import { clickAndExpectUrl, clickUntil } from './helpers/nav';
  * health strip, the capabilities block, the Guardrails card, the 6-tab strip
  * wiring, the 5-pill instructions editor presence, and the Settings status
  * controls that differ per lifecycle state (draft → Activate, active → Pause,
- * paused → Resume). Data is seeded via the API as the SAME seeded user the
+ * paused → Resume).
+ *
+ * Navigation consolidation (docs/specs/features/navigation-consolidation):
+ * /agents is tab 2 of the Teams hub, so this file also covers the Agents Chart
+ * CTA + the /agents/chart page (org chart with human members stripped), the
+ * Skills catalog block (anchor #skills) and the /skills → /agents redirect.
+ *
+ * Data is seeded via the API as the SAME seeded user the
  * `chromium` project's storageState authenticates as, so create-via-API agents
  * are visible + mutable in the UI.
  *
@@ -122,6 +129,48 @@ test.describe('Agents catalog UI — prompt-first surface', () => {
         // The "Or → Create Agent Manually" alternative below the composer.
         await expect(page.getByText('Or', { exact: true }).first()).toBeVisible();
         await expect(page.getByText('Create Agent Manually').first()).toBeVisible();
+    });
+
+    test('the header exposes the Agents Chart CTA and the Skills block renders below the grid', async ({
+        page,
+    }) => {
+        // Navigation consolidation (docs/specs/features/navigation-consolidation
+        // §3.5): /agents is tab 2 of the Teams hub — it owns the Agents Chart
+        // entry point and hosts the Skills catalog as a block (anchor #skills;
+        // /skills redirects here).
+        await page.goto('/en/agents', { waitUntil: 'domcontentloaded' });
+        await expect(page).not.toHaveURL(/\/login/);
+
+        const chartLink = page.getByTestId('agents-chart-link');
+        await expect(chartLink).toBeVisible({ timeout: 30_000 });
+        await expect(chartLink).toHaveAttribute('href', /\/agents\/chart$/);
+
+        const skills = page.getByTestId('agents-skills-section');
+        await expect(skills).toBeVisible({ timeout: 30_000 });
+        await expect(skills).toHaveAttribute('id', 'skills');
+        // The block keeps the old page's chrome: an h2 (the page's single h1
+        // stays "Agents") plus the two catalog CTAs.
+        await expect(skills.getByRole('heading', { name: 'Skills', level: 2 })).toBeVisible();
+    });
+
+    test('/skills redirects into the Agents tab, filters intact', async ({ page }) => {
+        await page.goto('/en/skills?section=custom', { waitUntil: 'domcontentloaded' });
+
+        // Playwright reports the hash inconsistently across navigations, so the
+        // pathname + query are the post-condition, not the raw url string.
+        //
+        // The pathname is asserted prefix-agnostically because `/en/…` never
+        // survives: `i18n/routing.ts` runs `localePrefix: 'never'`, so
+        // `proxy.ts` (`detectLegacyLocalePrefix`) 307s the legacy `/en/skills`
+        // bookmark to `/skills` before this page's own redirect ever runs, and
+        // next-intl's `redirect()` emits an unprefixed `Location` in that mode.
+        // Same contract as the meetings journey (`flow-meetings-ui-journey`)
+        // and `flow-i18n-locale-switching` ("legacy /en/login collapses").
+        await expect
+            .poll(() => new URL(page.url()).pathname, { timeout: 30_000 })
+            .toMatch(/^\/(en\/)?agents$/);
+        expect(new URL(page.url()).searchParams.get('section')).toBe('custom');
+        await expect(page.getByTestId('agents-skills-section')).toBeVisible({ timeout: 30_000 });
     });
 
     test('an API-created draft agent appears as a card with its name, Draft badge, and Workspace scope', async ({
@@ -518,5 +567,54 @@ test.describe('Agent settings — scorecard section', () => {
         await expect(page.getByRole('button', { name: 'Add metric' })).toBeVisible({
             timeout: 15_000,
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Agents Chart (/agents/chart) — the org chart with human members stripped
+// ---------------------------------------------------------------------------
+
+test.describe('Agents Chart — /agents/chart', () => {
+    test('renders the chart (or its empty state) and never draws a human member card', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(90_000);
+        // Seed an Agent so the chart has something to draw — without one the
+        // page legitimately renders `agents-chart-empty` and the member-count
+        // assertion below would be vacuous.
+        await createSeededAgent(request);
+        await page.goto('/en/agents/chart', { waitUntil: 'domcontentloaded' });
+        await expect(page).not.toHaveURL(/\/login/);
+
+        // Exactly one of the three terminal surfaces must render: no-org,
+        // empty, or the canvas. Which one depends on the shared seeded org's
+        // state, so accept any of them rather than pinning a fixture.
+        const surface = page.locator(
+            '[data-testid="agents-chart-no-org"], [data-testid="agents-chart-empty"], [data-testid="org-chart-canvas"]',
+        );
+        await expect(surface.first()).toBeVisible({ timeout: 30_000 });
+
+        const canvas = page.getByTestId('org-chart-canvas');
+        if (await canvas.isVisible().catch(() => false)) {
+            await expect(page.getByRole('heading', { name: 'Agents Chart' })).toBeVisible();
+            // CONTROL: nodes exist and do carry `data-node-kind`, so the zero
+            // member count below is a real absence and not a selector typo.
+            expect(await page.locator('[data-node-kind]').count()).toBeGreaterThan(0);
+            await expect(page.locator('[data-node-kind="member"]')).toHaveCount(0);
+        }
+    });
+
+    test('the back-link returns to the Agents tab', async ({ page }) => {
+        await page.goto('/en/agents/chart', { waitUntil: 'domcontentloaded' });
+
+        const back = page.getByRole('link', { name: /Back to Agents/ });
+        // The no-org branch renders a different CTA, so only assert the
+        // back-link when the org-scoped page actually rendered.
+        if (await back.isVisible().catch(() => false)) {
+            await expect(back).toHaveAttribute('href', /\/agents$/);
+        } else {
+            await expect(page.getByTestId('agents-chart-no-org')).toBeVisible({ timeout: 30_000 });
+        }
     });
 });

--- a/apps/web/e2e/flow-email-verification-deep.spec.ts
+++ b/apps/web/e2e/flow-email-verification-deep.spec.ts
@@ -57,7 +57,16 @@ import {
  *        already-verified actor (svc short-circuit)      -> 400 { message:'Email already verified' }
  *        (asserted as a REAL 400 when MailHog delivers a token; else the cross-account /
  *        no-gate contract is asserted instead — never a fictional success).
- *   POST /api/auth/resend-verification                   -> 404 (does not exist).
+ *   POST /api/auth/resend-verification { email }         -> 200, @Public() (EW-070, #2108).
+ *        ANTI-ENUMERATION: unknown address, already-verified address and deactivated
+ *        account all return the SAME status and byte-identical body
+ *        ('If an account exists for that address and still needs verification, a
+ *        verification email has been sent'), with a throwaway bcrypt on every branch so
+ *        timing does not leak what the body hides. Throttled (5/60s by default) —
+ *        without that it is a mail cannon aimed at any address an attacker names.
+ *        A malformed address is still a 400 (@IsEmail on the DTO).
+ *        (Previously documented here as '-> 404 (does not exist)', which was the EW-070
+ *        DEFECT: a user whose verification mail never arrived was locked out for good.)
  *
  *   POST /api/auth/verify-email { token }                -> 200 + fresh session on a valid token
  *        bad/unknown token   -> 400 { message:'Invalid verification token' }
@@ -404,17 +413,58 @@ test.describe('Flow: email-verification deep (oracle / send / web-route)', () =>
         }
     });
 
-    test('send-verification is auth-gated (401), resend-verification does not exist (404), and send is NON-throttled (4x 200)', async ({
+    test('send-verification is auth-gated (401); resend-verification is PUBLIC, non-enumerating (200) — EW-070', async ({
         request,
     }) => {
         // Unauthenticated => 401 (AuthSessionGuard).
         const anon = await request.post(`${API_BASE}/api/auth/send-verification`);
         expect(anon.status()).toBe(401);
-        // resend-verification is NOT a real route.
-        const wrongPath = await request.post(`${API_BASE}/api/auth/resend-verification`);
-        expect(wrongPath.status()).toBe(404);
 
-        const u = await registerUserViaAPI(request);
+        // ── EW-070 ────────────────────────────────────────────────────────
+        // This assertion used to read `expect(wrongPath.status()).toBe(404)`
+        // — it PINNED the defect: a user whose verification mail never arrived
+        // was permanently locked out because no signed-out resend existed.
+        // #2108 added the endpoint, so 404 is now the wrong answer and this
+        // test was failing for the best possible reason.
+        //
+        // The contract that matters is anti-enumeration: an address with no
+        // account and an address that genuinely needs verification must be
+        // INDISTINGUISHABLE — same status, same byte-identical body.
+        const RESEND = `${API_BASE}/api/auth/resend-verification`;
+        const CONSTANT_BODY =
+            'If an account exists for that address and still needs verification, a verification email has been sent';
+
+        // (a) an address that certainly has no account
+        const unknown = await request.post(RESEND, {
+            data: { email: `no-such-user-${Date.now()}@test.local` },
+        });
+        expect(unknown.status(), 'unknown address must not 404/401 — the route is @Public()').toBe(
+            200,
+        );
+        expect((await unknown.json()).message).toBe(CONSTANT_BODY);
+
+        // (b) a real, freshly-registered (therefore unverified) account
+        const known = await registerUserViaAPI(request);
+        const existing = await request.post(RESEND, { data: { email: known.email } });
+        expect(existing.status()).toBe(200);
+
+        // (c) the oracle check — the two responses must be identical. If these
+        // ever diverge, the endpoint has become an account-existence probe.
+        expect(
+            (await existing.json()).message,
+            'known and unknown addresses must return the SAME body',
+        ).toBe(CONSTANT_BODY);
+
+        // A malformed address is still rejected by the DTO (@IsEmail) — the
+        // anti-enumeration guarantee is about real addresses, not about
+        // accepting garbage.
+        const malformed = await request.post(RESEND, { data: { email: 'not-an-email' } });
+        expect(malformed.status()).toBe(400);
+
+        // Reuse the account registered above rather than creating a second
+        // one — this suite is load-sensitive and registration is its most
+        // expensive step.
+        const u = known;
 
         // send-verification carries NO @Throttle, so four rapid authed calls all return 200 with
         // the documented envelope (an unverified actor each time regenerates a verification token).

--- a/apps/web/e2e/flow-goals-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-goals-ui-journey.spec.ts
@@ -352,6 +352,13 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         });
         await expect(page.getByRole('link', { name: 'Back to Goals' })).toBeVisible();
 
+        // The autonomy layer (#2093) turned this page into a tab strip —
+        // Definition of Done | Progress log | Sessions | Orchestrator | Results
+        // — and it opens on 'dod'. The Progress/Details/Outcome sections still
+        // exist under exactly these names, but they are inside the 'progress'
+        // panel, so the tab has to be opened before they render at all.
+        await page.getByRole('tab', { name: 'Progress log' }).click();
+
         // Section scaffold.
         await expect(page.getByRole('heading', { name: 'Progress' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
@@ -485,6 +492,12 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         await expect(page.getByRole('heading', { name: goal.title, level: 1 })).toBeVisible({
             timeout: 30_000,
         });
+        // The outcome override lives in the 'progress' panel, and #2093 made
+        // this page open on 'dod' — without this click the trigger below is
+        // not in the DOM at all and the test fails looking like a missing
+        // control rather than an unopened tab.
+        await page.getByRole('tab', { name: 'Progress log' }).click();
+
         // The only listbox trigger INSIDE the page content is the outcome
         // override. Scoped to #main-content because since a350801a the chat
         // composer carries a second listbox trigger (the voice-provider

--- a/apps/web/e2e/flow-meetings-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-meetings-ui-journey.spec.ts
@@ -4,16 +4,25 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { clickAndExpectUrl, clickUntil } from './helpers/nav';
 
 /**
- * flow-meetings-ui-journey — the `/meetings` DASHBOARD UI, end-to-end.
+ * flow-meetings-ui-journey — the Meetings DASHBOARD UI, end-to-end.
  *
  * `flow-meetings-crud-contract.spec.ts` drives the `/api/meetings` REST surface
  * with fresh registered users. This file is the DISTINCT, additive UI angle: it
  * seeds meetings through the API as the SEEDED storageState user (so they render
  * for the authenticated browser session) and then asserts the real rendered
  * Next.js pages:
- *   - `/meetings`        list catalog          (MeetingsList + MeetingCard)
+ *   - `/memory#meetings` list catalog          (MeetingsList + MeetingCard)
  *   - `/meetings/new`    capture form          (MeetingForm + createMeetingAction)
  *   - `/meetings/[id]`   detail + mutations    (MeetingDetailClient)
+ *
+ * NAVIGATION CONSOLIDATION (docs/specs/features/navigation-consolidation):
+ * meetings are a memory source, so the catalog moved off its own sidebar entry
+ * and onto the Memory page as the `#meetings` block. Only the INDEX moved —
+ * `/meetings/new` and `/meetings/[id]` are untouched, and `/meetings` itself
+ * still resolves as a redirect carrying its filters. The block is the same
+ * `MeetingsList` in its `panel` chrome, so every `data-testid` this file used
+ * still exists; what changed is the URL it lives at and that its heading is an
+ * `h2` under the Memory page's `h1`.
  *
  * The Meetings surface is a server component that fetches with the seeded user's
  * Better-Auth session cookie, so a meeting created via the JWT API for that same
@@ -123,19 +132,38 @@ function cardFor(page: Page, id: string) {
     return page.locator(`a[href*="/meetings/${id}"]`);
 }
 
+/**
+ * The catalog block on the Memory page. Scoping to it keeps the
+ * assertions honest — the Memory page around it has its own headings,
+ * links and empty states.
+ */
+function catalog(page: Page) {
+    return page.getByTestId('meetings-shell');
+}
+
+/** Open the Memory page at the Meetings block, with optional filters. */
+async function gotoCatalog(page: Page, query = ''): Promise<void> {
+    await page.goto(`/en/memory${query}#meetings`, { waitUntil: 'domcontentloaded' });
+    await expect(catalog(page)).toBeVisible({ timeout: 30_000 });
+}
+
 // ============================================================================
-// A. /meetings list catalog
+// A. Meetings catalog — the `#meetings` block on /memory
 // ============================================================================
 
-test.describe('Meetings — /meetings list catalog (UI)', () => {
+test.describe('Meetings — /memory#meetings list catalog (UI)', () => {
     test('list shell renders header, subtitle, connect hint and New meeting CTA', async ({
         page,
     }) => {
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page);
         await expect(page).not.toHaveURL(/\/login/);
-        await expect(page.getByRole('heading', { name: 'Meetings', level: 1 })).toBeVisible({
+        // The Memory page owns the h1; the block announces itself with an h2.
+        await expect(page.getByRole('heading', { name: 'Memory', level: 1 })).toBeVisible({
             timeout: 30_000,
         });
+        await expect(
+            catalog(page).getByRole('heading', { name: 'Meetings', level: 2 }),
+        ).toBeVisible({ timeout: 30_000 });
         await expect(
             page.getByText('Every meeting the platform captured', { exact: false }),
         ).toBeVisible();
@@ -150,21 +178,22 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
             /\/plugins/,
         );
 
-        const cta = page.getByRole('link', { name: /New meeting/i }).first();
+        const cta = catalog(page)
+            .getByRole('link', { name: /New meeting/i })
+            .first();
         await expect(cta).toBeVisible();
         await expect(cta).toHaveAttribute('href', /\/meetings\/new/);
     });
 
     test('filter bar exposes the Source control, Apply and Reset', async ({ page }) => {
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
-        await expect(page.getByRole('heading', { name: 'Meetings', level: 1 })).toBeVisible({
-            timeout: 30_000,
-        });
+        await gotoCatalog(page);
         await expect(page.getByTestId('meetings-source-filter')).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
-        const reset = page.getByRole('link', { name: 'Reset' });
+        await expect(catalog(page).getByRole('button', { name: 'Apply' })).toBeVisible();
+        const reset = catalog(page).getByRole('link', { name: 'Reset' });
         await expect(reset).toBeVisible();
-        await expect(reset).toHaveAttribute('href', /\/meetings$/);
+        // Applying/resetting filters re-lands on the block, not on the top of
+        // the Memory page — the GET form posts to `/memory#meetings`.
+        await expect(reset).toHaveAttribute('href', /\/memory#meetings$/);
     });
 
     test('a seeded meeting renders as a card with source, transcript chip and roster', async ({
@@ -178,7 +207,7 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
             participants: [{ name: 'Ada Lovelace', email: 'ada@example.com' }, { name: 'Grace' }],
         });
 
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page);
         const card = cardFor(page, meeting.id);
         await expect(card).toBeVisible({ timeout: 30_000 });
         await expect(card).toContainText(title);
@@ -205,7 +234,7 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
             transcriptText: 'Ada: the gate is green. Grace: merging the task branch.',
         });
 
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page);
         const card = cardFor(page, meeting.id);
         await expect(card).toBeVisible({ timeout: 30_000 });
         // The list projection omits the transcript BODY but keeps the flag —
@@ -223,14 +252,14 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
         // ?offset=480 always overshoots the seeded user's meeting count → API []
         // → the empty-state block AND the "No results on this page" nav. This is
         // deterministic regardless of how many meetings the shared seed owns.
-        await page.goto('/en/meetings?offset=480', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page, '?offset=480');
         await expect(page.getByTestId('meetings-empty')).toBeVisible({ timeout: 30_000 });
         await expect(page.getByText('No meetings yet.')).toBeVisible();
         await expect(
             page.getByText('Capture a meeting by hand and paste its transcript', { exact: false }),
         ).toBeVisible();
         await expect(page.getByText('No results on this page')).toBeVisible();
-        await expect(page.getByRole('link', { name: 'Previous' })).toBeVisible();
+        await expect(catalog(page).getByRole('link', { name: 'Previous' })).toBeVisible();
     });
 
     test('the source filter narrows the list to matching meetings', async ({ page, request }) => {
@@ -244,7 +273,7 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
             source: 'manual',
         });
 
-        await page.goto('/en/meetings?source=zoom', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page, '?source=zoom');
         await expect(cardFor(page, zoom.id)).toBeVisible({ timeout: 30_000 });
         // The manual meeting must be filtered OUT of the zoom view.
         await expect(cardFor(page, manual.id)).toHaveCount(0);
@@ -257,7 +286,7 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
         const token = await seededToken(request);
         const meeting = await createMeeting(request, token, { title: `Bogus Source ${suffix()}` });
 
-        await page.goto('/en/meetings?source=telepathy', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page, '?source=telepathy');
         // The page whitelists `source` against the closed set → drops the bogus
         // value → unfiltered list, and the load-error alert never renders.
         await expect(cardFor(page, meeting.id)).toBeVisible({ timeout: 30_000 });
@@ -273,7 +302,7 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
 
         // `workId` is compared straight against a uuid column server-side, so an
         // arbitrary string would be a cast error (500). The page must drop it.
-        await page.goto('/en/meetings?workId=not-a-uuid', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page, '?workId=not-a-uuid');
         await expect(cardFor(page, meeting.id)).toBeVisible({ timeout: 30_000 });
         await expect(page.getByTestId('meetings-load-error')).toHaveCount(0);
     });
@@ -283,7 +312,7 @@ test.describe('Meetings — /meetings list catalog (UI)', () => {
         const title = `Click Through ${suffix()}`;
         const meeting = await createMeeting(request, token, { title });
 
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page);
         const card = cardFor(page, meeting.id);
         await expect(card).toBeVisible({ timeout: 30_000 });
         // The card is a client <Link>: a click landing before hydration is
@@ -317,7 +346,10 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         await expect(page.getByRole('heading', { name: title, level: 1 })).toBeVisible({
             timeout: 30_000,
         });
-        await expect(page.getByRole('link', { name: 'Back to Meetings' })).toBeVisible();
+        // The back link points at the catalog's new home — the Memory block.
+        const back = page.getByRole('link', { name: 'Back to Meetings' });
+        await expect(back).toBeVisible();
+        await expect(back).toHaveAttribute('href', /\/memory#meetings$/);
 
         await expect(page.getByRole('heading', { name: 'Summary' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Transcript' })).toBeVisible();
@@ -570,7 +602,7 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         }).toPass({ timeout: 60_000 });
 
         // …and the catalog shows the new title on the same card.
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page);
         await expect(cardFor(page, meeting.id)).toContainText(renamed, { timeout: 30_000 });
     });
 
@@ -603,8 +635,11 @@ test.describe('Meetings — /meetings/:id detail (UI)', () => {
         );
         expect(await getMeetingStatus(request, token, meeting.id)).toBe(404);
 
-        // …and the successful delete pushed us back to the catalog.
-        await expect(page).toHaveURL(/\/meetings$/, { timeout: 30_000 });
+        // …and the successful delete pushed us back to the catalog, which is
+        // the Memory page's block now. The trailing `#meetings` is asserted
+        // optionally — a soft nav's fragment is not reliably reflected in
+        // `page.url()` across browsers.
+        await expect(page).toHaveURL(/\/memory(#meetings)?$/, { timeout: 30_000 });
         await expect(cardFor(page, meeting.id)).toHaveCount(0);
     });
 
@@ -710,7 +745,7 @@ test.describe('Meetings — /meetings/new capture form (UI)', () => {
         });
 
         // And it now appears back in the catalog.
-        await page.goto('/en/meetings', { waitUntil: 'domcontentloaded' });
+        await gotoCatalog(page);
         await expect(page.getByText(title, { exact: true }).first()).toBeVisible({
             timeout: 30_000,
         });
@@ -819,18 +854,60 @@ test.describe('Meetings — /meetings/new capture form (UI)', () => {
 // ============================================================================
 
 test.describe('Meetings — dashboard navigation', () => {
-    test('the sidebar Meetings link routes to the catalog', async ({ page }) => {
+    test('the sidebar no longer carries a Meetings entry', async ({ page }) => {
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
-        const link = page.locator('a[href$="/meetings"], a[href*="/meetings?"]').first();
-        if (!(await link.isVisible({ timeout: 10_000 }).catch(() => false))) {
-            test.skip(true, 'no Meetings nav link surfaced in this build');
-        }
-        // Post-condition: the catalog URL. Sidebar entries are client <Link>s —
-        // a pre-hydration click never starts the soft nav, and `load` never
-        // re-fires on one either, so waitForURL would time out regardless.
-        await clickAndExpectUrl(page, link, /\/meetings(\?|$)/);
-        await expect(page.getByRole('heading', { name: 'Meetings', level: 1 })).toBeVisible({
+        // The dashboard chrome has to be up before "absent" means anything —
+        // asserting a count of 0 against an unrendered page always passes.
+        await expect(page.locator('nav a[href$="/memory"]').first()).toBeVisible({
             timeout: 30_000,
         });
+        // Meetings folded into Memory, so no nav entry points at the retired
+        // index any more. Detail/new links live on pages, not in the sidebar.
+        await expect(
+            page.locator('nav a[href$="/meetings"], nav a[href*="/meetings?"]'),
+        ).toHaveCount(0);
+    });
+
+    test('the sidebar Memory link routes to the page hosting the catalog', async ({ page }) => {
+        await page.goto('/en', { waitUntil: 'domcontentloaded' });
+        const link = page.locator('nav a[href$="/memory"]').first();
+        await expect(link).toBeVisible({ timeout: 30_000 });
+        // Sidebar entries are client <Link>s — a pre-hydration click never
+        // starts the soft nav, and `load` never re-fires on one either, so
+        // waitForURL would time out regardless.
+        await clickAndExpectUrl(page, link, /\/memory(\?|#|$)/);
+        await expect(catalog(page)).toBeVisible({ timeout: 30_000 });
+        await expect(
+            catalog(page).getByRole('heading', { name: 'Meetings', level: 2 }),
+        ).toBeVisible();
+    });
+
+    test('/meetings redirects to the Memory block and carries its filters', async ({ page }) => {
+        await page.goto('/en/meetings?source=zoom', { waitUntil: 'domcontentloaded' });
+        await expect(catalog(page)).toBeVisible({ timeout: 30_000 });
+
+        // Assert the parts, not the whole string: the locale prefix collapses
+        // and Playwright does not reflect the fragment consistently, but the
+        // pathname and the preserved filter are the actual contract.
+        const url = new URL(page.url());
+        expect(url.pathname).toMatch(/^\/(en\/)?memory$/);
+        expect(url.searchParams.get('source')).toBe('zoom');
+
+        // The filter really applied — the source picker shows Zoom, not "Any".
+        await expect(page.getByTestId('meetings-source-filter')).toContainText('Zoom');
+    });
+
+    test('a junk filter is dropped by the redirect rather than forwarded', async ({ page }) => {
+        // `workId` is compared against a uuid column server-side, so the
+        // redirect re-parses instead of passing the query through verbatim.
+        await page.goto('/en/meetings?workId=not-a-uuid&source=telepathy', {
+            waitUntil: 'domcontentloaded',
+        });
+        await expect(catalog(page)).toBeVisible({ timeout: 30_000 });
+        const url = new URL(page.url());
+        expect(url.pathname).toMatch(/^\/(en\/)?memory$/);
+        expect(url.searchParams.get('workId')).toBeNull();
+        expect(url.searchParams.get('source')).toBeNull();
+        await expect(page.getByTestId('meetings-load-error')).toHaveCount(0);
     });
 });

--- a/apps/web/e2e/flow-skill-bulk-operations.spec.ts
+++ b/apps/web/e2e/flow-skill-bulk-operations.spec.ts
@@ -70,7 +70,8 @@ async function createOwnedWorkId(request: APIRequestContext, token: string): Pro
  * registerUserViaAPI() users with unique titles (Date.now suffix). Counts are
  * asserted against this run's own private dataset (a fresh user starts empty),
  * so exact equality is safe here. The seeded storageState user is used ONLY
- * for the one UI-driven assertion. Routes are unprefixed (/skills, /skills/:id).
+ * for the one UI-driven assertion. Routes are unprefixed (/agents#skills for
+ * the catalog block, /skills/:id for the detail page).
  */
 
 const BULK = 12;
@@ -674,16 +675,19 @@ test.describe('Skills — bulk operations + at-scale list semantics', () => {
     });
 
     /**
-     * Flow 7 (UI) — A bulk-created skill is discoverable on the /skills hub for the
-     * seeded user, with its slug + version chip, and its detail page resolves.
+     * Flow 7 (UI) — A bulk-created skill is discoverable in the Skills block on
+     * the Agents tab for the seeded user, with its slug + version chip, and its
+     * detail page resolves.
      *
      * Uses the SEEDED storageState user (UI-driven). Creates a uniquely-titled
-     * skill via the seeded user's API token, loads /skills (the Installed section
-     * server-fetches up to 50 rows), asserts the title + slug render, then opens
-     * the detail page and confirms the title shows there too. Resilient to
-     * next-dev local/CI route divergence via .or() fallbacks.
+     * skill via the seeded user's API token, loads `/agents#skills` (navigation
+     * consolidation: the catalog is a block there now and `/skills` only
+     * redirects to it; the Installed section still server-fetches up to 50
+     * rows), asserts the title + slug render, then opens the detail page and
+     * confirms the title shows there too. Resilient to next-dev local/CI route
+     * divergence via .or() fallbacks.
      */
-    test('UI: a bulk-created skill surfaces on the /skills hub and its detail page', async ({
+    test('UI: a bulk-created skill surfaces in the Agents tab Skills block and its detail page', async ({
         page,
         request,
         baseURL,
@@ -711,7 +715,8 @@ test.describe('Skills — bulk operations + at-scale list semantics', () => {
         });
 
         const origin = baseURL ?? 'http://localhost:3000';
-        await page.goto(`${origin}/skills`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`${origin}/agents#skills`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByTestId('agents-skills-section')).toBeVisible({ timeout: 30_000 });
 
         // Title may render in the Installed grid. Tolerate ordering / dev hydration.
         // The card renders BOTH the title (<h3>) and slug (<span.font-mono>), so the

--- a/apps/web/e2e/flow-skill-crud-scoping.spec.ts
+++ b/apps/web/e2e/flow-skill-crud-scoping.spec.ts
@@ -716,10 +716,13 @@ test.describe('Skill CRUD + scope/owner validation', () => {
         expect(skill.slug).toBe(`crud-ui-${stamp}`);
         expect(skill.version).toBe('3.1.4');
 
-        // The index hub renders (section toggles present). Navigation uses
-        // relative paths against the playwright-configured baseURL.
-        await page.goto('/skills', { waitUntil: 'domcontentloaded' });
+        // The catalog block renders (section toggles present). Navigation
+        // consolidation: the catalog lives on the Agents tab and `/skills`
+        // only redirects there. Navigation uses relative paths against the
+        // playwright-configured baseURL.
+        await page.goto('/agents#skills', { waitUntil: 'domcontentloaded' });
         await page.waitForLoadState('networkidle').catch(() => {});
+        await expect(page.getByTestId('agents-skills-section')).toBeVisible({ timeout: 30_000 });
         await expect(page.getByText(/installed/i).first()).toBeVisible({ timeout: 30_000 });
 
         // The detail page renders the skill's title heading. Local-vs-CI route

--- a/apps/web/e2e/flow-skill-marketplace-share.spec.ts
+++ b/apps/web/e2e/flow-skill-marketplace-share.spec.ts
@@ -549,7 +549,9 @@ test.describe('Skill marketplace / share / visibility', () => {
     });
 
     /**
-     * Flow 6 — UI: the marketplace HUB at /skills. Driven as the SEEDED user via
+     * Flow 6 — UI: the marketplace HUB, which the navigation consolidation moved
+     * into the Skills block on the Agents tab (`/agents#skills`; `/skills` only
+     * redirects there now). Driven as the SEEDED user via
      * storageState. The hub has three section toggles — Installed / Available /
      * Custom. We seed (via API as the same seeded user) one workspace skill so
      * the Installed section is non-empty, then: switch to "Available" and assert
@@ -575,8 +577,9 @@ test.describe('Skill marketplace / share / visibility', () => {
         });
         expect(skill.sourceCatalogSlug).toBeNull();
 
-        await page.goto('/skills', { waitUntil: 'domcontentloaded' });
+        await page.goto('/agents#skills', { waitUntil: 'domcontentloaded' });
         await page.waitForLoadState('networkidle');
+        await expect(page.getByTestId('agents-skills-section')).toBeVisible({ timeout: 30_000 });
 
         // The three section toggles render as ARIA tabs (a `tablist` of
         // `<button role="tab">`). Because the explicit role="tab" overrides the

--- a/apps/web/e2e/flow-teams-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-teams-ui-journey.spec.ts
@@ -7,8 +7,10 @@
  * lazily-created org is `orgs[0]` — see e2e/global-setup.ts step 1b) and pins
  * the RENDERED content of every teams route:
  *
- *   • /en/teams            list header (title/subtitle/org chip + New Team /
- *                          Org Chart CTAs), seeded team cards, card → detail nav
+ *   • /en/teams            hub tab strip (Teams | Agents | Sessions | Archived,
+ *                          Teams active), list header (title/subtitle/org chip +
+ *                          New Team / Org Chart CTAs), seeded team cards,
+ *                          card → detail nav
  *   • /en/teams/new        create-team form (name/description/parent/manager),
  *                          submit disabled-until-name, parent-select population,
  *                          and the true UI create flow → lands on /teams/:id
@@ -159,6 +161,9 @@ test.describe('Teams UI — list page', () => {
         await expect(page.getByRole('heading', { name: 'Teams', exact: true })).toBeVisible({
             timeout: 30_000,
         });
+        // Navigation consolidation: /teams is tab 1 of the Teams hub.
+        await expect(page.getByTestId('agents-page-tab-teams')).toBeVisible();
+        await expect(page.getByTestId('agents-page-tab-teams')).toHaveAttribute('href', /\/teams$/);
         await expect(page.getByText('Organize your Agents and members into teams')).toBeVisible();
         // The active org's displayName is shown as a chip (dynamic — read from
         // the same GET /api/organizations the page resolves orgs[0] from).
@@ -170,6 +175,24 @@ test.describe('Teams UI — list page', () => {
         const chartLink = page.getByTestId('teams-org-chart-link');
         await expect(chartLink).toBeVisible();
         await expect(chartLink).toHaveAttribute('href', /\/teams\/org-chart$/);
+    });
+
+    test('the hub tab strip renders Teams | Agents | Sessions | Archived with Teams active', async ({
+        page,
+    }) => {
+        await page.goto('/en/teams', { waitUntil: 'domcontentloaded' });
+
+        await expect(page.getByTestId('agents-page-tabs')).toBeVisible({ timeout: 30_000 });
+        const tabs = page.getByTestId('agents-page-tabs').getByRole('link');
+        await expect(tabs).toHaveCount(4);
+        await expect(tabs.nth(0)).toHaveAttribute('href', /\/teams$/);
+        await expect(tabs.nth(1)).toHaveAttribute('href', /\/agents$/);
+        await expect(tabs.nth(2)).toHaveAttribute('href', /\/agents\/sessions$/);
+        await expect(tabs.nth(3)).toHaveAttribute('href', /\/agents\/archived$/);
+        // Active = the `border-primary` underline. Asserted on Teams AND
+        // negated on Agents so a class-name drift can't pass silently.
+        await expect(page.getByTestId('agents-page-tab-teams')).toHaveClass(/border-primary/);
+        await expect(page.getByTestId('agents-page-tab-agents')).not.toHaveClass(/border-primary/);
     });
 
     test('a seeded team renders as a card inside teams-list with its name + description', async ({

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "تحقق من بريدك الإلكتروني",
                 "description": "لقد أرسلنا رابط التحقق إلى عنوان بريدك الإلكتروني. يرجى التحقق من صندوق الوارد ومجلد البريد غير المرغوب فيه.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "إعادة إرسال البريد الإلكتروني"
             },
             "verified": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Потвърдете имейла си",
                 "description": "Изпратихме връзка за потвърждение на имейл адреса ви. Моля, проверете входящите и спам папката.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Изпрати имейл отново"
             },
             "verified": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Verifizieren Sie Ihre E-Mail",
                 "description": "Wir haben einen Verifizierungslink an Ihre E-Mail-Adresse gesendet. Bitte überprüfen Sie Ihren Posteingang und den Spam-Ordner.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "E-Mail erneut senden"
             },
             "verified": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1151,6 +1151,9 @@
             },
             "title": "Memory",
             "subtitle": "Everything your organization knows, in one place — aggregated across every Work's Knowledge Base.",
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
+            },
             "searchPlaceholder": "Search across everything the organization knows…",
             "newDocument": "New",
             "documentsIndexed": "{count, plural, =0 {No documents indexed} one {# document indexed} other {# documents indexed}}",
@@ -1233,6 +1236,11 @@
             "title": "Agents",
             "subtitle": "Your AI teammates. Each one carries a soul (who they are), instructions, and a budget — and acts on Missions, Works, or your whole Workspace.",
             "newAgent": "New Agent",
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
+            },
             "scorecard": {
                 "title": "Scorecard",
                 "empty": "No metrics yet. Add quantified goals so this Agent's output is measurable.",
@@ -1388,6 +1396,7 @@
                 "resetSuccess": "Guardrails reset to default"
             },
             "pageTabs": {
+                "teams": "Teams",
                 "agents": "Agents",
                 "sessions": "Sessions",
                 "archived": "Archived"
@@ -8100,6 +8109,13 @@
             "membersBadge": "{count, plural, one {# member} other {# members}}",
             "empty": "Nothing to chart yet — create teams or Agents in this organization first.",
             "noOrg": "Create an organization to see its Org Chart."
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -910,6 +912,7 @@
             "emailVerification": {
                 "title": "Verify your email",
                 "description": "We've sent a verification link to your email address. Please check your inbox and spam folder.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Resend email"
             },
             "verified": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Verifica tu correo electrónico",
                 "description": "Hemos enviado un enlace de verificación a tu dirección de correo electrónico. Por favor, revisa tu bandeja de entrada y la carpeta de spam.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Reenviar correo electrónico"
             },
             "verified": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "Nous vous enverrons un lien unique pour vous connecter. Aucun mot de passe requis.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Envoyer le lien",
                     "submitting": "Envoi en cours..."
@@ -101,6 +102,7 @@
                     "title": "Connexion en cours",
                     "loading": "Vérification de votre lien...",
                     "errorTitle": "Ce lien ne peut pas être utilisé",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Votre lien est invalide ou expiré. Les liens magiques sont à usage unique et restent valides pendant 15 minutes.",
                     "requestNewLink": "Envoyer un nouveau lien",
                     "missingToken": "Ce lien ne contient pas de jeton. Demandez-en un nouveau pour continuer."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Vérifiez votre email",
                 "description": "Nous avons envoyé un lien de vérification à votre adresse email. Veuillez vérifier votre boîte de réception et votre dossier spam.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Renvoyer l'email"
             },
             "verified": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "אמת את הדוא\"ל שלך",
                 "description": "שלחנו קישור אימות לכתובת הדוא\"ל שלך. נא בדוק את תיבת הדואר הנכנס ותיקיית הספאם.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "שלח דוא\"ל שוב"
             },
             "verified": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "अपना ईमेल सत्यापित करें",
                 "description": "हमने आपके ईमेल पते पर सत्यापन लिंक भेज दिया है। कृपया अपना इनबॉक्स और स्पैम फोल्डर जांचें।",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "ईमेल पुनः भेजें"
             },
             "verified": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Verifikasi email Anda",
                 "description": "Kami telah mengirimkan tautan verifikasi ke alamat email Anda. Silakan periksa kotak masuk dan folder spam Anda.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Kirim ulang email"
             },
             "verified": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Verifica la tua email",
                 "description": "Abbiamo inviato un link di verifica al tuo indirizzo email. Controlla la cartella in arrivo e la spam.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Invia nuovamente l'email"
             },
             "verified": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "メールを認証",
                 "description": "認証リンクをメールアドレスに送信しました。受信トレイと迷惑メールフォルダを確認してください。",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "メールを再送信"
             },
             "verified": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "이메일 확인",
                 "description": "이메일 주소로 확인 링크를 보냈습니다. 받은편지함과 스팸 폴더를 확인하세요.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "이메일 재전송"
             },
             "verified": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Verifieer je e-mail",
                 "description": "We hebben een verificatielink naar je e-mailadres gestuurd. Controleer je inbox en spam-map.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "E-mail opnieuw verzenden"
             },
             "verified": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Zweryfikuj swój e-mail",
                 "description": "Wysłaliśmy link weryfikacyjny na Twój adres e-mail. Sprawdź skrzynkę odbiorczą i folder spam.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Wyślij ponownie e-mail"
             },
             "verified": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Verifique seu e-mail",
                 "description": "Enviamos um link de verificação para seu endereço de e-mail. Verifique sua caixa de entrada e pasta de spam.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Reenviar e-mail"
             },
             "verified": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Подтвердите электронную почту",
                 "description": "Мы отправили ссылку для подтверждения на ваш адрес электронной почты. Проверьте папки «Входящие» и «Спам».",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Отправить повторно"
             },
             "verified": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "ยืนยันอีเมลของคุณ",
                 "description": "เราได้ส่งลิงก์ยืนยันไปยังที่อยู่อีเมลของคุณแล้ว กรุณาตรวจสอบกล่องจดหมายเข้าและโฟลเดอร์สแปม",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "ส่งอีเมลใหม่"
             },
             "verified": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "E-postanızı doğrulayın",
                 "description": "E-posta adresinize bir doğrulama bağlantısı gönderdik. Gelen kutunuzu ve spam klasörünüzü kontrol edin.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "E-postayı yeniden gönder"
             },
             "verified": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Підтвердіть свою електронну пошту",
                 "description": "Ми надіслали посилання для підтвердження на вашу адресу електронної пошти. Будь ласка, перевірте вхідні та папку спаму.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Надіслати email повторно"
             },
             "verified": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "Xác minh email của bạn",
                 "description": "Chúng tôi đã gửi liên kết xác minh đến địa chỉ email của bạn. Vui lòng kiểm tra hộp thư đến và thư rác.",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "Gửi lại email"
             },
             "verified": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -85,6 +85,7 @@
             },
             "magicLink": {
                 "subtitle": "We'll email you a one-time link to sign in. No password needed.",
+                "worksWhenUnverified": "Opening the link proves you own the address, so this works even if you haven't confirmed your email yet.",
                 "form": {
                     "submit": "Send magic link",
                     "submitting": "Sending..."
@@ -101,6 +102,7 @@
                     "title": "Signing you in",
                     "loading": "Verifying your magic link...",
                     "errorTitle": "This link can't be used",
+                    "errorSubtitle": "We couldn't sign you in with that link.",
                     "errorBody": "Your magic link is invalid or has expired. Magic links can only be used once and stay valid for 15 minutes.",
                     "requestNewLink": "Send a new link",
                     "missingToken": "This magic link is missing a token. Request a new one to continue."
@@ -710,6 +712,7 @@
             "emailVerification": {
                 "title": "验证您的电子邮件",
                 "description": "我们已向您的电子邮件地址发送验证链接。请检查您的收件箱和垃圾邮件文件夹。",
+                "pendingDescription": "You can keep using your account now, but you'll need to confirm this address before you can sign in again. We've emailed you a link — check your inbox and spam folder, or resend it from Profile settings.",
                 "action": "重新发送电子邮件"
             },
             "verified": {

--- a/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
@@ -281,6 +281,22 @@ export function LoginClient({ availableSocialProviders, magicLinkEnabled }: Logi
                         {t('magicLink.subtitle')}
                     </p>
 
+                    {/* EW-080: these two tabs apply different rules to the same
+                        account — password sign-in is refused until the address
+                        is confirmed, a magic link is not (opening a link that
+                        only ever went to that mailbox IS the proof; see
+                        `redeemMagicLink`). That is intended, but it used to be
+                        invisible: someone turned away by "Please verify your
+                        email address before signing in" had no way to know the
+                        tab beside it would let them in. Stating it here is what
+                        stops the two from silently disagreeing. */}
+                    <p
+                        data-testid="magic-link-unverified-note"
+                        className="text-xs text-text-muted dark:text-text-muted-dark"
+                    >
+                        {t('magicLink.worksWhenUnverified')}
+                    </p>
+
                     {magicLinkSentTo ? (
                         <MagicLinkSuccessMessage
                             email={magicLinkSentTo}

--- a/apps/web/src/app/[locale]/(auth)/login/magic-link/magic-link-redeem-client.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/magic-link/magic-link-redeem-client.tsx
@@ -52,11 +52,24 @@ export function MagicLinkRedeemClient() {
         '?tab=magic-link' +
         (redirectUrl ? `&${REDIRECT_SEARCH_PARAM}=${encodeURIComponent(redirectUrl)}` : '');
 
+    // EW-081: the page header was hardcoded to the in-progress copy — "Signing
+    // you in" / "Verifying your magic link..." — and stayed there after the
+    // redemption failed. The two halves of the screen then said opposite
+    // things: the banner explained the link could not be used while the
+    // heading above it still claimed a sign-in was under way. On a page whose
+    // whole job is to report the outcome of one action, the largest text on it
+    // was the one part that never reflected that outcome. Derive both from the
+    // same state the body renders from, so they cannot disagree.
+    const isLoading = state.status === 'loading';
+
     return (
-        <AuthLayout title={t('title')} subtitle={t('loading')}>
+        <AuthLayout
+            title={isLoading ? t('title') : t('errorTitle')}
+            subtitle={isLoading ? t('loading') : t('errorSubtitle')}
+        >
             <ThemeToggle variant="fixed" />
 
-            {state.status === 'loading' && (
+            {isLoading && (
                 <div
                     data-testid="magic-link-loading"
                     className="flex items-center justify-center py-8"
@@ -67,11 +80,14 @@ export function MagicLinkRedeemClient() {
                 </div>
             )}
 
-            {state.status !== 'loading' && (
+            {!isLoading && (
                 <div data-testid="magic-link-error" className="space-y-4">
                     <div className="bg-danger/10 border border-danger/20 px-4 py-3 rounded-lg space-y-2">
-                        <p className="text-sm font-medium text-danger">{t('errorTitle')}</p>
-                        <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                        {/* `errorTitle` moved up into the page heading (EW-081);
+                            repeating it here would just say the same sentence
+                            twice. The box keeps the part the heading cannot
+                            carry — WHY this particular link was refused. */}
+                        <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
                             {state.status === 'missing-token' ? t('missingToken') : state.message}
                         </p>
                     </div>

--- a/apps/web/src/app/[locale]/(auth)/login/magic-link/magic-link-redeem-client.unit.spec.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/magic-link/magic-link-redeem-client.unit.spec.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * EW-081 — after a magic link fails, the page header still read "Signing you
+ * in" / "Verifying your magic link...".
+ *
+ * The heading is the largest text on a page whose entire job is to report the
+ * outcome of one action, and it was the one part hardcoded to the in-progress
+ * copy. The body said the link could not be used while the header above it
+ * claimed a sign-in was under way.
+ *
+ * These assert on the RENDERED HEADER, not on the error box — the error box
+ * was already correct before the fix, so a test that only looked there would
+ * have passed against the bug.
+ */
+
+const { redeemMagicLinkMock, searchParamsMock } = vi.hoisted(() => ({
+    redeemMagicLinkMock: vi.fn(),
+    searchParamsMock: { current: new URLSearchParams() },
+}));
+
+vi.mock('next-intl', () => ({
+    // Return the key path so the assertions name the message being rendered.
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => searchParamsMock.current,
+}));
+
+vi.mock('@/app/actions/auth', () => ({ redeemMagicLink: redeemMagicLinkMock }));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+    useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+// AuthLayout renders the title/subtitle inside a lot of marketing chrome that
+// pulls in the next-intl client entry. Stub it down to just the two strings
+// under test, tagged so the assertions cannot accidentally match body copy.
+vi.mock('@/components/layout/AuthLayout', () => ({
+    AuthLayout: ({
+        title,
+        subtitle,
+        children,
+    }: {
+        title: string;
+        subtitle: string;
+        children: React.ReactNode;
+    }) => (
+        <div>
+            <h1 data-testid="page-title">{title}</h1>
+            <p data-testid="page-subtitle">{subtitle}</p>
+            {children}
+        </div>
+    ),
+}));
+
+vi.mock('@/components/theme-toggle', () => ({ ThemeToggle: () => null }));
+
+import { MagicLinkRedeemClient } from './magic-link-redeem-client';
+
+const NS = 'auth.login.magicLink.redeem';
+const title = () => screen.getByTestId('page-title').textContent;
+const subtitle = () => screen.getByTestId('page-subtitle').textContent;
+
+describe('MagicLinkRedeemClient — page header tracks the outcome (EW-081)', () => {
+    beforeEach(() => {
+        redeemMagicLinkMock.mockReset();
+        searchParamsMock.current = new URLSearchParams({ token: 'a'.repeat(64) });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('control: while the redemption is in flight the header DOES say "signing you in"', async () => {
+        // Without this, "the header changed" below could be satisfied by a
+        // component that never shows the in-progress copy at all.
+        redeemMagicLinkMock.mockReturnValue(new Promise(() => {}));
+
+        render(<MagicLinkRedeemClient />);
+
+        expect(title()).toBe(`${NS}.title`);
+        expect(subtitle()).toBe(`${NS}.loading`);
+        expect(screen.getByTestId('magic-link-loading')).toBeTruthy();
+    });
+
+    it('switches the header to the failure copy once the redemption fails', async () => {
+        redeemMagicLinkMock.mockResolvedValue({ success: false, error: 'Invalid magic link' });
+
+        render(<MagicLinkRedeemClient />);
+
+        await waitFor(() => expect(screen.getByTestId('magic-link-error')).toBeTruthy());
+
+        expect(title()).toBe(`${NS}.errorTitle`);
+        expect(subtitle()).toBe(`${NS}.errorSubtitle`);
+
+        // The exact strings the bug left on screen must be gone.
+        expect(title()).not.toBe(`${NS}.title`);
+        expect(subtitle()).not.toBe(`${NS}.loading`);
+    });
+
+    it('switches the header to the failure copy when the link carries no token', async () => {
+        searchParamsMock.current = new URLSearchParams();
+
+        render(<MagicLinkRedeemClient />);
+
+        await waitFor(() => expect(screen.getByTestId('magic-link-error')).toBeTruthy());
+
+        expect(title()).toBe(`${NS}.errorTitle`);
+        expect(subtitle()).toBe(`${NS}.errorSubtitle`);
+        expect(redeemMagicLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('still explains WHY the link failed and offers a new one', async () => {
+        // The header now carries the headline, so the body must still carry
+        // the specific reason and the recovery path — otherwise this "fix"
+        // would have traded one missing message for another.
+        redeemMagicLinkMock.mockResolvedValue({
+            success: false,
+            error: 'Your magic link is invalid or has expired.',
+        });
+
+        render(<MagicLinkRedeemClient />);
+
+        await waitFor(() => expect(screen.getByTestId('magic-link-error')).toBeTruthy());
+
+        expect(screen.getByText('Your magic link is invalid or has expired.')).toBeTruthy();
+        expect(screen.getByTestId('magic-link-request-new')).toBeTruthy();
+    });
+});

--- a/apps/web/src/app/[locale]/(dashboard)/agents/chart/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/chart/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { Building2 } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { teamsAPI, type TeamsOrganization } from '@/lib/api/teams';
+import { OrgChartClient } from '@/components/teams/OrgChartClient';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.agentsChartPage');
+    return { title: t('title') };
+}
+
+/**
+ * Agents Chart — `/agents/chart` (navigation consolidation,
+ * `docs/specs/features/navigation-consolidation` §3.6).
+ *
+ * The org chart with human members stripped: reached from the "Agents Chart"
+ * CTA on the Agents tab, it answers "how are my *Agents* organised?" without
+ * the people rows the Teams tab's Org Chart deliberately includes. Teams still
+ * group agents and `reportsToAgentId` chains still nest — all of that lives in
+ * `buildOrgTree`, which is untouched; the only difference is `members: []` in
+ * the payload handed to the shared renderer.
+ *
+ * Same active-org resolution and same defensive posture as
+ * `/teams/org-chart`: `orgs[0]` from the user's Tenant, `listOrganizations` /
+ * `orgChart` already swallow API errors into `[]` / `null`, so a flaky API
+ * degrades to the no-org / empty state instead of a 500.
+ */
+export default async function AgentsChartPage() {
+    const t = await getTranslations('dashboard.agentsChartPage');
+    const orgs: TeamsOrganization[] = await teamsAPI.listOrganizations().catch(() => []);
+
+    if (orgs.length === 0) {
+        const tTeams = await getTranslations('dashboard.teamsPage');
+        return (
+            <div
+                data-testid="agents-chart-no-org"
+                className="flex flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-border/60 dark:border-border-dark/60 px-6 py-16 text-center"
+            >
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-info/20 bg-info/10">
+                    <Building2 className="h-5 w-5 text-info" strokeWidth={1.5} />
+                </div>
+                <p className="max-w-md text-sm text-text-secondary dark:text-text-secondary-dark">
+                    {t('noOrg')}
+                </p>
+                <Link
+                    href={ROUTES.DASHBOARD}
+                    className="rounded-md border border-border dark:border-border-dark px-3 py-1.5 text-sm text-text dark:text-text-dark transition-colors hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark"
+                >
+                    {tTeams('noOrg.cta')}
+                </Link>
+            </div>
+        );
+    }
+
+    const org = orgs[0];
+    const payload = await teamsAPI.orgChart(org.id);
+    // Human members dropped before the tree is built, so they cannot surface
+    // as cards or widen a team's row. Teams with only humans still render —
+    // they are part of how the Agents are organised.
+    const agentsOnly = payload ? { ...payload, members: [] } : null;
+    const isEmpty = !agentsOnly || agentsOnly.agents.length === 0;
+
+    return (
+        <div className="w-full space-y-5">
+            <Link
+                href={ROUTES.DASHBOARD_AGENTS}
+                className="text-xs text-text-muted hover:text-text"
+            >
+                ← {t('backToAgents')}
+            </Link>
+            <div>
+                <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h1>
+                <p className="mt-1 text-sm text-text-secondary dark:text-text-secondary-dark">
+                    {org.displayName} — {t('subtitle')}
+                </p>
+            </div>
+            {isEmpty ? (
+                <div
+                    data-testid="agents-chart-empty"
+                    className="rounded-xl border border-dashed border-border/60 dark:border-border-dark/60 px-6 py-16 text-center"
+                >
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                        {t('empty')}
+                    </p>
+                </div>
+            ) : (
+                <OrgChartClient payload={agentsOnly} />
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/page.tsx
@@ -5,6 +5,10 @@ import type { AstTemplateEntry } from '@/lib/api/agent-templates';
 import { fetchAgentTemplateCatalog } from '@/lib/api/agent-templates.server';
 import { AgentsList } from '@/components/agents';
 import { AgentsPageTabs } from '@/components/agents/AgentsPageTabs';
+import { SkillsSection } from '@/components/skills/SkillsSection';
+import { loadSkillsPageData, parseSkillsSearchParams } from '@/lib/skills-page-data';
+
+type SearchParams = Record<string, string | string[] | undefined>;
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.agentsPage');
@@ -21,14 +25,44 @@ export async function generateMetadata(): Promise<Metadata> {
  * agent-prompt-first-creation — the catalog feeds the quick-pick chips
  * + `View All` panel below the prompt composer; the user's existing
  * Agents are surfaced as "Your templates" (spec FR-29, Q2 default).
+ *
+ * Navigation consolidation (`docs/specs/features/navigation-consolidation`
+ * §3.5): this page is tab 2 of the Teams hub and now also hosts the **Skills
+ * catalog** as a block below the Agent grid (anchor `#skills`; `/skills`
+ * redirects here). It therefore reads the four Skills query params the old
+ * `/skills` page owned — parsing and fetching both live in
+ * `lib/skills-page-data.ts` so the two surfaces cannot drift — and adds that
+ * fetch to the same `Promise.all`, keeping the page one round of waterfall.
+ *
+ * Known and accepted cost of hosting Skills here: `SkillsPageClient.updateUrl`
+ * does a `router.replace` on this route, so every Skills tab/search/page click
+ * re-runs THIS server component — `agentsAPI.list` and
+ * `fetchAgentTemplateCatalog` are re-issued alongside `loadSkillsPageData`,
+ * where the old standalone `/skills` page re-fetched skills only. They stay in
+ * one `Promise.all`, so the click costs one extra *parallel* upstream call, not
+ * extra serial latency, and `fetchAgentTemplateCatalog` degrades to the
+ * built-in `listAstTemplates` list rather than failing. Deliberately NOT fixed
+ * by caching: both fetches are per-user/cookie-scoped, and an `unstable_cache`
+ * keyed wrongly would serve one tenant's Agents to another. If this ever shows
+ * up in traces, the safe lever is a `<Suspense>` boundary around the Skills
+ * block (stream it) — not a shared cache.
  */
-export default async function AgentsPage() {
-    const [result, templates] = await Promise.all([
+export default async function AgentsPage({
+    searchParams,
+}: {
+    searchParams?: Promise<SearchParams>;
+}) {
+    const skillsFilters = parseSkillsSearchParams((await searchParams) ?? {});
+
+    const [result, templates, skills] = await Promise.all([
         agentsAPI.list({ limit: 50 }).catch(() => ({
             data: [] as Agent[],
             meta: { total: 0, limit: 50, offset: 0 },
         })),
         fetchAgentTemplateCatalog('agent').catch(() => [] as AstTemplateEntry[]),
+        // Already defensive internally: a failing side reports through
+        // `loadErrors` instead of throwing the Agents page into the boundary.
+        loadSkillsPageData(skillsFilters),
     ]);
 
     // "Your templates" — the user's existing Agents as reusable
@@ -47,6 +81,7 @@ export default async function AgentsPage() {
         <div className="w-full">
             <AgentsPageTabs active="agents" />
             <AgentsList agents={result.data} templates={templates} userTemplates={userTemplates} />
+            <SkillsSection data={skills} filters={skillsFilters} />
         </div>
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/meetings/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/meetings/page.tsx
@@ -1,116 +1,31 @@
-import type { Metadata } from 'next';
-import { getTranslations } from 'next-intl/server';
-import { meetingsAPI, type Meeting } from '@/lib/api/meetings';
-import { MEETING_SOURCES, type MeetingSource } from '@/lib/api/meetings.shared';
-import { workAPI } from '@/lib/api/work';
-import { MeetingsList, type MeetingWorkOption } from '@/components/meetings';
-
-export async function generateMetadata(): Promise<Metadata> {
-    const t = await getTranslations('dashboard.meetingsPage');
-    return { title: t('title') };
-}
-
-const PAGE_SIZE = 24;
-const WORK_OPTIONS_LIMIT = 100;
-
-/** Canonical uuid shape — anything else is dropped before it reaches the API. */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-type MeetingsSearchParams = Promise<{
-    source?: string | string[];
-    workId?: string | string[];
-    offset?: string | string[];
-}>;
-
-function firstParam(value: string | string[] | undefined): string | undefined {
-    return Array.isArray(value) ? value[0] : value;
-}
-
-function buildMeetingsHref(input: {
-    source?: MeetingSource;
-    workId?: string;
-    offset?: number;
-}): string {
-    const params = new URLSearchParams();
-    if (input.source) params.set('source', input.source);
-    if (input.workId) params.set('workId', input.workId);
-    if (input.offset && input.offset > 0) params.set('offset', String(input.offset));
-    const qs = params.toString();
-    return qs ? `/meetings?${qs}` : '/meetings';
-}
+import { redirect } from '@/i18n/navigation';
+import { getLocale } from 'next-intl/server';
+import { buildMeetingsHref, parseMeetingsSearchParams } from '@/lib/api/meetings-page-params';
+import { ROUTES } from '@/lib/constants';
 
 /**
- * Meetings — `/meetings` catalog page. Server-fetches the user's
- * meetings with bounded pagination and hands load errors to the client
- * so a flaky API doesn't masquerade as an empty meeting history (same
- * contract as the Goals catalog).
+ * `/meetings` (index) — retired as a standalone page by the navigation
+ * consolidation: meetings are a memory source, so the catalog now
+ * renders as a block on the Memory page
+ * (docs/specs/features/navigation-consolidation).
  *
- * Both filters are whitelisted here before they reach the API:
- *   - `source` must be one of the closed `MeetingSource` set — the API
- *     silently ignores unknown values, so dropping it locally keeps the
- *     rendered filter chip and the actual query in agreement.
- *   - `workId` must look like a uuid. The API compares it straight
- *     against a uuid column, so an arbitrary string would be a Postgres
- *     cast error (a 500) rather than an empty result.
+ * Kept as a redirect rather than deleted so every bookmark, deep link
+ * and older doc keeps working — the filters come along, since the target
+ * block reads the same `source`/`workId`/`offset` params. The params are
+ * re-parsed (not forwarded verbatim) so a junk `workId` can't ride
+ * through into the redirect URL.
  *
- * The Work options powering the "routed to" filter are a best-effort
- * side fetch (`.catch(() => [])`) — the meetings list must render even
- * when the works endpoint is unhappy.
+ * `/meetings/new` and `/meetings/[id]` are untouched.
  */
-export default async function MeetingsPage({
+export default async function MeetingsIndexRedirect({
     searchParams,
 }: {
-    searchParams: MeetingsSearchParams;
+    searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-    const params = await searchParams;
-    const sourceParam = firstParam(params.source);
-    const source = MEETING_SOURCES.includes(sourceParam as MeetingSource)
-        ? (sourceParam as MeetingSource)
-        : undefined;
-    const workIdParam = firstParam(params.workId);
-    const workId = workIdParam && UUID_RE.test(workIdParam) ? workIdParam : undefined;
-    const offset = Math.max(0, parseInt(firstParam(params.offset) ?? '0', 10) || 0);
-
-    const worksPromise = workAPI
-        .getAll({ limit: WORK_OPTIONS_LIMIT })
-        .then<MeetingWorkOption[]>((res) =>
-            (res?.works ?? []).map((work) => ({ id: work.id, name: work.name })),
-        )
-        .catch<MeetingWorkOption[]>(() => []);
-
-    let meetings: Meeting[] = [];
-    let loadError: string | null = null;
-    try {
-        meetings = await meetingsAPI.list({
-            source,
-            workId,
-            offset,
-            limit: PAGE_SIZE + 1,
-        });
-    } catch (err) {
-        loadError = err instanceof Error ? err.message : 'Failed to load meetings.';
-    }
-
-    const works = await worksPromise;
-
-    const hasNext = meetings.length > PAGE_SIZE;
-    const pageMeetings = hasNext ? meetings.slice(0, PAGE_SIZE) : meetings;
-    const prevOffset = Math.max(0, offset - PAGE_SIZE);
-    const nextOffset = offset + PAGE_SIZE;
-
-    return (
-        <MeetingsList
-            meetings={pageMeetings}
-            works={works}
-            loadError={loadError}
-            filters={{ source, workId }}
-            pagination={{
-                offset,
-                hasPrevious: offset > 0,
-                hasNext,
-                previousHref: buildMeetingsHref({ source, workId, offset: prevOffset }),
-                nextHref: buildMeetingsHref({ source, workId, offset: nextOffset }),
-            }}
-        />
-    );
+    const query = parseMeetingsSearchParams(await searchParams);
+    const locale = await getLocale();
+    redirect({
+        locale,
+        href: buildMeetingsHref(ROUTES.DASHBOARD_MEMORY, query, '#meetings'),
+    });
 }

--- a/apps/web/src/app/[locale]/(dashboard)/memory/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/memory/page.tsx
@@ -1,12 +1,23 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { memoryAPI, EMPTY_MEMORY_RESPONSE, type MemoryResponse } from '@/lib/api/memory';
-import { MemoryShell } from '@/components/memory';
+import { meetingsAPI, type Meeting } from '@/lib/api/meetings';
+import {
+    MEETINGS_PAGE_SIZE,
+    buildMeetingsHref,
+    parseMeetingsSearchParams,
+} from '@/lib/api/meetings-page-params';
+import { workAPI } from '@/lib/api/work';
+import { ROUTES } from '@/lib/constants';
+import { MemoryShell, type MemoryMeetingsData } from '@/components/memory';
+import type { MeetingWorkOption } from '@/components/meetings';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.memoryPage');
     return { title: t('title') };
 }
+
+const WORK_OPTIONS_LIMIT = 100;
 
 /**
  * Org-wide Memory (Cortex P1) — `/memory` catalog page.
@@ -18,14 +29,81 @@ export async function generateMetadata(): Promise<Metadata> {
  * payload when there is no resolvable Organization, so the shell reads
  * `documents.length === 0` and shows the appropriate empty state.
  *
+ * The page also owns the **Meetings block** (`#meetings`), which used to
+ * be the standalone `/meetings` catalog — meetings are a memory source,
+ * every transcript and summary lands in Memory
+ * (docs/specs/features/navigation-consolidation). Its `source`/`workId`/
+ * `offset` params are whitelisted by the shared helper before they reach
+ * the API, and its two side fetches are independently defensive: a
+ * meetings failure surfaces as a load-error box *inside the block* and a
+ * works failure just costs the "routed to" filter its options. Neither
+ * can take the Memory page down.
+ *
  * All interactivity (search, filter chips, view toggle) lives in the
  * client `MemoryShell`, which re-queries the same-origin BFF proxy
  * (`/api/memory`).
  */
-export default async function MemoryPage() {
-    const initial: MemoryResponse = await memoryAPI
+export default async function MemoryPage({
+    searchParams,
+}: {
+    searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+    const query = parseMeetingsSearchParams(await searchParams);
+    const { source, workId, offset } = query;
+
+    const initialPromise: Promise<MemoryResponse> = memoryAPI
         .get({ limit: 200 })
         .catch(() => EMPTY_MEMORY_RESPONSE);
 
-    return <MemoryShell initial={initial} />;
+    const worksPromise = workAPI
+        .getAll({ limit: WORK_OPTIONS_LIMIT })
+        .then<MeetingWorkOption[]>((res) =>
+            (res?.works ?? []).map((work) => ({ id: work.id, name: work.name })),
+        )
+        .catch<MeetingWorkOption[]>(() => []);
+
+    // A `+1` look-ahead row is what tells the block whether a next page
+    // exists without a second count query.
+    const meetingsPromise = meetingsAPI
+        .list({ source, workId, offset, limit: MEETINGS_PAGE_SIZE + 1 })
+        .then((rows) => ({ rows, error: null as string | null }))
+        .catch((err: unknown) => ({
+            rows: [] as Meeting[],
+            error: err instanceof Error ? err.message : 'Failed to load meetings.',
+        }));
+
+    const [initial, works, meetingsResult] = await Promise.all([
+        initialPromise,
+        worksPromise,
+        meetingsPromise,
+    ]);
+
+    const hasNext = meetingsResult.rows.length > MEETINGS_PAGE_SIZE;
+    const pageMeetings = hasNext
+        ? meetingsResult.rows.slice(0, MEETINGS_PAGE_SIZE)
+        : meetingsResult.rows;
+
+    const meetings: MemoryMeetingsData = {
+        meetings: pageMeetings,
+        works,
+        loadError: meetingsResult.error,
+        filters: { source, workId },
+        pagination: {
+            offset,
+            hasPrevious: offset > 0,
+            hasNext,
+            previousHref: buildMeetingsHref(
+                ROUTES.DASHBOARD_MEMORY,
+                { source, workId, offset: Math.max(0, offset - MEETINGS_PAGE_SIZE) },
+                '#meetings',
+            ),
+            nextHref: buildMeetingsHref(
+                ROUTES.DASHBOARD_MEMORY,
+                { source, workId, offset: offset + MEETINGS_PAGE_SIZE },
+                '#meetings',
+            ),
+        },
+    };
+
+    return <MemoryShell initial={initial} meetings={meetings} />;
 }

--- a/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
@@ -1,125 +1,27 @@
-import type { Metadata } from 'next';
-import { getTranslations } from 'next-intl/server';
-import { Plus, Sparkles } from 'lucide-react';
-import { skillsAPI } from '@/lib/api/skills';
-import type { Skill, SkillCatalogEntry } from '@/lib/api/skills';
-import { SkillsPageClient } from '@/components/skills/SkillsPageClient';
-import { PageHeader } from '@/components/common/PageHeader';
-import { Button } from '@/components/ui/button';
+import { getLocale } from 'next-intl/server';
+import { redirect } from '@/i18n/navigation';
+import { buildSkillsHref, parseSkillsSearchParams } from '@/lib/skills-page-data';
 import { ROUTES } from '@/lib/constants';
-
-const PAGE_SIZE = 50;
-const SECTIONS = ['installed', 'available', 'custom'] as const;
-type Section = (typeof SECTIONS)[number];
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
-function firstParam(value: string | string[] | undefined): string | undefined {
-    return Array.isArray(value) ? value[0] : value;
-}
-
-function parseOffset(value: string | string[] | undefined): number {
-    const raw = firstParam(value);
-    if (!raw) return 0;
-    const parsed = Number(raw);
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
-}
-
-function parseSection(value: string | string[] | undefined): Section {
-    const raw = firstParam(value);
-    return SECTIONS.includes(raw as Section) ? (raw as Section) : 'installed';
-}
-
-export async function generateMetadata(): Promise<Metadata> {
-    const t = await getTranslations('dashboard.skillsPage');
-    return { title: t('title') };
-}
-
 /**
- * Agents/Skills/Tasks PR #1017 — Phase 9. Real `/skills` page.
+ * `/skills` (index) — retired as a standalone page (navigation consolidation,
+ * docs/specs/features/navigation-consolidation): the Skills catalog now renders
+ * as a block on the Agents tab, because nobody browses Skills without an Agent
+ * in mind.
  *
- * Server-fetches installed Skills + the catalog union in parallel.
- * The client component renders the three-section layout
- * (Installed / Available / Custom) per `features/skills/plan.md §6`.
- *
- * Defensive `.catch(...)` so a partial backend failure (e.g.
- * a flaky catalog plugin) still renders the page with the
- * sections that did load.
+ * Kept as a redirect rather than deleted so every bookmark, deep link, doc and
+ * e2e journey keeps working; the filters ride along so `/skills?section=custom`
+ * lands on `/agents?section=custom#skills`. `/skills/new`, `/skills/[id]` and
+ * `/skills/templates` are unchanged.
  */
-export default async function SkillsPage({
+export default async function SkillsIndexRedirect({
     searchParams,
 }: {
     searchParams?: Promise<SearchParams>;
 }) {
-    const t = await getTranslations('dashboard.skillsPage');
-    const params = (await searchParams) ?? {};
-    const section = parseSection(params.section);
-    const search = firstParam(params.search)?.trim() ?? '';
-    const installedOffset = parseOffset(params.installedOffset);
-    const catalogOffset = parseOffset(params.catalogOffset);
-    const [installed, catalog] = await Promise.all([
-        skillsAPI.listInstalled({ limit: PAGE_SIZE, offset: installedOffset, search }).then(
-            (result) => ({ result, error: null as string | null }),
-            () => ({
-                result: {
-                    data: [] as Skill[],
-                    meta: { total: 0, limit: PAGE_SIZE, offset: installedOffset },
-                },
-                error: 'installed',
-            }),
-        ),
-        skillsAPI.listCatalog({ limit: PAGE_SIZE, offset: catalogOffset, search }).then(
-            (result) => ({ result, error: null as string | null }),
-            () => ({
-                result: { entries: [] as SkillCatalogEntry[], total: 0 },
-                error: 'catalog',
-            }),
-        ),
-    ]);
-
-    return (
-        <div className="w-full">
-            <PageHeader
-                icon={Sparkles}
-                title={t('title')}
-                subtitle={t('subtitle')}
-                tone="success"
-                actions={
-                    <>
-                        {/* EW-058: first inbound link to the orphaned
-                            /skills/templates browser (route existed, nothing
-                            linked to it). */}
-                        <Button
-                            href={ROUTES.DASHBOARD_SKILL_TEMPLATES}
-                            variant="secondary"
-                            size="sm"
-                            className="gap-1.5 shrink-0"
-                        >
-                            {t('list.browseTemplates')}
-                        </Button>
-                        <Button
-                            href={ROUTES.DASHBOARD_SKILL_NEW}
-                            size="sm"
-                            className="gap-1.5 shrink-0"
-                        >
-                            <Plus className="w-3.5 h-3.5" aria-hidden="true" />
-                            {t('list.newSkill')}
-                        </Button>
-                    </>
-                }
-            />
-            <SkillsPageClient
-                installed={installed.result.data ?? []}
-                installedMeta={installed.result.meta}
-                catalog={catalog.result.entries ?? []}
-                catalogTotal={catalog.result.total ?? 0}
-                catalogLimit={PAGE_SIZE}
-                filters={{ section, search, installedOffset, catalogOffset }}
-                loadErrors={{
-                    installed: installed.error,
-                    catalog: catalog.error,
-                }}
-            />
-        </div>
-    );
+    const filters = parseSkillsSearchParams((await searchParams) ?? {});
+    const locale = await getLocale();
+    redirect({ href: buildSkillsHref(ROUTES.DASHBOARD_AGENTS, filters, '#skills'), locale });
 }

--- a/apps/web/src/app/[locale]/(dashboard)/skills/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/templates/page.tsx
@@ -20,8 +20,10 @@ export default async function SkillTemplatesPage() {
     const entries = await listAstTemplates('skill');
     return (
         <div className="w-full space-y-5">
+            {/* Navigation consolidation: the Skills catalog is a block on the
+                Agents tab now — `/skills` only redirects there. */}
             <Link
-                href={ROUTES.DASHBOARD_SKILLS}
+                href={ROUTES.DASHBOARD_AGENTS_SKILLS}
                 className="text-xs text-text-muted hover:text-text"
             >
                 ← Skills

--- a/apps/web/src/app/[locale]/(dashboard)/teams/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/teams/page.tsx
@@ -21,6 +21,8 @@ import {
 import { Link } from '@/i18n/navigation';
 import { teamsAPI, type Team } from '@/lib/api/teams';
 import { PageHeader } from '@/components/common/PageHeader';
+import { TeamsPageTabs } from '@/components/agents/AgentsPageTabs';
+import { HumanAgentIcon } from '@/components/icons/HumanAgentIcon';
 import { ROUTES } from '@/lib/constants';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -34,6 +36,14 @@ export async function generateMetadata(): Promise<Metadata> {
  * renders the create-first-org empty state, else `orgs[0]` is the
  * active org. The team list fetch is defensive (`.catch`) so a flaky
  * API renders the empty state instead of a 500.
+ *
+ * Navigation consolidation (`docs/specs/features/navigation-consolidation`
+ * §3.4): this is now **tab 1 of the Teams hub** — Teams | Agents | Sessions
+ * | Archived — reached from the single merged "Teams" sidebar entry. Both
+ * return branches (no-org and the list) render the strip, and the page-local
+ * `p-6 max-w-screen-2xl mx-auto` wrapper gave way to the `w-full` the other
+ * hub tabs use so the four tabs line up at the same width. The URL, the
+ * content and every test id are unchanged.
  */
 
 /**
@@ -73,7 +83,8 @@ export default async function TeamsPage() {
 
     if (orgs.length === 0) {
         return (
-            <div className="p-6 max-w-screen-2xl mx-auto">
+            <div className="w-full">
+                <TeamsPageTabs active="teams" />
                 <div
                     data-testid="teams-no-org"
                     className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-10 flex flex-col items-center text-center gap-3"
@@ -100,9 +111,13 @@ export default async function TeamsPage() {
     const teamById = new Map(teams.map((team) => [team.id, team]));
 
     return (
-        <div className="p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
+            <TeamsPageTabs active="teams" />
+            {/* The hub icon is the merged human+agent glyph — a Team here is
+                people AND agents, the same thing the sidebar entry promises.
+                `Users` stays the glyph for team cards and empty states. */}
             <PageHeader
-                icon={Users}
+                icon={HumanAgentIcon}
                 title={t('title')}
                 subtitle={t('subtitle')}
                 actions={

--- a/apps/web/src/app/[locale]/(dashboard)/toasts.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/toasts.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import { APP_NAME } from '@/lib/constants';
 import { OAuthProvider } from '@/lib/api/enums';
+import { VERIFY_EMAIL_PARAM, VERIFY_EMAIL_REQUIRED } from '@/lib/auth/unverified-email';
 
 export default function DashboardToasts() {
     const searchParams = useSearchParams();
@@ -13,6 +14,10 @@ export default function DashboardToasts() {
 
     const isNewUser = searchParams.get('newUser') === 'true';
     const isVerified = searchParams.get('verified') === 'true';
+    // EW-077 / EW-080: set by `register` and `redeemMagicLink` when the session
+    // they just minted belongs to an address nobody has confirmed yet.
+    const isEmailUnconfirmed =
+        searchParams.get(VERIFY_EMAIL_PARAM) === VERIFY_EMAIL_REQUIRED && !isVerified;
     const isOAuthConnected = searchParams.get('oauth_connected') === 'true';
     const oauthError = searchParams.get('oauth_error');
     // Security: validate oauth_provider against a known allow-list before
@@ -49,17 +54,29 @@ export default function DashboardToasts() {
                     </svg>
                 ),
             });
+        }
 
-            // Show email verification reminder
-            toast.info(t('emailVerification.title'), {
-                description: t('emailVerification.description'),
-                duration: 8000,
-                // action: {
-                //     label: t('emailVerification.action'),
-                //     onClick: () => {
-                //         window.location.href = '/resend-verification';
-                //     },
-                // },
+        // EW-077 / EW-080: the honest version of the old reminder.
+        //
+        // This used to fire inside the `isNewUser` branch above, unconditionally
+        // and with no idea whether the address actually needed confirming — so
+        // it told people to check their inbox even when the deployment does not
+        // require verification at all. Worse, it described only the email
+        // ("we've sent a link, check your spam folder") and never the part that
+        // matters: that this session keeps working, and the NEXT one will not.
+        // That omission is the whole of EW-077 — the gate looked like a new
+        // failure days later because nothing ever announced it.
+        //
+        // Now it fires on the actual state reported by the API, says what
+        // happens next, and does not auto-dismiss: a 4-second toast is not a
+        // reasonable way to deliver "you will be locked out later". The
+        // matching persistent banner (with a working Resend button) lives in
+        // profile settings, which is where the copy points.
+        if (isEmailUnconfirmed) {
+            toast.warning(t('emailVerification.title'), {
+                description: t('emailVerification.pendingDescription'),
+                duration: Infinity,
+                closeButton: true,
             });
         }
 
@@ -111,7 +128,7 @@ export default function DashboardToasts() {
         }
 
         // Clean up URL after showing toasts
-        if (isNewUser || isVerified || isOAuthConnected || oauthError) {
+        if (isNewUser || isVerified || isOAuthConnected || oauthError || isEmailUnconfirmed) {
             const timer = setTimeout(() => {
                 // Remove query params without page refresh
                 const url = new URL(window.location.href);
@@ -120,12 +137,13 @@ export default function DashboardToasts() {
                 url.searchParams.delete('oauth_connected');
                 url.searchParams.delete('oauth_error');
                 url.searchParams.delete('oauth_provider');
+                url.searchParams.delete(VERIFY_EMAIL_PARAM);
                 window.history.replaceState({}, '', url.pathname + url.search);
             }, 1000);
 
             return () => clearTimeout(timer);
         }
-    }, [isNewUser, isVerified, isOAuthConnected, oauthError, providerLabel, t]);
+    }, [isNewUser, isVerified, isOAuthConnected, oauthError, isEmailUnconfirmed, providerLabel, t]);
 
     return null; // This component doesn't render anything
 }

--- a/apps/web/src/app/actions/agent-capabilities.ts
+++ b/apps/web/src/app/actions/agent-capabilities.ts
@@ -138,6 +138,9 @@ export async function installAndBindSkillAction(
     revalidatePath(`/agents/${agentId}/capabilities`);
     revalidatePath(`/agents/${agentId}/skills`);
     revalidatePath('/skills');
+    // Navigation consolidation: the Skills catalog is also a block on the
+    // Agents tab, so a freshly installed Skill has to invalidate `/agents` too.
+    revalidatePath('/agents');
     return { skill, binding };
 }
 

--- a/apps/web/src/app/actions/auth-unverified.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-unverified.unit.spec.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * EW-077 / EW-080 — the two server actions that mint a session for an address
+ * nobody has confirmed yet.
+ *
+ *   EW-077  `register` signs the new user straight into the app. The account
+ *           works until the session ends, and then the password gate refuses
+ *           them for the first time — a rule that was in force from the first
+ *           second, surfacing days later as what looks like a new failure.
+ *
+ *   EW-080  `redeemMagicLink` admits a user the password tab would turn away.
+ *           That asymmetry is intended (the mailed link IS the ownership
+ *           proof), but the API does not flip `emailVerified`, so the password
+ *           tab keeps refusing the same person with nothing anywhere
+ *           connecting the two.
+ *
+ * Both are fixed the same way: carry the true state to the landing page.
+ */
+
+const {
+    registerMock,
+    redeemMagicLinkApiMock,
+    setAuthCookiesMock,
+    getRedirectUrlMock,
+    redirectMock,
+} = vi.hoisted(() => ({
+    registerMock: vi.fn(),
+    redeemMagicLinkApiMock: vi.fn(),
+    setAuthCookiesMock: vi.fn(),
+    getRedirectUrlMock: vi.fn(),
+    redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+    authAPI: {
+        register: registerMock,
+        redeemMagicLink: redeemMagicLinkApiMock,
+        login: vi.fn(),
+        logout: vi.fn(),
+        getOAuthAuthUrl: vi.fn(),
+    },
+}));
+
+vi.mock('@/lib/auth', () => ({
+    setAuthCookies: setAuthCookiesMock,
+    removeAuthAccessCookies: vi.fn(),
+    setOAuthStateCookie: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/redirect', () => ({ getRedirectUrl: getRedirectUrlMock }));
+
+vi.mock('next-intl/server', () => ({
+    getTranslations: async () => (key: string) => key,
+    getLocale: async () => 'en',
+}));
+
+vi.mock('@/i18n/navigation', () => ({ redirect: redirectMock }));
+
+const VALID_TERMS = [
+    {
+        documentId: 'tos',
+        version: '1.0.0',
+        sha256: 'a'.repeat(64),
+        locale: 'en',
+    },
+];
+
+function authResponse(emailVerified: boolean | undefined) {
+    return {
+        access_token: 'tok-1',
+        user: {
+            id: 'u1',
+            username: 'someone',
+            email: 'someone@example.com',
+            ...(emailVerified === undefined ? {} : { emailVerified }),
+        },
+    };
+}
+
+/** The href the action redirected to. */
+function redirectedHref(): string {
+    expect(redirectMock).toHaveBeenCalledTimes(1);
+    return redirectMock.mock.calls[0][0].href;
+}
+
+function noticeParam(href: string): string | null {
+    return new URL(href, 'https://app.ever.works').searchParams.get('verifyEmail');
+}
+
+describe('EW-077 — register tells the user the address is unconfirmed', () => {
+    beforeEach(() => {
+        registerMock.mockReset();
+        setAuthCookiesMock.mockReset();
+        redirectMock.mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+        vi.restoreAllMocks();
+    });
+
+    it('flags the landing page when the new account is unconfirmed', async () => {
+        registerMock.mockResolvedValue(authResponse(false));
+
+        const { register } = await import('./auth');
+        await register('someone', 'someone@example.com', 'password1', VALID_TERMS);
+
+        const href = redirectedHref();
+        expect(noticeParam(href)).toBe('required');
+        // The existing new-user onboarding signal must survive — it drives the
+        // welcome toast and the dashboard's first-run proposal kick.
+        expect(new URL(href, 'https://x.invalid').searchParams.get('newUser')).toBe('true');
+    });
+
+    it('stays quiet when the deployment does not require verification', async () => {
+        // REQUIRE_EMAIL_VERIFICATION=false, or an already-confirmed account:
+        // nagging about a gate that is switched off is its own dishonesty.
+        registerMock.mockResolvedValue(authResponse(true));
+
+        const { register } = await import('./auth');
+        await register('someone', 'someone@example.com', 'password1', VALID_TERMS);
+
+        expect(noticeParam(redirectedHref())).toBeNull();
+    });
+
+    it('stays quiet when the API omits the field entirely', async () => {
+        registerMock.mockResolvedValue(authResponse(undefined));
+
+        const { register } = await import('./auth');
+        await register('someone', 'someone@example.com', 'password1', VALID_TERMS);
+
+        expect(noticeParam(redirectedHref())).toBeNull();
+    });
+
+    it('does not redirect at all when registration fails', async () => {
+        registerMock.mockRejectedValue(new Error('email already exists'));
+
+        const { register } = await import('./auth');
+        const result = await register('someone', 'someone@example.com', 'password1', VALID_TERMS);
+
+        expect(result.success).toBe(false);
+        expect(redirectMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('EW-080 — a magic-link sign-in says the address is still unconfirmed', () => {
+    beforeEach(() => {
+        redeemMagicLinkApiMock.mockReset();
+        setAuthCookiesMock.mockReset();
+        getRedirectUrlMock.mockReset();
+        redirectMock.mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+        vi.restoreAllMocks();
+    });
+
+    it('still signs the unconfirmed user in — the bypass is intended, not a bug', async () => {
+        // Redeeming a link that only ever existed inside that mailbox IS proof
+        // of ownership. Refusing here would break the recovery path for exactly
+        // the people the password gate has locked out.
+        redeemMagicLinkApiMock.mockResolvedValue(authResponse(false));
+        getRedirectUrlMock.mockImplementation(async (_r: unknown, href: string) => href);
+
+        const { redeemMagicLink } = await import('./auth');
+        const result = await redeemMagicLink('a'.repeat(64), null);
+
+        expect(setAuthCookiesMock).toHaveBeenCalledWith('tok-1');
+        expect(result).toEqual({ success: true });
+    });
+
+    it('flags the landing page so the disagreement with the password tab is not silent', async () => {
+        redeemMagicLinkApiMock.mockResolvedValue(authResponse(false));
+        getRedirectUrlMock.mockImplementation(async (_r: unknown, href: string) => href);
+
+        const { redeemMagicLink } = await import('./auth');
+        await redeemMagicLink('a'.repeat(64), null);
+
+        expect(noticeParam(redirectedHref())).toBe('required');
+    });
+
+    it('stays quiet for a confirmed account', async () => {
+        redeemMagicLinkApiMock.mockResolvedValue(authResponse(true));
+        getRedirectUrlMock.mockImplementation(async (_r: unknown, href: string) => href);
+
+        const { redeemMagicLink } = await import('./auth');
+        await redeemMagicLink('a'.repeat(64), null);
+
+        expect(noticeParam(redirectedHref())).toBeNull();
+    });
+
+    it('does not decorate an allowlisted absolute redirect target', async () => {
+        // `ALLOWED_REDIRECT_URLS` defaults to `localhost,127.0.0.1`, so this is
+        // a host the redirect guard actually honours. An external page has no
+        // idea what `verifyEmail` means, so the param must not travel off-site.
+        redeemMagicLinkApiMock.mockResolvedValue(authResponse(false));
+        getRedirectUrlMock.mockImplementation(async (_r: unknown, href: string) => href);
+
+        const { redeemMagicLink } = await import('./auth');
+        await redeemMagicLink('a'.repeat(64), 'http://localhost:3000/welcome');
+
+        expect(redirectedHref()).toBe('http://localhost:3000/welcome');
+    });
+
+    it('does not redirect at all when redemption fails', async () => {
+        redeemMagicLinkApiMock.mockRejectedValue(new Error('Invalid magic link'));
+
+        const { redeemMagicLink } = await import('./auth');
+        const result = await redeemMagicLink('a'.repeat(64), null);
+
+        expect(result.success).toBe(false);
+        expect(redirectMock).not.toHaveBeenCalled();
+        expect(setAuthCookiesMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -9,6 +9,7 @@ import { redirect } from '@/i18n/navigation';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { isValidRedirectUrl } from '@/lib/utils';
 import { getRedirectUrl } from '@/lib/auth/redirect';
+import { isEmailUnconfirmed, withUnverifiedEmailNotice } from '@/lib/auth/unverified-email';
 import { classifyResetPasswordError, resetLinkIsDead } from '@/lib/auth/reset-password-error';
 import { OAuthProvider } from '@/lib/api/enums';
 
@@ -276,9 +277,31 @@ export async function register(
         };
     }
 
+    // EW-077: registration signs the new user in immediately, so the account
+    // works right now — and stops working the moment this session ends, when
+    // the password gate (`requireEmailVerification`, H-07) starts refusing
+    // them with "Please verify your email address before signing in". Nothing
+    // used to mark that difference, so a restriction that applied from the
+    // first second surfaced days later looking like a fresh breakage, on a
+    // page that gives no hint the two things are connected.
+    //
+    // Rather than gate here — which would throw away the working session the
+    // API deliberately issued, and take the new-user onboarding on the
+    // dashboard with it — say what is true: you are in, the address is not
+    // confirmed yet, here is what happens if you leave it that way.
+    //
+    // Read from the response the API actually returned rather than assumed:
+    // when `REQUIRE_EMAIL_VERIFICATION=false` (local dev, e2e) or the account
+    // arrives already confirmed, `emailVerified` is not `false` and the notice
+    // correctly stays quiet instead of nagging about a rule that isn't on.
+    let href = ROUTES.DASHBOARD + '?newUser=true';
+    if (isEmailUnconfirmed(authResponse?.user)) {
+        href = withUnverifiedEmailNotice(href);
+    }
+
     redirect({
         locale: await getLocale(),
-        href: ROUTES.DASHBOARD + '?newUser=true',
+        href,
     });
 
     return {
@@ -545,6 +568,36 @@ export async function issueMagicLink(email: string) {
  * the caller is redirected to the dashboard (or the requested
  * `redirectUrl`, when valid). On failure returns an error string so
  * the UI can render a "Send a new link" recovery path.
+ *
+ * ---
+ * EW-080 — why this signs in a user the password tab would refuse.
+ *
+ * The two tabs on the login page apply different rules to the same account.
+ * Password sign-in is gated on `emailVerified` (`requireEmailVerification`,
+ * H-07): register with someone else's address and you must not get a session
+ * out of it. Magic-link sign-in is not gated, and that is deliberate, not an
+ * oversight in the gate.
+ *
+ * H-07 exists to stop an attacker turning "I typed this address" into a
+ * session. A magic link cannot be used that way. `requestMagicLink` only ever
+ * mints a token for an address already on an account, the raw token is never
+ * returned in the HTTP response — it exists solely inside the email body —
+ * and redemption is single-use with a 15-minute TTL. So holding a redeemable
+ * token IS possession of the mailbox. That is the identical proof the
+ * verification link provides; asking someone who just demonstrated it to go
+ * demonstrate it again would be theatre, and it would break the recovery path
+ * for exactly the users who need it: someone locked out by the password gate
+ * can still get in through their inbox.
+ *
+ * So: intentional, and left as-is.
+ *
+ * What was NOT acceptable is that the disagreement was silent. The API does
+ * not set `emailVerified` when a magic link is redeemed, so this session is
+ * live while the account is still, on the record, unconfirmed — and the
+ * password tab will keep refusing the same person, with no explanation
+ * anywhere connecting the two. The notice below makes that state visible and
+ * tells them the one action that clears it (the verification link in their
+ * inbox); the magic-link tab on the login page states the rule up front.
  */
 export async function redeemMagicLink(token: string, redirectUrl: string | null) {
     const t = await getTranslations('validation.auth');
@@ -587,6 +640,12 @@ export async function redeemMagicLink(token: string, redirectUrl: string | null)
         href = redirectUrl;
     } else if (authResponse) {
         href = await getRedirectUrl(authResponse, href);
+    }
+
+    // EW-080: signed in, but the address is still unconfirmed on the record —
+    // so the password tab will refuse this same person next time. Say so.
+    if (isEmailUnconfirmed(authResponse?.user)) {
+        href = withUnverifiedEmailNotice(href);
     }
 
     redirect({ locale: await getLocale(), href });

--- a/apps/web/src/app/actions/skills.ts
+++ b/apps/web/src/app/actions/skills.ts
@@ -16,6 +16,11 @@ import { getAuthFromCookie } from '@/lib/auth';
  * Skills feature. Each mutation invalidates `/skills` so the page
  * re-fetches on the next render.
  *
+ * Navigation consolidation: the catalog also renders as a block on the
+ * Agents tab (`/agents#skills`), so every `/skills` invalidation is
+ * paired with `/agents`. `/skills` itself is kept (it is still a real
+ * route — a redirect — and other surfaces may link to it).
+ *
  * `installCatalogSkillAction` defaults to tenant-scope using the
  * current userId as ownerId. The userId is read from the encrypted
  * auth cookie (`everworks_auth_token`) at server-action time via
@@ -41,6 +46,7 @@ export async function installCatalogSkillAction(input: {
     const ownerId = input.ownerId ?? (await getCurrentUserId());
     const skill = await skillsAPI.install({ slug: input.slug, ownerType, ownerId });
     revalidatePath('/skills');
+    revalidatePath('/agents');
     return skill;
 }
 
@@ -64,6 +70,7 @@ export async function createCustomSkillAction(input: {
         input.ownerType === 'tenant' && !input.ownerId ? await getCurrentUserId() : input.ownerId;
     const skill = await skillsAPI.create({ ...input, ownerId });
     revalidatePath('/skills');
+    revalidatePath('/agents');
     return skill;
 }
 
@@ -83,6 +90,7 @@ export async function updateSkillAction(
 ): Promise<Skill> {
     const skill = await skillsAPI.update(id, body);
     revalidatePath('/skills');
+    revalidatePath('/agents');
     revalidatePath(`/skills/${id}`);
     return skill;
 }
@@ -90,6 +98,7 @@ export async function updateSkillAction(
 export async function deleteSkillAction(id: string): Promise<{ deleted: true }> {
     const res = await skillsAPI.remove(id);
     revalidatePath('/skills');
+    revalidatePath('/agents');
     return res;
 }
 
@@ -111,6 +120,7 @@ export async function createBindingAction(
 export async function deleteBindingAction(bindingId: string): Promise<{ deleted: true }> {
     const res = await skillsAPI.deleteBinding(bindingId);
     revalidatePath('/skills');
+    revalidatePath('/agents');
     return res;
 }
 

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -5,6 +5,7 @@ import { getRedirectUrl } from '@/lib/auth/redirect';
 import { ROUTES } from '@/lib/constants';
 import { getLocale } from 'next-intl/server';
 import { NextRequest } from 'next/server';
+import { verifyEmailErrorCode } from './verify-email-error';
 
 export async function GET(request: NextRequest) {
     const token = request.nextUrl.searchParams.get('token');
@@ -17,7 +18,6 @@ export async function GET(request: NextRequest) {
         });
     }
 
-    let href = ROUTES.DASHBOARD + '?verified=true';
     let authResponse: AuthResponse | null = null;
 
     try {
@@ -25,10 +25,34 @@ export async function GET(request: NextRequest) {
 
         await setAuthCookies(authResponse.access_token);
     } catch (error) {
-        href = ROUTES.AUTH_ERROR + '?error=verify_email_invalid_token';
+        console.error('Email verification failed', error);
+
+        // EW-078: report what actually went wrong. See `verify-email-error.ts`
+        // — every rejection used to collapse into "invalid or already used".
+        //
+        // EW-079: and go STRAIGHT to the error page. This return is the fix.
+        // The failure path used to fall through to the shared
+        // `getRedirectUrl(...)` call below, which reads the `redirect_url`
+        // cookie and, when one is set, returns it in place of whatever href it
+        // was given. So a user whose verification had just failed was sent to
+        // the page they were originally headed for and shown nothing at all:
+        // no error, no "resend" button, no hint that the link they clicked did
+        // not work. The error page was computed and then thrown away.
+        //
+        // The cookie is deliberately left in place. It is consumed
+        // (`removeRedirectCookie`) by the success path only, so the
+        // destination survives until a verification actually succeeds — the
+        // user requests a new link, clicks it, and still lands where they were
+        // originally going.
+        return redirect({
+            locale,
+            href: ROUTES.AUTH_ERROR + `?error=${verifyEmailErrorCode(error)}`,
+        });
     }
 
-    href = await getRedirectUrl(authResponse, href);
+    // Success only. `authResponse` is non-null here, so the stored redirect
+    // gets the session token stitched into it as intended.
+    const href = await getRedirectUrl(authResponse, ROUTES.DASHBOARD + '?verified=true');
 
     return redirect({ locale, href });
 }

--- a/apps/web/src/app/api/auth/verify-email/route.unit.spec.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.unit.spec.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * EW-078 / EW-079 — the email-verification callback route.
+ *
+ * Two defects, both on the failure path:
+ *
+ *   EW-078  Every rejection was reported as `verify_email_invalid_token`
+ *           ("invalid or has already been used"), including an expired link.
+ *           `verify_email_expired_token` existed, was translated into all 21
+ *           locales, was wired into the error page's switch — and was
+ *           unreachable.
+ *
+ *   EW-079  The failure path fell through to `getRedirectUrl`, which returns
+ *           the `redirect_url` cookie in place of the href it is handed. With
+ *           a redirect cookie set, a failed verification silently landed the
+ *           user on their original destination and showed them nothing.
+ */
+
+const { verifyEmailMock, setAuthCookiesMock, getRedirectUrlMock, redirectMock } = vi.hoisted(
+    () => ({
+        verifyEmailMock: vi.fn(),
+        setAuthCookiesMock: vi.fn(),
+        getRedirectUrlMock: vi.fn(),
+        redirectMock: vi.fn(),
+    }),
+);
+
+vi.mock('@/lib/api', () => ({
+    authAPI: { verifyEmail: verifyEmailMock },
+}));
+
+vi.mock('@/lib/auth', () => ({
+    setAuthCookies: setAuthCookiesMock,
+}));
+
+vi.mock('@/lib/auth/redirect', () => ({
+    getRedirectUrl: getRedirectUrlMock,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    redirect: redirectMock,
+}));
+
+vi.mock('next-intl/server', () => ({
+    getLocale: async () => 'en',
+}));
+
+/** The `ApiResponseError` shape `serverFetch` actually throws. */
+class FakeApiResponseError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: number,
+    ) {
+        super(message);
+        this.name = 'ApiResponseError';
+    }
+}
+
+function requestWith(token: string | null) {
+    const url = new URL('https://app.ever.works/api/auth/verify-email');
+    if (token !== null) url.searchParams.set('token', token);
+    return { nextUrl: url } as unknown as import('next/server').NextRequest;
+}
+
+/** The `?error=` code the route redirected to, or null if it went elsewhere. */
+function redirectedErrorCode(): string | null {
+    expect(redirectMock).toHaveBeenCalledTimes(1);
+    const href: string = redirectMock.mock.calls[0][0].href;
+    return new URL(href, 'https://app.ever.works').searchParams.get('error');
+}
+
+describe('GET /api/auth/verify-email', () => {
+    beforeEach(() => {
+        verifyEmailMock.mockReset();
+        setAuthCookiesMock.mockReset();
+        getRedirectUrlMock.mockReset();
+        redirectMock.mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+        vi.restoreAllMocks();
+    });
+
+    describe('EW-078 — the rejection is classified, not assumed', () => {
+        it('routes an EXPIRED token to verify_email_expired_token', async () => {
+            // The API's own wording: auth.service.ts#verifyEmail throws
+            // BadRequestException('Verification token expired').
+            verifyEmailMock.mockRejectedValue(
+                new FakeApiResponseError('Verification token expired', 400),
+            );
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(redirectedErrorCode()).toBe('verify_email_expired_token');
+        });
+
+        it('still routes a genuinely unknown token to verify_email_invalid_token', async () => {
+            verifyEmailMock.mockRejectedValue(
+                new FakeApiResponseError('Invalid verification token', 400),
+            );
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(redirectedErrorCode()).toBe('verify_email_invalid_token');
+        });
+
+        it('routes an API outage to verify_email_failed, not a verdict on the token', async () => {
+            verifyEmailMock.mockRejectedValue(
+                new FakeApiResponseError('Internal server error', 503),
+            );
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(redirectedErrorCode()).toBe('verify_email_failed');
+        });
+
+        it('routes a transport failure (no status) to verify_email_failed', async () => {
+            verifyEmailMock.mockRejectedValue(new TypeError('fetch failed'));
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(redirectedErrorCode()).toBe('verify_email_failed');
+        });
+
+        it('does NOT call a transport error "expired" just because it says so', async () => {
+            // The API's TLS certificate lapsing produces a plain Error reading
+            // "certificate has expired" and carries NO statusCode. If the
+            // /expir/ stem match runs before the no-status check, this is
+            // reported to the user as an expired VERIFICATION LINK — they go
+            // and request a new one, which fails identically, because the link
+            // was never the problem. That is exactly the confident-but-wrong
+            // diagnosis EW-078 removed, so it is pinned here.
+            verifyEmailMock.mockRejectedValue(new Error('certificate has expired'));
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(redirectedErrorCode()).toBe('verify_email_failed');
+        });
+
+        it('still reports a missing token as verify_email_missing_token', async () => {
+            const { GET } = await import('./route');
+            await GET(requestWith(null));
+
+            expect(redirectedErrorCode()).toBe('verify_email_missing_token');
+            expect(verifyEmailMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('EW-079 — a failure is never redirected away from the error page', () => {
+        it('does not consult the redirect cookie when verification fails', async () => {
+            // A redirect cookie IS set and points somewhere valid. Before the
+            // fix this value replaced the error href and the user saw nothing.
+            getRedirectUrlMock.mockResolvedValue('/dashboard/works/42');
+            verifyEmailMock.mockRejectedValue(
+                new FakeApiResponseError('Verification token expired', 400),
+            );
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            // The redirect helper is not even called, so the cookie survives
+            // for the retry after the user requests a fresh link.
+            expect(getRedirectUrlMock).not.toHaveBeenCalled();
+
+            const href: string = redirectMock.mock.calls[0][0].href;
+            expect(href).toContain('/auth/error');
+            expect(href).not.toContain('/dashboard/works/42');
+        });
+
+        it('does not mint a session when verification fails', async () => {
+            verifyEmailMock.mockRejectedValue(
+                new FakeApiResponseError('Invalid verification token', 400),
+            );
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(setAuthCookiesMock).not.toHaveBeenCalled();
+        });
+
+        it('DOES honour the redirect cookie on success (the behaviour worth keeping)', async () => {
+            verifyEmailMock.mockResolvedValue({
+                access_token: 'tok-123',
+                user: { id: 'u1', username: 'a', email: 'a@b.c', emailVerified: true },
+            });
+            getRedirectUrlMock.mockResolvedValue('/dashboard/works/42?session=tok-123');
+
+            const { GET } = await import('./route');
+            await GET(requestWith('a'.repeat(64)));
+
+            expect(setAuthCookiesMock).toHaveBeenCalledWith('tok-123');
+            // Called with the real auth response, so the session token gets
+            // stitched into the stored destination as designed.
+            expect(getRedirectUrlMock).toHaveBeenCalledTimes(1);
+            expect(getRedirectUrlMock.mock.calls[0][0]).toMatchObject({ access_token: 'tok-123' });
+            const { ROUTES } = await import('@/lib/constants');
+            expect(getRedirectUrlMock.mock.calls[0][1]).toBe(ROUTES.DASHBOARD + '?verified=true');
+            expect(redirectMock.mock.calls[0][0].href).toBe('/dashboard/works/42?session=tok-123');
+        });
+    });
+});

--- a/apps/web/src/app/api/auth/verify-email/verify-email-error.ts
+++ b/apps/web/src/app/api/auth/verify-email/verify-email-error.ts
@@ -1,0 +1,87 @@
+import 'server-only';
+
+/**
+ * Which of the four `auth.error.verifyEmail.*` messages is actually true for a
+ * failed email verification?
+ *
+ * EW-078: the route used to answer this question with a constant. Every
+ * rejection — an expired link, an unreachable API, a TLS reset — became
+ * `verify_email_invalid_token`, which renders as "Email verification link is
+ * invalid or has already been used." Three of the four messages were dead
+ * strings: `expiredToken` and `failed` were written, translated into all 21
+ * locales, wired into the error page's `switch` and its icon table, and could
+ * not be reached by any input.
+ *
+ * That is worse than vague, it is wrong, and it sends people the wrong way. A
+ * link that merely aged out is told it was "already used" — so the user goes
+ * hunting for the session they think they already spent, instead of clicking
+ * the one button that fixes it ("Resend verification"). An API outage is
+ * reported as a bad link, so the user requests a new one and gets the same
+ * failure, because the link was never the problem.
+ *
+ * The mapping below mirrors the password-reset route, which has always
+ * distinguished expiry (`reset_password_expired_token`) by looking at the
+ * API's own wording.
+ */
+export const VERIFY_EMAIL_ERROR = {
+    /** The token was real but past `emailVerificationExpires`. Resend fixes it. */
+    EXPIRED: 'verify_email_expired_token',
+    /** No such token: never issued, already consumed, or mangled in transit. */
+    INVALID: 'verify_email_invalid_token',
+    /** Verification never ran. The link may well still be good — retry it. */
+    FAILED: 'verify_email_failed',
+} as const;
+
+export type VerifyEmailErrorCode = (typeof VERIFY_EMAIL_ERROR)[keyof typeof VERIFY_EMAIL_ERROR];
+
+/**
+ * Classify a rejection from `authAPI.verifyEmail`.
+ *
+ * `serverFetch` throws `ApiResponseError`, which carries the API's own
+ * `message` and the HTTP `statusCode`. Anything else that can escape the try
+ * block (a transport-level `TypeError`, a cookie write that blew up) arrives
+ * as a plain `Error` with no `statusCode` — deliberately handled, because the
+ * one thing it definitely is not is evidence about the token.
+ *
+ * Matching is on the message stem rather than the exact sentence so the API
+ * rewording "Verification token expired" does not silently push this back to
+ * the constant it replaced. It is still narrow: only the word that carries the
+ * meaning, and only on a response that actually came from the API.
+ */
+export function verifyEmailErrorCode(error: unknown): VerifyEmailErrorCode {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    const statusCode = (error as { statusCode?: number } | null)?.statusCode;
+
+    // A 5xx says nothing about the token — verification did not run. Calling
+    // the link "invalid or already used" here is a guess, and it points the
+    // user away from the fix: retrying the SAME link is the right next step.
+    if (typeof statusCode === 'number' && statusCode >= 500) {
+        return VERIFY_EMAIL_ERROR.FAILED;
+    }
+
+    // No status at all means the request never got an answer (DNS, TLS,
+    // connection reset, or a throw on our own side). Same reasoning as the
+    // 5xx branch: the token is unjudged, so don't judge it.
+    //
+    // 🛑 This MUST stay ahead of the /expir/ test below. The docblock promises
+    // the stem match happens "only on a response that actually came from the
+    // API", and ordering is the only thing that keeps that promise. Reversed,
+    // an expired TLS certificate on the API arrives as a plain Error reading
+    // "certificate has expired", matches /expir/, and tells the user their
+    // VERIFICATION LINK expired — a confident, wrong diagnosis that sends them
+    // to request a new link that will fail exactly the same way. That is the
+    // very failure mode EW-078 exists to remove, so it would be an unfortunate
+    // one to reintroduce here.
+    if (typeof statusCode !== 'number') {
+        return VERIFY_EMAIL_ERROR.FAILED;
+    }
+
+    // `auth.service.ts#verifyEmail` → `BadRequestException('Verification token
+    // expired')`. This is the branch EW-078 is about.
+    if (/expir/i.test(message)) {
+        return VERIFY_EMAIL_ERROR.EXPIRED;
+    }
+
+    // A 4xx that the API did answer: the token really was rejected.
+    return VERIFY_EMAIL_ERROR.INVALID;
+}

--- a/apps/web/src/components/agents/AgentsList.tsx
+++ b/apps/web/src/components/agents/AgentsList.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { Bot, Plus } from 'lucide-react';
+import { Bot, Network, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants';
-import { useRouter } from '@/i18n/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import {
     PromptComposer,
     buildAttachmentRefs,
@@ -36,6 +36,22 @@ const PROMPT_INPUT_ID = 'agents-prompt';
 
 /** Agent-flavoured placeholder cycle — mirrors the agent examples used
  *  by the unified `/new` page so the surfaces feel like one primitive. */
+/**
+ * Secondary-button chrome for the header's "Agents Chart" link. A plain
+ * `<Link>` rather than `<Button href>` on purpose: the Button's href branch
+ * renders a `LinkComponent` with an explicit prop list (href/className/
+ * target/rel/children) and therefore drops every extra prop — including the
+ * `data-testid` the e2e journey and the unit spec below select the CTA by.
+ * Classes mirror `<Button variant="secondary" size="sm">` so the two controls
+ * are visually identical; the same idiom is used on the Teams page.
+ */
+const CHART_LINK_CLASSES =
+    'inline-flex cursor-pointer select-none items-center justify-center gap-1.5 whitespace-nowrap rounded-md font-medium transition-colors ' +
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:focus-visible:ring-white/20 [&_svg]:shrink-0 ' +
+    'h-8 px-3 text-xs border border-border dark:border-border-dark ' +
+    'bg-button-primary dark:bg-button-primary-dark hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark ' +
+    'text-button-primary-foreground dark:text-button-primary-foreground-dark';
+
 const AGENT_PLACEHOLDERS: ReadonlyArray<string> = [
     'e.g. "Research assistant that fetches AI safety papers and summarizes them weekly"',
     'e.g. "Content editor that rewrites our directory descriptions in a consistent voice"',
@@ -97,7 +113,25 @@ export function AgentsList({ agents, templates = [], userTemplates = [] }: Agent
 
     return (
         <div className="w-full">
-            <PageHeader icon={Bot} title={t('title')} subtitle={t('subtitle')} tone="agent" />
+            <PageHeader
+                icon={Bot}
+                title={t('title')}
+                subtitle={t('subtitle')}
+                tone="agent"
+                actions={
+                    /* Navigation consolidation §3.6 — the Agents Chart is the
+                       agent-only view of the org chart (human members stripped),
+                       and this header CTA is its only entry point. */
+                    <Link
+                        href={ROUTES.DASHBOARD_AGENTS_CHART}
+                        data-testid="agents-chart-link"
+                        className={CHART_LINK_CLASSES}
+                    >
+                        <Network className="w-3.5 h-3.5" strokeWidth={1.5} aria-hidden="true" />
+                        {t('agentsChartCta')}
+                    </Link>
+                }
+            />
 
             {/* Prompt-first surface — describe the Agent you want. Chips
                 with quick-pick templates + `View All` render below the

--- a/apps/web/src/components/agents/AgentsList.unit.spec.tsx
+++ b/apps/web/src/components/agents/AgentsList.unit.spec.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentsList } from './AgentsList';
+
+/**
+ * Navigation consolidation (`docs/specs/features/navigation-consolidation`
+ * §3.5): the Agents tab is the only door to the Agents Chart, so the header
+ * CTA that opens it is a contract — `flow-agents-ui-journey.spec.ts` asserts
+ * the same test id and href end-to-end.
+ */
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+vi.mock('@/lib/hooks/use-start-from-prompt', () => ({
+    useStartFromPrompt: () => vi.fn(),
+}));
+
+// The composer owns a textarea, attachment uploads and a placeholder
+// animation loop — none of it is under test here.
+vi.mock('@/components/common/PromptComposer', () => ({
+    PromptComposer: ({ testId }: { testId?: string }) => <div data-testid={testId} />,
+    buildAttachmentRefs: () => [],
+}));
+
+vi.mock('./AgentTemplateChips', () => ({
+    AgentTemplateChips: () => <div data-testid="agent-template-chips" />,
+}));
+
+vi.mock('./AgentCard', () => ({
+    AgentCard: () => <div data-testid="agent-card" />,
+}));
+
+describe('AgentsList — header actions', () => {
+    it('renders the Agents Chart CTA pointing at /agents/chart', () => {
+        render(<AgentsList agents={[]} />);
+
+        const link = screen.getByTestId('agents-chart-link');
+        expect(link.tagName).toBe('A');
+        expect(link.getAttribute('href')).toBe('/agents/chart');
+        expect(link.textContent).toContain('agentsChartCta');
+    });
+
+    it('keeps the chart CTA in the page header, beside the title', () => {
+        const { container } = render(<AgentsList agents={[]} />);
+
+        const heading = container.querySelector('h1');
+        expect(heading).not.toBeNull();
+        // The CTA lives in the PageHeader's actions slot — same header row as
+        // the page title, not floated somewhere down the catalog.
+        const headerRow = screen.getByTestId('agents-chart-link').closest('div.justify-between');
+        expect(headerRow?.querySelector('h1')).toBe(heading);
+    });
+});

--- a/apps/web/src/components/agents/AgentsPageTabs.tsx
+++ b/apps/web/src/components/agents/AgentsPageTabs.tsx
@@ -6,15 +6,27 @@ import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 
 /**
- * Run orchestration (Wave 4 M4) — top-level tab strip on the Agents
- * page: the Agents catalog and the org-wide Sessions view (a filtered
- * projection of `agent_runs`, exactly as the Tasks kanban is a view
- * over Task). Same visual language as the per-agent `AgentDetailTabs`.
+ * Teams hub tab strip: Teams | Agents | Sessions | Archived — rendered on
+ * `/teams`, `/agents`, `/agents/sessions` and `/agents/archived`.
+ *
+ * Run orchestration (Wave 4 M4) introduced it over the Agents catalog and
+ * the org-wide Sessions view (a filtered projection of `agent_runs`, exactly
+ * as the Tasks kanban is a view over Task). Navigation consolidation
+ * (`docs/specs/features/navigation-consolidation`) then folded Teams in as
+ * the first tab, since people and agents are one org seen through two doors
+ * — hence the `TeamsPageTabs` alias below for the `/teams` entry point.
+ * Same visual language as the per-agent `AgentDetailTabs`.
  */
-export function AgentsPageTabs({ active }: { active: 'agents' | 'sessions' | 'archived' }) {
+export function AgentsPageTabs({
+    active,
+}: {
+    active: 'teams' | 'agents' | 'sessions' | 'archived';
+}) {
     const t = useTranslations('dashboard.agentsPage.pageTabs');
 
     const tabs = [
+        // The hub's front door — the old standalone Teams page, now tab 1.
+        { key: 'teams' as const, href: ROUTES.DASHBOARD_TEAMS, label: t('teams') },
         { key: 'agents' as const, href: ROUTES.DASHBOARD_AGENTS, label: t('agents') },
         {
             key: 'sessions' as const,
@@ -57,3 +69,10 @@ export function AgentsPageTabs({ active }: { active: 'agents' | 'sessions' | 'ar
         </nav>
     );
 }
+
+/**
+ * Alias for the `/teams` side of the same hub — identical component, named
+ * after the page that renders it so the Teams pages don't read as importing
+ * "Agents" tabs. The test ids stay `agents-page-tab-*` either way.
+ */
+export const TeamsPageTabs = AgentsPageTabs;

--- a/apps/web/src/components/agents/AgentsPageTabs.unit.spec.tsx
+++ b/apps/web/src/components/agents/AgentsPageTabs.unit.spec.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentsPageTabs, TeamsPageTabs } from './AgentsPageTabs';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+describe('AgentsPageTabs', () => {
+    it('renders Teams | Agents | Sessions | Archived in that order and marks the active one', () => {
+        render(<AgentsPageTabs active="teams" />);
+        const tabs = screen.getAllByRole('link');
+        expect(tabs.map((a) => a.getAttribute('data-testid'))).toEqual([
+            'agents-page-tab-teams',
+            'agents-page-tab-agents',
+            'agents-page-tab-sessions',
+            'agents-page-tab-archived',
+        ]);
+        expect(tabs[0].getAttribute('href')).toBe('/teams');
+        expect(tabs[0].className).toContain('border-primary');
+        expect(tabs[1].className).not.toContain('border-primary');
+    });
+
+    it('keeps the existing tab hrefs and the strip test id', () => {
+        const { container } = render(<AgentsPageTabs active="agents" />);
+        expect(container.querySelector('[data-testid="agents-page-tabs"]')).not.toBeNull();
+        const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+        expect(hrefs).toEqual(['/teams', '/agents', '/agents/sessions', '/agents/archived']);
+        expect(screen.getByTestId('agents-page-tab-agents').className).toContain('border-primary');
+        expect(screen.getByTestId('agents-page-tab-teams').className).not.toContain(
+            'border-primary',
+        );
+    });
+
+    it('marks sessions and archived active when selected', () => {
+        const { unmount } = render(<AgentsPageTabs active="sessions" />);
+        expect(screen.getByTestId('agents-page-tab-sessions').className).toContain(
+            'border-primary',
+        );
+        unmount();
+
+        render(<AgentsPageTabs active="archived" />);
+        expect(screen.getByTestId('agents-page-tab-archived').className).toContain(
+            'border-primary',
+        );
+    });
+
+    it('exposes a TeamsPageTabs alias for the Teams hub entry point', () => {
+        expect(TeamsPageTabs).toBe(AgentsPageTabs);
+        render(<TeamsPageTabs active="teams" />);
+        expect(screen.getByTestId('agents-page-tab-teams').className).toContain('border-primary');
+    });
+});

--- a/apps/web/src/components/common/PageHeader.tsx
+++ b/apps/web/src/components/common/PageHeader.tsx
@@ -32,6 +32,14 @@ interface PageHeaderProps {
     tone?: PageHeaderTone;
     actions?: ReactNode;
     className?: string;
+    /**
+     * Heading level for the title. Defaults to `h1` — this component *is* the
+     * page title on every dashboard index. Pass `h2` when the header is reused
+     * as a *block* header inside a page that already owns an `h1` (e.g. the
+     * Skills block on the Agents tab, per the navigation consolidation), so
+     * the document outline keeps exactly one `h1`.
+     */
+    as?: 'h1' | 'h2';
 }
 
 const toneClasses: Record<PageHeaderTone, { bg: string; border: string; text: string }> = {
@@ -99,6 +107,7 @@ export function PageHeader({
     tone = 'primary',
     actions,
     className,
+    as: Heading = 'h1',
 }: PageHeaderProps) {
     const t = toneClasses[tone];
     return (
@@ -114,9 +123,9 @@ export function PageHeader({
                     <Icon className={cn('w-4 h-4', t.text)} />
                 </div>
                 <div className="min-w-0">
-                    <h1 className="text-2xl font-semibold text-text dark:text-text-dark truncate">
+                    <Heading className="text-2xl font-semibold text-text dark:text-text-dark truncate">
                         {title}
-                    </h1>
+                    </Heading>
                     {subtitle ? (
                         <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1 max-w-2xl">
                             {subtitle}

--- a/apps/web/src/components/common/PageHeader.unit.spec.tsx
+++ b/apps/web/src/components/common/PageHeader.unit.spec.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Sparkles } from 'lucide-react';
+import { PageHeader } from './PageHeader';
+
+/**
+ * The heading level is load-bearing: `PageHeader` is the page title on every
+ * dashboard index, but the navigation consolidation also renders it as a
+ * *block* header inside another page (the Skills block on the Agents tab),
+ * where a second `h1` would break the document outline. Lock both branches.
+ */
+describe('PageHeader', () => {
+    it('renders the title as an h1 by default', () => {
+        render(<PageHeader icon={Sparkles} title="Skills" subtitle="Reusable instructions" />);
+        expect(screen.getByRole('heading', { level: 1, name: 'Skills' })).toBeTruthy();
+        expect(screen.getByText('Reusable instructions')).toBeTruthy();
+    });
+
+    it('renders the title as an h2 when nested in a page that already has an h1', () => {
+        render(<PageHeader icon={Sparkles} title="Skills" as="h2" />);
+        expect(screen.getByRole('heading', { level: 2, name: 'Skills' })).toBeTruthy();
+        expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+    });
+});

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -25,6 +25,11 @@ import {
     Lightbulb,
     Target,
     Gauge,
+    // Bot / Sparkles / Users / Video no longer label a nav entry of their own —
+    // Agents, Skills, Teams and Meetings folded into the two merged entries
+    // below (navigation consolidation §3.2). Kept per the repo's no-removal
+    // rule: neither eslint nor tsc flags them, they cost nothing after
+    // tree-shaking, and re-splitting an entry shouldn't need an import hunt.
     Bot,
     Brain,
     ListChecks,
@@ -34,8 +39,10 @@ import {
     BarChart3,
     Video,
     Inbox,
+    type LucideIcon,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { HumanAgentIcon } from '@/components/icons/HumanAgentIcon';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import {
@@ -114,7 +121,19 @@ export function DashboardSidebar({
         });
     };
 
-    const navigation = [
+    /**
+     * `matchPrefixes` (navigation consolidation,
+     * `docs/specs/features/navigation-consolidation` §3.2) lets one entry own
+     * more than its own href: three features folded into two entries, but their
+     * URLs deliberately did not move, so the highlight has to follow them.
+     * Omitted = the old behaviour, `[item.href]`.
+     */
+    const navigation: Array<{
+        name: string;
+        href: string;
+        icon: LucideIcon | typeof HumanAgentIcon;
+        matchPrefixes?: string[];
+    }> = [
         { name: t('navigation.dashboard'), href: ROUTES.DASHBOARD, icon: Home },
         // Inbox (operator message center) — the one surface carrying
         // messages ADDRESSED TO the human: blocking agent questions
@@ -145,21 +164,37 @@ export function DashboardSidebar({
         },
         // Agents/Skills/Tasks PR #1017 — Phase 5.
         { name: t('navigation.tasks'), href: ROUTES.DASHBOARD_TASKS, icon: ListChecks },
-        { name: t('navigation.agents'), href: ROUTES.DASHBOARD_AGENTS, icon: Bot },
+        // Teams & Prebuilt Companies (teams-and-companies spec §4.1), merged
+        // with the former Agents entry: one hub for people AND agents, tabs
+        // Teams | Agents | Sessions | Archived, with Skills as a block on the
+        // Agents tab. It takes the slot Agents held (right after Tasks) and
+        // stays lit across /teams/*, /agents/* and the /skills/* detail pages.
+        {
+            name: t('navigation.teams'),
+            href: ROUTES.DASHBOARD_TEAMS,
+            icon: HumanAgentIcon,
+            matchPrefixes: [
+                ROUTES.DASHBOARD_TEAMS,
+                ROUTES.DASHBOARD_AGENTS,
+                ROUTES.DASHBOARD_SKILLS,
+            ],
+        },
         // Org-wide Memory (Cortex P1) — one place to search everything the
         // active Organization knows, aggregated across all its Works' KB.
-        // Sits directly below Agents per spec §4.1.
-        { name: t('navigation.memory'), href: ROUTES.DASHBOARD_MEMORY, icon: Brain },
-        // Meetings (Wave 8, feature a) — captured meetings, transcripts
-        // and their AI summaries. Sits right after Memory: a meeting
-        // transcript is one of the richest things the platform learns
-        // from, and its ingest writes straight into Memory + Activity.
-        { name: t('navigation.meetings'), href: ROUTES.DASHBOARD_MEETINGS, icon: Video },
-        // Teams & Prebuilt Companies (teams-and-companies spec §4.1).
-        { name: t('navigation.teams'), href: ROUTES.DASHBOARD_TEAMS, icon: Users },
+        // Sits directly below the Teams hub per spec §4.1.
+        //
+        // Meetings (Wave 8, feature a) folded in here: a meeting transcript is
+        // one of the richest things the platform learns from and its ingest
+        // writes straight into Memory, so the catalog is a block on this page
+        // (`/memory#meetings`) and /meetings/* keeps Memory highlighted.
+        {
+            name: t('navigation.memory'),
+            href: ROUTES.DASHBOARD_MEMORY,
+            icon: Brain,
+            matchPrefixes: [ROUTES.DASHBOARD_MEMORY, ROUTES.DASHBOARD_MEETINGS],
+        },
         { name: t('navigation.templates'), href: ROUTES.DASHBOARD_TEMPLATES, icon: LayoutTemplate },
         { name: t('navigation.plugins'), href: ROUTES.DASHBOARD_PLUGINS, icon: Plug },
-        { name: t('navigation.skills'), href: ROUTES.DASHBOARD_SKILLS, icon: Sparkles },
         { name: t('navigation.activity'), href: ROUTES.DASHBOARD_ACTIVITY, icon: Activity },
         { name: t('navigation.settings'), href: ROUTES.DASHBOARD_SETTINGS, icon: Settings },
     ];
@@ -315,8 +350,11 @@ export function DashboardSidebar({
                         )}
                     >
                         {navigation.map((item) => {
-                            const isActive =
-                                pathname === item.href || pathname?.startsWith(item.href + '/');
+                            const prefixes = item.matchPrefixes ?? [item.href];
+                            const isActive = prefixes.some(
+                                (prefix) =>
+                                    pathname === prefix || pathname?.startsWith(prefix + '/'),
+                            );
                             return (
                                 <li
                                     key={item.name}

--- a/apps/web/src/components/dashboard/DashboardSidebar.unit.spec.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.unit.spec.tsx
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AuthUser } from '@/lib/auth';
+import { DashboardSidebar } from './DashboardSidebar';
+
+/**
+ * Navigation consolidation (`docs/specs/features/navigation-consolidation`
+ * §3.2): the sidebar is the whole point of the change, so its shape is
+ * pinned here — one merged "Teams" entry carrying the human+agent glyph, no
+ * separate Agents / Skills / Meetings entries, and `matchPrefixes` keeping
+ * the right entry highlighted on the routes that folded into it.
+ */
+
+const nav = vi.hoisted(() => ({ pathname: '/' }));
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+    usePathname: () => nav.pathname,
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@/app/actions/auth', () => ({ logout: vi.fn() }));
+vi.mock('@/lib/hooks/use-mounted', () => ({ useMounted: () => true }));
+vi.mock('../works/detail/WorkDetailContext', () => ({
+    useWorkDetail: () => ({ config: {} }),
+}));
+vi.mock('../layout/WorkspaceSwitcher', () => ({
+    WorkspaceSwitcher: () => <div data-testid="workspace-switcher" />,
+}));
+vi.mock('./RunnerStatusPill', () => ({ RunnerStatusPill: () => null }));
+vi.mock('./SidebarActivityIndicator', () => ({ SidebarActivityIndicator: () => null }));
+vi.mock('./SidebarInboxBadge', () => ({ SidebarInboxBadge: () => null }));
+vi.mock('@/components/ai/ChatPanel', () => ({ ChatPanelExpandButton: () => null }));
+
+const user: AuthUser = {
+    id: 'u1',
+    email: 'op@example.com',
+    username: 'operator',
+    emailVerified: true,
+    avatar: null,
+};
+
+/** The nav `<ul>` only — the footer/profile menu also renders links. */
+function navLinks(container: HTMLElement): HTMLAnchorElement[] {
+    return Array.from(container.querySelectorAll('nav a'));
+}
+
+function renderSidebar() {
+    return render(<DashboardSidebar user={user} isOpen onToggle={() => {}} />);
+}
+
+/**
+ * Token-exact, deliberately NOT `className.includes('bg-surface-secondary')`:
+ * the INACTIVE variant carries `hover:bg-surface-secondary`, so a substring
+ * check reports every link as active and the test can never fail.
+ */
+function isActive(link: HTMLAnchorElement | undefined): boolean {
+    return (link?.className ?? '').split(/\s+/).includes('bg-surface-secondary');
+}
+
+function linkFor(container: HTMLElement, label: string): HTMLAnchorElement | undefined {
+    return navLinks(container).find((a) => a.textContent?.trim() === label);
+}
+
+beforeEach(() => {
+    nav.pathname = '/';
+});
+
+describe('DashboardSidebar — navigation consolidation', () => {
+    it('has one merged Teams entry and no Agents / Skills / Meetings entries', () => {
+        const { container } = renderSidebar();
+        const labels = navLinks(container).map((a) => a.textContent?.trim());
+
+        expect(labels).toContain('navigation.teams');
+        expect(labels.filter((l) => l === 'navigation.teams')).toHaveLength(1);
+        expect(labels).not.toContain('navigation.agents');
+        expect(labels).not.toContain('navigation.skills');
+        expect(labels).not.toContain('navigation.meetings');
+        // The hub's front door is /teams.
+        expect(linkFor(container, 'navigation.teams')?.getAttribute('href')).toBe('/teams');
+    });
+
+    it('draws the Teams entry with the human+agent glyph, not a lucide stand-in', () => {
+        const { container } = renderSidebar();
+        const svg = linkFor(container, 'navigation.teams')?.querySelector('svg');
+
+        expect(svg).not.toBeNull();
+        // HumanAgentIcon = person (circle) + bot head (rect); no lucide sidebar
+        // icon in this nav pairs a rect with a circle.
+        expect(svg?.querySelector('rect')).not.toBeNull();
+        expect(svg?.querySelector('circle')).not.toBeNull();
+    });
+
+    it('keeps Teams active on /agents/* and /skills/* (the routes it absorbed)', () => {
+        for (const path of ['/teams', '/teams/abc', '/agents/abc', '/skills/abc']) {
+            nav.pathname = path;
+            const { container, unmount } = renderSidebar();
+            expect(
+                isActive(linkFor(container, 'navigation.teams')),
+                `Teams should be active on ${path}`,
+            ).toBe(true);
+            unmount();
+        }
+    });
+
+    it('keeps Memory active on /meetings/* (the meeting detail + new pages)', () => {
+        for (const path of ['/memory', '/meetings/xyz', '/meetings/new']) {
+            nav.pathname = path;
+            const { container, unmount } = renderSidebar();
+            expect(
+                isActive(linkFor(container, 'navigation.memory')),
+                `Memory should be active on ${path}`,
+            ).toBe(true);
+            unmount();
+        }
+    });
+
+    it('does not activate an entry on an unrelated route', () => {
+        nav.pathname = '/works/abc';
+        const { container } = renderSidebar();
+
+        expect(isActive(linkFor(container, 'navigation.teams'))).toBe(false);
+        expect(isActive(linkFor(container, 'navigation.memory'))).toBe(false);
+        // Control: the entry that SHOULD be lit on this route is lit, so a
+        // green "not active" above can't come from a broken matcher.
+        expect(isActive(linkFor(container, 'navigation.works'))).toBe(true);
+    });
+
+    it('places Teams between Tasks and Memory — the slot Agents used to hold', () => {
+        const { container } = renderSidebar();
+        const labels = navLinks(container).map((a) => a.textContent?.trim());
+
+        expect(labels.indexOf('navigation.teams')).toBe(labels.indexOf('navigation.tasks') + 1);
+        expect(labels.indexOf('navigation.memory')).toBe(labels.indexOf('navigation.teams') + 1);
+    });
+});
+
+describe('DashboardSidebar — untouched entries', () => {
+    it('still lists every other nav destination', () => {
+        const { container } = renderSidebar();
+        const labels = navLinks(container).map((a) => a.textContent?.trim());
+
+        for (const key of [
+            'navigation.dashboard',
+            'navigation.inbox',
+            'navigation.missions',
+            'navigation.goals',
+            'navigation.ideas',
+            'navigation.works',
+            'navigation.tasks',
+            'navigation.memory',
+            'navigation.templates',
+            'navigation.plugins',
+            'navigation.activity',
+            'navigation.settings',
+        ]) {
+            expect(labels, `missing ${key}`).toContain(key);
+        }
+    });
+
+    it('renders the collapsed rail as icons only, with the label in a tooltip', () => {
+        const { container } = render(
+            <DashboardSidebar user={user} isOpen onToggle={() => {}} isCollapsed />,
+        );
+        const teams = navLinks(container).find((a) => a.getAttribute('href') === '/teams');
+        expect(teams).toBeDefined();
+        // Icon only inside the link; the text moves to the hover tooltip.
+        expect(teams?.textContent?.trim()).toBe('');
+        expect(teams?.querySelector('svg')).not.toBeNull();
+        expect(screen.getByRole('tooltip', { name: 'navigation.teams' })).toBeDefined();
+    });
+});

--- a/apps/web/src/components/icons/HumanAgentIcon.tsx
+++ b/apps/web/src/components/icons/HumanAgentIcon.tsx
@@ -1,0 +1,57 @@
+import { forwardRef } from 'react';
+import type { LucideProps } from 'lucide-react';
+
+/**
+ * Human + Agent — the icon for the merged "Teams" hub (navigation
+ * consolidation, `docs/specs/features/navigation-consolidation`): one entry
+ * that covers people AND agents, so the glyph has to say both.
+ *
+ * Hand-drawn in lucide's 24×24 stroke grammar (currentColor, round caps and
+ * joins, default stroke width 2) so it sits next to the other sidebar icons
+ * without a visible seam: the left half is lucide `user` (head + shoulders),
+ * the right half is lucide `bot`'s head (rounded rect, antenna, two eyes).
+ *
+ * Declared with `forwardRef` so it is structurally a lucide `LucideIcon` —
+ * that is what `PageHeader`'s `icon` prop and the sidebar's navigation array
+ * are typed as, and a plain function component is not assignable to it.
+ */
+export const HumanAgentIcon = forwardRef<SVGSVGElement, LucideProps>(function HumanAgentIcon(
+    { size = 24, strokeWidth = 2, absoluteStrokeWidth = false, className, ...rest },
+    ref,
+) {
+    // Same rule as lucide's own icons: with `absoluteStrokeWidth` the stroke
+    // stays the same visual weight at any `size` instead of scaling with the
+    // viewBox. Destructured either way so it never lands on the <svg> as an
+    // unknown attribute.
+    const numericSize = Number(size) || 24;
+    const resolvedStrokeWidth = absoluteStrokeWidth
+        ? (Number(strokeWidth) * 24) / numericSize
+        : strokeWidth;
+    return (
+        <svg
+            ref={ref}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width={size}
+            height={size}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={resolvedStrokeWidth}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            aria-hidden="true"
+            {...rest}
+        >
+            {/* person (left) — lucide `user` */}
+            <circle cx="7.5" cy="7" r="3" />
+            <path d="M2 21v-2a4.5 4.5 0 0 1 4.5-4.5h2A4.5 4.5 0 0 1 13 19v2" />
+            {/* bot head (right) — lucide `bot` */}
+            <rect x="13" y="10" width="9" height="8" rx="2" />
+            <path d="M17.5 10V7" />
+            <circle cx="17.5" cy="6" r="1" />
+            <path d="M15.5 14v1" />
+            <path d="M19.5 14v1" />
+        </svg>
+    );
+});

--- a/apps/web/src/components/icons/HumanAgentIcon.unit.spec.tsx
+++ b/apps/web/src/components/icons/HumanAgentIcon.unit.spec.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { LucideIcon } from 'lucide-react';
+import { HumanAgentIcon } from './HumanAgentIcon';
+
+/**
+ * Type-level guard (checked by `pnpm type-check`, not at runtime): the icon
+ * must be assignable to `LucideIcon`, because that is how `PageHeader.icon`
+ * and the sidebar navigation array are typed.
+ */
+const asLucideIcon: LucideIcon = HumanAgentIcon;
+
+describe('HumanAgentIcon', () => {
+    it("is assignable to lucide's LucideIcon type", () => {
+        expect(asLucideIcon).toBe(HumanAgentIcon);
+    });
+
+    it('renders a lucide-compatible svg with the given class and stroke width', () => {
+        const { container } = render(<HumanAgentIcon className="w-5 h-5" strokeWidth={1.5} />);
+        const svg = container.querySelector('svg');
+        expect(svg).not.toBeNull();
+        expect(svg?.getAttribute('viewBox')).toBe('0 0 24 24');
+        expect(svg?.getAttribute('class')).toContain('w-5');
+        expect(svg?.getAttribute('stroke-width')).toBe('1.5');
+        expect(svg?.getAttribute('aria-hidden')).toBe('true');
+        // both halves present: a person head (circle) and a bot head (rect)
+        expect(container.querySelector('circle')).not.toBeNull();
+        expect(container.querySelector('rect')).not.toBeNull();
+    });
+
+    it('defaults to lucide stroke width 2 and paints with currentColor', () => {
+        const { container } = render(<HumanAgentIcon />);
+        const svg = container.querySelector('svg');
+        expect(svg?.getAttribute('stroke-width')).toBe('2');
+        expect(svg?.getAttribute('stroke')).toBe('currentColor');
+        expect(svg?.getAttribute('fill')).toBe('none');
+    });
+
+    it('honours absoluteStrokeWidth like lucide (stroke = width * 24 / size) and does not forward it', () => {
+        const { container } = render(
+            <HumanAgentIcon size={48} strokeWidth={2} absoluteStrokeWidth />,
+        );
+        const svg = container.querySelector('svg');
+        expect(svg?.getAttribute('width')).toBe('48');
+        expect(svg?.getAttribute('stroke-width')).toBe('1');
+        expect(svg?.hasAttribute('absoluteStrokeWidth')).toBe(false);
+        expect(svg?.hasAttribute('absolutestrokewidth')).toBe(false);
+    });
+});

--- a/apps/web/src/components/meetings/MeetingDetailClient.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.tsx
@@ -457,7 +457,10 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
             try {
                 await deleteMeetingAction(meeting.id);
                 toast.success(t('toasts.deleted'));
-                router.push(ROUTES.DASHBOARD_MEETINGS);
+                // The catalog lives on the Memory page now (navigation
+                // consolidation) — send the user to the block, not to the
+                // `/meetings` redirect that would bounce them there anyway.
+                router.push(ROUTES.DASHBOARD_MEMORY_MEETINGS);
             } catch (err) {
                 setDeleteError(err instanceof Error ? err.message : t('deleteDialog.error'));
             }
@@ -470,7 +473,7 @@ export function MeetingDetailClient({ meeting: initial, works = [] }: MeetingDet
             <div>
                 <div className="flex items-center justify-between gap-3">
                     <Link
-                        href={ROUTES.DASHBOARD_MEETINGS}
+                        href={ROUTES.DASHBOARD_MEMORY_MEETINGS}
                         className="inline-flex min-w-0 items-center gap-1 text-xs text-text-muted transition-colors hover:text-text dark:text-text-muted-dark dark:hover:text-text-dark"
                     >
                         <ChevronLeft className="h-3.5 w-3.5 shrink-0" />

--- a/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingDetailClient.unit.spec.tsx
@@ -114,8 +114,10 @@ describe('MeetingDetailClient — header', () => {
         // row and once as the Details "source" row value.
         expect(screen.getAllByTestId('meeting-source-badge')).toHaveLength(2);
         expect(screen.getByTestId('meeting-transcript-badge')).toBeTruthy();
+        // The catalog is the Memory page's `#meetings` block since the
+        // navigation consolidation — `/meetings` only redirects there.
         expect(screen.getByText('backToMeetings').closest('a')?.getAttribute('href')).toBe(
-            '/meetings',
+            '/memory#meetings',
         );
     });
 
@@ -160,7 +162,7 @@ describe('MeetingDetailClient — delete', () => {
         fireEvent.click(screen.getByTestId('meeting-delete-confirm'));
 
         await waitFor(() => expect(deleteMock).toHaveBeenCalledWith('mtg-1'));
-        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/meetings'));
+        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/memory#meetings'));
     });
 
     it('a failed delete surfaces the error inline and stays on the page', async () => {

--- a/apps/web/src/components/meetings/MeetingForm.tsx
+++ b/apps/web/src/components/meetings/MeetingForm.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils/cn';
+import { ROUTES } from '@/lib/constants';
 import {
     MEETING_CREATABLE_SOURCES,
     MEETING_EXTERNAL_ID_MAX_CHARS,
@@ -152,8 +153,10 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
     return (
         <div className="mx-auto w-full max-w-3xl space-y-6 p-6" data-testid="meeting-form">
             <div>
+                {/* Back to the catalog — which is the Memory page's
+                    `#meetings` block since the navigation consolidation. */}
                 <Link
-                    href="/meetings"
+                    href={ROUTES.DASHBOARD_MEMORY_MEETINGS}
                     className="inline-flex items-center gap-1 text-xs text-text-muted transition-colors hover:text-text dark:text-text-muted-dark dark:hover:text-text-dark"
                 >
                     <ChevronLeft className="h-3.5 w-3.5" />
@@ -332,7 +335,7 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
             {/* Cancel then submit, secondary beside primary — the pairing the
                 edit dialog's footer uses, so the two forms end the same way. */}
             <div className="flex items-center justify-end gap-2">
-                <Button href="/meetings" variant="secondary" size="sm">
+                <Button href={ROUTES.DASHBOARD_MEMORY_MEETINGS} variant="secondary" size="sm">
                     {t('actions.cancel')}
                 </Button>
                 <Button

--- a/apps/web/src/components/meetings/MeetingsList.tsx
+++ b/apps/web/src/components/meetings/MeetingsList.tsx
@@ -49,17 +49,41 @@ interface MeetingsListProps {
         previousHref: string;
         nextHref: string;
     };
+    /**
+     * Which chrome to draw. `'page'` is the standalone catalog (a
+     * `PageHeader` with the page's single `h1`); `'panel'` is the block
+     * the Memory page embeds — card chrome, an `h2`, and an `id` the
+     * `#meetings` anchor can land on.
+     */
+    variant?: 'page' | 'panel';
+    /**
+     * Page the filter form and the Reset link post back to. Defaults to
+     * the historical `/meetings`; the Memory block passes `/memory`.
+     * Pagination hrefs arrive already built by the caller.
+     */
+    basePath?: string;
+    /** Anchor appended to `basePath` so a filter submit re-lands on the block. */
+    hash?: string;
+    /** Optional one-liner from the host page, shown above the connect hint. */
+    hint?: string;
 }
 
 /**
- * Meetings — `/meetings` catalog list client. Grid of MeetingCards with
- * source + Work filters and a "+ New meeting" CTA routing to the
- * dedicated capture form. Load failures are surfaced explicitly so a
- * flaky API never masquerades as an empty meeting history (same
- * contract as `GoalsList`).
+ * Meetings — the catalog list client. Grid of MeetingCards with source +
+ * Work filters and a "+ New meeting" CTA routing to the dedicated
+ * capture form. Load failures are surfaced explicitly so a flaky API
+ * never masquerades as an empty meeting history (same contract as
+ * `GoalsList`).
  *
  * The filter form is a plain GET form (no client router push), so the
  * filtered view is a real, shareable URL and works before hydration.
+ *
+ * Two chromes, one body: navigation consolidation moved the catalog off
+ * `/meetings` and onto the Memory page as a block, so the same component
+ * renders either the standalone page or the embedded panel rather than
+ * the panel being a divergent copy
+ * (docs/specs/features/navigation-consolidation). Every `data-testid` is
+ * shared by both, so the e2e journey only had to change its URLs.
  */
 export function MeetingsList({
     meetings,
@@ -67,6 +91,10 @@ export function MeetingsList({
     loadError = null,
     filters,
     pagination,
+    variant = 'page',
+    basePath = '/meetings',
+    hash = '',
+    hint,
 }: MeetingsListProps) {
     const t = useTranslations('dashboard.meetingsPage');
     const [sourceFilter, setSourceFilter] = useState<string>(filters?.source ?? '');
@@ -79,21 +107,12 @@ export function MeetingsList({
         setWorkFilter(filters?.workId ?? '');
     }, [filters?.workId]);
 
-    return (
-        <div className="w-full" data-testid="meetings-shell">
-            <PageHeader
-                icon={Video}
-                title={t('title')}
-                subtitle={t('subtitle')}
-                tone="info"
-                actions={
-                    <Button href="/meetings/new" size="sm">
-                        <Plus className="h-4 w-4" />
-                        <span className="font-medium">{t('newMeeting')}</span>
-                    </Button>
-                }
-            />
+    const isPanel = variant === 'panel';
+    /** Where "apply filters" and "reset" land — the host page, re-anchored. */
+    const catalogHref = `${basePath}${hash}`;
 
+    const body = (
+        <>
             {/*
                 Connect affordance: provider-synced meetings (Zoom
                 recordings, Google Meet transcripts picked up by the
@@ -111,7 +130,17 @@ export function MeetingsList({
                 </Link>
             </p>
 
-            <form className="mb-5 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end">
+            {/*
+                The panel is embedded in a page that owns a different URL,
+                so the GET form needs an explicit action — without one the
+                browser would post the filters back to `/memory` and drop
+                the `#meetings` anchor, scrolling the user to the top.
+                The standalone page keeps no action (submits to itself).
+            */}
+            <form
+                action={isPanel ? catalogHref : undefined}
+                className="mb-5 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end"
+            >
                 <div className="min-w-40">
                     <span className="mb-1 block text-xs text-text-secondary dark:text-text-secondary-dark">
                         {t('filterBar.source')}
@@ -163,7 +192,7 @@ export function MeetingsList({
                     <Button type="submit" size="sm">
                         {t('filterBar.apply')}
                     </Button>
-                    <Button href="/meetings" size="sm" variant="ghost">
+                    <Button href={catalogHref} size="sm" variant="ghost">
                         {t('filterBar.reset')}
                     </Button>
                 </div>
@@ -248,6 +277,69 @@ export function MeetingsList({
                     </div>
                 </nav>
             ) : null}
+        </>
+    );
+
+    if (isPanel) {
+        return (
+            <section
+                id="meetings"
+                data-testid="meetings-shell"
+                className="w-full scroll-mt-6 rounded-lg border border-card-border bg-card p-4 dark:border-white/9 dark:bg-card-primary-dark sm:p-5"
+            >
+                {/* Compact header — the host page owns the h1, so the block
+                    announces itself with an h2 and a smaller icon tile. */}
+                <div className="mb-5 flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-info/20 bg-info/10">
+                            <Video className="h-4 w-4 text-info" />
+                        </span>
+                        <div className="min-w-0">
+                            <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                                {t('title')}
+                            </h2>
+                            <p className="mt-0.5 max-w-2xl text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('subtitle')}
+                            </p>
+                        </div>
+                    </div>
+                    <div className="shrink-0">
+                        <Button href="/meetings/new" size="sm">
+                            <Plus className="h-4 w-4" />
+                            <span className="font-medium">{t('newMeeting')}</span>
+                        </Button>
+                    </div>
+                </div>
+
+                {hint ? (
+                    <p
+                        data-testid="meetings-panel-hint"
+                        className="mb-4 text-xs text-text-muted dark:text-text-muted-dark"
+                    >
+                        {hint}
+                    </p>
+                ) : null}
+
+                {body}
+            </section>
+        );
+    }
+
+    return (
+        <div className="w-full" data-testid="meetings-shell">
+            <PageHeader
+                icon={Video}
+                title={t('title')}
+                subtitle={t('subtitle')}
+                tone="info"
+                actions={
+                    <Button href="/meetings/new" size="sm">
+                        <Plus className="h-4 w-4" />
+                        <span className="font-medium">{t('newMeeting')}</span>
+                    </Button>
+                }
+            />
+            {body}
         </div>
     );
 }

--- a/apps/web/src/components/meetings/MeetingsList.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingsList.unit.spec.tsx
@@ -1,0 +1,120 @@
+// MeetingsList — the two chromes the catalog renders in: the standalone
+// page (`variant="page"`, PageHeader + h1) it has always had, and the
+// card-in-a-page panel the Memory page embeds (`variant="panel"`, no h1,
+// every href rebased onto `/memory…#meetings`).
+
+import React, { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: ReactNode; href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('./MeetingCard', () => ({
+    MeetingCard: () => <div data-testid="meeting-card" />,
+}));
+
+import { MeetingsList } from './MeetingsList';
+import type { Meeting } from '@/lib/api/meetings';
+
+const meeting = {
+    id: 'meet-1',
+    title: 'Weekly sync',
+    source: 'manual',
+    startedAt: '2026-08-01T10:00:00.000Z',
+    endedAt: null,
+    hasTranscript: false,
+    createdAt: '2026-08-01T10:00:00.000Z',
+    updatedAt: '2026-08-01T10:00:00.000Z',
+} as unknown as Meeting;
+
+describe('MeetingsList — panel variant', () => {
+    it('drops the PageHeader h1 and wraps the catalog in an anchored card', () => {
+        const { container } = render(
+            <MeetingsList
+                meetings={[meeting]}
+                variant="panel"
+                basePath="/memory"
+                hash="#meetings"
+            />,
+        );
+
+        expect(container.querySelector('h1')).toBeNull();
+        expect(container.querySelector('h2')).not.toBeNull();
+
+        const shell = screen.getByTestId('meetings-shell');
+        expect(shell.getAttribute('id')).toBe('meetings');
+        expect(screen.getByTestId('meetings-grid')).not.toBeNull();
+    });
+
+    it('rebases the filter form and the reset link onto the host page', () => {
+        const { container } = render(
+            <MeetingsList
+                meetings={[meeting]}
+                variant="panel"
+                basePath="/memory"
+                hash="#meetings"
+            />,
+        );
+
+        expect(container.querySelector('form')?.getAttribute('action')).toBe('/memory#meetings');
+        const reset = screen.getByText('filterBar.reset').closest('a');
+        expect(reset?.getAttribute('href')).toBe('/memory#meetings');
+    });
+
+    it('renders the optional host-page hint', () => {
+        render(
+            <MeetingsList
+                meetings={[meeting]}
+                variant="panel"
+                basePath="/memory"
+                hash="#meetings"
+                hint="Meetings feed Memory."
+            />,
+        );
+        expect(screen.getByTestId('meetings-panel-hint').textContent).toBe('Meetings feed Memory.');
+    });
+
+    it('keeps the load-error box instead of the grid when the fetch failed', () => {
+        render(
+            <MeetingsList
+                meetings={[]}
+                variant="panel"
+                basePath="/memory"
+                hash="#meetings"
+                loadError="boom"
+            />,
+        );
+        expect(screen.getByTestId('meetings-load-error')).not.toBeNull();
+        expect(screen.queryByTestId('meetings-empty')).toBeNull();
+        expect(screen.queryByTestId('meetings-grid')).toBeNull();
+    });
+
+    it('keeps the empty state when there are zero meetings', () => {
+        render(<MeetingsList meetings={[]} variant="panel" basePath="/memory" hash="#meetings" />);
+        expect(screen.getByTestId('meetings-empty')).not.toBeNull();
+    });
+});
+
+describe('MeetingsList — page variant (default)', () => {
+    it('keeps the PageHeader h1 and the /meetings hrefs', () => {
+        const { container } = render(<MeetingsList meetings={[meeting]} />);
+
+        expect(container.querySelector('h1')).not.toBeNull();
+        expect(screen.getByTestId('meetings-shell').getAttribute('id')).toBeNull();
+        // A page-variant GET form posts back to the page it is already on.
+        expect(container.querySelector('form')?.getAttribute('action')).toBeNull();
+        expect(screen.getByText('filterBar.reset').closest('a')?.getAttribute('href')).toBe(
+            '/meetings',
+        );
+    });
+});

--- a/apps/web/src/components/meetings/actions.ts
+++ b/apps/web/src/components/meetings/actions.ts
@@ -27,6 +27,23 @@ async function requireMeetingAuth() {
 
 const MEETINGS_LIST_PATH = '/[locale]/(dashboard)/meetings';
 
+/**
+ * Navigation consolidation (docs/specs/features/navigation-consolidation
+ * §3.7): the Meetings catalog now renders as a block on the **Memory** page
+ * (`/memory#meetings`); `/meetings` itself is only a redirect. So every
+ * catalog invalidation has to hit Memory too — invalidating just
+ * `MEETINGS_LIST_PATH` would bust a page that renders nothing and leave the
+ * page that actually lists meetings holding a stale render. Mirrors the
+ * `revalidatePath('/skills')` + `revalidatePath('/agents')` pairing in
+ * `app/actions/skills.ts`. Both are kept: `/meetings` is still a real route.
+ */
+const MEMORY_PAGE_PATH = '/[locale]/(dashboard)/memory';
+
+function revalidateMeetingsCatalog() {
+    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidatePath(MEMORY_PAGE_PATH, 'page');
+}
+
 function revalidateMeetingDetail(id: string) {
     revalidatePath(`/[locale]/(dashboard)/meetings/${id}`, 'page');
 }
@@ -34,14 +51,14 @@ function revalidateMeetingDetail(id: string) {
 export async function createMeetingAction(input: CreateMeetingInput) {
     await requireMeetingAuth();
     const meeting = await meetingsAPI.create(input);
-    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidateMeetingsCatalog();
     return meeting;
 }
 
 export async function updateMeetingAction(id: string, input: UpdateMeetingInput) {
     await requireMeetingAuth();
     const meeting = await meetingsAPI.update(id, input);
-    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidateMeetingsCatalog();
     revalidateMeetingDetail(id);
     return meeting;
 }
@@ -49,7 +66,7 @@ export async function updateMeetingAction(id: string, input: UpdateMeetingInput)
 export async function deleteMeetingAction(id: string) {
     await requireMeetingAuth();
     await meetingsAPI.remove(id);
-    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidateMeetingsCatalog();
     return { deleted: true as const };
 }
 
@@ -63,7 +80,7 @@ export async function deleteMeetingAction(id: string) {
 export async function ingestMeetingTranscriptAction(id: string, transcriptText: string) {
     await requireMeetingAuth();
     const result = await meetingsAPI.ingestTranscript(id, transcriptText);
-    revalidatePath(MEETINGS_LIST_PATH, 'page');
+    revalidateMeetingsCatalog();
     revalidateMeetingDetail(id);
     return result;
 }

--- a/apps/web/src/components/memory/MemoryMeetingsPanel.tsx
+++ b/apps/web/src/components/memory/MemoryMeetingsPanel.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { ROUTES } from '@/lib/constants';
+import { MeetingsList, type MeetingWorkOption } from '@/components/meetings/MeetingsList';
+import type { MeetingSource } from '@/lib/api/meetings.shared';
+import type { Meeting } from '@/lib/api/meetings';
+
+/**
+ * Everything the Memory page server-fetched for the Meetings block —
+ * exactly what `MeetingsList` needs, with the pagination hrefs already
+ * built against `/memory#meetings` (the page owns the base path, so the
+ * panel never has to re-derive it).
+ */
+export interface MemoryMeetingsData {
+    meetings: Meeting[];
+    works: MeetingWorkOption[];
+    loadError: string | null;
+    filters: { source?: MeetingSource; workId?: string };
+    pagination: {
+        offset: number;
+        hasPrevious: boolean;
+        hasNext: boolean;
+        previousHref: string;
+        nextHref: string;
+    };
+}
+
+/**
+ * Meetings on Memory (`/memory#meetings`).
+ *
+ * Meetings are a memory *source*, not a separate feature — every
+ * transcript and summary is ingested straight into Memory — so the
+ * catalog lives here rather than in its own sidebar entry
+ * (docs/specs/features/navigation-consolidation). `/meetings` still
+ * resolves: it redirects here carrying its query string.
+ *
+ * The catalog itself is the same `MeetingsList` the standalone page
+ * used, in its `panel` chrome with every href rebased onto this page —
+ * not a second implementation that would drift.
+ */
+export function MemoryMeetingsPanel({ data }: { data: MemoryMeetingsData }) {
+    const t = useTranslations('dashboard.memoryPage');
+
+    return (
+        <MeetingsList
+            variant="panel"
+            basePath={ROUTES.DASHBOARD_MEMORY}
+            hash="#meetings"
+            hint={t('meetings.hint')}
+            meetings={data.meetings}
+            works={data.works}
+            loadError={data.loadError}
+            filters={data.filters}
+            pagination={data.pagination}
+        />
+    );
+}

--- a/apps/web/src/components/memory/MemoryShell.tsx
+++ b/apps/web/src/components/memory/MemoryShell.tsx
@@ -20,6 +20,7 @@ import { MemoryFilesPanel } from './MemoryFilesPanel';
 import { AgentMemoryPanel } from './AgentMemoryPanel';
 import { MemoryReviewPanel } from './MemoryReviewPanel';
 import { MemoryConsolidationSettings } from './MemoryConsolidationSettings';
+import { MemoryMeetingsPanel, type MemoryMeetingsData } from './MemoryMeetingsPanel';
 import {
     buildMemoryQuery,
     type MemoryConsolidationReport,
@@ -30,6 +31,12 @@ import {
 
 interface MemoryShellProps {
     initial: MemoryResponse;
+    /**
+     * Meetings catalog for the `#meetings` block, server-fetched by the
+     * page. Optional so the shell still renders standalone (and in specs)
+     * without it — the block is simply absent.
+     */
+    meetings?: MemoryMeetingsData;
 }
 
 /** Facet kinds that map to a filter chip group. */
@@ -62,7 +69,7 @@ function formatDate(iso: string): string {
  * (they depend on cross-feature prerequisites — see the Memory spec
  * §2.4 / §4.3).
  */
-export function MemoryShell({ initial }: MemoryShellProps) {
+export function MemoryShell({ initial, meetings }: MemoryShellProps) {
     const t = useTranslations('dashboard.memoryPage');
 
     const [data, setData] = useState<MemoryResponse>(initial);
@@ -268,6 +275,11 @@ export function MemoryShell({ initial }: MemoryShellProps) {
 
             {/* Agent memory — the half of Memory that is not a knowledge base */}
             <AgentMemoryPanel />
+
+            {/* Meetings — a memory SOURCE, so it sits with the other sources
+                rather than below the document list. Anchored `#meetings`;
+                `/meetings` redirects here. */}
+            {meetings && <MemoryMeetingsPanel data={meetings} />}
 
             {/* Memory Consolidation — dry-run confirm surface / applied summary */}
             {consolidateFailed && (

--- a/apps/web/src/components/memory/MemoryShell.unit.spec.tsx
+++ b/apps/web/src/components/memory/MemoryShell.unit.spec.tsx
@@ -1,0 +1,125 @@
+// MemoryShell — placement contract for the Meetings block.
+//
+// Navigation consolidation folded the Meetings catalog into the Memory
+// page as a block anchored at `#meetings`. It has to sit directly after
+// the Agent-memory panel (the two memory *sources* read together) and
+// before the consolidation surface and the document list — and the page
+// must still render when the meetings fetch failed or returned nothing.
+
+import React, { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: ReactNode; href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+// The sibling panels each own a network lifecycle of their own; this
+// spec is about DOM order, so they are stubbed down to markers.
+vi.mock('./MemoryReviewPanel', () => ({
+    MemoryReviewPanel: () => <div data-testid="memory-review-panel" />,
+}));
+vi.mock('./MemoryFilesPanel', () => ({
+    MemoryFilesPanel: () => <div data-testid="memory-files-panel" />,
+}));
+vi.mock('./MemoryUploadsPanel', () => ({
+    MemoryUploadsPanel: () => <div data-testid="memory-uploads-panel" />,
+}));
+vi.mock('./AgentMemoryPanel', () => ({
+    AgentMemoryPanel: () => <div data-testid="agent-memory-panel" />,
+}));
+vi.mock('./MemoryConsolidationSettings', () => ({
+    MemoryConsolidationSettings: () => <div data-testid="memory-consolidation-settings" />,
+}));
+vi.mock('./MeetingCard', () => ({}));
+vi.mock('../meetings/MeetingCard', () => ({
+    MeetingCard: () => <div data-testid="meeting-card" />,
+}));
+
+import { MemoryShell } from './MemoryShell';
+import type { MemoryMeetingsData } from './MemoryMeetingsPanel';
+import type { MemoryResponse } from '@/lib/api/memory-types';
+import type { Meeting } from '@/lib/api/meetings';
+
+const initial: MemoryResponse = {
+    documents: [],
+    counts: { documents: 0, indexed: 0 },
+    facets: { types: [], works: [], sources: [], statuses: [] },
+} as unknown as MemoryResponse;
+
+const meeting = {
+    id: 'meet-1',
+    title: 'Weekly sync',
+    source: 'manual',
+    startedAt: '2026-08-01T10:00:00.000Z',
+    endedAt: null,
+    hasTranscript: false,
+    createdAt: '2026-08-01T10:00:00.000Z',
+    updatedAt: '2026-08-01T10:00:00.000Z',
+} as unknown as Meeting;
+
+function meetingsData(overrides: Partial<MemoryMeetingsData> = {}): MemoryMeetingsData {
+    return {
+        meetings: [meeting],
+        works: [],
+        loadError: null,
+        filters: {},
+        pagination: {
+            offset: 0,
+            hasPrevious: false,
+            hasNext: false,
+            previousHref: '/memory#meetings',
+            nextHref: '/memory#meetings',
+        },
+        ...overrides,
+    };
+}
+
+describe('MemoryShell — Meetings block', () => {
+    it('renders the block directly after the Agent memory panel', () => {
+        render(<MemoryShell initial={initial} meetings={meetingsData()} />);
+
+        const agentPanel = screen.getByTestId('agent-memory-panel');
+        const meetingsShell = screen.getByTestId('meetings-shell');
+        expect(meetingsShell.getAttribute('id')).toBe('meetings');
+        // DOCUMENT_POSITION_FOLLOWING === 4: the block comes after.
+        expect(agentPanel.compareDocumentPosition(meetingsShell) & 4).toBeTruthy();
+        expect(agentPanel.nextElementSibling).toBe(meetingsShell);
+
+        // …and before the document search box the page ends with.
+        const search = screen.getByTestId('memory-search');
+        expect(meetingsShell.compareDocumentPosition(search) & 4).toBeTruthy();
+    });
+
+    it('omits the block entirely when the page passes no meetings data', () => {
+        render(<MemoryShell initial={initial} />);
+        expect(screen.queryByTestId('meetings-shell')).toBeNull();
+        expect(screen.getByTestId('agent-memory-panel')).not.toBeNull();
+    });
+
+    it('still renders the page when the meetings fetch failed', () => {
+        render(
+            <MemoryShell
+                initial={initial}
+                meetings={meetingsData({ meetings: [], loadError: 'upstream 503' })}
+            />,
+        );
+        expect(screen.getByTestId('memory-shell')).not.toBeNull();
+        expect(screen.getByTestId('meetings-load-error')).not.toBeNull();
+        expect(screen.queryByTestId('meetings-grid')).toBeNull();
+    });
+
+    it('shows the meetings empty state when there are none', () => {
+        render(<MemoryShell initial={initial} meetings={meetingsData({ meetings: [] })} />);
+        expect(screen.getByTestId('memory-shell')).not.toBeNull();
+        expect(screen.getByTestId('meetings-empty')).not.toBeNull();
+    });
+});

--- a/apps/web/src/components/memory/index.ts
+++ b/apps/web/src/components/memory/index.ts
@@ -1,2 +1,3 @@
 export { MemoryShell } from './MemoryShell';
 export { MemoryFilesPanel } from './MemoryFilesPanel';
+export { MemoryMeetingsPanel, type MemoryMeetingsData } from './MemoryMeetingsPanel';

--- a/apps/web/src/components/skills/SkillDetailClient.tsx
+++ b/apps/web/src/components/skills/SkillDetailClient.tsx
@@ -73,8 +73,10 @@ export function SkillDetailClient({
 
     return (
         <div className="max-w-screen-2xl mx-auto p-6 space-y-6">
+            {/* Navigation consolidation: the catalog lives on the Agents tab
+                (`/agents#skills`) — `/skills` only redirects there now. */}
             <Link
-                href={ROUTES.DASHBOARD_SKILLS}
+                href={ROUTES.DASHBOARD_AGENTS_SKILLS}
                 className="inline-flex items-center gap-1.5 text-sm text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark transition-colors"
             >
                 <ArrowLeft className="w-4 h-4" />
@@ -948,7 +950,9 @@ function DangerZone({ skillId }: { skillId: string }) {
             void (async () => {
                 try {
                     await deleteSkillAction(skillId);
-                    router.push(ROUTES.DASHBOARD_SKILLS);
+                    // Navigation consolidation: back to the catalog, which is
+                    // now the Skills block on the Agents tab.
+                    router.push(ROUTES.DASHBOARD_AGENTS_SKILLS);
                 } catch (err) {
                     setError(err instanceof Error ? err.message : 'Delete failed');
                     setConfirming(false);

--- a/apps/web/src/components/skills/SkillsPageClient.tsx
+++ b/apps/web/src/components/skills/SkillsPageClient.tsx
@@ -33,6 +33,15 @@ interface SkillsPageClientProps {
         installed?: string | null;
         catalog?: string | null;
     };
+    /**
+     * Navigation consolidation: this client is hosted twice — standalone on
+     * `/skills` and as the Skills block on the Agents tab. `basePath`/`hash`
+     * tell it which URL its tab/search/pagination state belongs to, so the
+     * block rewrites `/agents?section=…#skills` instead of navigating the
+     * user away to `/skills`.
+     */
+    basePath?: string;
+    hash?: string;
 }
 
 const SECTIONS: Section[] = ['installed', 'available', 'custom'];
@@ -45,6 +54,8 @@ export function SkillsPageClient({
     catalogLimit,
     filters,
     loadErrors = {},
+    basePath = ROUTES.DASHBOARD_SKILLS,
+    hash = '',
 }: SkillsPageClientProps) {
     const t = useTranslations('dashboard.skillsPage');
     const router = useRouter();
@@ -85,7 +96,7 @@ export function SkillsPageClient({
         if (next.search.trim()) params.set('search', next.search.trim());
         if (next.installedOffset > 0) params.set('installedOffset', String(next.installedOffset));
         if (next.catalogOffset > 0) params.set('catalogOffset', String(next.catalogOffset));
-        router.replace(`${ROUTES.DASHBOARD_SKILLS}${params.size ? `?${params}` : ''}`);
+        router.replace(`${basePath}${params.size ? `?${params}` : ''}${hash}`);
     };
 
     const handleSectionChange = (next: Section) => {

--- a/apps/web/src/components/skills/SkillsPageClient.unit.spec.tsx
+++ b/apps/web/src/components/skills/SkillsPageClient.unit.spec.tsx
@@ -113,6 +113,21 @@ describe('SkillsPageClient', () => {
         expect(routerReplace).toHaveBeenCalledWith('/skills?section=available');
     });
 
+    // Navigation consolidation: the same client renders inside the Agents tab's
+    // Skills block, where its URL updates must stay on `/agents` and keep the
+    // `#skills` anchor so the browser doesn't scroll back to the agent grid.
+    it('rewrites the URL onto basePath + hash when hosted as a block', () => {
+        renderPage({ basePath: '/agents', hash: '#skills' });
+        fireEvent.click(screen.getByRole('tab', { name: 'tabs.custom' }));
+        expect(routerReplace).toHaveBeenCalledWith('/agents?section=custom#skills');
+    });
+
+    it('defaults to the standalone /skills base path with no hash', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('tab', { name: 'tabs.custom' }));
+        expect(routerReplace).toHaveBeenCalledWith('/skills?section=custom');
+    });
+
     it('guards pagination copy when the current page is empty', () => {
         renderPage({
             installedMeta: { total: 75, limit: 50, offset: 50 },

--- a/apps/web/src/components/skills/SkillsSection.tsx
+++ b/apps/web/src/components/skills/SkillsSection.tsx
@@ -1,0 +1,73 @@
+import { Plus, Sparkles } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+import { PageHeader } from '@/components/common/PageHeader';
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants';
+import type { SkillsPageData, SkillsPageFilters } from '@/lib/skills-page-data';
+import { SkillsPageClient } from './SkillsPageClient';
+
+/**
+ * Navigation consolidation (docs/specs/features/navigation-consolidation §3.5):
+ * the Skills catalog is a block on the Agents tab rather than its own sidebar
+ * entry — nobody browses Skills without an Agent in mind. `/skills` (index)
+ * redirects to `/agents#skills`; the detail routes are unchanged.
+ *
+ * Server component: it only reads translations and forwards already-fetched
+ * data. `SkillsPageClient` inside is the client island that owns the
+ * section/search state, pointed at `/agents` + `#skills` so its `router.replace`
+ * keeps the reader on this page and on this anchor.
+ */
+export async function SkillsSection({
+    data,
+    filters,
+}: {
+    data: SkillsPageData;
+    filters: SkillsPageFilters;
+}) {
+    const t = await getTranslations('dashboard.agentsPage');
+    const tSkills = await getTranslations('dashboard.skillsPage');
+
+    return (
+        <section
+            id="skills"
+            data-testid="agents-skills-section"
+            className="mt-10 rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 sm:p-6"
+        >
+            <PageHeader
+                icon={Sparkles}
+                as="h2"
+                title={t('skillsBlock.title')}
+                subtitle={t('skillsBlock.subtitle')}
+                tone="success"
+                actions={
+                    <>
+                        {/* EW-058: the only inbound link to the /skills/templates
+                            browser — it moved here with the catalog. */}
+                        <Button
+                            href={ROUTES.DASHBOARD_SKILL_TEMPLATES}
+                            variant="secondary"
+                            size="sm"
+                            className="gap-1.5 shrink-0"
+                        >
+                            {tSkills('list.browseTemplates')}
+                        </Button>
+                        <Button
+                            href={ROUTES.DASHBOARD_SKILL_NEW}
+                            size="sm"
+                            className="gap-1.5 shrink-0"
+                        >
+                            <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                            {tSkills('list.newSkill')}
+                        </Button>
+                    </>
+                }
+            />
+            <SkillsPageClient
+                {...data}
+                filters={filters}
+                basePath={ROUTES.DASHBOARD_AGENTS}
+                hash="#skills"
+            />
+        </section>
+    );
+}

--- a/apps/web/src/components/skills/SkillsSection.unit.spec.tsx
+++ b/apps/web/src/components/skills/SkillsSection.unit.spec.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import type { SkillsPageData, SkillsPageFilters } from '@/lib/skills-page-data';
+
+vi.mock('next-intl/server', () => ({
+    getTranslations: async (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: ReactNode;
+    } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+// The catalog itself is exercised by SkillsPageClient.unit.spec.tsx; here we
+// only care that the block hands it the right host-page props.
+vi.mock('./SkillsPageClient', () => ({
+    SkillsPageClient: (props: { basePath?: string; hash?: string; filters: SkillsPageFilters }) => (
+        <div
+            data-testid="skills-page-client"
+            data-base-path={props.basePath}
+            data-hash={props.hash}
+            data-section={props.filters.section}
+        />
+    ),
+}));
+
+import { SkillsSection } from './SkillsSection';
+
+const FILTERS: SkillsPageFilters = {
+    section: 'custom',
+    search: '',
+    installedOffset: 0,
+    catalogOffset: 0,
+};
+
+const DATA: SkillsPageData = {
+    installed: [],
+    installedMeta: { total: 0, limit: 50, offset: 0 },
+    catalog: [],
+    catalogTotal: 0,
+    catalogLimit: 50,
+    loadErrors: { installed: null, catalog: null },
+};
+
+describe('SkillsSection', () => {
+    it('renders an anchorable block whose heading does not compete with the page h1', async () => {
+        const { container } = render(await SkillsSection({ data: DATA, filters: FILTERS }));
+
+        const section = container.querySelector('#skills');
+        expect(section).not.toBeNull();
+        expect(section?.getAttribute('data-testid')).toBe('agents-skills-section');
+        expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+        expect(
+            screen.getByRole('heading', {
+                level: 2,
+                name: 'dashboard.agentsPage.skillsBlock.title',
+            }),
+        ).toBeTruthy();
+        expect(screen.getByText('dashboard.agentsPage.skillsBlock.subtitle')).toBeTruthy();
+    });
+
+    it('keeps the catalog CTAs from the retired /skills page', async () => {
+        render(await SkillsSection({ data: DATA, filters: FILTERS }));
+
+        expect(
+            screen.getByRole('link', { name: 'dashboard.skillsPage.list.browseTemplates' }),
+        ).toHaveAttribute('href', '/skills/templates');
+        expect(
+            screen.getByRole('link', { name: /dashboard\.skillsPage\.list\.newSkill/ }),
+        ).toHaveAttribute('href', '/skills/new');
+    });
+
+    it('hosts the catalog client on /agents with the #skills anchor', async () => {
+        render(await SkillsSection({ data: DATA, filters: FILTERS }));
+
+        const client = screen.getByTestId('skills-page-client');
+        expect(client.getAttribute('data-base-path')).toBe('/agents');
+        expect(client.getAttribute('data-hash')).toBe('#skills');
+        expect(client.getAttribute('data-section')).toBe('custom');
+    });
+});

--- a/apps/web/src/components/teams/OrgChartClient.tsx
+++ b/apps/web/src/components/teams/OrgChartClient.tsx
@@ -220,11 +220,16 @@ function ChartNodeCard({ placed, onNodeClick }: ChartNodeCardProps) {
 
     const style = { left: placed.x, top: placed.y, width: NODE_W, height: NODE_H };
 
+    // `data-node-kind` is additive and purely for assertions: the Agents Chart
+    // (`/agents/chart`, navigation consolidation §3.6) renders this same chart
+    // with `members: []`, and the e2e journey proves the absence of human cards
+    // by counting `[data-node-kind="member"]`. Nothing reads it at runtime.
     if (interactive) {
         return (
             <button
                 type="button"
                 data-testid={`org-chart-node-${node.id}`}
+                data-node-kind={node.kind}
                 className={cardClass}
                 style={style}
                 onClick={() => onNodeClick(node)}
@@ -234,7 +239,12 @@ function ChartNodeCard({ placed, onNodeClick }: ChartNodeCardProps) {
         );
     }
     return (
-        <div data-testid={`org-chart-node-${node.id}`} className={cardClass} style={style}>
+        <div
+            data-testid={`org-chart-node-${node.id}`}
+            data-node-kind={node.kind}
+            className={cardClass}
+            style={style}
+        >
             {inner}
         </div>
     );

--- a/apps/web/src/lib/api/meetings-page-params.ts
+++ b/apps/web/src/lib/api/meetings-page-params.ts
@@ -1,0 +1,83 @@
+import { MEETING_SOURCES, type MeetingSource } from './meetings.shared';
+
+/**
+ * Meetings — search-param whitelisting and href building for whichever
+ * surface renders the Meetings catalog.
+ *
+ * The catalog used to live on `/meetings`, which owned this parsing
+ * inline. Navigation consolidation moved it onto the Memory page
+ * (`/memory#meetings`) and turned `/meetings` into a redirect — two
+ * callers, one contract, so the parsing lives here rather than being
+ * copied (docs/specs/features/navigation-consolidation).
+ *
+ * Pure and client-safe: no `server-only` import, so the client panel can
+ * import the same helpers a server page uses.
+ */
+
+/** Meetings shown per page in the Memory block (`+1` look-ahead on the fetch). */
+export const MEETINGS_PAGE_SIZE = 12;
+
+/** Canonical uuid shape — anything else is dropped before it reaches the API. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** The three filters the catalog understands, already validated. */
+export interface MeetingsPageQuery {
+    source?: MeetingSource;
+    workId?: string;
+    offset: number;
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Whitelist the raw `searchParams` bag before anything reaches the API:
+ *
+ *   - `source` must be one of the closed `MeetingSource` set — the API
+ *     silently ignores unknown values, so dropping it locally keeps the
+ *     rendered filter chip and the actual query in agreement.
+ *   - `workId` must look like a uuid. The API compares it straight
+ *     against a uuid column, so an arbitrary string would be a Postgres
+ *     cast error (a 500) rather than an empty result.
+ *   - `offset` is clamped to a non-negative integer.
+ *
+ * A repeated param (`?source=a&source=b`) takes its first entry, which
+ * is what a browser's own form submission would have produced.
+ */
+export function parseMeetingsSearchParams(
+    params: Record<string, string | string[] | undefined>,
+): MeetingsPageQuery {
+    const sourceParam = firstParam(params.source);
+    const source = MEETING_SOURCES.includes(sourceParam as MeetingSource)
+        ? (sourceParam as MeetingSource)
+        : undefined;
+    const workIdParam = firstParam(params.workId);
+    const workId = workIdParam && UUID_RE.test(workIdParam) ? workIdParam : undefined;
+    const offset = Math.max(0, parseInt(firstParam(params.offset) ?? '0', 10) || 0);
+    return { source, workId, offset };
+}
+
+/**
+ * Build a catalog href on an arbitrary base path, optionally anchored.
+ *
+ *   buildMeetingsHref('/meetings', {})                        → '/meetings'
+ *   buildMeetingsHref('/memory', {}, '#meetings')             → '/memory#meetings'
+ *   buildMeetingsHref('/memory', { source: 'zoom' }, '#meetings')
+ *                                              → '/memory?source=zoom#meetings'
+ *
+ * Defaults are omitted (no `offset=0`) so the "no filters" URL is the
+ * bare page — a shareable link nobody has to trim by hand.
+ */
+export function buildMeetingsHref(
+    basePath: string,
+    input: { source?: MeetingSource; workId?: string; offset?: number },
+    hash = '',
+): string {
+    const params = new URLSearchParams();
+    if (input.source) params.set('source', input.source);
+    if (input.workId) params.set('workId', input.workId);
+    if (input.offset && input.offset > 0) params.set('offset', String(input.offset));
+    const qs = params.toString();
+    return `${basePath}${qs ? `?${qs}` : ''}${hash}`;
+}

--- a/apps/web/src/lib/api/meetings-page-params.unit.spec.ts
+++ b/apps/web/src/lib/api/meetings-page-params.unit.spec.ts
@@ -1,0 +1,77 @@
+// Meetings page params — the whitelisting + href building shared by the
+// `/meetings` redirect route and the Meetings block on the Memory page
+// (navigation consolidation, docs/specs/features/navigation-consolidation).
+
+import { describe, expect, it } from 'vitest';
+import {
+    MEETINGS_PAGE_SIZE,
+    buildMeetingsHref,
+    parseMeetingsSearchParams,
+} from './meetings-page-params';
+
+describe('MEETINGS_PAGE_SIZE', () => {
+    it('is a positive page size the look-ahead fetch can add 1 to', () => {
+        expect(MEETINGS_PAGE_SIZE).toBeGreaterThan(0);
+        expect(Number.isInteger(MEETINGS_PAGE_SIZE)).toBe(true);
+    });
+});
+
+describe('parseMeetingsSearchParams', () => {
+    it('keeps a source from the closed set', () => {
+        expect(parseMeetingsSearchParams({ source: 'zoom' })).toEqual({
+            source: 'zoom',
+            workId: undefined,
+            offset: 0,
+        });
+    });
+
+    it('drops a source outside the closed set', () => {
+        expect(parseMeetingsSearchParams({ source: 'teams-meeting' }).source).toBeUndefined();
+    });
+
+    it('keeps a uuid workId and drops anything else', () => {
+        const uuid = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+        expect(parseMeetingsSearchParams({ workId: uuid }).workId).toBe(uuid);
+        expect(parseMeetingsSearchParams({ workId: '1; DROP TABLE works' }).workId).toBeUndefined();
+        expect(parseMeetingsSearchParams({ workId: 'not-a-uuid' }).workId).toBeUndefined();
+    });
+
+    it('clamps a negative, NaN or missing offset to 0', () => {
+        expect(parseMeetingsSearchParams({ offset: '-5' }).offset).toBe(0);
+        expect(parseMeetingsSearchParams({ offset: 'abc' }).offset).toBe(0);
+        expect(parseMeetingsSearchParams({}).offset).toBe(0);
+        expect(parseMeetingsSearchParams({ offset: '24' }).offset).toBe(24);
+    });
+
+    it('takes the first entry when a param repeats', () => {
+        expect(
+            parseMeetingsSearchParams({ source: ['manual', 'zoom'], offset: ['12', '99'] }),
+        ).toEqual({ source: 'manual', workId: undefined, offset: 12 });
+    });
+});
+
+describe('buildMeetingsHref', () => {
+    it('returns the bare base path when nothing is filtered', () => {
+        expect(buildMeetingsHref('/meetings', {})).toBe('/meetings');
+    });
+
+    it('appends the hash even with no query string', () => {
+        expect(buildMeetingsHref('/memory', {}, '#meetings')).toBe('/memory#meetings');
+    });
+
+    it('puts the query before the hash', () => {
+        expect(buildMeetingsHref('/memory', { source: 'zoom' }, '#meetings')).toBe(
+            '/memory?source=zoom#meetings',
+        );
+    });
+
+    it('omits a zero offset and keeps a positive one', () => {
+        const uuid = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+        expect(buildMeetingsHref('/memory', { workId: uuid, offset: 0 }, '#meetings')).toBe(
+            `/memory?workId=${uuid}#meetings`,
+        );
+        expect(buildMeetingsHref('/memory', { workId: uuid, offset: 12 }, '#meetings')).toBe(
+            `/memory?workId=${uuid}&offset=12#meetings`,
+        );
+    });
+});

--- a/apps/web/src/lib/auth/unverified-email.ts
+++ b/apps/web/src/lib/auth/unverified-email.ts
@@ -1,0 +1,72 @@
+/**
+ * "This session belongs to an address nobody has confirmed yet."
+ *
+ * Two flows in this app mint a session for an account whose email is still
+ * unconfirmed, and until now neither of them said so:
+ *
+ *   EW-077  Registration signs the new user straight in. The account works —
+ *           for exactly as long as that session lasts. When it ends, the
+ *           password gate (`requireEmailVerification`, H-07) refuses them with
+ *           "Please verify your email address before signing in", and because
+ *           nothing ever told them the address was unconfirmed, a rule that was
+ *           in force from the first second reads as a fault that appeared
+ *           overnight. The signup flow already emails a verification link and
+ *           then behaves as though it does not matter.
+ *
+ *   EW-080  A magic-link sign-in admits an unconfirmed user that the password
+ *           tab on the same page would turn away. That asymmetry is CORRECT —
+ *           see the note in `redeemMagicLink` — but it is invisible, so the
+ *           two tabs simply disagree in front of the user with no explanation.
+ *
+ * The fix both share: when the web mints a session for an unconfirmed address,
+ * carry that fact to the landing page so it can be stated plainly, along with
+ * the consequence. This module is the seam. It is deliberately free of
+ * `server-only` so the client component that renders the notice can import the
+ * same constants the server actions set — one definition, not two that drift.
+ */
+
+/** Query param the landing page reads to know it should say something. */
+export const VERIFY_EMAIL_PARAM = 'verifyEmail';
+
+/** The only value that means anything; anything else is ignored. */
+export const VERIFY_EMAIL_REQUIRED = 'required';
+
+/**
+ * Is this session's address unconfirmed?
+ *
+ * Deliberately strict about `false`. `emailVerified` is optional on
+ * `UserProfile`, and an API response that simply omits it is not evidence that
+ * the address is unconfirmed — treating `undefined` as "unverified" would make
+ * every user see the notice the moment the field is dropped from a payload.
+ * Only an explicit `false` triggers it.
+ */
+export function isEmailUnconfirmed(user: { emailVerified?: boolean } | null | undefined): boolean {
+    return user?.emailVerified === false;
+}
+
+/**
+ * Tag an in-app destination so the landing page shows the unconfirmed-address
+ * notice.
+ *
+ * Relative paths only. An absolute destination is an allowlisted external host
+ * (see `isRelativeOrAllowedRedirectHost`) whose pages know nothing about this
+ * param, so it is returned untouched rather than decorated with a query string
+ * it will never read. Existing params are preserved — `register` already
+ * appends `?newUser=true`, and both notices need to survive.
+ */
+export function withUnverifiedEmailNotice(href: string): string {
+    if (!href.startsWith('/')) {
+        return href;
+    }
+
+    // Parse against a throwaway base so relative paths, query strings and
+    // fragments are all handled by the URL parser rather than by string
+    // surgery (`href` may already contain a `?`, a `#`, or both).
+    try {
+        const url = new URL(href, 'https://placeholder.invalid');
+        url.searchParams.set(VERIFY_EMAIL_PARAM, VERIFY_EMAIL_REQUIRED);
+        return url.pathname + url.search + url.hash;
+    } catch {
+        return href;
+    }
+}

--- a/apps/web/src/lib/auth/unverified-email.unit.spec.ts
+++ b/apps/web/src/lib/auth/unverified-email.unit.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+    VERIFY_EMAIL_PARAM,
+    VERIFY_EMAIL_REQUIRED,
+    isEmailUnconfirmed,
+    withUnverifiedEmailNotice,
+} from './unverified-email';
+
+describe('isEmailUnconfirmed', () => {
+    it('is true only for an explicit false', () => {
+        expect(isEmailUnconfirmed({ emailVerified: false })).toBe(true);
+    });
+
+    it('is false for a confirmed address', () => {
+        expect(isEmailUnconfirmed({ emailVerified: true })).toBe(false);
+    });
+
+    it('is false when the API simply omits the field', () => {
+        // A missing field is not evidence of anything. Treating `undefined` as
+        // unverified would show the lock-out warning to every user the moment
+        // the field is dropped from a payload.
+        expect(isEmailUnconfirmed({})).toBe(false);
+        expect(isEmailUnconfirmed(undefined)).toBe(false);
+        expect(isEmailUnconfirmed(null)).toBe(false);
+    });
+});
+
+describe('withUnverifiedEmailNotice', () => {
+    it('tags a bare in-app path', () => {
+        expect(withUnverifiedEmailNotice('/')).toBe(
+            `/?${VERIFY_EMAIL_PARAM}=${VERIFY_EMAIL_REQUIRED}`,
+        );
+    });
+
+    it('preserves query params that are already there', () => {
+        // `register` appends `?newUser=true`, and the welcome toast depends on
+        // it surviving.
+        const out = withUnverifiedEmailNotice('/?newUser=true');
+        const params = new URL(out, 'https://x.invalid').searchParams;
+        expect(params.get('newUser')).toBe('true');
+        expect(params.get(VERIFY_EMAIL_PARAM)).toBe(VERIFY_EMAIL_REQUIRED);
+    });
+
+    it('preserves a fragment', () => {
+        expect(withUnverifiedEmailNotice('/works/42#tab')).toBe(
+            `/works/42?${VERIFY_EMAIL_PARAM}=${VERIFY_EMAIL_REQUIRED}#tab`,
+        );
+    });
+
+    it('leaves an absolute destination untouched', () => {
+        // An allowlisted external host has no idea what this param means, so
+        // decorating its URL would only leak an internal flag off-site.
+        const external = 'https://docs.ever.works/guide?a=1';
+        expect(withUnverifiedEmailNotice(external)).toBe(external);
+    });
+
+    it('is idempotent', () => {
+        const once = withUnverifiedEmailNotice('/');
+        expect(withUnverifiedEmailNotice(once)).toBe(once);
+    });
+});

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -169,6 +169,11 @@ export const ROUTES = {
     DASHBOARD_MEETINGS: '/meetings',
     DASHBOARD_MEETINGS_NEW: '/meetings/new',
     DASHBOARD_MEETING: (id: string) => `/meetings/${id}`,
+    // Navigation consolidation (docs/specs/features/navigation-consolidation):
+    // the Meetings catalog now renders as a block on the Memory page, so
+    // `/meetings` (index only) redirects here. `/meetings/new` and
+    // `/meetings/[id]` are unchanged.
+    DASHBOARD_MEMORY_MEETINGS: '/memory#meetings',
     // Templates
     DASHBOARD_TEMPLATES: '/templates',
     // Agents (Agents/Skills/Tasks PR #1017 — Phase 5)
@@ -192,6 +197,13 @@ export const ROUTES = {
     DASHBOARD_AGENT_SETTINGS: (id: string) => `/agents/${id}/settings`,
     // Phase 18.6 — Agents templates browser (ADR-010 scaffold).
     DASHBOARD_AGENT_TEMPLATES: '/agents/templates',
+    // Navigation consolidation (docs/specs/features/navigation-consolidation):
+    // the Skills catalog now renders as a block on the Agents tab, so
+    // `/skills` (index only) redirects here. Skill detail routes are
+    // unchanged.
+    DASHBOARD_AGENTS_SKILLS: '/agents#skills',
+    // Agents Chart — the org chart with human members stripped.
+    DASHBOARD_AGENTS_CHART: '/agents/chart',
     // Teams & Prebuilt Companies (docs/specs/features/teams-and-companies §4)
     DASHBOARD_TEAMS: '/teams',
     DASHBOARD_TEAM_NEW: '/teams/new',

--- a/apps/web/src/lib/skills-page-data.ts
+++ b/apps/web/src/lib/skills-page-data.ts
@@ -1,0 +1,144 @@
+import { skillsAPI } from '@/lib/api/skills';
+import type { Skill, SkillCatalogEntry } from '@/lib/api/skills';
+
+/**
+ * Navigation consolidation (docs/specs/features/navigation-consolidation):
+ * the Skills catalog is no longer a standalone page — it renders as a block
+ * on the Agents tab (`/agents#skills`) and `/skills` (index) redirects there.
+ *
+ * Both surfaces need the exact same search-param whitelisting and the exact
+ * same defensive `Promise.all` fetch the old `/skills` page did, so it lives
+ * here once instead of being duplicated into the redirect route and the
+ * Agents page.
+ *
+ * Server-side only: `@/lib/api/skills` declares `server-only`, so importing
+ * this module from a `'use client'` component breaks the Next build. Client
+ * components keep their own local copies of the section union.
+ */
+
+export const SKILLS_PAGE_SIZE = 50;
+
+export const SKILLS_SECTIONS = ['installed', 'available', 'custom'] as const;
+
+export type SkillsSection = (typeof SKILLS_SECTIONS)[number];
+
+export interface SkillsPageFilters {
+    section: SkillsSection;
+    search: string;
+    installedOffset: number;
+    catalogOffset: number;
+}
+
+export interface SkillsPageData {
+    installed: Skill[];
+    installedMeta: { total: number; limit: number; offset: number };
+    catalog: SkillCatalogEntry[];
+    catalogTotal: number;
+    catalogLimit: number;
+    loadErrors: { installed: string | null; catalog: string | null };
+}
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function parseOffset(value: string | string[] | undefined): number {
+    const raw = firstParam(value);
+    if (!raw) return 0;
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function parseSection(value: string | string[] | undefined): SkillsSection {
+    const raw = firstParam(value);
+    return SKILLS_SECTIONS.includes(raw as SkillsSection) ? (raw as SkillsSection) : 'installed';
+}
+
+/**
+ * Whitelists the four query params the Skills catalog understands. Anything
+ * unknown is dropped rather than forwarded, so a hand-crafted URL can't widen
+ * the backend query.
+ */
+export function parseSkillsSearchParams(params: SearchParams): SkillsPageFilters {
+    return {
+        section: parseSection(params.section),
+        search: firstParam(params.search)?.trim() ?? '',
+        installedOffset: parseOffset(params.installedOffset),
+        catalogOffset: parseOffset(params.catalogOffset),
+    };
+}
+
+/**
+ * Rebuilds a catalog URL on an arbitrary base path, omitting every filter that
+ * is already at its default so the common case stays a clean `/agents#skills`.
+ * Mirrors `SkillsPageClient`'s `updateUrl` param order.
+ */
+export function buildSkillsHref(
+    basePath: string,
+    filters: SkillsPageFilters,
+    hash: string = '',
+): string {
+    const params = new URLSearchParams();
+    if (filters.section !== 'installed') params.set('section', filters.section);
+    if (filters.search.trim()) params.set('search', filters.search.trim());
+    if (filters.installedOffset > 0) params.set('installedOffset', String(filters.installedOffset));
+    if (filters.catalogOffset > 0) params.set('catalogOffset', String(filters.catalogOffset));
+    return `${basePath}${params.size ? `?${params}` : ''}${hash}`;
+}
+
+/**
+ * Server-fetches the installed Skills + the catalog union in parallel.
+ *
+ * Defensive `.then(ok, fail)` so a partial backend failure (e.g. a flaky
+ * catalog plugin) still renders the surface with the section that did load —
+ * the failing side reports through `loadErrors` instead of throwing the whole
+ * page into the error boundary.
+ */
+export async function loadSkillsPageData(filters: SkillsPageFilters): Promise<SkillsPageData> {
+    const [installed, catalog] = await Promise.all([
+        skillsAPI
+            .listInstalled({
+                limit: SKILLS_PAGE_SIZE,
+                offset: filters.installedOffset,
+                search: filters.search,
+            })
+            .then(
+                (result) => ({ result, error: null as string | null }),
+                () => ({
+                    result: {
+                        data: [] as Skill[],
+                        meta: {
+                            total: 0,
+                            limit: SKILLS_PAGE_SIZE,
+                            offset: filters.installedOffset,
+                        },
+                    },
+                    error: 'installed',
+                }),
+            ),
+        skillsAPI
+            .listCatalog({
+                limit: SKILLS_PAGE_SIZE,
+                offset: filters.catalogOffset,
+                search: filters.search,
+            })
+            .then(
+                (result) => ({ result, error: null as string | null }),
+                () => ({
+                    result: { entries: [] as SkillCatalogEntry[], total: 0 },
+                    error: 'catalog',
+                }),
+            ),
+    ]);
+
+    return {
+        installed: installed.result.data ?? [],
+        installedMeta: installed.result.meta,
+        catalog: catalog.result.entries ?? [],
+        catalogTotal: catalog.result.total ?? 0,
+        catalogLimit: SKILLS_PAGE_SIZE,
+        loadErrors: { installed: installed.error, catalog: catalog.error },
+    };
+}

--- a/apps/web/src/lib/skills-page-data.unit.spec.ts
+++ b/apps/web/src/lib/skills-page-data.unit.spec.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Skill, SkillCatalogEntry } from '@/lib/api/skills';
+
+const listInstalled = vi.fn();
+const listCatalog = vi.fn();
+
+vi.mock('@/lib/api/skills', () => ({
+    skillsAPI: {
+        listInstalled: (...args: unknown[]) => listInstalled(...args),
+        listCatalog: (...args: unknown[]) => listCatalog(...args),
+    },
+}));
+
+import {
+    SKILLS_PAGE_SIZE,
+    buildSkillsHref,
+    loadSkillsPageData,
+    parseSkillsSearchParams,
+    type SkillsPageFilters,
+} from './skills-page-data';
+
+const DEFAULT_FILTERS: SkillsPageFilters = {
+    section: 'installed',
+    search: '',
+    installedOffset: 0,
+    catalogOffset: 0,
+};
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+    return {
+        id: 'skill-1',
+        userId: 'u1',
+        ownerType: 'tenant',
+        ownerId: 'u1',
+        slug: 'custom',
+        title: 'Custom',
+        description: 'Custom skill',
+        frontmatter: { name: 'custom', description: 'Custom skill' },
+        instructionsMd: '# Custom',
+        contentHash: 'hash',
+        sourcePath: null,
+        sourceCatalogSlug: null,
+        sourceCatalogVersion: null,
+        version: '1.0.0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function makeCatalogEntry(overrides: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry {
+    return {
+        slug: 'catalog-one',
+        title: 'Catalog One',
+        description: 'Catalog skill',
+        frontmatter: { name: 'catalog-one', description: 'Catalog skill' },
+        body: '# Catalog',
+        version: '1.0.0',
+        tags: [],
+        ...overrides,
+    };
+}
+
+describe('parseSkillsSearchParams', () => {
+    it('falls back to the installed section with empty search and zero offsets', () => {
+        expect(parseSkillsSearchParams({})).toEqual(DEFAULT_FILTERS);
+    });
+
+    it('keeps a known section and drops an unknown one', () => {
+        expect(parseSkillsSearchParams({ section: 'custom' }).section).toBe('custom');
+        expect(parseSkillsSearchParams({ section: 'available' }).section).toBe('available');
+        expect(parseSkillsSearchParams({ section: 'bogus' }).section).toBe('installed');
+    });
+
+    it('takes the first value when a param repeats', () => {
+        const filters = parseSkillsSearchParams({
+            section: ['custom', 'available'],
+            search: ['  alpha  ', 'beta'],
+            installedOffset: ['50', '100'],
+        });
+        expect(filters.section).toBe('custom');
+        expect(filters.search).toBe('alpha');
+        expect(filters.installedOffset).toBe(50);
+    });
+
+    it('clamps non-positive, fractional and non-numeric offsets to 0', () => {
+        expect(parseSkillsSearchParams({ installedOffset: '-5' }).installedOffset).toBe(0);
+        expect(parseSkillsSearchParams({ installedOffset: 'abc' }).installedOffset).toBe(0);
+        expect(parseSkillsSearchParams({ installedOffset: '1.5' }).installedOffset).toBe(0);
+        expect(parseSkillsSearchParams({ catalogOffset: '0' }).catalogOffset).toBe(0);
+        expect(parseSkillsSearchParams({ catalogOffset: '50' }).catalogOffset).toBe(50);
+    });
+});
+
+describe('buildSkillsHref', () => {
+    it('omits an empty query string and appends the hash', () => {
+        expect(buildSkillsHref('/agents', DEFAULT_FILTERS, '#skills')).toBe('/agents#skills');
+        expect(buildSkillsHref('/skills', DEFAULT_FILTERS)).toBe('/skills');
+    });
+
+    it('serialises only the non-default filters, hash last', () => {
+        expect(
+            buildSkillsHref('/agents', { ...DEFAULT_FILTERS, section: 'custom' }, '#skills'),
+        ).toBe('/agents?section=custom#skills');
+        expect(
+            buildSkillsHref(
+                '/agents',
+                {
+                    section: 'available',
+                    search: 'pdf tools',
+                    installedOffset: 50,
+                    catalogOffset: 100,
+                },
+                '#skills',
+            ),
+        ).toBe(
+            '/agents?section=available&search=pdf+tools&installedOffset=50&catalogOffset=100#skills',
+        );
+    });
+});
+
+describe('loadSkillsPageData', () => {
+    beforeEach(() => {
+        listInstalled.mockReset();
+        listCatalog.mockReset();
+    });
+
+    it('passes the paging window + search to both endpoints and returns their payloads', async () => {
+        const skill = makeSkill();
+        const entry = makeCatalogEntry();
+        listInstalled.mockResolvedValue({
+            data: [skill],
+            meta: { total: 1, limit: SKILLS_PAGE_SIZE, offset: 0 },
+        });
+        listCatalog.mockResolvedValue({ entries: [entry], total: 1 });
+
+        const data = await loadSkillsPageData({
+            section: 'available',
+            search: 'pdf',
+            installedOffset: 50,
+            catalogOffset: 100,
+        });
+
+        expect(listInstalled).toHaveBeenCalledWith({
+            limit: SKILLS_PAGE_SIZE,
+            offset: 50,
+            search: 'pdf',
+        });
+        expect(listCatalog).toHaveBeenCalledWith({
+            limit: SKILLS_PAGE_SIZE,
+            offset: 100,
+            search: 'pdf',
+        });
+        expect(data.installed).toEqual([skill]);
+        expect(data.catalog).toEqual([entry]);
+        expect(data.catalogTotal).toBe(1);
+        expect(data.catalogLimit).toBe(SKILLS_PAGE_SIZE);
+        expect(data.loadErrors).toEqual({ installed: null, catalog: null });
+    });
+
+    it('degrades to an empty installed list flagged with loadErrors.installed', async () => {
+        listInstalled.mockRejectedValue(new Error('boom'));
+        listCatalog.mockResolvedValue({ entries: [makeCatalogEntry()], total: 1 });
+
+        const data = await loadSkillsPageData({ ...DEFAULT_FILTERS, installedOffset: 50 });
+
+        expect(data.loadErrors).toEqual({ installed: 'installed', catalog: null });
+        expect(data.installed).toEqual([]);
+        expect(data.installedMeta).toEqual({ total: 0, limit: SKILLS_PAGE_SIZE, offset: 50 });
+        expect(data.catalog).toHaveLength(1);
+    });
+
+    it('degrades to an empty catalog flagged with loadErrors.catalog', async () => {
+        listInstalled.mockResolvedValue({
+            data: [makeSkill()],
+            meta: { total: 1, limit: SKILLS_PAGE_SIZE, offset: 0 },
+        });
+        listCatalog.mockRejectedValue(new Error('catalog plugin down'));
+
+        const data = await loadSkillsPageData(DEFAULT_FILTERS);
+
+        expect(data.loadErrors).toEqual({ installed: null, catalog: 'catalog' });
+        expect(data.catalog).toEqual([]);
+        expect(data.catalogTotal).toBe(0);
+        expect(data.installed).toHaveLength(1);
+    });
+
+    it('normalises missing collections from a partial backend payload', async () => {
+        listInstalled.mockResolvedValue({ meta: { total: 0, limit: SKILLS_PAGE_SIZE, offset: 0 } });
+        listCatalog.mockResolvedValue({});
+
+        const data = await loadSkillsPageData(DEFAULT_FILTERS);
+
+        expect(data.installed).toEqual([]);
+        expect(data.catalog).toEqual([]);
+        expect(data.catalogTotal).toBe(0);
+    });
+});

--- a/docs/advanced/teams-and-organizations.md
+++ b/docs/advanced/teams-and-organizations.md
@@ -15,6 +15,15 @@ documents that model — what an Organization is, how membership and
 ownership are enforced, the register-company flow, slug rules, and how
 Organizations relate to platform admins and per-work isolation.
 
+:::note Where to find it
+**Sidebar → Teams** is the hub for both halves of your organization — people
+and Agents. It opens on the **Teams** tab (the teams below, plus the **Org
+Chart** covering humans _and_ agents); the other tabs are **Agents** (the
+Agent catalog, its **Agents Chart** at `/agents/chart` — the same tree with
+human members stripped — and the **Skills** block), **Sessions** and
+**Archived**. Organizations themselves are still managed under Settings.
+:::
+
 :::note Two isolation layers
 This page covers the **account/Tenant/Organization** scope. A separate,
 finer-grained layer scopes content _inside_ a single Work via

--- a/docs/features/agents-catalog.md
+++ b/docs/features/agents-catalog.md
@@ -18,6 +18,14 @@ and **how the platform reads it**. For the Agent runtime and REST surface,
 see [Agents (Your AI Employees)](./agents.md) and the
 [Agents API](/api/agents).
 
+:::note Where to find it
+The Create-Agent wizard that surfaces these templates opens from
+**Sidebar → Teams → Agents tab → + New Agent**. Agents are tab 2 of the
+**Teams** hub (**Teams | Agents | Sessions | Archived**); the same tab hosts
+the **Agents Chart** button (`/agents/chart`) and the **Skills** block
+(`/agents#skills`).
+:::
+
 **Key sources:**
 
 - `apps/api/src/agents/agent-template-catalog.service.ts` — the catalog reader

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -98,7 +98,11 @@ Every Agent can have one budget row. Before any AI call, the platform checks the
 
 ## The Agents workbench
 
-- **Sidebar → Agents** lists every Agent you own, with Cards/Table views and filters for status (`All / Active / Paused / Error`) and scope (`Tenant / Mission / Idea / Work`).
+:::note Where to find it
+Agents live under **Sidebar → Teams**, which is the hub for your people _and_ your AI workforce: tabs **Teams | Agents | Sessions | Archived**. The **Agents** tab is the catalog below, and it also carries the **Agents Chart** button (your Agent hierarchy without human members) and the **Skills** block. `/agents` and `/skills` still work as links — `/skills` redirects to the Skills block on the Agents tab.
+:::
+
+- **Sidebar → Teams → Agents tab** lists every Agent you own, with Cards/Table views and filters for status (`All / Active / Paused / Error`) and scope (`Tenant / Mission / Idea / Work`).
 - Each **Agent detail page** has six tabs: **Dashboard** (live status, run history, tasks, cost snapshot), **Activity**, **Instructions**, **Skills**, **Budgets**, and **Settings**.
 - Header actions: **Run heartbeat now**, **Assign Task**, **Pause / Resume**, **Archive**, **Delete**.
 - Work, Mission, and Idea detail pages each gain an **Agents** tab listing the Agents that can act on them.
@@ -107,7 +111,7 @@ A **dry-run** mode (`POST /agents/:id/dry-run`) builds the prompt and estimates 
 
 ## Creating an Agent
 
-1. Sidebar → **Agents** → **+ New Agent**.
+1. Sidebar → **Teams** → **Agents** tab → **+ New Agent**.
 2. Give it a `name` and `title`, and describe its `capabilities`.
 3. Pick a provider/model (or keep your account default).
 4. Choose a scope — Tenant for a company-wide role, or a specific Mission/Idea/Work.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,6 +13,10 @@ This section covers the individual capabilities that make that possible, beyond 
 
 > New here? Read the [Platform Overview](../overview.md) for the big picture, or the [Founder Journey guide](../guides/founder-journey.md) for the Start → Build → Sell → Scale playbook that ties these features together.
 
+:::note Where these live in the sidebar
+A few features share a sidebar entry rather than owning one. **Teams** is the hub for people _and_ Agents — tabs **Teams | Agents | Sessions | Archived**, with the **Agents Chart** button (`/agents/chart`) and the **Skills** catalog on the Agents tab. **Memory** hosts the **Meetings** catalog as a block. The retired index links still work: `/skills` redirects to `/agents#skills` and `/meetings` to `/memory#meetings`, filters and all. Detail pages (`/agents/:id`, `/teams/:id`, `/skills/:id`, `/meetings/:id`) are unchanged.
+:::
+
 ## Getting started
 
 | Feature                                      | Description                                                                                   |

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -73,6 +73,10 @@ Enable them like any other [plugin](../plugin-system/index.md), under **Settings
 
 A **Meeting** is a first-class record: title, start/end, source, participants, a deep link, and optionally a transcript.
 
+:::note Where to find it
+Meetings have no sidebar entry of their own — a meeting is a _memory source_, so the catalog renders as the **Meetings** block on **Sidebar → Memory** (anchor `/memory#meetings`), right under the agent-memory panel. The source and Work filters, pagination and **New meeting** button are unchanged. The old `/meetings` link still works: it redirects to that block and carries its filters across. `/meetings/new` and the meeting detail pages (`/meetings/:id`) are unchanged.
+:::
+
 | Endpoint                            | What it does                                                 |
 | ----------------------------------- | ------------------------------------------------------------ |
 | `GET /api/meetings`                 | Your meetings, newest first. Filter by `workId` or `source`. |

--- a/docs/features/skills-catalog.md
+++ b/docs/features/skills-catalog.md
@@ -18,6 +18,17 @@ This page covers the catalog **format**, the first-party provider
 (catalog reads, per-user installs), see the
 [Skills API](/api/skills).
 
+:::note Where to find it
+Skills have no sidebar entry of their own — nobody browses Skills without an
+Agent in mind — so the catalog renders as the **Skills** block at the bottom
+of **Sidebar → Teams → Agents tab** (anchor `/agents#skills`). Its tabs
+(**Installed / Available / Custom**), search, **Browse templates** and **New
+skill** are unchanged. The old `/skills` link still works: it redirects to
+that block and carries your filters across. Skill detail pages
+(`/skills/:id`), `/skills/new` and `/skills/templates` are unchanged, as is
+the per-Agent **Skills** tab on an Agent's detail page.
+:::
+
 **Key sources:**
 
 - `packages/plugins/everworks-skills/src/everworks-skills.plugin.ts` — the provider plugin

--- a/docs/specs/features/navigation-consolidation/plan.md
+++ b/docs/specs/features/navigation-consolidation/plan.md
@@ -1,0 +1,514 @@
+# Navigation consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold Meetings into the Memory page, turn the Agents sidebar entry into a "Teams" hub with tabs Teams | Agents | Sessions | Archived (Teams content in tab 1, an Agents Chart on tab 2), and fold the Skills catalog into the Agents tab — with no URL renames for detail pages and redirects for the two retired index routes.
+
+**Architecture:** `apps/web` only (Next.js 16 App Router, React 19, next-intl, Tailwind 4, vitest, Playwright). Existing server pages keep their fetch/whitelisting posture; existing client components gain `variant`/`basePath` props instead of being duplicated. The org-chart renderer is reused for the Agents Chart by stripping `members` from the payload. Sidebar active-state matching gains `matchPrefixes`.
+
+**Tech Stack:** Next.js 16.1.5, React 19, next-intl (`@/i18n/navigation` `Link`/`useRouter`/`redirect`), lucide-react, vitest (`pnpm --filter ever-works-web test`), Playwright e2e specs under `apps/web/e2e` (cannot run locally here — update by reading the DOM contract).
+
+Spec: [`spec.md`](./spec.md) (same folder). Worktree: `E:\Coding\_wt-nav-teams-memory`, branch `feat/nav-teams-memory-consolidation` (based on `origin/develop`).
+
+## Global Constraints
+
+- Package manager **pnpm only**. Run web checks from `apps/web`: `pnpm type-check`, `pnpm lint`, `pnpm test` (vitest).
+- **Prettier**: tabs, width 4, single quotes, semicolons, arrow parens always, print width 120 (root `package.json` config wins). Run `pnpm prettier --write <files>` on touched files.
+- **No-removal rule**: retired index routes become **redirects**, never deleted. Keep every existing `ROUTES.*` constant and every existing i18n key. Keep every existing `data-testid`.
+- **i18n**: add new copy to `apps/web/messages/en.json` only (other locales deep-merge from `en`).
+- **Server components by default**; `'use client'` only where interactivity exists (existing files already tell you which).
+- **Conventional commits** (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`), one commit per task, from the worktree root.
+- Do not touch `apps/api`, `packages/*`, or any migration.
+- Never invent test ids used by e2e without also updating the e2e spec that asserts them (and vice versa).
+
+---
+
+## File map
+
+| Area                                     | Create                                                                                                                                                           | Modify                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Foundations                              | `src/components/icons/HumanAgentIcon.tsx`, `src/components/icons/HumanAgentIcon.unit.spec.tsx`, `src/components/agents/AgentsPageTabs.unit.spec.tsx`             | `src/lib/constants.ts`, `messages/en.json`, `src/components/agents/AgentsPageTabs.tsx`                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Meetings → Memory                        | `src/components/memory/MemoryMeetingsPanel.tsx`, `src/components/meetings/MeetingsList.unit.spec.tsx`, `src/lib/api/meetings-page-params.ts` (+ `.unit.spec.ts`) | `src/components/meetings/MeetingsList.tsx`, `src/components/memory/MemoryShell.tsx`, `src/components/memory/index.ts`, `src/app/[locale]/(dashboard)/memory/page.tsx`, `src/app/[locale]/(dashboard)/meetings/page.tsx` (→ redirect), `src/components/meetings/MeetingDetailClient.tsx`, `src/components/meetings/MeetingForm.tsx`, `e2e/flow-meetings-ui-journey.spec.ts`, `e2e/flow-memory-ui-journey.spec.ts` (only if it asserts panel order)                                                                 |
+| Skills → Agents                          | `src/components/skills/SkillsSection.tsx`, `src/lib/skills-page-data.ts` (+ `.unit.spec.ts`), `src/components/skills/SkillsSection.unit.spec.tsx`                | `src/components/skills/SkillsPageClient.tsx`, `src/components/skills/SkillDetailClient.tsx`, `src/app/[locale]/(dashboard)/skills/page.tsx` (→ redirect), `src/app/[locale]/(dashboard)/skills/templates/page.tsx`, `src/app/actions/skills.ts`, `src/app/actions/agent-capabilities.ts`, `e2e/flow-skill-bulk-operations.spec.ts`, `e2e/flow-skill-crud-scoping.spec.ts`, `e2e/flow-skill-marketplace-share.spec.ts`, `e2e/skills.spec.ts`, `e2e/skills-list-filter.spec.ts` (only where they open `/skills` UI) |
+| Teams hub + Agents tab + chart + sidebar | `src/app/[locale]/(dashboard)/agents/chart/page.tsx`, `src/components/dashboard/DashboardSidebar.unit.spec.tsx` (if none exists; else extend)                    | `src/app/[locale]/(dashboard)/teams/page.tsx`, `src/app/[locale]/(dashboard)/agents/page.tsx`, `src/components/agents/AgentsList.tsx`, `src/components/dashboard/DashboardSidebar.tsx`, `e2e/flow-teams-ui-journey.spec.ts`, `e2e/flow-agents-ui-journey.spec.ts`                                                                                                                                                                                                                                                 |
+| Docs                                     | —                                                                                                                                                                | `docs/features/agents-catalog.md`, `docs/features/skills-catalog.md`, `docs/features/index.md`, `docs/advanced/teams-and-organizations.md`, meetings/memory feature doc if present (`grep -ril "meetings" docs/features`)                                                                                                                                                                                                                                                                                         |
+
+Paths are relative to `apps/web/` unless they start with `docs/`.
+
+---
+
+## Phase 0 — Foundations (sequential; everything else depends on it)
+
+### Task 0.1: ROUTES constants + i18n keys
+
+**Files:**
+
+- Modify: `src/lib/constants.ts` (ROUTES block around lines 145–195)
+- Modify: `messages/en.json`
+
+**Produces:** `ROUTES.DASHBOARD_AGENTS_CHART = '/agents/chart'`, `ROUTES.DASHBOARD_AGENTS_SKILLS = '/agents#skills'`, `ROUTES.DASHBOARD_MEMORY_MEETINGS = '/memory#meetings'`; i18n keys listed below.
+
+- [ ] **Step 1: Add constants** — inside the ROUTES object, next to the related entries:
+
+```ts
+    // Navigation consolidation (docs/specs/features/navigation-consolidation):
+    // the Skills catalog now renders as a block on the Agents tab, and the
+    // Meetings catalog as a block on the Memory page. `/skills` and
+    // `/meetings` (index only) redirect here; detail routes are unchanged.
+    DASHBOARD_AGENTS_SKILLS: '/agents#skills',
+    DASHBOARD_MEMORY_MEETINGS: '/memory#meetings',
+    // Agents Chart — the org chart with human members stripped.
+    DASHBOARD_AGENTS_CHART: '/agents/chart',
+```
+
+- [ ] **Step 2: Add i18n keys to `messages/en.json`** (find each parent object; keep alphabetical-ish placement near siblings):
+
+```jsonc
+// dashboard.agentsPage.pageTabs  (existing object with agents/sessions/archived)
+"teams": "Teams",
+
+// dashboard.agentsPage  (top-level of that object)
+"agentsChartCta": "Agents Chart",
+"skillsBlock": {
+    "title": "Skills",
+    "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
+},
+
+// dashboard  (new sibling of agentsPage / orgChartPage)
+"agentsChartPage": {
+    "title": "Agents Chart",
+    "subtitle": "How your Agents are organised — teams and reporting lines, without human members.",
+    "backToAgents": "Back to Agents",
+    "empty": "No Agents yet. Create an Agent and it will appear here.",
+    "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
+},
+
+// dashboard.memoryPage  (existing object)
+"meetings": {
+    "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
+}
+```
+
+- [ ] **Step 3: Verify JSON + types** — `cd apps/web && node -e "JSON.parse(require('fs').readFileSync('messages/en.json','utf8'))" && pnpm type-check`
+- [ ] **Step 4: Commit** — `git commit -m "feat(web): routes + i18n keys for navigation consolidation"`
+
+### Task 0.2: `HumanAgentIcon`
+
+**Files:**
+
+- Create: `src/components/icons/HumanAgentIcon.tsx`
+- Test: `src/components/icons/HumanAgentIcon.unit.spec.tsx`
+
+**Produces:** `export function HumanAgentIcon(props: React.SVGProps<SVGSVGElement> & { strokeWidth?: number })` — a lucide-compatible 24×24 stroke icon (accepts `className`, `strokeWidth`), usable as `<item.icon className="w-5 h-5" strokeWidth={1.5} />` and as `PageHeader`'s `icon` prop (typed as `LucideIcon` — export the component typed as `LucideIcon` via `as unknown as LucideIcon` re-export `HumanAgentLucideIcon` if the PageHeader prop type rejects it; prefer making the component's props structurally compatible: `(props: LucideProps) => JSX.Element`).
+
+- [ ] **Step 1: Failing test** (`vitest` + `@testing-library/react` are already used by sibling `*.unit.spec.tsx` files — copy their imports):
+
+```tsx
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { HumanAgentIcon } from './HumanAgentIcon';
+
+describe('HumanAgentIcon', () => {
+	it('renders a lucide-compatible svg with the given class and stroke width', () => {
+		const { container } = render(<HumanAgentIcon className="w-5 h-5" strokeWidth={1.5} />);
+		const svg = container.querySelector('svg');
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute('viewBox')).toBe('0 0 24 24');
+		expect(svg?.getAttribute('class')).toContain('w-5');
+		expect(svg?.getAttribute('stroke-width')).toBe('1.5');
+		expect(svg?.getAttribute('aria-hidden')).toBe('true');
+		// both halves present: a person head (circle) and a bot head (rect)
+		expect(container.querySelector('circle')).not.toBeNull();
+		expect(container.querySelector('rect')).not.toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run** `pnpm vitest run src/components/icons/HumanAgentIcon.unit.spec.tsx` → FAIL (module not found).
+- [ ] **Step 3: Implement**
+
+```tsx
+import type { LucideProps } from 'lucide-react';
+
+/**
+ * Human + Agent — sidebar icon for the merged "Teams" hub (people AND
+ * agents). Hand-drawn in lucide's 24×24 stroke grammar so it sits next to
+ * lucide icons without a visible seam: left half is lucide `user` (head +
+ * shoulders), right half is lucide `bot`'s head (rounded rect, antenna,
+ * two eyes). Accepts the same props as a lucide icon.
+ */
+export function HumanAgentIcon({ strokeWidth = 2, className, ...rest }: LucideProps) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width={24}
+			height={24}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={strokeWidth}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			aria-hidden="true"
+			{...rest}
+		>
+			{/* person (left) */}
+			<circle cx="7.5" cy="7" r="3" />
+			<path d="M2 21v-2a4.5 4.5 0 0 1 4.5-4.5h2A4.5 4.5 0 0 1 13 19v2" />
+			{/* bot head (right) */}
+			<rect x="13" y="10" width="9" height="8" rx="2" />
+			<path d="M17.5 10V7" />
+			<circle cx="17.5" cy="6" r="1" />
+			<path d="M15.5 14v1" />
+			<path d="M19.5 14v1" />
+		</svg>
+	);
+}
+```
+
+- [ ] **Step 4: Run test** → PASS. `pnpm type-check` clean.
+- [ ] **Step 5: Commit** — `git commit -m "feat(web): HumanAgentIcon for the merged Teams sidebar entry"`
+
+### Task 0.3: Tab strip gets a first "Teams" tab
+
+**Files:**
+
+- Modify: `src/components/agents/AgentsPageTabs.tsx`
+- Test: `src/components/agents/AgentsPageTabs.unit.spec.tsx`
+
+**Produces:** `AgentsPageTabs({ active }: { active: 'teams' | 'agents' | 'sessions' | 'archived' })`, plus `export const TeamsPageTabs = AgentsPageTabs;`. Tab order: Teams (`ROUTES.DASHBOARD_TEAMS`), Agents, Sessions, Archived. Test ids unchanged: `agents-page-tabs`, `agents-page-tab-<key>`.
+
+- [ ] **Step 1: Failing test** — mock `next-intl` (`useTranslations: () => (k) => k`) and `@/i18n/navigation` (`Link: ({href, children, ...p}) => <a href={href} {...p}>{children}</a>`) the way other `*.unit.spec.tsx` in `components/agents` do (look at `AgentCard.unit.spec.tsx` for the exact mocking idiom):
+
+```tsx
+it('renders Teams | Agents | Sessions | Archived in that order and marks the active one', () => {
+	render(<AgentsPageTabs active="teams" />);
+	const tabs = screen.getAllByRole('link');
+	expect(tabs.map((a) => a.getAttribute('data-testid'))).toEqual([
+		'agents-page-tab-teams',
+		'agents-page-tab-agents',
+		'agents-page-tab-sessions',
+		'agents-page-tab-archived'
+	]);
+	expect(tabs[0].getAttribute('href')).toBe('/teams');
+	expect(tabs[0].className).toContain('border-primary');
+	expect(tabs[1].className).not.toContain('border-primary');
+});
+```
+
+- [ ] **Step 2: Run** → FAIL (3 links, no teams tab).
+- [ ] **Step 3: Implement** — extend the `active` union, prepend `{ key: 'teams', href: ROUTES.DASHBOARD_TEAMS, label: t('teams') }`, update the doc comment ("Teams hub tab strip: Teams | Agents | Sessions | Archived — rendered on `/teams`, `/agents`, `/agents/sessions`, `/agents/archived`"), add `export const TeamsPageTabs = AgentsPageTabs;` at the bottom.
+- [ ] **Step 4: Run test** → PASS. `pnpm type-check`.
+- [ ] **Step 5: Commit** — `git commit -m "feat(web): Teams tab first in the Agents/Teams hub tab strip"`
+
+---
+
+## Phase 1 — Two independent lanes (may run in parallel; disjoint files)
+
+### Lane A — Meetings → Memory
+
+#### Task A.1: Shared meetings page-param helper
+
+**Files:**
+
+- Create: `src/lib/api/meetings-page-params.ts`
+- Test: `src/lib/api/meetings-page-params.unit.spec.ts`
+
+**Produces:**
+
+```ts
+export const MEETINGS_PAGE_SIZE = 12;
+export interface MeetingsPageQuery {
+	source?: MeetingSource;
+	workId?: string;
+	offset: number;
+}
+export function parseMeetingsSearchParams(params: Record<string, string | string[] | undefined>): MeetingsPageQuery;
+export function buildMeetingsHref(
+	basePath: string,
+	input: { source?: MeetingSource; workId?: string; offset?: number },
+	hash?: string
+): string;
+```
+
+`parseMeetingsSearchParams` = the whitelisting the old `/meetings/page.tsx` did (source ∈ `MEETING_SOURCES`, workId must match the uuid regex, offset ≥ 0 int). `buildMeetingsHref('/memory', {source:'zoom'}, '#meetings')` → `'/memory?source=zoom#meetings'`; `buildMeetingsHref('/meetings', {})` → `'/meetings'`.
+
+- [ ] **Step 1: Failing tests** covering: unknown source dropped; non-uuid workId dropped; negative/NaN offset → 0; href with/without qs and hash.
+- [ ] **Step 2: Run** → FAIL. **Step 3:** implement (move the regex + `firstParam` from `meetings/page.tsx`). **Step 4:** PASS. **Step 5:** commit `refactor(web): extract meetings page-param parsing`.
+
+#### Task A.2: `MeetingsList` gains `variant` + `basePath`
+
+**Files:**
+
+- Modify: `src/components/meetings/MeetingsList.tsx`
+- Test: `src/components/meetings/MeetingsList.unit.spec.tsx` (create)
+
+**Produces:** `MeetingsListProps` gains `variant?: 'page' | 'panel'` (default `'page'`), `basePath?: string` (default `'/meetings'`), `hash?: string` (default `''`). In `'panel'` variant: no `PageHeader`; instead a card wrapper `<section id="meetings" data-testid="meetings-shell" className="rounded-lg border p-4 bg-card dark:bg-card-primary-dark border-card-border dark:border-white/9 flex flex-col gap-4">` with a compact header row (Video icon tile `w-8 h-8 rounded-md bg-info/10 border border-info/20`, `<h2 className="text-sm font-semibold">{t('title')}</h2>`, subtitle `text-xs text-text-muted`, right-aligned **New meeting** button `href="/meetings/new"`), then the (optional) `hint` prop paragraph, then everything else as today. The filter `<form action={basePath + hash}>` (GET) and the **Reset** button href → `basePath + hash`; pagination hrefs are passed in already-built by the caller (unchanged). Keep every existing test id.
+
+- [ ] **Step 1: Failing test**: render `variant="panel" basePath="/memory" hash="#meetings"` with one meeting → asserts no `h1`, presence of `#meetings` section, form `action="/memory#meetings"`, reset link href `/memory#meetings`, `meetings-grid` present. Mock `next-intl`, `@/i18n/navigation`, and `./MeetingCard` (`() => <div data-testid="meeting-card" />`).
+- [ ] **Step 2** FAIL → **Step 3** implement → **Step 4** PASS + `pnpm type-check` → **Step 5** commit `feat(web): MeetingsList panel variant with rebased hrefs`.
+
+#### Task A.3: `MemoryMeetingsPanel` + `MemoryShell` + `MemoryPage` + `/meetings` redirect + back-links
+
+**Files:**
+
+- Create: `src/components/memory/MemoryMeetingsPanel.tsx`
+- Modify: `src/components/memory/index.ts` (export it), `src/components/memory/MemoryShell.tsx`, `src/app/[locale]/(dashboard)/memory/page.tsx`, `src/app/[locale]/(dashboard)/meetings/page.tsx`, `src/components/meetings/MeetingDetailClient.tsx` (lines ~460, ~473), `src/components/meetings/MeetingForm.tsx` (lines ~156, ~335)
+
+**Produces:**
+
+```ts
+// MemoryMeetingsPanel.tsx ('use client')
+export interface MemoryMeetingsData {
+	meetings: Meeting[];
+	works: MeetingWorkOption[];
+	loadError: string | null;
+	filters: { source?: MeetingSource; workId?: string };
+	pagination: { offset: number; hasPrevious: boolean; hasNext: boolean; previousHref: string; nextHref: string };
+}
+export function MemoryMeetingsPanel({ data }: { data: MemoryMeetingsData }): JSX.Element;
+// renders <MeetingsList variant="panel" basePath={ROUTES.DASHBOARD_MEMORY} hash="#meetings" hint={t('meetings.hint')} {...data} />
+```
+
+`MemoryShellProps` gains `meetings?: MemoryMeetingsData`; when present render `<MemoryMeetingsPanel data={meetings} />` **directly after `<AgentMemoryPanel />`** (before the consolidation error/preview blocks).
+
+`MemoryPage({ searchParams })`: `const q = parseMeetingsSearchParams(await searchParams)`; fetch `memoryAPI.get` (as today) and, in parallel, `meetingsAPI.list({ ...q, limit: MEETINGS_PAGE_SIZE + 1 })` (try/catch → `loadError`) and `workAPI.getAll({ limit: 100 })` mapped to `{id,name}` with `.catch(() => [])`; build `pagination` with `buildMeetingsHref(ROUTES.DASHBOARD_MEMORY, {...}, '#meetings')`; pass `meetings` to `MemoryShell`.
+
+`meetings/page.tsx` becomes:
+
+```tsx
+import { redirect } from '@/i18n/navigation';
+import { getLocale } from 'next-intl/server';
+import { buildMeetingsHref, parseMeetingsSearchParams } from '@/lib/api/meetings-page-params';
+import { ROUTES } from '@/lib/constants';
+
+/**
+ * `/meetings` (index) — retired as a standalone page (navigation
+ * consolidation): the Meetings catalog now lives as a block on the Memory
+ * page. Kept as a redirect so bookmarks and older deep links keep working;
+ * `/meetings/new` and `/meetings/[id]` are unchanged.
+ */
+export default async function MeetingsIndexRedirect({
+	searchParams
+}: {
+	searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+	const q = parseMeetingsSearchParams(await searchParams);
+	const locale = await getLocale();
+	redirect({ href: buildMeetingsHref(ROUTES.DASHBOARD_MEMORY, q, '#meetings'), locale });
+}
+```
+
+(Check `src/i18n/navigation.ts` for the exact `redirect` signature — next-intl v3 uses `redirect(href)` in some setups and `redirect({href, locale})` in others; use whatever the file exports and other pages already use — `grep -rn "redirect(" src/app | head`.)
+
+Back-links: replace `ROUTES.DASHBOARD_MEETINGS` / `"/meetings"` in `MeetingDetailClient.tsx` (both) and `MeetingForm.tsx` (both) with `ROUTES.DASHBOARD_MEMORY_MEETINGS`.
+
+- [ ] **Step 1: Failing unit test** for `MemoryShell` (extend or create `MemoryShell.unit.spec.tsx`): with `meetings` prop, `#meetings` section renders after `agent-memory-panel` in DOM order (`compareDocumentPosition`); without it, no `#meetings`. Mock the heavy panels (`./MemoryFilesPanel` etc.) with stubs — see how `MemoryFilesPanel.unit.spec.tsx` mocks fetch.
+- [ ] **Step 2** FAIL → **Step 3** implement all files above → **Step 4** PASS, `pnpm type-check`, `pnpm lint` → **Step 5** commit `feat(web): Meetings catalog moves into the Memory page; /meetings redirects`.
+
+#### Task A.4: e2e updates (meetings)
+
+**Files:** `e2e/flow-meetings-ui-journey.spec.ts` (and `e2e/flow-memory-ui-journey.spec.ts` only if it enumerates panel order).
+
+- [ ] Replace `page.goto('/en/meetings…')` for the **index** with `page.goto('/en/memory…#meetings')` keeping the same query strings; keep `/en/meetings/new` and `/en/meetings/<id>` as-is.
+- [ ] Rewrite the "sidebar Meetings link routes to the catalog" test (line ~822) into two: (a) sidebar has **no** link whose href ends with `/meetings`; (b) `page.goto('/en/meetings?source=zoom')` ends at a URL matching `/\/en\/memory\?source=zoom(#meetings)?$/` (Playwright drops hashes from `page.url()` inconsistently — assert `new URL(page.url()).pathname === '/en/memory'` and `searchParams.get('source') === 'zoom'`).
+- [ ] Any assertion on `h1` "Meetings" → assert `getByTestId('meetings-shell')` and `getByRole('heading', { name: /meetings/i })`.
+- [ ] Commit `test(e2e): meetings journey follows the Memory page block`.
+
+### Lane C — Skills → Agents tab block
+
+#### Task C.1: `loadSkillsPageData` helper
+
+**Files:**
+
+- Create: `src/lib/skills-page-data.ts`, `src/lib/skills-page-data.unit.spec.ts`
+
+**Produces:**
+
+```ts
+export const SKILLS_PAGE_SIZE = 50;
+export type SkillsSection = 'installed' | 'available' | 'custom';
+export interface SkillsPageFilters {
+	section: SkillsSection;
+	search: string;
+	installedOffset: number;
+	catalogOffset: number;
+}
+export function parseSkillsSearchParams(params: Record<string, string | string[] | undefined>): SkillsPageFilters;
+export function buildSkillsHref(basePath: string, filters: SkillsPageFilters, hash?: string): string; // omits defaults, e.g. '/agents?section=custom#skills'
+export interface SkillsPageData {
+	installed: Skill[];
+	installedMeta: { total: number; limit: number; offset: number };
+	catalog: SkillCatalogEntry[];
+	catalogTotal: number;
+	catalogLimit: number;
+	loadErrors: { installed: string | null; catalog: string | null };
+}
+export async function loadSkillsPageData(filters: SkillsPageFilters): Promise<SkillsPageData>; // the exact Promise.all + .then/.catch from the old skills/page.tsx
+```
+
+- [ ] Tests for `parseSkillsSearchParams` (bad section → installed, negative offset → 0, arrays take first) and `buildSkillsHref` (default filters → basePath+hash only; non-default → query). `loadSkillsPageData` is a thin wrapper over `skillsAPI` — mock `@/lib/api/skills` and assert the two error branches produce `loadErrors.installed === 'installed'` / `catalog === 'catalog'` with empty data.
+- [ ] Commit `refactor(web): extract skills page data loading + param parsing`.
+
+#### Task C.2: `SkillsPageClient.basePath` + `SkillsSection`
+
+**Files:**
+
+- Modify: `src/components/skills/SkillsPageClient.tsx` (props + `updateUrl` line ~88)
+- Create: `src/components/skills/SkillsSection.tsx`, `src/components/skills/SkillsSection.unit.spec.tsx`
+
+**Produces:**
+
+- `SkillsPageClientProps` gains `basePath?: string` (default `ROUTES.DASHBOARD_SKILLS`) and `hash?: string` (default `''`); `updateUrl` → `router.replace(\`${basePath}${params.size ? \`?${params}\` : ''}${hash}\`)`.
+- `SkillsSection({ data, filters }: { data: SkillsPageData; filters: SkillsPageFilters })` (client or server — it has no state of its own, so a **server** component is fine; `SkillsPageClient` inside is the client island): renders
+
+```tsx
+<section
+	id="skills"
+	data-testid="agents-skills-section"
+	className="mt-10 rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 sm:p-6"
+>
+	<PageHeader
+		icon={Sparkles}
+		title={t('skillsBlock.title')}
+		subtitle={t('skillsBlock.subtitle')}
+		tone="success"
+		actions={
+			<>
+				<Button href={ROUTES.DASHBOARD_SKILL_TEMPLATES} variant="secondary" size="sm">
+					{tSkills('list.browseTemplates')}
+				</Button>
+				<Button href={ROUTES.DASHBOARD_SKILL_NEW} size="sm">
+					<Plus className="w-3.5 h-3.5" aria-hidden="true" />
+					{tSkills('list.newSkill')}
+				</Button>
+			</>
+		}
+	/>
+	<SkillsPageClient {...data} filters={filters} basePath={ROUTES.DASHBOARD_AGENTS} hash="#skills" />
+</section>
+```
+
+with `t = getTranslations('dashboard.agentsPage')`, `tSkills = getTranslations('dashboard.skillsPage')` (server) — if `PageHeader` renders an `h1`, pass a smaller heading: check `PageHeader` and, if it hard-codes `h1`, add an optional `as?: 'h1' | 'h2'` prop (default `'h1'`) and use `as="h2"` here so the Agents page keeps a single `h1`.
+
+- [ ] **Step 1: Failing test** for `SkillsPageClient`: mock `@/i18n/navigation` `useRouter` → `{ replace: vi.fn() }`; render with `basePath="/agents" hash="#skills"`; click the "custom" tab; expect `replace` called with `'/agents?section=custom#skills'`. Second test: default props → `'/skills?section=custom'`.
+- [ ] **Step 2** FAIL → **Step 3** implement → **Step 4** PASS → **Step 5** commit `feat(web): SkillsSection block + SkillsPageClient basePath`.
+
+#### Task C.3: `/skills` redirect, back-links, revalidatePath, e2e
+
+**Files:**
+
+- Modify: `src/app/[locale]/(dashboard)/skills/page.tsx` → redirect to `buildSkillsHref(ROUTES.DASHBOARD_AGENTS, parseSkillsSearchParams(await searchParams), '#skills')` (same `redirect` idiom as Task A.3; doc comment mirrors it).
+- Modify: `src/components/skills/SkillDetailClient.tsx` (~77 href, ~951 `router.push`) and `src/app/[locale]/(dashboard)/skills/templates/page.tsx` (~24) → `ROUTES.DASHBOARD_AGENTS_SKILLS`.
+- Modify: `src/app/actions/skills.ts` (5 sites) and `src/app/actions/agent-capabilities.ts` (1 site): after each `revalidatePath('/skills')` add `revalidatePath('/agents')`.
+- e2e: in `flow-skill-bulk-operations.spec.ts:714`, `flow-skill-crud-scoping.spec.ts:721`, `flow-skill-marketplace-share.spec.ts:578` change `goto('/skills')` → `goto('/agents#skills')` (keep `${origin}` prefix where used) and re-target any `h1`/title assertions to `getByTestId('agents-skills-section')`; grep `skills.spec.ts`, `skills-list-filter.spec.ts`, `sec-pin-skills-scoping.spec.ts` for `goto(` on `/skills` index (they looked API-only — confirm and leave alone if so).
+- [ ] `pnpm type-check && pnpm lint && pnpm test -- skills` green → commit `feat(web): Skills catalog moves into the Agents tab; /skills redirects`.
+
+---
+
+## Phase 2 — Teams hub, Agents tab, Agents Chart, sidebar (after Phase 1 lane C, because it integrates `SkillsSection`)
+
+### Task B.1: `/teams` becomes tab 1 of the hub
+
+**Files:** `src/app/[locale]/(dashboard)/teams/page.tsx`
+
+- [ ] Import `TeamsPageTabs` from `@/components/agents/AgentsPageTabs`; wrap **both** return branches: outer `<div className="w-full">` (replace `p-6 max-w-screen-2xl mx-auto`), first child `<TeamsPageTabs active="teams" />`, then the existing content unchanged. Header icon: swap `Users` for `HumanAgentIcon` from `@/components/icons/HumanAgentIcon` in the `PageHeader` only (keep `Users` for cards/empty states). Update the doc comment: "Teams hub — tab 1 of Teams | Agents | Sessions | Archived".
+- [ ] `pnpm type-check` → commit `feat(web): Teams page renders as the first hub tab`.
+
+### Task B.2: Agents tab — Agents Chart button + Skills block
+
+**Files:** `src/app/[locale]/(dashboard)/agents/page.tsx`, `src/components/agents/AgentsList.tsx`
+
+- [ ] `AgentsList` PageHeader: add `actions={<Button href={ROUTES.DASHBOARD_AGENTS_CHART} variant="secondary" size="sm" className="gap-1.5" data-testid="agents-chart-link"><Network className="w-3.5 h-3.5" strokeWidth={1.5} aria-hidden="true" />{t('agentsChartCta')}</Button>}` (import `Network` from lucide). Confirm `Button` forwards `data-testid` (grep `components/ui/button.tsx`); if not, wrap in a `<span data-testid>`.
+- [ ] `AgentsPage({ searchParams })`: parse `parseSkillsSearchParams(await searchParams)`; add `loadSkillsPageData(filters)` to the existing `Promise.all`; render `<SkillsSection data={skills} filters={filters} />` after `<AgentsList … />`. Update the doc comment.
+- [ ] Unit test (create `AgentsList.unit.spec.tsx` or extend an existing one): renders `agents-chart-link` with href `/agents/chart`.
+- [ ] `pnpm type-check && pnpm lint` → commit `feat(web): Agents tab gets the Agents Chart button and the Skills block`.
+
+### Task B.3: `/agents/chart` page
+
+**Files:** Create `src/app/[locale]/(dashboard)/agents/chart/page.tsx`
+
+- [ ] Copy `teams/org-chart/page.tsx` structure; translations `dashboard.agentsChartPage`; back-link `← {t('backToAgents')}` → `ROUTES.DASHBOARD_AGENTS`; test ids `agents-chart-no-org` / `agents-chart-empty`; `const agentsOnly = payload ? { ...payload, members: [] } : null; const isEmpty = !agentsOnly || agentsOnly.agents.length === 0;` then `<OrgChartClient payload={agentsOnly} />`. Doc comment: "Agents Chart — the org chart with human members stripped; teams still group agents and `reportsToAgentId` chains still nest (all in `buildOrgTree`, untouched)."
+- [ ] `pnpm type-check` → commit `feat(web): Agents Chart page (org chart without human members)`.
+
+### Task B.4: Sidebar
+
+**Files:** `src/components/dashboard/DashboardSidebar.tsx` (navigation array lines 115–154, active check line ~307), unit spec (create `DashboardSidebar.unit.spec.tsx` if absent — check first: `ls src/components/dashboard/*.spec.tsx`).
+
+- [ ] Navigation becomes (comments preserved/adapted):
+
+```ts
+const navigation: Array<{
+	name: string;
+	href: string;
+	icon: LucideIcon | typeof HumanAgentIcon;
+	matchPrefixes?: string[];
+}> = [
+	{ name: t('navigation.dashboard'), href: ROUTES.DASHBOARD, icon: Home },
+	{ name: t('navigation.missions'), href: ROUTES.DASHBOARD_MISSIONS, icon: Target },
+	{ name: t('navigation.goals'), href: '/goals', icon: Gauge },
+	{ name: t('navigation.ideas'), href: ROUTES.DASHBOARD_IDEAS, icon: Lightbulb },
+	{ name: t('navigation.works'), href: ROUTES.DASHBOARD_WORKS, icon: FolderClosed },
+	{ name: t('navigation.tasks'), href: ROUTES.DASHBOARD_TASKS, icon: ListChecks },
+	// Navigation consolidation — "Teams" is the hub for people AND agents
+	// (tabs Teams | Agents | Sessions | Archived); Skills live on the Agents
+	// tab. Active for /teams/*, /agents/*, /skills/* (skill detail pages).
+	{
+		name: t('navigation.teams'),
+		href: ROUTES.DASHBOARD_TEAMS,
+		icon: HumanAgentIcon,
+		matchPrefixes: [ROUTES.DASHBOARD_TEAMS, ROUTES.DASHBOARD_AGENTS, ROUTES.DASHBOARD_SKILLS]
+	},
+	// Memory now also hosts the Meetings catalog; meeting detail/new pages
+	// keep Memory highlighted.
+	{
+		name: t('navigation.memory'),
+		href: ROUTES.DASHBOARD_MEMORY,
+		icon: Brain,
+		matchPrefixes: [ROUTES.DASHBOARD_MEMORY, ROUTES.DASHBOARD_MEETINGS]
+	},
+	{ name: t('navigation.templates'), href: ROUTES.DASHBOARD_TEMPLATES, icon: LayoutTemplate },
+	{ name: t('navigation.plugins'), href: ROUTES.DASHBOARD_PLUGINS, icon: Plug },
+	{ name: t('navigation.activity'), href: ROUTES.DASHBOARD_ACTIVITY, icon: Activity },
+	{ name: t('navigation.settings'), href: ROUTES.DASHBOARD_SETTINGS, icon: Settings }
+];
+```
+
+and the active check: `const prefixes = item.matchPrefixes ?? [item.href]; const isActive = prefixes.some((p) => pathname === p || pathname?.startsWith(p + '/'));`. Remove now-unused lucide imports (`Bot`, `Users`, `Sparkles`, `Video`) only if lint flags them (they are unused → yes, drop them; that is lint hygiene, not feature removal). Keep `key={item.name}` unique (Teams appears once).
+
+- [ ] Unit test: mock `@/i18n/navigation` (`usePathname` → configurable, `Link` → `a`, `useRouter`), `next-intl`, `../works/detail/WorkDetailContext` (`useWorkDetail: () => ({ config: {} })`), `../layout/WorkspaceSwitcher`, `./RunnerStatusPill`, `./SidebarActivityIndicator`, `@/components/ai/ChatPanel` (`ChatPanelExpandButton: () => null`), `@/lib/hooks/use-mounted` (`() => true`), `@/app/actions/auth`. Render with a minimal `user`; assert link texts contain no `navigation.meetings` / `navigation.skills` / `navigation.agents`, contain `navigation.teams` exactly once with an `svg` child containing a `rect` (HumanAgentIcon), and that with `usePathname` = `/agents/abc` the Teams link has the active class (`bg-surface-secondary`), and with `/meetings/xyz` the Memory link does.
+- [ ] `pnpm test -- DashboardSidebar && pnpm type-check && pnpm lint` → commit `feat(web): sidebar — Teams hub replaces Agents/Teams/Skills entries, Meetings folds into Memory`.
+
+### Task B.5: e2e (teams/agents)
+
+**Files:** `e2e/flow-teams-ui-journey.spec.ts`, `e2e/flow-agents-ui-journey.spec.ts`
+
+- [ ] Teams journey: on `/en/teams` additionally `await expect(page.getByTestId('agents-page-tab-teams')).toBeVisible()`; any assertion on the page wrapper padding/`h1` unchanged (PageHeader stays).
+- [ ] Agents journey: on `/en/agents` add `expect(page.getByTestId('agents-chart-link')).toHaveAttribute('href', /\/agents\/chart$/)` and `expect(page.getByTestId('agents-skills-section')).toBeVisible()`; add a test `page.goto('/en/agents/chart')` → either `agents-chart-empty` or the chart container is visible and `page.locator('[data-kind="member"]')` count is 0 (check `OrgChartClient` for how member cards are marked — if there is no attribute, add `data-node-kind={node.kind}` to the card wrapper in `OrgChartClient.tsx`; that is an additive attribute).
+- [ ] Commit `test(e2e): teams hub tabs, agents chart, skills block`.
+
+---
+
+## Phase 3 — Verify, review, docs, PR
+
+### Task V.1: Whole-app checks
+
+- [ ] From `apps/web`: `pnpm type-check` · `pnpm lint` · `pnpm test` (all vitest) — all green; paste the summary lines into the PR body.
+- [ ] `pnpm build` **only if** the machine has the RAM (Next build of this app is heavy); otherwise rely on type-check + the CI build.
+
+### Task V.2: Docs
+
+- [ ] `docs/features/agents-catalog.md`, `docs/features/skills-catalog.md`, `docs/features/index.md`, `docs/advanced/teams-and-organizations.md`, and the meetings/memory feature doc(s) found by `grep -ril "meetings" docs/features docs/advanced` — add/adjust one short paragraph each: where the feature now lives in the sidebar/tabs (`Teams → Agents tab → Skills block`, `Memory → Meetings block`, `Teams hub tabs`), and note that `/skills` and `/meetings` redirect. Commit `docs: navigation consolidation (Teams hub, Meetings in Memory, Skills in Agents)`.
+
+### Task V.3: Review + PR
+
+- [ ] Two independent review passes on the full diff (`git diff origin/develop...HEAD`): (1) correctness/regressions (redirects, params, RSC boundaries, i18n keys exist, test ids), (2) UX consistency vs spec (order of tabs, block placement, icon). Fix findings, re-run V.1.
+- [ ] Push branch, open PR to `develop` titled `feat(web): navigation consolidation — Teams hub, Meetings in Memory, Skills in Agents`, body = spec §2 + §3.1 table + verification output. Do **not** merge; the owner reviews. Report the PR URL.
+
+---
+
+## Self-review (done while writing)
+
+- Spec coverage: §3.1 (redirects A.3/C.3), §3.2 (B.4), §3.3 (0.3), §3.4 (B.1), §3.5 (B.2, C.1–C.3), §3.6 (B.3), §3.7 (A.1–A.4), §3.8 (0.1), §3.9 (0.1), §3.10 (per-task tests + A.4/B.5/C.3), §3.11 (V.2). ✔
+- Type consistency: `SkillsPageData`/`SkillsPageFilters` (C.1) are what `SkillsSection` (C.2) and `AgentsPage` (B.2) consume; `MemoryMeetingsData` (A.3) is what `MemoryShell` consumes; `TeamsPageTabs` alias (0.3) used in B.1. ✔

--- a/docs/specs/features/navigation-consolidation/spec.md
+++ b/docs/specs/features/navigation-consolidation/spec.md
@@ -1,0 +1,168 @@
+# Navigation consolidation — Meetings → Memory, Agents → Teams hub, Skills → Agents
+
+**Status:** approved (owner request, 2026-08-17) · **Owner:** Ever Works platform · **Scope:** `apps/web` only (no API changes)
+
+## 1. Problem
+
+The dashboard sidebar has grown one entry per feature. Three of them are really facets of a bigger
+concept and read as clutter:
+
+| Today (sidebar)            | Really is …                                                              |
+| -------------------------- | ------------------------------------------------------------------------ |
+| **Meetings** (`/meetings`) | a memory source — transcripts + AI summaries ingest straight into Memory |
+| **Agents** + **Teams**     | one org — the same people/agents hierarchy seen from two doors           |
+| **Skills** (`/skills`)     | something Agents own — nobody browses skills without an agent in mind    |
+
+## 2. Goal (owner's words, normalised)
+
+1. **Meetings** — remove from the sidebar; the Meetings catalog becomes a **block on the Memory page**.
+2. **Agents → Teams** — rename the sidebar entry to **Teams** with a **human/agent** icon. The page has
+   tabs **Teams | Agents | Sessions | Archived**. The old `/teams` page content moves into the first tab.
+   The **Agents** tab gets an **"Agents Chart"** button (agent hierarchy, no human members). The **Teams**
+   tab keeps its **Org Chart** (humans + agents).
+3. **Skills** — remove from the sidebar; the Skills catalog becomes a **block inside the Agents tab**.
+
+Non-goals: no API/schema changes; no URL renames of detail pages (`/agents/[id]`, `/teams/[id]`,
+`/skills/[id]`, `/meetings/[id]`); no change to per-agent Skills bindings (`/agents/[id]/skills`).
+
+## 3. Design decisions
+
+### 3.1 URLs stay; the sidebar and tab strip are what change
+
+Deep links, e2e matrices, docs, and the AI/MCP tools all reference `/agents/*`, `/teams/*`,
+`/skills/*`, `/meetings/*`. Moving routes would be churn with no user value. So:
+
+- **`/teams`** = hub, tab **Teams** (old Teams page content). Sidebar "Teams" links here.
+- **`/agents`** = tab **Agents** (existing catalog) + **Skills block** + **Agents Chart** button.
+- **`/agents/sessions`**, **`/agents/archived`** = tabs 3–4, unchanged content.
+- **`/agents/chart`** = new page, "Agents Chart".
+- **`/memory`** = Memory page + **Meetings block** (anchor `#meetings`).
+- **`/meetings`** (index only) → **redirect** to `/memory?<same query>#meetings`.
+  `/meetings/new`, `/meetings/[id]` untouched.
+- **`/skills`** (index only) → **redirect** to `/agents?<same query>#skills`.
+  `/skills/new`, `/skills/[id]`, `/skills/templates` untouched.
+
+Redirects (not deletions) honour the no-removal rule and keep every bookmark working.
+
+### 3.2 Sidebar
+
+New order (removed: Agents-as-is, Meetings, Skills, old Teams; added: merged **Teams**):
+
+`Dashboard · Missions · Goals · Ideas · Works · Tasks · **Teams** · Memory · Templates · Plugins · Activity · Settings`
+
+- **Teams** takes the slot Agents had (after Tasks); `href = ROUTES.DASHBOARD_TEAMS`.
+- Active-state matching gains optional `matchPrefixes`:
+    - Teams: `['/teams', '/agents', '/skills']`
+    - Memory: `['/memory', '/meetings']`
+- **Icon** — new `HumanAgentIcon` (`components/icons/HumanAgentIcon.tsx`): a lucide-style 24×24 stroke
+  SVG, left half a person (head circle + shoulders, from lucide `user`), right half a bot head (rounded
+  rect + antenna + two eyes, from lucide `bot`). Same `strokeWidth`/`className` contract as lucide icons so
+  it drops into the nav item's `<item.icon>` slot. Also used as the Teams hub PageHeader icon.
+
+### 3.3 Tab strip
+
+`AgentsPageTabs` → extended in place (file kept, exported name kept, plus a new alias `TeamsPageTabs`) with
+`active: 'teams' | 'agents' | 'sessions' | 'archived'`, first tab **Teams** → `/teams`. Test ids stay
+`agents-page-tabs` / `agents-page-tab-<key>` (adds `agents-page-tab-teams`). Rendered on `/teams`, `/agents`,
+`/agents/sessions`, `/agents/archived`. Sub-pages (`/teams/new`, `/teams/[id]`, `/teams/org-chart`,
+`/agents/[id]/*`, `/agents/chart`) do not render it (same as today for agent detail).
+
+### 3.4 Teams tab (`/teams`)
+
+Existing `TeamsPage` body, unchanged in behaviour, wrapped as `<div className="w-full"><TeamsPageTabs
+active="teams" /> …existing content… </div>` (drop the page-local `p-6 max-w-screen-2xl mx-auto` wrapper so
+it matches the other tabs' width). Both the no-org state and the empty state still render under the tabs.
+Header keeps org chip · **Org Chart** · **New team**.
+
+### 3.5 Agents tab (`/agents`)
+
+- `AgentsList` PageHeader gains `actions` = **Agents Chart** secondary button (lucide `Network` icon) →
+  `ROUTES.DASHBOARD_AGENTS_CHART` (`/agents/chart`), `data-testid="agents-chart-link"`.
+- Below the agent grid: **Skills block** (`components/skills/SkillsSection.tsx`, client wrapper):
+  a card (`rounded-xl border … bg-card`) with `id="skills"`, header (Sparkles icon tile, title
+  `skillsPage.title`, subtitle, actions **Browse templates** + **New skill** — same buttons as the old page),
+  then the existing `SkillsPageClient` unchanged in behaviour.
+- `SkillsPageClient` gains an optional `basePath` prop (default `ROUTES.DASHBOARD_SKILLS`) used by
+  `updateUrl` → on `/agents` it replaces to `/agents?section=…&search=…#skills`.
+- `AgentsPage` reads the same search params the old Skills page did (`section`, `search`,
+  `installedOffset`, `catalogOffset`) and server-fetches installed + catalog with the same defensive
+  `.then/.catch` shape (extract the fetch into a small shared helper `lib/skills-page-data.ts` so `/skills`'s
+  logic is not duplicated — the redirect route no longer needs it, but the helper is where the parsing
+  lives).
+- `revalidatePath('/skills')` calls in `app/actions/skills.ts` and `agent-capabilities.ts` gain a sibling
+  `revalidatePath('/agents')` (additive).
+- Back-links: `SkillDetailClient` (2 places) and `skills/templates/page.tsx` point at
+  `ROUTES.DASHBOARD_AGENTS_SKILLS` (`/agents#skills`) instead of `/skills`.
+
+### 3.6 Agents Chart (`/agents/chart`)
+
+New server page mirroring `teams/org-chart/page.tsx`: resolve org, fetch `teamsAPI.orgChart(org.id)`, then
+render `OrgChartClient` with `payload = { ...payload, members: [] }` — teams still group, agents nest by
+`reportsToAgentId` exactly as `buildOrgTree` already does, humans are omitted. Title/subtitle/back-link copy
+under `dashboard.agentsChartPage.*`; back-link → `/agents`. Empty state when there are no agents.
+Test ids: `agents-chart-no-org`, `agents-chart-empty`. No new tree logic; `buildOrgTree` untouched.
+
+### 3.7 Meetings block on Memory (`/memory#meetings`)
+
+- New `components/memory/MemoryMeetingsPanel.tsx` (client, same card chrome as `AgentMemoryPanel`):
+  header (Video icon, title `meetingsPage.title`, subtitle, **New meeting** button → `/meetings/new`),
+  the connect hint, the source/Work filter form (plain GET form, `action="/memory#meetings"`), the
+  `MeetingCard` grid, load-error box, empty state, prev/next pagination — i.e. `MeetingsList` minus the
+  `PageHeader`, with all hrefs rebased to `/memory…#meetings`. Implement by giving `MeetingsList` two props:
+  `variant: 'page' | 'panel'` (panel = card chrome + no PageHeader) and `basePath` (default `/meetings`),
+  and have the panel render `<MeetingsList variant="panel" basePath="/memory" … />`. Existing test ids
+  (`meetings-shell`, `meetings-grid`, `meetings-empty`, `meetings-load-error`, `meetings-source-filter`,
+  `meetings-work-filter`, `meetings-connect-hint`) are preserved so the e2e journey only changes its URLs.
+- `MemoryPage` reads `searchParams` (`source`, `workId`, `offset` — same names and same whitelisting the old
+  Meetings page did; move `buildMeetingsHref` + parsing into `lib/api/meetings.shared.ts` or a sibling
+  helper so both the redirect route and the panel share it), server-fetches meetings (`PAGE_SIZE = 12`,
+  `+1` look-ahead) and the Work options, and passes them to `MemoryShell` as a new optional `meetings` prop.
+- Placement in `MemoryShell`: directly after `AgentMemoryPanel` (memory sources together), before the
+  consolidation surface and the document search/list.
+- Sidebar Memory item is active on `/meetings/*` (detail/new pages).
+- Back-links: `MeetingDetailClient` (2 places), `MeetingForm` (2 places) → `ROUTES.DASHBOARD_MEMORY_MEETINGS`
+  (`/memory#meetings`).
+
+### 3.8 Constants (`lib/constants.ts`)
+
+Add: `DASHBOARD_AGENTS_CHART: '/agents/chart'`, `DASHBOARD_AGENTS_SKILLS: '/agents#skills'`,
+`DASHBOARD_MEMORY_MEETINGS: '/memory#meetings'`. Keep every existing constant.
+
+### 3.9 i18n (`messages/en.json` only — other locales deep-merge from `en`)
+
+- `dashboard.sidebar.navigation.teams` — keep "Teams" (already exists). `navigation.agents/meetings/skills`
+  keys stay (unused now, harmless; other surfaces may reference them).
+- `dashboard.agentsPage.pageTabs.teams: "Teams"`.
+- `dashboard.agentsPage.agentsChartCta: "Agents Chart"`.
+- `dashboard.agentsChartPage.{title,subtitle,backToAgents,empty,noOrg}`.
+- `dashboard.memoryPage.meetings.{title?}` — reuse `dashboard.meetingsPage.*` for all copy; only add
+  `dashboard.memoryPage.meetingsBlockHint` if a Memory-specific one-liner is wanted (optional).
+- `dashboard.agentsPage.skillsBlock.subtitle` (optional; default to `skillsPage.subtitle`).
+
+### 3.10 Tests
+
+- **Unit (vitest):** `AgentsPageTabs` (4 tabs, active state, teams first) · `HumanAgentIcon` renders an svg ·
+  `MeetingsList` panel variant rebases hrefs to `/memory…#meetings` and hides the PageHeader ·
+  `SkillsPageClient` `basePath` drives `router.replace` · sidebar: no Meetings/Skills/Agents entries, Teams
+  present with the merged icon, active on `/agents/x` and `/skills/x`; Memory active on `/meetings/x`.
+- **e2e (Playwright) updates:** `flow-meetings-ui-journey.spec.ts` (URLs `/en/meetings…` →
+  `/en/memory…#meetings`; the "sidebar Meetings link" test becomes "sidebar has no Meetings link; `/meetings`
+  redirects to `/memory#meetings`"), `flow-teams-ui-journey.spec.ts` (tab strip present, `agents-page-tab-teams`
+  active), `flow-agents-ui-journey.spec.ts` (Skills block + Agents Chart link on `/en/agents`), the `/skills`
+  gotos in `flow-skill-bulk-operations`, `flow-skill-crud-scoping`, `flow-skill-marketplace-share`
+  (→ `/agents#skills`, or assert the redirect), `skills.spec.ts` / `skills-list-filter.spec.ts` if they touch
+  the index UI. New: `/en/agents/chart` renders and contains no `member` cards.
+- **Type-check + lint + unit** must be green in `apps/web`. e2e cannot run locally in this session (needs the
+  API + DB); the updated specs are reviewed for correctness against the new DOM/test ids instead.
+
+### 3.11 Docs
+
+Update the user-facing feature docs that describe the sidebar/pages: `docs/features/agents-catalog.md`,
+`docs/features/skills-catalog.md`, `docs/features/index.md`, `docs/advanced/teams-and-organizations.md`, and
+the Meetings/Memory feature doc if one exists — one short "where to find it" paragraph each; no rewrites.
+
+## 4. Out of scope / follow-ups
+
+- Merging `/agents/*` under `/teams/*` URLs (deliberately not done).
+- A dedicated agent-only reports-to chart that ignores teams (the Agents Chart keeps team grouping).
+- Removing the now-unused `navigation.meetings/skills/agents` i18n keys.

--- a/packages/agent/src/utils/index.ts
+++ b/packages/agent/src/utils/index.ts
@@ -12,3 +12,7 @@ export * from './generation-cancellation.utils';
 export * from './ssrf-guard';
 export * from './redaction';
 export * from './secret-scan';
+// `isUniqueConstraintError` — services outside this package need it too. It was
+// only reachable via a deep relative import, so `apps/api` could not use it and
+// `organization.service.ts` let a lost slug race escape as a raw 500.
+export * from './db-error.utils';


### PR DESCRIPTION
Routine promotion. **4 commits, zero DB migrations** — a plain image roll.

| PR | What |
|---|---|
| [#2105](https://github.com/ever-works/ever-works/pull/2105) | EW-077…081 honest verification/magic-link failures, **+ a TLS-classifier defect found in review**, **+ the org-slug race 500** |
| [#2111](https://github.com/ever-works/ever-works/pull/2111) | three E2E specs that were asserting the defects #2106/#2108/#2093 fixed |
| [#2113](https://github.com/ever-works/ever-works/pull/2113) | uptime monitor: its retry and vantage-point control had never run on a transport failure |
| [#2112](https://github.com/ever-works/ever-works/pull/2112) | navigation consolidation (another session) |

## The two that touch production behaviour

**Org-slug race → 500.** `allocateUsername` reserves nothing, so two people registering a company with the same name at the same moment both get told the slug is free; the loser's UNIQUE violation escaped as HTTP 500. Now retried (not 409 — the slug is *derived*, so "Acme" should yield `acme-2` and a 201). Control-verified: retry disabled → exactly the 2 new race tests fail (29/31); with it, 31/31.

**Verification-error classifier.** `verifyEmailErrorCode` stem-matched `/expir/i` *before* checking for a `statusCode`, so an expired **TLS certificate** on the API would tell the user their *verification link* had expired — sending them to fetch a new link that fails identically. Reordered; control-verified 1-of-9 → 9/9.

## Gating

`develop` is green on `363d74f9` (CI, k8s-build, Docker Images Dev, Post-Deploy Smoke) and each PR merged only after its own full-green run. The stage E2E gate runs on the push to `stage` and is **not** bypassed here.

Expect the stage E2E to still be red overall — it has been since 2026-08-11 for pre-existing reasons. #2111 removes three failures the last cascade caused; it does not fix the older ones.