### PR TITLE
chore(cascade): stage → main — CLI agent credential isolation fixes

### DIFF
--- a/packages/plugins/claude-code/src/__tests__/auth-resolution.spec.ts
+++ b/packages/plugins/claude-code/src/__tests__/auth-resolution.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { authModeForEnv, resolveAuthEnv, resolveAuthMode } from '../utils/pipeline-helpers.js';
+
+describe('resolveAuthMode', () => {
+	it('recognizes the two supported modes', () => {
+		expect(resolveAuthMode({ authMode: 'subscription' })).toBe('subscription');
+		expect(resolveAuthMode({ authMode: 'api-key' })).toBe('api-key');
+	});
+
+	it('treats an unset or unknown mode as unpinned', () => {
+		expect(resolveAuthMode({})).toBeUndefined();
+		expect(resolveAuthMode({ authMode: 'bedrock' })).toBeUndefined();
+	});
+});
+
+describe('resolveAuthEnv', () => {
+	it('keeps the legacy inference when no mode is pinned', () => {
+		expect(resolveAuthEnv({ oauthToken: 'oauth', apiKey: 'sk-key' })).toEqual({
+			CLAUDE_CODE_OAUTH_TOKEN: 'oauth'
+		});
+		expect(resolveAuthEnv({ apiKey: 'sk-key' })).toEqual({ ANTHROPIC_API_KEY: 'sk-key' });
+		expect(resolveAuthEnv({})).toEqual({});
+	});
+
+	it('resolves a pinned subscription agent to the OAuth token only', () => {
+		expect(
+			resolveAuthEnv({
+				authMode: 'subscription',
+				oauthToken: 'oauth',
+				apiKey: 'sk-key'
+			})
+		).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'oauth' });
+	});
+
+	it('never degrades a subscription agent into per-token API billing', () => {
+		// The whole point of pinning: an operator who chose their Claude plan must
+		// not get a Console invoice because an API key happened to be configured.
+		expect(
+			resolveAuthEnv({
+				authMode: 'subscription',
+				apiKey: 'sk-should-not-be-used'
+			})
+		).toEqual({});
+	});
+
+	it('resolves a pinned api-key agent to the API key only', () => {
+		expect(
+			resolveAuthEnv({
+				authMode: 'api-key',
+				oauthToken: 'oauth',
+				apiKey: 'sk-key'
+			})
+		).toEqual({ ANTHROPIC_API_KEY: 'sk-key' });
+	});
+
+	it('falls back from a keyless api-key agent to the subscription token', () => {
+		// Falling this direction costs plan quota rather than money, so it is the
+		// safe degradation — unlike the reverse, which is blocked above.
+		expect(
+			resolveAuthEnv({
+				authMode: 'api-key',
+				oauthToken: 'oauth'
+			})
+		).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'oauth' });
+	});
+});
+
+describe('authModeForEnv', () => {
+	it('reports which credential actually served the run', () => {
+		expect(authModeForEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'oauth' })).toBe('subscription');
+		expect(authModeForEnv({ ANTHROPIC_API_KEY: 'sk-key' })).toBe('api-key');
+		expect(authModeForEnv({})).toBeUndefined();
+	});
+});

--- a/packages/plugins/claude-code/src/__tests__/claude-code.plugin.spec.ts
+++ b/packages/plugins/claude-code/src/__tests__/claude-code.plugin.spec.ts
@@ -207,7 +207,7 @@ describe('ClaudeCodePlugin', () => {
 			expect(vi.mocked(executeClaudeCode)).toHaveBeenCalledWith(
 				expect.objectContaining({
 					env: expect.objectContaining({
-						CLAUDE_CODE_CONFIG_DIR: '/tmp/claude-code-generator/config/user1'
+						CLAUDE_CONFIG_DIR: '/tmp/claude-code-generator/config/user1'
 					})
 				})
 			);

--- a/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
+++ b/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
@@ -44,11 +44,10 @@ describe('buildSubprocessEnv (C-10)', () => {
 		expect(env.PATH).toBe('/usr/local/bin:/usr/bin');
 	});
 
-	it('forwards the explicitly named Anthropic / Claude Code vars (exact-name allow-list)', () => {
+	it('forwards the non-credential ANTHROPIC_BASE_URL but never a host credential', () => {
 		process.env.ANTHROPIC_BASE_URL = 'https://proxy.local';
 		process.env.ANTHROPIC_API_KEY = 'sk-from-env';
 		process.env.ANTHROPIC_AUTH_TOKEN = 'anthropic-auth-token';
-		process.env.CLAUDE_CODE_CONFIG_DIR = '/tmp/cfg';
 		process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token';
 		// Negative case: a var that just contains "ANTHROPIC" but doesn't START with the prefix
 		// must NOT pass through.
@@ -57,11 +56,53 @@ describe('buildSubprocessEnv (C-10)', () => {
 		const env = buildSubprocessEnv();
 
 		expect(env.ANTHROPIC_BASE_URL).toBe('https://proxy.local');
-		expect(env.ANTHROPIC_API_KEY).toBe('sk-from-env');
-		expect(env.ANTHROPIC_AUTH_TOKEN).toBe('anthropic-auth-token');
-		expect(env.CLAUDE_CODE_CONFIG_DIR).toBe('/tmp/cfg');
-		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
 		expect(env.MY_ANTHROPIC_HELPER).toBeUndefined();
+
+		// Credentials are supplied by resolved plugin settings, never inherited.
+		expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+	});
+
+	it('does not let a host ANTHROPIC_API_KEY hijack a subscription-mode run', () => {
+		// Regression guard for silent mis-billing. Claude Code resolves
+		// ANTHROPIC_API_KEY (rank 3) ahead of CLAUDE_CODE_OAUTH_TOKEN (rank 5),
+		// and in `-p` mode "the key is always used when present". A stray host
+		// API key would therefore bill the Console org for an agent the operator
+		// pinned to their Claude subscription — with no error and no warning.
+		process.env.ANTHROPIC_API_KEY = 'sk-from-env';
+		process.env.ANTHROPIC_AUTH_TOKEN = 'anthropic-auth-token';
+
+		const env = buildSubprocessEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'subscription-token' }, { authMode: 'subscription' });
+
+		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('subscription-token');
+		expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+	});
+
+	it('strips the subscription token when the agent is pinned to api-key mode', () => {
+		process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-from-env';
+
+		const env = buildSubprocessEnv({ ANTHROPIC_API_KEY: 'sk-configured' }, { authMode: 'api-key' });
+
+		expect(env.ANTHROPIC_API_KEY).toBe('sk-configured');
+		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+	});
+
+	it('never inherits a provider-selection var that would outrank the chosen credential', () => {
+		// CLAUDE_CODE_USE_BEDROCK and friends sit above every credential in the
+		// CLI's resolution order, so a stray one on the host would silently move
+		// a subscription-mode agent onto a cloud provider account.
+		process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+		process.env.CLAUDE_CODE_USE_VERTEX = '1';
+		process.env.ANTHROPIC_PROFILE = 'some-profile';
+
+		const env = buildSubprocessEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'subscription-token' }, { authMode: 'subscription' });
+
+		expect(env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+		expect(env.CLAUDE_CODE_USE_VERTEX).toBeUndefined();
+		expect(env.ANTHROPIC_PROFILE).toBeUndefined();
+		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('subscription-token');
 	});
 
 	it('drops arbitrary ANTHROPIC_*/CLAUDE_CODE_*-prefixed vars not on the allow-list', () => {
@@ -69,7 +110,7 @@ describe('buildSubprocessEnv (C-10)', () => {
 		// merely STARTED WITH `ANTHROPIC_` or `CLAUDE_CODE_`, which silently
 		// forwarded any future/custom var with those prefixes into the model's
 		// subprocess. Only the exact-name allow-list may pass through.
-		process.env.ANTHROPIC_API_KEY = 'sk-from-env';
+		process.env.ANTHROPIC_BASE_URL = 'https://proxy.local';
 		process.env.ANTHROPIC_CUSTOM_VAR = 'should-be-dropped';
 		process.env.ANTHROPIC_SECRET_PROXY_TOKEN = 'leak-me';
 		process.env.CLAUDE_CODE_INTERNAL_DEBUG = 'leak-me-too';
@@ -77,7 +118,7 @@ describe('buildSubprocessEnv (C-10)', () => {
 		const env = buildSubprocessEnv();
 
 		// Allow-listed var still forwarded.
-		expect(env.ANTHROPIC_API_KEY).toBe('sk-from-env');
+		expect(env.ANTHROPIC_BASE_URL).toBe('https://proxy.local');
 		// Arbitrary prefixed vars are NOT forwarded.
 		expect(env.ANTHROPIC_CUSTOM_VAR).toBeUndefined();
 		expect(env.ANTHROPIC_SECRET_PROXY_TOKEN).toBeUndefined();

--- a/packages/plugins/claude-code/src/claude-code.plugin.ts
+++ b/packages/plugins/claude-code/src/claude-code.plugin.ts
@@ -67,6 +67,7 @@ import {
 	reportItemProgress,
 	resolveSettings,
 	resolveAuthEnv,
+	authModeForEnv,
 	buildMetrics,
 	buildErrorResult,
 	buildCancelledResult,
@@ -184,6 +185,14 @@ export class ClaudeCodePlugin implements IPlugin, IPipelinePlugin, IFormSchemaPr
 	readonly settingsSchema: JsonSchema = {
 		type: 'object',
 		properties: {
+			authMode: {
+				type: 'string',
+				title: 'Billing Mode',
+				enum: ['subscription', 'api-key'],
+				description:
+					'Which credential this agent runs on. "subscription" uses the OAuth token from `claude setup-token` and bills your Claude plan; "api-key" bills your Anthropic Console org per token. When set, the agent uses only that credential and fails if it is missing, instead of silently falling back to the other one. Leave unset to keep the legacy behaviour (OAuth token preferred when both are configured).',
+				'x-scope': 'user'
+			},
 			oauthToken: {
 				type: 'string',
 				title: 'OAuth Token (Claude Pro/Max subscription — no per-token cost)',
@@ -613,8 +622,9 @@ export class ClaudeCodePlugin implements IPlugin, IPipelinePlugin, IFormSchemaPr
 					cwd: workspacePath,
 					env: {
 						...authEnv,
-						CLAUDE_CODE_CONFIG_DIR: configDir
+						CLAUDE_CONFIG_DIR: configDir
 					},
+					authMode: authModeForEnv(authEnv),
 					maxTurns,
 					maxBudgetUsd,
 					model,
@@ -1153,7 +1163,8 @@ export class ClaudeCodePlugin implements IPlugin, IPipelinePlugin, IFormSchemaPr
 				prompt: request.prompt,
 				systemPrompt,
 				cwd: request.workspaceDir,
-				env: { ...authEnv, CLAUDE_CODE_CONFIG_DIR: configDir },
+				env: { ...authEnv, CLAUDE_CONFIG_DIR: configDir },
+				authMode: authModeForEnv(authEnv),
 				maxTurns,
 				maxBudgetUsd,
 				model,

--- a/packages/plugins/claude-code/src/utils/pipeline-helpers.ts
+++ b/packages/plugins/claude-code/src/utils/pipeline-helpers.ts
@@ -1,5 +1,6 @@
 import type { PluginSettings, PipelineState } from '@ever-works/plugin';
 import { createPipelineRuntimeHelpers } from '@ever-works/plugin';
+import type { ClaudeAuthMode } from './subprocess-env.js';
 import type { ClaudeCodeStepId } from '../types.js';
 import { CLAUDE_CODE_STEP_IDS } from '../types.js';
 import { STEP_DEFINITIONS } from '../steps.js';
@@ -20,9 +21,36 @@ export const buildErrorResult = runtime.buildErrorResult;
 export const buildCancelledResult = runtime.buildCancelledResult;
 export const delay = runtime.delay;
 
+/**
+ * Decide which credential this agent authenticates with.
+ *
+ * `authMode` pins the choice. An explicit mode resolves its own credential
+ * first; when that credential is missing we fall back only *away* from
+ * per-token billing, never toward it. An agent pinned to `subscription` that
+ * quietly ran on an API key would bill the Console org for work the operator
+ * expected their Claude plan to cover — no error, just an unexpected invoice —
+ * so `subscription` fails closed rather than degrading. The reverse is
+ * harmless (it costs plan quota, not money), so `api-key` may degrade to the
+ * subscription token. An unset `authMode` keeps the historical inference
+ * (OAuth token wins when both are present) so existing plugin configurations
+ * keep working unchanged.
+ */
+export function resolveAuthMode(settings: PluginSettings): ClaudeAuthMode | undefined {
+	const mode = settings.authMode;
+	return mode === 'subscription' || mode === 'api-key' ? mode : undefined;
+}
+
 export function resolveAuthEnv(settings: PluginSettings): Record<string, string> {
 	const oauthToken = settings.oauthToken as string | undefined;
 	const apiKey = settings.apiKey as string | undefined;
+	const authMode = resolveAuthMode(settings);
+
+	if (authMode === 'subscription') {
+		return oauthToken ? { CLAUDE_CODE_OAUTH_TOKEN: oauthToken } : {};
+	}
+	if (authMode === 'api-key' && apiKey) {
+		return { ANTHROPIC_API_KEY: apiKey };
+	}
 
 	if (oauthToken) {
 		return { CLAUDE_CODE_OAUTH_TOKEN: oauthToken };
@@ -31,4 +59,14 @@ export function resolveAuthEnv(settings: PluginSettings): Record<string, string>
 		return { ANTHROPIC_API_KEY: apiKey };
 	}
 	return {};
+}
+
+/**
+ * The mode a resolved auth env actually represents, for pinning
+ * `buildSubprocessEnv` and for recording on the run which credential served it.
+ */
+export function authModeForEnv(authEnv: Record<string, string>): ClaudeAuthMode | undefined {
+	if (authEnv.CLAUDE_CODE_OAUTH_TOKEN) return 'subscription';
+	if (authEnv.ANTHROPIC_API_KEY) return 'api-key';
+	return undefined;
 }

--- a/packages/plugins/claude-code/src/utils/process-runner.ts
+++ b/packages/plugins/claude-code/src/utils/process-runner.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'child_process';
 import { MAX_BUFFER_SIZE, KILL_TIMEOUT_MS } from '../types.js';
-import { buildSubprocessEnv } from './subprocess-env.js';
+import { buildSubprocessEnv, type ClaudeAuthMode } from './subprocess-env.js';
 
 export interface ExecuteOptions {
 	/** Path to the Claude Code binary */
@@ -13,6 +13,12 @@ export interface ExecuteOptions {
 	readonly cwd: string;
 	/** Environment variables to set */
 	readonly env: Record<string, string>;
+	/**
+	 * Credential this run must authenticate with. Any credential variable
+	 * belonging to another mode is stripped from the subprocess environment, so
+	 * the CLI's own precedence order cannot select a credential we didn't choose.
+	 */
+	readonly authMode?: ClaudeAuthMode;
 	/** Maximum agentic turns */
 	readonly maxTurns: number;
 	/** Maximum budget in USD (optional) */
@@ -96,13 +102,17 @@ export function executeClaudeCode(options: ExecuteOptions): {
 		// and is fed user prompts + scraped web content + community-PR text — any
 		// prompt-injection in those inputs can drive the model to `printenv` and
 		// exfiltrate every host secret. Mirror the codex / gemini / opencode
-		// pattern: only PATH/HOME/TMPDIR, proxy/CA vars, and ANTHROPIC_*/
-		// CLAUDE_CODE_* keys are forwarded.
-		const env: Record<string, string> = buildSubprocessEnv({
-			...options.env,
-			DISABLE_AUTOUPDATER: '1',
-			DISABLE_TELEMETRY: '1'
-		});
+		// pattern: only PATH/HOME/TMPDIR, proxy/CA vars, and the non-credential
+		// ANTHROPIC_BASE_URL are forwarded. Credentials arrive only via
+		// `options.env`, and `authMode` drops any that belong to another mode.
+		const env: Record<string, string> = buildSubprocessEnv(
+			{
+				...options.env,
+				DISABLE_AUTOUPDATER: '1',
+				DISABLE_TELEMETRY: '1'
+			},
+			{ authMode: options.authMode }
+		);
 
 		childProcess = spawn(options.binaryPath, args, {
 			cwd: options.cwd,

--- a/packages/plugins/claude-code/src/utils/subprocess-env.ts
+++ b/packages/plugins/claude-code/src/utils/subprocess-env.ts
@@ -30,20 +30,76 @@ const PASSTHROUGH_ENV_KEYS = [
 	'CURL_CA_BUNDLE'
 ] as const;
 
-// Explicit allow-list of Anthropic-/Claude-Code-specific vars the CLI actually
-// consumes. We list each var by exact name rather than matching by prefix so a
-// future/custom var that merely starts with ANTHROPIC_ or CLAUDE_CODE_ is NOT
-// silently forwarded into the subprocess (audit: prefix forwarding leaks any
-// such var to the model).
-const PASSTHROUGH_ANTHROPIC_KEYS = [
-	'ANTHROPIC_API_KEY',
-	'ANTHROPIC_BASE_URL',
-	'ANTHROPIC_AUTH_TOKEN',
-	'CLAUDE_CODE_OAUTH_TOKEN',
-	'CLAUDE_CODE_CONFIG_DIR'
+// Non-credential Anthropic vars that are safe to inherit from the host. Listed
+// by exact name rather than by prefix so a future/custom var that merely starts
+// with ANTHROPIC_ or CLAUDE_CODE_ is NOT silently forwarded into the subprocess
+// (audit: prefix forwarding leaks any such var to the model).
+//
+// 🛑 Credentials are deliberately NOT in this list — see AUTH_ENV_KEYS below.
+const PASSTHROUGH_ANTHROPIC_KEYS = ['ANTHROPIC_BASE_URL'] as const;
+
+/**
+ * Which credential this run is supposed to authenticate with.
+ *
+ * - `subscription` → `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`), billed
+ *   against a Claude Pro/Max/Team/Enterprise plan.
+ * - `api-key` → `ANTHROPIC_API_KEY`, billed per token against the Console org.
+ */
+export type ClaudeAuthMode = 'subscription' | 'api-key';
+
+/**
+ * Every environment variable Claude Code will accept as a credential, in the
+ * CLI's own resolution order (highest priority first).
+ *
+ * 🛑 This ordering is why credentials must never be inherited from the host.
+ * Claude Code resolves `ANTHROPIC_AUTH_TOKEN` (rank 2) and `ANTHROPIC_API_KEY`
+ * (rank 3) ahead of `CLAUDE_CODE_OAUTH_TOKEN` (rank 5), and the docs are
+ * explicit that "in non-interactive mode (-p), the key is always used when
+ * present". So an agent configured for subscription billing that inherits a
+ * stray `ANTHROPIC_API_KEY` from the server environment would silently bill the
+ * API key instead of the subscription — no error, no warning, just an unexpected
+ * Console invoice. We therefore accept credentials ONLY from the caller's
+ * explicit overrides (i.e. resolved plugin settings) and strip any credential
+ * that does not match the selected mode.
+ *
+ * https://code.claude.com/docs/en/authentication
+ */
+const AUTH_ENV_KEYS = ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'] as const;
+
+/** The single credential variable each mode is allowed to set. */
+const AUTH_ENV_KEY_FOR_MODE: Record<ClaudeAuthMode, (typeof AUTH_ENV_KEYS)[number]> = {
+	subscription: 'CLAUDE_CODE_OAUTH_TOKEN',
+	'api-key': 'ANTHROPIC_API_KEY'
+};
+
+/**
+ * Variables that move the session onto a different inference provider entirely
+ * and outrank every credential in AUTH_ENV_KEYS. Never inherited — a stray
+ * `CLAUDE_CODE_USE_BEDROCK` on the host would silently redirect a
+ * subscription-mode agent onto a cloud provider account.
+ */
+const PROVIDER_SELECTION_KEYS = [
+	'CLAUDE_CODE_USE_BEDROCK',
+	'CLAUDE_CODE_USE_VERTEX',
+	'CLAUDE_CODE_USE_FOUNDRY',
+	'ANTHROPIC_PROFILE',
+	'ANTHROPIC_FEDERATION_RULE_ID',
+	'ANTHROPIC_ORGANIZATION_ID'
 ] as const;
 
-export function buildSubprocessEnv(overrides: Record<string, string> = {}): Record<string, string> {
+export interface BuildSubprocessEnvOptions {
+	/**
+	 * Pin the run to one credential. When set, any credential variable that
+	 * does not belong to this mode is dropped from the resulting environment,
+	 * so the CLI cannot resolve a higher-precedence credential we did not choose.
+	 */
+	readonly authMode?: ClaudeAuthMode;
+}
+
+export function buildSubprocessEnv(
+	overrides: Record<string, string> = {},
+	options: BuildSubprocessEnvOptions = {}
+): Record<string, string> {
 	const env: Record<string, string> = {
 		PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
 		HOME: process.env.HOME ?? os.homedir(),
@@ -70,11 +126,6 @@ export function buildSubprocessEnv(overrides: Record<string, string> = {}): Reco
 		}
 	}
 
-	// Allow through the explicitly named Anthropic-/Claude-Code vars only. The
-	// caller is expected to set the actual auth token via `overrides`
-	// (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY) — passing them through here
-	// too is harmless and preserves manual overrides in dev (e.g.
-	// ANTHROPIC_BASE_URL pointed at a local proxy).
 	for (const key of PASSTHROUGH_ANTHROPIC_KEYS) {
 		const value = process.env[key];
 		if (value) {
@@ -86,5 +137,30 @@ export function buildSubprocessEnv(overrides: Record<string, string> = {}): Reco
 		env[key] = value;
 	}
 
+	// A provider-selection variable outranks every credential, so it can only
+	// ever arrive deliberately, from the caller — never from the host.
+	for (const key of PROVIDER_SELECTION_KEYS) {
+		if (!(key in overrides)) {
+			delete env[key];
+		}
+	}
+
+	// Enforce exactly one credential so the CLI's precedence order cannot pick a
+	// different one than the mode we resolved from plugin settings.
+	if (options.authMode) {
+		const allowed = AUTH_ENV_KEY_FOR_MODE[options.authMode];
+		for (const key of AUTH_ENV_KEYS) {
+			if (key !== allowed) {
+				delete env[key];
+			}
+		}
+	}
+
 	return env;
 }
+
+/**
+ * Names of every credential variable, exported so callers and tests can assert
+ * that nothing else leaked into a subprocess environment.
+ */
+export const CLAUDE_AUTH_ENV_KEYS: readonly string[] = AUTH_ENV_KEYS;

--- a/packages/plugins/codex/src/__tests__/pipeline-helpers.spec.ts
+++ b/packages/plugins/codex/src/__tests__/pipeline-helpers.spec.ts
@@ -72,6 +72,63 @@ describe('pipeline-helpers', () => {
 		expect(await resolveExecutionAuth({})).toBeNull();
 	});
 
+	it('resolves an explicit access-token mode to CODEX_ACCESS_TOKEN', async () => {
+		expect(
+			await resolveExecutionAuth({
+				authMode: 'access-token',
+				accessToken: 'ctk-workspace-token'
+			})
+		).toEqual({
+			mode: 'access-token',
+			env: { CODEX_ACCESS_TOKEN: 'ctk-workspace-token' }
+		});
+	});
+
+	it('never degrades a subscription-backed mode into per-token API billing', async () => {
+		// An agent pinned to the ChatGPT workspace entitlement must not silently
+		// start billing the platform org just because an API key is also on file.
+		expect(
+			await resolveExecutionAuth({
+				authMode: 'access-token',
+				apiKey: 'sk-should-not-be-used'
+			})
+		).toBeNull();
+	});
+
+	it('falls back from access-token to device auth, not to the api key', async () => {
+		expect(
+			await resolveExecutionAuth({
+				authMode: 'access-token',
+				apiKey: 'sk-should-not-be-used',
+				[DEVICE_AUTH_AUTH_JSON_SETTING]: '{"token":"abc"}'
+			})
+		).toEqual({
+			mode: 'device-auth',
+			authJson: '{"token":"abc"}'
+		});
+	});
+
+	it('falls back from a keyless api-key mode to the workspace access token', async () => {
+		expect(
+			await resolveExecutionAuth({
+				authMode: 'api-key',
+				accessToken: 'ctk-workspace-token'
+			})
+		).toEqual({
+			mode: 'access-token',
+			env: { CODEX_ACCESS_TOKEN: 'ctk-workspace-token' }
+		});
+	});
+
+	it('ignores a masked access token placeholder', async () => {
+		expect(
+			await resolveExecutionAuth({
+				authMode: 'access-token',
+				accessToken: '••••••••'
+			})
+		).toBeNull();
+	});
+
 	it('materializes and cleans up a per-run device-auth home', async () => {
 		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-device-auth-home-'));
 		tempDirs.push(tempRoot);

--- a/packages/plugins/codex/src/codex.plugin.ts
+++ b/packages/plugins/codex/src/codex.plugin.ts
@@ -46,6 +46,7 @@ import * as https from 'https';
 import type { CodexStepId } from './types.js';
 import { DEFAULT_MODEL } from './types.js';
 import { DEFAULT_CLI_VERSION } from './types.js';
+import { CODEX_AUTH_MODES, CODEX_AUTH_MODE_LABELS } from './types.js';
 import { STEP_DEFINITIONS } from './steps.js';
 import {
 	DEFAULT_TARGET_ITEMS,
@@ -260,8 +261,9 @@ export class CodexPlugin
 			authMode: {
 				type: 'string',
 				title: 'Authentication Mode',
-				description: 'Choose whether Codex uses an OpenAI API key or user-scoped device authentication.',
-				enum: ['api-key', 'device-auth'],
+				description:
+					'How Codex authenticates: an OpenAI API key (per-token billing), a ChatGPT workspace access token (billed against the workspace Codex entitlement), or user-scoped device authentication.',
+				enum: ['api-key', 'access-token', 'device-auth'],
 				default: 'api-key',
 				'x-scope': 'user',
 				'x-hidden': true
@@ -273,6 +275,15 @@ export class CodexPlugin
 				'x-secret': true,
 				'x-scope': 'user',
 				'x-envVar': 'OPENAI_API_KEY'
+			},
+			accessToken: {
+				type: 'string',
+				title: 'Codex Access Token (ChatGPT Business/Enterprise subscription)',
+				description:
+					'A Codex access token from your ChatGPT workspace admin console. This is the credential OpenAI documents for trusted non-interactive Codex runs (scripts, schedulers, private CI runners), and it bills the workspace Codex entitlement instead of per-token API pricing. Requires a ChatGPT Business or Enterprise workspace with the access-token permission enabled. Tokens are tied to the workspace user who created them — give each agent its own.',
+				'x-secret': true,
+				'x-scope': 'user',
+				'x-envVar': 'CODEX_ACCESS_TOKEN'
 			},
 			[DEVICE_AUTH_AUTH_JSON_SETTING]: {
 				type: 'string',
@@ -386,12 +397,23 @@ export class CodexPlugin
 			return apiKey ? this.validateApiKey(apiKey, model) : false;
 		}
 
+		if (authMode === 'access-token') {
+			// A Codex access token is a ChatGPT workspace credential, not an API
+			// key — the /models endpoint we probe for API keys rejects it, so
+			// presence is the only check we can make without burning a real run.
+			return Boolean(this.getRealSecret(resolved.accessToken)?.trim());
+		}
+
 		if (authMode === 'device-auth') {
 			return this.validateCliAuth(resolved);
 		}
 
 		if (apiKey) {
 			return this.validateApiKey(apiKey, model);
+		}
+
+		if (this.getRealSecret(resolved.accessToken)?.trim()) {
+			return true;
 		}
 
 		return this.validateCliAuth(resolved);
@@ -418,16 +440,30 @@ export class CodexPlugin
 	}
 
 	validateSettings(settings: Record<string, unknown>): ValidationResult {
-		if (settings.authMode !== undefined && settings.authMode !== 'api-key' && settings.authMode !== 'device-auth') {
+		if (
+			settings.authMode !== undefined &&
+			!CODEX_AUTH_MODES.includes(settings.authMode as (typeof CODEX_AUTH_MODES)[number])
+		) {
 			return {
 				valid: false,
-				errors: [{ path: 'authMode', message: 'Authentication mode must be "api-key" or "device-auth"' }]
+				errors: [
+					{
+						path: 'authMode',
+						message: `Authentication mode must be one of ${CODEX_AUTH_MODES.map((m) => `"${m}"`).join(', ')}`
+					}
+				]
 			};
 		}
 		if (settings.apiKey !== undefined && typeof settings.apiKey !== 'string') {
 			return {
 				valid: false,
 				errors: [{ path: 'apiKey', message: 'API key must be a string when provided' }]
+			};
+		}
+		if (settings.accessToken !== undefined && typeof settings.accessToken !== 'string') {
+			return {
+				valid: false,
+				errors: [{ path: 'accessToken', message: 'Access token must be a string when provided' }]
 			};
 		}
 		if (settings.unsafeBypassSandbox !== undefined && typeof settings.unsafeBypassSandbox !== 'boolean') {
@@ -464,6 +500,23 @@ export class CodexPlugin
 						success: false,
 						message:
 							'OpenAI API key validation failed. Verify the key, model access, and billing, or switch to device authentication.'
+					};
+		}
+
+		if (authMode === 'access-token') {
+			// Codex access tokens are ChatGPT workspace credentials, so the API
+			// /models probe used for API keys does not apply. Confirm presence
+			// and let the first real run surface an expired or revoked token.
+			return this.getRealSecret(settings.accessToken)?.trim()
+				? {
+						success: true,
+						message:
+							'Codex access token configured. It authenticates against your ChatGPT workspace entitlement; runs will fail if it is revoked or past its expiry.'
+					}
+				: {
+						success: false,
+						message:
+							'Provide a Codex access token from your ChatGPT workspace admin console, or switch authentication mode.'
 					};
 		}
 
@@ -593,7 +646,7 @@ export class CodexPlugin
 				stepId: 'setup-codex',
 				event: 'message',
 				level: 'info',
-				message: `Using Codex ${executionAuth.mode === 'api-key' ? 'API key' : 'device auth'} mode`
+				message: `Using Codex ${CODEX_AUTH_MODE_LABELS[executionAuth.mode]} mode`
 			});
 			this.completeStep('setup-codex', setupStartedAt, onLogEntry);
 
@@ -613,7 +666,7 @@ export class CodexPlugin
 			});
 
 			executionAuthEnv =
-				executionAuth.mode === 'api-key'
+				executionAuth.mode !== 'device-auth'
 					? executionAuth.env
 					: {
 							// Security: materialize the device-auth CODEX_HOME (which writes the
@@ -1407,13 +1460,16 @@ export class CodexPlugin
 				error: 'Configure an OpenAI API key or complete Codex device authentication first.'
 			};
 		}
-		if (executionAuth.mode !== 'api-key') {
+		// device-auth needs a materialized CODEX_HOME, which the code-edit path
+		// does not build yet. api-key and access-token are both plain env
+		// credentials, so they work here unchanged.
+		if (executionAuth.mode === 'device-auth') {
 			return {
 				success: false,
 				summary: 'Codex device-auth mode is not yet supported for code-edit',
 				filesChanged: [],
 				duration: Date.now() - startTime,
-				error: 'Use api-key mode for code-edit runs; device-auth mode is not supported for this operation yet.'
+				error: 'Use api-key or access-token mode for code-edit runs; device-auth mode is not supported for this operation yet.'
 			};
 		}
 

--- a/packages/plugins/codex/src/types.ts
+++ b/packages/plugins/codex/src/types.ts
@@ -19,6 +19,26 @@ export function isCodexStepId(value: string): value is CodexStepId {
 	return (CODEX_STEP_IDS as readonly string[]).includes(value);
 }
 
+/**
+ * How a Codex run authenticates.
+ *
+ * - `api-key`      → `OPENAI_API_KEY`, billed per token against the OpenAI platform org.
+ * - `access-token` → `CODEX_ACCESS_TOKEN`, a ChatGPT Business/Enterprise workspace
+ *                    credential. This is the path OpenAI documents for trusted
+ *                    non-interactive runs ("scripts, schedulers, and private CI
+ *                    runners"), billed against the workspace Codex entitlement.
+ * - `device-auth`  → a materialized `CODEX_HOME` from the user's device-auth session.
+ */
+export const CODEX_AUTH_MODES = ['api-key', 'access-token', 'device-auth'] as const;
+
+export type CodexAuthMode = (typeof CODEX_AUTH_MODES)[number];
+
+export const CODEX_AUTH_MODE_LABELS: Record<CodexAuthMode, string> = {
+	'api-key': 'API key',
+	'access-token': 'workspace access token',
+	'device-auth': 'device auth'
+};
+
 export const BASE_TEMP_DIR = '/tmp/codex-generator';
 export const DEFAULT_MODEL = 'gpt-5.4';
 export const CODEX_RELEASES_URL = 'https://github.com/openai/codex/releases/download';

--- a/packages/plugins/codex/src/utils/pipeline-helpers.ts
+++ b/packages/plugins/codex/src/utils/pipeline-helpers.ts
@@ -25,6 +25,10 @@ export type ResolvedExecutionAuth =
 			readonly mode: 'api-key';
 	  }
 	| {
+			readonly env: Record<string, string>;
+			readonly mode: 'access-token';
+	  }
+	| {
 			readonly authJson: string;
 			readonly mode: 'device-auth';
 	  };
@@ -65,16 +69,32 @@ export async function hasDeviceCodexAuth(settings: PluginSettings): Promise<bool
 	return Boolean(getPortableDeviceAuthJson(settings));
 }
 
+export function getCodexAccessToken(settings: PluginSettings): string | undefined {
+	return getUsableSecret(settings.accessToken);
+}
+
 export async function resolveExecutionAuth(settings: PluginSettings): Promise<ResolvedExecutionAuth | null> {
 	const authMode = typeof settings.authMode === 'string' ? settings.authMode : undefined;
 	const apiKey = getUsableSecret(settings.apiKey);
+	const accessToken = getCodexAccessToken(settings);
 	const deviceAuthAuthJson = getPortableDeviceAuthJson(settings);
 
+	// An explicit mode always resolves its own credential first. When that
+	// credential is missing we fall back only *away* from per-token billing —
+	// never toward it. Landing on a subscription credential the operator didn't
+	// pick costs them nothing but plan quota; landing on an API key bills the
+	// Console org for a run they expected their subscription to cover, which is
+	// the surprise worth preventing. So `api-key` may degrade to a subscription
+	// credential, but no mode ever degrades into `api-key`.
 	if (authMode === 'api-key' && apiKey) {
-		return {
-			mode: 'api-key',
-			env: { OPENAI_API_KEY: apiKey }
-		};
+		return { mode: 'api-key', env: { OPENAI_API_KEY: apiKey } };
+	}
+
+	if (authMode === 'access-token') {
+		if (accessToken) {
+			return { mode: 'access-token', env: { CODEX_ACCESS_TOKEN: accessToken } };
+		}
+		return deviceAuthAuthJson ? { mode: 'device-auth', authJson: deviceAuthAuthJson } : null;
 	}
 
 	if (authMode === 'device-auth') {
@@ -91,6 +111,13 @@ export async function resolveExecutionAuth(settings: PluginSettings): Promise<Re
 		return {
 			mode: 'api-key',
 			env: { OPENAI_API_KEY: apiKey }
+		};
+	}
+
+	if (accessToken) {
+		return {
+			mode: 'access-token',
+			env: { CODEX_ACCESS_TOKEN: accessToken }
 		};
 	}
 

--- a/packages/plugins/codex/src/utils/subprocess-env.ts
+++ b/packages/plugins/codex/src/utils/subprocess-env.ts
@@ -16,6 +16,17 @@ const PASSTHROUGH_ENV_KEYS = [
 	'CURL_CA_BUNDLE'
 ] as const;
 
+/**
+ * Every environment variable Codex will accept as a credential.
+ *
+ * Only the one belonging to the resolved auth mode may reach the subprocess:
+ * `OPENAI_API_KEY` bills the platform org per token while `CODEX_ACCESS_TOKEN`
+ * draws the ChatGPT workspace entitlement, so letting both through would make
+ * which one pays depend on the CLI's internal precedence rather than on the
+ * mode the operator picked. Neither is ever inherited from the host.
+ */
+const AUTH_ENV_KEYS = ['OPENAI_API_KEY', 'CODEX_ACCESS_TOKEN'] as const;
+
 export function buildSubprocessEnv(overrides: Record<string, string> = {}): Record<string, string> {
 	const tmpdir = process.env.TMPDIR ?? os.tmpdir();
 
@@ -50,5 +61,17 @@ export function buildSubprocessEnv(overrides: Record<string, string> = {}): Reco
 		env[key] = value;
 	}
 
+	// Credentials arrive only from the caller's resolved auth mode. Drop any
+	// that the caller did not explicitly supply, so a stray value can never
+	// decide which account pays for the run.
+	for (const key of AUTH_ENV_KEYS) {
+		if (!(key in overrides)) {
+			delete env[key];
+		}
+	}
+
 	return env;
 }
+
+/** Names of every credential variable, exported for assertions in tests. */
+export const CODEX_AUTH_ENV_KEYS: readonly string[] = AUTH_ENV_KEYS;


### PR DESCRIPTION
Cascade of #2146 / #2147 — `stage` → `main` (production).

Exactly one functional commit, no other work riding along:

- `fix(claude-code,codex)`: stop a host `ANTHROPIC_API_KEY` from silently hijacking subscription-mode runs; fix `CLAUDE_CODE_CONFIG_DIR` → `CLAUDE_CONFIG_DIR` (the former is not a real Claude Code variable, so per-run config isolation was a no-op — every agent shared `~/.claude`, credentials included); add `authMode` to claude-code and a `CODEX_ACCESS_TOKEN` (`access-token`) mode to codex.

CI on #2146: **0 failed of 15 checks**. Plugin suites: claude-code 75 pass, codex 55 pass, both `tsc` clean.

Behaviour change worth noting for reviewers: credentials are no longer inherited from the host process environment — they must come from resolved plugin settings. A deployment that relied on an ambient `ANTHROPIC_API_KEY` reaching the CLI without being configured in plugin settings will now correctly report "no credentials configured" instead of silently billing that key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)