### PR TITLE
ci: install through the internal Verdaccio cache on self-hosted runners

### DIFF
--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -1,0 +1,176 @@
+# Chooses the npm registry for this job, and is the single place that logic lives in this repo.
+#
+# WHY THIS IS A LOCAL COPY RATHER THAN `ever-co/ever-gauzy/.github/actions/configure-registry`
+# ---------------------------------------------------------------------------------------------
+# The shared Gauzy action (pinned at adbc9bcbf72960d49c3853552d69d5b5b3b5e56d) opens with an
+# unconditional
+#
+#     if ! git checkout -- .npmrc yarn.lock; then <error>; exit 1; fi
+#
+# ever-works is a **pnpm** workspace: it tracks neither `.npmrc` nor `yarn.lock` at the repo root.
+# `git checkout --` errors with "pathspec ... did not match any file(s) known to git" and exits 1
+# when a pathspec matches nothing -- verified locally, and it exits 1 even when only ONE of the
+# two pathspecs is missing. Using the shared action verbatim here would therefore not be a no-op,
+# it would hard-fail every job it was added to.
+#
+# This copy keeps the shared action's inputs, semantics, probe, retry policy and warnings intact,
+# and changes exactly one thing: the reset step is guarded so it resets what is actually tracked
+# and deletes untracked leftovers, instead of assuming a yarn repo. It stays drop-in compatible,
+# so once the shared action grows the same guard this file can be replaced by a
+# `uses: ever-co/ever-gauzy/...` reference with no other edit.
+#
+# WHY THE LOCKFILE REWRITE IS A NO-OP HERE (and is still kept, guarded)
+# ---------------------------------------------------------------------------------------------
+# yarn v1 and npm record an absolute `resolved` URL per package and fetch THAT, ignoring the
+# `registry` setting -- so for those package managers a config-only change moves zero bytes and
+# the lockfile has to be rewritten at CI time. pnpm does not work that way: `pnpm-lock.yaml` v9
+# stores only `resolution: {integrity: sha512-...}` and derives the tarball URL from the
+# configured registry at install time. Verified on this repo's lockfile: zero occurrences of
+# `registry.npmjs.org` or `registry.yarnpkg.com`. Config alone is therefore both sufficient and
+# load-bearing here.
+#
+# The yarn.lock rewrite below is kept, gated on the file existing, so this action keeps working
+# unchanged if any part of the repo ever grows a yarn.lock.
+#
+# Nothing is ever committed: every edit below lives only in the runner's checkout, so developers
+# and the files in git are unaffected.
+name: Configure npm registry
+description: >-
+  Point the job at the internal Verdaccio VIP when it is reachable, otherwise at the public npm
+  registry. The Cloudflare-fronted packages.ever.co route is gated behind an explicit opt-in.
+
+inputs:
+  verdaccio-registry:
+    description: Internal Verdaccio VIP, normally vars.VERDACCIO_REGISTRY. Empty disables the probe.
+    required: false
+    default: ''
+  verdaccio-token:
+    description: Auth token for the public packages.ever.co route. Only used when force-public is true.
+    required: false
+    default: ''
+  force-public:
+    description: Set to 'true' to force the public packages.ever.co route even when the VIP answers.
+    required: false
+    default: ''
+  expect-vip:
+    description: >-
+      'true' for in-network runners. Controls whether an unreachable VIP is retried and warned
+      about. Derive it from the runner variable the job really uses, e.g.
+      vars.RUNNER_LINUX_X64_4 != ''. Do NOT use contains(matrix.os, ...) unless the job actually
+      defines strategy.matrix.os -- the expression then silently evaluates false and quietly
+      disables both the retry and the warning, which is a mute switch rather than an error.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Registry
+      shell: bash
+      env:
+        VERDACCIO_REGISTRY: ${{ inputs.verdaccio-registry }}
+        VERDACCIO_TOKEN: ${{ inputs.verdaccio-token }}
+        VERDACCIO_FORCE_PUBLIC: ${{ inputs.force-public }}
+        EXPECT_VIP: ${{ inputs.expect-vip }}
+      run: |
+        # Registry selection is CONDITIONAL on where this job runs.
+        #
+        # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+        # large tarballs mid-stream, and the truncation is UNDETECTABLE by the client: Cloudflare
+        # always sends "Accept-Encoding: gzip" to the origin, Verdaccio re-gzips the already
+        # gzipped .tgz, and Content-Length is dropped in favour of chunked encoding. A cut stream
+        # is therefore a complete-looking HTTP 200 whose body fails gunzip. That route is GATED
+        # behind VERDACCIO_FORCE_PUBLIC rather than removed.
+        #
+        # Every job that uses this action runs on `vars.RUNNER_LINUX_X64_* || ubuntu-latest`, so
+        # the runner is not statically known: if the org variable were unset the job would land on
+        # a GitHub-hosted runner that can never reach a 192.168.x.x VIP. The choice is therefore
+        # made by PROBING the VIP, and `expect-vip` only controls how loudly a miss is reported.
+
+        # Start from a known state. Self-hosted runners can check out with clean: false, so
+        # registry edits from a PREVIOUS run can still be on disk -- .npmrc and .yarnrc are
+        # untracked in this repo, so nothing else restores them and a stale "registry" line from
+        # an earlier run would silently win over this run's decision.
+        #
+        # Guarded, unlike the Gauzy original: reset what git actually tracks, delete what it does
+        # not. Failing to reach a known state is still fatal -- selecting a registry from an
+        # unknown state would mean installing against whatever the last job left behind.
+        rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
+        for f in .npmrc yarn.lock; do
+          if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+            if ! git checkout -- "$f"; then
+              echo "::error title=Could not reset registry configuration::git checkout -- $f failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+              exit 1
+            fi
+          elif ! rm -f "$f"; then
+            # Untracked (the normal case in this pnpm repo): a leftover from a previous run on a
+            # clean: false runner is the only way it can exist, so remove it.
+            echo "::error title=Could not reset registry configuration::rm -f $f failed on this workspace. Refusing to select a registry from an unknown state."
+            exit 1
+          fi
+        done
+
+        REGISTRY=""
+        if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+          # this wants the public route even when the VIP is up (e.g. the internal cache is
+          # serving bad data). Gating it on a failed probe would make the flag a no-op.
+          REGISTRY="https://packages.ever.co/"
+          echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+          echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
+          echo "always-auth=true" >> .npmrc
+        else
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+          fi
+          # Retry only where the VIP is expected to answer. A GitHub-hosted runner can never
+          # reach it, so a second attempt would just add dead time to the job.
+          if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            attempt=1
+            while [ "$attempt" -le "$ATTEMPTS" ]; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              attempt=$((attempt + 1))
+              if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+            echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+          elif [ -z "$REGISTRY" ]; then
+            echo "Verdaccio VIP did not answer - resolving from the public npm registry."
+            # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+            # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+            # has a recurring MetalLB speaker flap that presents exactly this way), so surface it.
+            # Deliberately a warning, not a failure: a cache blip must never redden a pipeline
+            # that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+        fi
+        if [ -n "$REGISTRY" ]; then
+          # Appended, never overwritten: last key wins in ini parsing, and yarn v1 does not
+          # reliably read .npmrc for the registry. pnpm reads .npmrc at the workspace root, which
+          # is the working directory of every install step in this repo.
+          #
+          # This sets the DEFAULT registry only. It does not affect publishing: publish-cli.yml
+          # publishes from apps/*/dist (a different npm prefix, so this file is not read at all),
+          # and publish-plugins.yml passes an explicit --registry to every `pnpm publish`, which
+          # is a CLI flag and outranks any .npmrc.
+          echo "registry=$REGISTRY" >> .npmrc
+          echo "registry \"$REGISTRY\"" >> .yarnrc
+          # No-op in this pnpm repo (there is no yarn.lock), kept so the action keeps working if
+          # one ever appears. One pass, no -i: an -i.bak backup survives on a clean: false runner
+          # if the step fails between the rewrite and its cleanup, and bare -i is not portable to
+          # the BSD sed on macOS runners. The temp file is only ever the finished rewrite.
+          if [ -f yarn.lock ]; then
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
+          fi
+        fi
+        echo "Using npm registry: ${REGISTRY:-https://registry.npmjs.org/ (repo default)}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -266,6 +277,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -360,6 +382,17 @@ jobs:
         with:
           node-version: 22.x
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -487,6 +520,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -501,6 +512,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -72,6 +72,17 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -63,6 +63,17 @@ jobs:
           node-version: 22.x
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -72,6 +72,17 @@ jobs:
           node-version: 22.x
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -135,6 +146,17 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -193,6 +215,17 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ever-works'
           cache: 'pnpm'
+
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -39,6 +39,17 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -35,6 +35,17 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -100,6 +100,18 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        if: steps.env.outputs.skip != 'true'
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         if: steps.env.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -35,6 +35,17 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/smoke-deployed.yml
+++ b/.github/workflows/smoke-deployed.yml
@@ -120,6 +120,17 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
+      # Resolve dependencies through the internal Verdaccio cache when this job runs
+      # on the in-network ARC pool, so the install does not re-pull the tree from the
+      # public registry. Falls back to npmjs automatically when the VIP does not answer.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## What

Routes CI dependency installs through the internal **Verdaccio** cache (`vars.VERDACCIO_REGISTRY`, the VIP `192.168.1.183:4873`) instead of the public npm registry, by adding a `Configure Registry` step before every host-side `pnpm install` — **16 jobs across 10 workflows**.

The goal is **traffic reduction**; the wall-clock gain is a bonus.

Purely additive: **353 insertions, 0 deletions**, workflow YAML only. Line endings unchanged (LF — verified with `git ls-files --eol` before and after).

## Why this repo does not use the shared Gauzy action

The campaign's standard step is `ever-co/ever-gauzy/.github/actions/configure-registry` (pinned `adbc9bcb`). **It cannot be used here.** It opens with:

```bash
if ! git checkout -- .npmrc yarn.lock; then <error>; exit 1; fi
```

`git checkout --` exits 1 when a pathspec matches nothing — and it does so even when only **one** of the two pathspecs is missing. `ever-works` is a **pnpm** workspace that tracks neither `.npmrc` nor `yarn.lock` at the root, so adding the shared action verbatim would not be a no-op, it would **hard-fail every job it was added to**.

Verified rather than assumed — the shared action's own script, run against a simulated checkout of this repo:

```
error: pathspec '.npmrc' did not match any file(s) known to git
error: pathspec 'yarn.lock' did not match any file(s) known to git
::error title=Could not reset registry configuration::...
-- UPSTREAM exit=1
-- .npmrc: (absent - registry NOT configured)
```

`.github/actions/configure-registry/` in this PR is therefore a **guarded copy**: same inputs, same probe, same retry policy, same warnings, same public-route gating. Exactly one thing changed — the reset step resets what git actually tracks and deletes untracked leftovers, instead of assuming a yarn repo. It stays **drop-in compatible**, so once the shared action grows the same guard this directory can be replaced by a `uses: ever-co/ever-gauzy/...` reference with no other edit.

> 📌 **Upstream follow-up for whoever owns the shared action:** it has this bug for *every* pnpm repo, not just this one. The fix is to guard the reset per-path.

## Why there is no lockfile rewrite

yarn v1 and npm record an absolute `resolved` URL per package and fetch **that**, ignoring the `registry` setting — which is why the campaign rewrites lockfiles at CI time. **pnpm does not work that way:** `pnpm-lock.yaml` v9 stores only `resolution: {integrity: sha512-…}` and derives the tarball URL from the configured registry at install time.

Confirmed on this repo's lockfile — **zero** occurrences of `registry.npmjs.org` or `registry.yarnpkg.com`. So the `registry=` line is what actually redirects the downloads here, and it is load-bearing rather than cosmetic. The yarn.lock rewrite is **kept but gated** on the file existing, so the action keeps working unchanged if one ever appears.

## Verification

The action's shell body was executed against simulated checkouts, five cases:

| Case | Result |
|---|---|
| A — VIP up, `expect-vip=true` (the real ever-works shape) | ✅ exit 0, `.npmrc` = `registry=http://192.168.1.183:4873/` |
| B — stale `.npmrc`/`.yarnrc` left by a previous run | ✅ reset first, single registry line, no double-append |
| C — VIP unreachable from an in-network runner | ✅ retries twice, warns, falls back to npmjs, exit 0, writes nothing |
| D — `VERDACCIO_REGISTRY` empty | ✅ quiet public fallback |
| E — **control**: a repo that *does* track `.npmrc` + `yarn.lock` | ✅ still appends and still rewrites `resolved` → proves upstream parity is intact |

VIP reachability and proxying were probed live (`/-/ping` → 200). All `@ever-works/*` dependencies are `workspace:` links (152 refs), so there is no scope-proxy risk.

Every workflow was re-parsed and every `run:` block `bash -n`'d after the edit; all 16 inserted steps land **before** their install step.

## Safety

- **Self-hosted only.** Every touched job runs on `vars.RUNNER_LINUX_X64_{4,8} || 'ubuntu-latest'`, and `expect-vip` is derived from *that same variable* (`vars.RUNNER_LINUX_X64_4 != ''`) — **not** `contains(matrix.os, …)`. These jobs define no `matrix.os`, so that expression would silently evaluate false and quietly disable both the retry and the unreachable-VIP warning: a mute switch, not an error.
- **Fails open.** The registry is chosen by *probing* the VIP, so if the org variable were ever unset and a job landed on a GitHub-hosted runner, it simply falls back to npmjs. A VIP blip warns; it never reddens a pipeline npmjs can serve.
- **Publishing is unaffected.** `publish-cli.yml` publishes from `apps/*/dist` — a different npm prefix, so the repo-root `.npmrc` is not read there at all. `publish-plugins.yml` passes an explicit `--registry` to every `pnpm publish`, which is a CLI flag and outranks any `.npmrc`.
- **No cache key can bifurcate.** There is no `actions/cache` step keyed on `hashFiles()` anywhere in this repo, and `setup-node`'s `cache: pnpm` keys on `pnpm-lock.yaml`, which this action never touches. So VIP-up and VIP-down runs compute identical cache keys.
- **Nothing is committed by the action** — every edit lives only in the runner's checkout. Developers and the files in git are unaffected.

## Deliberately not touched

| Target | Why |
|---|---|
| `ci.yml` → `dependency-audit` | No install by design, and `pnpm audit` needs the public registry's audit endpoint, which Verdaccio does not implement. Redirecting it would break the job for zero traffic saved. |
| `deploy-vercel-docs-prod.yml` | Gated off behind `vars.VERCEL_ENABLED` (Vercel is decommissioned), and only does `npm install -g vercel@latest`. |
| `publish-cli.yml` → `publish-internal-cli`, `publish-external-cli`, `create-release-*` | They download artifacts and publish; they never install. The `npm install -g …` lines a regex audit flags there are **inside GitHub Release body markdown**, not steps. |
| `external-uptime-monitor.yml` | Pinned to `ubuntu-latest` on purpose (it must probe from outside the homelab) and installs nothing. |
| `apps/docs/.npmrc` | Pins `registry.yarnpkg.com` for the docs app, but nothing installs from that directory on a runner today. Left alone per the no-removal rule; noted for a follow-up. |
| `docker-build-publish-*.yml`, `k8s-build.yml`, `desktop-build.yml` | Their installs happen **inside the Docker build** (or on a `matrix.runner`), which needs a different mechanism (build args) — out of scope for this PR. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated package registry selection for CI and release workflows.
  - Uses the internal registry when available, with configurable public-registry fallback.
  - Supports registry authentication, network detection, retries, warnings, and lockfile updates.
  - Applied consistent registry configuration across testing, publishing, deployment, and end-to-end workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->