### PR TITLE
fix(meetings): give the capture form's roster section a heading

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -7264,6 +7264,7 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
+                "participants": "Participants",
                 "transcript": "Transcript"
             },
             "sources": {

--- a/apps/web/src/components/meetings/MeetingForm.tsx
+++ b/apps/web/src/components/meetings/MeetingForm.tsx
@@ -296,11 +296,17 @@ export function MeetingForm({ works = [] }: { works?: MeetingWorkOption[] }) {
                 capture form was the last surface still teaching that format;
                 it now authors the roster exactly the way the detail page's
                 edit dialog does, so there is one way to name a participant.
-                The editor carries its own label and count, so the section
-                needs no heading of its own. */}
+
+                The editor owns the label (it pairs it with the capacity
+                counter on one line), so the section's heading is that label
+                promoted to an `h2` via `labelAs` rather than a second heading
+                above it — which would print "Participants" twice. Before
+                `labelAs` existed this section had no heading at all while its
+                peers did, and the e2e assertion for it sat red on stage. */}
             <section className={sectionCard}>
                 <MeetingParticipantsEditor
-                    label={t('fields.participants')}
+                    label={t('sections.participants')}
+                    labelAs="h2"
                     rows={participantRows}
                     onChange={setParticipantRows}
                     disabled={pending}

--- a/apps/web/src/components/meetings/MeetingForm.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingForm.unit.spec.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../messages/en.json';
+import { MeetingForm } from './MeetingForm';
+
+/**
+ * MeetingForm — the `/meetings/new` capture form's rendered contract.
+ *
+ * This spec deliberately mirrors, assertion for assertion, the e2e test
+ * `flow-meetings-ui-journey.spec.ts › "the capture form renders its sections,
+ * fields and actions"`. That test had been red on `stage` for days because the
+ * roster section lost its heading when the structured editor replaced the old
+ * textarea (a2791b66), and nothing caught it: the e2e suite runs ONLY on a
+ * `stage` push, so the regression could not fail a PR.
+ *
+ * Two consequences shaped how this file is written:
+ *
+ *  1. Translations resolve from the REAL `messages/en.json`, not the usual
+ *     echo-the-key mock. The e2e test asserts on user-visible English
+ *     ("Participants", "Where it came from", "Title"), so a spec that echoed
+ *     keys would pass while a missing or misspelled key shipped.
+ *  2. Every assertion the e2e makes is repeated here, not just the heading
+ *     that regressed. The e2e failed on its THIRD assertion, which means the
+ *     nine after it had not executed in days — this pins all of them.
+ */
+
+/** Resolve `t('a.b')` against a namespace of the real message catalogue. */
+function translator(namespace: string) {
+    return (key: string) => {
+        const path = `${namespace}.${key}`.split('.');
+        let node: unknown = messages;
+        for (const segment of path) {
+            if (typeof node !== 'object' || node === null) return path.join('.');
+            node = (node as Record<string, unknown>)[segment];
+        }
+        return typeof node === 'string' ? node : path.join('.');
+    };
+}
+
+vi.mock('next-intl', () => ({
+    useTranslations: (namespace: string) => translator(namespace),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock('./actions', () => ({
+    createMeetingAction: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+describe('MeetingForm — capture form contract', () => {
+    it('renders its three section headings, every field, and both actions', () => {
+        render(<MeetingForm />);
+
+        // Sections. "Participants" is the one that regressed: the roster's
+        // label is promoted to an h2 so the section is a peer of the other two
+        // rather than the only unlabelled one.
+        expect(screen.getByRole('heading', { level: 1, name: 'New meeting' })).toBeVisible();
+        expect(screen.getByRole('heading', { name: 'Where it came from' })).toBeVisible();
+        expect(screen.getByRole('heading', { name: 'Participants' })).toBeVisible();
+        expect(screen.getByRole('heading', { name: 'Transcript' })).toBeVisible();
+
+        // Fields.
+        expect(screen.getByLabelText('Title')).toBeVisible();
+        expect(screen.getByTestId('meeting-started-at')).toBeVisible();
+        expect(screen.getByTestId('meeting-ended-at')).toBeVisible();
+        expect(screen.getByTestId('meeting-source-select')).toBeVisible();
+        expect(screen.getByTestId('meeting-edit-participants')).toBeVisible();
+        expect(screen.getByTestId('meeting-transcript-input')).toBeVisible();
+
+        // Actions.
+        expect(screen.getByTestId('meeting-create-submit')).toBeVisible();
+        expect(screen.getByRole('link', { name: 'Cancel' })).toBeVisible();
+    });
+
+    it('prints "Participants" exactly once — the heading IS the roster label', () => {
+        render(<MeetingForm />);
+
+        expect(screen.getAllByText('Participants')).toHaveLength(1);
+    });
+});

--- a/apps/web/src/components/meetings/MeetingParticipantsEditor.tsx
+++ b/apps/web/src/components/meetings/MeetingParticipantsEditor.tsx
@@ -100,11 +100,24 @@ const rowIcon =
 
 export function MeetingParticipantsEditor({
     label,
+    labelAs = 'span',
     rows,
     onChange,
     disabled = false,
 }: {
     label: string;
+    /**
+     * Element the label renders as. Defaults to a `span` — inside the edit
+     * dialog the roster is one field among others and has no business
+     * appearing in the page's heading outline.
+     *
+     * The `/meetings/new` capture form passes `h2`, because there the roster
+     * IS a section, peer to "Where it came from" and "Transcript". The editor
+     * carries the label (it owns the row that pairs it with the capacity
+     * counter), so promoting it here is what gives that section a heading —
+     * a second heading in the form would put the word on screen twice.
+     */
+    labelAs?: 'span' | 'h2';
     rows: ParticipantRow[];
     onChange: (rows: ParticipantRow[]) => void;
     disabled?: boolean;
@@ -121,6 +134,9 @@ export function MeetingParticipantsEditor({
 
     const atCapacity = rows.length >= MEETING_PARTICIPANTS_MAX;
 
+    /** `span` in the dialog, `h2` on the capture form — see `labelAs`. */
+    const Label = labelAs;
+
     const addRow = () => {
         if (atCapacity) return;
         const row = newParticipantRow();
@@ -136,7 +152,17 @@ export function MeetingParticipantsEditor({
     return (
         <div data-testid="meeting-edit-participants">
             <div className="mb-2 flex items-baseline justify-between gap-3">
-                <span className="text-xs font-medium text-text dark:text-text-dark">{label}</span>
+                {/* As a heading it takes the sibling sections' weight
+                    (`text-sm font-semibold`); as a field label it keeps the
+                    quieter one it has always had. */}
+                <Label
+                    className={cn(
+                        'text-text dark:text-text-dark',
+                        labelAs === 'h2' ? 'text-sm font-semibold' : 'text-xs font-medium',
+                    )}
+                >
+                    {label}
+                </Label>
                 {/* Pure numerals — nothing to translate, and the cap only
                     becomes interesting as you approach it. */}
                 <span

--- a/apps/web/src/components/meetings/MeetingParticipantsEditor.unit.spec.tsx
+++ b/apps/web/src/components/meetings/MeetingParticipantsEditor.unit.spec.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { MeetingParticipantsEditor, newParticipantRow } from './MeetingParticipantsEditor';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+/**
+ * MeetingParticipantsEditor — the roster editor's own label.
+ *
+ * The editor is used in two places that need the label to carry different
+ * weight in the document outline: inside the `/meetings/[id]` edit dialog it
+ * is one field among others (a plain `<span>`), while on the `/meetings/new`
+ * capture form its section is a peer of "Where it came from" and
+ * "Transcript", both of which are `<h2>`s.
+ *
+ * That mismatch was a real defect, not a cosmetic one: the capture form's
+ * roster section had no heading at all, so the e2e assertion
+ * `getByRole('heading', { name: 'Participants' })` had been red on stage for
+ * days. These specs pin both renderings so the outline cannot drift back —
+ * unit specs run on every PR, the e2e suite only on `stage`.
+ */
+describe('MeetingParticipantsEditor label', () => {
+    const rows = [newParticipantRow('Ada Lovelace', 'ada@example.com')];
+
+    it('renders the label as a non-heading by default (the edit dialog)', () => {
+        render(<MeetingParticipantsEditor label="Participants" rows={rows} onChange={() => {}} />);
+
+        expect(screen.getByText('Participants').tagName).toBe('SPAN');
+        expect(screen.queryByRole('heading', { name: 'Participants' })).toBeNull();
+    });
+
+    it('renders the label as a section heading when asked (the capture form)', () => {
+        render(
+            <MeetingParticipantsEditor
+                label="Participants"
+                labelAs="h2"
+                rows={rows}
+                onChange={() => {}}
+            />,
+        );
+
+        const heading = screen.getByRole('heading', { name: 'Participants' });
+        expect(heading.tagName).toBe('H2');
+    });
+
+    it('keeps the capacity counter alongside the heading', () => {
+        render(
+            <MeetingParticipantsEditor
+                label="Participants"
+                labelAs="h2"
+                rows={rows}
+                onChange={() => {}}
+            />,
+        );
+
+        expect(screen.getByTestId('meeting-edit-participants-count')).toHaveTextContent('1/');
+    });
+});


### PR DESCRIPTION
## Summary

`/meetings/new` has had a section with no heading since `a2791b66` replaced the free-text participants textarea with the structured row editor. Its two peers — **Where it came from** and **Transcript** — are `h2`s; the roster had only the editor's own quiet field label. That is a real gap in the form's outline, and it is why this e2e assertion has been **red on `stage` for days**:

```
apps/web/e2e/flow-meetings-ui-journey.spec.ts
  › "the capture form renders its sections, fields and actions"
  › await expect(page.getByRole('heading', { name: 'Participants' })).toBeVisible();
```

## The fix

The editor **owns** the label — it pairs it with the capacity counter on one line — so adding a second heading above it would print "Participants" on screen twice. Instead:

- `MeetingParticipantsEditor` takes an optional **`labelAs`** (`'span' | 'h2'`, default `'span'`), rendering the label at the sibling sections' weight (`text-sm font-semibold`) when it is a heading.
- The capture form passes `labelAs="h2"` with a new `dashboard.meetingNew.sections.participants` key (`en.json` only — other locales deep-merge from `en`).
- The `/meetings/[id]` **edit dialog is unchanged** (still a `span`): inside a dialog the roster is one field among others and has no business in the page's heading outline.

No test ids changed. No API, schema or route change.

## Why unit specs, not just the e2e

The e2e suite runs **only on a `stage` push**, which is exactly how this shipped unnoticed. Two new specs run on every PR:

- `MeetingParticipantsEditor.unit.spec.tsx` — pins both renderings (`span` by default, `h2` on request) and that the counter stays alongside.
- `MeetingForm.unit.spec.tsx` — **mirrors the e2e test assertion for assertion**, resolving real `messages/en.json` strings so a missing or misspelled key fails too. This matters: the e2e failed on its **third** assertion, so the nine after it (Title field, five test ids, submit, Cancel link) had not executed in days. All of them are now pinned and pass.

## Verification

- New specs run against **unfixed** code first: 2 failed with exactly `Unable to find an accessible element with the role "heading" and name "Participants"`; green after the fix.
- `pnpm type-check` — 0 errors · `pnpm eslint <touched files>` — clean · `pnpm prettier --check` — clean.
- Full web unit suite: **204 files / 2007 tests passed**.
- Playwright not run locally (needs the API + a booted stack); the assertion it makes is mirrored 1:1 by `MeetingForm.unit.spec.tsx`.

Root cause confirmed by log triage of E2E runs `32118481160` and `31972666572` — this failure is present in **both**, so it predates and is unrelated to the navigation consolidation (#2112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved meeting form structure by presenting the Participants section as a properly styled heading.
  - Preserved participant editing, capacity tracking, and other existing behavior.

- **Localization**
  - Added the English “Participants” label for the meeting form.

- **Tests**
  - Added coverage for meeting form sections, fields, actions, participant labels, heading behavior, and capacity counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->