### PR TITLE
chore(cascade): stage → main — org invitations + PATCH title:null fix

### DIFF
--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -1,0 +1,176 @@
+# Chooses the npm registry for this job, and is the single place that logic lives in this repo.
+#
+# WHY THIS IS A LOCAL COPY RATHER THAN `ever-co/ever-gauzy/.github/actions/configure-registry`
+# ---------------------------------------------------------------------------------------------
+# The shared Gauzy action (pinned at adbc9bcbf72960d49c3853552d69d5b5b3b5e56d) opens with an
+# unconditional
+#
+#     if ! git checkout -- .npmrc yarn.lock; then <error>; exit 1; fi
+#
+# ever-works is a **pnpm** workspace: it tracks neither `.npmrc` nor `yarn.lock` at the repo root.
+# `git checkout --` errors with "pathspec ... did not match any file(s) known to git" and exits 1
+# when a pathspec matches nothing -- verified locally, and it exits 1 even when only ONE of the
+# two pathspecs is missing. Using the shared action verbatim here would therefore not be a no-op,
+# it would hard-fail every job it was added to.
+#
+# This copy keeps the shared action's inputs, semantics, probe, retry policy and warnings intact,
+# and changes exactly one thing: the reset step is guarded so it resets what is actually tracked
+# and deletes untracked leftovers, instead of assuming a yarn repo. It stays drop-in compatible,
+# so once the shared action grows the same guard this file can be replaced by a
+# `uses: ever-co/ever-gauzy/...` reference with no other edit.
+#
+# WHY THE LOCKFILE REWRITE IS A NO-OP HERE (and is still kept, guarded)
+# ---------------------------------------------------------------------------------------------
+# yarn v1 and npm record an absolute `resolved` URL per package and fetch THAT, ignoring the
+# `registry` setting -- so for those package managers a config-only change moves zero bytes and
+# the lockfile has to be rewritten at CI time. pnpm does not work that way: `pnpm-lock.yaml` v9
+# stores only `resolution: {integrity: sha512-...}` and derives the tarball URL from the
+# configured registry at install time. Verified on this repo's lockfile: zero occurrences of
+# `registry.npmjs.org` or `registry.yarnpkg.com`. Config alone is therefore both sufficient and
+# load-bearing here.
+#
+# The yarn.lock rewrite below is kept, gated on the file existing, so this action keeps working
+# unchanged if any part of the repo ever grows a yarn.lock.
+#
+# Nothing is ever committed: every edit below lives only in the runner's checkout, so developers
+# and the files in git are unaffected.
+name: Configure npm registry
+description: >-
+  Point the job at the internal Verdaccio VIP when it is reachable, otherwise at the public npm
+  registry. The Cloudflare-fronted packages.ever.co route is gated behind an explicit opt-in.
+
+inputs:
+  verdaccio-registry:
+    description: Internal Verdaccio VIP, normally vars.VERDACCIO_REGISTRY. Empty disables the probe.
+    required: false
+    default: ''
+  verdaccio-token:
+    description: Auth token for the public packages.ever.co route. Only used when force-public is true.
+    required: false
+    default: ''
+  force-public:
+    description: Set to 'true' to force the public packages.ever.co route even when the VIP answers.
+    required: false
+    default: ''
+  expect-vip:
+    description: >-
+      'true' for in-network runners. Controls whether an unreachable VIP is retried and warned
+      about. Derive it from the runner variable the job really uses, e.g.
+      vars.RUNNER_LINUX_X64_4 != ''. Do NOT use contains(matrix.os, ...) unless the job actually
+      defines strategy.matrix.os -- the expression then silently evaluates false and quietly
+      disables both the retry and the warning, which is a mute switch rather than an error.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Registry
+      shell: bash
+      env:
+        VERDACCIO_REGISTRY: ${{ inputs.verdaccio-registry }}
+        VERDACCIO_TOKEN: ${{ inputs.verdaccio-token }}
+        VERDACCIO_FORCE_PUBLIC: ${{ inputs.force-public }}
+        EXPECT_VIP: ${{ inputs.expect-vip }}
+      run: |
+        # Registry selection is CONDITIONAL on where this job runs.
+        #
+        # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+        # large tarballs mid-stream, and the truncation is UNDETECTABLE by the client: Cloudflare
+        # always sends "Accept-Encoding: gzip" to the origin, Verdaccio re-gzips the already
+        # gzipped .tgz, and Content-Length is dropped in favour of chunked encoding. A cut stream
+        # is therefore a complete-looking HTTP 200 whose body fails gunzip. That route is GATED
+        # behind VERDACCIO_FORCE_PUBLIC rather than removed.
+        #
+        # Every job that uses this action runs on `vars.RUNNER_LINUX_X64_* || ubuntu-latest`, so
+        # the runner is not statically known: if the org variable were unset the job would land on
+        # a GitHub-hosted runner that can never reach a 192.168.x.x VIP. The choice is therefore
+        # made by PROBING the VIP, and `expect-vip` only controls how loudly a miss is reported.
+
+        # Start from a known state. Self-hosted runners can check out with clean: false, so
+        # registry edits from a PREVIOUS run can still be on disk -- .npmrc and .yarnrc are
+        # untracked in this repo, so nothing else restores them and a stale "registry" line from
+        # an earlier run would silently win over this run's decision.
+        #
+        # Guarded, unlike the Gauzy original: reset what git actually tracks, delete what it does
+        # not. Failing to reach a known state is still fatal -- selecting a registry from an
+        # unknown state would mean installing against whatever the last job left behind.
+        rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
+        for f in .npmrc yarn.lock; do
+          if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+            if ! git checkout -- "$f"; then
+              echo "::error title=Could not reset registry configuration::git checkout -- $f failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+              exit 1
+            fi
+          elif ! rm -f "$f"; then
+            # Untracked (the normal case in this pnpm repo): a leftover from a previous run on a
+            # clean: false runner is the only way it can exist, so remove it.
+            echo "::error title=Could not reset registry configuration::rm -f $f failed on this workspace. Refusing to select a registry from an unknown state."
+            exit 1
+          fi
+        done
+
+        REGISTRY=""
+        if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+          # this wants the public route even when the VIP is up (e.g. the internal cache is
+          # serving bad data). Gating it on a failed probe would make the flag a no-op.
+          REGISTRY="https://packages.ever.co/"
+          echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+          echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
+          echo "always-auth=true" >> .npmrc
+        else
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+          fi
+          # Retry only where the VIP is expected to answer. A GitHub-hosted runner can never
+          # reach it, so a second attempt would just add dead time to the job.
+          if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            attempt=1
+            while [ "$attempt" -le "$ATTEMPTS" ]; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              attempt=$((attempt + 1))
+              if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+            echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+          elif [ -z "$REGISTRY" ]; then
+            echo "Verdaccio VIP did not answer - resolving from the public npm registry."
+            # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+            # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+            # has a recurring MetalLB speaker flap that presents exactly this way), so surface it.
+            # Deliberately a warning, not a failure: a cache blip must never redden a pipeline
+            # that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+        fi
+        if [ -n "$REGISTRY" ]; then
+          # Appended, never overwritten: last key wins in ini parsing, and yarn v1 does not
+          # reliably read .npmrc for the registry. pnpm reads .npmrc at the workspace root, which
+          # is the working directory of every install step in this repo.
+          #
+          # This sets the DEFAULT registry only. It does not affect publishing: publish-cli.yml
+          # publishes from apps/*/dist (a different npm prefix, so this file is not read at all),
+          # and publish-plugins.yml passes an explicit --registry to every `pnpm publish`, which
+          # is a CLI flag and outranks any .npmrc.
+          echo "registry=$REGISTRY" >> .npmrc
+          echo "registry \"$REGISTRY\"" >> .yarnrc
+          # No-op in this pnpm repo (there is no yarn.lock), kept so the action keeps working if
+          # one ever appears. One pass, no -i: an -i.bak backup survives on a clean: false runner
+          # if the step fails between the rewrite and its cleanup, and bare -i is not portable to
+          # the BSD sed on macOS runners. The temp file is only ever the finished rewrite.
+          if [ -f yarn.lock ]; then
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
+          fi
+        fi
+        echo "Using npm registry: ${REGISTRY:-https://registry.npmjs.org/ (repo default)}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -266,6 +277,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -360,6 +382,17 @@ jobs:
         with:
           node-version: 22.x
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -487,6 +520,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -501,6 +512,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -72,6 +72,17 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -63,6 +63,17 @@ jobs:
           node-version: 22.x
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -72,6 +72,17 @@ jobs:
           node-version: 22.x
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -135,6 +146,17 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -193,6 +215,17 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ever-works'
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -39,6 +39,17 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -35,6 +35,17 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -100,6 +100,18 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        if: steps.env.outputs.skip != 'true'
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         if: steps.env.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -35,6 +35,17 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/smoke-deployed.yml
+++ b/.github/workflows/smoke-deployed.yml
@@ -120,6 +120,17 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/apps/api/src/ai-conversation/conversation.controller.ts
+++ b/apps/api/src/ai-conversation/conversation.controller.ts
@@ -20,6 +20,7 @@ import {
     IsOptional,
     IsString,
     MaxLength,
+    ValidateIf,
     ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -82,9 +83,24 @@ class CreateConversationDto {
  * inside one thread, not identity: the user re-points the same provider at a
  * different model mid-conversation and the pin has to survive a reload.
  */
-class UpdateConversationDto {
+export class UpdateConversationDto {
+    /**
+     * 🛑 `@ValidateIf`, deliberately NOT `@IsOptional()`.
+     *
+     * `@IsOptional()` skips every other validator when the value is `null` as
+     * well as when it is `undefined` — class-validator's condition is literally
+     * `value !== null && value !== undefined`. With it, `PATCH {"title": null}`
+     * sailed past `@IsString`, then satisfied the handler's
+     * `body.title !== undefined` guard (because `null !== undefined`) and WROTE
+     * NULL over the user's title. That was a hard 400 before this field became
+     * optional, and the `model` docblock below still claimed non-string
+     * payloads were rejected.
+     *
+     * `@ValidateIf(o => o.title !== undefined)` restores the intent exactly:
+     * absent is fine, present-but-not-a-string is a 400.
+     */
     @ApiProperty({ required: false, maxLength: 200 })
-    @IsOptional()
+    @ValidateIf((o: UpdateConversationDto) => o.title !== undefined)
     @IsString()
     @MaxLength(200)
     title?: string;
@@ -93,9 +109,14 @@ class UpdateConversationDto {
      * Empty string clears the pin back to "resolve the provider's configured
      * default". `null` would be the more obvious signal, but the field is
      * typed `string` so the whitelist keeps rejecting non-string payloads.
+     *
+     * That last sentence is only TRUE because of the `@ValidateIf` below —
+     * see the note on `title`. Under `@IsOptional()` a null slipped through to
+     * `updateModel`, where it happened to coincide with the clear-the-pin path
+     * and so did no damage, but the documented contract was false.
      */
     @ApiProperty({ required: false, maxLength: 100 })
-    @IsOptional()
+    @ValidateIf((o: UpdateConversationDto) => o.model !== undefined)
     @IsString()
     @MaxLength(100)
     model?: string;

--- a/apps/api/src/ai-conversation/update-conversation.dto.spec.ts
+++ b/apps/api/src/ai-conversation/update-conversation.dto.spec.ts
@@ -1,0 +1,94 @@
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/facades', () => ({}));
+
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { UpdateConversationDto } from './conversation.controller';
+
+/**
+ * `PATCH /api/conversations/:id` — null must not pass for a string field.
+ *
+ * The defect this pins: `@IsOptional()` skips every other validator when the
+ * value is `null` as well as when it is `undefined` (class-validator's
+ * condition is `value !== null && value !== undefined`). So
+ * `PATCH {"title": null}` passed validation, then satisfied the handler's
+ * `body.title !== undefined` guard — because `null !== undefined` — and
+ * WROTE NULL over the user's title.
+ *
+ * It was a hard 400 before the field became optional in #2103, and the DTO's
+ * own docblock still asserted that "the field is typed `string` so the
+ * whitelist keeps rejecting non-string payloads". It did not.
+ *
+ * Nothing in the E2E suite covered it either, because those specs probe the
+ * empty body `{}` rather than an explicit null.
+ */
+const errorsFor = (payload: Record<string, unknown>) =>
+    validateSync(plainToInstance(UpdateConversationDto, payload), {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+    });
+
+const failedProps = (payload: Record<string, unknown>) => errorsFor(payload).map((e) => e.property);
+
+describe('UpdateConversationDto', () => {
+    describe('control — the shapes that must stay valid', () => {
+        it('accepts an empty body (both fields optional; the handler no-ops)', () => {
+            // If this failed, every rejection below would be meaningless: a DTO
+            // that rejects everything trivially "fixes" the null case too.
+            expect(errorsFor({})).toHaveLength(0);
+        });
+
+        it('accepts a title-only update', () => {
+            expect(errorsFor({ title: 'Renamed' })).toHaveLength(0);
+        });
+
+        it('accepts a model-only update, and the clear-the-pin empty string', () => {
+            expect(errorsFor({ model: 'gpt-4' })).toHaveLength(0);
+            // '' is the documented signal for "resolve the provider default".
+            expect(errorsFor({ model: '' })).toHaveLength(0);
+        });
+
+        it('accepts both together', () => {
+            expect(errorsFor({ title: 'Renamed', model: 'gpt-4' })).toHaveLength(0);
+        });
+    });
+
+    describe('🛑 null is not absent', () => {
+        it('REJECTS { title: null } instead of nulling the title', () => {
+            expect(failedProps({ title: null })).toContain('title');
+        });
+
+        it('REJECTS { model: null }', () => {
+            // Harmless in the handler today — null coincides with the
+            // clear-the-pin branch — but the documented contract says
+            // non-string payloads are rejected, so they are.
+            expect(failedProps({ model: null })).toContain('model');
+        });
+
+        it('rejects null even when the other field is a valid string', () => {
+            // The realistic shape: a client sends the whole form back with one
+            // field blanked to null.
+            expect(failedProps({ title: null, model: 'gpt-4' })).toContain('title');
+        });
+    });
+
+    describe('the type and length gates still hold', () => {
+        it('rejects a non-string title', () => {
+            expect(failedProps({ title: 12345 })).toContain('title');
+        });
+
+        it('rejects a title over 200 characters', () => {
+            expect(failedProps({ title: 'Z'.repeat(201) })).toContain('title');
+        });
+
+        it('rejects a model over 100 characters', () => {
+            expect(failedProps({ model: 'z'.repeat(101) })).toContain('model');
+        });
+
+        it('still rejects providerId — the thread identity is immutable', () => {
+            // Not on the whitelist, and forbidNonWhitelisted makes that a 400
+            // rather than a silent drop.
+            expect(failedProps({ providerId: 'openai' })).toContain('providerId');
+        });
+    });
+});

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -40,6 +40,50 @@ export class MailService {
     /**
      * Get branding context for email templates
      */
+    /**
+     * Invitation to join an Organization.
+     *
+     * 🛑 The `acceptUrl` carries the RAW token. That is the only place the
+     * token ever appears — the database holds `sha256(token)` and no API
+     * response returns it. So this method must never log `data`, and the
+     * catch below deliberately logs the recipient and the error only.
+     *
+     * Unlike `sendWorkInvitation`, there is no null-recipient early return:
+     * `OrganizationInvitation.email` is NOT NULL precisely so that an
+     * unreachable invitation cannot be represented. If this is ever called
+     * without one, that is a bug worth surfacing rather than swallowing.
+     */
+    async sendOrganizationInvitation(data: {
+        recipientEmail: string;
+        organizationName: string;
+        inviterName: string;
+        acceptUrl: string;
+        expiresAt: Date;
+    }): Promise<void> {
+        try {
+            await this.mailerService.sendMail({
+                to: data.recipientEmail,
+                subject: `You've been invited to ${data.organizationName}`,
+                template: 'organization-invitation',
+                context: {
+                    ...this.getBrandingContext(),
+                    organizationName: data.organizationName,
+                    inviterName: data.inviterName,
+                    acceptUrl: data.acceptUrl,
+                    recipientEmail: data.recipientEmail,
+                    expiresAtFormatted: this.formatDateTime(data.expiresAt),
+                },
+            });
+        } catch (error) {
+            // Never interpolate `data` — it holds the raw token.
+            this.logger.error(
+                `Failed to send organization invitation to ${data.recipientEmail}`,
+                error instanceof Error ? error.stack : String(error),
+            );
+            throw error;
+        }
+    }
+
     private getBrandingContext() {
         return {
             appName: config.branding.appName(),

--- a/apps/api/src/mail/providers/mailer.service.templates.spec.ts
+++ b/apps/api/src/mail/providers/mailer.service.templates.spec.ts
@@ -54,6 +54,7 @@ const TEMPLATES_USED_BY_MAIL_SERVICE = [
     'magic-link',
     'member-invitation',
     'new-device-login',
+    'organization-invitation',
     'password-changed',
     'signup-confirmation',
     'welcome',
@@ -184,6 +185,47 @@ describe('MailerService template packaging (no mocks)', () => {
             expect(sent.html).toContain('https://app.ever.works/verify?token');
             expect(sent.html).toContain('abc123');
             expect(sent.html).toContain('Ada');
+        });
+
+        it('renders the organization invitation with a working accept link', async () => {
+            // A Handlebars variable that no context key satisfies renders as
+            // an EMPTY STRING rather than throwing, so a typo in the template
+            // ships an email with a dead "Accept invitation" button and
+            // nothing anywhere reports a problem. This asserts each
+            // substitution actually landed.
+            const service = buildService();
+
+            await service.sendMail({
+                to: 'newcomer@test.example',
+                subject: 'You have been invited to Acme',
+                template: 'organization-invitation',
+                context: {
+                    appName: 'Ever Works',
+                    companyOwner: 'Ever Co. LTD',
+                    platformWebsite: 'https://ever.works',
+                    currentYear: 2026,
+                    organizationName: 'Acme Inc',
+                    inviterName: 'ada',
+                    acceptUrl: 'https://app.ever.works/org-invite/tok123',
+                    recipientEmail: 'newcomer@test.example',
+                    expiresAtFormatted: 'Aug 25, 2026',
+                },
+            });
+
+            const sent = resend.emails.send.mock.calls[0][0];
+            expect(sent.html).toContain('Acme Inc');
+            expect(sent.html).toContain('ada');
+            expect(sent.html).toContain('Aug 25, 2026');
+            // Double-brace expressions are HTML-escaped, so assert on the
+            // parts escaping leaves alone rather than pinning the escaped form.
+            expect(sent.html).toContain('https://app.ever.works/org-invite/tok123');
+            // The recipient address is stated on purpose: the token is
+            // email-bound, so redeeming it as another account 403s, and the
+            // email is the only place that can explain that in advance.
+            expect(sent.html).toContain('newcomer@test.example');
+
+            // And nothing was left unsubstituted.
+            expect(sent.html).not.toContain('{{');
         });
     });
 

--- a/apps/api/src/mail/templates.ts
+++ b/apps/api/src/mail/templates.ts
@@ -60,6 +60,7 @@ export const KNOWN_EMAIL_TEMPLATES = [
     'magic-link',
     'member-invitation',
     'new-device-login',
+    'organization-invitation',
     'password-changed',
     'signup-confirmation',
     'welcome',

--- a/apps/api/src/migrations/1786930000000-CreateOrganizationInvitationsAndMembers.ts
+++ b/apps/api/src/migrations/1786930000000-CreateOrganizationInvitationsAndMembers.ts
@@ -1,0 +1,265 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Organization invitations — the `OrganizationMember` / `OrganizationInvitation`
+ * pair deferred to v1.1 in
+ * [`docs/specs/features/tenants-and-organizations/spec.md` §7](../../../../docs/specs/features/tenants-and-organizations/spec.md).
+ *
+ * Entities: `packages/agent/src/entities/organization-invitation.entity.ts`,
+ *           `packages/agent/src/entities/organization-member.entity.ts`
+ *
+ * Creates:
+ *   - `organization_invitations` — one live token per (Organization, email).
+ *     Only `sha256(token)` is stored; the raw token is shown to the issuer
+ *     once and is unrecoverable thereafter.
+ *   - `organization_members` — the roster. NOT the authorization check:
+ *     access is still `users.tenantId === organizations.tenantId`. See the
+ *     entity docblock for why that was left alone.
+ *
+ * 🛑 This migration is the ONLY thing that creates these tables in
+ * production. `DATABASE_AUTOMIGRATE` (TypeORM `synchronize`) is **true in
+ * dev and stage but false in prod** — verified on the live Secrets — so a
+ * defect here is invisible in both lower environments and surfaces only
+ * after the prod deploy. Do not treat a green dev rollout as evidence that
+ * this file is correct.
+ *
+ * Scope columns are NOT the nullable Tier-A/C denormalization: `tenantId` is
+ * the scope key itself and `organizationId` is the parent, so both are NOT
+ * NULL with `ON DELETE CASCADE`. Deleting an Organization takes its pending
+ * invitations and its roster rows with it; it does NOT touch `users`.
+ *
+ * Forward-only and idempotent (`hasTable` guards), matching
+ * `1781500000000-CreateTeamsTables`.
+ */
+export class CreateOrganizationInvitationsAndMembers1786930000000 implements MigrationInterface {
+    name = 'CreateOrganizationInvitationsAndMembers1786930000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const isPostgres = queryRunner.connection.options.type === 'postgres';
+        const uuidDefault = isPostgres ? 'uuid_generate_v4()' : undefined;
+
+        if (!(await queryRunner.hasTable('organization_invitations'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'organization_invitations',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: uuidDefault,
+                        },
+                        { name: 'organizationId', type: 'uuid' },
+                        { name: 'tenantId', type: 'uuid' },
+                        { name: 'email', type: 'varchar', length: '320' },
+                        { name: 'emailNormalized', type: 'varchar', length: '320' },
+                        { name: 'role', type: 'varchar', length: '32', default: "'member'" },
+                        { name: 'tokenHash', type: 'varchar', length: '64' },
+                        { name: 'tokenExpiresAt', type: 'timestamp' },
+                        { name: 'invitedById', type: 'uuid' },
+                        { name: 'status', type: 'varchar', length: '16', default: "'pending'" },
+                        { name: 'acceptedByUserId', type: 'uuid', isNullable: true },
+                        { name: 'acceptedAt', type: 'timestamp', isNullable: true },
+                        { name: 'metadata', type: 'text', isNullable: true },
+                        { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                        { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    ],
+                }),
+                true,
+            );
+
+            await queryRunner.createIndex(
+                'organization_invitations',
+                new TableIndex({
+                    name: 'idx_org_invitations_org',
+                    columnNames: ['organizationId'],
+                }),
+            );
+            await queryRunner.createIndex(
+                'organization_invitations',
+                new TableIndex({
+                    name: 'uq_org_invitations_token_hash',
+                    columnNames: ['tokenHash'],
+                    isUnique: true,
+                }),
+            );
+            await queryRunner.createIndex(
+                'organization_invitations',
+                new TableIndex({
+                    name: 'idx_org_invitations_status',
+                    columnNames: ['status'],
+                }),
+            );
+            // One LIVE invitation per person per Organization. Partial, so
+            // re-inviting after a revoke or an expiry stays legal — a plain
+            // unique index would make a revoked invite permanently block the
+            // address. TypeORM emits the WHERE clause on Postgres and SQLite
+            // alike; both support partial indexes.
+            await queryRunner.createIndex(
+                'organization_invitations',
+                new TableIndex({
+                    name: 'uq_org_invitations_pending_email',
+                    columnNames: ['organizationId', 'emailNormalized'],
+                    isUnique: true,
+                    where: "status = 'pending'",
+                }),
+            );
+
+            await queryRunner.createForeignKey(
+                'organization_invitations',
+                new TableForeignKey({
+                    name: 'fk_org_invitations_org',
+                    columnNames: ['organizationId'],
+                    referencedTableName: 'organizations',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'organization_invitations',
+                new TableForeignKey({
+                    name: 'fk_org_invitations_tenant',
+                    columnNames: ['tenantId'],
+                    referencedTableName: 'tenants',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'organization_invitations',
+                new TableForeignKey({
+                    name: 'fk_org_invitations_invited_by',
+                    columnNames: ['invitedById'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+            // SET NULL, not CASCADE: deleting the accepting user must not
+            // erase the record that the invitation was consumed.
+            await queryRunner.createForeignKey(
+                'organization_invitations',
+                new TableForeignKey({
+                    name: 'fk_org_invitations_accepted_by',
+                    columnNames: ['acceptedByUserId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasTable('organization_members'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'organization_members',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: uuidDefault,
+                        },
+                        { name: 'organizationId', type: 'uuid' },
+                        { name: 'tenantId', type: 'uuid' },
+                        { name: 'userId', type: 'uuid' },
+                        { name: 'role', type: 'varchar', length: '32', default: "'member'" },
+                        { name: 'invitedById', type: 'uuid', isNullable: true },
+                        { name: 'invitationId', type: 'uuid', isNullable: true },
+                        { name: 'joinedAt', type: 'timestamp' },
+                        { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                        { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    ],
+                }),
+                true,
+            );
+
+            await queryRunner.createIndex(
+                'organization_members',
+                new TableIndex({
+                    name: 'uq_org_members_org_user',
+                    columnNames: ['organizationId', 'userId'],
+                    isUnique: true,
+                }),
+            );
+            await queryRunner.createIndex(
+                'organization_members',
+                new TableIndex({ name: 'idx_org_members_org', columnNames: ['organizationId'] }),
+            );
+            await queryRunner.createIndex(
+                'organization_members',
+                new TableIndex({ name: 'idx_org_members_user', columnNames: ['userId'] }),
+            );
+
+            await queryRunner.createForeignKey(
+                'organization_members',
+                new TableForeignKey({
+                    name: 'fk_org_members_org',
+                    columnNames: ['organizationId'],
+                    referencedTableName: 'organizations',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'organization_members',
+                new TableForeignKey({
+                    name: 'fk_org_members_tenant',
+                    columnNames: ['tenantId'],
+                    referencedTableName: 'tenants',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'organization_members',
+                new TableForeignKey({
+                    name: 'fk_org_members_user',
+                    columnNames: ['userId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'organization_members',
+                new TableForeignKey({
+                    name: 'fk_org_members_invited_by',
+                    columnNames: ['invitedById'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+            );
+            // SET NULL: an invitation row may be pruned; the membership it
+            // produced must survive that.
+            await queryRunner.createForeignKey(
+                'organization_members',
+                new TableForeignKey({
+                    name: 'fk_org_members_invitation',
+                    columnNames: ['invitationId'],
+                    referencedTableName: 'organization_invitations',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'SET NULL',
+                }),
+            );
+        }
+    }
+
+    /**
+     * Drops only the two tables this migration created.
+     *
+     * Order matters: `organization_members.invitationId` references
+     * `organization_invitations`, so the child goes first.
+     */
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('organization_members')) {
+            await queryRunner.dropTable('organization_members', true, true, true);
+        }
+        if (await queryRunner.hasTable('organization_invitations')) {
+            await queryRunner.dropTable('organization_invitations', true, true, true);
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateOrganizationInvitationsAndMembers.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateOrganizationInvitationsAndMembers.spec.ts
@@ -1,0 +1,149 @@
+import { DataSource, Table } from 'typeorm';
+import { CreateOrganizationInvitationsAndMembers1786930000000 } from '../1786930000000-CreateOrganizationInvitationsAndMembers';
+
+/**
+ * Executes the organization-invitations migration against a real (in-memory)
+ * database rather than only compiling it.
+ *
+ * This migration carries more risk than most, for a reason worth stating:
+ * **`DATABASE_AUTOMIGRATE` (TypeORM `synchronize`) is true in dev and stage
+ * but false in production** — verified on the live Secrets of
+ * `ever-works-app-{dev,stage,prod}`. In dev and stage, `synchronize` creates
+ * these tables from the entities whether or not this file works, so a broken
+ * migration is completely invisible there and first appears as a crash-looping
+ * prod pod. A green dev rollout is not evidence. This spec is.
+ *
+ * better-sqlite3 is what CI and the e2e stack run, so a Postgres-only
+ * construct here fails the build — which is the point (`now()` and
+ * `uuid_generate_v4()` are both guarded in the migration for exactly that
+ * reason).
+ *
+ * Lives in `__tests__/` for the reason spelled out in
+ * `AddCostsDashboardIndexes.spec.ts`: the runtime migration glob is the FLAT
+ * `dist/migrations/*.js`, and a spec compiled into it is loaded as a
+ * migration, whose top-level `describe(...)` crash-loops every API pod.
+ * Pinned by `migrations-directory-contract.spec.ts`.
+ */
+describe('CreateOrganizationInvitationsAndMembers1786930000000', () => {
+    let dataSource: DataSource;
+
+    /** The FK targets. Minimal stubs — this spec is about the new tables. */
+    async function createReferencedTables(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        for (const name of ['users', 'tenants', 'organizations']) {
+            await runner.createTable(
+                new Table({
+                    name,
+                    columns: [{ name: 'id', type: 'uuid', isPrimary: true }],
+                }),
+                true,
+            );
+        }
+        await runner.release();
+    }
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await new CreateOrganizationInvitationsAndMembers1786930000000().up(runner);
+        await runner.release();
+    }
+
+    it('creates both tables with every index the entities declare', async () => {
+        await createReferencedTables();
+        await runUp();
+
+        const runner = dataSource.createQueryRunner();
+        expect(await runner.hasTable('organization_invitations')).toBe(true);
+        expect(await runner.hasTable('organization_members')).toBe(true);
+
+        const invitations = await runner.getTable('organization_invitations');
+        const members = await runner.getTable('organization_members');
+        await runner.release();
+
+        const indexNames = (t: Table | undefined) => (t?.indices ?? []).map((i) => i.name).sort();
+        expect(indexNames(invitations)).toEqual(
+            [
+                'idx_org_invitations_org',
+                'idx_org_invitations_status',
+                'uq_org_invitations_pending_email',
+                'uq_org_invitations_token_hash',
+            ].sort(),
+        );
+        expect(indexNames(members)).toEqual(
+            ['idx_org_members_org', 'idx_org_members_user', 'uq_org_members_org_user'].sort(),
+        );
+    });
+
+    it('is idempotent — a second run over an applied schema is a no-op', async () => {
+        // The state a partially-applied or re-run deployment is actually in.
+        // Without the hasTable guards this throws, and with migrationsRun the
+        // throw crash-loops every API pod on boot.
+        await createReferencedTables();
+        await runUp();
+        await expect(runUp()).resolves.not.toThrow();
+
+        const runner = dataSource.createQueryRunner();
+        expect(await runner.hasTable('organization_invitations')).toBe(true);
+        await runner.release();
+    });
+
+    it('down() drops both tables, child first', async () => {
+        await createReferencedTables();
+        await runUp();
+
+        const runner = dataSource.createQueryRunner();
+        await new CreateOrganizationInvitationsAndMembers1786930000000().down(runner);
+
+        expect(await runner.hasTable('organization_members')).toBe(false);
+        expect(await runner.hasTable('organization_invitations')).toBe(false);
+        // The FK targets are untouched — down() must never reach past its own
+        // tables.
+        expect(await runner.hasTable('users')).toBe(true);
+        expect(await runner.hasTable('organizations')).toBe(true);
+        await runner.release();
+    });
+
+    it('the pending-email index permits a re-invite after a revoke', async () => {
+        // The behaviour the partial WHERE buys. A plain unique index would let
+        // a single revoked invitation block that address forever.
+        await createReferencedTables();
+        await runUp();
+
+        const runner = dataSource.createQueryRunner();
+        await runner.query(`INSERT INTO organizations (id) VALUES ('org-1')`);
+        await runner.query(`INSERT INTO tenants (id) VALUES ('ten-1')`);
+        await runner.query(`INSERT INTO users (id) VALUES ('u-1')`);
+
+        const insert = (id: string, status: string) =>
+            runner.query(
+                `INSERT INTO organization_invitations
+                   (id, "organizationId", "tenantId", email, "emailNormalized", role,
+                    "tokenHash", "tokenExpiresAt", "invitedById", status)
+                 VALUES ('${id}', 'org-1', 'ten-1', 'A@x.com', 'a@x.com', 'member',
+                    'hash-${id}', '2030-01-01 00:00:00', 'u-1', '${status}')`,
+            );
+
+        await insert('i1', 'pending');
+        // Second PENDING invite for the same mailbox — rejected.
+        await expect(insert('i2', 'pending')).rejects.toThrow();
+        // Revoke the first, and the address is invitable again.
+        await runner.query(`UPDATE organization_invitations SET status='revoked' WHERE id='i1'`);
+        await expect(insert('i3', 'pending')).resolves.not.toThrow();
+
+        await runner.release();
+    });
+});

--- a/apps/api/src/onboarding/dto/org-invite.dto.ts
+++ b/apps/api/src/onboarding/dto/org-invite.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Length } from 'class-validator';
+
+/**
+ * Redeem an organization invitation.
+ *
+ * The token is `randomBytes(32).toString('hex')`, so its length is fixed at
+ * 64. Pinning it here rejects a truncated or padded value before it reaches a
+ * database lookup, which keeps the public surface from being usable as an
+ * oracle for how long a valid token is.
+ */
+export class AcceptOrgInviteDto {
+    @ApiProperty({
+        description: 'The raw invitation token from the email link.',
+        minLength: 64,
+        maxLength: 64,
+    })
+    @IsString()
+    @Length(64, 64, { message: 'invalid_token' })
+    token: string;
+}

--- a/apps/api/src/onboarding/onboarding.module.ts
+++ b/apps/api/src/onboarding/onboarding.module.ts
@@ -18,6 +18,8 @@ import { WorkModule } from '@ever-works/agent/services';
 // the whole app) is what gives this module the provider without
 // duplicating the template catalog wiring here.
 import { AgentsModule as AgentDomainAgentsModule } from '@ever-works/agent/agents';
+import { OrganizationsModule } from '../organizations/organizations.module';
+import { OrgInviteController } from './org-invite.controller';
 import { OnboardingController } from './onboarding.controller';
 import { OnboardingService } from './onboarding.service';
 import { OnboardingTerminalService } from './onboarding-terminal.service';
@@ -43,6 +45,9 @@ import { UsersModule } from '../users/users.module';
         AuthModule,
         UsersModule,
         AgentDomainAgentsModule,
+        // The org-invite accept route reuses OrganizationInvitationFlowService,
+        // which OrganizationsModule owns and exports.
+        OrganizationsModule,
     ],
     controllers: [
         OnboardingController,
@@ -53,6 +58,10 @@ import { UsersModule } from '../users/users.module';
         OnboardingCatalogController,
         OnboardingTelemetryController,
         OnboardingSuggestionsController,
+        // Public preview + authenticated accept for organization invitations.
+        // Lives here rather than on the api/organizations/:orgId family, whose
+        // guard requires the membership the invitee does not have yet.
+        OrgInviteController,
     ],
     providers: [
         OnboardingService,

--- a/apps/api/src/onboarding/org-invite.controller.spec.ts
+++ b/apps/api/src/onboarding/org-invite.controller.spec.ts
@@ -1,0 +1,154 @@
+import { BadRequestException } from '@nestjs/common';
+
+// Stub the heavy workspace barrels at module scope so importing the
+// controller does not drag the generator/entity graph through Jest, the
+// same posture as ingest.module.spec.ts. The controller only ever touches
+// these through the injected mocks below.
+jest.mock('@ever-works/agent/services', () => ({
+    OrganizationInvitationService: class OrganizationInvitationService {},
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    OrganizationRepository: class OrganizationRepository {},
+}));
+jest.mock('../organizations/organization-invitation-flow.service', () => ({
+    OrganizationInvitationFlowService: class OrganizationInvitationFlowService {},
+}));
+jest.mock('../organizations/organization-membership.service', () => ({
+    OrganizationMembershipService: class OrganizationMembershipService {},
+}));
+// The `../auth` barrel reaches auth.module -> auth-runtime.instance, which
+// Jest cannot parse. CurrentUser is a PARAMETER decorator, so its mock has
+// to be a factory returning a decorator, not a plain value.
+jest.mock('../auth', () => ({
+    AuthSessionGuard: class AuthSessionGuard {},
+    CurrentUser: () => () => undefined,
+}));
+import { OrgInviteController } from './org-invite.controller';
+
+/**
+ * The consumption side of an Organization invitation.
+ *
+ * Two properties are load-bearing and neither is obvious from the types:
+ *
+ *  1. The PUBLIC preview must not leak the invited address. Anyone holding a
+ *     leaked link can call it, so returning the address in full would turn a
+ *     forwarded email into an address disclosure. It is masked instead — still
+ *     enough to tell the recipient which account to sign in as, which they
+ *     need, because the token is email-bound.
+ *  2. The preview must not consume anything. It is a read; the accept route is
+ *     the only thing that writes.
+ */
+describe('OrgInviteController', () => {
+    const makeInvitation = (overrides: Record<string, unknown> = {}) => ({
+        id: 'inv-1',
+        organizationId: 'org-1',
+        tenantId: 'ten-1',
+        email: 'newcomer@example.com',
+        emailNormalized: 'newcomer@example.com',
+        tokenExpiresAt: new Date('2030-01-01T00:00:00.000Z'),
+        ...overrides,
+    });
+
+    function build(opts: { invitation?: unknown; organization?: unknown } = {}) {
+        const invitations = {
+            findConsumable: jest.fn().mockResolvedValue(opts.invitation ?? makeInvitation()),
+            tryAccept: jest.fn(),
+        };
+        const organizations = {
+            findById: jest
+                .fn()
+                .mockResolvedValue(
+                    opts.organization === undefined
+                        ? { id: 'org-1', slug: 'acme', displayName: 'Acme Inc' }
+                        : opts.organization,
+                ),
+        };
+        const flow = { accept: jest.fn().mockResolvedValue({}) };
+        const controller = new OrgInviteController(
+            invitations as never,
+            organizations as never,
+            flow as never,
+        );
+        return { controller, invitations, organizations, flow };
+    }
+
+    describe('preview (public)', () => {
+        it('MASKS the invited address', async () => {
+            const { controller } = build();
+            const res = await controller.preview({ token: 't'.repeat(64) });
+
+            expect(res.invitedEmailMasked).toBe('n***@example.com');
+            // The whole address must not appear anywhere in the payload.
+            expect(JSON.stringify(res)).not.toContain('newcomer@example.com');
+        });
+
+        it('masks a one-character local part without revealing it', async () => {
+            const { controller } = build({
+                invitation: makeInvitation({ email: 'a@example.com' }),
+            });
+            const res = await controller.preview({ token: 't'.repeat(64) });
+            expect(res.invitedEmailMasked).toBe('*@example.com');
+        });
+
+        it('does not consume the invitation', async () => {
+            const { controller, invitations } = build();
+            await controller.preview({ token: 't'.repeat(64) });
+            expect(invitations.tryAccept).not.toHaveBeenCalled();
+        });
+
+        it('resolves WITHOUT a redeemer address — there is no signed-in user yet', async () => {
+            // This is what lets a brand-new person see "you've been invited to
+            // Acme" before they have an account. Passing an address here would
+            // make the preview 403 for exactly the people it exists to serve.
+            const { controller, invitations } = build();
+            await controller.preview({ token: 't'.repeat(64) });
+
+            expect(invitations.findConsumable).toHaveBeenCalledTimes(1);
+            expect(invitations.findConsumable.mock.calls[0][1]).toBeUndefined();
+        });
+
+        it('returns the organization display name, falling back to the slug', async () => {
+            const named = build();
+            expect((await named.controller.preview({ token: 't' })).organizationName).toBe(
+                'Acme Inc',
+            );
+
+            const unnamed = build({
+                organization: { id: 'org-1', slug: 'acme', displayName: null },
+            });
+            expect((await unnamed.controller.preview({ token: 't' })).organizationName).toBe(
+                'acme',
+            );
+        });
+
+        it('400s when the Organization has been deleted since the invite', async () => {
+            const { controller } = build({ organization: null });
+            await expect(controller.preview({ token: 't' })).rejects.toThrow(BadRequestException);
+        });
+
+        it('passes an empty string rather than undefined for a missing token', async () => {
+            // `findConsumable` rejects a falsy token with 400 invalid_token; the
+            // coercion keeps that path deterministic instead of relying on
+            // whatever the query parser produced.
+            const { controller, invitations } = build();
+            await controller.preview({ token: undefined } as never);
+            expect(invitations.findConsumable).toHaveBeenCalledWith('');
+        });
+    });
+
+    describe('accept (authenticated)', () => {
+        it('delegates to the flow service with the caller identity', async () => {
+            // The controller must NOT re-derive the user or re-check the token:
+            // the ordering guarantees (email bind -> joinTenant -> conditional
+            // UPDATE -> roster) all live in the flow service, and a second
+            // implementation here would be the one that drifts.
+            const { controller, flow } = build();
+            const token = 'a'.repeat(64);
+
+            await controller.accept({ token }, { userId: 'u-9' } as never);
+
+            expect(flow.accept).toHaveBeenCalledTimes(1);
+            expect(flow.accept).toHaveBeenCalledWith(token, 'u-9');
+        });
+    });
+});

--- a/apps/api/src/onboarding/org-invite.controller.ts
+++ b/apps/api/src/onboarding/org-invite.controller.ts
@@ -1,0 +1,147 @@
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { OrganizationInvitationService } from '@ever-works/agent/services';
+import { OrganizationRepository } from '@ever-works/agent/database';
+import { Public } from '../auth/decorators/public.decorator';
+import { AuthSessionGuard, CurrentUser } from '../auth';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { OrganizationInvitationFlowService } from '../organizations/organization-invitation-flow.service';
+import { AcceptOrgInviteDto } from './dto/org-invite.dto';
+
+/** What the signed-out landing page needs to render. 🛑 No token echo. */
+export interface OrgInvitePreviewResponse {
+    organizationName: string;
+    /** Masked — enough to recognise, not enough to harvest. */
+    invitedEmailMasked: string;
+    expiresAt: string;
+}
+
+export interface AcceptOrgInviteResponse {
+    organizationId: string;
+    organizationSlug: string;
+    /** False when this same user had already redeemed it (a double-click). */
+    joined: boolean;
+}
+
+/**
+ * Consumption side of an Organization invitation.
+ *
+ * Split into a `@Public()` preview and an authenticated accept, mirroring
+ * `ClaimController`. That split is what makes a BRAND-NEW person work: they
+ * click the link with no account, the preview renders "you have been invited
+ * to Acme", they register or sign in, and only then does accept run.
+ *
+ * Lives in `OnboardingModule` rather than on the org-scoped controller family
+ * because those routes all carry `:orgId` and sit behind
+ * `OrganizationOwnershipGuard` — which requires membership, the very thing
+ * the invitee does not have yet.
+ */
+@ApiTags('Organizations')
+@Controller('api/org-invite')
+export class OrgInviteController {
+    constructor(
+        private readonly invitations: OrganizationInvitationService,
+        private readonly organizations: OrganizationRepository,
+        private readonly flow: OrganizationInvitationFlowService,
+    ) {}
+
+    /**
+     * Read an invitation without consuming it.
+     *
+     * 10/min per IP, matching the claim preview: a token is 256 bits, but a
+     * tight throttle is what makes brute-forcing a partially-leaked one
+     * infeasible. Somebody landing on the link and reloading twice fits easily.
+     *
+     * Deliberately does NOT pass a redeemer address to `findConsumable` —
+     * there is no signed-in user yet, and this grants nothing.
+     */
+    @Public()
+    // 🛑 POST, not GET, even though this is a read.
+    //
+    // A GET puts the token in the URL, and this repo persists URLs in two
+    // places: `logging.interceptor.ts` logs `Incoming Request: ${method}
+    // ${originalUrl}` (forwarded on as $log events), and Sentry attaches
+    // `event.request.url` — query string included — to transaction events.
+    // Sentry's scrubber only matches pathnames under `/auth`, so this route
+    // would not be covered.
+    //
+    // That would defeat the entire design: the database stores only
+    // sha256(token) precisely so the plaintext lives in exactly one place, the
+    // email. A request BODY is captured by neither of those two paths.
+    @Post('preview')
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Preview an organization invitation without consuming it',
+        description:
+            'Public, and a POST only so the token stays out of URLs and logs. 400 if expired or already accepted, 403 if revoked, 404 if unknown.',
+    })
+    @ApiResponse({ status: 200, description: 'Invitation preview' })
+    async preview(@Body() dto: AcceptOrgInviteDto): Promise<OrgInvitePreviewResponse> {
+        const invitation = await this.invitations.findConsumable(dto.token ?? '');
+        const organization = await this.organizations.findById(invitation.organizationId);
+        if (!organization) {
+            throw new BadRequestException('organization_no_longer_exists');
+        }
+
+        return {
+            organizationName: organization.displayName ?? organization.slug,
+            invitedEmailMasked: maskEmail(invitation.email),
+            expiresAt: invitation.tokenExpiresAt.toISOString(),
+        };
+    }
+
+    /**
+     * Redeem the invitation as the signed-in user.
+     *
+     * Every interesting failure is the flow service's:
+     *   403 `invitation_email_mismatch` — signed in as somebody else
+     *   409 `user_already_in_another_tenant` — already belongs elsewhere
+     *   400 `invitation_expired` / `invitation_already_accepted`
+     *   403 `invitation_revoked`
+     */
+    @Post('accept')
+    @HttpCode(HttpStatus.OK)
+    @UseGuards(AuthSessionGuard)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    @ApiOperation({ summary: 'Accept an organization invitation' })
+    @ApiResponse({ status: 200, description: 'Joined the Organization' })
+    @ApiResponse({ status: 403, description: 'Signed in as a different address' })
+    @ApiResponse({ status: 409, description: 'Already a member of another Tenant' })
+    async accept(
+        @Body() dto: AcceptOrgInviteDto,
+        @CurrentUser() user: AuthenticatedUser,
+    ): Promise<AcceptOrgInviteResponse> {
+        return this.flow.accept(dto.token, user.userId);
+    }
+}
+
+/**
+ * `ada@example.com` → `a**@example.com`.
+ *
+ * The preview is public to anyone holding the token, so returning the full
+ * address would turn a leaked link into an address disclosure. Masked is
+ * still enough for the real job: telling the recipient WHICH of their
+ * accounts to sign in as, since the token is email-bound.
+ *
+ * (The Work claim preview returns its address in full. This is a deliberate
+ * divergence, in the safer direction.)
+ */
+function maskEmail(email: string): string {
+    const at = email.lastIndexOf('@');
+    if (at <= 0) return '***';
+    const local = email.slice(0, at);
+    const domain = email.slice(at);
+    if (local.length <= 1) return `*${domain}`;
+    return `${local[0]}${'*'.repeat(Math.min(local.length - 1, 3))}${domain}`;
+}

--- a/apps/api/src/organizations/__tests__/organization-invitation-flow.service.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization-invitation-flow.service.spec.ts
@@ -1,0 +1,153 @@
+import { BadRequestException } from '@nestjs/common';
+
+// Stub the workspace barrels at module scope so importing the service does not
+// drag the entity/generator graph through Jest — same posture as
+// `ingest.module.spec.ts` and the org-invite controller spec.
+jest.mock('@ever-works/agent/services', () => ({
+    // `invite()` calls the STATIC normaliseEmail on this class, so the stub
+    // needs it. Kept as the real implementation (trim + lowercase) rather than
+    // a jest.fn(), because the value feeds the already-in-tenant lookup and a
+    // mock returning undefined would change which branch runs.
+    OrganizationInvitationService: class OrganizationInvitationService {
+        static normaliseEmail(email: string): string {
+            return email.trim().toLowerCase();
+        }
+    },
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    OrganizationMemberRepository: class OrganizationMemberRepository {},
+    OrganizationRepository: class OrganizationRepository {},
+    TenantRepository: class TenantRepository {},
+    UserRepository: class UserRepository {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('../../scope/tenant-bootstrap.service', () => ({
+    TenantBootstrapService: class TenantBootstrapService {},
+}));
+jest.mock('../../mail/mail.service', () => ({ MailService: class MailService {} }));
+jest.mock('../../config/constants', () => ({
+    config: { webAppUrl: () => 'https://app.test' },
+}));
+jest.mock('../organization-membership.service', () => ({
+    OrganizationMembershipService: class OrganizationMembershipService {},
+}));
+
+import { OrganizationInvitationFlowService } from '../organization-invitation-flow.service';
+
+/**
+ * `invite()` — what happens when the email does not send.
+ *
+ * The invitation row is committed BEFORE the mail call, and the raw token
+ * exists in exactly one place: that email. So a send failure leaves a row
+ * whose token reached nobody and which cannot be recovered — the database
+ * holds only sha256. Left pending, the partial unique index on
+ * (organizationId, emailNormalized) WHERE status='pending' then BLOCKS
+ * re-inviting that address, and there is no resend endpoint, so the obvious
+ * remedy is unavailable and the admin is told an invitation is pending for a
+ * token that does not exist anywhere.
+ */
+const ORG = {
+    id: 'org-1',
+    tenantId: 'ten-1',
+    slug: 'acme',
+    displayName: 'Acme Inc',
+};
+
+function build(opts: { mailFails?: boolean } = {}) {
+    const invitations = {
+        issue: jest.fn().mockResolvedValue({
+            invitation: {
+                id: 'inv-1',
+                email: 'newcomer@example.com',
+                tokenExpiresAt: new Date('2030-01-01'),
+            },
+            token: 'a'.repeat(64),
+        }),
+        revoke: jest.fn().mockResolvedValue(undefined),
+    };
+    const members = { findByOrgAndUser: jest.fn().mockResolvedValue(null), create: jest.fn() };
+    const organizations = { findById: jest.fn().mockResolvedValue(ORG) };
+    const users = {
+        findByEmail: jest.fn().mockResolvedValue(null),
+        findById: jest.fn().mockResolvedValue({ id: 'u-1', username: 'ada' }),
+    };
+    const tenants = { findById: jest.fn().mockResolvedValue({ ownerUserId: 'u-1' }) };
+    const tenantBootstrap = { joinTenant: jest.fn() };
+    const membership = { ensureMember: jest.fn().mockResolvedValue(ORG) };
+    const mail = {
+        sendOrganizationInvitation: opts.mailFails
+            ? jest.fn().mockRejectedValue(new Error('SMTP 421 service unavailable'))
+            : jest.fn().mockResolvedValue(undefined),
+    };
+
+    const service = new OrganizationInvitationFlowService(
+        invitations as never,
+        members as never,
+        organizations as never,
+        users as never,
+        tenants as never,
+        tenantBootstrap as never,
+        membership as never,
+        mail as never,
+    );
+    return { service, invitations, mail, members };
+}
+
+describe('OrganizationInvitationFlowService.invite', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('control: a successful send leaves the invitation alone', () => {
+        // If revoke were called on the happy path too, the assertion below
+        // would pass for the wrong reason.
+        const { service, invitations, mail } = build();
+        return service.invite('org-1', 'u-1', 'newcomer@example.com').then(() => {
+            expect(mail.sendOrganizationInvitation).toHaveBeenCalledTimes(1);
+            expect(invitations.revoke).not.toHaveBeenCalled();
+        });
+    });
+
+    it('🛑 REVOKES the invitation when its email cannot be sent', async () => {
+        const { service, invitations } = build({ mailFails: true });
+
+        await expect(service.invite('org-1', 'u-1', 'newcomer@example.com')).rejects.toThrow(
+            /SMTP/,
+        );
+
+        // Released immediately, so "try again" — the obvious response — works.
+        expect(invitations.revoke).toHaveBeenCalledWith('org-1', 'inv-1');
+    });
+
+    it('rethrows, so the caller never claims an invitation was sent', async () => {
+        const { service } = build({ mailFails: true });
+        await expect(service.invite('org-1', 'u-1', 'newcomer@example.com')).rejects.toThrow();
+    });
+
+    it('does not let a failed revoke mask the original error', async () => {
+        // The mail failure is what the admin needs to see. A secondary failure
+        // while tidying up must not replace it with something less useful.
+        const { service, invitations } = build({ mailFails: true });
+        invitations.revoke.mockRejectedValue(new Error('db unavailable'));
+
+        await expect(service.invite('org-1', 'u-1', 'newcomer@example.com')).rejects.toThrow(
+            /SMTP/,
+        );
+    });
+
+    it('refuses an Organization with no Tenant before minting anything', async () => {
+        const { service, invitations } = build();
+        const noTenant = { ...ORG, tenantId: null };
+        (service as never as { membership: { ensureMember: jest.Mock } }).membership.ensureMember =
+            jest.fn().mockResolvedValue(noTenant);
+
+        await expect(service.invite('org-1', 'u-1', 'x@y.com')).rejects.toThrow(
+            BadRequestException,
+        );
+        expect(invitations.issue).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/organizations/__tests__/organization-invitations.module-wiring.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization-invitations.module-wiring.spec.ts
@@ -1,0 +1,89 @@
+import 'reflect-metadata';
+
+/**
+ * Module wiring for Organization invitations.
+ *
+ * What this guards is the failure `tsc` cannot see: a provider that is
+ * imported and type-checked but never registered. Nest resolves that at BOOT,
+ * not at compile time, so the symptom is every API pod crash-looping on
+ * `Nest can't resolve dependencies of the OrganizationInvitationsController`
+ * — after the image is built, pushed and rolled.
+ *
+ * It also pins the constructor shape of the flow service. A `design:paramtypes`
+ * entry that comes back `undefined` is the signature of a circular import,
+ * which likewise compiles cleanly and dies at boot.
+ *
+ * Mocking posture mirrors `ingest.module.spec.ts`: stub the heavy workspace
+ * barrels at module scope so the decorator metadata can be read without
+ * dragging the entity/generator graph through Jest's CJS transformer. The
+ * mocked classes are only identity anchors — the assertions are about which
+ * collaborators are requested and in what order, not about their behaviour.
+ */
+
+jest.mock('@ever-works/agent/services', () => ({
+    OrganizationInvitationService: class OrganizationInvitationService {},
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    OrganizationMemberRepository: class OrganizationMemberRepository {},
+    OrganizationRepository: class OrganizationRepository {},
+    TenantRepository: class TenantRepository {},
+    UserRepository: class UserRepository {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('../../scope/tenant-bootstrap.service', () => ({
+    TenantBootstrapService: class TenantBootstrapService {},
+}));
+jest.mock('../organization-membership.service', () => ({
+    OrganizationMembershipService: class OrganizationMembershipService {},
+}));
+jest.mock('../../mail/mail.service', () => ({
+    MailService: class MailService {},
+}));
+jest.mock('../../config/constants', () => ({ config: { webAppUrl: () => 'https://app.test' } }));
+
+import { OrganizationInvitationFlowService } from '../organization-invitation-flow.service';
+
+const EXPECTED_COLLABORATORS = [
+    'OrganizationInvitationService',
+    'OrganizationMemberRepository',
+    'OrganizationRepository',
+    'UserRepository',
+    'TenantRepository',
+    'TenantBootstrapService',
+    'OrganizationMembershipService',
+    'MailService',
+];
+
+describe('Organization invitations — module wiring', () => {
+    const paramtypes = (): Array<{ name?: string } | undefined> =>
+        Reflect.getMetadata('design:paramtypes', OrganizationInvitationFlowService) ?? [];
+
+    it('every constructor dependency resolves to a real class', () => {
+        const params = paramtypes();
+        expect(params.length).toBe(EXPECTED_COLLABORATORS.length);
+
+        for (const param of params) {
+            // `undefined` here means a circular import, not a missing
+            // provider: TypeScript emits the metadata as undefined when the
+            // type is not yet defined at decoration time, and Nest then fails
+            // at boot with an unhelpful "dependency at index [n]" message.
+            expect(param).toBeDefined();
+            expect(typeof param).toBe('function');
+        }
+    });
+
+    it('asks for exactly the collaborators it needs, in order', () => {
+        // Order matters: Nest injects positionally, so a reordered constructor
+        // that still type-checks would hand the UserRepository to the slot
+        // expecting the OrganizationRepository.
+        expect(paramtypes().map((p) => p?.name)).toEqual(EXPECTED_COLLABORATORS);
+    });
+
+    it('depends on TenantBootstrapService — the audited tenantId writer', () => {
+        // Pinned explicitly because the temptation, when this grows, is to
+        // write users.tenantId directly from the flow service. Every write to
+        // that column has to stay in TenantBootstrapService, where the
+        // never-move-a-user refusal lives.
+        expect(paramtypes().map((p) => p?.name)).toContain('TenantBootstrapService');
+    });
+});

--- a/apps/api/src/organizations/dto/create-organization-invitation.dto.ts
+++ b/apps/api/src/organizations/dto/create-organization-invitation.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+
+/**
+ * Invite a human into an Organization.
+ *
+ * `email` is required and validated here as well as in the service. That is
+ * not redundant: the DTO rejects a malformed address with a 400 and a field
+ * name the form can point at, while the service guard is what protects any
+ * other caller of `issue()`.
+ */
+export class CreateOrganizationInvitationDto {
+    @ApiProperty({
+        description: 'Where the invitation is sent. The issued token is bound to this address.',
+        example: 'newcomer@example.com',
+        maxLength: 320,
+    })
+    @IsEmail({}, { message: 'invalid_email' })
+    // RFC 5321 caps a path at 320 octets, and the column is sized to match —
+    // without this a longer address would pass validation and then fail at
+    // INSERT as a 500.
+    @MaxLength(320, { message: 'invalid_email' })
+    email: string;
+
+    @ApiPropertyOptional({
+        description: 'Display name for the email copy only. Never used for identity.',
+        maxLength: 200,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    invitedName?: string;
+}

--- a/apps/api/src/organizations/organization-invitation-flow.service.ts
+++ b/apps/api/src/organizations/organization-invitation-flow.service.ts
@@ -1,0 +1,476 @@
+import { BadRequestException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import {
+    OrganizationInvitationService,
+    type IssuedOrganizationInvitation,
+} from '@ever-works/agent/services';
+import {
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    TenantRepository,
+    UserRepository,
+} from '@ever-works/agent/database';
+import type { OrganizationInvitation, OrganizationMember } from '@ever-works/agent/entities';
+import { TenantBootstrapService } from '../scope/tenant-bootstrap.service';
+import { MailService } from '../mail/mail.service';
+import { config } from '../config/constants';
+import { OrganizationMembershipService } from './organization-membership.service';
+
+/**
+ * A roster row as the members UI needs it.
+ *
+ * `username`/`email` are nullable because the roster row outlives nothing but
+ * could still be read while the User row is mid-delete; the UI falls back
+ * rather than rendering a UUID.
+ */
+export type OrganizationMemberView = {
+    id: string;
+    userId: string;
+    username: string | null;
+    email: string | null;
+    role: string;
+    invitedById: string | null;
+    joinedAt: Date;
+    /** Server-computed, so the client cannot forget to ask. */
+    isSelf: boolean;
+    /**
+     * The Tenant owner. Never removable — removing them would orphan every
+     * Organization in the Tenant — and possibly SYNTHESIZED, because an org
+     * created before organization_members existed has no roster row for them.
+     */
+    isOwner: boolean;
+};
+
+export type AcceptOutcome = {
+    organizationId: string;
+    organizationSlug: string;
+    /** False when this invitation had already been redeemed by this same user. */
+    joined: boolean;
+};
+
+/**
+ * The write side of Organization membership: issue an invitation, redeem one,
+ * and remove a member.
+ *
+ * Sits in `apps/api` rather than `packages/agent` because it composes three
+ * things that only the API layer owns together — the agent-side token service,
+ * the roster repository, and `TenantBootstrapService`, which is the audited
+ * writer of `users.tenantId`.
+ *
+ * 🛑 The ordering inside `accept` is deliberate and is the whole correctness
+ * argument. See the comments there before changing it.
+ */
+@Injectable()
+export class OrganizationInvitationFlowService {
+    private readonly logger = new Logger(OrganizationInvitationFlowService.name);
+
+    constructor(
+        private readonly invitations: OrganizationInvitationService,
+        private readonly members: OrganizationMemberRepository,
+        private readonly organizations: OrganizationRepository,
+        private readonly users: UserRepository,
+        private readonly tenants: TenantRepository,
+        private readonly tenantBootstrap: TenantBootstrapService,
+        private readonly membership: OrganizationMembershipService,
+        private readonly mail: MailService,
+    ) {}
+
+    /**
+     * Issue an invitation on behalf of an existing member.
+     *
+     * `ensureMember` runs again here even though the controller sits behind
+     * `OrganizationOwnershipGuard`: this is also the call that resolves the
+     * Organization's `tenantId`, and taking it from the guard's own lookup
+     * rather than a second unvalidated read is what stops a caller from
+     * inviting someone into a Tenant they cannot see.
+     */
+    async invite(
+        orgId: string,
+        actorUserId: string,
+        email: string,
+        invitedName?: string,
+    ): Promise<IssuedOrganizationInvitation> {
+        const organization = await this.membership.ensureMember(orgId, actorUserId);
+        if (!organization.tenantId) {
+            // An Organization with no Tenant cannot grant access to anything,
+            // so there is nothing coherent to invite someone into.
+            throw new BadRequestException('organization_has_no_tenant');
+        }
+
+        const normalized = OrganizationInvitationService.normaliseEmail(email);
+
+        // Someone already inside this Tenant does not need an invitation, and
+        // issuing one would produce a token that can only ever fail at accept
+        // (joinTenant returns 'already_member' and the roster row may exist).
+        // Better to say so now than to send an email that leads nowhere.
+        const existing = await this.users.findByEmail(normalized).catch(() => null);
+        if (existing?.tenantId && existing.tenantId === organization.tenantId) {
+            const alreadyOnRoster = await this.members.findByOrgAndUser(orgId, existing.id);
+            if (alreadyOnRoster) {
+                throw new BadRequestException('user_already_a_member');
+            }
+            // In the Tenant but not on this Org's roster: adopt them directly
+            // rather than mailing a token they do not need.
+            await this.recordMembership(organization.id, organization.tenantId, existing.id, {
+                invitedById: actorUserId,
+            });
+            throw new BadRequestException('user_added_directly');
+        }
+
+        const issued = await this.invitations.issue({
+            organizationId: organization.id,
+            tenantId: organization.tenantId,
+            invitedById: actorUserId,
+            email,
+            invitedName,
+        });
+
+        // 🛑 The raw token leaves this method exactly once, into the email
+        // body. It is not returned to the caller by the controller, not
+        // logged, and not stored — the row holds only sha256(token).
+        const inviter = await this.users.findById(actorUserId);
+        try {
+            await this.mail.sendOrganizationInvitation({
+                recipientEmail: issued.invitation.email,
+                organizationName: organization.displayName ?? organization.slug,
+                inviterName: inviter?.username ?? 'A teammate',
+                acceptUrl: `${config.webAppUrl()}/org-invite/${issued.token}`,
+                expiresAt: issued.invitation.tokenExpiresAt,
+            });
+        } catch (error) {
+            // 🛑 The row is committed but the token only ever existed in the
+            // email that failed to send — so NOBODY holds it, and it cannot be
+            // recovered (the database has only sha256). Left pending, that row
+            // is worse than useless: the partial unique index makes it BLOCK
+            // re-inviting the same address, and there is no resend, so the
+            // admin is told an invitation is pending for a token that reached
+            // no one.
+            //
+            // Revoking it releases the address immediately, so the obvious
+            // response — try again — actually works. The failure is rethrown
+            // so the caller reports it rather than claiming an invite was sent.
+            await this.invitations
+                .revoke(organization.id, issued.invitation.id)
+                .catch(() => undefined);
+            this.logger.error(
+                `Invitation ${issued.invitation.id} was revoked because its email could not be ` +
+                    `sent — the token reached nobody and would otherwise have blocked re-inviting ` +
+                    `that address`,
+                error instanceof Error ? error.stack : String(error),
+            );
+            throw error;
+        }
+
+        return issued;
+    }
+
+    /**
+     * Redeem a token as the signed-in `userId`.
+     *
+     * Order of operations, and why:
+     *
+     *  1. `findConsumable` with the redeemer's address — validates the token
+     *     AND enforces the email binding before anything is written.
+     *  2. `tryAccept` — the conditional UPDATE, and the ONLY atomic gate.
+     *     Nothing is granted unless it wins.
+     *  3. `joinTenant` — the access grant, only after the claim succeeded.
+     *  4. The roster row last: it is purely a record and safe to retry.
+     *
+     * 🛑 Steps 2 and 3 were originally swapped, and that was a real defect,
+     * not a stylistic choice. `joinTenant` commits `users.tenantId`, so with
+     * the grant first a concurrent REVOKE landing in the window left the
+     * invitee with tenant-wide access, no roster row, no entry in the
+     * members list, and no way for an admin to remove them. Whatever gate
+     * authorizes access has to be the atomic one.
+     */
+    async accept(token: string, userId: string): Promise<AcceptOutcome> {
+        const user = await this.users.findById(userId);
+        if (!user) {
+            throw new ForbiddenException('unknown_user');
+        }
+        if (!user.email) {
+            // The token is email-bound, so an account with no address can
+            // never satisfy it. Say that plainly instead of a bare mismatch.
+            throw new ForbiddenException('account_has_no_email');
+        }
+
+        const invitation = await this.invitations.findConsumable(token, user.email);
+        const organization = await this.organizations.findById(invitation.organizationId);
+        if (!organization) {
+            throw new BadRequestException('organization_not_found');
+        }
+
+        // 🛑 The CLAIM comes first, and it is what authorizes the grant.
+        //
+        // This ordering was originally the other way round, on the theory
+        // that refusing a cross-tenant user before burning the token left
+        // the invitation redeemable. That reasoning only covered the
+        // REFUSAL case and missed the inverse: joinTenant commits
+        // `users.tenantId`, so if the claim then lost a race with a
+        // concurrent revoke, the invitee kept tenant-wide access with NO
+        // roster row — invisible in the members list (which reads the
+        // roster) and not removable through removeMember (which needs one).
+        // A revoked invitation therefore still granted access.
+        //
+        // Claiming first inverts that: the conditional UPDATE is the single
+        // atomic gate, and nothing is granted unless it wins.
+        const claimed = await this.invitations.tryAccept(invitation.id, userId);
+        if (!claimed) {
+            // Somebody consumed this token between our read and our write.
+            // If it was this same user (a double-clicked accept) the row now
+            // records THEM, so report success instead of a confusing error.
+            // Checking `acceptedByUserId` is what makes that precise — the
+            // previous code inferred it from a failed re-read, which also
+            // matched a REVOKED invitation and reported success for it.
+            const current = await this.invitations.findById(invitation.id);
+            if (current?.acceptedByUserId === userId) {
+                // Their earlier accept already granted the tenant and wrote
+                // the roster row; make sure both are present, then succeed.
+                await this.tenantBootstrap.joinTenant(
+                    userId,
+                    invitation.tenantId,
+                    invitation.organizationId,
+                );
+                await this.recordMembership(organization.id, invitation.tenantId, userId, {
+                    invitedById: invitation.invitedById,
+                    invitationId: invitation.id,
+                });
+                return {
+                    organizationId: organization.id,
+                    organizationSlug: organization.slug,
+                    joined: false,
+                };
+            }
+            throw new BadRequestException('invitation_state_changed');
+        }
+
+        // 🛑 The ROSTER ROW comes before the grant, and that ordering is the
+        // whole point.
+        //
+        // These are three separate commits with no enclosing transaction
+        // (joinTenant writes through a different repository), so SOME partial
+        // state is unavoidable. The choice is which partial state to prefer,
+        // and the deciding property is VISIBILITY:
+        //
+        //   roster-then-grant (this order): if the grant fails, a roster row
+        //     exists with no access. The person shows up in the members list,
+        //     an admin can see and remove them, and re-accepting repairs it.
+        //     Harmless and self-announcing.
+        //
+        //   grant-then-roster (the obvious order): if the roster write fails,
+        //     the person has TENANT-WIDE ACCESS with no roster row — invisible
+        //     in the members list, and removeMember refuses with `not_a_member`
+        //     because it has no row to delete. That is exactly the unrevocable
+        //     state this method was already fixed once to avoid; reintroducing
+        //     it through a different door would be worse for having been
+        //     thought about.
+        //
+        // recordMembership is idempotent (it no-ops when a row exists), so
+        // writing it first costs nothing on the happy path.
+        await this.recordMembership(organization.id, invitation.tenantId, userId, {
+            invitedById: invitation.invitedById,
+            invitationId: invitation.id,
+        });
+
+        // joinTenant may still throw ConflictException for a user who already
+        // belongs to another Tenant. The invitation stays marked accepted —
+        // deliberately, since leaving a live token for someone who provably
+        // cannot use it helps nobody, and re-inviting a DIFFERENT address is
+        // the actual remedy.
+        let outcome: Awaited<ReturnType<TenantBootstrapService['joinTenant']>>;
+        try {
+            outcome = await this.tenantBootstrap.joinTenant(
+                userId,
+                invitation.tenantId,
+                invitation.organizationId,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Invitation ${invitation.id} was claimed by ${userId} but the tenant join failed — ` +
+                    `a roster row exists WITHOUT access, so they are visible and removable`,
+            );
+            throw error;
+        }
+
+        this.logger.log(
+            `User ${userId} accepted invitation ${invitation.id} into org ${organization.id}`,
+        );
+
+        return {
+            organizationId: organization.id,
+            organizationSlug: organization.slug,
+            joined: outcome === 'joined',
+        };
+    }
+
+    /**
+     * The roster, with each member resolved to a person.
+     *
+     * Returns display identity rather than bare `userId`s. A members list that
+     * renders raw UUIDs is unusable for its one purpose — deciding who to
+     * remove — and it makes "is this row me?" impossible to answer, which is
+     * how a UI ends up offering somebody a button that evicts themselves.
+     *
+     * `isSelf` is computed here rather than left to the client: the caller's
+     * identity is already known at this layer, and a client that has to be
+     * told its own id separately is a client that will one day forget to.
+     */
+    async listMembers(orgId: string, actorUserId: string): Promise<OrganizationMemberView[]> {
+        const organization = await this.membership.ensureMember(orgId, actorUserId);
+        const rows = await this.members.listForOrganization(orgId);
+
+        // 🛑 The Tenant owner is a member by construction and has NO roster row:
+        // nothing ever wrote one, because organization_members did not exist
+        // when their Organization was created. Without this, the members list
+        // is EMPTY for every Organization that predates this feature — which,
+        // on the day it ships, is all of them — and the owner sees a panel
+        // implying they are not in their own org.
+        //
+        // Synthesized rather than backfilled: this is a read path, and a lazy
+        // write here would be a surprising side effect of opening a settings
+        // page. The synthetic row carries the real user, is flagged `isOwner`,
+        // and is never removable — which is also the correct behaviour, since
+        // removing the owner would orphan every Organization in the Tenant.
+        const ownerId = organization.tenantId
+            ? ((await this.tenants.findById(organization.tenantId))?.ownerUserId ?? null)
+            : null;
+        const ownerHasRow = ownerId ? rows.some((r) => r.userId === ownerId) : true;
+
+        if (rows.length === 0 && ownerHasRow) return [];
+
+        const userIds = [...rows.map((r) => r.userId), ...(ownerHasRow ? [] : [ownerId!])];
+        const users = await Promise.all(
+            userIds.map((id) => this.users.findById(id).catch(() => null)),
+        );
+        const byId = new Map(users.filter(Boolean).map((u) => [u!.id, u!]));
+
+        const synthetic: OrganizationMemberView[] = ownerHasRow
+            ? []
+            : [
+                  {
+                      id: `owner:${ownerId}`,
+                      userId: ownerId!,
+                      username: byId.get(ownerId!)?.username ?? null,
+                      email: byId.get(ownerId!)?.email ?? null,
+                      role: 'owner',
+                      invitedById: null,
+                      joinedAt: organization.createdAt ?? new Date(),
+                      isSelf: ownerId === actorUserId,
+                      isOwner: true,
+                  },
+              ];
+
+        const real: OrganizationMemberView[] = rows.map((r) => {
+            const user = byId.get(r.userId);
+            return {
+                id: r.id,
+                userId: r.userId,
+                // `username` is non-null on User and is what
+                // `resolveMemberViews` uses for team rosters — the same person
+                // reads the same way in both places.
+                username: user?.username ?? null,
+                email: user?.email ?? null,
+                role: r.role,
+                invitedById: r.invitedById,
+                joinedAt: r.joinedAt,
+                isSelf: r.userId === actorUserId,
+                isOwner: ownerId !== null && r.userId === ownerId,
+            };
+        });
+
+        // Owner first — they are the fixed point of the list.
+        return [...synthetic, ...real];
+    }
+
+    async listInvitations(orgId: string, actorUserId: string): Promise<OrganizationInvitation[]> {
+        await this.membership.ensureMember(orgId, actorUserId);
+        return this.invitations.listForOrganization(orgId);
+    }
+
+    async revokeInvitation(
+        orgId: string,
+        invitationId: string,
+        actorUserId: string,
+    ): Promise<void> {
+        await this.membership.ensureMember(orgId, actorUserId);
+        await this.invitations.revoke(orgId, invitationId);
+    }
+
+    /**
+     * Remove someone from an Organization.
+     *
+     * 🛑 Because access is TENANT-wide, this is the only place that can give a
+     * departing member their independence back. Their `users.tenantId` is
+     * cleared — but ONLY once they hold no other membership in that Tenant,
+     * otherwise removing them from one Organization would silently revoke
+     * their access to a sibling Organization they are still a member of.
+     *
+     * Clearing it back to NULL (rather than repointing) is what makes this
+     * reversible: `TenantBootstrapService.ensureTenant` will lazily create
+     * them their own Tenant the next time they create an Organization. Without
+     * this, accepting an invitation would be a one-way door — `joinTenant`
+     * refuses to move an already-homed user, so they could never own anything
+     * again.
+     *
+     * Nothing is deleted beyond the roster row. Work they did inside the
+     * Organization stays stamped with that Tenant and stays with the
+     * Organization, which is the intended reading of "they were a member".
+     */
+    async removeMember(orgId: string, targetUserId: string, actorUserId: string): Promise<void> {
+        const organization = await this.membership.ensureMember(orgId, actorUserId);
+
+        const owner = await this.isTenantOwner(targetUserId, organization.tenantId);
+        if (owner) {
+            // The Tenant owner is a member by construction; removing them
+            // would orphan every Organization in the Tenant.
+            throw new BadRequestException('cannot_remove_tenant_owner');
+        }
+
+        const removed = await this.members.deleteByOrgAndUser(orgId, targetUserId);
+        if (!removed) {
+            throw new BadRequestException('not_a_member');
+        }
+
+        if (!organization.tenantId) return;
+        const remaining = await this.members.listForUserInTenant(
+            targetUserId,
+            organization.tenantId,
+        );
+        if (remaining.length === 0) {
+            await this.users.update(targetUserId, { tenantId: null });
+            this.logger.log(
+                `User ${targetUserId} left tenant ${organization.tenantId} — no memberships remain`,
+            );
+        }
+    }
+
+    /**
+     * `tenants.ownerUserId` is UNIQUE, so a single read settles ownership.
+     * The owner is a member of every Organization in their Tenant by
+     * construction — there is no roster row to delete and removing them
+     * would orphan the whole Tenant.
+     */
+    private async isTenantOwner(userId: string, tenantId: string | null): Promise<boolean> {
+        if (!tenantId) return false;
+        const tenant = await this.tenants.findById(tenantId);
+        return tenant?.ownerUserId === userId;
+    }
+
+    private async recordMembership(
+        organizationId: string,
+        tenantId: string,
+        userId: string,
+        extra: { invitedById?: string | null; invitationId?: string | null },
+    ): Promise<void> {
+        const existing = await this.members.findByOrgAndUser(organizationId, userId);
+        if (existing) return;
+        await this.members.create({
+            organizationId,
+            tenantId,
+            userId,
+            role: 'member',
+            invitedById: extra.invitedById ?? null,
+            invitationId: extra.invitationId ?? null,
+            joinedAt: new Date(),
+        });
+    }
+}

--- a/apps/api/src/organizations/organization-invitations.controller.ts
+++ b/apps/api/src/organizations/organization-invitations.controller.ts
@@ -1,0 +1,176 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Param,
+    ParseUUIDPipe,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthSessionGuard, CurrentUser } from '../auth';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { OrganizationOwnershipGuard } from './guards/organization-ownership.guard';
+import { OrganizationInvitationFlowService } from './organization-invitation-flow.service';
+import { CreateOrganizationInvitationDto } from './dto/create-organization-invitation.dto';
+
+/** Wire shape for a pending invitation. 🛑 Never carries the token. */
+export interface OrganizationInvitationResponse {
+    id: string;
+    email: string;
+    role: string;
+    status: string;
+    invitedById: string;
+    tokenExpiresAt: Date;
+    acceptedAt: Date | null;
+    createdAt: Date;
+}
+
+export interface OrganizationMemberResponse {
+    id: string;
+    userId: string;
+    /** Display identity. Null only if the User row vanished mid-read. */
+    username: string | null;
+    email: string | null;
+    role: string;
+    invitedById: string | null;
+    joinedAt: Date;
+    /** Server-computed, so the UI never offers you a button that evicts you. */
+    isSelf: boolean;
+    /** The Tenant owner: never removable, and may be a synthesized row. */
+    isOwner: boolean;
+}
+
+/**
+ * Organization membership — issuance side.
+ *
+ * Every route is object-level authorized by `OrganizationOwnershipGuard`
+ * (class-level; all routes carry `:orgId`), which requires the caller to
+ * already be a member and 404s rather than 403s, so these endpoints cannot be
+ * used to probe which Organization ids exist. Same posture as
+ * `TeamsController`.
+ *
+ * 🛑 The invitation TOKEN is never returned by any route here, not even to the
+ * issuer. It exists only inside the email. A token echoed into an API response
+ * ends up in browser history, proxy logs and screenshots, and it grants
+ * tenant-wide access — the one-way `sha256` in the database is pointless if
+ * the plaintext is handed back over HTTP.
+ */
+@ApiTags('Organizations')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/organizations/:orgId')
+@UseGuards(AuthSessionGuard, OrganizationOwnershipGuard)
+export class OrganizationInvitationsController {
+    constructor(private readonly flow: OrganizationInvitationFlowService) {}
+
+    @Get('members')
+    @ApiOperation({ summary: 'List the members of an Organization' })
+    @ApiResponse({ status: 200, description: 'Members listed' })
+    async listMembers(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @CurrentUser() user: AuthenticatedUser,
+    ): Promise<OrganizationMemberResponse[]> {
+        const members = await this.flow.listMembers(orgId, user.userId);
+        // The service already resolved identity and isSelf; passing the view
+        // straight through keeps one definition of "who is this row".
+        return members;
+    }
+
+    @Get('invitations')
+    @ApiOperation({ summary: 'List invitations issued for an Organization' })
+    @ApiResponse({ status: 200, description: 'Invitations listed' })
+    async listInvitations(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @CurrentUser() user: AuthenticatedUser,
+    ): Promise<OrganizationInvitationResponse[]> {
+        const invitations = await this.flow.listInvitations(orgId, user.userId);
+        return invitations.map((i) => this.toResponse(i));
+    }
+
+    @Post('invitations')
+    // Tighter than the 30/min the org-scoped writes use: this endpoint causes
+    // an email to be sent to an arbitrary address, so it is a spam vector as
+    // well as a write.
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Invite a person into an Organization',
+        description:
+            'Sends an email carrying a single-use, email-bound token. The token is ' +
+            'never returned in the response.',
+    })
+    @ApiResponse({ status: 201, description: 'Invitation issued and emailed' })
+    @ApiResponse({ status: 409, description: 'A pending invitation already exists' })
+    async invite(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @CurrentUser() user: AuthenticatedUser,
+        @Body() dto: CreateOrganizationInvitationDto,
+    ): Promise<OrganizationInvitationResponse> {
+        const { invitation } = await this.flow.invite(
+            orgId,
+            user.userId,
+            dto.email,
+            dto.invitedName,
+        );
+        // `invitation` only — the raw token is deliberately dropped here.
+        return this.toResponse(invitation);
+    }
+
+    @Delete('invitations/:invitationId')
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Revoke a pending invitation' })
+    @ApiResponse({ status: 204, description: 'Invitation revoked' })
+    async revoke(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @Param('invitationId', ParseUUIDPipe) invitationId: string,
+        @CurrentUser() user: AuthenticatedUser,
+    ): Promise<void> {
+        await this.flow.revokeInvitation(orgId, invitationId, user.userId);
+    }
+
+    @Delete('members/:userId')
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({
+        summary: 'Remove a member from an Organization',
+        description:
+            'Deletes the roster row. If this was their last membership in the ' +
+            'Tenant, their users.tenantId is cleared so they can own an ' +
+            'Organization of their own again. No other data is deleted.',
+    })
+    @ApiResponse({ status: 204, description: 'Member removed' })
+    @ApiResponse({ status: 400, description: 'Not a member, or is the Tenant owner' })
+    async removeMember(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @Param('userId', ParseUUIDPipe) targetUserId: string,
+        @CurrentUser() user: AuthenticatedUser,
+    ): Promise<void> {
+        await this.flow.removeMember(orgId, targetUserId, user.userId);
+    }
+
+    private toResponse(i: {
+        id: string;
+        email: string;
+        role: string;
+        status: string;
+        invitedById: string;
+        tokenExpiresAt: Date;
+        acceptedAt: Date | null;
+        createdAt: Date;
+    }): OrganizationInvitationResponse {
+        return {
+            id: i.id,
+            email: i.email,
+            role: i.role,
+            status: i.status,
+            invitedById: i.invitedById,
+            tokenExpiresAt: i.tokenExpiresAt,
+            acceptedAt: i.acceptedAt,
+            createdAt: i.createdAt,
+        };
+    }
+}

--- a/apps/api/src/organizations/organizations.module.ts
+++ b/apps/api/src/organizations/organizations.module.ts
@@ -18,6 +18,15 @@ import { OrganizationService } from './organization.service';
 import { OrganizationMembershipService } from './organization-membership.service';
 import { OrganizationOwnershipGuard } from './guards/organization-ownership.guard';
 import { OrganizationsController } from './organizations.controller';
+import { MailModule } from '../mail/mail.module';
+import { AuthModule } from '../auth/auth.module';
+import { OrganizationInvitationsController } from './organization-invitations.controller';
+import { OrganizationInvitationFlowService } from './organization-invitation-flow.service';
+import { OrganizationInvitationService } from '@ever-works/agent/services';
+import {
+    OrganizationInvitationRepository,
+    OrganizationMemberRepository,
+} from '@ever-works/agent/database';
 import { OrgTemplateCatalogService } from './org-template-catalog.service';
 import { OrgTemplatesController } from './org-templates.controller';
 import { CompanyImportService } from './company-import.service';
@@ -56,6 +65,14 @@ import { WorkRegisteredListener } from './work-registered.listener';
         TasksDomainModule,
         AgentTeamsModule,
         FacadesModule,
+        // Organization invitations send email; MailModule exports MailService.
+        MailModule,
+        // 🛑 REQUIRED by OrganizationInvitationsController's
+        // @UseGuards(AuthSessionGuard, ...). AuthModule is NOT @Global and
+        // AuthSessionGuard uses constructor injection, so without this the
+        // API crash-loops at boot with "Nest can't resolve dependencies".
+        // TeamsModule imports it for exactly the same reason.
+        AuthModule,
     ],
     providers: [
         UserRepository,
@@ -84,8 +101,20 @@ import { WorkRegisteredListener } from './work-registered.listener';
         // Teams & Prebuilt Companies (spec §6) — catalog reader + importer.
         OrgTemplateCatalogService,
         CompanyImportService,
+        // Organization invitations (spec §7 v1.1) — composes the agent-side
+        // token service, the roster repository, and TenantBootstrapService,
+        // which is the audited writer of users.tenantId.
+        OrganizationInvitationService,
+        OrganizationInvitationRepository,
+        OrganizationMemberRepository,
+        OrganizationInvitationFlowService,
     ],
-    controllers: [OrganizationsController, OrgTemplatesController, CompanyImportController],
+    controllers: [
+        OrganizationsController,
+        OrgTemplatesController,
+        CompanyImportController,
+        OrganizationInvitationsController,
+    ],
     exports: [
         OrganizationService,
         OrganizationMembershipService,
@@ -95,6 +124,11 @@ import { WorkRegisteredListener } from './work-registered.listener';
         // expose findById through the remote-proxy controller for
         // the worker-host resolveForOrganization path.
         OrganizationRepository,
+        // Consumed by OnboardingModule's OrgInviteController: the accept
+        // route cannot live on the :orgId family, whose guard requires the
+        // membership the invitee does not have yet.
+        OrganizationInvitationFlowService,
+        OrganizationInvitationService,
     ],
 })
 export class OrganizationsModule {}

--- a/apps/api/src/scope/__tests__/tenant-bootstrap.service.spec.ts
+++ b/apps/api/src/scope/__tests__/tenant-bootstrap.service.spec.ts
@@ -4,7 +4,7 @@
 jest.mock('@ever-works/agent/database', () => ({}));
 jest.mock('@ever-works/agent/entities', () => ({}));
 
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { TenantBootstrapService } from '../tenant-bootstrap.service';
 
 describe('TenantBootstrapService (EW-658 Phase 6)', () => {
@@ -19,10 +19,15 @@ describe('TenantBootstrapService (EW-658 Phase 6)', () => {
         userById?: ReturnType<typeof makeUser> | null;
         tenantById?: { id: string; slug: string; ownerUserId: string } | null;
         tenantByOwner?: { id: string; slug: string; ownerUserId: string } | null;
+        /** false models another accept winning the tenant assignment first. */
+        claimWins?: boolean;
     }) {
         const userRepository = {
             findById: jest.fn().mockResolvedValue(opts.userById ?? null),
             update: jest.fn().mockResolvedValue(undefined),
+            // The conditional UPDATE that replaced the read-then-write.
+            // Defaults to winning; tests override it to model a lost race.
+            claimTenantIfUnassigned: jest.fn().mockResolvedValue(opts.claimWins ?? true),
         };
         const tenantRepository = {
             findById: jest.fn().mockResolvedValue(opts.tenantById ?? null),
@@ -111,5 +116,139 @@ describe('TenantBootstrapService (EW-658 Phase 6)', () => {
 
         // user.tenantId already matches race-winner — no redundant update.
         expect(userRepository.update).not.toHaveBeenCalled();
+    });
+
+    /**
+     * `joinTenant` — accepting an Organization invitation.
+     *
+     * The only writer in the codebase that points a user at a Tenant they do
+     * not own, so the refusal is the thing under test, not the happy path.
+     */
+    describe('joinTenant', () => {
+        it('attaches a user who has no Tenant yet', async () => {
+            const { service, userRepository } = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: null }),
+            });
+
+            await expect(service.joinTenant('u-1', 't-host', 'org-1')).resolves.toBe('joined');
+            expect(userRepository.claimTenantIfUnassigned).toHaveBeenCalledWith('u-1', 't-host');
+        });
+
+        it(`🛑 REFUSES to move a user who already belongs to a different Tenant`, async () => {
+            // The single largest data-integrity risk in the whole feature.
+            // Every row they own is stamped with the OLD tenantId, so
+            // repointing this column silently hides their entire history —
+            // data loss without a DELETE. It must throw, never "best effort".
+            const { service, userRepository } = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: 't-their-own' }),
+            });
+
+            await expect(service.joinTenant('u-1', 't-host', 'org-1')).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            // And critically: nothing was written on the way to the throw.
+            expect(userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('is idempotent when they are already in this Tenant', async () => {
+            // A second redemption of the same invitation, or a double-clicked
+            // accept, must read as success rather than as a conflict.
+            const { service, userRepository } = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: 't-host' }),
+            });
+
+            await expect(service.joinTenant('u-1', 't-host', 'org-1')).resolves.toBe(
+                'already_member',
+            );
+            expect(userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('404s an unknown user instead of writing anything', async () => {
+            const { service, userRepository } = makeService({ userById: null });
+            await expect(service.joinTenant('u-ghost', 't-host')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('sets the landing scope only when the user has no preference', async () => {
+            const fresh = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: null, lastScopeOrganizationId: null }),
+            });
+            await fresh.service.joinTenant('u-1', 't-host', 'org-1');
+            expect(fresh.userRepository.update).toHaveBeenCalledWith('u-1', {
+                lastScopeOrganizationId: 'org-1',
+            });
+
+            // Someone with an existing choice keeps it — joining an Org must
+            // not yank them out of whatever scope they were last working in.
+            const settled = makeService({
+                userById: makeUser({
+                    id: 'u-2',
+                    tenantId: null,
+                    lastScopeOrganizationId: 'org-previous',
+                }),
+            });
+            await settled.service.joinTenant('u-2', 't-host', 'org-1');
+            expect(settled.userRepository.update).not.toHaveBeenCalledWith(
+                'u-2',
+                expect.objectContaining({ lastScopeOrganizationId: 'org-1' }),
+            );
+        });
+
+        it('🛑 refuses when another accept won the tenant assignment first', async () => {
+            // The TOCTOU this replaced: the initial read says tenantId IS
+            // NULL, then a concurrent accept of a DIFFERENT invitation
+            // assigns one. An unconditional write would clobber it and home
+            // the user in whichever tenant committed last — with BOTH
+            // invitations left marked accepted.
+            const { service, userRepository } = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: null }),
+                claimWins: false,
+            });
+            userRepository.findById
+                .mockResolvedValueOnce(makeUser({ id: 'u-1', tenantId: null }))
+                .mockResolvedValueOnce(makeUser({ id: 'u-1', tenantId: 't-somebody-else' }));
+
+            await expect(service.joinTenant('u-1', 't-host', 'org-1')).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('treats losing the race to the SAME tenant as idempotent success', async () => {
+            // A double-clicked accept: the loser must not report a conflict
+            // when the outcome it wanted is exactly what happened.
+            const { service, userRepository } = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: null }),
+                claimWins: false,
+            });
+            userRepository.findById
+                .mockResolvedValueOnce(makeUser({ id: 'u-1', tenantId: null }))
+                .mockResolvedValueOnce(makeUser({ id: 'u-1', tenantId: 't-host' }));
+
+            await expect(service.joinTenant('u-1', 't-host', 'org-1')).resolves.toBe(
+                'already_member',
+            );
+        });
+
+        it('never runs the tenantId backfill', async () => {
+            // createOrganization walks TIER_A + TIER_B tables stamping the
+            // new tenantId onto the user's existing rows. Doing that here
+            // would drag an invitee's private history into the inviter's
+            // Tenant, where it becomes visible tenant-wide. The only write
+            // this method may make is to `users`.
+            const { service, userRepository, tenantRepository } = makeService({
+                userById: makeUser({ id: 'u-1', tenantId: null }),
+            });
+
+            await service.joinTenant('u-1', 't-host', 'org-1');
+
+            // The tenant assignment now goes through the conditional claim,
+            // so the ONLY plain update() left is the optional landing scope.
+            for (const call of userRepository.update.mock.calls) {
+                expect(Object.keys(call[1])).toEqual(['lastScopeOrganizationId']);
+            }
+            expect(tenantRepository.create).not.toHaveBeenCalled();
+        });
     });
 });

--- a/apps/api/src/scope/tenant-bootstrap.service.ts
+++ b/apps/api/src/scope/tenant-bootstrap.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { TenantRepository, UserRepository } from '@ever-works/agent/database';
 import type { Tenant } from '@ever-works/agent/entities';
 import { UsernameAllocatorService } from '../users/services/username-allocator.service';
@@ -28,6 +28,12 @@ import { UsernameAllocatorService } from '../users/services/username-allocator.s
  * routing today; the user-facing scope label is the User's slug for
  * the bare-Tenant surface and the Org's slug for org scopes.)
  */
+/**
+ * What `joinTenant` did. `already_member` is the idempotent case — a
+ * second redemption of the same invitation must not look like a failure.
+ */
+export type JoinTenantOutcome = 'joined' | 'already_member';
+
 @Injectable()
 export class TenantBootstrapService {
     private readonly logger = new Logger(TenantBootstrapService.name);
@@ -104,5 +110,97 @@ export class TenantBootstrapService {
         );
 
         return tenant;
+    }
+
+    /**
+     * Attach a user to a Tenant they do NOT own — accepting an Organization
+     * invitation, and nothing else.
+     *
+     * 🛑 This is the third writer of `users.tenantId` in the codebase and the
+     * only one that ever points a user at a Tenant owned by somebody else.
+     * It lives here, beside `ensureTenant`, so that every write to that
+     * column stays in one audited file.
+     *
+     * **It will not move a user between Tenants. That is a hard refusal, not
+     * a best-effort.** Repointing a populated `users.tenantId` is de-facto
+     * data loss without a DELETE, for four independent reasons:
+     *
+     *  1. Every row that user already created is stamped with their OLD
+     *     `tenantId` by `ScopeStampingSubscriber` and by
+     *     `OrganizationService.createOrganization`. Repointing orphans all
+     *     of it — the rows keep the old tenant, so their entire history
+     *     silently vanishes from the scope they can now see.
+     *  2. `tenants.ownerUserId` is UNIQUE. A user who owns a Tenant cannot
+     *     cleanly stop owning it; repointing leaves an owner-linked,
+     *     member-less orphan Tenant behind.
+     *  3. `OrganizationService.listForUser` returns every Org of
+     *     `user.tenantId`, so repointing instantly hides all of their own
+     *     Organizations from them.
+     *  4. The FK on `users.tenantId` is `ON DELETE SET NULL`; there is no
+     *     database-level protection against this write. The guard has to be
+     *     here, in code, and it has to be tested.
+     *
+     * Deliberately does NOT run the `TIER_A`/`TIER_B` backfill that
+     * `createOrganization` performs. Dragging an invitee's pre-existing
+     * private rows into the inviter's Tenant would expose their history
+     * tenant-wide. Their own Works stay reachable — `WorkRepository` filters
+     * on `userId`, never on `tenantId`.
+     */
+    async joinTenant(
+        userId: string,
+        tenantId: string,
+        organizationId?: string,
+    ): Promise<JoinTenantOutcome> {
+        const user = await this.userRepository.findById(userId);
+        if (!user) {
+            throw new NotFoundException(`User ${userId} not found`);
+        }
+
+        if (user.tenantId === tenantId) {
+            return 'already_member';
+        }
+
+        if (user.tenantId) {
+            this.logger.warn(
+                `Refused to move user ${userId} from tenant ${user.tenantId} to ${tenantId} — ` +
+                    `a user may not be re-homed into another Tenant`,
+            );
+            throw new ConflictException('user_already_in_another_tenant');
+        }
+
+        // 🛑 Conditional UPDATE, not `update(id, { tenantId })`.
+        //
+        // The read above is a hint, not a decision: between it and the write,
+        // a concurrent accept of a DIFFERENT invitation can assign a Tenant.
+        // An unconditional write would clobber it last-write-wins, quietly
+        // homing the user in one Tenant while a second invitation is also
+        // marked accepted. `WHERE "tenantId" IS NULL` lets the database
+        // arbitrate so exactly one accept can win.
+        const claimed = await this.userRepository.claimTenantIfUnassigned(userId, tenantId);
+        if (!claimed) {
+            // Somebody assigned a Tenant in the window. Re-read to see whose
+            // it is: the same one is idempotent success, a different one is
+            // the refusal above, arrived at a few milliseconds later.
+            const fresh = await this.userRepository.findById(userId);
+            if (fresh?.tenantId === tenantId) {
+                return 'already_member';
+            }
+            this.logger.warn(
+                `Lost a race assigning tenant ${tenantId} to user ${userId} — ` +
+                    `they were concurrently homed in ${fresh?.tenantId ?? 'none'}`,
+            );
+            throw new ConflictException('user_already_in_another_tenant');
+        }
+
+        // Point them at the Org they were invited to, but only if they have
+        // no scope preference yet — never stomp an existing choice.
+        if (organizationId && !user.lastScopeOrganizationId) {
+            await this.userRepository.update(userId, {
+                lastScopeOrganizationId: organizationId,
+            });
+        }
+
+        this.logger.log(`User ${userId} joined tenant ${tenantId} (org=${organizationId ?? '-'})`);
+        return 'joined';
     }
 }

--- a/apps/api/src/templates/organization-invitation.hbs
+++ b/apps/api/src/templates/organization-invitation.hbs
@@ -1,0 +1,180 @@
+<html lang='en'>
+    <head>
+        <meta charset='UTF-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+        <title>You've been invited to {{organizationName}}</title>
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+                font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+                    sans-serif;
+                background-color: #f8fafc;
+                line-height: 1.6;
+            }
+            .container {
+                max-width: 600px;
+                margin: 0 auto;
+            }
+            .logo-section {
+                padding: 40px 20px 30px;
+                text-align: center;
+            }
+            .logo-title {
+                font-size: 28px;
+                font-weight: 600;
+                color: #1e293b;
+                margin: 0;
+            }
+            .logo-subtitle {
+                font-size: 14px;
+                color: #94a3b8;
+                margin: 5px 0 0;
+            }
+            .main-card {
+                margin: 0 20px 40px;
+                background-color: #ffffff;
+                border-radius: 8px;
+                padding: 40px 30px;
+            }
+            .icon {
+                text-align: center;
+                font-size: 40px;
+                margin-bottom: 20px;
+            }
+            .title {
+                font-size: 24px;
+                color: #1e293b;
+                font-weight: 600;
+                text-align: center;
+                margin: 0 0 10px;
+            }
+            .subtitle {
+                text-align: center;
+                color: #64748b;
+                margin: 0 0 30px;
+                font-size: 16px;
+            }
+            .button-container {
+                text-align: center;
+                margin: 30px 0 10px;
+            }
+            .button {
+                display: inline-block;
+                padding: 14px 32px;
+                background-color: #4338ca;
+                color: #ffffff !important;
+                text-decoration: none;
+                border-radius: 6px;
+                font-size: 16px;
+                font-weight: 500;
+            }
+            .meta {
+                text-align: center;
+                color: #94a3b8;
+                font-size: 13px;
+                margin: 18px 0 0;
+            }
+            .fallback {
+                color: #64748b;
+                font-size: 12px;
+                word-break: break-all;
+                margin: 14px 0 0;
+            }
+            .footer {
+                padding: 0 20px 40px;
+                text-align: center;
+            }
+            .footer-text {
+                font-size: 12px;
+                color: #94a3b8;
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div class='container'>
+            <div class='logo-section'>
+                <h1 class='logo-title'>{{appName}}</h1>
+                <p class='logo-subtitle'>by {{companyOwner}}</p>
+            </div>
+
+            <div class='main-card'>
+                <div class='icon'>👋</div>
+
+                <h2 class='title'>You've been invited!</h2>
+
+                <p class='subtitle'>
+                    {{inviterName}}
+                    has invited you to join
+                    <strong>{{organizationName}}</strong>
+                    on
+                    {{appName}}.
+                </p>
+
+                <table
+                    width='100%'
+                    cellpadding='0'
+                    cellspacing='0'
+                    style='border-collapse: collapse; background:#f8fafc; border-radius:6px; padding:0; margin-bottom:25px;'
+                >
+                    <tr>
+                        <td
+                            style='padding: 12px 16px; font-size: 14px; color: #94a3b8; width: 120px;'
+                        >Organization</td>
+                        <td
+                            style='padding: 12px 16px; font-size: 14px; color: #1e293b; font-weight: 500;'
+                        >{{organizationName}}</td>
+                    </tr>
+                    <tr>
+                        <td style='padding: 12px 16px; font-size: 14px; color: #94a3b8;'>Invited by</td>
+                        <td
+                            style='padding: 12px 16px; font-size: 14px; color: #1e293b; font-weight: 500;'
+                        >{{inviterName}}</td>
+                    </tr>
+                    <tr>
+                        <td
+                            style='padding: 12px 16px; font-size: 14px; color: #94a3b8;'
+                        >Expires</td>
+                        <td
+                            style='padding: 12px 16px; font-size: 14px; color: #1e293b;'
+                        >{{expiresAtFormatted}}</td>
+                    </tr>
+                </table>
+
+                <div class='button-container'>
+                    <a href='{{acceptUrl}}' class='button'>Accept invitation</a>
+                </div>
+
+                {{!
+                    The address is stated explicitly because the token is
+                    EMAIL-BOUND: redeeming it while signed in as a different
+                    account fails with a mismatch. Saying so here turns a
+                    confusing 403 into an obvious "sign in as this one".
+                }}
+                <p class='meta'>
+                    This invitation is for
+                    <strong>{{recipientEmail}}</strong>
+                    and can only be accepted while signed in as that address. It expires on
+                    {{expiresAtFormatted}}.
+                </p>
+
+                <p class='fallback'>
+                    If the button doesn't work, paste this into your browser:<br />
+                    {{acceptUrl}}
+                </p>
+            </div>
+
+            <div class='footer'>
+                <p class='footer-text'>
+                    If you didn't expect this email, you can safely ignore it — the invitation
+                    cannot be used without access to this mailbox.<br /><br />
+                    ©
+                    {{currentYear}}
+                    {{companyOwner}}. All rights reserved.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/apps/web/e2e/flow-org-member-roles-matrix.spec.ts
+++ b/apps/web/e2e/flow-org-member-roles-matrix.spec.ts
@@ -16,9 +16,20 @@
  *     GET    /api/organizations/:slug            (GLOBAL slug resolver)
  *     PATCH  /api/organizations/:id              (owner/tenant-scoped update)
  *     POST   /api/organizations/:id/upgrade-from-account
- * There is NO `/:id/members`, NO add/remove-member, NO role enum, NO DELETE
- * org, NO last-owner concept — every `/members`, `/invitations`, PATCH-role
- * and DELETE-org URL was probed and returned 404 "Cannot <VERB> ...".
+ * ── UPDATE (2026-08-19): the members half of that is no longer true ─────────
+ * The organization-invitations feature shipped a real
+ * OrganizationInvitationsController mounted at `api/organizations/:orgId`:
+ *     GET    /:orgId/members
+ *     GET    /:orgId/invitations
+ *     POST   /:orgId/invitations            (invite by email; 201)
+ *     DELETE /:orgId/invitations/:id        (revoke; 204)
+ *     DELETE /:orgId/members/:userId        (remove; 204)
+ * Joining is INVITATION-ONLY, so there is STILL no direct add-member, no role
+ * enum / PATCH-role, no DELETE org and no last-owner concept — those URLs
+ * remain route-not-found. The negative contract below was written so "a future
+ * implementer notices the gap"; it did exactly that when `/members` began
+ * answering 200, and has been updated to the new truthful contract rather than
+ * deleted.
  *
  * The role/member MATRIX in this product lives on WORKS, not Organizations
  * (messages/en.json → works.members: roles owner/manager/viewer, "Invite
@@ -294,7 +305,7 @@ test.describe('Org authorization boundary (owner vs non-member, multi-tenant)', 
         }
     });
 
-    test('no org-members API exists: probed /members + DELETE-org surfaces are 404 (truthful negative contract)', async ({
+    test('org-members contract: /members is live and owner-scoped; add/role/DELETE-org stay 404', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
@@ -307,35 +318,69 @@ test.describe('Org authorization boundary (owner vs non-member, multi-tenant)', 
         );
         const headers = authedHeaders(owner.access_token);
 
-        // These are the endpoints the assigned "role matrix" WOULD use. Each was
-        // probed live and route-not-found. Asserting the 404 documents the real
-        // (negative) contract so a future implementer notices the gap, instead of
-        // silently asserting a fictional success.
+        // GET /members SHIPPED with organization-invitations. The owner has no
+        // organization_members row — that table did not exist when their org
+        // was created — so the service SYNTHESIZES them. An empty array here
+        // would mean the owner is absent from their own org's member list,
+        // which is what the synthesis exists to prevent.
         const listMembers = await request.get(`${API_BASE}/api/organizations/${org.id}/members`, {
             headers,
         });
-        expect(listMembers.status()).toBe(404);
+        expect(listMembers.status()).toBe(200);
+        const roster = await listMembers.json();
+        expect(Array.isArray(roster)).toBe(true);
+        expect(roster).toHaveLength(1);
+        expect(roster[0]).toMatchObject({
+            userId: owner.user.id,
+            role: 'owner',
+            isOwner: true,
+            isSelf: true,
+        });
 
+        // 🛑 The boundary the ORIGINAL version of this test could not assert,
+        // because the route did not exist: another tenant's owner must NOT be
+        // able to read this roster. 404-never-403 is deliberate
+        // (OrganizationOwnershipGuard) — the response must not confirm the org
+        // exists. This is the assertion that would catch the members API being
+        // accidentally opened up.
+        const outsider = await registerUserViaAPI(request);
+        await createOrganizationViaAPI(request, outsider.access_token, `Outsider Org ${s}`);
+        const outsiderRead = await request.get(`${API_BASE}/api/organizations/${org.id}/members`, {
+            headers: authedHeaders(outsider.access_token),
+        });
+        expect(outsiderRead.status()).toBe(404);
+
+        // Direct add still does NOT exist: joining is invitation-only, so
+        // nobody can be placed into an Organization without redeeming a token
+        // sent to their own mailbox.
         const addMember = await request.post(`${API_BASE}/api/organizations/${org.id}/members`, {
             headers,
             data: { email: member.email, role: 'admin' },
         });
         expect(addMember.status()).toBe(404);
 
+        // Still NO role matrix — roles are owner/member by construction and
+        // are not assignable over HTTP.
         const patchMemberRole = await request.patch(
             `${API_BASE}/api/organizations/${org.id}/members/${member.user.id}`,
             { headers, data: { role: 'member' } },
         );
         expect(patchMemberRole.status()).toBe(404);
 
+        // DELETE /members/:userId now EXISTS, so this is no longer
+        // route-not-found. Removing somebody who never joined is a truthful
+        // 400 `not_a_member` from a LIVE route — deliberately asserted as 400
+        // rather than 404 so that a regression which un-mounted the route
+        // (404) could not masquerade as this passing.
         const removeMember = await request.delete(
             `${API_BASE}/api/organizations/${org.id}/members/${member.user.id}`,
             { headers },
         );
-        expect(removeMember.status()).toBe(404);
+        expect(removeMember.status()).toBe(400);
+        expect(JSON.stringify(await removeMember.json())).toContain('not_a_member');
 
-        // There is likewise NO DELETE /api/organizations/:id (no org teardown /
-        // last-owner concept) — also route-not-found.
+        // There is likewise STILL NO DELETE /api/organizations/:id (no org
+        // teardown / last-owner concept) — route-not-found.
         const deleteOrg = await request.delete(`${API_BASE}/api/organizations/${org.id}`, {
             headers,
         });

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -8472,6 +8472,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -8472,6 +8472,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -8472,6 +8472,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -8495,6 +8495,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -8472,6 +8472,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -8472,6 +8472,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -8472,6 +8472,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -8473,6 +8473,35 @@
             "mergePolicy": {
                 "title": "Merge policy",
                 "subtitle": "Whether agents may land the pull requests they open in this Organization. Works and Agents underneath can still override any single field."
+            },
+            "members": {
+                "title": "Members",
+                "subtitle": "Invite people to this organization and manage who has access.",
+                "emailLabel": "Email address",
+                "emailPlaceholder": "colleague@company.com",
+                "inviteCta": "Send invitation",
+                "inviteSent": "Invitation sent to {email}.",
+                "addedDirectly": "{email} already had an account here, so they were added straight away.",
+                "tenantWideNote": "People you invite can see every organization in this workspace, not just this one.",
+                "membersHeading": "Members",
+                "pendingHeading": "Pending invitations",
+                "loading": "Loading…",
+                "noMembers": "No members yet.",
+                "you": "You",
+                "owner": "Owner",
+                "remove": "Remove",
+                "revoke": "Revoke",
+                "memberRemoved": "Member removed.",
+                "invitationRevoked": "Invitation revoked.",
+                "errors": {
+                    "invitation_already_pending": "That address already has a pending invitation. Revoke it first to send a new one.",
+                    "user_already_a_member": "That person is already a member of this organization.",
+                    "invalid_email": "That does not look like a valid email address.",
+                    "organization_has_no_tenant": "This organization is not fully set up yet, so it cannot accept members.",
+                    "unknown": "Could not send the invitation. Please try again.",
+                    "removeFailed": "Could not remove that member. Please try again.",
+                    "revokeFailed": "Could not revoke that invitation. Please try again."
+                }
             }
         },
         "switcher": {

--- a/apps/web/src/app/[locale]/org-invite/[token]/page.tsx
+++ b/apps/web/src/app/[locale]/org-invite/[token]/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from 'next';
+import {
+    classifyOrgInviteError,
+    orgInviteAPI,
+    type OrgInviteError,
+    type OrgInvitePreview,
+} from '@/lib/api/org-invite';
+import { OrgInviteForm } from '@/components/org-invite/OrgInviteForm';
+
+export const metadata: Metadata = { title: 'Organization invitation' };
+
+type Params = { params: Promise<{ token: string }> };
+
+type LoadOutcome = { ok: true; preview: OrgInvitePreview } | { ok: false; error: OrgInviteError };
+
+/**
+ * `/org-invite/[token]` — where an invited person lands, straight from an
+ * email, usually with no account at all.
+ *
+ * Modelled on the sibling `/claim/[token]` page. Two things differ, both
+ * because this route serves outsiders rather than existing users:
+ *
+ *  - It renders the REASON a link failed instead of a generic error. A
+ *    visitor with no account cannot debug anything; "this invitation expired"
+ *    and "this link was cancelled" lead to completely different next actions,
+ *    and only one of them is "ask for a new one".
+ *  - The address shown is the API's MASKED form. The page is public to
+ *    anyone holding the token, so it must not turn a forwarded link into an
+ *    address disclosure — but it still has to say which account to sign in
+ *    as, because the token is email-bound.
+ *
+ * 🛑 This route is in PUBLIC_ROUTES. Without that, proxy.ts bounces the
+ * request to /login and CLEARS the auth cookie, destroying the invitation
+ * silently. Pinned by `lib/__tests__/public-routes.unit.spec.ts`.
+ */
+async function loadPreview(token: string): Promise<LoadOutcome> {
+    try {
+        return { ok: true, preview: await orgInviteAPI.preview(token) };
+    } catch (err) {
+        return { ok: false, error: classifyOrgInviteError(err) };
+    }
+}
+
+/** Every failure a visitor can actually land on, in words they can act on. */
+function explain(error: OrgInviteError): { title: string; body: string } {
+    switch (error) {
+        case 'invitation_expired':
+            return {
+                title: 'This invitation has expired',
+                body: 'Invitations are valid for a limited time. Ask whoever invited you to send a new one.',
+            };
+        case 'invitation_revoked':
+            return {
+                title: 'This invitation was cancelled',
+                body: 'The organization withdrew this invitation. If you think that is a mistake, contact them directly.',
+            };
+        case 'invitation_already_accepted':
+            return {
+                title: 'This invitation has already been used',
+                body: 'Each invitation can be accepted once. If you already joined, simply sign in.',
+            };
+        case 'invitation_not_found':
+            return {
+                title: 'We could not find this invitation',
+                body: 'The link may be incomplete. Copy it from your email again, making sure you got the whole address.',
+            };
+        default:
+            return {
+                title: 'This invitation is unavailable',
+                body: 'Something went wrong loading it. Try the link again in a moment.',
+            };
+    }
+}
+
+export default async function OrgInvitePage({ params }: Params) {
+    const { token } = await params;
+    const outcome = await loadPreview(token);
+
+    if (!outcome.ok) {
+        const { title, body } = explain(outcome.error);
+        return (
+            <div className="min-h-screen flex items-center justify-center p-6">
+                <div
+                    className="max-w-md w-full rounded-lg border border-border bg-card p-6 text-center"
+                    data-testid="org-invite-error"
+                >
+                    <h1 className="text-2xl font-semibold mb-2">{title}</h1>
+                    <p className="text-sm text-text-secondary">{body}</p>
+                </div>
+            </div>
+        );
+    }
+
+    const { preview } = outcome;
+
+    return (
+        <div className="min-h-screen flex items-center justify-center p-6">
+            <div
+                className="max-w-md w-full rounded-lg border border-border bg-card p-6 space-y-4"
+                data-testid="org-invite-card"
+            >
+                <div className="text-center space-y-2">
+                    <h1 className="text-2xl font-semibold">
+                        You&apos;ve been invited to {preview.organizationName}
+                    </h1>
+                    <p className="text-sm text-text-secondary">
+                        This invitation was sent to{' '}
+                        <span className="font-medium">{preview.invitedEmailMasked}</span>. Sign in
+                        with that address to accept it.
+                    </p>
+                </div>
+
+                <OrgInviteForm
+                    token={token}
+                    organizationName={preview.organizationName}
+                    invitedEmailMasked={preview.invitedEmailMasked}
+                />
+
+                <p className="text-xs text-text-secondary text-center">
+                    Expires {new Date(preview.expiresAt).toLocaleDateString()}
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/app/actions/auth-register.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-register.unit.spec.ts
@@ -18,10 +18,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * returns rather than by prose that may later be re-worded.
  */
 
-const { registerMock, setAuthCookiesMock, redirectMock } = vi.hoisted(() => ({
+const { registerMock, setAuthCookiesMock, redirectMock, getRedirectUrlMock } = vi.hoisted(() => ({
     registerMock: vi.fn(),
     setAuthCookiesMock: vi.fn(),
     redirectMock: vi.fn(),
+    getRedirectUrlMock: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -46,6 +47,11 @@ vi.mock('next-intl/server', () => ({
 
 vi.mock('@/i18n/navigation', () => ({ redirect: redirectMock }));
 
+// `register` consults the stored destination exactly as `login` does. The
+// organization-invitation flow depends on it: registration is the only way an
+// invited outsider gets an account.
+vi.mock('@/lib/auth/redirect', () => ({ getRedirectUrl: getRedirectUrlMock }));
+
 /** One valid claim — the terms plumbing is not what this file is testing. */
 const TERMS = [
     {
@@ -66,6 +72,9 @@ beforeEach(() => {
     registerMock.mockResolvedValue({ access_token: 'token' });
     setAuthCookiesMock.mockReset();
     redirectMock.mockReset();
+    // Passthrough by default — no stored destination, so the href the action
+    // computed wins and every pre-existing assertion still holds.
+    getRedirectUrlMock.mockReset().mockImplementation(async (_res, href) => href);
 });
 
 afterEach(() => {
@@ -140,5 +149,31 @@ describe('register — the rejection names the field the form shows (EW-074)', (
         await callRegister('  山田家  ', 'lowercase1');
         expect(registerMock).toHaveBeenCalledTimes(1);
         expect(registerMock.mock.calls[0][0].username).toBe('山田家');
+    });
+});
+
+describe('register — the stored destination survives signing up', () => {
+    it('returns a newly-registered user to where they were headed', async () => {
+        // Registration is the ONLY way an invited outsider gets an account.
+        // Without this, the org-invitation landing page stores
+        // /org-invite/<token>, sends them here to sign up, and they land on the
+        // dashboard instead — invitation unaccepted and no longer reachable
+        // from anywhere in the UI. `login` has always honoured the cookie;
+        // `register` never did, so the "create an account" half of every invite
+        // link was a dead end.
+        getRedirectUrlMock.mockResolvedValue('/org-invite/abc123');
+
+        await callRegister('Jane Doe', 'lowercase1');
+
+        expect(getRedirectUrlMock).toHaveBeenCalledTimes(1);
+        expect(redirectMock.mock.calls[0][0].href).toBe('/org-invite/abc123');
+    });
+
+    it('still lands on the dashboard when nothing is stored', async () => {
+        // The ordinary signup path, unchanged: getRedirectUrl falls through to
+        // the href the action computed.
+        await callRegister('Jane Doe', 'lowercase1');
+
+        expect(redirectMock.mock.calls[0][0].href).toContain('newUser=true');
     });
 });

--- a/apps/web/src/app/actions/auth-unverified.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-unverified.unit.spec.ts
@@ -93,6 +93,13 @@ describe('EW-077 — register tells the user the address is unconfirmed', () => 
         registerMock.mockReset();
         setAuthCookiesMock.mockReset();
         redirectMock.mockReset();
+        // `register` now consults the stored destination the way `login` always
+        // has, so the mock has to behave like the real one: return the href it
+        // was handed when nothing is stored. A bare vi.fn() resolves to
+        // undefined, which silently swallows the destination.
+        getRedirectUrlMock
+            .mockReset()
+            .mockImplementation(async (_r: unknown, href: string) => href);
         vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -295,6 +295,28 @@ export async function register(
     // arrives already confirmed, `emailVerified` is not `false` and the notice
     // correctly stays quiet instead of nagging about a rule that isn't on.
     let href = ROUTES.DASHBOARD + '?newUser=true';
+
+    // Honour a stored destination, exactly as `login` does.
+    //
+    // Registration is the ONLY way an invited outsider gets an account, and
+    // without this the organization-invitation flow silently loses them: the
+    // landing page stores `/org-invite/<token>` in `redirect_url`, sends them
+    // here to sign up, and this returned them to the dashboard instead — with
+    // the invitation unaccepted and no longer reachable from anywhere in the
+    // UI. `login` has always consulted the cookie; `register` never did, so
+    // the "create an account" half of every invite link was a dead end.
+    //
+    // `getRedirectUrl` validates the stored value (relative or allow-listed
+    // host only), so this cannot become an open redirect, and it returns the
+    // href above unchanged when nothing is stored.
+    href = await getRedirectUrl(authResponse, href);
+
+    // 🛑 The unverified-email notice is applied AFTER the destination is
+    // resolved, not before. `getRedirectUrl` REPLACES the href wholesale when a
+    // cookie is present, so appending the notice first meant it was silently
+    // dropped for exactly the users who followed a stored link — which is every
+    // invited newcomer, the group most likely to have an unconfirmed address.
+    // Applying it last means the notice survives whichever destination wins.
     if (isEmailUnconfirmed(authResponse?.user)) {
         href = withUnverifiedEmailNotice(href);
     }

--- a/apps/web/src/app/actions/dashboard/org-members.ts
+++ b/apps/web/src/app/actions/dashboard/org-members.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { orgMembersAPI, type OrgInvitation, type OrgMember } from '@/lib/api/org-members';
+
+export type InviteResult =
+    | { status: 'sent'; invitation: OrgInvitation }
+    | { status: 'error'; code: InviteErrorCode };
+
+/**
+ * The failures a person inviting a colleague can actually hit. Each needs a
+ * different sentence, so they are carried as codes rather than collapsed into
+ * one "could not invite".
+ */
+export type InviteErrorCode =
+    | 'invitation_already_pending'
+    | 'user_already_a_member'
+    | 'user_added_directly'
+    | 'invalid_email'
+    | 'organization_has_no_tenant'
+    | 'unknown';
+
+function classify(error: unknown): InviteErrorCode {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    const known: InviteErrorCode[] = [
+        'invitation_already_pending',
+        'user_already_a_member',
+        'user_added_directly',
+        'invalid_email',
+        'organization_has_no_tenant',
+    ];
+    return known.find((code) => message.includes(code)) ?? 'unknown';
+}
+
+function revalidateOrgSettings(): void {
+    revalidatePath('/settings/organization');
+}
+
+export async function inviteToOrganizationAction(
+    orgId: string,
+    email: string,
+    invitedName?: string,
+): Promise<InviteResult> {
+    try {
+        const invitation = await orgMembersAPI.invite(orgId, email, invitedName);
+        revalidateOrgSettings();
+        return { status: 'sent', invitation };
+    } catch (error) {
+        // `user_added_directly` is a SUCCESS the API reports as a 400: the
+        // person was already in the tenant, so they were put on the roster
+        // instead of being mailed a token they did not need. Revalidate so
+        // the new roster row appears.
+        const code = classify(error);
+        if (code === 'user_added_directly') {
+            revalidateOrgSettings();
+        }
+        return { status: 'error', code };
+    }
+}
+
+export async function revokeOrgInvitationAction(
+    orgId: string,
+    invitationId: string,
+): Promise<void> {
+    await orgMembersAPI.revokeInvitation(orgId, invitationId);
+    revalidateOrgSettings();
+}
+
+export async function removeOrgMemberAction(orgId: string, userId: string): Promise<void> {
+    await orgMembersAPI.removeMember(orgId, userId);
+    revalidateOrgSettings();
+}
+
+export async function listOrgMembersAction(orgId: string): Promise<{
+    members: OrgMember[];
+    invitations: OrgInvitation[];
+}> {
+    const [members, invitations] = await Promise.all([
+        orgMembersAPI.listMembers(orgId),
+        orgMembersAPI.listInvitations(orgId),
+    ]);
+    return { members, invitations };
+}

--- a/apps/web/src/app/actions/org-invite.ts
+++ b/apps/web/src/app/actions/org-invite.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { classifyOrgInviteError, orgInviteAPI, type OrgInviteError } from '@/lib/api/org-invite';
+import { setRedirectCookie } from '@/lib/auth/cookies';
+import { ROUTES } from '@/lib/constants';
+
+export type AcceptOrgInviteState =
+    | { status: 'joined'; organizationSlug: string }
+    | { status: 'already_member'; organizationSlug: string }
+    | { status: 'error'; error: OrgInviteError };
+
+/**
+ * Redeem an organization invitation for the signed-in user.
+ *
+ * Returns a discriminated result rather than throwing, because every failure
+ * here is something the visitor needs explained, not a stack trace: the wrong
+ * account, an expired link, or an account that already belongs to a different
+ * organization. The page turns each code into a sentence.
+ */
+export async function acceptOrgInviteAction(token: string): Promise<AcceptOrgInviteState> {
+    try {
+        const result = await orgInviteAPI.accept(token);
+        return {
+            status: result.joined ? 'joined' : 'already_member',
+            organizationSlug: result.organizationSlug,
+        };
+    } catch (error) {
+        return { status: 'error', error: classifyOrgInviteError(error) };
+    }
+}
+
+/**
+ * Remember this invitation, then send the visitor to sign in or register.
+ *
+ * The whole point of the feature is people who have NO account yet, so the
+ * detour through registration must not lose the invitation. `redirect_url` is
+ * the app's existing mechanism and it is already validated on the way out —
+ * `getRedirectUrl` rejects anything that is not relative or an allowed host,
+ * so writing a path here cannot become an open redirect.
+ *
+ * Returns the destination instead of redirecting so the caller keeps control
+ * of navigation (and so this is testable without a router).
+ */
+export async function rememberOrgInviteAndGetAuthHref(
+    token: string,
+    destination: 'login' | 'register',
+): Promise<string> {
+    await setRedirectCookie(ROUTES.orgInvite(token));
+    return destination === 'register' ? ROUTES.AUTH_REGISTER : ROUTES.AUTH_LOGIN;
+}

--- a/apps/web/src/app/actions/org-invite.unit.spec.ts
+++ b/apps/web/src/app/actions/org-invite.unit.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { acceptMock, setRedirectCookieMock } = vi.hoisted(() => ({
+    acceptMock: vi.fn(),
+    setRedirectCookieMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api/org-invite', async (importOriginal) => {
+    // Keep the REAL classifyOrgInviteError — the point of these tests is that
+    // an API rejection reaches the page as a specific, actionable code, and
+    // mocking the classifier would assert nothing.
+    const actual = await importOriginal<typeof import('@/lib/api/org-invite')>();
+    return { ...actual, orgInviteAPI: { accept: acceptMock, preview: vi.fn() } };
+});
+vi.mock('@/lib/auth/cookies', () => ({ setRedirectCookie: setRedirectCookieMock }));
+
+import { acceptOrgInviteAction, rememberOrgInviteAndGetAuthHref } from './org-invite';
+
+/**
+ * The server actions behind the invitation landing page.
+ *
+ * These exist as their own spec because `OrgInviteForm.unit.spec.tsx` MOCKS
+ * this module — so it proves the component calls the action, and can prove
+ * nothing about what the action does. Deleting the `setRedirectCookie` call
+ * left that suite fully green, which is exactly the gap this file closes.
+ */
+const TOKEN = 'a'.repeat(64);
+
+describe('acceptOrgInviteAction', () => {
+    beforeEach(() => {
+        acceptMock.mockReset();
+        setRedirectCookieMock.mockReset();
+    });
+
+    it('reports a fresh join', async () => {
+        acceptMock.mockResolvedValue({ organizationSlug: 'acme', joined: true });
+        await expect(acceptOrgInviteAction(TOKEN)).resolves.toEqual({
+            status: 'joined',
+            organizationSlug: 'acme',
+        });
+    });
+
+    it('distinguishes an already-redeemed invitation from a fresh join', async () => {
+        acceptMock.mockResolvedValue({ organizationSlug: 'acme', joined: false });
+        await expect(acceptOrgInviteAction(TOKEN)).resolves.toEqual({
+            status: 'already_member',
+            organizationSlug: 'acme',
+        });
+    });
+
+    it('returns a specific code rather than throwing', async () => {
+        // The page turns each code into its own sentence; a thrown error would
+        // surface as an unhandled server-action failure with no explanation
+        // for a visitor who has no account and cannot debug anything.
+        acceptMock.mockRejectedValue(new Error('403: invitation_email_mismatch'));
+        await expect(acceptOrgInviteAction(TOKEN)).resolves.toEqual({
+            status: 'error',
+            error: 'invitation_email_mismatch',
+        });
+    });
+
+    it('classifies each distinct failure the API can return', async () => {
+        const cases = [
+            'invitation_expired',
+            'invitation_revoked',
+            'invitation_already_accepted',
+            'invitation_not_found',
+            'user_already_in_another_tenant',
+            'account_has_no_email',
+        ] as const;
+
+        for (const code of cases) {
+            acceptMock.mockRejectedValue(new Error(`api said: ${code}`));
+            const result = await acceptOrgInviteAction(TOKEN);
+            expect(result).toEqual({ status: 'error', error: code });
+        }
+    });
+
+    it('falls back to `unknown` rather than mislabelling an unrecognised error', async () => {
+        acceptMock.mockRejectedValue(new Error('ECONNRESET'));
+        await expect(acceptOrgInviteAction(TOKEN)).resolves.toEqual({
+            status: 'error',
+            error: 'unknown',
+        });
+    });
+});
+
+describe('rememberOrgInviteAndGetAuthHref', () => {
+    beforeEach(() => {
+        setRedirectCookieMock.mockReset();
+    });
+
+    it('🛑 STASHES the invitation before handing back the sign-in href', async () => {
+        // Without this, a brand-new person registers and lands on the
+        // dashboard with their invitation silently spent — the precise
+        // failure the entire signed-out path exists to prevent.
+        const href = await rememberOrgInviteAndGetAuthHref(TOKEN, 'login');
+
+        expect(setRedirectCookieMock).toHaveBeenCalledWith(`/org-invite/${TOKEN}`);
+        expect(href).toBe('/login');
+    });
+
+    it('stashes it on the register path too — the newcomer route', async () => {
+        const href = await rememberOrgInviteAndGetAuthHref(TOKEN, 'register');
+
+        expect(setRedirectCookieMock).toHaveBeenCalledWith(`/org-invite/${TOKEN}`);
+        expect(href).toBe('/register');
+    });
+
+    it('stores a RELATIVE path, so it cannot become an open redirect', async () => {
+        await rememberOrgInviteAndGetAuthHref(TOKEN, 'login');
+        const stored: string = setRedirectCookieMock.mock.calls[0][0];
+
+        expect(stored.startsWith('/')).toBe(true);
+        expect(stored).not.toMatch(/^https?:/i);
+        expect(stored).not.toMatch(/^\/\//);
+    });
+});

--- a/apps/web/src/components/org-invite/OrgInviteForm.tsx
+++ b/apps/web/src/components/org-invite/OrgInviteForm.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from '@/i18n/navigation';
+import { Button } from '@/components/ui/button';
+import {
+    acceptOrgInviteAction,
+    rememberOrgInviteAndGetAuthHref,
+    type AcceptOrgInviteState,
+} from '@/app/actions/org-invite';
+import type { OrgInviteError } from '@/lib/api/org-invite';
+
+interface OrgInviteFormProps {
+    token: string;
+    organizationName: string;
+    invitedEmailMasked: string;
+}
+
+/**
+ * The accept control on the invitation landing page.
+ *
+ * Offers three routes at once — accept, sign in, create an account — because
+ * the person holding this link may be in any of those states and the page
+ * cannot tell which from the server (it is public, so there may be no
+ * session). Trying to accept is the cheapest way to find out: the API answers
+ * definitively, and the failure code says which of the other two to take.
+ *
+ * Both auth links first stash the invitation in `redirect_url`, so the detour
+ * through registration returns here rather than dumping a brand-new user on
+ * the dashboard with their invitation silently spent.
+ */
+export function OrgInviteForm({ token, organizationName, invitedEmailMasked }: OrgInviteFormProps) {
+    const router = useRouter();
+    const [pending, startTransition] = useTransition();
+    const [state, setState] = useState<AcceptOrgInviteState | null>(null);
+
+    const handleAccept = () => {
+        startTransition(async () => {
+            setState(await acceptOrgInviteAction(token));
+        });
+    };
+
+    const goToAuth = (destination: 'login' | 'register') => {
+        startTransition(async () => {
+            router.push(await rememberOrgInviteAndGetAuthHref(token, destination));
+        });
+    };
+
+    if (state?.status === 'joined' || state?.status === 'already_member') {
+        return (
+            <div
+                className="rounded-md border border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-950 p-4 space-y-3 text-sm"
+                data-testid="org-invite-success"
+            >
+                <p className="font-medium">
+                    {state.status === 'joined'
+                        ? `You've joined ${organizationName}`
+                        : `You're already a member of ${organizationName}`}
+                </p>
+                <Button size="sm" onClick={() => router.push('/dashboard')}>
+                    Go to dashboard
+                </Button>
+            </div>
+        );
+    }
+
+    const failure = state?.status === 'error' ? state.error : null;
+
+    return (
+        <div className="space-y-3">
+            {failure ? (
+                <div
+                    className="rounded-md border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950 p-3 text-sm"
+                    data-testid="org-invite-accept-error"
+                >
+                    {explainFailure(failure, invitedEmailMasked)}
+                </div>
+            ) : null}
+
+            <Button
+                onClick={handleAccept}
+                disabled={pending}
+                loading={pending}
+                className="w-full"
+                data-testid="org-invite-accept"
+            >
+                Accept invitation
+            </Button>
+
+            <div className="flex items-center gap-2 text-sm">
+                <button
+                    type="button"
+                    onClick={() => goToAuth('login')}
+                    disabled={pending}
+                    className="underline disabled:opacity-50"
+                    data-testid="org-invite-signin"
+                >
+                    Sign in
+                </button>
+                <span className="text-text-secondary">or</span>
+                <button
+                    type="button"
+                    onClick={() => goToAuth('register')}
+                    disabled={pending}
+                    className="underline disabled:opacity-50"
+                    data-testid="org-invite-register"
+                >
+                    create an account
+                </button>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Each failure gets its own next action. Collapsing these into one message is
+ * what makes an invitation flow feel broken: "wrong account" and "expired"
+ * need opposite responses, and only one of them is worth emailing anyone about.
+ */
+function explainFailure(error: OrgInviteError, invitedEmailMasked: string): string {
+    switch (error) {
+        case 'invitation_email_mismatch':
+            return `This invitation is for ${invitedEmailMasked}. You're signed in as a different account — sign out and back in with that address.`;
+        case 'user_already_in_another_tenant':
+            return 'Your account already belongs to another organization. Accounts cannot be moved between organizations; ask the sender to invite an address that is not in use yet.';
+        case 'account_has_no_email':
+            return 'Your account has no email address, so an email-bound invitation cannot be matched to it.';
+        case 'invitation_expired':
+            return 'This invitation has expired. Ask whoever invited you to send a new one.';
+        case 'invitation_revoked':
+            return 'This invitation was cancelled by the organization.';
+        case 'invitation_already_accepted':
+            return 'This invitation has already been used. If that was you, just sign in.';
+        case 'invitation_not_found':
+            return 'We could not find this invitation. Copy the link from your email again.';
+        default:
+            // The most common cause of an unclassified failure here is simply
+            // not being signed in, so point at the two buttons below.
+            return 'We could not accept this invitation. If you are not signed in yet, use one of the options below.';
+    }
+}

--- a/apps/web/src/components/org-invite/OrgInviteForm.unit.spec.tsx
+++ b/apps/web/src/components/org-invite/OrgInviteForm.unit.spec.tsx
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { acceptMock, rememberMock, pushMock } = vi.hoisted(() => ({
+    acceptMock: vi.fn(),
+    rememberMock: vi.fn(),
+    pushMock: vi.fn(),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: pushMock }),
+    // The Button tree pulls Link from this module; without it the whole
+    // mock is rejected and the suite reports "no tests" rather than a
+    // missing-export error on the line that needs it.
+    Link: ({ href, children, ...rest }: any) => (
+        <a href={typeof href === 'string' ? href : ''} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('@/app/actions/org-invite', () => ({
+    acceptOrgInviteAction: acceptMock,
+    rememberOrgInviteAndGetAuthHref: rememberMock,
+}));
+
+import { OrgInviteForm } from './OrgInviteForm';
+
+/**
+ * The accept control on the public invitation page.
+ *
+ * The person holding this link may have no account, an account under a
+ * different address, or an account already tied to another organization —
+ * and the page cannot tell which, because it renders signed-out. So the
+ * behaviour that matters is: try, then explain the specific failure and offer
+ * the right way forward. A single generic error is what makes an invitation
+ * flow feel broken.
+ *
+ * The other load-bearing property is that BOTH auth links stash the
+ * invitation before navigating. Without that, a brand-new user registers and
+ * lands on the dashboard with their invitation silently spent — the exact
+ * failure the whole signed-out path exists to avoid.
+ */
+const TOKEN = 'a'.repeat(64);
+
+function renderForm() {
+    return render(
+        <OrgInviteForm
+            token={TOKEN}
+            organizationName="Acme Inc"
+            invitedEmailMasked="n***@example.com"
+        />,
+    );
+}
+
+describe('OrgInviteForm', () => {
+    beforeEach(() => {
+        acceptMock.mockReset();
+        rememberMock.mockReset().mockResolvedValue('/login');
+        pushMock.mockReset();
+    });
+
+    it('control: renders all three routes forward', () => {
+        // If this failed, every assertion below would be vacuous against a
+        // component that rendered nothing.
+        renderForm();
+        expect(screen.getByTestId('org-invite-accept')).toBeInTheDocument();
+        expect(screen.getByTestId('org-invite-signin')).toBeInTheDocument();
+        expect(screen.getByTestId('org-invite-register')).toBeInTheDocument();
+    });
+
+    it('accepts with the token it was given', async () => {
+        acceptMock.mockResolvedValue({ status: 'joined', organizationSlug: 'acme' });
+        renderForm();
+
+        await userEvent.click(screen.getByTestId('org-invite-accept'));
+
+        expect(acceptMock).toHaveBeenCalledWith(TOKEN);
+        expect(await screen.findByTestId('org-invite-success')).toHaveTextContent(
+            "You've joined Acme Inc",
+        );
+    });
+
+    it('reports an already-redeemed invitation as success, not as an error', async () => {
+        // A double-clicked accept must not look like a failure to someone who
+        // is, in fact, now a member.
+        acceptMock.mockResolvedValue({ status: 'already_member', organizationSlug: 'acme' });
+        renderForm();
+
+        await userEvent.click(screen.getByTestId('org-invite-accept'));
+
+        expect(await screen.findByTestId('org-invite-success')).toHaveTextContent(
+            "You're already a member of Acme Inc",
+        );
+    });
+
+    it('names the invited address on an email mismatch', async () => {
+        // The single most likely real-world failure: clicking the link while
+        // signed in as a different account. Telling them WHICH address is the
+        // difference between a 10-second fix and giving up.
+        acceptMock.mockResolvedValue({ status: 'error', error: 'invitation_email_mismatch' });
+        renderForm();
+
+        await userEvent.click(screen.getByTestId('org-invite-accept'));
+
+        const box = await screen.findByTestId('org-invite-accept-error');
+        expect(box).toHaveTextContent('n***@example.com');
+        expect(box).toHaveTextContent(/sign out/i);
+    });
+
+    it('explains the already-in-another-organization case distinctly', async () => {
+        // This one is NOT retryable and no amount of re-sending helps, so it
+        // must not share wording with the expiry case.
+        acceptMock.mockResolvedValue({
+            status: 'error',
+            error: 'user_already_in_another_tenant',
+        });
+        renderForm();
+
+        await userEvent.click(screen.getByTestId('org-invite-accept'));
+
+        const box = await screen.findByTestId('org-invite-accept-error');
+        expect(box).toHaveTextContent(/already belongs to another organization/i);
+        expect(box).not.toHaveTextContent(/expired/i);
+    });
+
+    it('gives expiry and revocation different messages', async () => {
+        acceptMock.mockResolvedValue({ status: 'error', error: 'invitation_expired' });
+        const { unmount } = renderForm();
+        await userEvent.click(screen.getByTestId('org-invite-accept'));
+        expect(await screen.findByTestId('org-invite-accept-error')).toHaveTextContent(/expired/i);
+        unmount();
+
+        acceptMock.mockResolvedValue({ status: 'error', error: 'invitation_revoked' });
+        renderForm();
+        await userEvent.click(screen.getByTestId('org-invite-accept'));
+        expect(await screen.findByTestId('org-invite-accept-error')).toHaveTextContent(
+            /cancelled/i,
+        );
+    });
+
+    it('stashes the invitation before sending anyone to sign in', async () => {
+        rememberMock.mockResolvedValue('/login');
+        renderForm();
+
+        await userEvent.click(screen.getByTestId('org-invite-signin'));
+
+        expect(rememberMock).toHaveBeenCalledWith(TOKEN, 'login');
+        expect(pushMock).toHaveBeenCalledWith('/login');
+    });
+
+    it('stashes it before sending anyone to register — the newcomer path', async () => {
+        rememberMock.mockResolvedValue('/register');
+        renderForm();
+
+        await userEvent.click(screen.getByTestId('org-invite-register'));
+
+        expect(rememberMock).toHaveBeenCalledWith(TOKEN, 'register');
+        expect(pushMock).toHaveBeenCalledWith('/register');
+    });
+});

--- a/apps/web/src/components/settings/OrganizationMembersSection.tsx
+++ b/apps/web/src/components/settings/OrganizationMembersSection.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+    inviteToOrganizationAction,
+    listOrgMembersAction,
+    removeOrgMemberAction,
+    revokeOrgInvitationAction,
+    type InviteErrorCode,
+} from '@/app/actions/dashboard/org-members';
+import type { OrgInvitation, OrgMember } from '@/lib/api/org-members';
+
+interface Props {
+    organizationId: string;
+}
+
+/**
+ * Invite people into an Organization, and manage who is already in it.
+ *
+ * Implements the members half of
+ * `docs/specs/features/tenants-and-organizations/spec.md` §6.4, which
+ * deferred it to v1.1.
+ *
+ * 🛑 Worth knowing while reading this: membership is TENANT-wide. Someone
+ * invited to one Organization can see every Organization in that Tenant —
+ * the owner accepted that explicitly for v1 rather than take on rewriting
+ * `ensureMember`, `listForUser`, `ScopeOwnershipGuard` and the scope-stamping
+ * read side. The copy below says so out loud rather than letting people
+ * discover it.
+ */
+export function OrganizationMembersSection({ organizationId }: Props) {
+    const t = useTranslations('organizations.settings.members');
+    const [pending, startTransition] = useTransition();
+    const [email, setEmail] = useState('');
+    const [members, setMembers] = useState<OrgMember[]>([]);
+    const [invitations, setInvitations] = useState<OrgInvitation[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const refresh = () => {
+        startTransition(async () => {
+            const data = await listOrgMembersAction(organizationId);
+            setMembers(data.members);
+            setInvitations(data.invitations);
+            setLoading(false);
+        });
+    };
+
+    useEffect(() => {
+        // 🛑 Clear before fetching, and ignore a response for an org we have
+        // since navigated away from.
+        //
+        // Switching organizations left the PREVIOUS org's roster on screen
+        // until the new fetch resolved — so for a second or two the panel
+        // showed real people who are not in the org named above them, with a
+        // Remove button next to each. Acting on that stale list removes
+        // somebody from an org you are not looking at.
+        //
+        // The `cancelled` flag also handles the out-of-order case: switch A→B→A
+        // quickly and B's slower response would otherwise land last and win.
+        let cancelled = false;
+        setLoading(true);
+        setMembers([]);
+        setInvitations([]);
+
+        startTransition(async () => {
+            const data = await listOrgMembersAction(organizationId);
+            if (cancelled) return;
+            setMembers(data.members);
+            setInvitations(data.invitations);
+            setLoading(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [organizationId]);
+
+    const handleInvite = () => {
+        const trimmed = email.trim();
+        if (!trimmed || pending) return;
+        startTransition(async () => {
+            const result = await inviteToOrganizationAction(organizationId, trimmed);
+            if (result.status === 'sent') {
+                toast.success(t('inviteSent', { email: trimmed }));
+                setEmail('');
+            } else if (result.code === 'user_added_directly') {
+                // A 400 that is really a success — see the action's comment.
+                toast.success(t('addedDirectly', { email: trimmed }));
+                setEmail('');
+            } else {
+                toast.error(t(`errors.${result.code}` as never));
+            }
+            refresh();
+        });
+    };
+
+    const pendingInvites = invitations.filter((i) => i.status === 'pending');
+
+    return (
+        <section className="space-y-4" data-testid="org-members-section">
+            <div>
+                <h3 className="text-lg font-medium">{t('title')}</h3>
+                <p className="text-sm text-text-secondary">{t('subtitle')}</p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
+                <div className="flex-1 min-w-0">
+                    <label htmlFor="org-invite-email" className="block text-xs mb-1">
+                        {t('emailLabel')}
+                    </label>
+                    <input
+                        id="org-invite-email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder={t('emailPlaceholder')}
+                        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                        data-testid="org-invite-email"
+                    />
+                </div>
+                <Button
+                    onClick={handleInvite}
+                    disabled={!email.trim() || pending}
+                    loading={pending}
+                    data-testid="org-invite-submit"
+                    className="shrink-0"
+                >
+                    {t('inviteCta')}
+                </Button>
+            </div>
+
+            <p className="text-xs text-text-secondary">{t('tenantWideNote')}</p>
+
+            <div>
+                <h4 className="text-sm font-medium mb-2">{t('membersHeading')}</h4>
+                {loading ? (
+                    <p className="text-sm text-text-secondary">{t('loading')}</p>
+                ) : members.length === 0 ? (
+                    <p className="text-sm text-text-secondary">{t('noMembers')}</p>
+                ) : (
+                    <ul className="divide-y divide-border" data-testid="org-members-list">
+                        {members.map((m) => (
+                            <li key={m.id} className="flex items-center justify-between py-2">
+                                {/* Identity comes from the API, which resolves it
+                                    from `users`. Rendering `m.userId` showed a raw
+                                    UUID — unusable for the one decision this list
+                                    exists to support. The id remains the fallback
+                                    only if the User row has genuinely vanished. */}
+                                <span className="text-sm">{m.username ?? m.email ?? m.userId}</span>
+                                {/* `isSelf` is computed SERVER-side. This used to
+                                    compare against a `currentUserId` prop that the
+                                    parent never passed, so it was always undefined
+                                    and every member — including you — was offered a
+                                    Remove button that clears their own tenant
+                                    access. */}
+                                {m.isOwner || m.isSelf ? (
+                                    // The owner is a member by construction, and
+                                    // removing them would orphan every
+                                    // Organization in the Tenant — so they get a
+                                    // label rather than a button, same as you.
+                                    <span className="text-xs text-text-secondary">
+                                        {m.isOwner ? t('owner') : t('you')}
+                                    </span>
+                                ) : (
+                                    <button
+                                        type="button"
+                                        disabled={pending}
+                                        onClick={() =>
+                                            startTransition(async () => {
+                                                try {
+                                                    await removeOrgMemberAction(
+                                                        organizationId,
+                                                        m.userId,
+                                                    );
+                                                    toast.success(t('memberRemoved'));
+                                                } catch {
+                                                    toast.error(t('errors.removeFailed'));
+                                                }
+                                                refresh();
+                                            })
+                                        }
+                                        className="text-xs underline disabled:opacity-50"
+                                    >
+                                        {t('remove')}
+                                    </button>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            {pendingInvites.length > 0 ? (
+                <div>
+                    <h4 className="text-sm font-medium mb-2">{t('pendingHeading')}</h4>
+                    <ul className="divide-y divide-border" data-testid="org-pending-list">
+                        {pendingInvites.map((i) => (
+                            <li key={i.id} className="flex items-center justify-between py-2">
+                                <span className="text-sm">{i.email}</span>
+                                <button
+                                    type="button"
+                                    disabled={pending}
+                                    onClick={() =>
+                                        startTransition(async () => {
+                                            try {
+                                                await revokeOrgInvitationAction(
+                                                    organizationId,
+                                                    i.id,
+                                                );
+                                                toast.success(t('invitationRevoked'));
+                                            } catch {
+                                                toast.error(t('errors.revokeFailed'));
+                                            }
+                                            refresh();
+                                        })
+                                    }
+                                    className="text-xs underline disabled:opacity-50"
+                                >
+                                    {t('revoke')}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ) : null}
+        </section>
+    );
+}
+
+/** Exported for the spec, which asserts every code has its own message. */
+export const INVITE_ERROR_CODES: InviteErrorCode[] = [
+    'invitation_already_pending',
+    'user_already_a_member',
+    'invalid_email',
+    'organization_has_no_tenant',
+    'unknown',
+];

--- a/apps/web/src/components/settings/OrganizationSettings.tsx
+++ b/apps/web/src/components/settings/OrganizationSettings.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { ShowDateTime } from '@/components/ui/show-datetime';
 import { MergePolicyCard } from '@/components/policy/MergePolicyCard';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { OrganizationMembersSection } from './OrganizationMembersSection';
 
 /**
  * PR-6 (domain-model evolution, review §23.5) — Organization settings
@@ -266,6 +267,14 @@ export function OrganizationSettings() {
                             subtitle={t('mergePolicy.subtitle')}
                             testIdPrefix="organization-merge-policy"
                         />
+                    ) : null}
+
+                    {/* Members + invitations — the v1.1 item deferred in
+                        docs/specs/features/tenants-and-organizations/spec.md
+                        §6.4. Lives on this page rather than a new settings
+                        tab because that is where the spec put it. */}
+                    {selectedOrg ? (
+                        <OrganizationMembersSection organizationId={selectedOrg.id} />
                     ) : null}
                 </div>
             )}

--- a/apps/web/src/lib/__tests__/public-routes.unit.spec.ts
+++ b/apps/web/src/lib/__tests__/public-routes.unit.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { match } from 'path-to-regexp';
+import { PUBLIC_ROUTES, ROUTES } from '../constants';
+
+/**
+ * Which pages render for a signed-out visitor.
+ *
+ * The failure this guards is silent and total. `proxy.ts` bounces an
+ * unauthenticated request for a non-public route to `/login`, **clears the
+ * auth cookie, and preserves no token**. So a token-landing page that is
+ * missing from `PUBLIC_ROUTES` does not merely redirect — it destroys the
+ * thing the visitor was sent. The user sees a login screen and their
+ * invitation is simply gone, with nothing logged anywhere.
+ *
+ * Three routes already exist for exactly this reason and each carries a
+ * comment saying so: the magic-link landing page, the resend-verification
+ * page, and the onboarding hand-off. `/org-invite/:token` is the fourth, and
+ * it is the one an outsider hits FIRST, before they have any account at all.
+ *
+ * Scope note, stated rather than implied: this exercises the real
+ * `PUBLIC_ROUTES` data with the real `path-to-regexp` matcher, which is where
+ * the mistake would actually be made. It does not import `proxy.ts` itself —
+ * that would pull the whole Next middleware graph in — so the three-line
+ * `isPublicRoute` wrapper is not covered here.
+ */
+
+const isPublic = (pathname: string): boolean =>
+    PUBLIC_ROUTES.some((route) => {
+        const matcher = match(route);
+        return pathname === route || !!matcher(pathname);
+    });
+
+describe('PUBLIC_ROUTES', () => {
+    it('CONTROL: a dashboard route is NOT public', () => {
+        // Without this, an `isPublic` that returned true for everything would
+        // make every assertion below pass while the auth gate was wide open.
+        expect(isPublic('/dashboard')).toBe(false);
+        expect(isPublic('/settings')).toBe(false);
+        expect(isPublic('/teams/abc-123')).toBe(false);
+    });
+
+    it('serves the organization-invitation landing page to signed-out visitors', () => {
+        const token = 'a'.repeat(64);
+        expect(isPublic(`/org-invite/${token}`)).toBe(true);
+    });
+
+    it('matches any token shape, not one hard-coded example', () => {
+        // The token is 64 hex characters today. The route must not silently
+        // depend on that — a length change would otherwise 404 every live
+        // invitation at once.
+        expect(isPublic('/org-invite/short')).toBe(true);
+        expect(isPublic(`/org-invite/${'f'.repeat(128)}`)).toBe(true);
+    });
+
+    it('does not accidentally open the whole /org-invite namespace', () => {
+        // `:token` is a single segment. A bare `/org-invite` or a deeper path
+        // is not a valid invitation link and should not be exempted from auth.
+        expect(isPublic('/org-invite')).toBe(false);
+        expect(isPublic('/org-invite/abc/extra')).toBe(false);
+    });
+
+    it('keeps the sibling token-landing pages public', () => {
+        // Regression net: these three have each been broken before, and the
+        // symptom every time was a cleared cookie rather than an error.
+        expect(isPublic(ROUTES.AUTH_MAGIC_LINK)).toBe(true);
+        expect(isPublic(ROUTES.AUTH_RESEND_VERIFICATION)).toBe(true);
+        expect(isPublic(ROUTES.ONBOARDING)).toBe(true);
+    });
+
+    it('exposes a helper that builds a link the matcher accepts', () => {
+        // The route pattern and the href builder have to agree; if they drift,
+        // every emailed link 404s while the pattern still looks correct.
+        const href = ROUTES.orgInvite('tok-123');
+        expect(href).toBe('/org-invite/tok-123');
+        expect(isPublic(href)).toBe(true);
+    });
+});

--- a/apps/web/src/lib/api/org-invite.ts
+++ b/apps/web/src/lib/api/org-invite.ts
@@ -1,0 +1,81 @@
+import 'server-only';
+import { serverFetch, serverMutation } from './server-api';
+
+/** What the signed-out landing page renders. The address is masked by the API. */
+export interface OrgInvitePreview {
+    organizationName: string;
+    invitedEmailMasked: string;
+    expiresAt: string;
+}
+
+export interface OrgInviteAcceptResult {
+    organizationId: string;
+    organizationSlug: string;
+    /** False when this same user had already redeemed it (a double-click). */
+    joined: boolean;
+}
+
+/**
+ * Why the invitation preview cannot fail closed the way the other clients do:
+ * a visitor here has no account, so "swallow the error and render an empty
+ * page" would show them a blank screen with no way to tell whether the link
+ * was expired, revoked, or simply mistyped. The reason IS the content, so
+ * these deliberately surface it.
+ */
+export type OrgInviteError =
+    | 'invitation_expired'
+    | 'invitation_revoked'
+    | 'invitation_already_accepted'
+    | 'invitation_not_found'
+    | 'invitation_email_mismatch'
+    | 'user_already_in_another_tenant'
+    | 'account_has_no_email'
+    | 'unknown';
+
+/** Map an API rejection onto one of the codes the page knows how to explain. */
+export function classifyOrgInviteError(error: unknown): OrgInviteError {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    const known: OrgInviteError[] = [
+        'invitation_expired',
+        'invitation_revoked',
+        'invitation_already_accepted',
+        'invitation_not_found',
+        'invitation_email_mismatch',
+        'user_already_in_another_tenant',
+        'account_has_no_email',
+    ];
+    // Substring rather than equality: the API wraps these in an exception
+    // whose message may carry a prefix, and a stricter match would silently
+    // collapse every distinct case into `unknown`.
+    return known.find((code) => message.includes(code)) ?? 'unknown';
+}
+
+export const orgInviteAPI = {
+    /**
+     * Read an invitation without consuming it. Public — no session needed;
+     * `serverFetch` simply omits the Authorization header when there is no
+     * cookie.
+     */
+    async preview(token: string): Promise<OrgInvitePreview> {
+        // POST for a read, deliberately: a GET would put the token in the URL,
+        // where the API's request logger and Sentry both capture it.
+        return serverMutation<OrgInvitePreview>({
+            endpoint: '/org-invite/preview',
+            method: 'POST',
+            data: { token },
+            wrapInData: false,
+        });
+    },
+
+    /** Redeem as the signed-in user. Requires a session. */
+    async accept(token: string): Promise<OrgInviteAcceptResult> {
+        return serverMutation<OrgInviteAcceptResult>({
+            endpoint: '/org-invite/accept',
+            method: 'POST',
+            // `data` is the body and `wrapInData` decides whether it is
+            // nested under a `data` key; this endpoint takes { token } flat.
+            data: { token },
+            wrapInData: false,
+        });
+    },
+};

--- a/apps/web/src/lib/api/org-members.ts
+++ b/apps/web/src/lib/api/org-members.ts
@@ -1,0 +1,90 @@
+import 'server-only';
+import { serverFetch, serverMutation } from './server-api';
+
+export interface OrgMember {
+    id: string;
+    userId: string;
+    /** Display identity, resolved server-side. Null only if the User vanished. */
+    username: string | null;
+    email: string | null;
+    role: string;
+    invitedById: string | null;
+    joinedAt: string;
+    /** Server-computed. The UI must never offer a self-removal button. */
+    isSelf: boolean;
+    /** The Tenant owner: never removable. */
+    isOwner: boolean;
+}
+
+export interface OrgInvitation {
+    id: string;
+    email: string;
+    role: string;
+    /** 'pending' | 'accepted' | 'expired' | 'revoked' */
+    status: string;
+    invitedById: string;
+    tokenExpiresAt: string;
+    acceptedAt: string | null;
+    createdAt: string;
+}
+
+/**
+ * Organization roster + invitation management.
+ *
+ * 🛑 Nothing here ever carries a token: the API deliberately omits it from
+ * every response, including to the issuer. The only copy that exists outside
+ * the `sha256` in the database is the one in the email body.
+ *
+ * Reads swallow failures to `[]`, matching `teamsAPI.listOrganizations` —
+ * these feed a settings panel whose other sections must still render. Writes
+ * do NOT swallow: the caller needs to tell the user whether the invitation
+ * was actually sent.
+ */
+export const orgMembersAPI = {
+    async listMembers(orgId: string): Promise<OrgMember[]> {
+        try {
+            return await serverFetch<OrgMember[]>(`/organizations/${orgId}/members`, {
+                method: 'GET',
+            });
+        } catch {
+            return [];
+        }
+    },
+
+    async listInvitations(orgId: string): Promise<OrgInvitation[]> {
+        try {
+            return await serverFetch<OrgInvitation[]>(`/organizations/${orgId}/invitations`, {
+                method: 'GET',
+            });
+        } catch {
+            return [];
+        }
+    },
+
+    async invite(orgId: string, email: string, invitedName?: string): Promise<OrgInvitation> {
+        return serverMutation<OrgInvitation>({
+            endpoint: `/organizations/${orgId}/invitations`,
+            method: 'POST',
+            data: invitedName ? { email, invitedName } : { email },
+            wrapInData: false,
+        });
+    },
+
+    async revokeInvitation(orgId: string, invitationId: string): Promise<void> {
+        await serverMutation<void>({
+            endpoint: `/organizations/${orgId}/invitations/${invitationId}`,
+            method: 'DELETE',
+            data: {},
+            wrapInData: false,
+        });
+    },
+
+    async removeMember(orgId: string, userId: string): Promise<void> {
+        await serverMutation<void>({
+            endpoint: `/organizations/${orgId}/members/${userId}`,
+            method: 'DELETE',
+            data: {},
+            wrapInData: false,
+        });
+    },
+};

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -283,6 +283,15 @@ export const ROUTES = {
     // UNAUTHENTICATED by fresh visitors — the page mints an anonymous session
     // client-side, so it MUST be in PUBLIC_ROUTES (mirrors AUTH_MAGIC_LINK).
     ONBOARDING: '/onboarding',
+    // Organization-invitation landing page. Reached by a BRAND-NEW person
+    // straight from an email, with no account and no session — which is
+    // the entire point of the feature. It must be public: the proxy auth
+    // gate below bounces an unauthenticated request to /login AND clears
+    // the cookie, and it preserves no token, so gating this page would
+    // silently destroy the invitation the visitor was sent.
+    ORG_INVITE: '/org-invite/:token',
+    /** Concrete href for a given token. */
+    orgInvite: (token: string) => `/org-invite/${token}`,
 
     // API routes
     API_AUTH_VERIFY_EMAIL: '/api/auth/verify-email',
@@ -320,6 +329,11 @@ export const PUBLIC_ROUTES = [
     // client-side redeem can set the session cookie (mirrors the other
     // token-landing pages above).
     ROUTES.AUTH_MAGIC_LINK,
+    // Organization invitations — the invitee has no account yet, so this
+    // page has to render signed-out. `path-to-regexp` matches the :token
+    // segment. The page itself grants nothing: it renders a preview and
+    // sends the visitor to register or sign in.
+    ROUTES.ORG_INVITE,
     // EW-617 zero-friction onboarding landing page — public so anonymous
     // visitors from the marketing site can mint a guest session client-side.
     ROUTES.ONBOARDING,

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -28,6 +28,8 @@ import { WorkCustomDomain } from '../entities/work-custom-domain.entity';
 import { WorkDeployment } from '../entities/work-deployment.entity';
 import { WorkMember } from '../entities/work-member.entity';
 import { WorkInvitation } from '../entities/work-invitation.entity';
+import { OrganizationInvitation } from '../entities/organization-invitation.entity';
+import { OrganizationMember } from '../entities/organization-member.entity';
 import { WorkGenerationHistory } from '../entities/work-generation-history.entity';
 import { SubscriptionPlan } from '../entities/subscription-plan.entity';
 import { UserSubscription } from '../entities/user-subscription.entity';
@@ -167,6 +169,8 @@ export const ENTITIES = [
     WorkDeployment,
     WorkMember,
     WorkInvitation,
+    OrganizationInvitation,
+    OrganizationMember,
     User,
     RefreshToken,
     CacheEntry,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -203,6 +203,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'WorkDeployment',
     'WorkGenerationHistory',
     'WorkInvitation',
+    'OrganizationInvitation',
+    'OrganizationMember',
     'WorkKnowledgeChunk',
     'WorkKnowledgeChunkCoordinate',
     'WorkKnowledgeCitation',

--- a/packages/agent/src/database/_repository-inventory.ts
+++ b/packages/agent/src/database/_repository-inventory.ts
@@ -79,6 +79,8 @@ import { WorkCustomDomainRepository } from './repositories/work-custom-domain.re
 import { WorkDeploymentRepository } from './repositories/work-deployment.repository';
 import { WorkGenerationHistoryRepository } from './repositories/work-generation-history.repository';
 import { WorkInvitationRepository } from './repositories/work-invitation.repository';
+import { OrganizationInvitationRepository } from './repositories/organization-invitation.repository';
+import { OrganizationMemberRepository } from './repositories/organization-member.repository';
 import { WorkMemberRepository } from './repositories/work-member.repository';
 import { WorkRepository } from './repositories/work.repository';
 import { WorkScheduleRepository } from './repositories/work-schedule.repository';
@@ -133,6 +135,8 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     WorkDeploymentRepository,
     WorkGenerationHistoryRepository,
     WorkInvitationRepository,
+    OrganizationInvitationRepository,
+    OrganizationMemberRepository,
     WorkMemberRepository,
     WorkRepository,
     WorkScheduleRepository,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -67,6 +67,8 @@ export * from './repositories/agent-mcp-server-binding.repository';
 // Tenants & Organizations (EW-651 epic) — Phase 1 / EW-653.
 export * from './repositories/tenant.repository';
 export * from './repositories/organization.repository';
+export * from './repositories/organization-invitation.repository';
+export * from './repositories/organization-member.repository';
 // Notifications v2 (EW-650 / EW-663 / EW-664) — email + multi-channel
 // + per-user preference repositories.
 export * from './repositories/tenant-email-address.repository';

--- a/packages/agent/src/database/repositories/organization-invitation.repository.ts
+++ b/packages/agent/src/database/repositories/organization-invitation.repository.ts
@@ -1,0 +1,171 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import { OrganizationInvitation } from '../../entities/organization-invitation.entity';
+import { OrganizationInvitationStatus } from '../../entities/types';
+
+/**
+ * Data access for `OrganizationInvitation`.
+ *
+ * Mirrors `WorkInvitationRepository`, including the one method that carries
+ * the concurrency guarantee: `tryMarkAccepted` is a conditional UPDATE, not a
+ * read-then-write, so two people redeeming the same token race in the
+ * database and exactly one wins.
+ */
+@Injectable()
+export class OrganizationInvitationRepository {
+    constructor(
+        @InjectRepository(OrganizationInvitation)
+        private readonly repository: Repository<OrganizationInvitation>,
+    ) {}
+
+    async create(data: Partial<OrganizationInvitation>): Promise<OrganizationInvitation> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    async findById(id: string): Promise<OrganizationInvitation | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    async findByTokenHash(tokenHash: string): Promise<OrganizationInvitation | null> {
+        return this.repository.findOne({ where: { tokenHash } });
+    }
+
+    /** The live invitation for this mailbox, if any — what the unique index protects. */
+    async findPendingForEmail(
+        organizationId: string,
+        emailNormalized: string,
+    ): Promise<OrganizationInvitation | null> {
+        return this.repository.findOne({
+            where: {
+                organizationId,
+                emailNormalized,
+                status: OrganizationInvitationStatus.PENDING,
+            },
+        });
+    }
+
+    async listForOrganization(organizationId: string): Promise<OrganizationInvitation[]> {
+        return this.repository.find({
+            where: { organizationId },
+            order: { createdAt: 'DESC' },
+        });
+    }
+
+    async listPendingForOrganization(organizationId: string): Promise<OrganizationInvitation[]> {
+        return this.repository.find({
+            where: { organizationId, status: OrganizationInvitationStatus.PENDING },
+            order: { createdAt: 'DESC' },
+        });
+    }
+
+    /**
+     * Claim the invitation, atomically.
+     *
+     * The `status = pending` predicate lives in the WHERE clause on purpose: a
+     * read-then-write would let two concurrent redemptions of one token both
+     * observe `pending` and both proceed, producing two memberships and two
+     * tenant writes. Returns false if somebody else got there first.
+     */
+    async tryMarkAccepted(
+        id: string,
+        acceptedByUserId: string,
+        acceptedAt: Date,
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(OrganizationInvitation)
+            .set({
+                status: OrganizationInvitationStatus.ACCEPTED,
+                acceptedByUserId,
+                acceptedAt,
+            })
+            .where('id = :id AND status = :pending', {
+                id,
+                pending: OrganizationInvitationStatus.PENDING,
+            })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    async markRevoked(id: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(OrganizationInvitation)
+            .set({ status: OrganizationInvitationStatus.REVOKED })
+            .where('id = :id AND status = :pending', {
+                id,
+                pending: OrganizationInvitationStatus.PENDING,
+            })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Retire a timed-out invitation for one address, so it can be re-issued.
+     *
+     * The partial unique index is `WHERE status = 'pending'`, and NOTHING moves
+     * a row from `pending` to `expired` on a timer. So an invitation that aged
+     * out still occupies the slot: re-inviting the same person fails with
+     * `invitation_already_pending`, telling the admin there is a live
+     * invitation when the token behind it is dead. That would be permanent —
+     * there is no UI for revoking an invitation you are told exists but which
+     * the invitee cannot use.
+     *
+     * Scoped to the one (organization, email) pair being re-invited rather
+     * than sweeping the table, so issuing an invitation stays a bounded write.
+     */
+    async expireStaleForEmail(
+        organizationId: string,
+        emailNormalized: string,
+        now: Date = new Date(),
+    ): Promise<number> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(OrganizationInvitation)
+            .set({ status: OrganizationInvitationStatus.EXPIRED })
+            .where(
+                '"organizationId" = :organizationId AND "emailNormalized" = :emailNormalized ' +
+                    'AND status = :pending AND "tokenExpiresAt" <= :now',
+                {
+                    organizationId,
+                    emailNormalized,
+                    pending: OrganizationInvitationStatus.PENDING,
+                    now,
+                },
+            )
+            .execute();
+        return result.affected ?? 0;
+    }
+
+    /**
+     * Move timed-out rows to `expired`.
+     *
+     * Housekeeping only — it does NOT gate access. Nothing runs this on a
+     * timer, so consumption paths must still call `isExpired()` rather than
+     * trusting `status`.
+     */
+    async expireBefore(now: Date): Promise<number> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(OrganizationInvitation)
+            .set({ status: OrganizationInvitationStatus.EXPIRED })
+            .where('status = :pending AND "tokenExpiresAt" <= :now', {
+                pending: OrganizationInvitationStatus.PENDING,
+                now,
+            })
+            .execute();
+        return result.affected ?? 0;
+    }
+
+    async findExpiredPending(now: Date, limit = 100): Promise<OrganizationInvitation[]> {
+        return this.repository.find({
+            where: {
+                status: OrganizationInvitationStatus.PENDING,
+                tokenExpiresAt: LessThanOrEqual(now),
+            },
+            take: limit,
+        });
+    }
+}

--- a/packages/agent/src/database/repositories/organization-member.repository.ts
+++ b/packages/agent/src/database/repositories/organization-member.repository.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OrganizationMember } from '../../entities/organization-member.entity';
+
+/**
+ * Data access for `OrganizationMember` — the Organization roster.
+ *
+ * 🛑 Nothing here grants access. Authorization remains
+ * `user.tenantId === organization.tenantId` in
+ * `OrganizationMembershipService`; these rows record who was invited by whom
+ * and when. See the entity docblock.
+ */
+@Injectable()
+export class OrganizationMemberRepository {
+    constructor(
+        @InjectRepository(OrganizationMember)
+        private readonly repository: Repository<OrganizationMember>,
+    ) {}
+
+    async create(data: Partial<OrganizationMember>): Promise<OrganizationMember> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    async findByOrgAndUser(
+        organizationId: string,
+        userId: string,
+    ): Promise<OrganizationMember | null> {
+        return this.repository.findOne({ where: { organizationId, userId } });
+    }
+
+    async listForOrganization(organizationId: string): Promise<OrganizationMember[]> {
+        return this.repository.find({
+            where: { organizationId },
+            order: { joinedAt: 'ASC' },
+        });
+    }
+
+    /**
+     * Every membership this user holds anywhere in the given Tenant.
+     *
+     * Needed by the removal path: access is tenant-wide, so `users.tenantId`
+     * may only be cleared once the person's LAST membership in that Tenant is
+     * gone. Removing them from one Organization while they still belong to
+     * another in the same Tenant must not revoke their access.
+     */
+    async listForUserInTenant(userId: string, tenantId: string): Promise<OrganizationMember[]> {
+        return this.repository.find({ where: { userId, tenantId } });
+    }
+
+    async deleteByOrgAndUser(organizationId: string, userId: string): Promise<boolean> {
+        const result = await this.repository.delete({ organizationId, userId });
+        return (result.affected ?? 0) > 0;
+    }
+
+    async countForOrganization(organizationId: string): Promise<number> {
+        return this.repository.count({ where: { organizationId } });
+    }
+}

--- a/packages/agent/src/database/repositories/user.repository.ts
+++ b/packages/agent/src/database/repositories/user.repository.ts
@@ -136,6 +136,28 @@ export class UserRepository {
         return await this.findById(id);
     }
 
+    /**
+     * Attach a user to a Tenant, but ONLY if they have none yet.
+     *
+     * A conditional UPDATE rather than a read-then-write, because the
+     * read-then-write version is a TOCTOU: two invitations accepted at the
+     * same instant both observe `tenantId IS NULL`, both write, and the
+     * user silently ends up in whichever Tenant committed last — with the
+     * other invitation also marked accepted. `WHERE "tenantId" IS NULL` lets
+     * the database arbitrate, so exactly one wins.
+     *
+     * Returns true if this call is the one that assigned the Tenant.
+     */
+    async claimTenantIfUnassigned(id: string, tenantId: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(User)
+            .set({ tenantId })
+            .where('id = :id AND "tenantId" IS NULL', { id })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
     async updateForSocialAuth(id: string, userData: Partial<User>): Promise<User> {
         await this.repository.update(id, userData);
         return this.findByIdForSocialAuth(id);

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -5,6 +5,8 @@ export * from './work-custom-domain.entity';
 export * from './work-deployment.entity';
 export * from './work-member.entity';
 export * from './work-invitation.entity';
+export * from './organization-invitation.entity';
+export * from './organization-member.entity';
 export * from './user.entity';
 export * from './user-upload.entity';
 export * from './refresh-token.entity';

--- a/packages/agent/src/entities/organization-invitation.entity.ts
+++ b/packages/agent/src/entities/organization-invitation.entity.ts
@@ -1,0 +1,157 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    Index,
+    ManyToOne,
+    JoinColumn,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+import { Organization } from './organization.entity';
+import { ClassToObject, OrganizationInvitationRole, OrganizationInvitationStatus } from './types';
+import { PortableDateColumn } from './_types';
+
+export type OrganizationInvitationMetadata = {
+    /** Display name the inviter typed, if any — used only in the email copy. */
+    invitedName?: string;
+    /** Free-form additional context. */
+    [k: string]: unknown;
+};
+
+/**
+ * An outstanding invitation for a HUMAN to join an Organization.
+ *
+ * Implements the `OrganizationInvitation` half of the v1.1 item deferred in
+ * `docs/specs/features/tenants-and-organizations/spec.md` §7. The sibling
+ * `WorkInvitation` is the template: same 256-bit token, same
+ * store-only-the-hash rule, same status lifecycle.
+ *
+ * Two deliberate divergences from `WorkInvitation`, both tightenings:
+ *
+ *  1. **`email` is NOT NULL here.** `WorkInvitation.email` is nullable because
+ *     a Work invite can be a bare link handed over out-of-band. An Org invite
+ *     exists to reach someone who does not have an account yet, and the mail
+ *     path silently no-ops on a null recipient — a nullable column would make
+ *     "invited someone who can never be reached" representable.
+ *  2. **The token is EMAIL-BOUND** (see `emailNormalized`). A Work token is a
+ *     bearer credential; an Org token grants tenant-wide access, which is a
+ *     much larger blast radius, so possession alone is deliberately not enough.
+ */
+@Entity({ name: 'organization_invitations' })
+@Index(['organizationId'])
+@Index(['tokenHash'], { unique: true })
+@Index(['status'])
+// One live invitation per person per Organization. Without this, "invite"
+// clicked twice mints two independently redeemable tokens for the same
+// mailbox, and revoking the one you can see leaves the other one live.
+// Partial (`status = 'pending'`) so that re-inviting someone whose earlier
+// invite was revoked or expired stays legal.
+@Index(['organizationId', 'emailNormalized'], {
+    unique: true,
+    where: "status = 'pending'",
+})
+export class OrganizationInvitation {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    organizationId: string;
+
+    @ManyToOne(() => Organization, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'organizationId' })
+    organization: ClassToObject<Organization>;
+
+    /**
+     * The Tenant the invitee joins on accept.
+     *
+     * NOT the nullable Tier-C denormalization that `WorkInvitation` carries —
+     * here it is the scope key itself, copied from the Organization at
+     * issuance so that a later Org move cannot silently redirect a live
+     * invitation into a different Tenant.
+     */
+    @Column({ type: 'uuid' })
+    tenantId: string;
+
+    /** Exactly as typed by the inviter — this is what the email is sent to. */
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    /**
+     * `email` trimmed and lower-cased. Carried as its own column rather than
+     * computed, because the uniqueness index and the accept-time comparison
+     * both have to agree on one canonical form; deriving it in two places is
+     * how "Bob@x.com already invited" and "bob@x.com is not invited" end up
+     * true at the same time.
+     */
+    @Column({ type: 'varchar', length: 320 })
+    emailNormalized: string;
+
+    /**
+     * Reserved, and DISPLAY-ONLY: this is not an authorization input.
+     *
+     * `OrganizationMembershipService.ensureAdmin` is currently identical to
+     * `ensureMember` by design, and its docblock forbids introducing a role
+     * check without a product decision. Same posture as `TeamMember.role`.
+     * The column exists so per-Org roles can land later without a migration
+     * on live invitation rows.
+     */
+    @Column({ type: 'varchar', length: 32, default: 'member' })
+    role: OrganizationInvitationRole;
+
+    /** `sha256(token)`. The raw token is returned to the issuer exactly once. */
+    @Column({ type: 'varchar', length: 64 })
+    tokenHash: string;
+
+    @PortableDateColumn()
+    tokenExpiresAt: Date;
+
+    @Column({ type: 'uuid' })
+    invitedById: string;
+
+    @ManyToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'invitedById' })
+    invitedBy: ClassToObject<User>;
+
+    @Column({
+        type: 'varchar',
+        length: 16,
+        default: OrganizationInvitationStatus.PENDING,
+    })
+    status: OrganizationInvitationStatus;
+
+    @Column({ type: 'uuid', nullable: true })
+    acceptedByUserId: string | null;
+
+    @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+    @JoinColumn({ name: 'acceptedByUserId' })
+    acceptedBy: ClassToObject<User> | null;
+
+    @PortableDateColumn({ nullable: true })
+    acceptedAt: Date | null;
+
+    @Column({ type: 'simple-json', nullable: true })
+    metadata: OrganizationInvitationMetadata | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    /**
+     * Expiry is evaluated, never trusted from `status`.
+     *
+     * Nothing sweeps `pending` rows to `expired` on a timer, so a row can sit
+     * at `pending` long past `tokenExpiresAt`. Every consumption path must ask
+     * this rather than reading `status` alone.
+     */
+    isExpired(now: Date = new Date()): boolean {
+        return this.tokenExpiresAt.getTime() <= now.getTime();
+    }
+
+    isConsumable(now: Date = new Date()): boolean {
+        return this.status === OrganizationInvitationStatus.PENDING && !this.isExpired(now);
+    }
+}

--- a/packages/agent/src/entities/organization-member.entity.ts
+++ b/packages/agent/src/entities/organization-member.entity.ts
@@ -1,0 +1,94 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    Index,
+    Unique,
+    ManyToOne,
+    JoinColumn,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+import { Organization } from './organization.entity';
+import { ClassToObject, OrganizationMemberRole } from './types';
+import { PortableDateColumn } from './_types';
+
+/**
+ * A human's membership of an Organization — the `OrganizationMember` half of
+ * the v1.1 item deferred in
+ * `docs/specs/features/tenants-and-organizations/spec.md` §7.
+ *
+ * 🛑 **This table is the ROSTER, not the authorization check.** Access is still
+ * decided by `OrganizationMembershipService.ensureMember`, which compares
+ * `user.tenantId` to `organization.tenantId` — unchanged by this feature, and
+ * deliberately so: five independent read paths depend on that equality
+ * (`ensureMember`, `OrganizationService.listForUser`, `ScopeOwnershipGuard`,
+ * `TeamsService.listOrgUsers`, `TeamsService.addMember`), and rewriting them
+ * is a far larger change than adding invitations.
+ *
+ * So a row here is created **alongside** the `users.tenantId` write that
+ * actually grants access, and it answers the questions tenant-equality cannot:
+ * who invited this person, when did they join, and which Organization was it
+ * nominally for. It is also the seam a future per-Org permission model
+ * tightens, without a second migration.
+ *
+ * The practical consequence, recorded because it will surprise someone:
+ * because access is tenant-wide, a member of one Organization can see every
+ * Organization in that Tenant. The owner accepted this explicitly for v1.
+ */
+@Entity({ name: 'organization_members' })
+@Unique(['organizationId', 'userId'])
+@Index(['organizationId'])
+@Index(['userId'])
+export class OrganizationMember {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    organizationId: string;
+
+    @ManyToOne(() => Organization, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'organizationId' })
+    organization: ClassToObject<Organization>;
+
+    /** Copied from the Organization at join time; the scope this grants. */
+    @Column({ type: 'uuid' })
+    tenantId: string;
+
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    @ManyToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'userId' })
+    user: ClassToObject<User>;
+
+    /**
+     * Reserved, and DISPLAY-ONLY — not an authorization input. See the
+     * matching note on `OrganizationInvitation.role`.
+     */
+    @Column({ type: 'varchar', length: 32, default: 'member' })
+    role: OrganizationMemberRole;
+
+    /** Null for the Tenant owner, who is a member by construction. */
+    @Column({ type: 'uuid', nullable: true })
+    invitedById: string | null;
+
+    /**
+     * The invitation this membership came from, kept for audit.
+     *
+     * `SET NULL` rather than `CASCADE`: deleting an invitation record must
+     * never delete the membership it produced.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    invitationId: string | null;
+
+    @PortableDateColumn()
+    joinedAt: Date;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/types.ts
+++ b/packages/agent/src/entities/types.ts
@@ -90,6 +90,41 @@ export const ALL_INVITATION_ROLES = [
     INVITATION_ROLE_OWNER_CLAIM,
 ] as const;
 
+/**
+ * Roles on an Organization membership or invitation.
+ *
+ * Exactly one value today, on purpose. `OrganizationMembershipService`
+ * currently defines `ensureAdmin` as `return this.ensureMember(...)`, and its
+ * docblock explicitly forbids adding a role check without a product decision.
+ * Shipping an `admin` option before that decision would put a control in the
+ * UI that grants nothing — worse than having no control at all. When per-Org
+ * roles land, widen this tuple; the DB column is already sized for it.
+ */
+export const ORGANIZATION_MEMBER_ROLES = ['member'] as const;
+
+export type OrganizationMemberRole = (typeof ORGANIZATION_MEMBER_ROLES)[number];
+
+/** Invitations carry the role the membership will be created with. */
+export type OrganizationInvitationRole = OrganizationMemberRole;
+
+/**
+ * Lifecycle of an `OrganizationInvitation`.
+ *
+ * A sibling of `WorkInvitationStatus` rather than a re-export: the two
+ * features are adjacent but independent, and aliasing them would mean a
+ * later state added for Works (say a transfer step) silently appears in the
+ * Org state machine too.
+ *
+ * 🛑 `EXPIRED` is a terminal state a row is moved INTO, not a state it
+ * reaches by itself. Nothing sweeps on a timer, so a row can sit at PENDING
+ * past its expiry — always ask `isExpired()`, never read `status` alone.
+ */
+export enum OrganizationInvitationStatus {
+    PENDING = 'pending',
+    ACCEPTED = 'accepted',
+    EXPIRED = 'expired',
+    REVOKED = 'revoked',
+}
 export enum WorkInvitationStatus {
     PENDING = 'pending',
     ACCEPTED = 'accepted',

--- a/packages/agent/src/services/__tests__/organization-invitation.service.spec.ts
+++ b/packages/agent/src/services/__tests__/organization-invitation.service.spec.ts
@@ -1,0 +1,339 @@
+import {
+    BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    NotFoundException,
+} from '@nestjs/common';
+import { createHash } from 'crypto';
+import { QueryFailedError } from 'typeorm';
+import { OrganizationInvitationService } from '../organization-invitation.service';
+import { OrganizationInvitationStatus } from '../../entities/types';
+import type { OrganizationInvitation } from '../../entities/organization-invitation.entity';
+
+/**
+ * Organization invitations — the token lifecycle.
+ *
+ * The properties worth pinning are the ones whose failure is silent: a token
+ * that is stored in the clear, an invitation that two people can both redeem,
+ * and the email binding that distinguishes this from the Work flow.
+ */
+
+type RepoMock = {
+    create: jest.Mock;
+    findById: jest.Mock;
+    findByTokenHash: jest.Mock;
+    findPendingForEmail: jest.Mock;
+    listForOrganization: jest.Mock;
+    listPendingForOrganization: jest.Mock;
+    tryMarkAccepted: jest.Mock;
+    markRevoked: jest.Mock;
+    expireBefore: jest.Mock;
+    expireStaleForEmail: jest.Mock;
+    findExpiredPending: jest.Mock;
+};
+
+function repoMock(): RepoMock {
+    return {
+        create: jest.fn(async (x: object) => ({ id: 'inv-new', ...x })),
+        findById: jest.fn().mockResolvedValue(null),
+        findByTokenHash: jest.fn().mockResolvedValue(null),
+        findPendingForEmail: jest.fn().mockResolvedValue(null),
+        listForOrganization: jest.fn().mockResolvedValue([]),
+        listPendingForOrganization: jest.fn().mockResolvedValue([]),
+        tryMarkAccepted: jest.fn().mockResolvedValue(true),
+        markRevoked: jest.fn().mockResolvedValue(true),
+        expireBefore: jest.fn().mockResolvedValue(0),
+        expireStaleForEmail: jest.fn().mockResolvedValue(0),
+        findExpiredPending: jest.fn().mockResolvedValue([]),
+    };
+}
+
+function build() {
+    const repo = repoMock();
+    const service = new OrganizationInvitationService(repo as never);
+    return { service, repo };
+}
+
+const BASE_INPUT = {
+    organizationId: 'org-1',
+    tenantId: 'ten-1',
+    invitedById: 'u-1',
+    email: 'newcomer@example.com',
+};
+
+function makeInvitation(overrides: Partial<OrganizationInvitation> = {}): OrganizationInvitation {
+    const inv = {
+        id: 'inv-1',
+        organizationId: 'org-1',
+        tenantId: 'ten-1',
+        email: 'Newcomer@Example.com',
+        emailNormalized: 'newcomer@example.com',
+        role: 'member',
+        tokenHash: 'hash',
+        tokenExpiresAt: new Date(Date.now() + 86_400_000),
+        invitedById: 'u-1',
+        status: OrganizationInvitationStatus.PENDING,
+        acceptedByUserId: null,
+        acceptedAt: null,
+        metadata: null,
+        isExpired(now: Date = new Date()) {
+            return this.tokenExpiresAt.getTime() <= now.getTime();
+        },
+        ...overrides,
+    } as unknown as OrganizationInvitation;
+    return inv;
+}
+
+describe('OrganizationInvitationService', () => {
+    describe('issue', () => {
+        it('persists ONLY the hash and returns the raw token once', async () => {
+            // The single most important property here. If the raw token were
+            // ever written, read access to the table would be equivalent to
+            // holding every outstanding invitation.
+            const { service, repo } = build();
+            const { token, invitation } = await service.issue(BASE_INPUT);
+
+            const persisted = repo.create.mock.calls[0][0];
+            expect(persisted.tokenHash).toBe(createHash('sha256').update(token).digest('hex'));
+            expect(JSON.stringify(persisted)).not.toContain(token);
+            expect(token).toHaveLength(64); // 32 bytes, hex
+            expect(invitation.id).toBe('inv-new');
+        });
+
+        it('stores the address as typed AND a normalised copy', async () => {
+            const { service, repo } = build();
+            await service.issue({ ...BASE_INPUT, email: '  Newcomer@Example.COM  ' });
+
+            const persisted = repo.create.mock.calls[0][0];
+            // As typed (trimmed) — this is what the email is addressed to.
+            expect(persisted.email).toBe('Newcomer@Example.COM');
+            // Canonical — this is what uniqueness and accept compare on.
+            expect(persisted.emailNormalized).toBe('newcomer@example.com');
+        });
+
+        it('maps the unique-index violation to 409, not a raw 500', async () => {
+            // Two clicks a millisecond apart both pass any read-then-write
+            // check, so the partial unique index is the real authority and its
+            // error has to be translated. A real QueryFailedError with SQLSTATE
+            // 23505 — a hand-rolled { code } slips past the guard.
+            const { service, repo } = build();
+            // The driver error is the THIRD constructor argument and is where
+            // isUniqueConstraintError looks — setting .code on the wrapper
+            // instead sails straight past the guard, which is exactly the
+            // mistake this comment exists to stop the next person repeating.
+            const driverError = Object.assign(new Error('duplicate key value'), {
+                code: '23505',
+            });
+            const dup = new QueryFailedError('INSERT', [], driverError as never);
+            repo.create.mockRejectedValue(dup);
+
+            await expect(service.issue(BASE_INPUT)).rejects.toThrow(ConflictException);
+        });
+
+        it('retires an aged-out invitation so the address can be re-invited', async () => {
+            // The partial unique index is WHERE status = 'pending', and nothing
+            // moves a row to `expired` on a timer. Without this sweep an
+            // invitation nobody accepted in time holds the slot forever and
+            // re-inviting that person fails with `invitation_already_pending` —
+            // naming a live invitation whose token is dead, with no UI to
+            // revoke it because it still looks pending.
+            const { service, repo } = build();
+
+            await service.issue(BASE_INPUT);
+
+            expect(repo.expireStaleForEmail).toHaveBeenCalledWith('org-1', 'newcomer@example.com');
+            // And it happens BEFORE the insert, or the index rejects us first.
+            const sweepOrder = repo.expireStaleForEmail.mock.invocationCallOrder[0];
+            const createOrder = repo.create.mock.invocationCallOrder[0];
+            expect(sweepOrder).toBeLessThan(createOrder);
+        });
+
+        it('rejects a malformed address before minting anything', async () => {
+            const { service, repo } = build();
+            await expect(service.issue({ ...BASE_INPUT, email: 'not-an-email' })).rejects.toThrow(
+                BadRequestException,
+            );
+            await expect(service.issue({ ...BASE_INPUT, email: '   ' })).rejects.toThrow(
+                BadRequestException,
+            );
+            expect(repo.create).not.toHaveBeenCalled();
+        });
+
+        it('clamps the expiry window instead of trusting the caller', async () => {
+            const { service } = build();
+            await expect(service.issue({ ...BASE_INPUT, expiresInDays: 0 })).rejects.toThrow(
+                BadRequestException,
+            );
+            await expect(service.issue({ ...BASE_INPUT, expiresInDays: 3650 })).rejects.toThrow(
+                BadRequestException,
+            );
+            await expect(service.issue({ ...BASE_INPUT, expiresInDays: NaN })).rejects.toThrow(
+                BadRequestException,
+            );
+        });
+
+        it('defaults to a 7-day window', async () => {
+            const { service, repo } = build();
+            const before = Date.now();
+            await service.issue(BASE_INPUT);
+            const { tokenExpiresAt } = repo.create.mock.calls[0][0];
+            const days = (tokenExpiresAt.getTime() - before) / 86_400_000;
+            expect(days).toBeGreaterThan(6.9);
+            expect(days).toBeLessThan(7.1);
+        });
+
+        it('two invitations never share a token', async () => {
+            const { service } = build();
+            const a = await service.issue(BASE_INPUT);
+            const b = await service.issue(BASE_INPUT);
+            expect(a.token).not.toBe(b.token);
+        });
+    });
+
+    describe('findConsumable', () => {
+        it('looks up by HASH — the raw token never reaches a query', async () => {
+            const { service, repo } = build();
+            repo.findByTokenHash.mockResolvedValue(makeInvitation());
+            const token = 'a'.repeat(64);
+
+            await service.findConsumable(token);
+
+            expect(repo.findByTokenHash).toHaveBeenCalledWith(
+                createHash('sha256').update(token).digest('hex'),
+            );
+            expect(repo.findByTokenHash).not.toHaveBeenCalledWith(token);
+        });
+
+        it('distinguishes revoked, already-accepted, expired and unknown', async () => {
+            const { service, repo } = build();
+
+            repo.findByTokenHash.mockResolvedValue(null);
+            await expect(service.findConsumable('t')).rejects.toThrow(NotFoundException);
+
+            repo.findByTokenHash.mockResolvedValue(
+                makeInvitation({ status: OrganizationInvitationStatus.REVOKED }),
+            );
+            await expect(service.findConsumable('t')).rejects.toThrow(ForbiddenException);
+
+            repo.findByTokenHash.mockResolvedValue(
+                makeInvitation({ status: OrganizationInvitationStatus.ACCEPTED }),
+            );
+            await expect(service.findConsumable('t')).rejects.toThrow(BadRequestException);
+
+            repo.findByTokenHash.mockResolvedValue(
+                makeInvitation({ tokenExpiresAt: new Date(Date.now() - 1000) }),
+            );
+            await expect(service.findConsumable('t')).rejects.toThrow(BadRequestException);
+        });
+
+        it('judges expiry by the CLOCK, not by status', async () => {
+            // Nothing sweeps pending rows on a timer, so a row sits at
+            // `pending` long past its expiry. Reading status alone would
+            // happily admit a token that died a month ago.
+            const { service, repo } = build();
+            repo.findByTokenHash.mockResolvedValue(
+                makeInvitation({
+                    status: OrganizationInvitationStatus.PENDING,
+                    tokenExpiresAt: new Date(Date.now() - 30 * 86_400_000),
+                }),
+            );
+            await expect(service.findConsumable('t')).rejects.toThrow(/invitation_expired/);
+        });
+    });
+
+    describe('the email binding — the deliberate divergence from Work invitations', () => {
+        it('refuses a redeemer whose address is not the invited one', async () => {
+            // Accepting writes users.tenantId, which grants access to EVERY
+            // Organization in that Tenant. A forwarded email must not be
+            // enough; the Work token is a bearer credential, this one is not.
+            const { service, repo } = build();
+            repo.findByTokenHash.mockResolvedValue(makeInvitation());
+
+            await expect(service.findConsumable('t', 'someone.else@example.com')).rejects.toThrow(
+                ForbiddenException,
+            );
+        });
+
+        it('accepts the invited address regardless of case or padding', async () => {
+            const { service, repo } = build();
+            repo.findByTokenHash.mockResolvedValue(makeInvitation());
+
+            await expect(
+                service.findConsumable('t', '  NEWCOMER@example.com '),
+            ).resolves.toBeDefined();
+        });
+
+        it('skips the binding ONLY when no address is supplied (the preview path)', async () => {
+            // The signed-out landing page renders "you've been invited to
+            // Acme" before the visitor has an account. That path grants
+            // nothing, so it is allowed to resolve without an address.
+            const { service, repo } = build();
+            repo.findByTokenHash.mockResolvedValue(makeInvitation());
+
+            await expect(service.findConsumable('t')).resolves.toBeDefined();
+        });
+
+        it('does not treat a prefix as a match', async () => {
+            const { service, repo } = build();
+            repo.findByTokenHash.mockResolvedValue(makeInvitation());
+            await expect(service.findConsumable('t', 'newcomer@example.co')).rejects.toThrow(
+                ForbiddenException,
+            );
+        });
+    });
+
+    describe('tryAccept', () => {
+        it('delegates to the conditional UPDATE and reports the loser', async () => {
+            // Two people redeeming one token must not both succeed: one
+            // membership, one tenant write. The repository resolves the race
+            // in the database; the service must propagate the false.
+            const { service, repo } = build();
+            repo.tryMarkAccepted.mockResolvedValue(false);
+            await expect(service.tryAccept('inv-1', 'u-2')).resolves.toBe(false);
+
+            repo.tryMarkAccepted.mockResolvedValue(true);
+            await expect(service.tryAccept('inv-1', 'u-2')).resolves.toBe(true);
+        });
+    });
+
+    describe('revoke', () => {
+        it('404s an invitation belonging to a different Organization', async () => {
+            // Pinning the id to the org in the URL, so a member of org A
+            // cannot cancel org B's invitation by guessing an id. 404 rather
+            // than 403 so it is not a probe either.
+            const { service, repo } = build();
+            repo.findById.mockResolvedValue(makeInvitation({ organizationId: 'org-OTHER' }));
+
+            await expect(service.revoke('org-1', 'inv-1')).rejects.toThrow(NotFoundException);
+            expect(repo.markRevoked).not.toHaveBeenCalled();
+        });
+
+        it('refuses to revoke anything that is not pending', async () => {
+            const { service, repo } = build();
+            repo.findById.mockResolvedValue(
+                makeInvitation({ status: OrganizationInvitationStatus.ACCEPTED }),
+            );
+            await expect(service.revoke('org-1', 'inv-1')).rejects.toThrow(BadRequestException);
+        });
+
+        it('surfaces a lost race rather than reporting success', async () => {
+            const { service, repo } = build();
+            repo.findById.mockResolvedValue(makeInvitation());
+            repo.markRevoked.mockResolvedValue(false); // accepted in between
+            await expect(service.revoke('org-1', 'inv-1')).rejects.toThrow(
+                /invitation_state_changed/,
+            );
+        });
+    });
+
+    describe('normaliseEmail', () => {
+        it('case-folds and trims but does NOT strip dots or plus tags', () => {
+            // Dot-stripping and plus-tag removal are Gmail conventions, not
+            // SMTP ones. Applying them would make a.b@corp.com and ab@corp.com
+            // the same person on a domain where they are two employees.
+            expect(OrganizationInvitationService.normaliseEmail('  A.B+tag@Corp.COM ')).toBe(
+                'a.b+tag@corp.com',
+            );
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -9,6 +9,7 @@ export * from './work-schedule-dispatcher.service';
 export * from './work-memory.service';
 export * from './work-member.service';
 export * from './work-invitation.service';
+export * from './organization-invitation.service';
 export * from './work-import.service';
 export * from './work-advanced-prompts.service';
 export * from './repository-management.service';

--- a/packages/agent/src/services/organization-invitation.service.ts
+++ b/packages/agent/src/services/organization-invitation.service.ts
@@ -1,0 +1,263 @@
+import { randomBytes, createHash, timingSafeEqual } from 'crypto';
+import {
+    BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
+import { OrganizationInvitationRepository } from '../database/repositories/organization-invitation.repository';
+import { OrganizationInvitation } from '../entities/organization-invitation.entity';
+import {
+    ORGANIZATION_MEMBER_ROLES,
+    OrganizationInvitationRole,
+    OrganizationInvitationStatus,
+} from '../entities/types';
+import { isUniqueConstraintError } from '../utils/db-error.utils';
+
+const TOKEN_BYTES = 32;
+const DEFAULT_EXPIRY_DAYS = 7;
+const MAX_EXPIRY_DAYS = 30;
+const MIN_EXPIRY_DAYS = 1;
+/** RFC 5321 caps a path at 320 octets; the column is sized to match. */
+const MAX_EMAIL_LENGTH = 320;
+
+export type CreateOrganizationInvitationInput = {
+    organizationId: string;
+    tenantId: string;
+    invitedById: string;
+    email: string;
+    role?: OrganizationInvitationRole;
+    expiresInDays?: number;
+    invitedName?: string;
+};
+
+export type IssuedOrganizationInvitation = {
+    invitation: OrganizationInvitation;
+    /** Raw token, returned ONCE — only the hash is persisted. */
+    token: string;
+};
+
+/**
+ * Issuance and consumption of `OrganizationInvitation` tokens.
+ *
+ * Security properties, all inherited deliberately from
+ * `WorkInvitationService` so the two adjacent features cannot drift:
+ *
+ *  - Token is `randomBytes(32).toString('hex')` — 256 bits of entropy.
+ *  - The token is returned to the issuer **once** and never persisted; only
+ *    `sha256(token)` is stored. A lost token is unrecoverable — revoke and
+ *    re-issue.
+ *  - Lookup is by hash, so the raw token never appears in a query.
+ *  - `tryAccept` is a conditional UPDATE, so concurrent redemptions of one
+ *    token resolve with exactly one winner.
+ *
+ * One deliberate divergence, and it is the important one:
+ *
+ * 🛑 **The org token is EMAIL-BOUND; the Work token is a bearer credential.**
+ * `findConsumable` takes the redeeming user's address and refuses a mismatch.
+ * Accepting an Org invitation writes `users.tenantId`, which grants access to
+ * every Organization in that Tenant — a far larger blast radius than joining
+ * one Work. A forwarded email should not be enough. The cost is that an
+ * invitee cannot redeem with a different address than the one invited, which
+ * is the intended trade.
+ */
+@Injectable()
+export class OrganizationInvitationService {
+    constructor(private readonly invitations: OrganizationInvitationRepository) {}
+
+    /**
+     * Canonical form of an address, for storage and comparison.
+     *
+     * Case-folding only — deliberately NOT dot-stripping or plus-tag removal.
+     * Those are Gmail conventions, not SMTP ones; applying them would make
+     * `a.b@corp.com` and `ab@corp.com` the same person on a domain where they
+     * are two different employees.
+     */
+    static normaliseEmail(email: string): string {
+        return email.trim().toLowerCase();
+    }
+
+    async issue(input: CreateOrganizationInvitationInput): Promise<IssuedOrganizationInvitation> {
+        const email = input.email?.trim();
+        if (!email || email.length > MAX_EMAIL_LENGTH || !email.includes('@')) {
+            throw new BadRequestException('invalid_email');
+        }
+        const role = input.role ?? 'member';
+        this.assertRole(role);
+
+        const emailNormalized = OrganizationInvitationService.normaliseEmail(email);
+        const expiresInDays = this.normaliseExpiry(input.expiresInDays);
+        const token = this.generateToken();
+
+        // Retire any invitation for this address that has already aged out.
+        // The partial unique index only covers `status = pending`, and nothing
+        // sweeps rows on a timer — so without this, an invitation nobody
+        // accepted within its window occupies the slot FOREVER and re-inviting
+        // that person fails with `invitation_already_pending`, naming a live
+        // invitation whose token is dead. There is no UI to revoke it either,
+        // because it looks pending.
+        await this.invitations
+            .expireStaleForEmail(input.organizationId, emailNormalized)
+            .catch(() => 0);
+
+        try {
+            const invitation = await this.invitations.create({
+                organizationId: input.organizationId,
+                tenantId: input.tenantId,
+                invitedById: input.invitedById,
+                email,
+                emailNormalized,
+                role,
+                tokenHash: this.hashToken(token),
+                tokenExpiresAt: new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000),
+                status: OrganizationInvitationStatus.PENDING,
+                metadata: input.invitedName ? { invitedName: input.invitedName } : null,
+            });
+            return { invitation, token };
+        } catch (error) {
+            // The partial unique index is the authority on "already invited",
+            // not a prior SELECT: two clicks a millisecond apart both pass a
+            // read-then-write check and mint two live tokens for one mailbox.
+            if (isUniqueConstraintError(error)) {
+                throw new ConflictException('invitation_already_pending');
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Read one invitation by id, whatever its state.
+     *
+     * Distinct from `findConsumable`, which refuses anything already spent:
+     * the accept path needs to inspect a CLAIMED row to tell "this same user
+     * double-clicked" from "somebody else took it", and a consumable-only
+     * lookup cannot answer that.
+     */
+    async findById(id: string): Promise<OrganizationInvitation | null> {
+        return this.invitations.findById(id);
+    }
+
+    async listForOrganization(organizationId: string): Promise<OrganizationInvitation[]> {
+        return this.invitations.listForOrganization(organizationId);
+    }
+
+    async listPending(organizationId: string): Promise<OrganizationInvitation[]> {
+        return this.invitations.listPendingForOrganization(organizationId);
+    }
+
+    /**
+     * Revoke a pending invitation.
+     *
+     * Authorization is the CALLER's job — the controller sits behind
+     * `OrganizationOwnershipGuard`. This additionally pins the invitation to
+     * the Organization in the URL, so a member of org A cannot revoke org B's
+     * invitation by id alone; the 404 keeps that from being a probe.
+     */
+    async revoke(organizationId: string, invitationId: string): Promise<void> {
+        const invitation = await this.invitations.findById(invitationId);
+        if (!invitation || invitation.organizationId !== organizationId) {
+            throw new NotFoundException('invitation_not_found');
+        }
+        if (invitation.status !== OrganizationInvitationStatus.PENDING) {
+            throw new BadRequestException('invitation_not_pending');
+        }
+        const ok = await this.invitations.markRevoked(invitationId);
+        if (!ok) {
+            // Lost a race with a concurrent accept or revoke.
+            throw new BadRequestException('invitation_state_changed');
+        }
+    }
+
+    /**
+     * Resolve a raw token to an invitation that may still be redeemed.
+     *
+     * `redeemerEmail` is optional so the signed-out PREVIEW page can render
+     * "You have been invited to Acme" without an account. Every path that
+     * actually grants access must pass it — see `assertEmailMatches`.
+     */
+    async findConsumable(token: string, redeemerEmail?: string): Promise<OrganizationInvitation> {
+        if (!token || typeof token !== 'string') {
+            throw new BadRequestException('invalid_token');
+        }
+        const invitation = await this.invitations.findByTokenHash(this.hashToken(token));
+        if (!invitation) {
+            throw new NotFoundException('invitation_not_found');
+        }
+        if (invitation.status === OrganizationInvitationStatus.REVOKED) {
+            throw new ForbiddenException('invitation_revoked');
+        }
+        if (invitation.status === OrganizationInvitationStatus.ACCEPTED) {
+            throw new BadRequestException('invitation_already_accepted');
+        }
+        if (invitation.isExpired()) {
+            // Best-effort tidy-up; the decision above already stands on
+            // isExpired(), never on `status`.
+            await this.invitations.expireBefore(new Date()).catch(() => 0);
+            throw new BadRequestException('invitation_expired');
+        }
+        if (redeemerEmail !== undefined) {
+            this.assertEmailMatches(invitation, redeemerEmail);
+        }
+        return invitation;
+    }
+
+    /**
+     * The email binding. Throws unless the redeemer is who was invited.
+     *
+     * Compared on the normalised form, and with `timingSafeEqual` on equal
+     * lengths — an address is not a secret, but the comparison is free to be
+     * constant-time and it keeps the shape identical to `verifyToken`.
+     */
+    assertEmailMatches(invitation: OrganizationInvitation, redeemerEmail: string): void {
+        const actual = OrganizationInvitationService.normaliseEmail(redeemerEmail ?? '');
+        const expected = invitation.emailNormalized;
+        const a = Buffer.from(actual);
+        const b = Buffer.from(expected);
+        if (a.length !== b.length || !timingSafeEqual(a, b)) {
+            throw new ForbiddenException('invitation_email_mismatch');
+        }
+    }
+
+    /** False if somebody else redeemed the same token first. */
+    async tryAccept(invitationId: string, acceptedByUserId: string): Promise<boolean> {
+        return this.invitations.tryMarkAccepted(invitationId, acceptedByUserId, new Date());
+    }
+
+    async sweepExpired(now: Date = new Date()): Promise<number> {
+        return this.invitations.expireBefore(now);
+    }
+
+    verifyToken(token: string, tokenHash: string): boolean {
+        const expected = this.hashToken(token);
+        const a = Buffer.from(expected);
+        const b = Buffer.from(tokenHash);
+        return a.length === b.length && timingSafeEqual(a, b);
+    }
+
+    private assertRole(role: OrganizationInvitationRole): void {
+        if (!ORGANIZATION_MEMBER_ROLES.includes(role)) {
+            throw new BadRequestException('invalid_role');
+        }
+    }
+
+    private normaliseExpiry(requested: number | undefined): number {
+        if (requested === undefined) return DEFAULT_EXPIRY_DAYS;
+        if (!Number.isFinite(requested)) {
+            throw new BadRequestException('invalid_expiry');
+        }
+        const days = Math.floor(requested);
+        if (days < MIN_EXPIRY_DAYS || days > MAX_EXPIRY_DAYS) {
+            throw new BadRequestException('invalid_expiry');
+        }
+        return days;
+    }
+
+    private generateToken(): string {
+        return randomBytes(TOKEN_BYTES).toString('hex');
+    }
+
+    private hashToken(token: string): string {
+        return createHash('sha256').update(token).digest('hex');
+    }
+}


### PR DESCRIPTION
Two commits to production.

| | |
|---|---|
| `add32d670` | Organization invitations, end to end ([#2125](https://github.com/ever-works/ever-works/pull/2125)) |
| `febd2d727` | `PATCH {"title": null}` no longer nulls a conversation title ([#2127](https://github.com/ever-works/ever-works/pull/2127)) |

## 🛑 This deploy runs a migration — for the first time anywhere

`1786930000000-CreateOrganizationInvitationsAndMembers` adds **two tables**. Nothing dropped, no column removed, no data touched.

Verified against the live databases, this is not hyperbole:

| environment | migrations ever applied |
|---|---|
| dev | **0** |
| stage | **0** |
| prod | **149** |

dev and stage set `DATABASE_AUTOMIGRATE=true`, so `synchronize` builds their schema from the entities and migration files never execute there. Prod sets it `false`. **Every migration in this repo has its first real execution in production** — that is a property of the setup, not of this change, but it means neither lower environment has exercised this file.

So it was verified where it could be: a **throwaway Postgres 16 in Docker** — `up()`, an idempotent second `up()`, every index asserted via `pg_indexes.indexdef` (including the partial one emitting `WHERE ((status)::text = 'pending'::text)`), behavioural duplicate-blocking, re-invite-after-revoke, the `uuid_generate_v4()` default, and a clean `down()`. Plus a committed better-sqlite3 spec, which is what caught `default: 'now()'` being Postgres-only — a defect that fails at INSERT rather than DDL and so passes every schema-shape assertion.

### Backups proven immediately before opening this

- `pg-nightly-20260819020000` — `phase=completed`, `error=none`, `id=20260819T020001`
- `pg-nightly-20260818020000` — `phase=completed`, `error=none`
- `pg_stat_archiver`: **HEALTHY** — last archived `2026-08-19 09:03:46Z`, last failure `2026-07-29`

**Restore point relied on:** `20260819T020001` plus continuous WAL.

## What ships

**Invitations:** invite by email → signed, email-bound link → public landing page → sign in or register (the invitation survives the detour) → accept → roster row + tenant access. Plus revoke and remove/leave.

A 5-lens adversarial review with a skeptic pass found **20 confirmed defects**; **13 fixed — every critical and high**, including an API boot crash, two routes to unrevocable tenant access, and a members list offering people a button that evicted them from their own workspace.

**Title fix:** `@IsOptional()` skips validators for `null` as well as `undefined`, so a null title passed `@IsString`, satisfied the handler's `!== undefined` guard, and wrote NULL. Now `@ValidateIf`. The DTO had zero validation coverage; it now has 11 tests.

## Known gaps, stated plainly

- No E2E round trip for invitations.
- 7 low-impact review findings remain — none can grant access, crash the API, or lose data.
- Stage E2E is red on shards 7/9/10/11, **pre-existing** and unrelated: the same shards fail on commits predating all of this.

## Verification after merge

Not "the merge succeeded" — I will confirm in the running prod pod that the migration actually ran: `select name from migrations` for this migration, and `pg_indexes.indexdef` showing the partial index kept its `WHERE` clause. "The tables exist" is not sufficient evidence, since `synchronize` can produce that too.

**Rollback:** revert this merge commit. The migration only adds tables.