### PR TITLE
test(e2e/goals): open the Progress tab with clickUntil, not a bare click

### DIFF
--- a/apps/web/e2e/flow-goals-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-goals-ui-journey.spec.ts
@@ -357,10 +357,18 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         // — and it opens on 'dod'. The Progress/Details/Outcome sections still
         // exist under exactly these names, but they are inside the 'progress'
         // panel, so the tab has to be opened before they render at all.
-        await page.getByRole('tab', { name: 'Progress log' }).click();
+        // 🛑 clickUntil, not click: the tab strip is client state, so a click
+        // dispatched before hydration is SWALLOWED and the panel never opens —
+        // the same hazard this file already documents for the outcome listbox.
+        // A bare click left this test failing on the heading below, which reads
+        // as "the section is gone" rather than "the tab never opened".
+        const progressHeading = page.getByRole('heading', { name: 'Progress' });
+        await clickUntil(page.getByRole('tab', { name: 'Progress log' }), () =>
+            progressHeading.isVisible().catch(() => false),
+        );
 
         // Section scaffold.
-        await expect(page.getByRole('heading', { name: 'Progress' })).toBeVisible();
+        await expect(progressHeading).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Outcome' })).toBeVisible();
 
@@ -496,7 +504,14 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         // this page open on 'dod' — without this click the trigger below is
         // not in the DOM at all and the test fails looking like a missing
         // control rather than an unopened tab.
-        await page.getByRole('tab', { name: 'Progress log' }).click();
+        // Same hydration caveat as above — the trigger below only exists once
+        // the Progress panel is actually open.
+        await clickUntil(page.getByRole('tab', { name: 'Progress log' }), () =>
+            page
+                .locator('#main-content button[aria-haspopup="listbox"]')
+                .isVisible()
+                .catch(() => false),
+        );
 
         // The only listbox trigger INSIDE the page content is the outcome
         // override. Scoped to #main-content because since a350801a the chat


### PR DESCRIPTION
Correcting my own miss from [#2111](https://github.com/ever-works/ever-works/pull/2111).

## What happened

#2093 turned the Goal detail page into a tab strip that opens on `dod`, so the `Progress` / `Details` / `Outcome` sections live in a panel that must be opened first. I added:

```ts
await page.getByRole('tab', { name: 'Progress log' }).click();
```

The stage E2E on `ea00ad6a` **still failed** — and it failed on the heading at line 363, not on the tab. So the click did not throw. It was **swallowed**.

## The idiom was already in this file

`flow-goals-ui-journey.spec.ts` documents this exact hazard for the outcome listbox:

> the dropdown is rendered by client state, so a trigger click before hydration is swallowed and no listbox ever appears

…and imports `clickUntil` three lines from the top for precisely that reason. The tab strip is the same kind of client state. I reached for the wrong idiom in a file that already had the right one.

`clickUntil` re-clicks until a post-condition holds, surviving an unhydrated first attempt. Both call sites now assert on what the click is *for* — the `Progress` heading, and the outcome listbox trigger — instead of assuming it landed.

## Why it matters beyond this test

A swallowed click doesn't fail at the click; it fails at the **next assertion**. So it reads as *"the section is gone"* when the truth is *"the tab never opened"* — which is what sent me hunting for a defect in the Goals UI that was never there.

## Context: the E2E is genuinely improving

Failing specs on stage went **13 → 8** with **zero new failures** after #2111, which fixed `auth.spec.ts` and `flow-email-verification-deep.spec.ts` (both were asserting the defects #2106/#2108 had *fixed*). Three `flow-conversations-*` specs also went green — not my doing, so not claimed.

This PR targets the one spec I said I had fixed and hadn't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for progress and outcome controls to become available after page hydration.
  * Added verification that tab interactions are successfully processed before tests continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->