### PR TITLE
Promote develop to stage: Verdaccio in the container images + gitignore hardening

### DIFF
--- a/.deploy/docker/api/Dockerfile
+++ b/.deploy/docker/api/Dockerfile
@@ -31,13 +31,25 @@ RUN echo "shamefully-hoist=true" > .npmrc
 # When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
 # Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
 # hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a fork,
-# or any build that does not pass it (e.g. prod) — this is a no-op and pnpm uses the
+# or any build that does not pass it (e.g. a local `docker build`) — this is a no-op and pnpm uses the
 # public npm registry, exactly as before. The pnpm-lock rewrite is best-effort
 # (non-fatal) so a URL/path mismatch degrades to public downloads, never a hard fail.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile

--- a/.deploy/docker/docs/Dockerfile
+++ b/.deploy/docker/docs/Dockerfile
@@ -23,6 +23,31 @@ ENV NODE_ENV=production
 
 # Install dependencies first (lockfile + package.jsons only — better cache)
 COPY --from=pruner /app/out/json/ .
+
+# Package registry selection (backward-compatible, fork-safe):
+# When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
+# Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
+# hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a
+# fork, or a plain `docker build` — this is a no-op and pnpm uses the public npm
+# registry, exactly as before. Same pattern as the api/web/mcp/node Dockerfiles.
+ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
+    fi
+
 RUN pnpm install --frozen-lockfile
 
 # Copy the rest of the pruned sources

--- a/.deploy/docker/mcp/Dockerfile
+++ b/.deploy/docker/mcp/Dockerfile
@@ -22,13 +22,25 @@ RUN echo "shamefully-hoist=true" > .npmrc
 # When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
 # Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
 # hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a fork,
-# or any build that does not pass it (e.g. prod) — this is a no-op and pnpm uses the
+# or any build that does not pass it (e.g. a local `docker build`) — this is a no-op and pnpm uses the
 # public npm registry, exactly as before. The pnpm-lock rewrite is best-effort
 # (non-fatal) so a URL/path mismatch degrades to public downloads, never a hard fail.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile
@@ -62,9 +74,21 @@ RUN echo "shamefully-hoist=true" > .npmrc
 
 # Package registry selection (backward-compatible, fork-safe) — see installer stage above.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile

--- a/.deploy/docker/node/Dockerfile
+++ b/.deploy/docker/node/Dockerfile
@@ -27,9 +27,21 @@ RUN echo "shamefully-hoist=true" > .npmrc
 # Package registry selection (backward-compatible, fork-safe) — see the
 # API/MCP Dockerfiles for the full rationale. Empty is a no-op.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile

--- a/.deploy/docker/web/Dockerfile
+++ b/.deploy/docker/web/Dockerfile
@@ -66,14 +66,26 @@ COPY --from=builder /app/.gitignore .gitignore
 # Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
 # hashes, so `pnpm install --frozen-lockfile` still verifies). We write the setting
 # to the workspace-root .npmrc (/app), which pnpm reads when installing under
-# apps/web. When empty — a fork, or any build that does not pass it (e.g. prod) —
+# apps/web. When empty — a fork, or any build that does not pass it (e.g. a local `docker build`) —
 # this is a no-op and pnpm uses the public npm registry, exactly as before. The
 # pnpm-lock rewrite is best-effort (non-fatal) so a URL/path mismatch degrades to
 # public downloads, never a hard fail.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 # Install deps

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -47,6 +47,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -51,6 +51,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}
@@ -154,6 +155,7 @@ jobs:
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
             NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
             NEXT_PUBLIC_BUILD_VERSION=${{ steps.meta.outputs.version }}

--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -93,6 +93,7 @@ jobs:
           push: true
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}
@@ -121,6 +122,7 @@ jobs:
           push: true
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}


### PR DESCRIPTION
Cascades develop whole (no cherry-pick): #2137 (Verdaccio build-args + reachability probe in all 6 Docker install stages — the largest remaining traffic item) and #2136 (git-ignore the CI-written registry files). No migrations. 🤖 Generated with [Claude Code](https://claude.com/claude-code)