### PR TITLE
fix(works): separate current health from run history

### DIFF
--- a/apps/web/src/components/works/WorkCard.tsx
+++ b/apps/web/src/components/works/WorkCard.tsx
@@ -7,7 +7,12 @@ import { Link, usePathname } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { useTranslations } from 'next-intl';
 import type { Work } from '@/lib/api/work';
-import { WorkMemberRole, WorkScheduleStatus, WorkScheduleCadence } from '@/lib/api/enums';
+import {
+    GenerateStatusType,
+    WorkMemberRole,
+    WorkScheduleStatus,
+    WorkScheduleCadence,
+} from '@/lib/api/enums';
 import { Github, Users, FolderClosed, AlertTriangle, AlertCircle } from 'lucide-react';
 import { WorkErrorPopup } from './WorkErrorPopup';
 import { ShowDateTime } from '../ui/show-datetime';
@@ -103,6 +108,7 @@ function StatusBadge({
                             role="button"
                             tabIndex={0}
                             className={badgeClasses}
+                            data-testid="work-last-run"
                         >
                             {badgeContent}
                         </span>
@@ -117,7 +123,9 @@ function StatusBadge({
                     />
                 </HoverPopup>
             ) : (
-                <span className={badgeClasses}>{badgeContent}</span>
+                <span className={badgeClasses} data-testid="work-last-run">
+                    {badgeContent}
+                </span>
             )}
 
             {/* Config-sync error badge — when generation is OK but works_config.sync_failed */}
@@ -160,23 +168,40 @@ const formatScheduledDate = (date: string, locale: string) => {
 export function WorkCard({ work }: WorkCardProps) {
     const t = useTranslations('dashboard.workCard');
     const tStatus = useTranslations('dashboard.workDetail.status');
+    const tSchedule = useTranslations('dashboard.workDetail.schedule.card.summary');
     const pathname = usePathname();
     const [isOpening, setIsOpening] = useState(false);
 
-    const status = work.generateStatus?.status;
+    const status = work.lastRun?.generation?.status ?? work.generateStatus?.status;
     const hasWarnings = !!work.generateStatus?.warnings?.length;
     const statusConfig = getGenerationStatusConfig(status, { hasWarnings });
     const isScheduled = work.scheduledStatus === WorkScheduleStatus.ACTIVE;
     const userRole = work.userRole;
     const isShared = userRole && userRole !== WorkMemberRole.OWNER;
-    const isGenerating = statusConfig.labelKey === 'generating' || isOpening;
-    const showStatusBadge = !isScheduled || isGenerating || isOpening;
-    const showScheduledBadge = isScheduled && !isOpening && !isGenerating;
-    const baseStatusLabel = isOpening
+    const currentHealthState =
+        work.currentHealth?.state ??
+        (status === 'generating'
+            ? 'running'
+            : work.scheduledStatus === WorkScheduleStatus.PAUSED
+              ? 'paused'
+              : 'idle');
+    const isGenerating = currentHealthState === 'running' || isOpening;
+    const showLastRunBadge = !isGenerating && !!status;
+    const showScheduledBadge = isScheduled && !isOpening;
+    const lastRunStatusLabel =
+        statusConfig.labelKey === 'generatedWithWarnings'
+            ? tStatus('generated')
+            : tStatus(statusConfig.labelKey);
+    const currentStatusLabel = isOpening
         ? t('status.opening')
-        : statusConfig.labelKey === 'generatedWithWarnings'
-          ? tStatus('generated')
-          : tStatus(statusConfig.labelKey);
+        : currentHealthState === 'running'
+          ? tStatus('generating')
+          : currentHealthState === 'paused'
+            ? tSchedule('statusMap.paused')
+            : t('status.idle');
+    const currentStatusConfig = getGenerationStatusConfig(
+        currentHealthState === 'running' ? GenerateStatusType.GENERATING : null,
+    );
 
     useEffect(() => {
         if (!isOpening) {
@@ -309,13 +334,29 @@ export function WorkCard({ work }: WorkCardProps) {
 
                 <div className="flex items-center justify-between text-[11px] pt-4 border-t border-border dark:border-border-dark mt-auto">
                     <div className="flex items-center gap-1.5">
-                        {showStatusBadge && (
+                        <span
+                            data-testid="work-current-health"
+                            className={cn(
+                                'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-normal whitespace-nowrap shrink-0',
+                                isOpening
+                                    ? 'bg-primary/15 text-primary dark:bg-white/12 dark:text-white'
+                                    : currentStatusConfig.badge,
+                                isGenerating && 'animate-pulse bg-gray-100',
+                            )}
+                        >
+                            {isGenerating || isOpening ? (
+                                <ShinyText text={currentStatusLabel} />
+                            ) : (
+                                currentStatusLabel
+                            )}
+                        </span>
+                        {showLastRunBadge && (
                             <StatusBadge
                                 work={work}
                                 statusConfig={statusConfig}
                                 isOpening={isOpening}
                                 isGenerating={isGenerating}
-                                baseStatusLabel={baseStatusLabel}
+                                baseStatusLabel={lastRunStatusLabel}
                             />
                         )}
                         {showScheduledBadge && (
@@ -326,7 +367,7 @@ export function WorkCard({ work }: WorkCardProps) {
                                 )}
                             >
                                 {hasWarnings && <AlertTriangle className="w-3 h-3" />}
-                                {baseStatusLabel}
+                                {t('status.active')}
                                 <AnimatedClock className="w-3 h-3" />
                             </span>
                         )}

--- a/apps/web/src/components/works/WorkCard.unit.spec.tsx
+++ b/apps/web/src/components/works/WorkCard.unit.spec.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { GenerateStatusType, WorkScheduleStatus } from '@/lib/api/enums';
 import type { Work } from '@/lib/api/work';
+import type { AnchorHTMLAttributes, HTMLAttributes, ReactNode, Ref } from 'react';
 
 vi.mock('next-intl', () => ({
     useTranslations: (namespace: string) => (key: string) => {
@@ -14,7 +15,14 @@ vi.mock('next-intl', () => ({
 }));
 
 vi.mock('@/i18n/navigation', () => ({
-    Link: ({ children, href, ...props }: any) => (
+    Link: ({
+        children,
+        href,
+        ...props
+    }: Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+        children: ReactNode;
+        href: string | object;
+    }) => (
         <a href={typeof href === 'string' ? href : '#'} {...props}>
             {children}
         </a>
@@ -23,11 +31,17 @@ vi.mock('@/i18n/navigation', () => ({
 }));
 
 vi.mock('../ui/show-datetime', () => ({ ShowDateTime: () => null }));
-vi.mock('../ui/tooltip', () => ({ Tooltip: ({ children }: any) => children }));
-vi.mock('../ui/ShinyText', () => ({ ShinyText: ({ text }: any) => text }));
+vi.mock('../ui/tooltip', () => ({
+    Tooltip: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('../ui/ShinyText', () => ({ ShinyText: ({ text }: { text: string }) => text }));
 vi.mock('../ui/AnimatedClock', () => ({ AnimatedClock: () => null }));
 vi.mock('./detail/items/HoverPopup', () => ({
-    HoverPopup: ({ trigger }: any) => trigger(undefined, {}),
+    HoverPopup: ({
+        trigger,
+    }: {
+        trigger: (ref: Ref<HTMLSpanElement>, props: HTMLAttributes<HTMLSpanElement>) => ReactNode;
+    }) => trigger(null, {}),
 }));
 vi.mock('./WorkErrorPopup', () => ({ WorkErrorPopup: () => null }));
 vi.mock('./shared/WorkKindBadge', () => ({ WorkKindBadge: () => null }));

--- a/apps/web/src/components/works/WorkCard.unit.spec.tsx
+++ b/apps/web/src/components/works/WorkCard.unit.spec.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GenerateStatusType, WorkScheduleStatus } from '@/lib/api/enums';
+import type { Work } from '@/lib/api/work';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (namespace: string) => (key: string) => {
+        const labels: Record<string, string> = {
+            'dashboard.workCard.status.idle': 'Idle',
+            'dashboard.workDetail.status.error': 'Error',
+        };
+        return labels[`${namespace}.${key}`] ?? key;
+    },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...props }: any) => (
+        <a href={typeof href === 'string' ? href : '#'} {...props}>
+            {children}
+        </a>
+    ),
+    usePathname: () => '/works',
+}));
+
+vi.mock('../ui/show-datetime', () => ({ ShowDateTime: () => null }));
+vi.mock('../ui/tooltip', () => ({ Tooltip: ({ children }: any) => children }));
+vi.mock('../ui/ShinyText', () => ({ ShinyText: ({ text }: any) => text }));
+vi.mock('../ui/AnimatedClock', () => ({ AnimatedClock: () => null }));
+vi.mock('./detail/items/HoverPopup', () => ({
+    HoverPopup: ({ trigger }: any) => trigger(undefined, {}),
+}));
+vi.mock('./WorkErrorPopup', () => ({ WorkErrorPopup: () => null }));
+vi.mock('./shared/WorkKindBadge', () => ({ WorkKindBadge: () => null }));
+
+import { WorkCard } from './WorkCard';
+
+describe('WorkCard status projection', () => {
+    it('shows current idle health separately from a historical failed generation', () => {
+        const work = {
+            id: 'work-1',
+            slug: 'legacy-site',
+            name: 'Legacy Site',
+            description: '',
+            organization: false,
+            gitProvider: 'github',
+            createdAt: '2026-05-01T10:00:00.000Z',
+            updatedAt: '2026-05-01T10:05:00.000Z',
+            scheduledStatus: WorkScheduleStatus.DISABLED,
+            generateStatus: {
+                status: GenerateStatusType.ERROR,
+                error: 'Unknown remote target: TemplateRepository',
+            },
+            lastRun: {
+                generation: {
+                    status: GenerateStatusType.ERROR,
+                    startedAt: '2026-05-01T10:00:00.000Z',
+                    finishedAt: '2026-05-01T10:05:00.000Z',
+                },
+                deployment: null,
+            },
+            currentHealth: {
+                state: 'idle',
+                deployment: {
+                    readiness: 'not_deployed',
+                    source: 'none',
+                    observedAt: null,
+                },
+            },
+        } as Work;
+
+        render(<WorkCard work={work} />);
+
+        expect(screen.getByTestId('work-current-health')).toHaveTextContent('Idle');
+        expect(screen.getByTestId('work-last-run')).toHaveTextContent('Error');
+    });
+});

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -24,6 +24,8 @@ import {
     type RepositoryTarget as ContractRepositoryTarget,
     type SourceRepository as ContractSourceRepository,
     type WorksConfigSnapshot as ContractWorksConfigSnapshot,
+    type WorkCurrentHealthDto,
+    type WorkLastRunDto,
 } from '@ever-works/contracts/api';
 import type {
     MergePolicyOverride,
@@ -263,6 +265,10 @@ export interface Work {
     deployProvider?: string;
     readmeConfig?: MarkdownReadmeConfig;
     generateStatus?: GenerateStatus;
+    /** Historical terminal outcomes; never rewritten by current-health reconciliation. */
+    lastRun?: WorkLastRunDto;
+    /** Derived current activity and deployment availability projection. */
+    currentHealth?: WorkCurrentHealthDto;
     createdAt: string;
     updatedAt: string;
     itemsCount?: number;

--- a/docs/internal/work-current-health-reconciliation-plan.md
+++ b/docs/internal/work-current-health-reconciliation-plan.md
@@ -1,0 +1,57 @@
+# Work Current Health Reconciliation Implementation Plan
+
+> **For Codex:** Execute this plan with systematic debugging, test-driven development, and verification before completion.
+
+**Goal:** Preserve historical generation/deployment outcomes while exposing and displaying a separate, truthful current Work health projection.
+
+**Architecture:** Extend the existing Work read projection with `lastRun` and `currentHealth`. Read the latest production deployment history row in batch, derive paused/idle/running and deployment readiness without mutating tenant data, and let the existing readiness poller idempotently reconcile stale failure projections only after a successful health probe.
+
+**Tech stack:** NestJS, TypeORM, shared TypeScript contracts, Next.js/React, Jest, Vitest/Testing Library.
+
+---
+
+### Task 1: Pin the API projection contract
+
+**Files:**
+
+- Modify: `packages/agent/src/services/__tests__/work-query.service.spec.ts`
+- Modify: `packages/agent/src/services/work-query.service.ts`
+- Modify: `packages/agent/src/database/repositories/work-deployment.repository.ts`
+- Create: `packages/contracts/src/api/work/work-status.dto.ts`
+- Modify: `packages/contracts/src/api/work/index.ts`
+
+- [x] Add a failing service test proving an old generation error and deployment timeout remain in `lastRun` while current state is paused/idle and current deployment readiness is independent.
+- [x] Add a batched latest-production-deployment lookup.
+- [x] Implement the shared contract and pure derivation.
+- [x] Run the focused service tests.
+
+### Task 2: Reconcile stale deployment projections safely
+
+**Files:**
+
+- Modify: `packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts`
+- Modify: `packages/agent/src/services/deploy-ready-poller.service.ts`
+
+- [x] Add a failing test proving stale `TIMEOUT` projections are health-probed.
+- [x] Include recoverable stale projection states without editing historical deployment rows.
+- [x] Run the focused poller tests.
+
+### Task 3: Separate the list badge from historical run state
+
+**Files:**
+
+- Create: `apps/web/src/components/works/WorkCard.unit.spec.tsx`
+- Modify: `apps/web/src/components/works/WorkCard.tsx`
+- Modify: `apps/web/src/lib/api/work.ts`
+
+- [x] Add a failing component test proving an idle Work with a failed last run displays current `Idle` as its primary badge while retaining the historical failure affordance.
+- [x] Render current health as the primary badge and last-run failure/warnings separately.
+- [x] Run focused web tests.
+
+### Task 4: Verify and deliver
+
+- [x] Run focused Jest/Vitest tests, package type checks, formatting/lint checks, and inspect the final diff.
+- [ ] Commit and push the feature branch.
+- [ ] Open a PR to `develop`, inspect check/review conclusions, and do not merge or deploy.
+- [ ] Release the shared maintenance claim with verification and rollback details.
+- [ ] Report the outcome to the originating Codex task.

--- a/docs/internal/work-current-health-reconciliation-plan.md
+++ b/docs/internal/work-current-health-reconciliation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Pin the API projection contract
+## Task 1: Pin the API projection contract
 
 **Files:**
 
@@ -25,7 +25,7 @@
 - [x] Implement the shared contract and pure derivation.
 - [x] Run the focused service tests.
 
-### Task 2: Reconcile stale deployment projections safely
+## Task 2: Reconcile stale deployment projections safely
 
 **Files:**
 
@@ -36,7 +36,7 @@
 - [x] Include recoverable stale projection states without editing historical deployment rows.
 - [x] Run the focused poller tests.
 
-### Task 3: Separate the list badge from historical run state
+## Task 3: Separate the list badge from historical run state
 
 **Files:**
 
@@ -48,7 +48,7 @@
 - [x] Render current health as the primary badge and last-run failure/warnings separately.
 - [x] Run focused web tests.
 
-### Task 4: Verify and deliver
+## Task 4: Verify and deliver
 
 - [x] Run focused Jest/Vitest tests, package type checks, formatting/lint checks, and inspect the final diff.
 - [ ] Commit and push the feature branch.

--- a/packages/agent/src/database/repositories/__tests__/work-deployment.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/work-deployment.repository.spec.ts
@@ -1,0 +1,59 @@
+import type { Repository, SelectQueryBuilder } from 'typeorm';
+import { WorkDeploymentRepository } from '../work-deployment.repository';
+import { DeploymentEnvironment, WorkDeployment } from '../../../entities/work-deployment.entity';
+
+describe('WorkDeploymentRepository', () => {
+    it('uses a correlated latest-row query instead of loading all deployment history', async () => {
+        const rows = [
+            { id: 'd2', workId: 'w1' },
+            { id: 'd4', workId: 'w2' },
+        ] as WorkDeployment[];
+        const subquery = buildQueryBuilder<WorkDeployment>();
+        subquery.getQuery.mockReturnValue('(SELECT latest.id)');
+        const query = buildQueryBuilder<WorkDeployment>();
+        query.subQuery.mockReturnValue(subquery as never);
+        query.getMany.mockResolvedValue(rows);
+        const repository = {
+            createQueryBuilder: jest.fn().mockReturnValue(query),
+            find: jest.fn(),
+        } as unknown as Repository<WorkDeployment>;
+        const service = new WorkDeploymentRepository(repository);
+
+        const result = await service.findLatestForWorks(
+            ['w1', 'w2'],
+            DeploymentEnvironment.PRODUCTION,
+        );
+
+        expect(repository.find as jest.Mock).not.toHaveBeenCalled();
+        expect(subquery.orderBy).toHaveBeenCalledWith('latest.createdAt', 'DESC');
+        expect(subquery.addOrderBy).toHaveBeenCalledWith('latest.id', 'DESC');
+        expect(subquery.limit).toHaveBeenCalledWith(1);
+        expect(query.andWhere).toHaveBeenCalledWith('deployment.id = (SELECT latest.id)');
+        expect(result).toEqual(
+            new Map([
+                ['w1', rows[0]],
+                ['w2', rows[1]],
+            ]),
+        );
+    });
+});
+
+function buildQueryBuilder<TEntity>() {
+    const query = {} as jest.Mocked<SelectQueryBuilder<TEntity>>;
+    for (const method of [
+        'select',
+        'from',
+        'where',
+        'andWhere',
+        'orderBy',
+        'addOrderBy',
+        'limit',
+        'setParameters',
+    ] as const) {
+        query[method] = jest.fn().mockReturnValue(query) as never;
+    }
+    query.subQuery = jest.fn() as never;
+    query.getQuery = jest.fn() as never;
+    query.getMany = jest.fn() as never;
+    return query;
+}

--- a/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
@@ -36,6 +36,8 @@ function buildChain<TResult>(terminalName: string, terminalResolved: TResult) {
         'leftJoinAndSelect',
         'skip',
         'take',
+        'update',
+        'set',
     ];
 
     for (const m of passthroughMethods) {
@@ -300,6 +302,50 @@ describe('WorkRepository', () => {
             expect(fns.orderBy).toHaveBeenCalledWith('work.id', 'ASC');
             expect(fns.take).toHaveBeenCalledWith(50);
             expect(fns.getMany).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('markDeploymentReadyIfCurrent', () => {
+        it('updates only the captured deployment identity', async () => {
+            const { chain, fns } = buildChain('execute', { affected: 1 });
+            repository.createQueryBuilder.mockReturnValueOnce(chain as never);
+            const startedAt = new Date('2026-08-22T08:00:00.000Z');
+
+            await expect(
+                service.markDeploymentReadyIfCurrent('w1', {
+                    deploymentState: 'TIMEOUT',
+                    deploymentStartedAt: startedAt,
+                    lastDeployCorrelationId: 'corr-1',
+                }),
+            ).resolves.toBe(true);
+
+            expect(fns.update).toHaveBeenCalledWith(Work);
+            expect(fns.set).toHaveBeenCalledWith({ deploymentState: 'READY' });
+            expect(fns.where).toHaveBeenCalledWith('id = :id', { id: 'w1' });
+            expect(fns.andWhere).toHaveBeenCalledWith('deploymentState = :deploymentState', {
+                deploymentState: 'TIMEOUT',
+            });
+            expect(fns.andWhere).toHaveBeenCalledWith(
+                'lastDeployCorrelationId = :lastDeployCorrelationId',
+                { lastDeployCorrelationId: 'corr-1' },
+            );
+            expect(fns.andWhere).toHaveBeenCalledWith(
+                'deploymentStartedAt = :deploymentStartedAt',
+                { deploymentStartedAt: startedAt },
+            );
+        });
+
+        it('returns false when a newer deployment changed the guarded fields', async () => {
+            const { chain } = buildChain('execute', { affected: 0 });
+            repository.createQueryBuilder.mockReturnValueOnce(chain as never);
+
+            await expect(
+                service.markDeploymentReadyIfCurrent('w1', {
+                    deploymentState: 'TIMEOUT',
+                    deploymentStartedAt: null,
+                    lastDeployCorrelationId: null,
+                }),
+            ).resolves.toBe(false);
         });
     });
 

--- a/packages/agent/src/database/repositories/work-deployment.repository.ts
+++ b/packages/agent/src/database/repositories/work-deployment.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { WorkDeployment, DeploymentEnvironment } from '../../entities/work-deployment.entity';
 
 @Injectable()
@@ -38,6 +38,29 @@ export class WorkDeploymentRepository {
             where: { workId, environment },
             order: { createdAt: 'DESC' },
         });
+    }
+
+    async findLatestForWorks(
+        workIds: string[],
+        environment: DeploymentEnvironment,
+    ): Promise<Map<string, WorkDeployment>> {
+        if (workIds.length === 0) {
+            return new Map();
+        }
+
+        const rows = await this.repository.find({
+            where: { workId: In(workIds), environment },
+            order: { createdAt: 'DESC', id: 'DESC' },
+        });
+        const latestByWork = new Map<string, WorkDeployment>();
+
+        for (const row of rows) {
+            if (!latestByWork.has(row.workId)) {
+                latestByWork.set(row.workId, row);
+            }
+        }
+
+        return latestByWork;
     }
 
     findByPr(workId: string, prNumber: number): Promise<WorkDeployment | null> {

--- a/packages/agent/src/database/repositories/work-deployment.repository.ts
+++ b/packages/agent/src/database/repositories/work-deployment.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { WorkDeployment, DeploymentEnvironment } from '../../entities/work-deployment.entity';
 
 @Injectable()
@@ -36,10 +36,15 @@ export class WorkDeploymentRepository {
     findLatest(workId: string, environment: DeploymentEnvironment): Promise<WorkDeployment | null> {
         return this.repository.findOne({
             where: { workId, environment },
-            order: { createdAt: 'DESC' },
+            order: { createdAt: 'DESC', id: 'DESC' },
         });
     }
 
+    /**
+     * Load one newest history row per Work. The correlated subquery keeps the
+     * result bounded to the requested Work count instead of materializing and
+     * folding every historical deployment in application memory.
+     */
     async findLatestForWorks(
         workIds: string[],
         environment: DeploymentEnvironment,
@@ -48,19 +53,23 @@ export class WorkDeploymentRepository {
             return new Map();
         }
 
-        const rows = await this.repository.find({
-            where: { workId: In(workIds), environment },
-            order: { createdAt: 'DESC', id: 'DESC' },
-        });
-        const latestByWork = new Map<string, WorkDeployment>();
+        const query = this.repository.createQueryBuilder('deployment');
+        const latestIdQuery = query
+            .subQuery()
+            .select('latest.id')
+            .from(WorkDeployment, 'latest')
+            .where('latest.workId = deployment.workId')
+            .andWhere('latest.environment = :environment')
+            .orderBy('latest.createdAt', 'DESC')
+            .addOrderBy('latest.id', 'DESC')
+            .limit(1);
+        const rows = await query
+            .where('deployment.workId IN (:...workIds)', { workIds })
+            .andWhere('deployment.environment = :environment', { environment })
+            .andWhere(`deployment.id = ${latestIdQuery.getQuery()}`)
+            .getMany();
 
-        for (const row of rows) {
-            if (!latestByWork.has(row.workId)) {
-                latestByWork.set(row.workId, row);
-            }
-        }
-
-        return latestByWork;
+        return new Map(rows.map((row) => [row.workId, row]));
     }
 
     findByPr(workId: string, prNumber: number): Promise<WorkDeployment | null> {

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -358,6 +358,43 @@ export class WorkRepository {
     }
 
     /**
+     * Reconcile a health-probed deployment projection without overwriting a
+     * deployment that started after the poller captured its candidate list.
+     */
+    async markDeploymentReadyIfCurrent(
+        workId: string,
+        expected: Pick<Work, 'deploymentState' | 'deploymentStartedAt' | 'lastDeployCorrelationId'>,
+    ): Promise<boolean> {
+        const query = this.repository
+            .createQueryBuilder()
+            .update(Work)
+            .set({ deploymentState: 'READY' })
+            .where('id = :id', { id: workId })
+            .andWhere('deploymentState = :deploymentState', {
+                deploymentState: expected.deploymentState,
+            });
+
+        if (expected.lastDeployCorrelationId == null) {
+            query.andWhere('lastDeployCorrelationId IS NULL');
+        } else {
+            query.andWhere('lastDeployCorrelationId = :lastDeployCorrelationId', {
+                lastDeployCorrelationId: expected.lastDeployCorrelationId,
+            });
+        }
+
+        if (expected.deploymentStartedAt == null) {
+            query.andWhere('deploymentStartedAt IS NULL');
+        } else {
+            query.andWhere('deploymentStartedAt = :deploymentStartedAt', {
+                deploymentStartedAt: expected.deploymentStartedAt,
+            });
+        }
+
+        const result = await query.execute();
+        return (result.affected ?? 0) === 1;
+    }
+
+    /**
      * Conditional UPDATE for the lazy bootstrap of `platformSyncSecretEncrypted`
      * (EW-120 pull transport). Two concurrent deploys can both call
      * `getOrGenerate` and both generate fresh plaintext; this method makes

--- a/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
+++ b/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
@@ -98,6 +98,27 @@ describe('DeployReadyPollerService.pollOnce', () => {
         expect(funnel.emit).not.toHaveBeenCalled();
     });
 
+    it('rechecks a stale TIMEOUT projection and reconciles it after a healthy probe', async () => {
+        const work = {
+            id: 'w-timeout',
+            slug: 'recovered-site',
+            deploymentState: 'TIMEOUT',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: null,
+        };
+        const httpFetch = jest.fn().mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
+        const { service, workRepository } = buildService([work], httpFetch);
+
+        await service.pollOnce({ fetch: httpFetch, now: () => NOW, domain: 'ever.works' });
+
+        expect(workRepository.findByDeploymentStates).toHaveBeenCalledWith(
+            expect.arrayContaining(['TIMEOUT']),
+        );
+        expect(workRepository.update).toHaveBeenCalledWith('w-timeout', {
+            deploymentState: 'READY',
+        });
+    });
+
     it('leaves the row alone and counts stillPending when the health probe returns non-200', async () => {
         const work = {
             id: 'w-3',

--- a/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
+++ b/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
@@ -41,7 +41,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
     ) => {
         const workRepository = {
             findByDeploymentStates: jest.fn().mockResolvedValue(works),
-            update: jest.fn().mockResolvedValue(undefined),
+            markDeploymentReadyIfCurrent: jest.fn().mockResolvedValue(true),
         };
         const funnel = { emit: jest.fn() };
         const service = new DeployReadyPollerService(workRepository as never, funnel as never);
@@ -52,6 +52,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const work = {
             id: 'w-1',
             slug: 'my-site',
+            deploymentState: 'pending',
             deploymentStartedAt: STARTED_AT,
             lastDeployCorrelationId: 'corr-abc123-uuid',
         };
@@ -71,7 +72,11 @@ describe('DeployReadyPollerService.pollOnce', () => {
             'https://my-site.ever.works/api/health',
             expect.objectContaining({ method: 'GET' }),
         );
-        expect(workRepository.update).toHaveBeenCalledWith('w-1', { deploymentState: 'READY' });
+        expect(workRepository.markDeploymentReadyIfCurrent).toHaveBeenCalledWith('w-1', {
+            deploymentState: 'pending',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: 'corr-abc123-uuid',
+        });
         expect(funnel.emit).toHaveBeenCalledTimes(1);
         const payload = funnel.emit.mock.calls[0][0];
         expect(payload.event).toBe(ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY);
@@ -86,6 +91,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const work = {
             id: 'w-2',
             slug: 'other-site',
+            deploymentState: 'pending',
             deploymentStartedAt: STARTED_AT,
             lastDeployCorrelationId: null,
         };
@@ -94,7 +100,11 @@ describe('DeployReadyPollerService.pollOnce', () => {
 
         await service.pollOnce({ fetch: httpFetch, now: () => NOW, domain: 'ever.works' });
 
-        expect(workRepository.update).toHaveBeenCalledWith('w-2', { deploymentState: 'READY' });
+        expect(workRepository.markDeploymentReadyIfCurrent).toHaveBeenCalledWith('w-2', {
+            deploymentState: 'pending',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: null,
+        });
         expect(funnel.emit).not.toHaveBeenCalled();
     });
 
@@ -114,9 +124,33 @@ describe('DeployReadyPollerService.pollOnce', () => {
         expect(workRepository.findByDeploymentStates).toHaveBeenCalledWith(
             expect.arrayContaining(['TIMEOUT']),
         );
-        expect(workRepository.update).toHaveBeenCalledWith('w-timeout', {
-            deploymentState: 'READY',
+        expect(workRepository.markDeploymentReadyIfCurrent).toHaveBeenCalledWith('w-timeout', {
+            deploymentState: 'TIMEOUT',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: null,
         });
+    });
+
+    it('does not overwrite a newer deployment when the compare-and-set loses the race', async () => {
+        const work = {
+            id: 'w-raced',
+            slug: 'raced-site',
+            deploymentState: 'TIMEOUT',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: 'old-correlation',
+        };
+        const httpFetch = jest.fn().mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
+        const { service, workRepository, funnel } = buildService([work], httpFetch);
+        workRepository.markDeploymentReadyIfCurrent.mockResolvedValue(false);
+
+        const summary = await service.pollOnce({
+            fetch: httpFetch,
+            now: () => NOW,
+            domain: 'ever.works',
+        });
+
+        expect(summary).toEqual({ scanned: 1, ready: 0, stillPending: 1, failed: 0 });
+        expect(funnel.emit).not.toHaveBeenCalled();
     });
 
     it('leaves the row alone and counts stillPending when the health probe returns non-200', async () => {
@@ -136,7 +170,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
         });
 
         expect(summary).toEqual({ scanned: 1, ready: 0, stillPending: 1, failed: 0 });
-        expect(workRepository.update).not.toHaveBeenCalled();
+        expect(workRepository.markDeploymentReadyIfCurrent).not.toHaveBeenCalled();
         expect(funnel.emit).not.toHaveBeenCalled();
     });
 

--- a/packages/agent/src/services/__tests__/work-query.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-query.service.spec.ts
@@ -12,6 +12,7 @@ describe('WorkQueryService', () => {
     let workMemberRepository: any;
     let dataGenerator: any;
     let generationHistoryRepository: any;
+    let workDeploymentRepository: any;
     let ownershipService: any;
     let websiteRepositoryState: any;
     let service: WorkQueryService;
@@ -30,6 +31,10 @@ describe('WorkQueryService', () => {
         generationHistoryRepository = {
             findLatestPositiveItemCounts: jest.fn(),
         };
+        workDeploymentRepository = {
+            findLatestForWorks: jest.fn().mockResolvedValue(new Map()),
+            findLatest: jest.fn().mockResolvedValue(null),
+        };
         ownershipService = {};
         websiteRepositoryState = {
             isInitialized: jest.fn().mockResolvedValue(false),
@@ -42,6 +47,7 @@ describe('WorkQueryService', () => {
             generationHistoryRepository,
             ownershipService as any,
             websiteRepositoryState,
+            workDeploymentRepository,
         );
     });
 
@@ -102,6 +108,100 @@ describe('WorkQueryService', () => {
                 itemsCount: 0,
             }),
         );
+    });
+
+    it('separates historical failures from a paused, ready current projection', async () => {
+        const work = {
+            id: 'dir-health',
+            userId: user.id,
+            owner: 'ever-works',
+            website: 'https://recovered-site.ever.works',
+            deploymentState: 'READY',
+            scheduledStatus: 'paused',
+            generateStatus: {
+                status: GenerateStatusType.ERROR,
+                error: 'Unknown remote target: TemplateRepository',
+            },
+            generationStartedAt: new Date('2026-05-01T10:00:00.000Z'),
+            generationFinishedAt: new Date('2026-05-01T10:05:00.000Z'),
+            itemsCount: 12,
+            getRepoOwner: jest.fn().mockReturnValue('ever-works'),
+        } as any;
+        const deployment = {
+            state: 'TIMEOUT',
+            startedAt: new Date('2026-05-01T10:06:00.000Z'),
+            completedAt: new Date('2026-05-01T10:16:00.000Z'),
+        };
+
+        workMemberRepository.getAccessibleWorkIds.mockResolvedValue([]);
+        workRepository.findAllAccessible.mockResolvedValue([work]);
+        workRepository.countAllAccessible.mockResolvedValue(1);
+        workMemberRepository.getMemberRolesForWorks.mockResolvedValue(new Map());
+        generationHistoryRepository.findLatestPositiveItemCounts.mockResolvedValue(new Map());
+        workDeploymentRepository.findLatestForWorks.mockResolvedValue(
+            new Map([['dir-health', deployment]]),
+        );
+
+        const result = await service.getWorks({}, user);
+
+        expect(result.works[0]).toEqual(
+            expect.objectContaining({
+                lastRun: {
+                    generation: {
+                        status: GenerateStatusType.ERROR,
+                        startedAt: '2026-05-01T10:00:00.000Z',
+                        finishedAt: '2026-05-01T10:05:00.000Z',
+                    },
+                    deployment: {
+                        status: 'TIMEOUT',
+                        startedAt: '2026-05-01T10:06:00.000Z',
+                        finishedAt: '2026-05-01T10:16:00.000Z',
+                    },
+                },
+                currentHealth: {
+                    state: 'paused',
+                    deployment: {
+                        readiness: 'ready',
+                        source: 'deployment_projection',
+                        observedAt: null,
+                    },
+                },
+            }),
+        );
+    });
+
+    it('reports the readiness observation time when the latest deployment completed READY', async () => {
+        const work = {
+            id: 'dir-ready',
+            userId: user.id,
+            owner: 'ever-works',
+            website: 'https://ready-site.ever.works',
+            deploymentState: 'READY',
+            itemsCount: 1,
+            getRepoOwner: jest.fn().mockReturnValue('ever-works'),
+        } as any;
+        const deployment = {
+            state: 'READY',
+            startedAt: new Date('2026-08-22T07:55:00.000Z'),
+            completedAt: new Date('2026-08-22T08:00:00.000Z'),
+        };
+
+        workMemberRepository.getAccessibleWorkIds.mockResolvedValue([]);
+        workRepository.findAllAccessible.mockResolvedValue([work]);
+        workRepository.countAllAccessible.mockResolvedValue(1);
+        workMemberRepository.getMemberRolesForWorks.mockResolvedValue(new Map());
+        generationHistoryRepository.findLatestPositiveItemCounts.mockResolvedValue(new Map());
+        workDeploymentRepository.findLatestForWorks.mockResolvedValue(
+            new Map([['dir-ready', deployment]]),
+        );
+
+        const result = await service.getWorks({}, user);
+
+        expect(result.works[0].currentHealth.deployment).toEqual({
+            readiness: 'ready',
+            source: 'deployment_projection',
+            observedAt: '2026-08-22T08:00:00.000Z',
+        });
     });
 
     /**

--- a/packages/agent/src/services/__tests__/work-query.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-query.service.spec.ts
@@ -4,6 +4,8 @@ jest.mock('@src/generators/data-generator/data-generator.service', () => ({
 
 import { WorkQueryService } from '../work-query.service';
 import { WorkMemberRole, GenerateStatusType } from '@src/entities/types';
+import type { WorkDeploymentRepository } from '@src/database/repositories/work-deployment.repository';
+import { WorkDeployment } from '@src/entities/work-deployment.entity';
 
 describe('WorkQueryService', () => {
     const user = { id: 'user-1' } as any;
@@ -12,7 +14,9 @@ describe('WorkQueryService', () => {
     let workMemberRepository: any;
     let dataGenerator: any;
     let generationHistoryRepository: any;
-    let workDeploymentRepository: any;
+    let workDeploymentRepository: jest.Mocked<
+        Pick<WorkDeploymentRepository, 'findLatestForWorks' | 'findLatest'>
+    >;
     let ownershipService: any;
     let websiteRepositoryState: any;
     let service: WorkQueryService;
@@ -47,7 +51,7 @@ describe('WorkQueryService', () => {
             generationHistoryRepository,
             ownershipService as any,
             websiteRepositoryState,
-            workDeploymentRepository,
+            workDeploymentRepository as unknown as WorkDeploymentRepository,
         );
     });
 
@@ -127,11 +131,11 @@ describe('WorkQueryService', () => {
             itemsCount: 12,
             getRepoOwner: jest.fn().mockReturnValue('ever-works'),
         } as any;
-        const deployment = {
+        const deployment = Object.assign(new WorkDeployment(), {
             state: 'TIMEOUT',
             startedAt: new Date('2026-05-01T10:06:00.000Z'),
             completedAt: new Date('2026-05-01T10:16:00.000Z'),
-        };
+        });
 
         workMemberRepository.getAccessibleWorkIds.mockResolvedValue([]);
         workRepository.findAllAccessible.mockResolvedValue([work]);
@@ -180,11 +184,11 @@ describe('WorkQueryService', () => {
             itemsCount: 1,
             getRepoOwner: jest.fn().mockReturnValue('ever-works'),
         } as any;
-        const deployment = {
+        const deployment = Object.assign(new WorkDeployment(), {
             state: 'READY',
             startedAt: new Date('2026-08-22T07:55:00.000Z'),
             completedAt: new Date('2026-08-22T08:00:00.000Z'),
-        };
+        });
 
         workMemberRepository.getAccessibleWorkIds.mockResolvedValue([]);
         workRepository.findAllAccessible.mockResolvedValue([work]);

--- a/packages/agent/src/services/deploy-ready-poller.service.ts
+++ b/packages/agent/src/services/deploy-ready-poller.service.ts
@@ -28,8 +28,10 @@ const HEALTH_PATH = '/api/health';
 const SLUG_PLACEHOLDER = /\{slug\}/g;
 
 /**
- * Pending-style states the poller probes for readiness. Mirrors the
- * states the DeploymentVerifierService transitions through.
+ * States the poller can reconcile by observing endpoint readiness. This
+ * includes pending-style verifier states plus historical TIMEOUT projections,
+ * because a timeout records the last verifier result rather than permanent
+ * endpoint availability.
  *
  * **Mixed case is intentional.** `'pending'` is the legacy internal
  * state value; `'INITIALIZING' | 'QUEUED' | 'BUILDING'` are Vercel's
@@ -38,7 +40,16 @@ const SLUG_PLACEHOLDER = /\{slug\}/g;
  * one canonical case. Normalising would require a one-shot
  * migration of historical rows — leave as-is until that's planned.
  */
-const PENDING_STATES: readonly string[] = ['pending', 'INITIALIZING', 'QUEUED', 'BUILDING'];
+const RECONCILABLE_STATES: readonly string[] = [
+    'pending',
+    'INITIALIZING',
+    'QUEUED',
+    'BUILDING',
+    // A TIMEOUT records what the last deploy verifier observed. It is not
+    // proof that the endpoint is still unavailable, so keep health-probing
+    // this denormalized projection until a 200 response reconciles it.
+    'TIMEOUT',
+];
 
 /**
  * EW-617 G8 — emits the funnel `deploy_ready` event when a freshly
@@ -134,15 +145,17 @@ export class DeployReadyPollerService {
             );
         }
 
-        const pendingWorks = await this.workRepository.findByDeploymentStates([...PENDING_STATES]);
+        const reconcilableWorks = await this.workRepository.findByDeploymentStates([
+            ...RECONCILABLE_STATES,
+        ]);
         const summary: DeployReadyPollerSummary = {
-            scanned: pendingWorks.length,
+            scanned: reconcilableWorks.length,
             ready: 0,
             stillPending: 0,
             failed: 0,
         };
 
-        for (const work of pendingWorks) {
+        for (const work of reconcilableWorks) {
             try {
                 // Security (SSRF): the slug is validated as DNS-safe on creation
                 // (DTO `@Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)`) but is re-read
@@ -171,6 +184,9 @@ export class DeployReadyPollerService {
                     : undefined;
                 const elapsedMs = startedAt ? now().getTime() - startedAt : 0;
 
+                // Reconcile only the denormalized current projection. The
+                // WorkDeployment TIMEOUT/ERROR rows are immutable run history
+                // and must continue to describe what that verifier observed.
                 await this.workRepository.update(work.id, { deploymentState: READY_STATE });
                 summary.ready += 1;
 

--- a/packages/agent/src/services/deploy-ready-poller.service.ts
+++ b/packages/agent/src/services/deploy-ready-poller.service.ts
@@ -10,8 +10,6 @@ export interface DeployReadyPollerSummary {
     failed: number;
 }
 
-const READY_STATE = 'READY';
-
 /**
  * Health endpoint probed on each tenant site.
  *
@@ -187,7 +185,15 @@ export class DeployReadyPollerService {
                 // Reconcile only the denormalized current projection. The
                 // WorkDeployment TIMEOUT/ERROR rows are immutable run history
                 // and must continue to describe what that verifier observed.
-                await this.workRepository.update(work.id, { deploymentState: READY_STATE });
+                const reconciled = await this.workRepository.markDeploymentReadyIfCurrent(work.id, {
+                    deploymentState: work.deploymentState,
+                    deploymentStartedAt: work.deploymentStartedAt,
+                    lastDeployCorrelationId: work.lastDeployCorrelationId,
+                });
+                if (!reconciled) {
+                    summary.stillPending += 1;
+                    continue;
+                }
                 summary.ready += 1;
 
                 if (work.lastDeployCorrelationId) {

--- a/packages/agent/src/services/work-query.service.ts
+++ b/packages/agent/src/services/work-query.service.ts
@@ -5,7 +5,7 @@ import { WorkGenerationHistoryRepository } from '@src/database/repositories/work
 import { DataGeneratorService } from '@src/generators/data-generator/data-generator.service';
 import { User } from '@src/entities/user.entity';
 import { Work } from '@src/entities/work.entity';
-import { WorkMemberRole, GenerateStatusType } from '@src/entities/types';
+import { WorkMemberRole, GenerateStatusType, WorkScheduleStatus } from '@src/entities/types';
 import { WorkOwnershipService } from './work-ownership.service';
 import { normalizeGeneratorError, rethrowAsNormalized } from './utils/error.utils';
 import {
@@ -15,6 +15,9 @@ import {
 import { WorkGenerationHistory } from '@src/entities/work-generation-history.entity';
 import { WorkHistoryActivityType } from '@ever-works/contracts/api';
 import { WorkWebsiteRepositoryStateService } from './work-website-repository-state.service';
+import { WorkDeploymentRepository } from '@src/database/repositories/work-deployment.repository';
+import { DeploymentEnvironment, WorkDeployment } from '@src/entities/work-deployment.entity';
+import type { WorkCurrentHealthDto, WorkStatusProjectionDto } from '@ever-works/contracts/api';
 
 // Extended work response type with userRole for API responses
 // Uses Omit to exclude class methods from Work, then adds userRole
@@ -33,7 +36,7 @@ type WorkMethods =
 export type WorkWithRole = Omit<Work, WorkMethods> & {
     userRole: WorkMemberRole;
     websiteRepositoryInitialized?: boolean;
-};
+} & WorkStatusProjectionDto;
 
 @Injectable()
 export class WorkQueryService {
@@ -46,6 +49,7 @@ export class WorkQueryService {
         private readonly generationHistoryRepository: WorkGenerationHistoryRepository,
         private readonly ownershipService: WorkOwnershipService,
         private readonly websiteRepositoryState: WorkWebsiteRepositoryStateService,
+        private readonly workDeploymentRepository: WorkDeploymentRepository,
     ) {}
 
     async getWorks(options: { limit?: number; offset?: number; search?: string } = {}, user: User) {
@@ -78,6 +82,11 @@ export class WorkQueryService {
                     workIdsNeedingRecoveredCounts,
                 );
 
+            const latestDeployments = await this.workDeploymentRepository.findLatestForWorks(
+                works.map((work) => work.id),
+                DeploymentEnvironment.PRODUCTION,
+            );
+
             // Separate works into owned vs member-accessed for role computation
             const nonOwnedWorkIds = works
                 .filter((dir) => dir.userId !== user.id)
@@ -109,6 +118,7 @@ export class WorkQueryService {
                     ...dir,
                     itemsCount,
                     userRole,
+                    ...this.toStatusProjection(dir, latestDeployments.get(dir.id)),
                 } as WorkWithRole;
             });
 
@@ -173,6 +183,10 @@ export class WorkQueryService {
                 work,
                 user,
             );
+            const latestDeployment = await this.workDeploymentRepository.findLatest(
+                work.id,
+                DeploymentEnvironment.PRODUCTION,
+            );
 
             // Lazy backfill of the denormalised cache columns
             // (configCache + counts). When a Work pre-dates the
@@ -213,6 +227,7 @@ export class WorkQueryService {
                 ...work,
                 userRole: accessResult.role,
                 websiteRepositoryInitialized,
+                ...this.toStatusProjection(work, latestDeployment ?? undefined),
             };
 
             return {
@@ -222,6 +237,84 @@ export class WorkQueryService {
         } catch (error) {
             rethrowAsNormalized(error, this.logger, 'getting work');
         }
+    }
+
+    private toStatusProjection(
+        work: Work,
+        latestDeployment?: WorkDeployment,
+    ): WorkStatusProjectionDto {
+        const generation = work.generateStatus
+            ? {
+                  status: work.generateStatus.status,
+                  startedAt: this.toIsoString(work.generationStartedAt),
+                  finishedAt: this.toIsoString(work.generationFinishedAt),
+              }
+            : null;
+        const deployment = latestDeployment
+            ? {
+                  status: latestDeployment.state,
+                  startedAt: this.toIsoString(latestDeployment.startedAt),
+                  finishedAt: this.toIsoString(latestDeployment.completedAt),
+              }
+            : null;
+
+        return {
+            lastRun: { generation, deployment },
+            currentHealth: {
+                state:
+                    work.generateStatus?.status === GenerateStatusType.GENERATING
+                        ? 'running'
+                        : work.scheduledStatus === WorkScheduleStatus.PAUSED
+                          ? 'paused'
+                          : 'idle',
+                deployment: this.toCurrentDeploymentHealth(work, latestDeployment),
+            },
+        };
+    }
+
+    private toCurrentDeploymentHealth(
+        work: Work,
+        latestDeployment?: WorkDeployment,
+    ): WorkCurrentHealthDto['deployment'] {
+        const deploymentState = work.deploymentState?.toUpperCase();
+
+        if (deploymentState === 'READY') {
+            return {
+                readiness: 'ready',
+                source: 'deployment_projection',
+                observedAt:
+                    latestDeployment?.state === 'READY'
+                        ? this.toIsoString(latestDeployment.completedAt)
+                        : null,
+            };
+        }
+
+        if (['PENDING', 'INITIALIZING', 'QUEUED', 'BUILDING'].includes(deploymentState ?? '')) {
+            return {
+                readiness: 'pending',
+                source: 'deployment_projection',
+                observedAt: null,
+            };
+        }
+
+        if (!work.website && !work.deployProjectId && !work.deploymentState) {
+            return { readiness: 'not_deployed', source: 'none', observedAt: null };
+        }
+
+        return {
+            readiness: 'unknown',
+            source: work.deploymentState ? 'deployment_projection' : 'none',
+            observedAt: null,
+        };
+    }
+
+    private toIsoString(value?: Date | string | null): string | null {
+        if (!value) {
+            return null;
+        }
+
+        const date = value instanceof Date ? value : new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date.toISOString();
     }
 
     /**

--- a/packages/agent/src/services/work-query.service.ts
+++ b/packages/agent/src/services/work-query.service.ts
@@ -73,30 +73,28 @@ export class WorkQueryService {
                 search: sanitizedSearch,
             });
 
+            const workIds = works.map((work) => work.id);
             const workIdsNeedingRecoveredCounts = works
                 .filter((dir) => this.shouldRecoverItemsCount(dir))
                 .map((dir) => dir.id);
-
-            const recoveredItemCounts =
-                await this.generationHistoryRepository.findLatestPositiveItemCounts(
-                    workIdsNeedingRecoveredCounts,
-                );
-
-            const latestDeployments = await this.workDeploymentRepository.findLatestForWorks(
-                works.map((work) => work.id),
-                DeploymentEnvironment.PRODUCTION,
-            );
-
-            // Separate works into owned vs member-accessed for role computation
             const nonOwnedWorkIds = works
                 .filter((dir) => dir.userId !== user.id)
                 .map((dir) => dir.id);
-
-            // Batch fetch member roles for non-owned works (single query)
-            const memberRoles = await this.workMemberRepository.getMemberRolesForWorks(
-                user.id,
-                nonOwnedWorkIds,
-            );
+            const [recoveredItemCounts, latestDeployments, memberRoles, total] = await Promise.all([
+                this.generationHistoryRepository.findLatestPositiveItemCounts(
+                    workIdsNeedingRecoveredCounts,
+                ),
+                this.workDeploymentRepository.findLatestForWorks(
+                    workIds,
+                    DeploymentEnvironment.PRODUCTION,
+                ),
+                this.workMemberRepository.getMemberRolesForWorks(user.id, nonOwnedWorkIds),
+                this.workRepository.countAllAccessible({
+                    userId: user.id,
+                    memberWorkIds,
+                    search: sanitizedSearch,
+                }),
+            ]);
 
             // Add userRole to each work without additional queries
             const worksWithRoles: WorkWithRole[] = works.map((dir) => {
@@ -120,12 +118,6 @@ export class WorkQueryService {
                     userRole,
                     ...this.toStatusProjection(dir, latestDeployments.get(dir.id)),
                 } as WorkWithRole;
-            });
-
-            const total = await this.workRepository.countAllAccessible({
-                userId: user.id,
-                memberWorkIds,
-                search: sanitizedSearch,
             });
 
             // Diagnostic: explicit log when listing returns empty so we can
@@ -239,6 +231,7 @@ export class WorkQueryService {
         }
     }
 
+    /** Build the immutable last-run and derived current-health read model. */
     private toStatusProjection(
         work: Work,
         latestDeployment?: WorkDeployment,
@@ -272,6 +265,7 @@ export class WorkQueryService {
         };
     }
 
+    /** Derive availability without treating historical failure as current downtime. */
     private toCurrentDeploymentHealth(
         work: Work,
         latestDeployment?: WorkDeployment,
@@ -308,6 +302,7 @@ export class WorkQueryService {
         };
     }
 
+    /** Serialize legacy Date/string timestamps defensively for the API contract. */
     private toIsoString(value?: Date | string | null): string | null {
         if (!value) {
             return null;

--- a/packages/contracts/src/api/work/index.ts
+++ b/packages/contracts/src/api/work/index.ts
@@ -5,6 +5,17 @@ export { GenerateStatusType } from './generate-status.enum.js';
 // Work DTOs
 export type { WorkScheduleAllowedCadence, WorkScheduleDto, UpdateWorkSchedulePayload } from './work-schedule.dto.js';
 export type {
+	WorkCurrentState,
+	WorkDeploymentReadiness,
+	WorkDeploymentHealthSource,
+	WorkLastGenerationRunDto,
+	WorkLastDeploymentRunDto,
+	WorkLastRunDto,
+	WorkCurrentDeploymentHealthDto,
+	WorkCurrentHealthDto,
+	WorkStatusProjectionDto
+} from './work-status.dto.js';
+export type {
 	GenerationMetrics,
 	WorkChangelog,
 	WorkHistoryChangeEntry,

--- a/packages/contracts/src/api/work/work-status.dto.ts
+++ b/packages/contracts/src/api/work/work-status.dto.ts
@@ -1,0 +1,41 @@
+import type { GenerateStatusType } from './generate-status.enum.js';
+
+export type WorkCurrentState = 'running' | 'paused' | 'idle';
+
+export type WorkDeploymentReadiness = 'ready' | 'pending' | 'unknown' | 'not_deployed';
+
+export type WorkDeploymentHealthSource = 'deployment_projection' | 'none';
+
+export interface WorkLastGenerationRunDto {
+	status: GenerateStatusType;
+	startedAt: string | null;
+	finishedAt: string | null;
+}
+
+export interface WorkLastDeploymentRunDto {
+	status: string;
+	startedAt: string | null;
+	finishedAt: string | null;
+}
+
+export interface WorkLastRunDto {
+	generation: WorkLastGenerationRunDto | null;
+	deployment: WorkLastDeploymentRunDto | null;
+}
+
+export interface WorkCurrentDeploymentHealthDto {
+	readiness: WorkDeploymentReadiness;
+	source: WorkDeploymentHealthSource;
+	/** Null for legacy projections because they pre-date persisted probe timestamps. */
+	observedAt: string | null;
+}
+
+export interface WorkCurrentHealthDto {
+	state: WorkCurrentState;
+	deployment: WorkCurrentDeploymentHealthDto;
+}
+
+export interface WorkStatusProjectionDto {
+	lastRun: WorkLastRunDto;
+	currentHealth: WorkCurrentHealthDto;
+}


### PR DESCRIPTION
## Summary
- expose historical generation/deployment last-run outcomes separately from derived current Work health
- keep historical TIMEOUT rows immutable while allowing the readiness poller to reconcile only the current deployment projection after an HTTP 200 health check
- render current idle/paused/running state separately from the historical generation badge on Work cards

## Safety
- no migrations, deletes, reruns, tenant/entity mutations, or direct production data changes
- no generated Work repositories, directory template, organization-switch, plugin, Kubernetes, GitOps, Cloudflare, merge, or deployment changes

## Verification
- packages/agent focused Jest: 19 passed
- apps/web focused Vitest: 1 passed
- contracts, agent, and web type checks passed
- focused web ESLint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Work cards now show current health separately from the outcome of the most recent generation or deployment.
  - Status indicators include clearer localized labels for health, generation, and scheduled activity.
  - Work details can report deployment readiness and the latest run information.

- **Bug Fixes**
  - Healthy work previously marked as timed out can now be correctly restored to a ready state without losing historical run information.

- **Tests**
  - Added coverage for status separation and timeout recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->