### PR TITLE
chore(cascade): stage → main — Verdaccio in the container image builds + K8s Plugin E2E crictl pre-load

### DIFF
--- a/.deploy/docker/api/Dockerfile
+++ b/.deploy/docker/api/Dockerfile
@@ -31,13 +31,25 @@ RUN echo "shamefully-hoist=true" > .npmrc
 # When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
 # Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
 # hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a fork,
-# or any build that does not pass it (e.g. prod) — this is a no-op and pnpm uses the
+# or any build that does not pass it (e.g. a local `docker build`) — this is a no-op and pnpm uses the
 # public npm registry, exactly as before. The pnpm-lock rewrite is best-effort
 # (non-fatal) so a URL/path mismatch degrades to public downloads, never a hard fail.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile

--- a/.deploy/docker/docs/Dockerfile
+++ b/.deploy/docker/docs/Dockerfile
@@ -23,6 +23,31 @@ ENV NODE_ENV=production
 
 # Install dependencies first (lockfile + package.jsons only — better cache)
 COPY --from=pruner /app/out/json/ .
+
+# Package registry selection (backward-compatible, fork-safe):
+# When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
+# Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
+# hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a
+# fork, or a plain `docker build` — this is a no-op and pnpm uses the public npm
+# registry, exactly as before. Same pattern as the api/web/mcp/node Dockerfiles.
+ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
+    fi
+
 RUN pnpm install --frozen-lockfile
 
 # Copy the rest of the pruned sources

--- a/.deploy/docker/mcp/Dockerfile
+++ b/.deploy/docker/mcp/Dockerfile
@@ -22,13 +22,25 @@ RUN echo "shamefully-hoist=true" > .npmrc
 # When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
 # Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
 # hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a fork,
-# or any build that does not pass it (e.g. prod) — this is a no-op and pnpm uses the
+# or any build that does not pass it (e.g. a local `docker build`) — this is a no-op and pnpm uses the
 # public npm registry, exactly as before. The pnpm-lock rewrite is best-effort
 # (non-fatal) so a URL/path mismatch degrades to public downloads, never a hard fail.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile
@@ -62,9 +74,21 @@ RUN echo "shamefully-hoist=true" > .npmrc
 
 # Package registry selection (backward-compatible, fork-safe) — see installer stage above.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile

--- a/.deploy/docker/node/Dockerfile
+++ b/.deploy/docker/node/Dockerfile
@@ -27,9 +27,21 @@ RUN echo "shamefully-hoist=true" > .npmrc
 # Package registry selection (backward-compatible, fork-safe) — see the
 # API/MCP Dockerfiles for the full rationale. Empty is a no-op.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 RUN pnpm install --frozen-lockfile

--- a/.deploy/docker/web/Dockerfile
+++ b/.deploy/docker/web/Dockerfile
@@ -66,14 +66,26 @@ COPY --from=builder /app/.gitignore .gitignore
 # Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
 # hashes, so `pnpm install --frozen-lockfile` still verifies). We write the setting
 # to the workspace-root .npmrc (/app), which pnpm reads when installing under
-# apps/web. When empty — a fork, or any build that does not pass it (e.g. prod) —
+# apps/web. When empty — a fork, or any build that does not pass it (e.g. a local `docker build`) —
 # this is a no-op and pnpm uses the public npm registry, exactly as before. The
 # pnpm-lock rewrite is best-effort (non-fatal) so a URL/path mismatch degrades to
 # public downloads, never a hard fail.
 ARG VERDACCIO_REGISTRY=""
+# Reachability probe (this repo's builds run inside BuildKit on our LAN
+# runners, where the VIP is normally reachable — but a Verdaccio outage, or a
+# build that ends up on a GitHub-hosted runner, must NOT fail the image build):
+# probe the registry with a 5s timeout in the SAME layer, and fall back to the
+# public npm registry with a loud warning when it is unreachable. `node` is the
+# probe because the base image has no curl/wget guarantee. Any HTTP response
+# counts as reachable; only a connect failure/timeout trips the fallback.
 RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
-        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
-        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        if node -e "fetch(process.argv[1],{signal:AbortSignal.timeout(5000)}).then(r=>{r.body&&r.body.cancel();process.exitCode=0},()=>{process.exitCode=1})" "${VERDACCIO_REGISTRY%/}/"; then \
+            echo "==> Verdaccio reachable - installing through ${VERDACCIO_REGISTRY}" && \
+            echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+            { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+        else \
+            echo "WARNING: VERDACCIO_REGISTRY=${VERDACCIO_REGISTRY} is unreachable from this builder - falling back to the public npm registry." >&2; \
+        fi; \
     fi
 
 # Install deps

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -47,6 +47,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -51,6 +51,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}
@@ -154,6 +155,7 @@ jobs:
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
             NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
             NEXT_PUBLIC_BUILD_VERSION=${{ steps.meta.outputs.version }}

--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -93,6 +93,7 @@ jobs:
           push: true
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}
@@ -121,6 +122,7 @@ jobs:
           push: true
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -127,9 +127,32 @@ jobs:
         # Loads nginx-unprivileged into kind nodes so the Deployment's
         # imagePullPolicy: IfNotPresent path resolves immediately,
         # cutting test time by ~30s on slow runners.
+        #
+        # Why `docker save --platform` + `kind load image-archive` instead of
+        # a plain `kind load docker-image`: on the self-hosted ARC pool the
+        # `docker:dind` sidecar runs Docker 29, whose fresh-install default is
+        # the containerd image store. There `docker save` (what `kind load
+        # docker-image` shells out to) writes the image's FULL multi-arch OCI
+        # index but only the blobs that were actually pulled (amd64), and the
+        # node-side `ctr images import --all-platforms` then fails with
+        # `ctr: content digest sha256:…: not found` for the linux/arm manifest.
+        # That made every run of this workflow red from 2026-07-17 on (the
+        # GitHub-hosted runners it ran on before use the classic overlay2 store,
+        # where `docker save` is self-contained). Upstream: kubernetes-sigs/kind#3795
+        # (pinned, open — kind cannot fix it on its side), containerd/containerd#11344.
+        # Saving only the platform we run makes the archive self-contained, so
+        # the import works on BOTH image stores. `docker save --platform` needs
+        # Docker API 1.48+ (Engine 28) — ubuntu-latest and the ARC dind both have it.
         run: |
-          docker pull nginxinc/nginx-unprivileged:1.27-alpine
-          kind load docker-image nginxinc/nginx-unprivileged:1.27-alpine --name ever-works-e2e
+          IMAGE=nginxinc/nginx-unprivileged:1.27-alpine
+          ARCHIVE="$RUNNER_TEMP/nginx-unprivileged.tar"
+          docker info --format 'docker {{.ServerVersion}} / storage {{.Driver}} {{range .DriverStatus}}{{index . 0}}={{index . 1}} {{end}}'
+          docker pull --platform linux/amd64 "$IMAGE"
+          docker save --platform linux/amd64 -o "$ARCHIVE" "$IMAGE"
+          kind load image-archive "$ARCHIVE" --name ever-works-e2e
+          # Prove the image actually landed on the node — a loud failure here
+          # beats a silent fallback to a registry pull inside the test.
+          docker exec ever-works-e2e-control-plane crictl images | grep -F 'nginxinc/nginx-unprivileged'             || { echo "::error::$IMAGE not present on the kind node after kind load"; exit 1; }
 
       - name: Run k8s plugin e2e suite
         run: pnpm --filter @ever-works/k8s-plugin test:e2e

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -124,35 +124,36 @@ jobs:
           echo "KUBECONFIG_E2E_PATH=$RUNNER_TEMP/kubeconfig" >> "$GITHUB_ENV"
 
       - name: Pre-pull image used by e2e Deployment
-        # Loads nginx-unprivileged into kind nodes so the Deployment's
+        # Loads nginx-unprivileged into the kind node so the Deployment's
         # imagePullPolicy: IfNotPresent path resolves immediately,
         # cutting test time by ~30s on slow runners.
         #
-        # Why `docker save --platform` + `kind load image-archive` instead of
-        # a plain `kind load docker-image`: on the self-hosted ARC pool the
-        # `docker:dind` sidecar runs Docker 29, whose fresh-install default is
-        # the containerd image store. There `docker save` (what `kind load
-        # docker-image` shells out to) writes the image's FULL multi-arch OCI
-        # index but only the blobs that were actually pulled (amd64), and the
-        # node-side `ctr images import --all-platforms` then fails with
+        # Why `crictl pull` INSIDE the node instead of `kind load docker-image`:
+        # on the self-hosted ARC pool the `docker:dind` sidecar runs Docker 29,
+        # whose fresh-install default is the containerd image store. There
+        # `docker save` (what `kind load docker-image` shells out to) writes the
+        # image's FULL multi-arch OCI index but only the blobs that were actually
+        # pulled, and the node-side `ctr images import --all-platforms` fails with
         # `ctr: content digest sha256:…: not found` for the linux/arm manifest.
-        # That made every run of this workflow red from 2026-07-17 on (the
-        # GitHub-hosted runners it ran on before use the classic overlay2 store,
-        # where `docker save` is self-contained). Upstream: kubernetes-sigs/kind#3795
-        # (pinned, open — kind cannot fix it on its side), containerd/containerd#11344.
-        # Saving only the platform we run makes the archive self-contained, so
-        # the import works on BOTH image stores. `docker save --platform` needs
-        # Docker API 1.48+ (Engine 28) — ubuntu-latest and the ARC dind both have it.
+        # `docker save --platform linux/amd64` is not enough either: the archive
+        # still carries the amd64 *attestation* manifest (unknown/unknown), which
+        # ctr then tries to unpack as an image and rejects with `mismatched image
+        # rootfs and manifest layers`. That made every run of this workflow red
+        # from 2026-07-17 on (the GitHub-hosted runners it ran on before use the
+        # classic overlay2 store, where `docker save` is self-contained).
+        # Upstream: kubernetes-sigs/kind#3795 (pinned, open — kind cannot fix it
+        # on its side), containerd/containerd#11344.
+        # Pulling through the node's own CRI fetches exactly what the kubelet
+        # would fetch (one platform, no attestations) and is independent of the
+        # host daemon's image store, so it behaves the same on ubuntu-latest and
+        # on ARC. The `docker info` line records the daemon mode in every run.
         run: |
           IMAGE=nginxinc/nginx-unprivileged:1.27-alpine
-          ARCHIVE="$RUNNER_TEMP/nginx-unprivileged.tar"
           docker info --format 'docker {{.ServerVersion}} / storage {{.Driver}} {{range .DriverStatus}}{{index . 0}}={{index . 1}} {{end}}'
-          docker pull --platform linux/amd64 "$IMAGE"
-          docker save --platform linux/amd64 -o "$ARCHIVE" "$IMAGE"
-          kind load image-archive "$ARCHIVE" --name ever-works-e2e
-          # Prove the image actually landed on the node — a loud failure here
-          # beats a silent fallback to a registry pull inside the test.
-          docker exec ever-works-e2e-control-plane crictl images | grep -F 'nginxinc/nginx-unprivileged'             || { echo "::error::$IMAGE not present on the kind node after kind load"; exit 1; }
+          docker exec ever-works-e2e-control-plane crictl pull "docker.io/$IMAGE"
+          # Prove the image is on the node — a loud failure here beats a silent
+          # fallback to a registry pull inside the test.
+          docker exec ever-works-e2e-control-plane crictl images | grep -F 'nginxinc/nginx-unprivileged'             || { echo "::error::$IMAGE not present on the kind node after pull"; exit 1; }
 
       - name: Run k8s plugin e2e suite
         run: pnpm --filter @ever-works/k8s-plugin test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ api-mem.log
 apps/desktop/release
 apps/desktop/bundle
 apps/desktop-node/release
+
+# CI writes registry configuration at the repo root (Configure Registry action) and removes it
+# again on the same run - but self-hosted runners check out with clean: false, so a crashed job
+# could leave one behind. Ignore them so a leftover can never be committed by a later job.
+/.npmrc
+/.yarnrc


### PR DESCRIPTION
Promotes stage to main. Carries:

- **#2137 via #2140 — Verdaccio inside the Docker image builds** (the largest remaining CI traffic item): all 5 image Dockerfiles (.deploy/docker/{api,web,mcp,docs,node}) now accept a VERDACCIO_REGISTRY build-arg; when set and reachable (5s probe in the same RUN layer) they write registry=... to the image-local .npmrc and rewrite pnpm-lock.yaml resolved URLs before pnpm install, falling back loudly to the public registry when unreachable. No token is baked into any layer (anonymous read). The build-arg is passed by docker-build-publish-{dev,stage,prod}.yml, the MCP variants, and k8s-build.yml.
- **#2138 — K8s Plugin E2E kind pre-load fix** under Docker 29's containerd image store (crictl pull).
- **#2136 — gitignore the CI-written registry files.**

Verified on develop and stage: k8s-build image logs show "==> Verdaccio reachable - installing through http://192.168.1.183:4873/" for every image, no fallback warnings.

Known red: dependency-audit fails on GHSA-r292-9mhp-454m (tar advisory published today) — identical dependency tree on main/stage/develop, repo-wide fix in #2141. Unrelated to this cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)