### PR TITLE
chore: git-ignore the CI-written registry files at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ api-mem.log
 apps/desktop/release
 apps/desktop/bundle
 apps/desktop-node/release
+
+# CI writes registry configuration at the repo root (Configure Registry action) and removes it
+# again on the same run - but self-hosted runners check out with clean: false, so a crashed job
+# could leave one behind. Ignore them so a leftover can never be committed by a later job.
+/.npmrc
+/.yarnrc


### PR DESCRIPTION
The Configure Registry action writes `/.npmrc` and `/.yarnrc` during a job and removes them again — but self-hosted runners check out with `clean: false`, so a crashed job could leave one behind for a later commit-making job to pick up. Ignoring them (root-anchored, so workspace-level files stay tracked) makes that impossible.

Follow-up to #2134. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added safeguards to prevent leftover CI registry configuration files from being committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->