### PR TITLE
cascade: stage → main (goals E2E clickUntil fix)

### DIFF
--- a/apps/web/e2e/flow-goals-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-goals-ui-journey.spec.ts
@@ -357,10 +357,18 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         // — and it opens on 'dod'. The Progress/Details/Outcome sections still
         // exist under exactly these names, but they are inside the 'progress'
         // panel, so the tab has to be opened before they render at all.
-        await page.getByRole('tab', { name: 'Progress log' }).click();
+        // 🛑 clickUntil, not click: the tab strip is client state, so a click
+        // dispatched before hydration is SWALLOWED and the panel never opens —
+        // the same hazard this file already documents for the outcome listbox.
+        // A bare click left this test failing on the heading below, which reads
+        // as "the section is gone" rather than "the tab never opened".
+        const progressHeading = page.getByRole('heading', { name: 'Progress' });
+        await clickUntil(page.getByRole('tab', { name: 'Progress log' }), () =>
+            progressHeading.isVisible().catch(() => false),
+        );
 
         // Section scaffold.
-        await expect(page.getByRole('heading', { name: 'Progress' })).toBeVisible();
+        await expect(progressHeading).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
         await expect(page.getByRole('heading', { name: 'Outcome' })).toBeVisible();
 
@@ -496,7 +504,14 @@ test.describe('Goals — /goals/:id detail (UI)', () => {
         // this page open on 'dod' — without this click the trigger below is
         // not in the DOM at all and the test fails looking like a missing
         // control rather than an unopened tab.
-        await page.getByRole('tab', { name: 'Progress log' }).click();
+        // Same hydration caveat as above — the trigger below only exists once
+        // the Progress panel is actually open.
+        await clickUntil(page.getByRole('tab', { name: 'Progress log' }), () =>
+            page
+                .locator('#main-content button[aria-haspopup="listbox"]')
+                .isVisible()
+                .catch(() => false),
+        );
 
         // The only listbox trigger INSIDE the page content is the outcome
         // override. Scoped to #main-content because since a350801a the chat


### PR DESCRIPTION
Promotion of [#2117](https://github.com/ever-works/ever-works/pull/2117). Owner pre-approved `stage → main` for Ever Works.

**Single commit, test-only** — [#2116](https://github.com/ever-works/ever-works/pull/2116) `e0541414`. No product code, no migrations, no runtime behaviour change. It only alters an E2E spec, so the shipped images are functionally identical to what is already running in production.

Opens the Goal detail `Progress log` tab with `clickUntil` instead of a bare `.click()`, which was swallowed before hydration and then failed on the *next* assertion — reading as "the section is gone" rather than "the tab never opened".

`#2117` merged with **34/34** checks green.

The promotion gate will fail on `stage E2E must be green` — red since 2026-08-11 for pre-existing reasons. Trend is good: **13 → 8** failing specs after #2111, zero new failures; this PR targets the one spec I had claimed fixed and hadn't.