### PR TITLE
chore(cascade): develop → stage — Teams can be staffed with people (#2120)

### DIFF
--- a/apps/api/src/teams/teams.controller.ts
+++ b/apps/api/src/teams/teams.controller.ts
@@ -18,6 +18,7 @@ import type { Team, TeamResourceType } from '@ever-works/agent/teams';
 import { OrgChartService, TeamResourcesService, TeamsService } from '@ever-works/agent/teams';
 import type {
     OrgChartPayload,
+    OrgUserView,
     ResourceTeamRef,
     TeamMemberView,
     TeamResourceItem,
@@ -79,6 +80,17 @@ export class TeamsController {
         private readonly orgChart: OrgChartService,
         private readonly teamResources: TeamResourcesService,
     ) {}
+
+    @Get('users')
+    @ApiOperation({
+        summary: 'List the people in an Organization',
+        description:
+            'The directory behind the Teams add-member picker. Returns exactly the users that POST teams/:teamId/members accepts as a human member, so the picker cannot offer someone it would then be refused.',
+    })
+    @ApiResponse({ status: 200, description: 'Users listed' })
+    async listUsers(@Param('orgId', ParseUUIDPipe) orgId: string): Promise<OrgUserView[]> {
+        return this.teamsService.listOrgUsers(orgId);
+    }
 
     @Get('teams')
     @ApiOperation({

--- a/apps/web/src/app/[locale]/(dashboard)/teams/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/teams/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { teamsAPI, type Team, type TeamResourcesGrouped } from '@/lib/api/teams';
+import { teamsAPI, type OrgUser, type Team, type TeamResourcesGrouped } from '@/lib/api/teams';
 import { agentsAPI, type Agent } from '@/lib/api/agents';
 import { getWorks } from '@/app/actions/dashboard/works';
 import { TeamDetailClient } from '@/components/teams/TeamDetailClient';
@@ -10,7 +10,8 @@ import type { ResourceOption } from '@/components/teams/TeamResourcesSection';
  * v1 resolution (`orgs[0]`); a team can only exist inside an org, so
  * zero orgs — like an unknown team id — is a `notFound()`. The full
  * team list rides along for parent/sub-team name resolution and the
- * Agent list feeds the add-member + manager displays; both defensive.
+ * Agent list feeds the add-member + manager displays; both defensive. The
+ * org user directory feeds the same picker's `Member` (human) option.
  */
 export default async function TeamDetailPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
@@ -26,13 +27,14 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
         idea: [],
     };
 
-    const [team, teams, agentsResp, resources, worksResp] = await Promise.all([
+    const [team, teams, agentsResp, users, resources, worksResp] = await Promise.all([
         teamsAPI.get(org.id, id),
         teamsAPI.list(org.id).catch(() => [] as Team[]),
         agentsAPI.list({ limit: 100 }).catch(() => ({
             data: [] as Agent[],
             meta: { total: 0, limit: 100, offset: 0 },
         })),
+        teamsAPI.listUsers(org.id).catch(() => [] as OrgUser[]),
         teamsAPI.listResources(org.id, id).catch(() => emptyResources),
         getWorks({ limit: 100, offset: 0 }).catch(() => ({ success: false, works: [], total: 0 })),
     ]);
@@ -56,6 +58,7 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
             team={team}
             teams={teams}
             agents={agents}
+            users={users}
             resources={resources}
             works={works}
         />

--- a/apps/web/src/components/teams/TeamDetailClient.tsx
+++ b/apps/web/src/components/teams/TeamDetailClient.tsx
@@ -28,6 +28,7 @@ import { ROUTES } from '@/lib/constants';
 import { addTeamMemberAction, removeTeamMemberAction } from '@/app/actions/dashboard/teams';
 import { TeamResourcesSection, type ResourceOption } from '@/components/teams/TeamResourcesSection';
 import type {
+    OrgUser,
     Team,
     TeamDetail,
     TeamMemberRole,
@@ -77,6 +78,8 @@ export interface TeamDetailClientProps {
     teams: Team[];
     /** Org Agents — add-member select + manager/member name resolution. */
     agents: TeamAgentOption[];
+    /** Org people — the human half of the add-member select + name resolution. */
+    users: OrgUser[];
     /** Resources (Works/Agents/…) attached to this team, grouped by type. */
     resources: TeamResourcesGrouped;
     /** Org Works available to attach in the Resources section. */
@@ -86,23 +89,24 @@ export interface TeamDetailClientProps {
 /**
  * Teams & Prebuilt Companies §4.2 — `/teams/[id]` overview client.
  * Header (icon, manager chip, parent link, settings), roster with
- * add/remove (v1: agent members only — the user option is telegraphed
- * but disabled), and sub-team cards. Mutations go through the server
- * actions then `router.refresh()` so the server payload stays the
- * single source of truth.
+ * add/remove (Agents and people — the Type select switches which
+ * directory the Who select is drawn from), and sub-team cards.
+ * Mutations go through the server actions then `router.refresh()` so
+ * the server payload stays the single source of truth.
  */
 export function TeamDetailClient({
     org,
     team,
     teams,
     agents,
+    users,
     resources,
     works,
 }: TeamDetailClientProps) {
     const t = useTranslations('dashboard.teamsPage');
     const router = useRouter();
     const [memberType, setMemberType] = useState<TeamMemberType>('agent');
-    const [selectedAgentId, setSelectedAgentId] = useState('');
+    const [selectedMemberId, setSelectedMemberId] = useState('');
     const [role, setRole] = useState<TeamMemberRole>('member');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
@@ -116,31 +120,59 @@ export function TeamDetailClient({
         .map((childId) => teamById.get(childId))
         .filter((entry): entry is Team => Boolean(entry));
 
-    const rosterAgentIds = new Set(
-        team.members
-            .filter((member) => member.memberType === 'agent')
-            .map((member) => member.memberId),
-    );
+    const userById = new Map(users.map((user) => [user.id, user]));
+
+    /** Already on the roster, so not offerable again — the DB carries a
+     *  matching UNIQUE(teamId, memberType, memberId), and an option that can
+     *  only 409 is not a choice. Keyed per type: Agent ids and user ids are
+     *  separate id spaces, so one shared set would hide real candidates. */
+    const rosterIdsByType = (type: TeamMemberType) =>
+        new Set(
+            team.members
+                .filter((member) => member.memberType === type)
+                .map((member) => member.memberId),
+        );
+    const rosterAgentIds = rosterIdsByType('agent');
+    const rosterUserIds = rosterIdsByType('user');
     const addableAgents = agents.filter((agent) => !rosterAgentIds.has(agent.id));
+    const addableUsers = users.filter((user) => !rosterUserIds.has(user.id));
+
+    /** What the Who select offers, for whichever directory is selected. */
+    const addableOptions =
+        memberType === 'agent'
+            ? addableAgents.map((agent) => ({
+                  id: agent.id,
+                  label: agent.title ? `${agent.name} — ${agent.title}` : agent.name,
+              }))
+            : addableUsers.map((user) => ({
+                  id: user.id,
+                  // Usernames are unique, but they are not always
+                  // recognisable — the email is what lets you tell which
+                  // colleague this actually is. Shown when there is one.
+                  label: user.email ? `${user.username} — ${user.email}` : user.username,
+              }));
 
     const memberName = (member: TeamMemberView): string => {
         if (member.name) return member.name;
         if (member.memberType === 'agent') {
             return agentById.get(member.memberId)?.name ?? member.memberId;
         }
-        return member.memberId;
+        // The server resolves human members to their username, so this only
+        // fires when the User row is gone. Try the directory before falling
+        // back to echoing a raw UUID at whoever is reading the roster.
+        return userById.get(member.memberId)?.username ?? member.memberId;
     };
 
     const handleAdd = async () => {
-        if (!selectedAgentId || isSubmitting) return;
+        if (!selectedMemberId || isSubmitting) return;
         setIsSubmitting(true);
         try {
             await addTeamMemberAction(org.id, team.id, {
-                memberType: 'agent',
-                memberId: selectedAgentId,
+                memberType,
+                memberId: selectedMemberId,
                 role,
             });
-            setSelectedAgentId('');
+            setSelectedMemberId('');
             setRole('member');
             router.refresh();
         } catch {
@@ -304,15 +336,18 @@ export function TeamDetailClient({
                             <select
                                 id="team-member-type"
                                 value={memberType}
-                                onChange={(event) =>
-                                    setMemberType(event.target.value as TeamMemberType)
-                                }
+                                onChange={(event) => {
+                                    setMemberType(event.target.value as TeamMemberType);
+                                    // Agent ids and user ids are separate id
+                                    // spaces. Carrying the old selection across
+                                    // a type switch would post an Agent id as a
+                                    // user — a 404 the user cannot explain.
+                                    setSelectedMemberId('');
+                                }}
                                 className={SELECT_CLASSES}
                             >
                                 <option value="agent">{t('detail.addMemberAgent')}</option>
-                                <option value="user" disabled>
-                                    {t('detail.addMemberUser')}
-                                </option>
+                                <option value="user">{t('detail.addMemberUser')}</option>
                             </select>
                         </div>
                         <div className="flex-1 min-w-0">
@@ -324,16 +359,14 @@ export function TeamDetailClient({
                             </label>
                             <select
                                 id="team-member-select"
-                                value={selectedAgentId}
-                                onChange={(event) => setSelectedAgentId(event.target.value)}
+                                value={selectedMemberId}
+                                onChange={(event) => setSelectedMemberId(event.target.value)}
                                 className={SELECT_CLASSES}
                             >
                                 <option value="">{t('detail.addMemberSelectLabel')}</option>
-                                {addableAgents.map((agent) => (
-                                    <option key={agent.id} value={agent.id}>
-                                        {agent.title
-                                            ? `${agent.name} — ${agent.title}`
-                                            : agent.name}
+                                {addableOptions.map((option) => (
+                                    <option key={option.id} value={option.id}>
+                                        {option.label}
                                     </option>
                                 ))}
                             </select>
@@ -352,7 +385,7 @@ export function TeamDetailClient({
                         <Button
                             size="sm"
                             onClick={handleAdd}
-                            disabled={!selectedAgentId || isSubmitting}
+                            disabled={!selectedMemberId || isSubmitting}
                             loading={isSubmitting}
                             data-testid="team-member-add"
                             className="shrink-0"

--- a/apps/web/src/components/teams/TeamDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/teams/TeamDetailClient.unit.spec.tsx
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { addMemberMock, removeMemberMock, refreshMock } = vi.hoisted(() => ({
+    addMemberMock: vi.fn(),
+    removeMemberMock: vi.fn(),
+    refreshMock: vi.fn(),
+}));
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ refresh: refreshMock }),
+    Link: ({ href, children, ...rest }: any) => (
+        <a href={typeof href === 'string' ? href : ''} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('@/app/actions/dashboard/teams', () => ({
+    addTeamMemberAction: addMemberMock,
+    removeTeamMemberAction: removeMemberMock,
+}));
+vi.mock('@/components/teams/TeamResourcesSection', () => ({
+    TeamResourcesSection: () => <div data-testid="resources-section" />,
+}));
+
+import { TeamDetailClient } from './TeamDetailClient';
+
+/**
+ * The Teams add-member picker could not add a human.
+ *
+ * The `Type` select shipped `<option value="user" disabled>`, so `Member` was
+ * visible but unselectable, and `handleAdd` hardcoded `memberType: 'agent'` —
+ * two independent defects, either of which alone would have kept humans off
+ * every team. Neither was reachable by any existing test: nothing in the E2E
+ * suite touched `team-member-type`, `team-member-select` or `team-member-add`.
+ *
+ * These render the real component and drive the real controls, because both
+ * defects lived in the markup and the submit handler rather than in any
+ * function a unit test could have called directly.
+ */
+
+const ORG = { id: 'org-1', slug: 'acme', displayName: 'Acme' } as any;
+
+const AGENTS = [
+    { id: 'ag-1', name: 'Scout', title: 'Researcher' },
+    { id: 'ag-2', name: 'Scribe', title: null },
+];
+
+const USERS = [
+    { id: 'u-1', username: 'ruslan', email: 'ruslan@ever.co', avatar: null },
+    { id: 'u-2', username: 'dana', email: null, avatar: null },
+];
+
+function makeTeam(members: any[] = []) {
+    return {
+        id: 'team-1',
+        name: 'Engineering',
+        slug: 'engineering',
+        description: null,
+        parentTeamId: null,
+        managerAgentId: null,
+        avatarIcon: null,
+        organizationId: 'org-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        members,
+        childTeamIds: [],
+    } as any;
+}
+
+function renderDetail(team = makeTeam()) {
+    return render(
+        <TeamDetailClient
+            org={ORG}
+            team={team}
+            teams={[team]}
+            agents={AGENTS}
+            users={USERS as any}
+            resources={{ work: [], task: [], agent: [], mission: [], idea: [] } as any}
+            works={[]}
+        />,
+    );
+}
+
+const typeSelect = () => document.getElementById('team-member-type') as HTMLSelectElement;
+const whoSelect = () => document.getElementById('team-member-select') as HTMLSelectElement;
+const whoValues = () => [...whoSelect().options].map((o) => o.value).filter((v) => v !== '');
+
+describe('TeamDetailClient — adding a human member', () => {
+    beforeEach(() => {
+        addMemberMock.mockReset().mockResolvedValue(undefined);
+        removeMemberMock.mockReset();
+        refreshMock.mockReset();
+    });
+
+    it('control: both controls render and Agent is the default type', () => {
+        // If this failed, every "the Member option is selectable" assertion
+        // below would be vacuously true against a component that never
+        // rendered its picker at all.
+        renderDetail();
+        expect(typeSelect()).toBeTruthy();
+        expect(whoSelect()).toBeTruthy();
+        expect(typeSelect().value).toBe('agent');
+        expect(whoValues()).toEqual(['ag-1', 'ag-2']);
+    });
+
+    it('the Member option is SELECTABLE — the reported bug', () => {
+        renderDetail();
+        const memberOption = [...typeSelect().options].find((o) => o.value === 'user');
+        expect(memberOption).toBeTruthy();
+        expect(memberOption!.disabled).toBe(false);
+    });
+
+    it('choosing Member swaps the Who list from Agents to people', async () => {
+        renderDetail();
+        await userEvent.selectOptions(typeSelect(), 'user');
+
+        expect(whoValues()).toEqual(['u-1', 'u-2']);
+        // And the Agents are genuinely gone, not merely appended after.
+        expect(whoValues()).not.toContain('ag-1');
+    });
+
+    it('submits memberType "user" with the chosen person', async () => {
+        // The second half of the defect: `handleAdd` hardcoded 'agent', so even
+        // an enabled option would have posted an Agent membership carrying a
+        // user's id.
+        renderDetail();
+        await userEvent.selectOptions(typeSelect(), 'user');
+        await userEvent.selectOptions(whoSelect(), 'u-1');
+        await userEvent.click(screen.getByTestId('team-member-add'));
+
+        expect(addMemberMock).toHaveBeenCalledTimes(1);
+        expect(addMemberMock).toHaveBeenCalledWith('org-1', 'team-1', {
+            memberType: 'user',
+            memberId: 'u-1',
+            role: 'member',
+        });
+    });
+
+    it('still submits memberType "agent" for an Agent (the path that worked)', async () => {
+        renderDetail();
+        await userEvent.selectOptions(whoSelect(), 'ag-2');
+        await userEvent.click(screen.getByTestId('team-member-add'));
+
+        expect(addMemberMock).toHaveBeenCalledWith('org-1', 'team-1', {
+            memberType: 'agent',
+            memberId: 'ag-2',
+            role: 'member',
+        });
+    });
+
+    it('clears a pending selection when the type changes', async () => {
+        // Agent ids and user ids are separate id spaces. Carrying a selection
+        // across the switch would post an Agent's id as a user — a 404 with
+        // nothing on screen to explain it.
+        renderDetail();
+        await userEvent.selectOptions(whoSelect(), 'ag-1');
+        expect(whoSelect().value).toBe('ag-1');
+
+        await userEvent.selectOptions(typeSelect(), 'user');
+        expect(whoSelect().value).toBe('');
+        // Submit is inert until something is picked again.
+        expect(screen.getByTestId('team-member-add')).toBeDisabled();
+    });
+
+    it('does not offer someone already on the roster', async () => {
+        // `team_members` carries UNIQUE(teamId, memberType, memberId), so
+        // offering them again could only ever 409.
+        renderDetail(
+            makeTeam([
+                {
+                    id: 'tm-1',
+                    memberType: 'user',
+                    memberId: 'u-1',
+                    role: 'member',
+                    name: 'ruslan',
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                },
+            ]),
+        );
+        await userEvent.selectOptions(typeSelect(), 'user');
+
+        expect(whoValues()).toEqual(['u-2']);
+    });
+
+    it('filters the roster per type, so an Agent does not hide a person', async () => {
+        // A single shared id set would be wrong the moment the two spaces
+        // collide; this pins that the exclusion is keyed by memberType.
+        renderDetail(
+            makeTeam([
+                {
+                    id: 'tm-1',
+                    memberType: 'agent',
+                    memberId: 'u-1', // deliberately an id from the USER space
+                    role: 'member',
+                    name: 'Scout',
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                },
+            ]),
+        );
+        await userEvent.selectOptions(typeSelect(), 'user');
+
+        expect(whoValues()).toEqual(['u-1', 'u-2']);
+    });
+});

--- a/apps/web/src/lib/api/teams.ts
+++ b/apps/web/src/lib/api/teams.ts
@@ -116,6 +116,17 @@ export interface TeamsOrganization {
     displayName: string;
 }
 
+/**
+ * A person in the org directory, for the add-member picker.
+ * Hand-mirrors `OrgUserView` in `packages/agent/src/teams/types.ts`.
+ */
+export interface OrgUser {
+    id: string;
+    username: string;
+    email: string | null;
+    avatar: string | null;
+}
+
 export const teamsAPI = {
     /** Organizations of the current user's Tenant (server-side). */
     async listOrganizations(): Promise<TeamsOrganization[]> {
@@ -128,6 +139,24 @@ export const teamsAPI = {
 
     async list(orgId: string): Promise<Team[]> {
         return serverFetch<Team[]>(`/organizations/${orgId}/teams`, { method: 'GET' });
+    },
+
+    /**
+     * The people who can be added to a team as human members.
+     *
+     * Swallows failures to `[]` like `listOrganizations` above: this feeds a
+     * picker on a page whose primary job (viewing the team) must still render
+     * if the directory call fails. An empty picker degrades; a thrown error
+     * would blank the whole team page.
+     */
+    async listUsers(orgId: string): Promise<OrgUser[]> {
+        try {
+            return await serverFetch<OrgUser[]>(`/organizations/${orgId}/users`, {
+                method: 'GET',
+            });
+        } catch {
+            return [];
+        }
     },
 
     async get(orgId: string, teamId: string): Promise<TeamDetail | null> {

--- a/packages/agent/src/teams/__tests__/teams.service.spec.ts
+++ b/packages/agent/src/teams/__tests__/teams.service.spec.ts
@@ -5,6 +5,7 @@ import type { Team } from '../../entities/team.entity';
 import type { TeamMember } from '../../entities/team-member.entity';
 import { OrgChartService } from '../org-chart.service';
 import { TeamsService } from '../teams.service';
+import { ORG_USER_DIRECTORY_LIMIT } from '../types';
 
 /**
  * Teams & Prebuilt Companies — TeamsService/OrgChartService unit specs
@@ -255,6 +256,108 @@ describe('TeamsService', () => {
         });
     });
 
+    describe(`listOrgUsers — the add-member picker's directory`, () => {
+        /**
+         * The Teams page shipped a `Type` select whose `Member` (human) option
+         * was hard-disabled, so a team could only ever be staffed with Agents —
+         * even though `addMember` has had a complete `memberType: 'user'` branch
+         * the whole time. The missing piece was this: nothing could list the
+         * people an org has, so the picker had nothing to offer.
+         */
+
+        it(`returns the tenant's people in the picker's shape`, async () => {
+            const { service, users } = build();
+            users.find.mockResolvedValue([
+                {
+                    id: 'u1',
+                    username: 'ruslan',
+                    email: 'ruslan@ever.co',
+                    avatar: 'https://cdn/av.png',
+                },
+            ]);
+
+            await expect(service.listOrgUsers('org-1')).resolves.toEqual([
+                {
+                    id: 'u1',
+                    username: 'ruslan',
+                    email: 'ruslan@ever.co',
+                    avatar: 'https://cdn/av.png',
+                },
+            ]);
+        });
+
+        it(`scopes the query to the org's tenant, never the org id`, async () => {
+            // Organization membership is expressed through the Tenant — it is
+            // what `addMember` checks before accepting a user. Querying by
+            // organizationId instead would return nobody, since `users` has no
+            // such column, and the picker would be permanently empty.
+            const { service, users } = build();
+            await service.listOrgUsers('org-1');
+
+            const where = users.find.mock.calls[0][0].where;
+            expect(where.tenantId).toBe('ten-1');
+        });
+
+        it('SELECTS an allowlist, so a new User column can never leak', async () => {
+            // `User` carries `password`, `emailVerificationToken`,
+            // `passwordResetToken` and `magicLinkToken`. This endpoint hands one
+            // user a list of others, so the select is an allowlist and this test
+            // is what keeps it one — a bare find() would ship every column.
+            const { service, users } = build();
+            await service.listOrgUsers('org-1');
+
+            const select = users.find.mock.calls[0][0].select;
+            expect(select).toEqual(['id', 'username', 'email', 'avatar']);
+            for (const secret of [
+                'password',
+                'emailVerificationToken',
+                'passwordResetToken',
+                'magicLinkToken',
+            ]) {
+                expect(select).not.toContain(secret);
+            }
+        });
+
+        it('excludes guests and deactivated accounts', async () => {
+            // `addMember` only checks the Tenant, so this filter is the only
+            // thing keeping an anonymous session or a disabled account out of
+            // the list of people you can staff a team with.
+            const { service, users } = build();
+            await service.listOrgUsers('org-1');
+
+            const where = users.find.mock.calls[0][0].where;
+            expect(where.isAnonymous).toBe(false);
+            expect(where.isActive).toBe(true);
+        });
+
+        it('caps the result rather than returning an unbounded list', async () => {
+            const { service, users } = build();
+            await service.listOrgUsers('org-1');
+
+            expect(users.find.mock.calls[0][0].take).toBe(ORG_USER_DIRECTORY_LIMIT);
+        });
+
+        it('404s an unknown org instead of listing anyone', async () => {
+            // 404-never-403, matching the rest of this controller surface: the
+            // response must not tell an attacker which org ids are real.
+            const { service, organizations, users } = build();
+            organizations.findOne.mockResolvedValue(null);
+
+            await expect(service.listOrgUsers('nope')).rejects.toThrow(NotFoundException);
+            expect(users.find).not.toHaveBeenCalled();
+        });
+
+        it('returns [] for an org with no tenant instead of querying', async () => {
+            // `tenantId` is nullable on Organization. Passing undefined into the
+            // where clause would drop the scope entirely and list EVERY user in
+            // the database, so the guard is a real one, not defensive noise.
+            const { service, organizations, users } = build();
+            organizations.findOne.mockResolvedValue({ ...ORG, tenantId: null });
+
+            await expect(service.listOrgUsers('org-1')).resolves.toEqual([]);
+            expect(users.find).not.toHaveBeenCalled();
+        });
+    });
     it('getOrThrow 404s a team of another org', async () => {
         const { service, teams } = build();
         teams.findOne.mockResolvedValue(null);

--- a/packages/agent/src/teams/teams.service.ts
+++ b/packages/agent/src/teams/teams.service.ts
@@ -15,6 +15,8 @@ import { slugifyText } from '../utils/text.utils';
 import {
     AddTeamMemberInput,
     CreateTeamInput,
+    ORG_USER_DIRECTORY_LIMIT,
+    OrgUserView,
     TEAM_HIERARCHY_WALK_LIMIT,
     TEAM_MAX_DEPTH,
     TeamMemberView,
@@ -149,6 +151,58 @@ export class TeamsService {
         await this.getOrThrow(orgId, teamId);
         const rows = await this.members.find({ where: { teamId }, order: { createdAt: 'ASC' } });
         return this.resolveMemberViews(rows);
+    }
+
+    /**
+     * The org-internal people directory, for the Teams "add a human member"
+     * picker.
+     *
+     * Membership in an Organization is expressed through its TENANT, not a
+     * join table: `addMember` accepts a user when `user.tenantId` matches the
+     * org, so the pickable set is exactly "users of this org's tenant". This
+     * method returns that same set, which keeps the picker and the write path
+     * from disagreeing — a directory that offers someone the API then refuses
+     * is worse than no directory.
+     *
+     * Authorization is the CONTROLLER's job: this sits behind
+     * `OrganizationOwnershipGuard`, which requires the caller to already be a
+     * member of `orgId` and 404s (never 403s) otherwise, so the endpoint
+     * cannot be used to probe which organizations exist.
+     */
+    async listOrgUsers(orgId: string): Promise<OrgUserView[]> {
+        const org = await this.organizations.findOne({ where: { id: orgId } });
+        if (!org) {
+            throw new NotFoundException(`Organization ${orgId} not found`);
+        }
+        if (!org.tenantId) {
+            return [];
+        }
+
+        const rows = await this.users.find({
+            where: {
+                tenantId: org.tenantId,
+                // Guests and deactivated accounts are in the Tenant but are not
+                // people you can staff a team with. `addMember` only checks the
+                // Tenant, so this filter is the only thing keeping them out of
+                // the picker.
+                isAnonymous: false,
+                isActive: true,
+            },
+            // EXPLICIT select — never a bare find(). This crosses a trust
+            // boundary (one user listing others) and `User` holds
+            // `password`, `emailVerificationToken`, `passwordResetToken` and
+            // `magicLinkToken`. An allowlist cannot leak a column added later.
+            select: ['id', 'username', 'email', 'avatar'],
+            order: { username: 'ASC' },
+            take: ORG_USER_DIRECTORY_LIMIT,
+        });
+
+        return rows.map((user) => ({
+            id: user.id,
+            username: user.username,
+            email: user.email ?? null,
+            avatar: user.avatar ?? null,
+        }));
     }
 
     async addMember(

--- a/packages/agent/src/teams/types.ts
+++ b/packages/agent/src/teams/types.ts
@@ -44,6 +44,33 @@ export interface TeamMemberView {
 }
 
 /** Flat org-chart payload — the tree is built client-side (spec §5). */
+/**
+ * A person in the org directory, as offered by the Teams add-member picker.
+ *
+ * Deliberately a SEPARATE shape from the `User` entity rather than a Pick<>:
+ * this crosses a trust boundary (one user reading a list of others), so the
+ * fields are enumerated here on purpose and adding a column to `User` must
+ * never silently widen what this exposes.
+ */
+export interface OrgUserView {
+    id: string;
+    /**
+     * The display identity. `User` has no `name` column — `username` is the
+     * only one there is, it is non-null, and it is unique (case-insensitively,
+     * via the expression index in `AddUniqueIndexToUsername`). It is also what
+     * `resolveMemberViews` puts in `TeamMemberView.name`, so the picker and the
+     * roster name the same person the same way.
+     */
+    username: string;
+    /** Nullable on `User`: OAuth and anonymous signups can carry no address. */
+    email: string | null;
+    /**
+     * Avatar URL. The entity types this `string`, but the column is
+     * `nullable: true`, so the value really can be null at runtime — narrowed
+     * honestly here rather than propagating the entity's optimistic type.
+     */
+    avatar: string | null;
+}
 export interface OrgChartPayload {
     organization: { id: string; slug: string; displayName: string };
     teams: Array<{
@@ -74,6 +101,15 @@ export interface OrgChartPayload {
 /** Service-enforced structural limits (spec §1.1). */
 export const TEAM_MAX_DEPTH = 10;
 export const TEAM_HIERARCHY_WALK_LIMIT = 50;
+
+/**
+ * How many people the org directory returns to the add-member picker.
+ *
+ * A hard cap, not a page: the picker is a plain <select>, so an unbounded
+ * list would be both a slow query and an unusable control. Orgs that outgrow
+ * it need a searching, paginated picker — a real change, not a bigger number.
+ */
+export const ORG_USER_DIRECTORY_LIMIT = 200;
 
 // ── Team ↔ resource association ("some Works belong to some Teams") ──
 


### PR DESCRIPTION
Cascade of a single commit: [#2120](https://github.com/ever-works/ever-works/pull/2120) `aec014155`.

**What it fixes:** on the Teams page the `Member` option in the add-member `Type` dropdown was hard-disabled and `handleAdd` hardcoded `memberType: 'agent'`, so a team could only ever be staffed with Agents. Owner-reported against prod build `87f149a`.

**What it adds:** `GET /api/organizations/:orgId/users` → `TeamsService.listOrgUsers`, scoped by **tenant** (what `addMember` actually checks), with an explicit `select` allowlist, guests and deactivated accounts filtered, `[]` without querying when the org has no `tenantId`, and a 200-row cap.

No schema change. No new i18n keys — `addMemberUser` was already translated in all 21 locales; it was just attached to a disabled option.

**CI:** 15/15 green on `aec014155`'s branch head. An earlier run failed `MergePolicyCard.unit.spec.tsx`, a file this branch does not touch; re-running the identical commit passed, and the full web suite reproduces locally at 203/203 files, 2010/2010 tests.

**Rollback:** revert the merge commit on `stage`.