### PR TITLE
chore(cascade): develop → stage — fix K8s Plugin E2E pre-load under Docker 29 (crictl pull)

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -127,9 +127,32 @@ jobs:
         # Loads nginx-unprivileged into kind nodes so the Deployment's
         # imagePullPolicy: IfNotPresent path resolves immediately,
         # cutting test time by ~30s on slow runners.
+        #
+        # Why `docker save --platform` + `kind load image-archive` instead of
+        # a plain `kind load docker-image`: on the self-hosted ARC pool the
+        # `docker:dind` sidecar runs Docker 29, whose fresh-install default is
+        # the containerd image store. There `docker save` (what `kind load
+        # docker-image` shells out to) writes the image's FULL multi-arch OCI
+        # index but only the blobs that were actually pulled (amd64), and the
+        # node-side `ctr images import --all-platforms` then fails with
+        # `ctr: content digest sha256:…: not found` for the linux/arm manifest.
+        # That made every run of this workflow red from 2026-07-17 on (the
+        # GitHub-hosted runners it ran on before use the classic overlay2 store,
+        # where `docker save` is self-contained). Upstream: kubernetes-sigs/kind#3795
+        # (pinned, open — kind cannot fix it on its side), containerd/containerd#11344.
+        # Saving only the platform we run makes the archive self-contained, so
+        # the import works on BOTH image stores. `docker save --platform` needs
+        # Docker API 1.48+ (Engine 28) — ubuntu-latest and the ARC dind both have it.
         run: |
-          docker pull nginxinc/nginx-unprivileged:1.27-alpine
-          kind load docker-image nginxinc/nginx-unprivileged:1.27-alpine --name ever-works-e2e
+          IMAGE=nginxinc/nginx-unprivileged:1.27-alpine
+          ARCHIVE="$RUNNER_TEMP/nginx-unprivileged.tar"
+          docker info --format 'docker {{.ServerVersion}} / storage {{.Driver}} {{range .DriverStatus}}{{index . 0}}={{index . 1}} {{end}}'
+          docker pull --platform linux/amd64 "$IMAGE"
+          docker save --platform linux/amd64 -o "$ARCHIVE" "$IMAGE"
+          kind load image-archive "$ARCHIVE" --name ever-works-e2e
+          # Prove the image actually landed on the node — a loud failure here
+          # beats a silent fallback to a registry pull inside the test.
+          docker exec ever-works-e2e-control-plane crictl images | grep -F 'nginxinc/nginx-unprivileged'             || { echo "::error::$IMAGE not present on the kind node after kind load"; exit 1; }
 
       - name: Run k8s plugin e2e suite
         run: pnpm --filter @ever-works/k8s-plugin test:e2e

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -124,35 +124,36 @@ jobs:
           echo "KUBECONFIG_E2E_PATH=$RUNNER_TEMP/kubeconfig" >> "$GITHUB_ENV"
 
       - name: Pre-pull image used by e2e Deployment
-        # Loads nginx-unprivileged into kind nodes so the Deployment's
+        # Loads nginx-unprivileged into the kind node so the Deployment's
         # imagePullPolicy: IfNotPresent path resolves immediately,
         # cutting test time by ~30s on slow runners.
         #
-        # Why `docker save --platform` + `kind load image-archive` instead of
-        # a plain `kind load docker-image`: on the self-hosted ARC pool the
-        # `docker:dind` sidecar runs Docker 29, whose fresh-install default is
-        # the containerd image store. There `docker save` (what `kind load
-        # docker-image` shells out to) writes the image's FULL multi-arch OCI
-        # index but only the blobs that were actually pulled (amd64), and the
-        # node-side `ctr images import --all-platforms` then fails with
+        # Why `crictl pull` INSIDE the node instead of `kind load docker-image`:
+        # on the self-hosted ARC pool the `docker:dind` sidecar runs Docker 29,
+        # whose fresh-install default is the containerd image store. There
+        # `docker save` (what `kind load docker-image` shells out to) writes the
+        # image's FULL multi-arch OCI index but only the blobs that were actually
+        # pulled, and the node-side `ctr images import --all-platforms` fails with
         # `ctr: content digest sha256:…: not found` for the linux/arm manifest.
-        # That made every run of this workflow red from 2026-07-17 on (the
-        # GitHub-hosted runners it ran on before use the classic overlay2 store,
-        # where `docker save` is self-contained). Upstream: kubernetes-sigs/kind#3795
-        # (pinned, open — kind cannot fix it on its side), containerd/containerd#11344.
-        # Saving only the platform we run makes the archive self-contained, so
-        # the import works on BOTH image stores. `docker save --platform` needs
-        # Docker API 1.48+ (Engine 28) — ubuntu-latest and the ARC dind both have it.
+        # `docker save --platform linux/amd64` is not enough either: the archive
+        # still carries the amd64 *attestation* manifest (unknown/unknown), which
+        # ctr then tries to unpack as an image and rejects with `mismatched image
+        # rootfs and manifest layers`. That made every run of this workflow red
+        # from 2026-07-17 on (the GitHub-hosted runners it ran on before use the
+        # classic overlay2 store, where `docker save` is self-contained).
+        # Upstream: kubernetes-sigs/kind#3795 (pinned, open — kind cannot fix it
+        # on its side), containerd/containerd#11344.
+        # Pulling through the node's own CRI fetches exactly what the kubelet
+        # would fetch (one platform, no attestations) and is independent of the
+        # host daemon's image store, so it behaves the same on ubuntu-latest and
+        # on ARC. The `docker info` line records the daemon mode in every run.
         run: |
           IMAGE=nginxinc/nginx-unprivileged:1.27-alpine
-          ARCHIVE="$RUNNER_TEMP/nginx-unprivileged.tar"
           docker info --format 'docker {{.ServerVersion}} / storage {{.Driver}} {{range .DriverStatus}}{{index . 0}}={{index . 1}} {{end}}'
-          docker pull --platform linux/amd64 "$IMAGE"
-          docker save --platform linux/amd64 -o "$ARCHIVE" "$IMAGE"
-          kind load image-archive "$ARCHIVE" --name ever-works-e2e
-          # Prove the image actually landed on the node — a loud failure here
-          # beats a silent fallback to a registry pull inside the test.
-          docker exec ever-works-e2e-control-plane crictl images | grep -F 'nginxinc/nginx-unprivileged'             || { echo "::error::$IMAGE not present on the kind node after kind load"; exit 1; }
+          docker exec ever-works-e2e-control-plane crictl pull "docker.io/$IMAGE"
+          # Prove the image is on the node — a loud failure here beats a silent
+          # fallback to a registry pull inside the test.
+          docker exec ever-works-e2e-control-plane crictl images | grep -F 'nginxinc/nginx-unprivileged'             || { echo "::error::$IMAGE not present on the kind node after pull"; exit 1; }
 
       - name: Run k8s plugin e2e suite
         run: pnpm --filter @ever-works/k8s-plugin test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ api-mem.log
 apps/desktop/release
 apps/desktop/bundle
 apps/desktop-node/release
+
+# CI writes registry configuration at the repo root (Configure Registry action) and removes it
+# again on the same run - but self-hosted runners check out with clean: false, so a crashed job
+# could leave one behind. Ignore them so a leftover can never be committed by a later job.
+/.npmrc
+/.yarnrc


### PR DESCRIPTION
Cascade `develop` → `stage` (whole branch, no cherry-pick). Content = exactly #2138:

- `ci(k8s-e2e)`: the `K8s Plugin E2E` suite has been red on every stage/main run since 2026-07-17 (all 4 legs) because the ARC `docker:dind` daemon moved to Docker 29's containerd image store, which breaks `kind load docker-image` (kubernetes-sigs/kind#3795). The pre-load step now pulls inside the kind node via `crictl pull`. Verified green on all 4 legs via `workflow_dispatch`: https://github.com/ever-works/ever-works/actions/runs/32508474627

This push to `stage` will itself trigger `K8s Plugin E2E` on `stage` (path filter matches) — that run is the real gate for the next hop to `main`, so no `override-e2e-gate` should be needed any more.
