### PR TITLE
fix(api): expose and enforce organization ownership

### DIFF
--- a/apps/api/src/agents/agents.controller.environment.spec.ts
+++ b/apps/api/src/agents/agents.controller.environment.spec.ts
@@ -117,6 +117,7 @@ describe('AgentsController — Environment assignment mapping', () => {
             'u1',
             agentId,
             expect.objectContaining({ environmentId }),
+            activeScope,
         );
     });
 
@@ -126,6 +127,7 @@ describe('AgentsController — Environment assignment mapping', () => {
             'u1',
             agentId,
             expect.objectContaining({ environmentId: null }),
+            activeScope,
         );
     });
 

--- a/apps/api/src/agents/agents.controller.environment.spec.ts
+++ b/apps/api/src/agents/agents.controller.environment.spec.ts
@@ -59,6 +59,10 @@ describe('AgentsController — Environment assignment mapping', () => {
     const auth = { userId: 'u1' } as any;
     const agentId = '00000000-0000-0000-0000-000000000001';
     const environmentId = '00000000-0000-0000-0000-0000000000e1';
+    const activeScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
 
     let service: any;
     let controller: AgentsController;
@@ -81,6 +85,11 @@ describe('AgentsController — Environment assignment mapping', () => {
             { log: jest.fn().mockResolvedValue(undefined) } as any,
             undefined,
             undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { getScope: () => activeScope } as any,
         );
     });
 
@@ -89,6 +98,7 @@ describe('AgentsController — Environment assignment mapping', () => {
         expect(service.create).toHaveBeenCalledWith(
             'u1',
             expect.objectContaining({ environmentId }),
+            activeScope,
         );
     });
 
@@ -97,6 +107,7 @@ describe('AgentsController — Environment assignment mapping', () => {
         expect(service.create).toHaveBeenCalledWith(
             'u1',
             expect.objectContaining({ environmentId: null }),
+            activeScope,
         );
     });
 

--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -96,7 +96,14 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
         organizationId: '22222222-2222-4222-8222-222222222222',
     };
 
-    function scopedController(options: { steering?: any; dispatchGate?: any } = {}) {
+    function scopedController(
+        options: {
+            steering?: any;
+            dispatchGate?: any;
+            scope?: { tenantId: string | null; organizationId: string | null };
+            scopeError?: Error;
+        } = {},
+    ) {
         return new AgentsController(
             service,
             files,
@@ -114,7 +121,12 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             options.dispatchGate,
             undefined,
             options.steering,
-            { getScope: () => everScope } as never,
+            {
+                getScope: () => {
+                    if (options.scopeError) throw options.scopeError;
+                    return options.scope ?? everScope;
+                },
+            } as never,
         );
     }
 
@@ -331,6 +343,55 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 0,
                 everScope,
             );
+        });
+
+        it('shows an Ever heartbeat session in Ever but excludes it from explicit personal scope', async () => {
+            const heartbeat = {
+                id: runId,
+                agentId,
+                userId: 'u1',
+                status: 'queued',
+                triggerKind: 'heartbeat',
+                taskId: null,
+                workId: null,
+                tenantId: everScope.tenantId,
+                organizationId: everScope.organizationId,
+                createdAt: new Date('2026-08-23T00:00:00.000Z'),
+            };
+            agentRuns.listSessionsForUser.mockImplementation(
+                async (
+                    _userId: string,
+                    _filter: object,
+                    _limit: number,
+                    _offset: number,
+                    scope?: typeof everScope,
+                ) =>
+                    scope?.tenantId === heartbeat.tenantId &&
+                    scope.organizationId === heartbeat.organizationId
+                        ? [[heartbeat], 1]
+                        : [[], 0],
+            );
+
+            const ever = await scopedController().listRunSessions(auth, { kind: 'heartbeat' });
+            const personal = await scopedController({
+                scope: { tenantId: everScope.tenantId, organizationId: null },
+            }).listRunSessions(auth, { kind: 'heartbeat' });
+
+            expect(ever.data).toEqual([
+                expect.objectContaining({ triggerKind: 'heartbeat', ...everScope }),
+            ]);
+            expect(personal.data).toEqual([]);
+        });
+
+        it('does not query heartbeat sessions when revoked membership blocks active-scope resolution', async () => {
+            const revoked = new NotFoundException('Organization not found.');
+
+            await expect(
+                scopedController({ scopeError: revoked }).listRunSessions(auth, {
+                    kind: 'heartbeat',
+                }),
+            ).rejects.toBe(revoked);
+            expect(agentRuns.listSessionsForUser).not.toHaveBeenCalled();
         });
 
         it('is owner-scoped at the repository layer — userId always comes from auth', async () => {

--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -91,6 +91,32 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     const agentId = '00000000-0000-0000-0000-000000000001';
     const runId = '00000000-0000-0000-0000-0000000000aa';
     const taskId = '00000000-0000-0000-0000-0000000000bb';
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+
+    function scopedController(options: { steering?: any; dispatchGate?: any } = {}) {
+        return new AgentsController(
+            service,
+            files,
+            exportService,
+            dispatcher,
+            agentRuns,
+            agentRunLogs,
+            skillBindings,
+            pluginUsage,
+            tasks,
+            activityLog,
+            heartbeatTrigger,
+            taskExecuteDispatcher,
+            runCanceller,
+            options.dispatchGate,
+            undefined,
+            options.steering,
+            { getScope: () => everScope } as never,
+        );
+    }
 
     beforeEach(() => {
         service = {
@@ -204,6 +230,42 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     });
 
     describe('GET /:id/runs', () => {
+        it('passes exact active scope into both repository queries and exposes persisted scope', async () => {
+            agentRuns.findByAgentAndUser.mockResolvedValueOnce([
+                {
+                    id: runId,
+                    agentId,
+                    userId: 'u1',
+                    ...everScope,
+                    status: 'completed',
+                    triggerKind: 'task',
+                    startedAt: null,
+                    finishedAt: null,
+                    durationMs: null,
+                    summary: null,
+                    errorMessage: null,
+                    taskId,
+                    createdAt: new Date('2026-08-22T00:00:00.000Z'),
+                },
+            ]);
+            agentRuns.countByAgentAndUser.mockResolvedValueOnce(1);
+
+            const result = await scopedController().listRuns(auth, agentId, {
+                limit: 25,
+                offset: 0,
+            });
+
+            expect(agentRuns.findByAgentAndUser).toHaveBeenCalledWith(
+                agentId,
+                'u1',
+                25,
+                0,
+                everScope,
+            );
+            expect(agentRuns.countByAgentAndUser).toHaveBeenCalledWith(agentId, 'u1', everScope);
+            expect(result.data[0]).toMatchObject(everScope);
+        });
+
         it('returns paginated runs + total', async () => {
             // Security (EW-710 wave M): the controller must use the
             // user-scoped findByAgentAndUser/countByAgentAndUser so run
@@ -519,6 +581,17 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             });
         });
 
+        it('steer forwards the exact active run scope to the steering boundary', async () => {
+            controller = scopedController({ steering });
+            await controller.steerRun(auth, agentId, runId, { message: 'go left' });
+            expect(steering.steer).toHaveBeenCalledWith({
+                runId,
+                userId: 'u1',
+                message: 'go left',
+                ownershipScope: everScope,
+            });
+        });
+
         it('steer 404s a cross-user Agent before touching the run', async () => {
             service.getOne.mockRejectedValueOnce(new NotFoundException('nope'));
             await expect(
@@ -562,6 +635,12 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             );
         });
 
+        it('interrupt forwards the exact active run scope', async () => {
+            controller = scopedController({ steering });
+            await controller.interruptRun(auth, agentId, runId);
+            expect(steering.interrupt).toHaveBeenCalledWith(runId, 'u1', everScope);
+        });
+
         it('resume forwards the optional message and returns the NEW run id', async () => {
             const result = await controller.resumeRun(auth, agentId, runId, { message: 'go on' });
             expect(steering.resume).toHaveBeenCalledWith(runId, 'u1', 'go on');
@@ -575,6 +654,12 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
         it('resume passes null when no message was sent ("carry on")', async () => {
             await controller.resumeRun(auth, agentId, runId, {});
             expect(steering.resume).toHaveBeenCalledWith(runId, 'u1', null);
+        });
+
+        it('resume forwards the exact active run scope', async () => {
+            controller = scopedController({ steering });
+            await controller.resumeRun(auth, agentId, runId, { message: 'continue' });
+            expect(steering.resume).toHaveBeenCalledWith(runId, 'u1', 'continue', everScope);
         });
 
         it('resume surfaces the service 409 for a non-resumable run', async () => {
@@ -596,6 +681,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
         const runRow = {
             id: runId,
             agentId,
+            ...everScope,
             status: 'failed',
             triggerKind: 'task',
             startedAt: new Date('2026-01-01T00:00:00Z'),
@@ -637,6 +723,44 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             });
             expect(agentRuns.findByIdAndUser).toHaveBeenCalledWith(runId, 'u1');
             expect(agentRunLogs.findByRun).toHaveBeenCalledWith(runId, 500);
+        });
+
+        it('gets the run in exact active scope and exposes the persisted scope', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(runRow);
+            const result = await scopedController().getRun(auth, agentId, runId);
+            expect(agentRuns.findByIdAndUser).toHaveBeenCalledWith(runId, 'u1', everScope);
+            expect(result).toMatchObject(everScope);
+        });
+
+        it('uses one opaque 404 for a foreign run row and a foreign Agent parent', async () => {
+            const scoped = scopedController();
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(null);
+            const foreignRunError = await scoped
+                .getRun(auth, agentId, runId)
+                .catch((error: unknown) => error);
+
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(runRow);
+            service.getOne.mockRejectedValueOnce(
+                new NotFoundException('Agent secret-id not found'),
+            );
+            const foreignAgentError = await scoped
+                .getRun(auth, agentId, runId)
+                .catch((error: unknown) => error);
+
+            expect(foreignRunError).toBeInstanceOf(NotFoundException);
+            expect(foreignAgentError).toBeInstanceOf(NotFoundException);
+            expect((foreignRunError as Error).message).toBe('AgentRun not found.');
+            expect((foreignAgentError as Error).message).toBe('AgentRun not found.');
+            expect(agentRunLogs.findByRun).not.toHaveBeenCalled();
+        });
+
+        it('does not disguise an Agent parent lookup outage as an ownership 404', async () => {
+            const outage = new Error('agent database unavailable');
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(runRow);
+            service.getOne.mockRejectedValueOnce(outage);
+
+            await expect(scopedController().getRun(auth, agentId, runId)).rejects.toBe(outage);
+            expect(agentRunLogs.findByRun).not.toHaveBeenCalled();
         });
 
         it('throws 404 when the run does not exist for this user', async () => {
@@ -758,6 +882,24 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     });
 
     describe('POST /:id/runs/:runId/cancel', () => {
+        it('checks and mutates the run in the same exact active scope', async () => {
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'queued',
+            });
+            await scopedController().cancelRun(auth, agentId, runId);
+            expect(agentRuns.findByIdAndUser).toHaveBeenCalledWith(runId, 'u1', everScope);
+            expect(agentRuns.cancel).toHaveBeenCalledWith(runId, 'u1', everScope);
+        });
+
+        it('does not mutate after membership revocation makes the active scope unreachable', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(null);
+            await expect(scopedController().cancelRun(auth, agentId, runId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(agentRuns.cancel).not.toHaveBeenCalled();
+        });
+
         it('cancels a queued run, fires AGENT_RUN_CANCELLED activity', async () => {
             agentRuns.cancel.mockResolvedValueOnce({ found: true, previousStatus: 'queued' });
             const result = await controller.cancelRun(auth, agentId, runId);
@@ -779,9 +921,12 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
 
         it('throws 404 when run-id not found', async () => {
             agentRuns.cancel.mockResolvedValueOnce({ found: false });
-            await expect(controller.cancelRun(auth, agentId, runId)).rejects.toBeInstanceOf(
-                NotFoundException,
-            );
+            const error = await controller
+                .cancelRun(auth, agentId, runId)
+                .catch((caught: unknown) => caught);
+
+            expect(error).toBeInstanceOf(NotFoundException);
+            expect((error as Error).message).toBe('AgentRun not found.');
         });
 
         it('does not cancel a known run UUID bound to a different Agent', async () => {
@@ -977,6 +1122,22 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     });
 
     describe('POST /:id/assign-task', () => {
+        it('binds Task lookup, in-flight dedup and the queued run to the exact active scope', async () => {
+            tasks.getOne.mockResolvedValueOnce({ id: taskId, workId: null, ...everScope });
+            agentRuns.createQueued.mockResolvedValueOnce({ id: runId });
+
+            await scopedController().assignTask(auth, agentId, { taskId });
+
+            expect(tasks.getOne).toHaveBeenCalledWith('u1', taskId, everScope);
+            expect(agentRuns.findInFlightForTaskAgent).toHaveBeenCalledWith(
+                taskId,
+                agentId,
+                'u1',
+                everScope,
+            );
+            expect(agentRuns.createQueued).toHaveBeenCalledWith(expect.objectContaining(everScope));
+        });
+
         it('pre-creates AgentRun + dispatches agent-task-execute', async () => {
             agentRuns.createQueued.mockResolvedValueOnce({ id: runId });
             const result = await controller.assignTask(auth, agentId, { taskId });

--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -116,7 +116,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             markFailed: jest.fn().mockResolvedValue(undefined),
             markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             setTriggerRunId: jest.fn().mockResolvedValue(undefined),
-            findByIdAndUser: jest.fn().mockResolvedValue(null),
+            findByIdAndUser: jest.fn().mockResolvedValue({ id: runId, agentId }),
             // Wave 4 M3 — org-wide Sessions list (owner-scoped variant).
             listSessionsForUser: jest.fn().mockResolvedValue([[], 0]),
         };
@@ -235,6 +235,42 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     });
 
     describe('GET /runs — Sessions list (Wave 4 M3)', () => {
+        it('passes the exact active Organization to the repository boundary', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            const scopedController = new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                activityLog,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+                runCanceller,
+                undefined,
+                undefined,
+                undefined,
+                { getScope: () => everScope } as never,
+            );
+
+            await scopedController.listRunSessions(auth, {});
+
+            expect(agentRuns.listSessionsForUser).toHaveBeenCalledWith(
+                'u1',
+                expect.any(Object),
+                25,
+                0,
+                everScope,
+            );
+        });
+
         it('is owner-scoped at the repository layer — userId always comes from auth', async () => {
             // Security: no agent ownership pre-check exists on this route
             // (it spans all the caller's Agents), so the repository-level
@@ -254,6 +290,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 },
                 25,
                 0,
+                undefined,
             );
         });
 
@@ -279,6 +316,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 },
                 5,
                 10,
+                undefined,
             );
         });
 
@@ -291,6 +329,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 expect.objectContaining({ attention: true }),
                 25,
                 0,
+                undefined,
             );
         });
 
@@ -482,6 +521,18 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
 
         it('steer 404s a cross-user Agent before touching the run', async () => {
             service.getOne.mockRejectedValueOnce(new NotFoundException('nope'));
+            await expect(
+                controller.steerRun(auth, agentId, runId, { message: 'go left' }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(steering.steer).not.toHaveBeenCalled();
+        });
+
+        it('steer 404s a known run UUID bound to a different Agent', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce({
+                id: runId,
+                agentId: '00000000-0000-0000-0000-000000000099',
+            });
+
             await expect(
                 controller.steerRun(auth, agentId, runId, { message: 'go left' }),
             ).rejects.toBeInstanceOf(NotFoundException);
@@ -731,6 +782,18 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             await expect(controller.cancelRun(auth, agentId, runId)).rejects.toBeInstanceOf(
                 NotFoundException,
             );
+        });
+
+        it('does not cancel a known run UUID bound to a different Agent', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce({
+                id: runId,
+                agentId: '00000000-0000-0000-0000-000000000099',
+            });
+
+            await expect(controller.cancelRun(auth, agentId, runId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(agentRuns.cancel).not.toHaveBeenCalled();
         });
 
         it('also cancels the Trigger.dev run when the row carries a triggerRunId', async () => {

--- a/apps/api/src/agents/agents.controller.session-detail.spec.ts
+++ b/apps/api/src/agents/agents.controller.session-detail.spec.ts
@@ -73,11 +73,16 @@ describe('AgentsController — session detail (Feature K)', () => {
 
     const auth = { userId: 'u1' } as any;
     const runId = '00000000-0000-0000-0000-0000000000aa';
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
 
     const baseRun = () => ({
         id: runId,
         agentId: '00000000-0000-0000-0000-000000000001',
         userId: 'u1',
+        ...everScope,
         status: 'running',
         triggerKind: 'task',
         taskId: '00000000-0000-0000-0000-0000000000bb',
@@ -159,6 +164,41 @@ describe('AgentsController — session detail (Feature K)', () => {
             NotFoundException,
         );
         expect(agentRuns.findByIdAndUser).toHaveBeenCalledWith(runId, 'u1');
+    });
+
+    it('queries the run in exact active scope and exposes its persisted scope', async () => {
+        controller = new AgentsController(
+            { getOne: jest.fn().mockResolvedValue({ id: baseRun().agentId }) } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            agentRuns,
+            agentRunLogs,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { getScope: () => everScope } as never,
+        );
+
+        const result = await controller.getRunSessionDetail(auth, runId, {});
+
+        expect(agentRuns.findByIdAndUser).toHaveBeenCalledWith(runId, 'u1', everScope);
+        expect(result.run).toMatchObject(everScope);
+    });
+
+    it('does not disguise an Agent parent lookup outage as an ownership 404', async () => {
+        const outage = new Error('agent database unavailable');
+        (controller as any).service.getOne.mockRejectedValueOnce(outage);
+
+        await expect(controller.getRunSessionDetail(auth, runId, {})).rejects.toBe(outage);
+        expect(agentRunLogs.findTimelineByRun).not.toHaveBeenCalled();
     });
 
     it('⭐ composes run row + counts + filesTouched + timeline', async () => {

--- a/apps/api/src/agents/agents.controller.session-detail.spec.ts
+++ b/apps/api/src/agents/agents.controller.session-detail.spec.ts
@@ -138,7 +138,7 @@ describe('AgentsController — session detail (Feature K)', () => {
             countByRunSteps: jest.fn().mockResolvedValue(0),
         };
         controller = new AgentsController(
-            {} as any, // service
+            { getOne: jest.fn().mockResolvedValue({ id: baseRun().agentId }) } as any, // service
             {} as any, // files
             {} as any, // exportService
             {} as any, // dispatcher

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -451,6 +451,8 @@ export class AgentsController {
     private toSessionRow(r: AgentRun): {
         id: string;
         agentId: string;
+        tenantId: string | null;
+        organizationId: string | null;
         status: string;
         triggerKind: string;
         taskId: string | null;
@@ -483,6 +485,8 @@ export class AgentsController {
         return {
             id: r.id,
             agentId: r.agentId,
+            tenantId: r.tenantId ?? null,
+            organizationId: r.organizationId ?? null,
             status: r.status,
             triggerKind: r.triggerKind,
             taskId: r.taskId ?? null,
@@ -547,11 +551,21 @@ export class AgentsController {
         filesTouched: string[];
         timeline: { entries: SessionTimelineEntry[]; nextCursor: string | null; limit: number };
     }> {
-        const run = await this.agentRuns.findByIdAndUser(runId, auth.userId);
+        const scope = this.scopeContext?.getScope();
+        const run = scope
+            ? await this.agentRuns.findByIdAndUser(runId, auth.userId, scope)
+            : await this.agentRuns.findByIdAndUser(runId, auth.userId);
         if (!run) {
-            throw new NotFoundException(`AgentRun ${runId} not found.`);
+            throw new NotFoundException(`AgentRun not found.`);
         }
-        await this.service.getOne(auth.userId, run.agentId, this.scopeContext?.getScope());
+        try {
+            await this.service.getOne(auth.userId, run.agentId, scope);
+        } catch (error) {
+            if (error instanceof NotFoundException) {
+                throw new NotFoundException(`AgentRun not found.`);
+            }
+            throw error;
+        }
         const limit = query.limit ?? 100;
         const after = parseTimelineCursor(query.cursor);
         const [timelineRows, messages, toolCalls] = await Promise.all([
@@ -1004,6 +1018,8 @@ export class AgentsController {
     ): Promise<{
         data: Array<{
             id: string;
+            tenantId: string | null;
+            organizationId: string | null;
             status: string;
             triggerKind: string;
             startedAt: string | null;
@@ -1023,13 +1039,21 @@ export class AgentsController {
         // the unscoped findByAgent/countByAgent are @internal-only and would
         // become a latent IDOR if the getOne() ownership gate above were ever
         // refactored away.
-        const [rows, total] = await Promise.all([
-            this.agentRuns.findByAgentAndUser(id, auth.userId, limit, offset),
-            this.agentRuns.countByAgentAndUser(id, auth.userId),
-        ]);
+        const scope = this.scopeContext?.getScope();
+        const [rows, total] = scope
+            ? await Promise.all([
+                  this.agentRuns.findByAgentAndUser(id, auth.userId, limit, offset, scope),
+                  this.agentRuns.countByAgentAndUser(id, auth.userId, scope),
+              ])
+            : await Promise.all([
+                  this.agentRuns.findByAgentAndUser(id, auth.userId, limit, offset),
+                  this.agentRuns.countByAgentAndUser(id, auth.userId),
+              ]);
         return {
             data: rows.map((r) => ({
                 id: r.id,
+                tenantId: r.tenantId ?? null,
+                organizationId: r.organizationId ?? null,
                 status: r.status,
                 triggerKind: r.triggerKind,
                 startedAt: r.startedAt?.toISOString() ?? null,
@@ -1055,6 +1079,8 @@ export class AgentsController {
         @Param('runId', ParseUUIDPipe) runId: string,
     ): Promise<{
         id: string;
+        tenantId: string | null;
+        organizationId: string | null;
         status: string;
         triggerKind: string;
         startedAt: string | null;
@@ -1079,6 +1105,8 @@ export class AgentsController {
         const logs = await this.agentRunLogs.findByRun(runId, 500);
         return {
             id: run.id,
+            tenantId: run.tenantId ?? null,
+            organizationId: run.organizationId ?? null,
             status: run.status,
             triggerKind: run.triggerKind,
             startedAt: run.startedAt?.toISOString() ?? null,
@@ -1158,9 +1186,12 @@ export class AgentsController {
         @Param('runId', ParseUUIDPipe) runId: string,
     ): Promise<{ cancelled: boolean; previousStatus?: string }> {
         await this.requireScopedRun(auth.userId, id, runId);
-        const result = await this.agentRuns.cancel(runId, auth.userId);
+        const scope = this.scopeContext?.getScope();
+        const result = scope
+            ? await this.agentRuns.cancel(runId, auth.userId, scope)
+            : await this.agentRuns.cancel(runId, auth.userId);
         if (!result.found) {
-            throw new NotFoundException(`AgentRun ${runId} not found.`);
+            throw new NotFoundException(`AgentRun not found.`);
         }
         const wasOpen = result.previousStatus === 'queued' || result.previousStatus === 'running';
         // DB first, then the remote run. The reverse order risks a cancelled
@@ -1231,7 +1262,13 @@ export class AgentsController {
     ): Promise<{ dispatched: 'injected' | 'new-run'; runId: string; queuedCount?: number }> {
         await this.requireScopedRun(auth.userId, id, runId);
         const steering = this.requireSteering();
-        return steering.steer({ runId, userId: auth.userId, message: body.message });
+        const scope = this.scopeContext?.getScope();
+        return steering.steer({
+            runId,
+            userId: auth.userId,
+            message: body.message,
+            ...(scope ? { ownershipScope: scope } : {}),
+        });
     }
 
     /**
@@ -1260,7 +1297,10 @@ export class AgentsController {
     ): Promise<{ interrupted: boolean; runId: string }> {
         await this.requireScopedRun(auth.userId, id, runId);
         const steering = this.requireSteering();
-        const outcome = await steering.interrupt(runId, auth.userId);
+        const scope = this.scopeContext?.getScope();
+        const outcome = scope
+            ? await steering.interrupt(runId, auth.userId, scope)
+            : await steering.interrupt(runId, auth.userId);
         void this.tryLog({
             userId: auth.userId,
             agentId: id,
@@ -1300,7 +1340,10 @@ export class AgentsController {
     }> {
         await this.requireScopedRun(auth.userId, id, runId);
         const steering = this.requireSteering();
-        const outcome = await steering.resume(runId, auth.userId, body.message ?? null);
+        const scope = this.scopeContext?.getScope();
+        const outcome = scope
+            ? await steering.resume(runId, auth.userId, body.message ?? null, scope)
+            : await steering.resume(runId, auth.userId, body.message ?? null);
         void this.tryLog({
             userId: auth.userId,
             agentId: id,
@@ -1330,10 +1373,20 @@ export class AgentsController {
         agentId: string,
         runId: string,
     ): Promise<AgentRun> {
-        await this.service.getOne(userId, agentId, this.scopeContext?.getScope());
-        const run = await this.agentRuns.findByIdAndUser(runId, userId);
+        const scope = this.scopeContext?.getScope();
+        const run = scope
+            ? await this.agentRuns.findByIdAndUser(runId, userId, scope)
+            : await this.agentRuns.findByIdAndUser(runId, userId);
         if (!run || run.agentId !== agentId) {
-            throw new NotFoundException(`AgentRun ${runId} not found.`);
+            throw new NotFoundException(`AgentRun not found.`);
+        }
+        try {
+            await this.service.getOne(userId, agentId, scope);
+        } catch (error) {
+            if (error instanceof NotFoundException) {
+                throw new NotFoundException(`AgentRun not found.`);
+            }
+            throw error;
         }
         return run;
     }
@@ -1433,7 +1486,10 @@ export class AgentsController {
     ): Promise<{ runId: string; queued?: boolean; queuedReason?: string }> {
         await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         // Cross-user 404 on the Task too — surfaces via TasksService.
-        const task = await this.tasks.getOne(auth.userId, body.taskId);
+        const scope = this.scopeContext?.getScope();
+        const task = scope
+            ? await this.tasks.getOne(auth.userId, body.taskId, scope)
+            : await this.tasks.getOne(auth.userId, body.taskId);
         if (!task) {
             throw new NotFoundException(`Task ${body.taskId} not found.`);
         }
@@ -1444,7 +1500,9 @@ export class AgentsController {
         }
         // Dedup: re-use an in-flight run for the same (taskId, agentId) pair
         // rather than spawning a parallel one.
-        const inflight = await this.agentRuns.findInFlightForTaskAgent(body.taskId, id);
+        const inflight = scope
+            ? await this.agentRuns.findInFlightForTaskAgent(body.taskId, id, auth.userId, scope)
+            : await this.agentRuns.findInFlightForTaskAgent(body.taskId, id);
         if (inflight) {
             return { runId: inflight.id };
         }
@@ -1469,6 +1527,7 @@ export class AgentsController {
                 taskId: body.taskId,
                 workId: task.workId ?? null,
                 queuedReason: verdict.admitted ? null : (verdict.queuedReason ?? null),
+                ...(scope ?? {}),
             });
         };
         let admission: { admitted: boolean; queuedReason?: string } = { admitted: true };

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -431,6 +431,7 @@ export class AgentsController {
             },
             limit,
             offset,
+            this.scopeContext?.getScope(),
         );
         return {
             data: rows.map((r) => this.toSessionRow(r)),
@@ -550,6 +551,7 @@ export class AgentsController {
         if (!run) {
             throw new NotFoundException(`AgentRun ${runId} not found.`);
         }
+        await this.service.getOne(auth.userId, run.agentId, this.scopeContext?.getScope());
         const limit = query.limit ?? 100;
         const after = parseTimelineCursor(query.cursor);
         const [timelineRows, messages, toolCalls] = await Promise.all([
@@ -623,13 +625,18 @@ export class AgentsController {
         if (!this.agentTemplates) {
             throw new InternalServerErrorException('Agent templates service is not available.');
         }
-        return this.agentTemplates.createFromTemplate(auth.userId, slug, {
-            name: body.name ?? null,
-            scope: body.scope,
-            missionId: body.missionId ?? null,
-            ideaId: body.ideaId ?? null,
-            workId: body.workId ?? null,
-        });
+        return this.agentTemplates.createFromTemplate(
+            auth.userId,
+            slug,
+            {
+                name: body.name ?? null,
+                scope: body.scope,
+                missionId: body.missionId ?? null,
+                ideaId: body.ideaId ?? null,
+                workId: body.workId ?? null,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Get(':id')
@@ -651,34 +658,39 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: UpdateAgentDto,
     ): Promise<AgentDto> {
-        return this.service.update(auth.userId, id, {
-            name: body.name,
-            title: body.title,
-            capabilities: body.capabilities,
-            aiProviderId: body.aiProviderId,
-            modelId: body.modelId,
-            // Environments — `undefined` leaves the assignment alone,
-            // `null` clears it, an id is validated by the service.
-            environmentId: body.environmentId,
-            maxSkillContextTokens: body.maxSkillContextTokens,
-            memoryRecallEnabled: body.memoryRecallEnabled,
-            heartbeatCadence: body.heartbeatCadence,
-            idleBehavior: body.idleBehavior,
-            pauseAfterFailures: body.pauseAfterFailures,
-            permissions: body.permissions,
-            targets: body.targets as AgentTarget[] | null | undefined,
-            avatarMode: body.avatarMode,
-            avatarIcon: body.avatarIcon,
-            avatarImageUploadId: body.avatarImageUploadId,
-            committerName: body.committerName,
-            committerEmail: body.committerEmail,
-            reportsToAgentId: body.reportsToAgentId,
-            scorecard: body.scorecard as AgentScorecardMetric[] | null | undefined,
-            // Merge-policy matrix (Wave 3, D4) — the Agent-scoped slice.
-            mergePolicy: body.mergePolicy,
-            // Capabilities tab — init script (advisory v1).
-            initScript: body.initScript,
-        });
+        return this.service.update(
+            auth.userId,
+            id,
+            {
+                name: body.name,
+                title: body.title,
+                capabilities: body.capabilities,
+                aiProviderId: body.aiProviderId,
+                modelId: body.modelId,
+                // Environments — `undefined` leaves the assignment alone,
+                // `null` clears it, an id is validated by the service.
+                environmentId: body.environmentId,
+                maxSkillContextTokens: body.maxSkillContextTokens,
+                memoryRecallEnabled: body.memoryRecallEnabled,
+                heartbeatCadence: body.heartbeatCadence,
+                idleBehavior: body.idleBehavior,
+                pauseAfterFailures: body.pauseAfterFailures,
+                permissions: body.permissions,
+                targets: body.targets as AgentTarget[] | null | undefined,
+                avatarMode: body.avatarMode,
+                avatarIcon: body.avatarIcon,
+                avatarImageUploadId: body.avatarImageUploadId,
+                committerName: body.committerName,
+                committerEmail: body.committerEmail,
+                reportsToAgentId: body.reportsToAgentId,
+                scorecard: body.scorecard as AgentScorecardMetric[] | null | undefined,
+                // Merge-policy matrix (Wave 3, D4) — the Agent-scoped slice.
+                mergePolicy: body.mergePolicy,
+                // Capabilities tab — init script (advisory v1).
+                initScript: body.initScript,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     /**
@@ -696,7 +708,12 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: AgentTargetBodyDto,
     ): Promise<AgentDto> {
-        return this.service.addTarget(auth.userId, id, { type: body.type, id: body.id });
+        return this.service.addTarget(
+            auth.userId,
+            id,
+            { type: body.type, id: body.id },
+            this.scopeContext?.getScope(),
+        );
     }
 
     /** Inverse of `addTarget` — also idempotent. */
@@ -715,7 +732,12 @@ export class AgentsController {
                 `Unsupported target type "${targetType}" — expected mission, idea or work.`,
             );
         }
-        return this.service.removeTarget(auth.userId, id, { type: targetType, id: targetId });
+        return this.service.removeTarget(
+            auth.userId,
+            id,
+            { type: targetType, id: targetId },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Put(':id/guardrails')
@@ -732,7 +754,12 @@ export class AgentsController {
     ): Promise<AgentDto> {
         // Cross-user 404 (never 403) + defense-in-depth validation both
         // happen inside the service (`requireOwned` + `validateGuardrails`).
-        return this.service.setGuardrails(auth.userId, id, body.guardrails ?? null);
+        return this.service.setGuardrails(
+            auth.userId,
+            id,
+            body.guardrails ?? null,
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Delete(':id')
@@ -747,9 +774,9 @@ export class AgentsController {
         @Query('hard') hard?: string,
     ): Promise<{ archived?: true; deleted?: true }> {
         if (hard === 'true') {
-            return this.service.deleteHard(auth.userId, id);
+            return this.service.deleteHard(auth.userId, id, this.scopeContext?.getScope());
         }
-        return this.service.archive(auth.userId, id);
+        return this.service.archive(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/pause')
@@ -760,7 +787,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentDto> {
-        const dto = await this.service.pause(auth.userId, id);
+        const dto = await this.service.pause(auth.userId, id, this.scopeContext?.getScope());
         // agents/spec.md — status transitions MUST leave an activity
         // trail; surfaced in the /agents/[id]/activity feed via
         // GET :id/events.
@@ -781,7 +808,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentDto> {
-        const dto = await this.service.resume(auth.userId, id);
+        const dto = await this.service.resume(auth.userId, id, this.scopeContext?.getScope());
         void this.tryLog({
             userId: auth.userId,
             agentId: id,
@@ -802,7 +829,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentDto> {
-        const dto = await this.service.unarchive(auth.userId, id);
+        const dto = await this.service.unarchive(auth.userId, id, this.scopeContext?.getScope());
         void this.tryLog({
             userId: auth.userId,
             agentId: id,
@@ -826,6 +853,7 @@ export class AgentsController {
         @Param('name') name: string,
     ): Promise<{ name: AgentFileName; body: string; hash: string; storage: 'git' | 'db' }> {
         this.assertValidFileName(name);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         return this.files.read(auth.userId, id, name as AgentFileName);
     }
 
@@ -846,6 +874,7 @@ export class AgentsController {
         @Body() body: { body: string; expectedHash?: string },
     ): Promise<{ newHash: string }> {
         this.assertValidFileName(name);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         if (typeof body?.body !== 'string') {
             throw new BadRequestException('Request body must include a string `body` field.');
         }
@@ -879,7 +908,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentExportEnvelope> {
-        return this.exportService.exportOne(auth.userId, id);
+        return this.exportService.exportOne(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post('import')
@@ -906,13 +935,18 @@ export class AgentsController {
             overrideScope && Object.values(AgentScope).includes(overrideScope as AgentScope)
                 ? (overrideScope as AgentScope)
                 : undefined;
-        return this.exportService.importOne(auth.userId, body, {
-            onConflict: mode,
-            overrideScope: scope,
-            missionId: missionId ?? null,
-            ideaId: ideaId ?? null,
-            workId: workId ?? null,
-        });
+        return this.exportService.importOne(
+            auth.userId,
+            body,
+            {
+                onConflict: mode,
+                overrideScope: scope,
+                missionId: missionId ?? null,
+                ideaId: ideaId ?? null,
+                workId: workId ?? null,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     // ── FU-2 — runtime endpoints (run-now / runs / cancel / skills / budget / assign-task) ─
@@ -929,7 +963,7 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<{ outcome: string; runId?: string; reason?: string }> {
         // Cross-user 404 via service-level access check.
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         if (!this.heartbeatTrigger) {
             throw new InternalServerErrorException(
                 'AGENT_HEARTBEAT_TRIGGER not bound — run-now is unavailable until the Trigger.dev adapter wires up.',
@@ -982,7 +1016,7 @@ export class AgentsController {
         }>;
         meta: { total: number; limit: number; offset: number };
     }> {
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         const limit = query.limit ?? 25;
         const offset = query.offset ?? 0;
         // Security (EW-710 wave M): use the user-scoped repository variants —
@@ -1041,13 +1075,7 @@ export class AgentsController {
             createdAt: string;
         }>;
     }> {
-        await this.service.getOne(auth.userId, id);
-        // Security: user-scoped lookup + agentId match — cross-user or
-        // cross-agent runIds 404 (architecture/security §9, no-existence-leak).
-        const run = await this.agentRuns.findByIdAndUser(runId, auth.userId);
-        if (!run || run.agentId !== id) {
-            throw new NotFoundException(`AgentRun ${runId} not found.`);
-        }
+        const run = await this.requireScopedRun(auth.userId, id, runId);
         const logs = await this.agentRunLogs.findByRun(runId, 500);
         return {
             id: run.id,
@@ -1092,7 +1120,7 @@ export class AgentsController {
         }>;
         meta: { total: number; limit: number; offset: number };
     }> {
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         const limit = query.limit ?? 25;
         const offset = query.offset ?? 0;
         // ActivityLogService is @Optional — when unbound the feed simply
@@ -1129,7 +1157,7 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('runId', ParseUUIDPipe) runId: string,
     ): Promise<{ cancelled: boolean; previousStatus?: string }> {
-        await this.service.getOne(auth.userId, id);
+        await this.requireScopedRun(auth.userId, id, runId);
         const result = await this.agentRuns.cancel(runId, auth.userId);
         if (!result.found) {
             throw new NotFoundException(`AgentRun ${runId} not found.`);
@@ -1201,7 +1229,7 @@ export class AgentsController {
         @Param('runId', ParseUUIDPipe) runId: string,
         @Body() body: SteerRunDto,
     ): Promise<{ dispatched: 'injected' | 'new-run'; runId: string; queuedCount?: number }> {
-        await this.service.getOne(auth.userId, id);
+        await this.requireScopedRun(auth.userId, id, runId);
         const steering = this.requireSteering();
         return steering.steer({ runId, userId: auth.userId, message: body.message });
     }
@@ -1230,7 +1258,7 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('runId', ParseUUIDPipe) runId: string,
     ): Promise<{ interrupted: boolean; runId: string }> {
-        await this.service.getOne(auth.userId, id);
+        await this.requireScopedRun(auth.userId, id, runId);
         const steering = this.requireSteering();
         const outcome = await steering.interrupt(runId, auth.userId);
         void this.tryLog({
@@ -1270,7 +1298,7 @@ export class AgentsController {
         carriedCliSession: boolean;
         queued: boolean;
     }> {
-        await this.service.getOne(auth.userId, id);
+        await this.requireScopedRun(auth.userId, id, runId);
         const steering = this.requireSteering();
         const outcome = await steering.resume(runId, auth.userId, body.message ?? null);
         void this.tryLog({
@@ -1297,6 +1325,19 @@ export class AgentsController {
         return this.steering;
     }
 
+    private async requireScopedRun(
+        userId: string,
+        agentId: string,
+        runId: string,
+    ): Promise<AgentRun> {
+        await this.service.getOne(userId, agentId, this.scopeContext?.getScope());
+        const run = await this.agentRuns.findByIdAndUser(runId, userId);
+        if (!run || run.agentId !== agentId) {
+            throw new NotFoundException(`AgentRun ${runId} not found.`);
+        }
+        return run;
+    }
+
     @Get(':id/skills')
     @ApiOperation({
         summary:
@@ -1314,7 +1355,7 @@ export class AgentsController {
             skill: { id: string; slug: string; title: string; version: string };
         }>;
     }> {
-        const agent = await this.service.getOne(auth.userId, id);
+        const agent = await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         const rows = await this.skillBindings.resolveActive({
             userId: auth.userId,
             agentId: id,
@@ -1354,7 +1395,7 @@ export class AgentsController {
         periodEnd: string;
         currency: string;
     }> {
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         // Default window — caller-tunable in a future revision; this
         // covers the rolling-30-day view shown in the budgets tab.
         const now = new Date();
@@ -1390,7 +1431,7 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: AssignTaskToAgentDto,
     ): Promise<{ runId: string; queued?: boolean; queuedReason?: string }> {
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
         // Cross-user 404 on the Task too — surfaces via TasksService.
         const task = await this.tasks.getOne(auth.userId, body.taskId);
         if (!task) {
@@ -1547,7 +1588,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return this.service.listAttachments(auth.userId, id);
+        return this.service.listAttachments(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/attachments')
@@ -1562,7 +1603,12 @@ export class AgentsController {
         // enforces a UUID `uploadId` instead of a raw inline object type.
         @Body() body: AddAgentAttachmentDto,
     ) {
-        return this.service.addAttachment(auth.userId, id, body?.uploadId);
+        return this.service.addAttachment(
+            auth.userId,
+            id,
+            body?.uploadId,
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Delete(':id/attachments/:attachmentId')
@@ -1573,6 +1619,11 @@ export class AgentsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('attachmentId', ParseUUIDPipe) attachmentId: string,
     ) {
-        return this.service.removeAttachment(auth.userId, id, attachmentId);
+        return this.service.removeAttachment(
+            auth.userId,
+            id,
+            attachmentId,
+            this.scopeContext?.getScope(),
+        );
     }
 }

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -61,6 +61,7 @@ import {
 import type { TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ScopeContextService } from '../scope';
 import {
     AddAgentAttachmentDto,
     AgentTargetBodyDto,
@@ -286,6 +287,8 @@ export class AgentsController {
         // pretending the control landed.
         @Optional()
         private readonly steering?: RunSteeringService,
+        @Optional()
+        private readonly scopeContext?: ScopeContextService,
     ) {}
 
     @Get()
@@ -297,18 +300,22 @@ export class AgentsController {
     ): Promise<{ data: AgentDto[]; meta: { total: number; limit: number; offset: number } }> {
         const limit = query.limit ?? 50;
         const offset = query.offset ?? 0;
-        const { rows, total } = await this.service.list(auth.userId, {
-            scope: query.scope,
-            status: query.status,
-            missionId: query.missionId,
-            ideaId: query.ideaId,
-            workId: query.workId,
-            assignedWorkId: query.assignedWorkId,
-            assignedIdeaId: query.assignedIdeaId,
-            search: query.search,
-            limit,
-            offset,
-        });
+        const { rows, total } = await this.service.list(
+            auth.userId,
+            {
+                scope: query.scope,
+                status: query.status,
+                missionId: query.missionId,
+                ideaId: query.ideaId,
+                workId: query.workId,
+                assignedWorkId: query.assignedWorkId,
+                assignedIdeaId: query.assignedIdeaId,
+                search: query.search,
+                limit,
+                offset,
+            },
+            this.scopeContext?.getScope(),
+        );
         return { data: rows, meta: { total, limit, offset } };
     }
 
@@ -320,31 +327,35 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Body() body: CreateAgentDto,
     ): Promise<AgentDto> {
-        return this.service.create(auth.userId, {
-            scope: body.scope,
-            missionId: body.missionId ?? null,
-            ideaId: body.ideaId ?? null,
-            workId: body.workId ?? null,
-            name: body.name,
-            title: body.title ?? null,
-            capabilities: body.capabilities ?? null,
-            aiProviderId: body.aiProviderId ?? null,
-            modelId: body.modelId ?? null,
-            // Environments — service validates same-user + published
-            // (draft → 422, cross-user/unknown → 404).
-            environmentId: body.environmentId ?? null,
-            maxSkillContextTokens: body.maxSkillContextTokens,
-            heartbeatCadence: body.heartbeatCadence ?? null,
-            idleBehavior: body.idleBehavior,
-            pauseAfterFailures: body.pauseAfterFailures,
-            permissions: body.permissions,
-            targets: (body.targets ?? null) as AgentTarget[] | null,
-            avatarMode: body.avatarMode,
-            avatarIcon: body.avatarIcon ?? null,
-            avatarImageUploadId: body.avatarImageUploadId ?? null,
-            committerName: body.committerName ?? null,
-            committerEmail: body.committerEmail ?? null,
-        });
+        return this.service.create(
+            auth.userId,
+            {
+                scope: body.scope,
+                missionId: body.missionId ?? null,
+                ideaId: body.ideaId ?? null,
+                workId: body.workId ?? null,
+                name: body.name,
+                title: body.title ?? null,
+                capabilities: body.capabilities ?? null,
+                aiProviderId: body.aiProviderId ?? null,
+                modelId: body.modelId ?? null,
+                // Environments — service validates same-user + published
+                // (draft → 422, cross-user/unknown → 404).
+                environmentId: body.environmentId ?? null,
+                maxSkillContextTokens: body.maxSkillContextTokens,
+                heartbeatCadence: body.heartbeatCadence ?? null,
+                idleBehavior: body.idleBehavior,
+                pauseAfterFailures: body.pauseAfterFailures,
+                permissions: body.permissions,
+                targets: (body.targets ?? null) as AgentTarget[] | null,
+                avatarMode: body.avatarMode,
+                avatarIcon: body.avatarIcon ?? null,
+                avatarImageUploadId: body.avatarImageUploadId ?? null,
+                committerName: body.committerName ?? null,
+                committerEmail: body.committerEmail ?? null,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     /**
@@ -628,7 +639,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentDto> {
-        return this.service.getOne(auth.userId, id);
+        return this.service.getOne(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Patch(':id')

--- a/apps/api/src/agents/sub-agent-delegation.runner.spec.ts
+++ b/apps/api/src/agents/sub-agent-delegation.runner.spec.ts
@@ -10,6 +10,14 @@ import { TasksService, TaskTransitionService } from '@ever-works/agent/tasks-dom
 const PARENT_AGENT = 'agent-parent';
 const CHILD_AGENT = 'agent-child';
 const OWNER = 'user-1';
+const EVER_SCOPE = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+const YO_SCOPE = {
+    tenantId: EVER_SCOPE.tenantId,
+    organizationId: '33333333-3333-4333-8333-333333333333',
+};
 
 /**
  * The real sub-agent delegation runner.
@@ -28,9 +36,9 @@ const OWNER = 'user-1';
  */
 describe('SubAgentDelegationRunnerService', () => {
     let runner: SubAgentDelegationRunnerService;
-    let agents: { findById: jest.Mock };
+    let agents: { findById: jest.Mock; findByIdAndUser: jest.Mock };
     let runs: { findById: jest.Mock };
-    let tasks: { create: jest.Mock };
+    let tasks: { create: jest.Mock; getOne: jest.Mock };
     let transitions: { dispatchAgentRun: jest.Mock };
     let collaborators: { listForAgent: jest.Mock };
 
@@ -46,10 +54,16 @@ describe('SubAgentDelegationRunnerService', () => {
 
     beforeEach(async () => {
         agents = {
-            findById: jest.fn(async (id: string) => ({ id, userId: OWNER })),
+            findById: jest.fn(async (id: string) => ({ id, userId: OWNER, ...EVER_SCOPE })),
+            findByIdAndUser: jest.fn(async (id: string) => ({ id, userId: OWNER, ...EVER_SCOPE })),
         };
         runs = { findById: jest.fn().mockResolvedValue({ status: 'completed', summary: 'done' }) };
-        tasks = { create: jest.fn().mockResolvedValue({ id: 'task-child' }) };
+        tasks = {
+            create: jest.fn().mockResolvedValue({ id: 'task-child', userId: OWNER, ...EVER_SCOPE }),
+            getOne: jest
+                .fn()
+                .mockResolvedValue({ id: 'task-parent', userId: OWNER, ...EVER_SCOPE }),
+        };
         transitions = {
             dispatchAgentRun: jest
                 .fn()
@@ -91,6 +105,7 @@ describe('SubAgentDelegationRunnerService', () => {
         expect(tasks.create).toHaveBeenCalledWith(
             OWNER,
             expect.objectContaining({ createdByType: 'agent', agentId: CHILD_AGENT }),
+            EVER_SCOPE,
         );
         expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
             expect.objectContaining({ id: 'task-child' }),
@@ -99,6 +114,62 @@ describe('SubAgentDelegationRunnerService', () => {
         );
         expect(result.status).toBe('completed');
         expect(result.childRunId).toBe('run-child');
+    });
+
+    it('propagates the persisted parent Agent scope into the child Task and dispatched run', async () => {
+        await runner.run(request({ childAgentId: CHILD_AGENT, parentTaskId: 'task-parent' }));
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(CHILD_AGENT, OWNER, EVER_SCOPE);
+        expect(tasks.getOne).toHaveBeenCalledWith(OWNER, 'task-parent', EVER_SCOPE);
+        expect(tasks.create).toHaveBeenCalledWith(
+            OWNER,
+            expect.objectContaining({ parentTaskId: 'task-parent', agentId: CHILD_AGENT }),
+            EVER_SCOPE,
+        );
+        expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
+            expect.objectContaining(EVER_SCOPE),
+            CHILD_AGENT,
+            expect.any(Object),
+        );
+    });
+
+    it('refuses a same-user child Agent from another Organization before creating work', async () => {
+        agents.findById.mockImplementation(async (id: string) => ({
+            id,
+            userId: OWNER,
+            ...(id === CHILD_AGENT ? YO_SCOPE : EVER_SCOPE),
+        }));
+        agents.findByIdAndUser.mockResolvedValue(null);
+
+        const result = await runner.run(request({ childAgentId: CHILD_AGENT }));
+
+        expect(result.status).toBe('failed');
+        expect(tasks.create).not.toHaveBeenCalled();
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+    });
+
+    it('keeps legacy personal delegation children and runs personal', async () => {
+        const personalScope = { tenantId: null, organizationId: null };
+        agents.findById.mockImplementation(async (id: string) => ({
+            id,
+            userId: OWNER,
+            ...personalScope,
+        }));
+        agents.findByIdAndUser.mockImplementation(async (id: string) => ({
+            id,
+            userId: OWNER,
+            ...personalScope,
+        }));
+        tasks.create.mockResolvedValue({ id: 'task-child', userId: OWNER, ...personalScope });
+
+        await runner.run(request({ childAgentId: CHILD_AGENT }));
+
+        expect(tasks.create).toHaveBeenCalledWith(OWNER, expect.any(Object), personalScope);
+        expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
+            expect.objectContaining(personalScope),
+            CHILD_AGENT,
+            expect.any(Object),
+        );
     });
 
     describe("inputs reach the child's brief", () => {
@@ -218,16 +289,14 @@ describe('SubAgentDelegationRunnerService', () => {
     });
 
     it('refuses a child agent owned by someone else', async () => {
-        agents.findById.mockImplementation(async (id: string) =>
-            id === CHILD_AGENT ? { id, userId: 'someone-else' } : { id, userId: OWNER },
-        );
+        agents.findByIdAndUser.mockResolvedValue(null);
 
         const result = await runner.run(request({ childAgentId: CHILD_AGENT }));
 
         // Otherwise a parent could spend another owner's budget and reach
         // their scope; the narrowing step cannot catch this.
         expect(result.status).toBe('failed');
-        expect(result.summary).toMatch(/different owner/);
+        expect(result.summary).toMatch(/not found/);
         expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
     });
 
@@ -274,11 +343,12 @@ describe('SubAgentDelegationRunnerService', () => {
         // way to see (let alone clear) the rule still pointing at it —
         // and nothing downstream of dispatch re-checks agent status, so
         // the archived agent would keep executing delegated work.
-        agents.findById.mockImplementation(async (id: string) =>
-            id === CHILD_AGENT
-                ? { id, userId: OWNER, status: 'archived' }
-                : { id, userId: OWNER, status: 'active' },
-        );
+        agents.findByIdAndUser.mockResolvedValue({
+            id: CHILD_AGENT,
+            userId: OWNER,
+            status: 'archived',
+            ...EVER_SCOPE,
+        });
         collaborators.listForAgent.mockResolvedValue([
             { collaboratorAgentId: CHILD_AGENT, enabled: true },
         ]);
@@ -293,10 +363,11 @@ describe('SubAgentDelegationRunnerService', () => {
     });
 
     it('still admits a non-archived child (the guard is not a blanket refusal)', async () => {
-        agents.findById.mockImplementation(async (id: string) => ({
+        agents.findByIdAndUser.mockImplementation(async (id: string) => ({
             id,
             userId: OWNER,
             status: 'paused',
+            ...EVER_SCOPE,
         }));
         collaborators.listForAgent.mockResolvedValue([
             { collaboratorAgentId: CHILD_AGENT, enabled: true },
@@ -318,9 +389,7 @@ describe('SubAgentDelegationRunnerService', () => {
     });
 
     it('checks ownership BEFORE the allow-list (cross-owner stays a failure)', async () => {
-        agents.findById.mockImplementation(async (id: string) =>
-            id === CHILD_AGENT ? { id, userId: 'someone-else' } : { id, userId: OWNER },
-        );
+        agents.findByIdAndUser.mockResolvedValue(null);
         collaborators.listForAgent.mockResolvedValue([
             { collaboratorAgentId: CHILD_AGENT, enabled: true },
         ]);
@@ -330,7 +399,7 @@ describe('SubAgentDelegationRunnerService', () => {
         // An enabled collaborator row must never launder a cross-owner
         // child into admissibility.
         expect(result.status).toBe('failed');
-        expect(result.summary).toMatch(/different owner/);
+        expect(result.summary).toMatch(/not found/);
     });
 
     it('reports a failed child run as failed, carrying its error', async () => {

--- a/apps/api/src/agents/sub-agent-delegation.runner.ts
+++ b/apps/api/src/agents/sub-agent-delegation.runner.ts
@@ -10,8 +10,9 @@ import {
     AgentCollaboratorRepository,
     AgentRepository,
     AgentRunRepository,
+    ownershipScopeOf,
 } from '@ever-works/agent/database';
-import { TasksService, TaskTransitionService } from '@ever-works/agent/tasks-domain';
+import { TasksService, TaskTransitionService, type Task } from '@ever-works/agent/tasks-domain';
 
 /**
  * The real sub-agent delegation runner (judgment layer G9).
@@ -97,9 +98,14 @@ export class SubAgentDelegationRunnerService implements SubAgentDelegationRunner
         if (!parent) {
             return this.failure(request, 'parent agent no longer exists');
         }
+        const ownershipScope = ownershipScopeOf(parent);
 
         const childAgentId = request.childAgentId ?? parent.id;
-        const child = await this.agents.findById(childAgentId);
+        const child = await this.agents.findByIdAndUser(
+            childAgentId,
+            parent.userId,
+            ownershipScope,
+        );
         if (!child) {
             return this.failure(request, `child agent ${childAgentId} not found`);
         }
@@ -165,36 +171,47 @@ export class SubAgentDelegationRunnerService implements SubAgentDelegationRunner
         // supplies `parentTaskId` — it only knows the run — so without
         // this recovery every delegated Task would be an orphan.
         const parentTaskId = await this.resolveParentTaskId(request);
+        if (parentTaskId) {
+            try {
+                await this.tasks.getOne(parent.userId, parentTaskId, ownershipScope);
+            } catch {
+                return this.failure(request, 'parent Task not found');
+            }
+        }
 
-        let childTask: { id: string };
+        let childTask: Task;
         try {
-            childTask = await this.tasks.create(parent.userId, {
-                title: this.titleFor(request),
-                description: this.describe(request),
-                parentTaskId,
-                workId: request.scope.workId ?? null,
-                // The child is raised BY an agent, not by a person. That
-                // provenance is what lets the UI (and any later audit)
-                // tell a delegated unit of work apart from one a human
-                // filed.
-                createdByType: 'agent',
-                // The PARENT agent is the author of the delegation; the
-                // child is merely assigned to execute it. Recording the
-                // child here would lose who actually decided this work
-                // should exist.
-                createdById: request.parentAgentId,
-                agentId: request.childAgentId ?? null,
-                // Judgment layer G9 — the recursion bound, written by the
-                // platform rather than declared by a caller.
-                //
-                // `request.depth` is the depth of THIS delegation (already
-                // raised to the server-derived value by
-                // `SubAgentDelegationService`), so the child sits one
-                // deeper. This stamp is what the depth resolver reads back
-                // on the next hop; without it the chain has no record of
-                // itself and the cap is unenforceable.
-                delegationDepth: (Number.isInteger(request.depth) ? request.depth : 0) + 1,
-            });
+            childTask = await this.tasks.create(
+                parent.userId,
+                {
+                    title: this.titleFor(request),
+                    description: this.describe(request),
+                    parentTaskId,
+                    workId: request.scope.workId ?? null,
+                    // The child is raised BY an agent, not by a person. That
+                    // provenance is what lets the UI (and any later audit)
+                    // tell a delegated unit of work apart from one a human
+                    // filed.
+                    createdByType: 'agent',
+                    // The PARENT agent is the author of the delegation; the
+                    // child is merely assigned to execute it. Recording the
+                    // child here would lose who actually decided this work
+                    // should exist.
+                    createdById: request.parentAgentId,
+                    agentId: request.childAgentId ?? null,
+                    // Judgment layer G9 — the recursion bound, written by the
+                    // platform rather than declared by a caller.
+                    //
+                    // `request.depth` is the depth of THIS delegation (already
+                    // raised to the server-derived value by
+                    // `SubAgentDelegationService`), so the child sits one
+                    // deeper. This stamp is what the depth resolver reads back
+                    // on the next hop; without it the chain has no record of
+                    // itself and the cap is unenforceable.
+                    delegationDepth: (Number.isInteger(request.depth) ? request.depth : 0) + 1,
+                },
+                ownershipScope,
+            );
         } catch (error) {
             return this.failure(
                 request,
@@ -202,7 +219,7 @@ export class SubAgentDelegationRunnerService implements SubAgentDelegationRunner
             );
         }
 
-        const dispatch = await this.transitions.dispatchAgentRun(childTask as never, childAgentId, {
+        const dispatch = await this.transitions.dispatchAgentRun(childTask, childAgentId, {
             dedupKey: `delegation:${request.delegationId}`,
             // The EFFECTIVE scope — `SubAgentDelegationService` already
             // narrowed it against the parent, and the port contract says

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
@@ -88,6 +88,21 @@ describe('fleet agent-task dispatch (AUDIT A46/A24 producer wiring)', () => {
             undefined,
             runs as never,
             dispatcher,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+                findByIdAndUser: jest.fn().mockImplementation((id, userId, scope) =>
+                    Promise.resolve({
+                        id,
+                        userId,
+                        tenantId: scope.tenantId,
+                        organizationId: scope.organizationId,
+                    }),
+                ),
+            } as never,
         );
 
     beforeEach(() => {

--- a/apps/api/src/goals/goals.controller.ts
+++ b/apps/api/src/goals/goals.controller.ts
@@ -266,17 +266,22 @@ export class GoalsController {
         // that collapsed the two would silently make "remove this cap"
         // impossible while the DTO advertised it.
         await this.requireScopedGoal(auth.userId, id);
-        return this.orchestrator.updateLimits(auth.userId, id, {
-            spendCapCents: body.spendCapCents,
-            wallClockLimitHours: body.wallClockLimitHours,
-            stuckThresholdIterations: body.stuckThresholdIterations,
-            sessionBudgetMinutes: body.sessionBudgetMinutes,
-            gracePeriodMinutes: body.gracePeriodMinutes,
-            executionTarget: body.executionTarget,
-            plannerModelHint: body.plannerModelHint,
-            workerModelHint: body.workerModelHint,
-            assignedAgentId: body.assignedAgentId,
-        });
+        return this.orchestrator.updateLimits(
+            auth.userId,
+            id,
+            {
+                spendCapCents: body.spendCapCents,
+                wallClockLimitHours: body.wallClockLimitHours,
+                stuckThresholdIterations: body.stuckThresholdIterations,
+                sessionBudgetMinutes: body.sessionBudgetMinutes,
+                gracePeriodMinutes: body.gracePeriodMinutes,
+                executionTarget: body.executionTarget,
+                plannerModelHint: body.plannerModelHint,
+                workerModelHint: body.workerModelHint,
+                assignedAgentId: body.assignedAgentId,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     // ─── autonomy layer — Definition of Done ────────────────────────

--- a/apps/api/src/goals/goals.controller.ts
+++ b/apps/api/src/goals/goals.controller.ts
@@ -6,6 +6,7 @@ import {
     Get,
     HttpCode,
     HttpStatus,
+    Optional,
     Param,
     ParseUUIDPipe,
     Patch,
@@ -28,6 +29,7 @@ import {
 } from '@ever-works/agent/goals';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ScopeContextService } from '../scope';
 import { CreateGoalDto, UpdateGoalDto } from './dto/goal.dto';
 import {
     ApproveGoalDodDto,
@@ -79,6 +81,7 @@ export class GoalsController {
     constructor(
         private readonly service: GoalsService,
         private readonly orchestrator: GoalOrchestratorService,
+        @Optional() private readonly scopeContext?: ScopeContextService,
     ) {}
 
     @Get()
@@ -91,12 +94,16 @@ export class GoalsController {
         @Query('offset') offset?: string,
         @Query('archived') archived?: string,
     ): Promise<GoalDto[]> {
-        return this.service.listForUser(auth.userId, {
-            status: this.parseStatus(status),
-            limit: this.parseIntParam(limit, 'limit', 1, 101),
-            offset: this.parseIntParam(offset, 'offset', 0),
-            archived: this.parseArchived(archived),
-        });
+        return this.service.listForUser(
+            auth.userId,
+            {
+                status: this.parseStatus(status),
+                limit: this.parseIntParam(limit, 'limit', 1, 101),
+                offset: this.parseIntParam(offset, 'offset', 0),
+                archived: this.parseArchived(archived),
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Post()
@@ -132,7 +139,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
-        return this.service.getForUser(auth.userId, id);
+        return this.service.getForUser(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Get(':id/samples')

--- a/apps/api/src/goals/goals.controller.ts
+++ b/apps/api/src/goals/goals.controller.ts
@@ -114,22 +114,26 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Body() body: CreateGoalDto,
     ): Promise<GoalDto> {
-        return this.service.create(auth.userId, {
-            title: body.title,
-            description: body.description ?? null,
-            metricSource: body.metricSource,
-            comparator: body.comparator,
-            targetValue: body.targetValue,
-            unit: body.unit,
-            window: body.window,
-            baselineValue: body.baselineValue ?? null,
-            deadline: this.parseDeadline(body.deadline),
-            checkFrequencyMinutes: body.checkFrequencyMinutes,
-            // Judgment layer G1 - additive. Omitted stays undefined, which
-            // the service persists as NULL: the single-metric Goal.
-            criteria: body.criteria,
-            constraints: body.constraints,
-        });
+        return this.service.create(
+            auth.userId,
+            {
+                title: body.title,
+                description: body.description ?? null,
+                metricSource: body.metricSource,
+                comparator: body.comparator,
+                targetValue: body.targetValue,
+                unit: body.unit,
+                window: body.window,
+                baselineValue: body.baselineValue ?? null,
+                deadline: this.parseDeadline(body.deadline),
+                checkFrequencyMinutes: body.checkFrequencyMinutes,
+                // Judgment layer G1 - additive. Omitted stays undefined, which
+                // the service persists as NULL: the single-metric Goal.
+                criteria: body.criteria,
+                constraints: body.constraints,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Get(':id')
@@ -154,6 +158,7 @@ export class GoalsController {
             auth.userId,
             id,
             this.parseIntParam(limit, 'limit', 1, 500) ?? 100,
+            this.scopeContext?.getScope(),
         );
     }
 
@@ -169,21 +174,27 @@ export class GoalsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: UpdateGoalDto,
     ): Promise<GoalDto> {
-        return this.service.update(auth.userId, id, {
-            title: body.title,
-            description: body.description,
-            metricSource: body.metricSource,
-            comparator: body.comparator,
-            targetValue: body.targetValue,
-            unit: body.unit,
-            window: body.window,
-            baselineValue: body.baselineValue,
-            deadline: body.deadline === undefined ? undefined : this.parseDeadline(body.deadline),
-            checkFrequencyMinutes: body.checkFrequencyMinutes,
-            outcome: body.outcome,
-            criteria: body.criteria,
-            constraints: body.constraints,
-        });
+        return this.service.update(
+            auth.userId,
+            id,
+            {
+                title: body.title,
+                description: body.description,
+                metricSource: body.metricSource,
+                comparator: body.comparator,
+                targetValue: body.targetValue,
+                unit: body.unit,
+                window: body.window,
+                baselineValue: body.baselineValue,
+                deadline:
+                    body.deadline === undefined ? undefined : this.parseDeadline(body.deadline),
+                checkFrequencyMinutes: body.checkFrequencyMinutes,
+                outcome: body.outcome,
+                criteria: body.criteria,
+                constraints: body.constraints,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Delete(':id')
@@ -194,7 +205,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<{ deleted: true }> {
-        return this.service.delete(auth.userId, id);
+        return this.service.delete(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/activate')
@@ -208,7 +219,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
-        return this.service.activate(auth.userId, id);
+        return this.service.activate(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/pause')
@@ -219,7 +230,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
-        return this.service.pause(auth.userId, id);
+        return this.service.pause(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/evaluate-now')
@@ -233,7 +244,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<{ entry: GoalEvaluationEntry; goal: GoalDto }> {
-        return this.service.evaluateNow(auth.userId, id);
+        return this.service.evaluateNow(auth.userId, id, this.scopeContext?.getScope());
     }
 
     // ─── autonomy layer — limits ────────────────────────────────────
@@ -254,6 +265,7 @@ export class GoalsController {
         // alone) is preserved as distinct from `null` (clear) — a mapping
         // that collapsed the two would silently make "remove this cap"
         // impossible while the DTO advertised it.
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.updateLimits(auth.userId, id, {
             spendCapCents: body.spendCapCents,
             wallClockLimitHours: body.wallClockLimitHours,
@@ -280,6 +292,7 @@ export class GoalsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: SetGoalDodDto,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.setDodCriteria(auth.userId, id, body.criteria ?? null);
     }
 
@@ -295,6 +308,7 @@ export class GoalsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: ProposeGoalDodDto,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.proposeDodCriteria(auth.userId, id, body.criteria);
     }
 
@@ -307,6 +321,7 @@ export class GoalsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: ApproveGoalDodDto,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.approveDodCriteria(auth.userId, id, body.criterionIds ?? null);
     }
 
@@ -320,6 +335,7 @@ export class GoalsController {
         @Param('criterionId') criterionId: string,
         @Body() body: PatchGoalDodCriterionDto,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.patchDodCriterion(auth.userId, id, criterionId, {
             status: body.status,
             text: body.text,
@@ -338,6 +354,7 @@ export class GoalsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Query('limit') limit?: string,
     ): Promise<GoalEventDto[]> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.listEvents(
             auth.userId,
             id,
@@ -352,6 +369,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalSessionDto[]> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.listSessions(auth.userId, id);
     }
 
@@ -363,6 +381,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.rollupSpend(auth.userId, id);
     }
 
@@ -376,6 +395,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.startLoop(auth.userId, id);
     }
 
@@ -387,6 +407,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.startLoop(auth.userId, id);
     }
 
@@ -398,6 +419,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.pauseLoop(auth.userId, id);
     }
 
@@ -409,6 +431,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.cancelLoop(auth.userId, id);
     }
 
@@ -420,6 +443,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalAdvanceResult> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.restartSession(auth.userId, id);
     }
 
@@ -434,6 +458,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalAdvanceResult> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.advance(auth.userId, id);
     }
 
@@ -446,6 +471,7 @@ export class GoalsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: NudgeGoalDto,
     ): Promise<{ goal: GoalDto; runId: string; queuedCount?: number }> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.nudge(auth.userId, id, body.message);
     }
 
@@ -459,6 +485,7 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.archive(auth.userId, id);
     }
 
@@ -470,7 +497,12 @@ export class GoalsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<GoalDto> {
+        await this.requireScopedGoal(auth.userId, id);
         return this.orchestrator.unarchive(auth.userId, id);
+    }
+
+    private async requireScopedGoal(userId: string, goalId: string): Promise<void> {
+        await this.service.getForUser(userId, goalId, this.scopeContext?.getScope());
     }
 
     private parseStatus(value?: string): GoalStatus | undefined {

--- a/apps/api/src/migrations/1786950000000-AddUserUploadScopeIndex.ts
+++ b/apps/api/src/migrations/1786950000000-AddUserUploadScopeIndex.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+/**
+ * Scope-aware lookup support for `UserUploadRepository.record` and
+ * `findOwnedByUser`. This is deliberately additive: the historical
+ * `(userId, sha256)` and `sha256` indexes remain in place and no row is
+ * rewritten. The index is non-unique because PostgreSQL/SQLite NULL
+ * uniqueness differs; repository-level dedupe implements the explicit
+ * legacy-personal compatibility rule.
+ */
+export class AddUserUploadScopeIndex1786950000000 implements MigrationInterface {
+    name = 'AddUserUploadScopeIndex1786950000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('user_uploads');
+        if (
+            !table ||
+            table.indices.some((index) => index.name === 'idx_user_uploads_user_scope_sha')
+        ) {
+            return;
+        }
+        await queryRunner.createIndex(
+            table,
+            new TableIndex({
+                name: 'idx_user_uploads_user_scope_sha',
+                columnNames: ['userId', 'tenantId', 'organizationId', 'sha256'],
+                isUnique: false,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('user_uploads');
+        const index = table?.indices.find(
+            (candidate) => candidate.name === 'idx_user_uploads_user_scope_sha',
+        );
+        if (table && index) await queryRunner.dropIndex(table, index);
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddUserUploadScopeIndex.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddUserUploadScopeIndex.spec.ts
@@ -1,0 +1,69 @@
+import { DataSource } from 'typeorm';
+import { AddUserUploadScopeIndex1786950000000 } from '../1786950000000-AddUserUploadScopeIndex';
+
+describe('AddUserUploadScopeIndex1786950000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddUserUploadScopeIndex1786950000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(`
+            CREATE TABLE "user_uploads" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "userId" varchar,
+                "tenantId" varchar,
+                "organizationId" varchar,
+                "sha256" varchar NOT NULL
+            )
+        `);
+        await dataSource.query(
+            `INSERT INTO "user_uploads" ("id","userId","tenantId","organizationId","sha256") VALUES ('up1','u1',NULL,NULL,'abc')`,
+        );
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('adds the non-unique scope lookup index without changing existing rows', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('user_uploads');
+        const index = table?.indices.find(
+            (candidate) => candidate.name === 'idx_user_uploads_user_scope_sha',
+        );
+        expect(index?.columnNames).toEqual(['userId', 'tenantId', 'organizationId', 'sha256']);
+        expect(index?.isUnique).toBe(false);
+        await expect(
+            dataSource.query(`SELECT * FROM "user_uploads" WHERE "id" = 'up1'`),
+        ).resolves.toHaveLength(1);
+
+        await runner.release();
+    });
+
+    it('is idempotent and only removes the additive index on rollback', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.not.toThrow();
+        await migration.down(runner);
+
+        const table = await runner.getTable('user_uploads');
+        expect(
+            table?.indices.some(
+                (candidate) => candidate.name === 'idx_user_uploads_user_scope_sha',
+            ),
+        ).toBe(false);
+        await expect(
+            dataSource.query(`SELECT * FROM "user_uploads" WHERE "id" = 'up1'`),
+        ).resolves.toHaveLength(1);
+
+        await runner.release();
+    });
+});

--- a/apps/api/src/missions/missions.controller.ts
+++ b/apps/api/src/missions/missions.controller.ts
@@ -117,17 +117,22 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Body() body: CreateMissionDto,
     ): Promise<MissionDto> {
-        return this.service.create(auth.userId, {
-            title: body.title,
-            description: body.description,
-            type: body.type,
-            schedule: body.schedule ?? null,
-            autoBuildWorks: body.autoBuildWorks,
-            outstandingIdeasCap: body.outstandingIdeasCap ?? null,
-            guardrailsOverride:
-                (body.guardrailsOverride as MissionGuardrailsOverride | null | undefined) ?? null,
-            missionTemplateRepo: body.missionTemplateRepo ?? null,
-        });
+        return this.service.create(
+            auth.userId,
+            {
+                title: body.title,
+                description: body.description,
+                type: body.type,
+                schedule: body.schedule ?? null,
+                autoBuildWorks: body.autoBuildWorks,
+                outstandingIdeasCap: body.outstandingIdeasCap ?? null,
+                guardrailsOverride:
+                    (body.guardrailsOverride as MissionGuardrailsOverride | null | undefined) ??
+                    null,
+                missionTemplateRepo: body.missionTemplateRepo ?? null,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Get(':id')
@@ -171,19 +176,24 @@ export class MissionsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: UpdateMissionDto,
     ): Promise<MissionDto> {
-        return this.service.update(auth.userId, id, {
-            title: body.title,
-            description: body.description,
-            type: body.type,
-            schedule: body.schedule,
-            autoBuildWorks: body.autoBuildWorks,
-            outstandingIdeasCap: body.outstandingIdeasCap,
-            guardrailsOverride: body.guardrailsOverride as
-                | MissionGuardrailsOverride
-                | null
-                | undefined,
-            missionTemplateRepo: body.missionTemplateRepo,
-        });
+        return this.service.update(
+            auth.userId,
+            id,
+            {
+                title: body.title,
+                description: body.description,
+                type: body.type,
+                schedule: body.schedule,
+                autoBuildWorks: body.autoBuildWorks,
+                outstandingIdeasCap: body.outstandingIdeasCap,
+                guardrailsOverride: body.guardrailsOverride as
+                    | MissionGuardrailsOverride
+                    | null
+                    | undefined,
+                missionTemplateRepo: body.missionTemplateRepo,
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Delete(':id')
@@ -194,7 +204,7 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<{ deleted: true }> {
-        return this.service.delete(auth.userId, id);
+        return this.service.delete(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/pause')
@@ -205,7 +215,7 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<MissionDto> {
-        return this.service.pause(auth.userId, id);
+        return this.service.pause(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/resume')
@@ -216,7 +226,7 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<MissionDto> {
-        return this.service.resume(auth.userId, id);
+        return this.service.resume(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/complete')
@@ -232,6 +242,7 @@ export class MissionsController {
             auth.userId,
             id,
             (body?.outcome ?? null) as MissionOutcome | null,
+            this.scopeContext?.getScope(),
         );
     }
 
@@ -247,9 +258,12 @@ export class MissionsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: CloneMissionDto,
     ): Promise<CloneMissionResult> {
-        return this.cloneService.cloneForUser(auth.userId, id, {
-            title: body.title,
-        });
+        return this.cloneService.cloneForUser(
+            auth.userId,
+            id,
+            { title: body.title },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Post(':id/run-now')
@@ -276,7 +290,7 @@ export class MissionsController {
         ideasQueued?: number;
         message?: string;
     }> {
-        return this.service.runNow(auth.userId, id);
+        return this.service.runNow(auth.userId, id, this.scopeContext?.getScope());
     }
 
     /**
@@ -378,7 +392,7 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return this.service.listAttachments(auth.userId, id);
+        return this.service.listAttachments(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/attachments')
@@ -390,7 +404,12 @@ export class MissionsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: AddMissionAttachmentDto,
     ) {
-        return this.service.addAttachment(auth.userId, id, body?.uploadId);
+        return this.service.addAttachment(
+            auth.userId,
+            id,
+            body?.uploadId,
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Delete(':id/attachments/:attachmentId')
@@ -401,7 +420,12 @@ export class MissionsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('attachmentId', ParseUUIDPipe) attachmentId: string,
     ) {
-        return this.service.removeAttachment(auth.userId, id, attachmentId);
+        return this.service.removeAttachment(
+            auth.userId,
+            id,
+            attachmentId,
+            this.scopeContext?.getScope(),
+        );
     }
 
     /**
@@ -421,7 +445,7 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<MissionGoalLinkDto[]> {
-        return this.goalsService.listForMission(auth.userId, id);
+        return this.goalsService.listForMission(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Post(':id/goals')
@@ -441,6 +465,7 @@ export class MissionsController {
             id,
             body.goalId,
             body.isPrimary ?? false,
+            this.scopeContext?.getScope(),
         );
     }
 
@@ -453,7 +478,12 @@ export class MissionsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('goalId', ParseUUIDPipe) goalId: string,
     ): Promise<{ deleted: true }> {
-        return this.goalsService.unlinkFromMission(auth.userId, id, goalId);
+        return this.goalsService.unlinkFromMission(
+            auth.userId,
+            id,
+            goalId,
+            this.scopeContext?.getScope(),
+        );
     }
 
     private parseStatus(value?: string): MissionStatus | undefined {

--- a/apps/api/src/missions/missions.controller.ts
+++ b/apps/api/src/missions/missions.controller.ts
@@ -6,6 +6,7 @@ import {
     Get,
     HttpCode,
     HttpStatus,
+    Optional,
     Param,
     ParseUUIDPipe,
     Patch,
@@ -27,6 +28,7 @@ import { BudgetOwnerType } from '@ever-works/agent/entities';
 import { GoalsService, type MissionGoalLinkDto } from '@ever-works/agent/goals';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ScopeContextService } from '../scope';
 import { LinkMissionGoalDto } from '../goals/dto/goal.dto';
 import {
     AddMissionAttachmentDto,
@@ -82,6 +84,7 @@ export class MissionsController {
         // GoalsService validates ownership of BOTH sides (Mission and
         // Goal) with 404-no-leak semantics.
         private readonly goalsService: GoalsService,
+        @Optional() private readonly scopeContext?: ScopeContextService,
     ) {}
 
     @Get()
@@ -94,12 +97,16 @@ export class MissionsController {
         @Query('limit') limit?: string,
         @Query('offset') offset?: string,
     ): Promise<MissionDto[]> {
-        return this.service.listForUser(auth.userId, {
-            status: this.parseStatus(status),
-            search: this.parseSearch(search),
-            limit: this.parseLimit(limit),
-            offset: this.parseOffset(offset),
-        });
+        return this.service.listForUser(
+            auth.userId,
+            {
+                status: this.parseStatus(status),
+                search: this.parseSearch(search),
+                limit: this.parseLimit(limit),
+                offset: this.parseOffset(offset),
+            },
+            this.scopeContext?.getScope(),
+        );
     }
 
     @Post()
@@ -130,7 +137,7 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<MissionDto> {
-        return this.service.getForUser(auth.userId, id);
+        return this.service.getForUser(auth.userId, id, this.scopeContext?.getScope());
     }
 
     @Get(':id/budget')
@@ -148,7 +155,7 @@ export class MissionsController {
         // service.getForUser call 404s when the Mission belongs to
         // another user, which translates to the standard NestJS
         // 404 response shape.
-        await this.service.getForUser(auth.userId, id);
+        await this.service.getForUser(auth.userId, id, this.scopeContext?.getScope());
         return this.budgetService.summarizeForOwner({
             ownerType: BudgetOwnerType.MISSION,
             ownerId: id,
@@ -286,7 +293,9 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return { relations: await this.service.listWorks(auth.userId, id) };
+        return {
+            relations: await this.service.listWorks(auth.userId, id, this.scopeContext?.getScope()),
+        };
     }
 
     @Post(':id/works')
@@ -299,7 +308,13 @@ export class MissionsController {
         @Body() body: AttachMissionWorkDto,
     ) {
         return {
-            relations: await this.service.attachWork(auth.userId, id, body.workId, body.relation),
+            relations: await this.service.attachWork(
+                auth.userId,
+                id,
+                body.workId,
+                body.relation,
+                this.scopeContext?.getScope(),
+            ),
         };
     }
 
@@ -317,7 +332,13 @@ export class MissionsController {
                 `Invalid relation "${relation}". Allowed: ${MISSION_WORK_RELATIONS.join(', ')}.`,
             );
         }
-        return this.service.detachWork(auth.userId, id, workId, relation as MissionWorkRelation);
+        return this.service.detachWork(
+            auth.userId,
+            id,
+            workId,
+            relation as MissionWorkRelation,
+            this.scopeContext?.getScope(),
+        );
     }
 
     /**
@@ -332,7 +353,13 @@ export class MissionsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('workId', ParseUUIDPipe) workId: string,
     ) {
-        return { relations: await this.service.listMissionsForWork(auth.userId, workId) };
+        return {
+            relations: await this.service.listMissionsForWork(
+                auth.userId,
+                workId,
+                this.scopeContext?.getScope(),
+            ),
+        };
     }
 
     /**

--- a/apps/api/src/organization-ownership.controller.spec.ts
+++ b/apps/api/src/organization-ownership.controller.spec.ts
@@ -1,0 +1,200 @@
+import 'reflect-metadata';
+
+jest.mock('@ever-works/agent/missions', () => ({
+    MissionCloneService: class {},
+    MissionsService: class {},
+    MissionStatus: { ACTIVE: 'active', PAUSED: 'paused', COMPLETED: 'completed' },
+}));
+jest.mock('@ever-works/agent/budgets', () => ({ BudgetService: class {} }));
+jest.mock('@ever-works/agent/goals', () => ({
+    GoalOrchestratorService: class {},
+    GoalsService: class {},
+    GoalStatus: { DRAFT: 'draft', ACTIVE: 'active', PAUSED: 'paused', COMPLETED: 'completed' },
+    GOAL_CONSTRAINT_CATEGORIES: ['budget', 'security'],
+    MAX_GOAL_CONSTRAINTS: 20,
+    MAX_GOAL_CRITERIA: 20,
+    GOAL_DOD_SOURCES: ['user', 'planner'],
+    GOAL_DOD_STATUSES: ['open', 'done', 'waived', 'proposed'],
+    GOAL_EXECUTION_TARGETS: ['local', 'remote'],
+    MAX_DOD_EVIDENCE_CHARS: 2000,
+    MAX_DOD_ID_CHARS: 100,
+    MAX_DOD_NOTE_CHARS: 2000,
+    MAX_DOD_TEXT_CHARS: 2000,
+    MAX_GOAL_DOD_CRITERIA: 50,
+    MAX_GRACE_PERIOD_MINUTES: 10080,
+    MAX_MODEL_HINT_CHARS: 200,
+    MAX_NUDGE_CHARS: 4000,
+    MAX_SESSION_BUDGET_MINUTES: 10080,
+    MAX_SPEND_CAP_CENTS: 100000000,
+    MAX_STUCK_THRESHOLD_ITERATIONS: 1000,
+    MAX_WALL_CLOCK_LIMIT_HOURS: 8760,
+}));
+jest.mock('@ever-works/agent/entities', () => ({
+    BudgetOwnerType: { MISSION: 'mission' },
+    MISSION_WORK_RELATIONS: ['creates', 'improves', 'operates', 'markets', 'researches', 'retires'],
+    MissionOutcome: {},
+}));
+jest.mock('@ever-works/agent/agents', () => ({
+    AGENT_HEARTBEAT_TRIGGER: 'AGENT_HEARTBEAT_TRIGGER',
+    AGENT_RUN_CANCELLER: 'AGENT_RUN_CANCELLER',
+    AGENT_FILE_NAMES: ['SOUL.md', 'AGENTS.md', 'HEARTBEAT.md', 'TOOLS.md', 'agent.yml'],
+    AGENT_GUARDRAIL_MODES: ['strict', 'guided', 'permissive'],
+    AgentScope: { TENANT: 'tenant', MISSION: 'mission', IDEA: 'idea', WORK: 'work' },
+    AgentStatus: {
+        DRAFT: 'draft',
+        ACTIVE: 'active',
+        PAUSED: 'paused',
+        ERROR: 'error',
+        ARCHIVED: 'archived',
+    },
+    AgentIdleBehavior: { PROPOSE: 'propose', SLEEP: 'sleep', SELF_IMPROVE: 'self-improve' },
+    AgentAvatarMode: { INITIALS: 'initials', ICON: 'icon', IMAGE: 'image' },
+    AgentsService: class {},
+    AgentFileService: class {},
+    AgentExportService: class {},
+    AgentScheduleDispatcherService: class {},
+    AgentRunRepository: class {},
+    AgentRunLogRepository: class {},
+    RunDispatchGateService: class {},
+    RunSteeringService: class {},
+    AgentTemplatesService: class {},
+    SkillBindingRepository: class {},
+    PluginUsageRepository: class {},
+}));
+jest.mock('@ever-works/agent/tasks-domain', () => ({
+    AGENT_TASK_EXECUTE_DISPATCHER: 'AGENT_TASK_EXECUTE_DISPATCHER',
+    TasksService: class {},
+}));
+jest.mock('@ever-works/agent/activity-log', () => ({
+    ActivityLogService: class {},
+    ActivityActionType: {
+        AGENT_CREATED: 'agent_created',
+        AGENT_PAUSED: 'agent_paused',
+        AGENT_RESUMED: 'agent_resumed',
+        AGENT_ARCHIVED: 'agent_archived',
+        AGENT_UNARCHIVED: 'agent_unarchived',
+        AGENT_EXPORTED: 'agent_exported',
+        AGENT_IMPORTED: 'agent_imported',
+        AGENT_BUDGET_EXCEEDED: 'agent_budget_exceeded',
+        AGENT_RUN_TRIGGERED: 'agent_run_triggered',
+        AGENT_RUN_CANCELLED: 'agent_run_cancelled',
+        AGENT_TASK_ASSIGNED: 'agent_task_assigned',
+        AGENT_COLLABORATOR_ENABLED: 'agent_collaborator_enabled',
+        AGENT_COLLABORATOR_DISABLED: 'agent_collaborator_disabled',
+        AGENT_COLLABORATOR_REMOVED: 'agent_collaborator_removed',
+    },
+    ActivityStatus: { COMPLETED: 'completed' },
+}));
+jest.mock('./missions/dto/mission.dto', () => ({
+    AddMissionAttachmentDto: class {},
+    AttachMissionWorkDto: class {},
+    CloneMissionDto: class {},
+    CompleteMissionDto: class {},
+    CreateMissionDto: class {},
+    UpdateMissionDto: class {},
+}));
+jest.mock('./goals/dto/goal.dto', () => ({
+    CreateGoalDto: class {},
+    LinkMissionGoalDto: class {},
+    UpdateGoalDto: class {},
+}));
+jest.mock('./goals/dto/goal-orchestration.dto', () => ({
+    ApproveGoalDodDto: class {},
+    NudgeGoalDto: class {},
+    PatchGoalDodCriterionDto: class {},
+    ProposeGoalDodDto: class {},
+    SetGoalDodDto: class {},
+    UpdateGoalLimitsDto: class {},
+}));
+jest.mock('./agents/dto/agent.dto', () => ({
+    AddAgentAttachmentDto: class {},
+    AgentTargetBodyDto: class {},
+    AssignTaskToAgentDto: class {},
+    CreateAgentDto: class {},
+    CreateAgentFromTemplateDto: class {},
+    ListAgentRunsQueryDto: class {},
+    ListAgentsQueryDto: class {},
+    ListRunSessionsQueryDto: class {},
+    ResumeRunDto: class {},
+    SessionDetailQueryDto: class {},
+    SteerRunDto: class {},
+    UpdateAgentDto: class {},
+    UpdateAgentGuardrailsDto: class {},
+}));
+
+import { AgentsController } from './agents/agents.controller';
+import { GoalsController } from './goals/goals.controller';
+import { MissionsController } from './missions/missions.controller';
+
+const scope = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+const auth = { userId: 'user-1' } as never;
+const scopeContext = { getScope: () => scope };
+
+describe('Organization ownership controller wiring', () => {
+    it('passes the active request scope to Mission list and get', async () => {
+        const service = {
+            listForUser: jest.fn(
+                async (_userId: string, _filter: unknown, activeScope?: unknown) =>
+                    activeScope ? [{ id: 'mission-ever', ...scope }] : [],
+            ),
+            getForUser: jest.fn(async (_userId: string, id: string, activeScope?: unknown) =>
+                activeScope ? { id, ...scope } : null,
+            ),
+        };
+        const controller = new (MissionsController as any)(service, {}, {}, {}, scopeContext);
+
+        await expect(controller.list(auth)).resolves.toEqual([{ id: 'mission-ever', ...scope }]);
+        await expect(controller.getOne(auth, 'mission-ever')).resolves.toEqual({
+            id: 'mission-ever',
+            ...scope,
+        });
+    });
+
+    it('passes the active request scope to Goal list and get', async () => {
+        const service = {
+            listForUser: jest.fn(
+                async (_userId: string, _filter: unknown, activeScope?: unknown) =>
+                    activeScope ? [{ id: 'goal-ever', ...scope }] : [],
+            ),
+            getForUser: jest.fn(async (_userId: string, id: string, activeScope?: unknown) =>
+                activeScope ? { id, ...scope } : null,
+            ),
+        };
+        const controller = new (GoalsController as any)(service, {}, scopeContext);
+
+        await expect(controller.list(auth)).resolves.toEqual([{ id: 'goal-ever', ...scope }]);
+        await expect(controller.getOne(auth, 'goal-ever')).resolves.toEqual({
+            id: 'goal-ever',
+            ...scope,
+        });
+    });
+
+    it('passes the active request scope to Agent list and get', async () => {
+        const service = {
+            list: jest.fn(async (_userId: string, _filter: unknown, activeScope?: unknown) => ({
+                rows: activeScope ? [{ id: 'agent-ever', ...scope }] : [],
+                total: activeScope ? 1 : 0,
+            })),
+            getOne: jest.fn(async (_userId: string, id: string, activeScope?: unknown) =>
+                activeScope ? { id, ...scope } : null,
+            ),
+        };
+        const controller = new (AgentsController as any)(
+            service,
+            ...Array.from({ length: 15 }, () => ({})),
+            scopeContext,
+        );
+
+        await expect(controller.list(auth, {})).resolves.toMatchObject({
+            data: [{ id: 'agent-ever', ...scope }],
+            meta: { total: 1 },
+        });
+        await expect(controller.getOne(auth, 'agent-ever')).resolves.toEqual({
+            id: 'agent-ever',
+            ...scope,
+        });
+    });
+});

--- a/apps/api/src/organization-ownership.controller.spec.ts
+++ b/apps/api/src/organization-ownership.controller.spec.ts
@@ -151,6 +151,8 @@ describe('Organization ownership controller wiring', () => {
             id: 'mission-ever',
             ...scope,
         });
+        expect(service.listForUser).toHaveBeenCalledWith('user-1', expect.any(Object), scope);
+        expect(service.getForUser).toHaveBeenCalledWith('user-1', 'mission-ever', scope);
     });
 
     it('passes the active request scope to Goal list and get', async () => {
@@ -170,6 +172,8 @@ describe('Organization ownership controller wiring', () => {
             id: 'goal-ever',
             ...scope,
         });
+        expect(service.listForUser).toHaveBeenCalledWith('user-1', expect.any(Object), scope);
+        expect(service.getForUser).toHaveBeenCalledWith('user-1', 'goal-ever', scope);
     });
 
     it('passes the active request scope to Agent list and get', async () => {
@@ -196,5 +200,7 @@ describe('Organization ownership controller wiring', () => {
             id: 'agent-ever',
             ...scope,
         });
+        expect(service.list).toHaveBeenCalledWith('user-1', expect.any(Object), scope);
+        expect(service.getOne).toHaveBeenCalledWith('user-1', 'agent-ever', scope);
     });
 });

--- a/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
+++ b/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
@@ -1,7 +1,7 @@
 jest.mock('@ever-works/agent/database', () => ({}));
 jest.mock('@ever-works/agent/entities', () => ({}));
 
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, NotFoundException } from '@nestjs/common';
 import { ScopeContextService } from '../scope-context.service';
 import { SessionScopeGuard } from '../session-scope.guard';
 
@@ -21,6 +21,36 @@ function makeContext(request: { user?: unknown }): ExecutionContext {
     } as unknown as ExecutionContext;
 }
 
+function makeGuard(
+    scopeContext: ScopeContextService,
+    userRepository: ConstructorParameters<typeof SessionScopeGuard>[1],
+): SessionScopeGuard {
+    const tenantForOrganization = (organizationId: string): string => {
+        if (organizationId === 'o-mine') return 't-mine';
+        if (organizationId === 'o-other') return 't-other';
+        if (organizationId === 'o-resolved') return 't-resolved';
+        return 't-1';
+    };
+    return new SessionScopeGuard(
+        scopeContext,
+        userRepository,
+        {
+            findById: jest.fn(async (organizationId: string) => ({
+                id: organizationId,
+                tenantId: tenantForOrganization(organizationId),
+            })),
+        } as never,
+        {
+            findByOrgAndUser: jest.fn(async (organizationId: string, userId: string) => ({
+                organizationId,
+                userId,
+                tenantId: tenantForOrganization(organizationId),
+            })),
+        } as never,
+        { findById: jest.fn(async () => ({ ownerUserId: 'tenant-owner' })) } as never,
+    );
+}
+
 type FindByIdResult = {
     tenantId?: string | null;
     lastScopeOrganizationId?: string | null;
@@ -37,7 +67,7 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
         const userRepository = { findById } as unknown as ConstructorParameters<
             typeof SessionScopeGuard
         >[1];
-        guard = new SessionScopeGuard(scopeContext, userRepository);
+        guard = makeGuard(scopeContext, userRepository);
     });
 
     it('returns true and makes no DB call for non-HTTP contexts', async () => {
@@ -143,6 +173,85 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
 
         expect(reqUser.tenantId).toBe('t-1');
     });
+
+    it.each([
+        [
+            'a removed Ever membership while Yo membership keeps the Tenant active',
+            { id: 'o-ever', tenantId: 't-1' },
+        ],
+        ['an Organization that no longer exists', null],
+    ])('returns the same opaque 404 for %s', async (_label, organization) => {
+        findById.mockResolvedValue({
+            tenantId: 't-1',
+            lastScopeOrganizationId: 'o-yo',
+        });
+        const organizationRepository = {
+            findById: jest.fn().mockResolvedValue(organization),
+        };
+        const organizationMembers = {
+            // The user still belongs to Yo, but their Ever roster row was revoked.
+            findByOrgAndUser: jest.fn().mockResolvedValue(null),
+        };
+        const tenants = {
+            findById: jest.fn().mockResolvedValue({ ownerUserId: 'tenant-owner' }),
+        };
+        const membershipGuard = new (SessionScopeGuard as any)(
+            scopeContext,
+            { findById },
+            organizationRepository,
+            organizationMembers,
+            tenants,
+        );
+        const ctx = makeContext({ user: { userId: 'u-1' } });
+
+        await expect(
+            scopeContext.runWith({ tenantId: 't-1', organizationId: 'o-ever' }, () =>
+                membershipGuard.canActivate(ctx),
+            ),
+        ).rejects.toMatchObject({
+            constructor: NotFoundException,
+            message: 'Organization not found',
+        });
+    });
+
+    it('does not silently fall back to personal scope after the last-active membership is revoked', async () => {
+        findById.mockResolvedValue({
+            tenantId: 't-1',
+            lastScopeOrganizationId: 'o-ever',
+        });
+        const membershipGuard = new SessionScopeGuard(
+            scopeContext,
+            { findById } as never,
+            { findById: jest.fn().mockResolvedValue({ id: 'o-ever', tenantId: 't-1' }) } as never,
+            { findByOrgAndUser: jest.fn().mockResolvedValue(null) } as never,
+            { findById: jest.fn().mockResolvedValue({ ownerUserId: 'tenant-owner' }) } as never,
+        );
+        const ctx = makeContext({ user: { userId: 'u-1' } });
+
+        await expect(
+            scopeContext.runWith({ tenantId: null, organizationId: null }, () =>
+                membershipGuard.canActivate(ctx),
+            ),
+        ).rejects.toMatchObject({ status: 404, message: 'Organization not found' });
+    });
+
+    it('keeps Tenant-owner access even though owners intentionally have no roster row', async () => {
+        findById.mockResolvedValue({ tenantId: 't-1', lastScopeOrganizationId: 'o-ever' });
+        const membershipGuard = new SessionScopeGuard(
+            scopeContext,
+            { findById } as never,
+            { findById: jest.fn().mockResolvedValue({ id: 'o-ever', tenantId: 't-1' }) } as never,
+            { findByOrgAndUser: jest.fn().mockResolvedValue(null) } as never,
+            { findById: jest.fn().mockResolvedValue({ ownerUserId: 'u-1' }) } as never,
+        );
+        const ctx = makeContext({ user: { userId: 'u-1' } });
+
+        await expect(
+            scopeContext.runWith({ tenantId: 't-1', organizationId: 'o-ever' }, () =>
+                membershipGuard.canActivate(ctx),
+            ),
+        ).resolves.toBe(true);
+    });
 });
 
 /**
@@ -173,7 +282,7 @@ describe('SessionScopeGuard + ScopeOwnershipGuard pipeline (EW-664 regression)',
         const findById = jest
             .fn()
             .mockResolvedValue({ tenantId: 't-1', lastScopeOrganizationId: 'o-1' });
-        const sessionGuard = new SessionScopeGuard(scopeContext, { findById } as never);
+        const sessionGuard = makeGuard(scopeContext, { findById } as never);
         const ownershipGuard = new ScopeOwnershipGuard(scopeContext);
 
         const reqUser: { userId: string; tenantId?: string | null } = { userId: 'u-1' };
@@ -200,7 +309,7 @@ describe('SessionScopeGuard + ScopeOwnershipGuard pipeline (EW-664 regression)',
         const findById = jest
             .fn()
             .mockResolvedValue({ tenantId: 't-mine', lastScopeOrganizationId: null });
-        const sessionGuard = new SessionScopeGuard(scopeContext, { findById } as never);
+        const sessionGuard = makeGuard(scopeContext, { findById } as never);
         const ownershipGuard = new ScopeOwnershipGuard(scopeContext);
         const ctx = makeHttpContext({ user: { userId: 'u-1' } });
 
@@ -221,7 +330,7 @@ describe('SessionScopeGuard + ScopeOwnershipGuard pipeline (EW-664 regression)',
         const findById = jest
             .fn()
             .mockResolvedValue({ tenantId: 't-mine', lastScopeOrganizationId: null });
-        const sessionGuard = new SessionScopeGuard(scopeContext, { findById } as never);
+        const sessionGuard = makeGuard(scopeContext, { findById } as never);
         const ownershipGuard = new ScopeOwnershipGuard(scopeContext);
         const ctx = makeHttpContext({ user: { userId: 'u-1' } });
 

--- a/apps/api/src/scope/session-scope.guard.ts
+++ b/apps/api/src/scope/session-scope.guard.ts
@@ -1,5 +1,16 @@
-import { CanActivate, ExecutionContext, Injectable, Logger, Optional } from '@nestjs/common';
-import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import {
+    CanActivate,
+    ExecutionContext,
+    Injectable,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
+import {
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    TenantRepository,
+    UserRepository,
+} from '@ever-works/agent/database';
 import { ScopeContextService } from './scope-context.service';
 
 /**
@@ -27,13 +38,16 @@ import { ScopeContextService } from './scope-context.service';
  * and, on legacy routes, seeds the default scope in place via
  * [`ScopeContextService.setScope`](./scope-context.service.ts).
  *
- * **Behavior** (always returns `true` — this guard never blocks):
+ * **Behavior:**
  *
  *   - Non-HTTP context (RPC / WS) → allow, do nothing.
  *   - No `request.user` → unauthenticated; nothing to hydrate → allow.
  *   - Otherwise: load the user row once and HYDRATE
  *     `req.user.tenantId` (the auth layer never sets it). This happens
  *     on BOTH legacy and slug-prefixed routes — see below.
+ *   - An Organization scope must still have an exact roster membership;
+ *     the Tenant owner is the sole row-less exception. A revoked/missing
+ *     Organization is an opaque 404.
  *   - Then SEED scope only if no slug already resolved one
  *     (`scope.tenantId === null`) AND the user has a Tenant →
  *     `{ tenantId, organizationId: lastScopeOrganizationId ?? null }`.
@@ -58,9 +72,9 @@ export class SessionScopeGuard implements CanActivate {
     constructor(
         private readonly scopeContext: ScopeContextService,
         private readonly userRepository: UserRepository,
-        // Security: @Optional keeps tests that construct the guard directly (without DI)
-        // working; in production the DI container always provides this via DatabaseModule.
-        @Optional() private readonly organizationRepository?: OrganizationRepository,
+        private readonly organizationRepository: OrganizationRepository,
+        private readonly organizationMembers: OrganizationMemberRepository,
+        private readonly tenants: TenantRepository,
     ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -102,24 +116,23 @@ export class SessionScopeGuard implements CanActivate {
         // ownership guard then verifies it belongs to this user's
         // hydrated tenant.
         const scope = this.scopeContext.getScope();
+        if (
+            scope.organizationId !== null &&
+            scope.tenantId !== null &&
+            scope.tenantId === tenantId
+        ) {
+            await this.requireActiveOrganization(user.userId, scope.tenantId, scope.organizationId);
+        }
         if (scope.tenantId === null && tenantId !== null) {
             // Security: validate that lastScopeOrganizationId still belongs to
             // this user's tenant before seeding it as the active scope.
-            // If the org is missing or owned by a different tenant (e.g. stale
-            // pointer after a data migration or future membership-removal feature),
-            // fall back to bare-tenant scope (organizationId: null) rather than
-            // stamping rows under a foreign org's scope.
-            let resolvedOrganizationId: string | null = dbUser?.lastScopeOrganizationId ?? null;
-            if (resolvedOrganizationId !== null && this.organizationRepository) {
-                const org = await this.organizationRepository.findById(resolvedOrganizationId);
-                if (!org || org.tenantId !== tenantId) {
-                    this.logger.warn(
-                        `Stale lastScopeOrganizationId ${resolvedOrganizationId} for user ${user.userId} ` +
-                            `(expected tenantId=${tenantId}, got tenantId=${org?.tenantId ?? 'null'}). ` +
-                            `Falling back to bare-tenant scope.`,
-                    );
-                    resolvedOrganizationId = null;
-                }
+            // Missing, foreign, or revoked last-active Organizations fail with
+            // the same opaque 404 as an explicit slug request. Falling back to
+            // bare personal scope here would make revocation grant a different
+            // data surface that the caller did not explicitly select.
+            const resolvedOrganizationId: string | null = dbUser?.lastScopeOrganizationId ?? null;
+            if (resolvedOrganizationId !== null) {
+                await this.requireActiveOrganization(user.userId, tenantId, resolvedOrganizationId);
             }
             this.scopeContext.setScope({
                 tenantId,
@@ -129,5 +142,34 @@ export class SessionScopeGuard implements CanActivate {
         }
 
         return true;
+    }
+
+    /**
+     * Exact active-Organization authorization. Organization slugs are public,
+     * so missing rows and revoked roster membership deliberately collapse to
+     * the same non-enumerating 404.
+     */
+    private async requireActiveOrganization(
+        userId: string,
+        tenantId: string,
+        organizationId: string,
+    ): Promise<void> {
+        const organization = await this.organizationRepository.findById(organizationId);
+        if (!organization || organization.tenantId !== tenantId) {
+            throw new NotFoundException('Organization not found');
+        }
+
+        const [membership, tenant] = await Promise.all([
+            this.organizationMembers.findByOrgAndUser(organizationId, userId),
+            this.tenants.findById(tenantId),
+        ]);
+        if (
+            tenant?.ownerUserId === userId ||
+            (membership !== null && membership.tenantId === tenantId)
+        ) {
+            return;
+        }
+
+        throw new NotFoundException('Organization not found');
     }
 }

--- a/apps/api/src/tasks/task-chat.controller.scope.spec.ts
+++ b/apps/api/src/tasks/task-chat.controller.scope.spec.ts
@@ -1,0 +1,37 @@
+jest.mock('@ever-works/agent/tasks-domain', () => ({ TaskChatService: class {} }));
+jest.mock('@ever-works/agent/database', () => ({ AgentRepository: class {} }));
+
+import { TaskChatController } from './task-chat.controller';
+
+describe('TaskChatController — active ownership scope', () => {
+    it('threads active scope through mention lookup and the edit ownership gate', async () => {
+        const scope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+        const chat = { edit: jest.fn().mockResolvedValue({ id: 'message-1' }) };
+        const agents = {
+            findByUserIdScoped: jest.fn().mockResolvedValue({
+                rows: [{ id: 'agent-ever', slug: 'ceo' }],
+            }),
+        };
+        const controller = new (TaskChatController as any)(chat, agents, {
+            getScope: () => scope,
+        }) as TaskChatController;
+
+        await controller.editChat(
+            { userId: 'user-1' } as never,
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            { body: 'hello @ceo' },
+        );
+
+        expect(agents.findByUserIdScoped).toHaveBeenCalledWith('user-1', { limit: 500 }, scope);
+        expect(chat.edit).toHaveBeenCalledWith(
+            'user-1',
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            'hello @ceo',
+            { ownedAgentSlugs: new Map([['ceo', 'agent-ever']]) },
+            scope,
+        );
+    });
+});

--- a/apps/api/src/tasks/task-chat.controller.ts
+++ b/apps/api/src/tasks/task-chat.controller.ts
@@ -15,6 +15,7 @@ import { TaskChatService } from '@ever-works/agent/tasks-domain';
 import { AgentRepository } from '@ever-works/agent/database';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ScopeContextService } from '../scope/scope-context.service';
 
 /**
  * Agents/Skills/Tasks PR #1017 — Phase 13.2. Standalone controller
@@ -33,6 +34,7 @@ export class TaskChatController {
         // TaskChatService.edit per Review-fix I3) honest when the user
         // changes which Agent they were tagging mid-edit.
         private readonly agents: AgentRepository,
+        private readonly scopeContext: ScopeContextService,
     ) {}
 
     @Patch(':id')
@@ -50,15 +52,20 @@ export class TaskChatController {
         if (typeof body?.body !== 'string') {
             throw new BadRequestException('body is required.');
         }
+        const scope = this.scopeContext.getScope();
         const ownedAgentSlugs = new Map<string, string>();
         try {
-            const { rows } = await this.agents.findByUserIdScoped(auth.userId, { limit: 500 });
+            const { rows } = await this.agents.findByUserIdScoped(
+                auth.userId,
+                { limit: 500 },
+                scope,
+            );
             for (const a of rows) {
                 if (a?.slug && a?.id) ownedAgentSlugs.set(a.slug, a.id);
             }
         } catch {
             // Best-effort.
         }
-        return this.chat.edit(auth.userId, id, body.body, { ownedAgentSlugs });
+        return this.chat.edit(auth.userId, id, body.body, { ownedAgentSlugs }, scope);
     }
 }

--- a/apps/api/src/tasks/tasks.controller.board-visibility.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.board-visibility.spec.ts
@@ -43,6 +43,7 @@ describe('TasksController — includeHidden query mapping', () => {
             {} as never,
             {} as never,
             {} as never,
+            undefined as never,
         );
         return { controller, list };
     }

--- a/apps/api/src/tasks/tasks.controller.board-visibility.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.board-visibility.spec.ts
@@ -30,6 +30,10 @@ import { TasksController } from './tasks.controller';
  */
 describe('TasksController — includeHidden query mapping', () => {
     const auth = { userId: 'user-1' } as never;
+    const scope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
 
     function make() {
         const list = jest.fn().mockResolvedValue({ rows: [], total: 0 });
@@ -43,7 +47,7 @@ describe('TasksController — includeHidden query mapping', () => {
             {} as never,
             {} as never,
             {} as never,
-            undefined as never,
+            { getScope: () => scope } as never,
         );
         return { controller, list };
     }

--- a/apps/api/src/tasks/tasks.controller.pr-insights.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.pr-insights.spec.ts
@@ -54,6 +54,7 @@ describe('TasksController — PR insights endpoints', () => {
             {} as never,
             {} as never,
             { getForTask, getDiffForTask } as never,
+            undefined as never,
         );
         return { controller, getForTask, getDiffForTask };
     }

--- a/apps/api/src/tasks/tasks.controller.pr-insights.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.pr-insights.spec.ts
@@ -40,12 +40,17 @@ import { TasksController } from './tasks.controller';
  */
 describe('TasksController — PR insights endpoints', () => {
     const auth = { userId: 'user-1' } as never;
+    const scope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
 
     function make() {
+        const getOne = jest.fn().mockResolvedValue({ id: 'task-1', ...scope });
         const getForTask = jest.fn().mockResolvedValue({ taskId: 'task-1', cached: true });
         const getDiffForTask = jest.fn().mockResolvedValue({ taskId: 'task-1', diff: {} });
         const controller = new TasksController(
-            {} as never,
+            { getOne } as never,
             {} as never,
             {} as never,
             {} as never,
@@ -54,15 +59,16 @@ describe('TasksController — PR insights endpoints', () => {
             {} as never,
             {} as never,
             { getForTask, getDiffForTask } as never,
-            undefined as never,
+            { getScope: () => scope } as never,
         );
-        return { controller, getForTask, getDiffForTask };
+        return { controller, getOne, getForTask, getDiffForTask };
     }
 
     describe('GET /tasks/:id/pr-status', () => {
         it('scopes the read to the authenticated user', async () => {
-            const { controller, getForTask } = make();
+            const { controller, getOne, getForTask } = make();
             await controller.prStatus(auth, 'task-1');
+            expect(getOne).toHaveBeenCalledWith('user-1', 'task-1', scope);
             expect(getForTask).toHaveBeenCalledWith('user-1', 'task-1', { refresh: false });
         });
 

--- a/apps/api/src/tasks/tasks.controller.scope.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.scope.spec.ts
@@ -1,0 +1,67 @@
+jest.mock('@ever-works/agent/tasks-domain', () => ({
+    TasksService: class {},
+    TaskChatService: class {},
+    TaskReviewRejectionService: class {},
+    TaskWorkspaceService: class {},
+    TaskPrStatusService: class {},
+    TaskStatus: {},
+    TaskPriority: {},
+    RUN_BATCH_MAX_TASKS: 20,
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    PluginUsageRepository: class {},
+    AgentRepository: class {},
+}));
+jest.mock('@ever-works/agent/services', () => ({ DecisionConflictService: class {} }));
+jest.mock('@ever-works/agent/activity-log', () => ({ ActivityLogService: class {} }));
+jest.mock('@ever-works/agent/agents', () => ({ AgentEscalationService: class {} }));
+
+import { TasksController } from './tasks.controller';
+
+describe('TasksController — board-run active scope', () => {
+    const userId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const auth = { userId } as never;
+    const taskId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const agentId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+
+    function build() {
+        const service = {
+            runTasksBatch: jest.fn().mockResolvedValue({ results: [] }),
+            listRunCandidates: jest.fn().mockResolvedValue([]),
+            runTask: jest.fn().mockResolvedValue({ taskId, agentId }),
+        };
+        const controller = new TasksController(
+            service as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            { getScope: () => everScope } as never,
+        );
+        return { controller, service };
+    }
+
+    it('threads the exact active tenant and Organization through run, batch, and candidates', async () => {
+        const { controller, service } = build();
+
+        await controller.run(auth, taskId, { agentId });
+        await controller.runBatch(auth, { items: [{ taskId, agentId }] });
+        await controller.runCandidates(auth, taskId);
+
+        expect(service.runTask).toHaveBeenCalledWith(userId, taskId, { agentId }, everScope);
+        expect(service.runTasksBatch).toHaveBeenCalledWith(
+            userId,
+            [{ taskId, agentId }],
+            everScope,
+        );
+        expect(service.listRunCandidates).toHaveBeenCalledWith(userId, taskId, everScope);
+    });
+});

--- a/apps/api/src/tasks/tasks.controller.scope.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.scope.spec.ts
@@ -11,12 +11,17 @@ jest.mock('@ever-works/agent/tasks-domain', () => ({
 jest.mock('@ever-works/agent/database', () => ({
     PluginUsageRepository: class {},
     AgentRepository: class {},
+    ownershipScopeOf: (row: { tenantId?: string | null; organizationId?: string | null }) => ({
+        tenantId: row.tenantId ?? null,
+        organizationId: row.organizationId ?? null,
+    }),
 }));
 jest.mock('@ever-works/agent/services', () => ({ DecisionConflictService: class {} }));
 jest.mock('@ever-works/agent/activity-log', () => ({ ActivityLogService: class {} }));
 jest.mock('@ever-works/agent/agents', () => ({ AgentEscalationService: class {} }));
 
 import { TasksController } from './tasks.controller';
+import { NotFoundException } from '@nestjs/common';
 
 describe('TasksController — board-run active scope', () => {
     const userId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
@@ -32,7 +37,7 @@ describe('TasksController — board-run active scope', () => {
         const service = {
             list: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
             create: jest.fn().mockResolvedValue({ id: taskId }),
-            getOne: jest.fn().mockResolvedValue({ id: taskId, workId: null }),
+            getOne: jest.fn().mockResolvedValue({ id: taskId, workId: null, ...everScope }),
             update: jest.fn().mockResolvedValue({ id: taskId }),
             listSubtasks: jest.fn().mockResolvedValue({ rows: [], total: 0, doneCount: 0 }),
             remove: jest.fn().mockResolvedValue({ deleted: true }),
@@ -60,6 +65,7 @@ describe('TasksController — board-run active scope', () => {
             post: jest.fn().mockResolvedValue({ id: 'message-1' }),
         };
         const agents = { findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [] }) };
+        const escalations = { resolveForTask: jest.fn().mockResolvedValue(true) };
         const controller = new TasksController(
             service as never,
             chat as never,
@@ -68,11 +74,11 @@ describe('TasksController — board-run active scope', () => {
             {} as never,
             {} as never,
             {} as never,
-            {} as never,
+            escalations as never,
             {} as never,
             { getScope: () => everScope } as never,
         );
-        return { controller, service, chat, agents };
+        return { controller, service, chat, agents, escalations };
     }
 
     it('threads the exact active tenant and Organization through run, batch, and candidates', async () => {
@@ -89,6 +95,32 @@ describe('TasksController — board-run active scope', () => {
             everScope,
         );
         expect(service.listRunCandidates).toHaveBeenCalledWith(userId, taskId, everScope);
+    });
+
+    it('binds escalation resolution to the routed Task and its persisted scope', async () => {
+        const { controller, service, escalations } = build();
+        const escalationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+        await controller.resolveEscalation(auth, taskId, escalationId, { note: 'Approved' });
+
+        expect(service.getOne).toHaveBeenCalledWith(userId, taskId, everScope);
+        expect(escalations.resolveForTask).toHaveBeenCalledWith(
+            escalationId,
+            userId,
+            taskId,
+            everScope,
+            'Approved',
+        );
+    });
+
+    it('uses the same opaque 404 when scoped Task escalation CAS loses', async () => {
+        const { controller, escalations } = build();
+        const escalationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+        escalations.resolveForTask.mockResolvedValueOnce(false);
+
+        await expect(
+            controller.resolveEscalation(auth, taskId, escalationId, { note: 'Approved' }),
+        ).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('threads the exact active scope through every core Task and chat request operation', async () => {

--- a/apps/api/src/tasks/tasks.controller.scope.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.scope.spec.ts
@@ -20,8 +20,21 @@ jest.mock('@ever-works/agent/services', () => ({ DecisionConflictService: class 
 jest.mock('@ever-works/agent/activity-log', () => ({ ActivityLogService: class {} }));
 jest.mock('@ever-works/agent/agents', () => ({ AgentEscalationService: class {} }));
 
-import { TasksController } from './tasks.controller';
 import { NotFoundException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+    TaskChatService,
+    TaskPrStatusService,
+    TaskReviewRejectionService,
+    TasksService,
+    TaskWorkspaceService,
+} from '@ever-works/agent/tasks-domain';
+import { AgentRepository, PluginUsageRepository } from '@ever-works/agent/database';
+import { DecisionConflictService } from '@ever-works/agent/services';
+import { ActivityLogService } from '@ever-works/agent/activity-log';
+import { AgentEscalationService } from '@ever-works/agent/agents';
+import { ScopeContextService } from '../scope/scope-context.service';
+import { TasksController } from './tasks.controller';
 
 describe('TasksController — board-run active scope', () => {
     const userId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
@@ -33,7 +46,7 @@ describe('TasksController — board-run active scope', () => {
         organizationId: '22222222-2222-4222-8222-222222222222',
     };
 
-    function build() {
+    async function build() {
         const service = {
             list: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
             create: jest.fn().mockResolvedValue({ id: taskId }),
@@ -66,23 +79,31 @@ describe('TasksController — board-run active scope', () => {
         };
         const agents = { findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [] }) };
         const escalations = { resolveForTask: jest.fn().mockResolvedValue(true) };
-        const controller = new TasksController(
-            service as never,
-            chat as never,
-            { getTotalSpendCentsForTask: jest.fn().mockResolvedValue(0) } as never,
-            agents as never,
-            {} as never,
-            {} as never,
-            {} as never,
-            escalations as never,
-            {} as never,
-            { getScope: () => everScope } as never,
-        );
+        const moduleRef = await Test.createTestingModule({
+            controllers: [TasksController],
+            providers: [
+                { provide: TasksService, useValue: service },
+                { provide: TaskChatService, useValue: chat },
+                {
+                    provide: PluginUsageRepository,
+                    useValue: { getTotalSpendCentsForTask: jest.fn().mockResolvedValue(0) },
+                },
+                { provide: AgentRepository, useValue: agents },
+                { provide: TaskWorkspaceService, useValue: {} },
+                { provide: DecisionConflictService, useValue: {} },
+                { provide: TaskReviewRejectionService, useValue: {} },
+                { provide: AgentEscalationService, useValue: escalations },
+                { provide: TaskPrStatusService, useValue: {} },
+                { provide: ScopeContextService, useValue: { getScope: () => everScope } },
+                { provide: ActivityLogService, useValue: {} },
+            ],
+        }).compile();
+        const controller = moduleRef.get(TasksController);
         return { controller, service, chat, agents, escalations };
     }
 
     it('threads the exact active tenant and Organization through run, batch, and candidates', async () => {
-        const { controller, service } = build();
+        const { controller, service } = await build();
 
         await controller.run(auth, taskId, { agentId });
         await controller.runBatch(auth, { items: [{ taskId, agentId }] });
@@ -98,7 +119,7 @@ describe('TasksController — board-run active scope', () => {
     });
 
     it('binds escalation resolution to the routed Task and its persisted scope', async () => {
-        const { controller, service, escalations } = build();
+        const { controller, service, escalations } = await build();
         const escalationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 
         await controller.resolveEscalation(auth, taskId, escalationId, { note: 'Approved' });
@@ -114,7 +135,7 @@ describe('TasksController — board-run active scope', () => {
     });
 
     it('uses the same opaque 404 when scoped Task escalation CAS loses', async () => {
-        const { controller, escalations } = build();
+        const { controller, escalations } = await build();
         const escalationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
         escalations.resolveForTask.mockResolvedValueOnce(false);
 
@@ -124,7 +145,7 @@ describe('TasksController — board-run active scope', () => {
     });
 
     it('threads the exact active scope through every core Task and chat request operation', async () => {
-        const { controller, service, chat, agents } = build();
+        const { controller, service, chat, agents } = await build();
         const assigneeId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
         const attachmentId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
         const relatedTaskId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';

--- a/apps/api/src/tasks/tasks.controller.scope.spec.ts
+++ b/apps/api/src/tasks/tasks.controller.scope.spec.ts
@@ -4,8 +4,8 @@ jest.mock('@ever-works/agent/tasks-domain', () => ({
     TaskReviewRejectionService: class {},
     TaskWorkspaceService: class {},
     TaskPrStatusService: class {},
-    TaskStatus: {},
-    TaskPriority: {},
+    TaskStatus: { TODO: 'todo', IN_PROGRESS: 'in_progress' },
+    TaskPriority: { P3: 'p3' },
     RUN_BATCH_MAX_TASKS: 20,
 }));
 jest.mock('@ever-works/agent/database', () => ({
@@ -30,15 +30,41 @@ describe('TasksController — board-run active scope', () => {
 
     function build() {
         const service = {
+            list: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+            create: jest.fn().mockResolvedValue({ id: taskId }),
+            getOne: jest.fn().mockResolvedValue({ id: taskId, workId: null }),
+            update: jest.fn().mockResolvedValue({ id: taskId }),
+            listSubtasks: jest.fn().mockResolvedValue({ rows: [], total: 0, doneCount: 0 }),
+            remove: jest.fn().mockResolvedValue({ deleted: true }),
+            setRecurring: jest.fn().mockResolvedValue({ id: taskId }),
+            clearRecurring: jest.fn().mockResolvedValue({ id: taskId }),
+            scheduleTask: jest.fn().mockResolvedValue({ id: taskId }),
+            unscheduleTask: jest.fn().mockResolvedValue({ id: taskId }),
+            transition: jest.fn().mockResolvedValue({ id: taskId }),
+            addAssignee: jest.fn().mockResolvedValue({}),
+            removeAssignee: jest.fn().mockResolvedValue({ deleted: true }),
+            addReviewer: jest.fn().mockResolvedValue({}),
+            addApprover: jest.fn().mockResolvedValue({}),
+            addBlocker: jest.fn().mockResolvedValue({}),
+            removeBlocker: jest.fn().mockResolvedValue({ deleted: true }),
+            listAttachments: jest.fn().mockResolvedValue([]),
+            addAttachment: jest.fn().mockResolvedValue({}),
+            removeAttachment: jest.fn().mockResolvedValue({ deleted: true }),
+            addRelation: jest.fn().mockResolvedValue({}),
             runTasksBatch: jest.fn().mockResolvedValue({ results: [] }),
             listRunCandidates: jest.fn().mockResolvedValue([]),
             runTask: jest.fn().mockResolvedValue({ taskId, agentId }),
         };
+        const chat = {
+            list: jest.fn().mockResolvedValue([]),
+            post: jest.fn().mockResolvedValue({ id: 'message-1' }),
+        };
+        const agents = { findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [] }) };
         const controller = new TasksController(
             service as never,
-            {} as never,
-            {} as never,
-            {} as never,
+            chat as never,
+            { getTotalSpendCentsForTask: jest.fn().mockResolvedValue(0) } as never,
+            agents as never,
             {} as never,
             {} as never,
             {} as never,
@@ -46,7 +72,7 @@ describe('TasksController — board-run active scope', () => {
             {} as never,
             { getScope: () => everScope } as never,
         );
-        return { controller, service };
+        return { controller, service, chat, agents };
     }
 
     it('threads the exact active tenant and Organization through run, batch, and candidates', async () => {
@@ -63,5 +89,91 @@ describe('TasksController — board-run active scope', () => {
             everScope,
         );
         expect(service.listRunCandidates).toHaveBeenCalledWith(userId, taskId, everScope);
+    });
+
+    it('threads the exact active scope through every core Task and chat request operation', async () => {
+        const { controller, service, chat, agents } = build();
+        const assigneeId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+        const attachmentId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+        const relatedTaskId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+        await (controller.list as any)(auth);
+        await controller.create(auth, { title: 'Scoped' } as never);
+        await controller.getOne(auth, taskId);
+        await controller.update(auth, taskId, {} as never);
+        await controller.listSubtasks(auth, taskId);
+        await controller.remove(auth, taskId);
+        await controller.setRecurring(auth, taskId, { recurrenceRule: 'FREQ=DAILY' } as never);
+        await controller.schedule(auth, taskId, { runAt: '2099-01-01T00:00:00.000Z' } as never);
+        await controller.unschedule(auth, taskId);
+        await controller.clearRecurring(auth, taskId);
+        await controller.transition(auth, taskId, { to: 'in_progress', force: false } as never);
+        await controller.addAssignee(auth, taskId, {
+            assigneeType: 'agent',
+            assigneeId,
+        } as never);
+        await controller.removeAssignee(auth, taskId, assigneeId);
+        await controller.addReviewer(auth, taskId, {
+            reviewerType: 'agent',
+            reviewerId: assigneeId,
+        } as never);
+        await controller.addApprover(auth, taskId, {
+            approverType: 'agent',
+            approverId: assigneeId,
+        } as never);
+        await controller.addBlocker(auth, taskId, { blockedByTaskId: relatedTaskId });
+        await controller.removeBlocker(auth, taskId, relatedTaskId);
+        await controller.listAttachments(auth, taskId);
+        await controller.addAttachment(auth, taskId, {
+            uploadId: attachmentId,
+            role: 'initial',
+        } as never);
+        await controller.removeAttachment(auth, taskId, attachmentId);
+        await controller.addRelation(auth, taskId, {
+            relatedTaskId,
+            kind: 'related',
+        } as never);
+        await (controller.listChat as any)(auth, taskId);
+        await (controller.spend as any)(auth, taskId);
+        await controller.postChat(auth, taskId, { body: 'hello' } as never);
+
+        const scopedMethods = [
+            'list',
+            'create',
+            'getOne',
+            'update',
+            'listSubtasks',
+            'remove',
+            'setRecurring',
+            'scheduleTask',
+            'unscheduleTask',
+            'clearRecurring',
+            'transition',
+            'addAssignee',
+            'removeAssignee',
+            'addReviewer',
+            'addApprover',
+            'addBlocker',
+            'removeBlocker',
+            'listAttachments',
+            'addAttachment',
+            'removeAttachment',
+            'addRelation',
+        ] as const;
+        for (const method of scopedMethods) {
+            expect(
+                service[method].mock.calls.some(
+                    (call: unknown[]) => call[call.length - 1] === everScope,
+                ),
+            ).toBe(true);
+        }
+        expect(chat.list).toHaveBeenCalledWith(userId, taskId, expect.any(Object), everScope);
+        expect(chat.post).toHaveBeenCalledWith(
+            userId,
+            expect.objectContaining({ taskId }),
+            expect.any(Object),
+            everScope,
+        );
+        expect(agents.findByUserIdScoped).toHaveBeenCalledWith(userId, { limit: 500 }, everScope);
     });
 });

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -43,7 +43,7 @@ import { PluginUsageRepository } from '@ever-works/agent/database';
 // drive the chat-dispatch fan-out (TaskChatService:136-168). The
 // repository class lives under `@ever-works/agent/database` (the
 // agents barrel re-exports services + module only).
-import { AgentRepository, type OwnershipScope } from '@ever-works/agent/database';
+import { AgentRepository, ownershipScopeOf, type OwnershipScope } from '@ever-works/agent/database';
 import { TaskWorkspaceService } from '@ever-works/agent/tasks-domain';
 // Re-litigation guard (memory upgrades M6) — provided + exported by
 // `KnowledgeBaseModule`, which the api-side TasksModule imports.
@@ -733,10 +733,12 @@ export class TasksController {
         @Param('escalationId', ParseUUIDPipe) escalationId: string,
         @Body() body: ResolveEscalationDto,
     ) {
-        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
-        const resolved = await this.escalations.resolve(
+        const task = await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
+        const resolved = await this.escalations.resolveForTask(
             escalationId,
             auth.userId,
+            id,
+            ownershipScopeOf(task),
             body.note ?? null,
         );
         if (!resolved) {

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -43,7 +43,7 @@ import { PluginUsageRepository } from '@ever-works/agent/database';
 // drive the chat-dispatch fan-out (TaskChatService:136-168). The
 // repository class lives under `@ever-works/agent/database` (the
 // agents barrel re-exports services + module only).
-import { AgentRepository } from '@ever-works/agent/database';
+import { AgentRepository, type OwnershipScope } from '@ever-works/agent/database';
 import { TaskWorkspaceService } from '@ever-works/agent/tasks-domain';
 // Re-litigation guard (memory upgrades M6) — provided + exported by
 // `KnowledgeBaseModule`, which the api-side TasksModule imports.
@@ -153,10 +153,14 @@ export class TasksController {
      * per post — Agent slugs change rarely enough that caching is
      * unnecessary for v1.
      */
-    private async buildMentionLookups(userId: string) {
+    private async buildMentionLookups(userId: string, ownershipScope: OwnershipScope) {
         const ownedAgentSlugs = new Map<string, string>();
         try {
-            const { rows } = await this.agents.findByUserIdScoped(userId, { limit: 500 });
+            const { rows } = await this.agents.findByUserIdScoped(
+                userId,
+                { limit: 500 },
+                ownershipScope,
+            );
             for (const a of rows) {
                 if (a?.slug && a?.id) ownedAgentSlugs.set(a.slug, a.id);
             }
@@ -209,9 +213,14 @@ export class TasksController {
             limit: limit ? Math.min(200, Math.max(1, parseInt(limit, 10) || 50)) : 50,
             offset: offset ? Math.max(0, parseInt(offset, 10) || 0) : 0,
         };
-        const { rows, total } = await this.service.list(auth.userId, filter, {
-            includeRun: includeRun === 'true',
-        });
+        const { rows, total } = await this.service.list(
+            auth.userId,
+            filter,
+            {
+                includeRun: includeRun === 'true',
+            },
+            this.scopeContext.getScope(),
+        );
         return { data: rows, meta: { total, limit: filter.limit, offset: filter.offset } };
     }
 
@@ -221,27 +230,31 @@ export class TasksController {
     @Throttle({ long: { limit: 60, ttl: 60_000 } })
     async create(@CurrentUser() auth: AuthenticatedUser, @Body() body: CreateTaskDto) {
         if (!body?.title) throw new BadRequestException('title is required.');
-        return this.service.create(auth.userId, {
-            title: body.title,
-            description: body.description ?? null,
-            status: body.status,
-            priority: body.priority,
-            labels: body.labels ?? null,
-            isolationMode: body.isolationMode ?? null,
-            missionId: body.missionId ?? null,
-            ideaId: body.ideaId ?? null,
-            workId: body.workId ?? null,
-            teamId: body.teamId ?? null,
-            agentId: body.agentId ?? null,
-            goalId: body.goalId ?? null,
-            parentTaskId: body.parentTaskId ?? null,
-            createdByType: 'user',
-            createdById: auth.userId,
-            requireAllApprovers: body.requireAllApprovers,
-            acceptanceChecks: body.acceptanceChecks ?? null,
-            maxGateAttempts: body.maxGateAttempts ?? null,
-            scheduledAt: body.scheduledAt ? new Date(body.scheduledAt) : null,
-        });
+        return this.service.create(
+            auth.userId,
+            {
+                title: body.title,
+                description: body.description ?? null,
+                status: body.status,
+                priority: body.priority,
+                labels: body.labels ?? null,
+                isolationMode: body.isolationMode ?? null,
+                missionId: body.missionId ?? null,
+                ideaId: body.ideaId ?? null,
+                workId: body.workId ?? null,
+                teamId: body.teamId ?? null,
+                agentId: body.agentId ?? null,
+                goalId: body.goalId ?? null,
+                parentTaskId: body.parentTaskId ?? null,
+                createdByType: 'user',
+                createdById: auth.userId,
+                requireAllApprovers: body.requireAllApprovers,
+                acceptanceChecks: body.acceptanceChecks ?? null,
+                maxGateAttempts: body.maxGateAttempts ?? null,
+                scheduledAt: body.scheduledAt ? new Date(body.scheduledAt) : null,
+            },
+            this.scopeContext.getScope(),
+        );
     }
 
     // Declared BEFORE every `:id` route: `run-batch` is a single path
@@ -267,7 +280,7 @@ export class TasksController {
     @ApiOperation({ summary: 'Get one Task.' })
     @HttpCode(HttpStatus.OK)
     async getOne(@CurrentUser() auth: AuthenticatedUser, @Param('id', ParseUUIDPipe) id: string) {
-        return this.service.getOne(auth.userId, id);
+        return this.service.getOne(auth.userId, id, this.scopeContext.getScope());
     }
 
     @Get(':id/decision-conflicts')
@@ -284,7 +297,7 @@ export class TasksController {
     ) {
         // Owner scope + existence: `getOne` throws NotFound for a Task
         // the caller doesn't own (no 403 existence leak).
-        const task = await this.service.getOne(auth.userId, id);
+        const task = await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         return this.decisionConflicts.checkIntent({
             workId: task.workId ?? null,
             userId: auth.userId,
@@ -306,15 +319,20 @@ export class TasksController {
         // service works in `Date` (the column is a timestamptz). The
         // three states are distinct: absent = untouched, null = clear
         // the schedule, string = (re-)schedule.
-        return this.service.update(auth.userId, id, {
-            ...body,
-            scheduledAt:
-                body.scheduledAt === undefined
-                    ? undefined
-                    : body.scheduledAt === null
-                      ? null
-                      : new Date(body.scheduledAt),
-        });
+        return this.service.update(
+            auth.userId,
+            id,
+            {
+                ...body,
+                scheduledAt:
+                    body.scheduledAt === undefined
+                        ? undefined
+                        : body.scheduledAt === null
+                          ? null
+                          : new Date(body.scheduledAt),
+            },
+            this.scopeContext.getScope(),
+        );
     }
 
     @Get(':id/subtasks')
@@ -327,7 +345,11 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        const { rows, total, doneCount } = await this.service.listSubtasks(auth.userId, id);
+        const { rows, total, doneCount } = await this.service.listSubtasks(
+            auth.userId,
+            id,
+            this.scopeContext.getScope(),
+        );
         return { data: rows, meta: { total, doneCount } };
     }
 
@@ -336,7 +358,7 @@ export class TasksController {
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     async remove(@CurrentUser() auth: AuthenticatedUser, @Param('id', ParseUUIDPipe) id: string) {
-        return this.service.remove(auth.userId, id);
+        return this.service.remove(auth.userId, id, this.scopeContext.getScope());
     }
 
     @Post(':id/recurring')
@@ -354,13 +376,18 @@ export class TasksController {
         if (!body?.recurrenceRule && !body?.recurrenceCron) {
             throw new BadRequestException('recurrenceRule or recurrenceCron is required.');
         }
-        return this.service.setRecurring(auth.userId, id, {
-            recurrenceRule: body.recurrenceRule ?? null,
-            recurrenceCron: body.recurrenceCron ?? null,
-            recurrenceTimezone: body.recurrenceTimezone,
-            recurrenceEndsAt: body.recurrenceEndsAt ? new Date(body.recurrenceEndsAt) : null,
-            recurrenceMaxOccurrences: body.recurrenceMaxOccurrences ?? null,
-        });
+        return this.service.setRecurring(
+            auth.userId,
+            id,
+            {
+                recurrenceRule: body.recurrenceRule ?? null,
+                recurrenceCron: body.recurrenceCron ?? null,
+                recurrenceTimezone: body.recurrenceTimezone,
+                recurrenceEndsAt: body.recurrenceEndsAt ? new Date(body.recurrenceEndsAt) : null,
+                recurrenceMaxOccurrences: body.recurrenceMaxOccurrences ?? null,
+            },
+            this.scopeContext.getScope(),
+        );
     }
 
     // ── Schedule mode "Scheduled" (one-shot) ──────────────────────
@@ -378,7 +405,12 @@ export class TasksController {
         @Body() body: ScheduleTaskDto,
     ) {
         if (!body?.runAt) throw new BadRequestException('runAt is required.');
-        return this.service.scheduleTask(auth.userId, id, new Date(body.runAt));
+        return this.service.scheduleTask(
+            auth.userId,
+            id,
+            new Date(body.runAt),
+            this.scopeContext.getScope(),
+        );
     }
 
     @Delete(':id/schedule')
@@ -388,7 +420,7 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return this.service.unscheduleTask(auth.userId, id);
+        return this.service.unscheduleTask(auth.userId, id, this.scopeContext.getScope());
     }
 
     // ── Tasks upgrades — per-Task activity feed ───────────────────
@@ -406,7 +438,7 @@ export class TasksController {
         @Query('offset') offset?: string,
     ) {
         // 404-no-leak gate before any activity row is read.
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         if (!this.activityLog) {
             return { data: [], meta: { total: 0 } };
         }
@@ -429,7 +461,7 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return this.service.clearRecurring(auth.userId, id);
+        return this.service.clearRecurring(auth.userId, id, this.scopeContext.getScope());
     }
 
     @Post(':id/transition')
@@ -444,7 +476,13 @@ export class TasksController {
         if (!Object.values(TaskStatus).includes(body?.to)) {
             throw new BadRequestException(`Invalid target status: ${body?.to}`);
         }
-        return this.service.transition(auth.userId, id, body.to, { force: body.force === true });
+        return this.service.transition(
+            auth.userId,
+            id,
+            body.to,
+            { force: body.force === true },
+            this.scopeContext.getScope(),
+        );
     }
 
     // ── Board dispatch (kanban M3 / M4) ───────────────────────────
@@ -504,6 +542,7 @@ export class TasksController {
         @Param('id', ParseUUIDPipe) id: string,
         @Query('refresh') refresh?: string,
     ) {
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         return this.prInsights.getForTask(auth.userId, id, { refresh: refresh === 'true' });
     }
 
@@ -525,6 +564,7 @@ export class TasksController {
         @Query('maxFiles') maxFiles?: string,
         @Query('maxBytes') maxBytes?: string,
     ) {
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         return this.prInsights.getDiffForTask(auth.userId, id, {
             maxFiles: clampNumeric(maxFiles, MAX_DIFF_FILES),
             maxBytes: clampNumeric(maxBytes, MAX_DIFF_BYTES),
@@ -539,6 +579,7 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         try {
             return await this.taskWorkspace.resolveConflicts(auth.userId, id);
         } catch (error) {
@@ -561,6 +602,7 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         try {
             await this.taskWorkspace.discardBranch(auth.userId, id);
             return { ok: true };
@@ -581,7 +623,13 @@ export class TasksController {
         @Body() body: AddAssigneeDto,
     ) {
         this.assertActorType(body.assigneeType);
-        return this.service.addAssignee(auth.userId, id, body.assigneeType, body.assigneeId);
+        return this.service.addAssignee(
+            auth.userId,
+            id,
+            body.assigneeType,
+            body.assigneeId,
+            this.scopeContext.getScope(),
+        );
     }
 
     @Delete(':id/assignees/:assigneeId')
@@ -592,7 +640,12 @@ export class TasksController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('assigneeId', ParseUUIDPipe) assigneeId: string,
     ) {
-        return this.service.removeAssignee(auth.userId, id, assigneeId);
+        return this.service.removeAssignee(
+            auth.userId,
+            id,
+            assigneeId,
+            this.scopeContext.getScope(),
+        );
     }
 
     @Post(':id/reviewers')
@@ -604,7 +657,13 @@ export class TasksController {
         @Body() body: AddReviewerDto,
     ) {
         this.assertActorType(body.reviewerType);
-        return this.service.addReviewer(auth.userId, id, body.reviewerType, body.reviewerId);
+        return this.service.addReviewer(
+            auth.userId,
+            id,
+            body.reviewerType,
+            body.reviewerId,
+            this.scopeContext.getScope(),
+        );
     }
 
     /**
@@ -629,6 +688,7 @@ export class TasksController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: RejectTaskDto,
     ) {
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         const row = await this.rejections.rejectTask(auth.userId, id, body.feedback, {
             runId: body.runId ?? null,
         });
@@ -659,7 +719,7 @@ export class TasksController {
     ) {
         // 404-no-leak gate: getOne is owner-scoped and throws for a
         // foreign or missing Task before any escalation row is read.
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         return { data: await this.escalations.listForTask(id) };
     }
 
@@ -673,7 +733,7 @@ export class TasksController {
         @Param('escalationId', ParseUUIDPipe) escalationId: string,
         @Body() body: ResolveEscalationDto,
     ) {
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         const resolved = await this.escalations.resolve(
             escalationId,
             auth.userId,
@@ -698,7 +758,13 @@ export class TasksController {
         @Body() body: AddApproverDto,
     ) {
         this.assertActorType(body.approverType);
-        return this.service.addApprover(auth.userId, id, body.approverType, body.approverId);
+        return this.service.addApprover(
+            auth.userId,
+            id,
+            body.approverType,
+            body.approverId,
+            this.scopeContext.getScope(),
+        );
     }
 
     @Post(':id/blocks')
@@ -710,7 +776,12 @@ export class TasksController {
         @Body() body: AddBlockerDto,
     ) {
         if (!body?.blockedByTaskId) throw new BadRequestException('blockedByTaskId is required.');
-        return this.service.addBlocker(auth.userId, id, body.blockedByTaskId);
+        return this.service.addBlocker(
+            auth.userId,
+            id,
+            body.blockedByTaskId,
+            this.scopeContext.getScope(),
+        );
     }
 
     @Delete(':id/blocks/:blockId')
@@ -721,7 +792,7 @@ export class TasksController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('blockId', ParseUUIDPipe) blockId: string,
     ) {
-        return this.service.removeBlocker(auth.userId, id, blockId);
+        return this.service.removeBlocker(auth.userId, id, blockId, this.scopeContext.getScope());
     }
 
     @Get(':id/attachments')
@@ -731,7 +802,7 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return this.service.listAttachments(auth.userId, id);
+        return this.service.listAttachments(auth.userId, id, this.scopeContext.getScope());
     }
 
     @Post(':id/attachments')
@@ -747,7 +818,13 @@ export class TasksController {
         @Body() body: AddAttachmentDto,
     ) {
         if (!body?.uploadId) throw new BadRequestException('uploadId is required.');
-        return this.service.addAttachment(auth.userId, id, body.uploadId, body.role ?? 'initial');
+        return this.service.addAttachment(
+            auth.userId,
+            id,
+            body.uploadId,
+            body.role ?? 'initial',
+            this.scopeContext.getScope(),
+        );
     }
 
     @Delete(':id/attachments/:attachmentId')
@@ -758,7 +835,12 @@ export class TasksController {
         @Param('id', ParseUUIDPipe) id: string,
         @Param('attachmentId', ParseUUIDPipe) attachmentId: string,
     ) {
-        return this.service.removeAttachment(auth.userId, id, attachmentId);
+        return this.service.removeAttachment(
+            auth.userId,
+            id,
+            attachmentId,
+            this.scopeContext.getScope(),
+        );
     }
 
     @Post(':id/relations')
@@ -773,7 +855,13 @@ export class TasksController {
         if (!['related', 'duplicates', 'follow-up'].includes(body.kind)) {
             throw new BadRequestException(`Invalid relation kind: ${body.kind}`);
         }
-        return this.service.addRelation(auth.userId, id, body.relatedTaskId, body.kind);
+        return this.service.addRelation(
+            auth.userId,
+            id,
+            body.relatedTaskId,
+            body.kind,
+            this.scopeContext.getScope(),
+        );
     }
 
     private parseStatusList(value?: string): TaskStatus | TaskStatus[] | undefined {
@@ -825,10 +913,15 @@ export class TasksController {
         @Query('limit') limit?: string,
         @Query('offset') offset?: string,
     ) {
-        const messages = await this.chat.list(auth.userId, id, {
-            limit: limit ? Math.min(200, Math.max(1, parseInt(limit, 10) || 50)) : 50,
-            offset: offset ? Math.max(0, parseInt(offset, 10) || 0) : 0,
-        });
+        const messages = await this.chat.list(
+            auth.userId,
+            id,
+            {
+                limit: limit ? Math.min(200, Math.max(1, parseInt(limit, 10) || 50)) : 50,
+                offset: offset ? Math.max(0, parseInt(offset, 10) || 0) : 0,
+            },
+            this.scopeContext.getScope(),
+        );
         return { data: messages };
     }
 
@@ -843,7 +936,7 @@ export class TasksController {
         @Query('currency') currency?: string,
     ) {
         // Cross-user ownership check — 404 if Task doesn't belong to user.
-        await this.service.getOne(auth.userId, id);
+        await this.service.getOne(auth.userId, id, this.scopeContext.getScope());
         const totalCents = await this.pluginUsage.getTotalSpendCentsForTask(id, {
             since: since ? new Date(since) : undefined,
             until: until ? new Date(until) : undefined,
@@ -873,7 +966,8 @@ export class TasksController {
         // mentioned Agent. Unknown tokens are still stripped (T6
         // posture). Known-user-slugs + known-kb-slugs maps land in
         // a follow-up once those domains expose lookup helpers.
-        const lookups = await this.buildMentionLookups(auth.userId);
+        const scope = this.scopeContext.getScope();
+        const lookups = await this.buildMentionLookups(auth.userId, scope);
         return this.chat.post(
             auth.userId,
             {
@@ -884,6 +978,7 @@ export class TasksController {
                 attachments: body.attachments,
             },
             lookups,
+            scope,
         );
     }
 }

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -50,6 +50,7 @@ import { TaskWorkspaceService } from '@ever-works/agent/tasks-domain';
 import { DecisionConflictService } from '@ever-works/agent/services';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ScopeContextService } from '../scope/scope-context.service';
 import {
     AddApproverDto,
     AddAssigneeDto,
@@ -133,6 +134,10 @@ export class TasksController {
         private readonly escalations: AgentEscalationService,
         // Kanban run cockpit (plan 04 M5/M6) — PR status pill + diff sheet.
         private readonly prInsights: TaskPrStatusService,
+        // Board run routes must use the active request scope, not only the
+        // authenticated user. Kept immediately before the optional tail so
+        // Nest treats this as a required production dependency.
+        private readonly scopeContext: ScopeContextService,
         // Tasks upgrades — per-Task activity feed. Appended LAST +
         // @Optional() so every existing positional construction in the
         // specs keeps compiling; the endpoint degrades to an empty feed
@@ -254,6 +259,7 @@ export class TasksController {
         return this.service.runTasksBatch(
             auth.userId,
             body.items.map((item) => ({ taskId: item.taskId, agentId: item.agentId ?? null })),
+            this.scopeContext.getScope(),
         );
     }
 
@@ -453,7 +459,13 @@ export class TasksController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ) {
-        return { data: await this.service.listRunCandidates(auth.userId, id) };
+        return {
+            data: await this.service.listRunCandidates(
+                auth.userId,
+                id,
+                this.scopeContext.getScope(),
+            ),
+        };
     }
 
     @Post(':id/run')
@@ -468,7 +480,12 @@ export class TasksController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: RunTaskDto,
     ) {
-        return this.service.runTask(auth.userId, id, { agentId: body?.agentId ?? null });
+        return this.service.runTask(
+            auth.userId,
+            id,
+            { agentId: body?.agentId ?? null },
+            this.scopeContext.getScope(),
+        );
     }
 
     // ── PR insights (kanban M5 / M6) ──────────────────────────────

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -357,6 +357,139 @@ describe('UploadsController', () => {
             expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
         });
 
+        it('hydrates and validates the persisted Ever default for a bearer with no explicit scope', async () => {
+            const ctx = publicController({
+                activeScope: { tenantId: null, organizationId: null },
+                bearer: true,
+                user: {
+                    id: bearerUserId,
+                    tenantId: everScope.tenantId,
+                    lastScopeOrganizationId: everScope.organizationId,
+                    isActive: true,
+                },
+            });
+
+            await ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined);
+
+            expect(ctx.members.findByOrgAndUser).toHaveBeenCalledWith(
+                everScope.organizationId,
+                bearerUserId,
+            );
+            expect(ctx.uploads.saveImage).toHaveBeenCalledWith(bearerUserId, expect.anything(), {
+                ownershipScope: everScope,
+            });
+            expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(everScope);
+        });
+
+        it.each([
+            [
+                'file',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymousFile(mkFile({}), ctx.req),
+            ],
+            [
+                'presign',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.presign(
+                        { filename: 'direct.png', mimeType: 'image/png', size: 100 },
+                        ctx.req,
+                    ),
+            ],
+        ] as const)(
+            'hydrates and validates the persisted Ever default before a headerless %s',
+            async (label, invoke) => {
+                const ctx = publicController({
+                    activeScope: { tenantId: null, organizationId: null },
+                    bearer: true,
+                    user: {
+                        id: bearerUserId,
+                        tenantId: everScope.tenantId,
+                        lastScopeOrganizationId: everScope.organizationId,
+                        isActive: true,
+                    },
+                });
+
+                await invoke(ctx);
+
+                expect(ctx.members.findByOrgAndUser).toHaveBeenCalledWith(
+                    everScope.organizationId,
+                    bearerUserId,
+                );
+                if (label === 'file') {
+                    expect(ctx.uploads.saveFile).toHaveBeenCalledWith(
+                        bearerUserId,
+                        expect.anything(),
+                        { ownershipScope: everScope },
+                    );
+                } else {
+                    expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
+                }
+                expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(everScope);
+            },
+        );
+
+        it.each([
+            [
+                'image',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined),
+            ],
+            [
+                'file',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymousFile(mkFile({}), ctx.req),
+            ],
+        ] as const)(
+            'opaquely rejects a revoked persisted Ever default before a headerless %s upload',
+            async (_label, invoke) => {
+                const ctx = publicController({
+                    activeScope: { tenantId: null, organizationId: null },
+                    bearer: true,
+                    user: {
+                        id: bearerUserId,
+                        tenantId: everScope.tenantId,
+                        lastScopeOrganizationId: everScope.organizationId,
+                        isActive: true,
+                    },
+                    member: null,
+                    tenant: { id: everScope.tenantId, ownerUserId: 'other' },
+                });
+
+                await expect(invoke(ctx)).rejects.toBeInstanceOf(NotFoundException);
+                expect(ctx.uploads.saveImage).not.toHaveBeenCalled();
+                expect(ctx.uploads.saveFile).not.toHaveBeenCalled();
+            },
+        );
+
+        it.each([
+            ['revoked', { member: null }],
+            ['unknown', { organization: null }],
+        ] as const)(
+            'opaquely rejects a bearer whose persisted Ever default is %s before presigning',
+            async (_label, overrides) => {
+                const ctx = publicController({
+                    activeScope: { tenantId: null, organizationId: null },
+                    bearer: true,
+                    user: {
+                        id: bearerUserId,
+                        tenantId: everScope.tenantId,
+                        lastScopeOrganizationId: everScope.organizationId,
+                        isActive: true,
+                    },
+                    tenant: { id: everScope.tenantId, ownerUserId: 'other' },
+                    ...overrides,
+                });
+
+                await expect(
+                    ctx.controller.presign(
+                        { filename: 'direct.png', mimeType: 'image/png', size: 100 },
+                        ctx.req,
+                    ),
+                ).rejects.toBeInstanceOf(NotFoundException);
+                expect(ctx.uploads.getBackend).not.toHaveBeenCalled();
+            },
+        );
+
         it.each([
             [
                 'known Yo member',

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -6,6 +6,10 @@
 jest.mock('@ever-works/agent/database', () => ({
     UserUploadRepository: class {},
     WorkRepository: class {},
+    UserRepository: class {},
+    OrganizationRepository: class {},
+    OrganizationMemberRepository: class {},
+    TenantRepository: class {},
     ownershipScopeMatches: (
         row: { tenantId?: string | null; organizationId?: string | null },
         scope?: { tenantId: string | null; organizationId: string | null },
@@ -29,7 +33,14 @@ import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Test } from '@nestjs/testing';
-import { UserUploadRepository, WorkRepository } from '@ever-works/agent/database';
+import {
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    TenantRepository,
+    UserRepository,
+    UserUploadRepository,
+    WorkRepository,
+} from '@ever-works/agent/database';
 import { UploadsController } from './uploads.controller';
 import { UploadsService, USER_UPLOAD_REPOSITORY } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
@@ -138,11 +149,297 @@ describe('UploadsController', () => {
             expect.arrayContaining([
                 { index: 3, param: WorkRepository },
                 { index: 4, param: UserUploadRepository },
+                { index: 6, param: UserRepository },
+                { index: 7, param: OrganizationRepository },
+                { index: 8, param: OrganizationMemberRepository },
+                { index: 9, param: TenantRepository },
             ]),
         );
         expect(Reflect.getMetadata('design:paramtypes', UploadsController)[5]).toBe(
             ScopeContextService,
         );
+    });
+
+    describe('public upload routes — bearer-aware scope hydration', () => {
+        const bearerUserId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        const yoMemberId = bearerUserId;
+        const fileResult = {
+            id: 'a'.repeat(64),
+            url: `/api/uploads/${bearerUserId}/${'a'.repeat(64)}.png`,
+            filename: `${'a'.repeat(64)}.png`,
+            size: TINY_PNG.length,
+            mimeType: 'image/png',
+            hash: 'a'.repeat(64),
+            key: `${bearerUserId}/${'a'.repeat(64)}.png`,
+        };
+
+        function publicController(options: {
+            activeScope: { tenantId: string | null; organizationId: string | null };
+            bearer?: boolean;
+            authRejects?: boolean;
+            user?: object | null;
+            organization?: object | null;
+            member?: object | null;
+            tenant?: object | null;
+        }) {
+            const uploads = {
+                saveImage: jest.fn().mockResolvedValue(fileResult),
+                saveFile: jest.fn().mockResolvedValue(fileResult),
+                getBackend: jest.fn().mockResolvedValue({
+                    presignPut: jest.fn().mockResolvedValue({
+                        url: 'https://storage.test/put',
+                        key: `${bearerUserId}/direct.png`,
+                        expiresAt: '2099-01-01T00:00:00.000Z',
+                    }),
+                }),
+            };
+            const anonymousAuth = {
+                createAnonymousUser: jest.fn().mockResolvedValue({
+                    user: {
+                        id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+                        anonymousExpiresAt: '2099-01-01T00:00:00.000Z',
+                    },
+                    access_token: 'anon-token',
+                }),
+            };
+            const authProvider = {
+                authenticate: options.authRejects
+                    ? jest.fn().mockRejectedValue(new Error('invalid bearer'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              options.bearer ? mkAuth({ userId: bearerUserId }) : null,
+                          ),
+            };
+            const scopeContext = {
+                getScope: jest.fn().mockReturnValue(options.activeScope),
+                setScope: jest.fn(),
+            };
+            const users = {
+                findById: jest
+                    .fn()
+                    .mockResolvedValue(
+                        options.user === undefined
+                            ? { id: bearerUserId, tenantId: everScope.tenantId, isActive: true }
+                            : options.user,
+                    ),
+            };
+            const organizations = {
+                findById: jest
+                    .fn()
+                    .mockResolvedValue(
+                        options.organization === undefined
+                            ? { id: everScope.organizationId, tenantId: everScope.tenantId }
+                            : options.organization,
+                    ),
+            };
+            const members = {
+                findByOrgAndUser: jest.fn().mockResolvedValue(
+                    options.member === undefined
+                        ? {
+                              userId: bearerUserId,
+                              tenantId: everScope.tenantId,
+                              organizationId: everScope.organizationId,
+                          }
+                        : options.member,
+                ),
+            };
+            const tenants = {
+                findById: jest
+                    .fn()
+                    .mockResolvedValue(
+                        options.tenant === undefined
+                            ? { id: everScope.tenantId, ownerUserId: 'owner-other' }
+                            : options.tenant,
+                    ),
+            };
+            const scopedController = new (UploadsController as any)(
+                uploads,
+                anonymousAuth,
+                authProvider,
+                undefined,
+                undefined,
+                scopeContext,
+                users,
+                organizations,
+                members,
+                tenants,
+            ) as UploadsController;
+            const req = {
+                headers:
+                    options.bearer || options.authRejects ? { authorization: 'Bearer token' } : {},
+            } as never;
+            return {
+                controller: scopedController,
+                uploads,
+                anonymousAuth,
+                authProvider,
+                scopeContext,
+                users,
+                organizations,
+                members,
+                tenants,
+                req,
+            };
+        }
+
+        it.each([
+            [
+                'image',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined),
+            ],
+            [
+                'file',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymousFile(mkFile({}), ctx.req),
+            ],
+        ] as const)(
+            'forces a truly anonymous spoofed-scope %s upload to explicit null/null',
+            async (_label, invoke) => {
+                const ctx = publicController({ activeScope: everScope });
+
+                await invoke(ctx);
+
+                expect(ctx.scopeContext.setScope).toHaveBeenCalledWith({
+                    tenantId: null,
+                    organizationId: null,
+                });
+                const save = _label === 'image' ? ctx.uploads.saveImage : ctx.uploads.saveFile;
+                expect(save).toHaveBeenCalledWith(
+                    'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+                    expect.anything(),
+                    { ownershipScope: { tenantId: null, organizationId: null } },
+                );
+            },
+        );
+
+        it.each([
+            [
+                'image',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined),
+            ],
+            [
+                'file',
+                (ctx: ReturnType<typeof publicController>) =>
+                    ctx.controller.uploadAnonymousFile(mkFile({}), ctx.req),
+            ],
+        ] as const)(
+            'hydrates and explicitly stamps a valid Ever bearer %s upload',
+            async (_label, invoke) => {
+                const ctx = publicController({ activeScope: everScope, bearer: true });
+
+                await invoke(ctx);
+
+                expect(ctx.anonymousAuth.createAnonymousUser).not.toHaveBeenCalled();
+                const save = _label === 'image' ? ctx.uploads.saveImage : ctx.uploads.saveFile;
+                expect(save).toHaveBeenCalledWith(bearerUserId, expect.anything(), {
+                    ownershipScope: everScope,
+                });
+                expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(everScope);
+            },
+        );
+
+        it('authorizes a valid Ever bearer before presigning', async () => {
+            const ctx = publicController({ activeScope: everScope, bearer: true });
+
+            await ctx.controller.presign(
+                { filename: 'direct.png', mimeType: 'image/png', size: 100 },
+                ctx.req,
+            );
+
+            expect(ctx.users.findById).toHaveBeenCalledWith(bearerUserId);
+            expect(ctx.members.findByOrgAndUser).toHaveBeenCalledWith(
+                everScope.organizationId,
+                bearerUserId,
+            );
+            expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            [
+                'known Yo member',
+                {
+                    member: {
+                        userId: bearerUserId,
+                        tenantId: yoScope.tenantId,
+                        organizationId: yoScope.organizationId,
+                    },
+                    tenant: { id: everScope.tenantId, ownerUserId: 'other' },
+                },
+            ],
+            [
+                'revoked Ever member',
+                { member: null, tenant: { id: everScope.tenantId, ownerUserId: 'other' } },
+            ],
+            ['unknown Organization', { organization: null }],
+        ] as const)(
+            'opaquely rejects a bearer with %s before upload or presign',
+            async (_label, overrides) => {
+                const uploadCtx = publicController({
+                    activeScope: everScope,
+                    bearer: true,
+                    ...overrides,
+                });
+                const presignCtx = publicController({
+                    activeScope: everScope,
+                    bearer: true,
+                    ...overrides,
+                });
+
+                await expect(
+                    uploadCtx.controller.uploadAnonymous(mkFile({}), uploadCtx.req, undefined),
+                ).rejects.toBeInstanceOf(NotFoundException);
+                await expect(
+                    presignCtx.controller.presign(
+                        { filename: 'direct.png', mimeType: 'image/png', size: 100 },
+                        presignCtx.req,
+                    ),
+                ).rejects.toBeInstanceOf(NotFoundException);
+                expect(uploadCtx.uploads.saveImage).not.toHaveBeenCalled();
+                expect(presignCtx.uploads.getBackend).not.toHaveBeenCalled();
+            },
+        );
+
+        it('rejects an invalid bearer instead of silently minting an anonymous owner', async () => {
+            const ctx = publicController({ activeScope: everScope, authRejects: true });
+
+            await expect(
+                ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined),
+            ).rejects.toBeDefined();
+            expect(ctx.anonymousAuth.createAnonymousUser).not.toHaveBeenCalled();
+            expect(ctx.uploads.saveImage).not.toHaveBeenCalled();
+        });
+
+        it('forces anonymous presign to null/null before reading the backend', async () => {
+            const ctx = publicController({ activeScope: everScope });
+
+            await ctx.controller.presign(
+                { filename: 'direct.png', mimeType: 'image/png', size: 100 },
+                ctx.req,
+            );
+
+            expect(ctx.scopeContext.setScope).toHaveBeenCalledWith({
+                tenantId: null,
+                organizationId: null,
+            });
+            expect(ctx.anonymousAuth.createAnonymousUser).toHaveBeenCalledTimes(1);
+            expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
+        });
+
+        it('derives an explicit personal scope for a valid bearer', async () => {
+            const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+            const ctx = publicController({ activeScope: personalScope, bearer: true });
+
+            await ctx.controller.uploadAnonymousFile(mkFile({}), ctx.req);
+
+            expect(ctx.uploads.saveFile).toHaveBeenCalledWith(bearerUserId, expect.anything(), {
+                ownershipScope: personalScope,
+            });
+            expect(ctx.organizations.findById).not.toHaveBeenCalled();
+            expect(ctx.members.findByOrgAndUser).not.toHaveBeenCalled();
+        });
     });
 
     beforeEach(async () => {

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -3,7 +3,10 @@
 // database module's @src/config alias is resolvable in the API runtime
 // but not in this isolated jest context, so we mock the agent surface
 // the same way auth.controller.spec.ts does.
-jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({
+    UserUploadRepository: class {},
+    WorkRepository: class {},
+}));
 
 import { BadRequestException, HttpStatus, Logger } from '@nestjs/common';
 import { promises as fs } from 'node:fs';
@@ -169,6 +172,26 @@ describe('UploadsController', () => {
     });
 
     describe('GET /api/uploads/:userId/:filename', () => {
+        const everScope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+        const yoScope = {
+            tenantId: everScope.tenantId,
+            organizationId: '33333333-3333-4333-8333-333333333333',
+        };
+
+        function guardedController(userUploads: { findOwnedByUser: jest.Mock }, scope: object) {
+            return new UploadsController(
+                service,
+                {} as never,
+                { authenticate: jest.fn().mockResolvedValue(null) } as never,
+                undefined,
+                userUploads as never,
+                { getScope: () => scope } as never,
+            );
+        }
+
         it("refuses to serve another user's file (returns 404 — never 200 / never leaks)", async () => {
             const owner = mkAuth({ userId: 'ffffffff-1111-2222-3333-444444444444' });
             const stored = await controller.upload(owner, mkFile({}));
@@ -192,6 +215,96 @@ describe('UploadsController', () => {
                 `inline; filename="${stored.filename}"`,
             );
             expect(Buffer.isBuffer(calls.sent)).toBe(true);
+            expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
+        });
+
+        it('serves an Ever upload only after resolving the exact active scope', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const userUploads = {
+                findOwnedByUser: jest.fn().mockResolvedValue({
+                    sha256: stored.id,
+                    userId: owner.userId,
+                    workId: null,
+                    ...everScope,
+                }),
+            };
+            const { res, calls } = mkRes();
+
+            await guardedController(userUploads, everScope).serve(
+                owner,
+                owner.userId,
+                stored.filename,
+                res,
+            );
+
+            expect(userUploads.findOwnedByUser).toHaveBeenCalledWith(
+                stored.id,
+                owner.userId,
+                everScope,
+            );
+            expect(calls.statusCode).toBeUndefined();
+            expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
+        });
+
+        it('opaque-404s the same-user known hash in Yo before reading bytes from Ever', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const yoUpload = {
+                sha256: stored.id,
+                userId: owner.userId,
+                workId: null,
+                ...yoScope,
+            };
+            const userUploads = {
+                findOwnedByUser: jest.fn(
+                    async (_sha: string, _userId: string, scope: typeof everScope) =>
+                        scope.organizationId === yoUpload.organizationId ? yoUpload : null,
+                ),
+            };
+            const readFile = jest.spyOn(service, 'readFile');
+            const { res, calls } = mkRes();
+
+            await guardedController(userUploads, everScope).serve(
+                owner,
+                owner.userId,
+                stored.filename,
+                res,
+            );
+
+            expect(calls.statusCode).toBe(HttpStatus.NOT_FOUND);
+            expect(calls.body).toEqual({ status: 'error', message: 'Not found' });
+            expect(calls.sent).toBeUndefined();
+            expect(readFile).not.toHaveBeenCalled();
+        });
+
+        it('keeps a legacy personal upload readable from explicit personal scope', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+            const userUploads = {
+                findOwnedByUser: jest.fn().mockResolvedValue({
+                    sha256: stored.id,
+                    userId: owner.userId,
+                    workId: null,
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            };
+            const { res, calls } = mkRes();
+
+            await guardedController(userUploads, personalScope).serve(
+                owner,
+                owner.userId,
+                stored.filename,
+                res,
+            );
+
+            expect(userUploads.findOwnedByUser).toHaveBeenCalledWith(
+                stored.id,
+                owner.userId,
+                personalScope,
+            );
             expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
         });
     });

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -31,7 +31,7 @@ import { tmpdir } from 'node:os';
 import { Test } from '@nestjs/testing';
 import { UserUploadRepository, WorkRepository } from '@ever-works/agent/database';
 import { UploadsController } from './uploads.controller';
-import { UploadsService } from './uploads.service';
+import { UploadsService, USER_UPLOAD_REPOSITORY } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
 import type { PluginContext } from '@ever-works/plugin';
 import type { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
@@ -154,7 +154,12 @@ describe('UploadsController', () => {
         delete process.env.UPLOADS_MAX_BYTES;
         const backend = new LocalFsStoragePlugin();
         await backend.onLoad(stubContext('local-fs'));
-        service = new UploadsService(backend);
+        service = new UploadsService(
+            backend,
+            undefined,
+            { record: jest.fn().mockResolvedValue({ id: 'upload-row' }) } as never,
+            { getScope: () => ({ tenantId: null, organizationId: null }) } as never,
+        );
         // The anonymous-auth service is only invoked by /anonymous and
         // /presign endpoints — pass a stub that throws if these tests
         // ever exercise it accidentally.
@@ -475,7 +480,14 @@ describe('UploadsService — Nest DI', () => {
         // accept that and lazily resolve on first call via the env-driven
         // backend factory (which we DO NOT exercise in this test).
         const moduleRef = await Test.createTestingModule({
-            providers: [UploadsService],
+            providers: [
+                UploadsService,
+                { provide: USER_UPLOAD_REPOSITORY, useValue: { record: jest.fn() } },
+                {
+                    provide: ScopeContextService,
+                    useValue: { getScope: () => ({ tenantId: null, organizationId: null }) },
+                },
+            ],
         }).compile();
         const svc = moduleRef.get(UploadsService);
         expect(svc).toBeInstanceOf(UploadsService);

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -6,13 +6,30 @@
 jest.mock('@ever-works/agent/database', () => ({
     UserUploadRepository: class {},
     WorkRepository: class {},
+    ownershipScopeMatches: (
+        row: { tenantId?: string | null; organizationId?: string | null },
+        scope?: { tenantId: string | null; organizationId: string | null },
+    ) => {
+        if (!scope) return true;
+        const tenantId = row.tenantId ?? null;
+        const organizationId = row.organizationId ?? null;
+        if (scope.organizationId) {
+            return tenantId === scope.tenantId && organizationId === scope.organizationId;
+        }
+        return (
+            organizationId === null &&
+            (tenantId === scope.tenantId || (scope.tenantId !== null && tenantId === null))
+        );
+    },
 }));
 
-import { BadRequestException, HttpStatus, Logger } from '@nestjs/common';
+import { BadRequestException, HttpStatus, Logger, NotFoundException } from '@nestjs/common';
+import { SELF_DECLARED_DEPS_METADATA } from '@nestjs/common/constants';
 import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Test } from '@nestjs/testing';
+import { UserUploadRepository, WorkRepository } from '@ever-works/agent/database';
 import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
@@ -20,6 +37,7 @@ import type { PluginContext } from '@ever-works/plugin';
 import type { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
 import type { AuthProvider } from '../auth/providers/auth-provider.abstract';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ScopeContextService } from '../scope/scope-context.service';
 
 const stubContext = (id: string): PluginContext => {
     const log = new Logger(`StoragePlugin/${id}`);
@@ -103,6 +121,29 @@ describe('UploadsController', () => {
     let root: string;
     let controller: UploadsController;
     let service: UploadsService;
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    const yoScope = {
+        tenantId: everScope.tenantId,
+        organizationId: '33333333-3333-4333-8333-333333333333',
+    };
+    const workId = '44444444-4444-4444-8444-444444444444';
+
+    it('declares concrete Nest injection tokens for optional ownership repositories', () => {
+        const tokens = Reflect.getMetadata(SELF_DECLARED_DEPS_METADATA, UploadsController) ?? [];
+
+        expect(tokens).toEqual(
+            expect.arrayContaining([
+                { index: 3, param: WorkRepository },
+                { index: 4, param: UserUploadRepository },
+            ]),
+        );
+        expect(Reflect.getMetadata('design:paramtypes', UploadsController)[5]).toBe(
+            ScopeContextService,
+        );
+    });
 
     beforeEach(async () => {
         root = resolve(
@@ -129,8 +170,30 @@ describe('UploadsController', () => {
         const authProviderStub = {
             authenticate: async () => null,
         } as unknown as AuthProvider;
-        controller = new UploadsController(service, anonStub, authProviderStub);
+        controller = new UploadsController(
+            service,
+            anonStub,
+            authProviderStub,
+            undefined,
+            undefined,
+            { getScope: () => ({ tenantId: null, organizationId: null }) } as never,
+        );
     });
+
+    function workScopedController(
+        scope: object,
+        work: object | null,
+        userUploads?: { findOwnedByUser: jest.Mock },
+    ) {
+        return new UploadsController(
+            service,
+            {} as never,
+            { authenticate: jest.fn().mockResolvedValue(null) } as never,
+            { findById: jest.fn().mockResolvedValue(work) } as never,
+            userUploads as never,
+            { getScope: () => scope } as never,
+        );
+    }
 
     afterEach(async () => {
         try {
@@ -169,18 +232,49 @@ describe('UploadsController', () => {
             expect(r.mimeType).toBe('image/png');
             expect(r.url).toContain('/api/uploads/');
         });
+
+        it('opaque-404s a same-user known Yo Work before associating an image in Ever', async () => {
+            const saveImage = jest.spyOn(service, 'saveImage');
+            const scoped = workScopedController(everScope, {
+                id: workId,
+                userId: mkAuth().userId,
+                ...yoScope,
+            });
+
+            await expect(scoped.upload(mkAuth(), mkFile({}), workId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(saveImage).not.toHaveBeenCalled();
+        });
+
+        it('opaque-404s a same-user known Yo Work before associating a general file in Ever', async () => {
+            const saveFile = jest.spyOn(service, 'saveFile');
+            const scoped = workScopedController(everScope, {
+                id: workId,
+                userId: mkAuth().userId,
+                ...yoScope,
+            });
+
+            await expect(scoped.uploadFile(mkAuth(), mkFile({}), workId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(saveFile).not.toHaveBeenCalled();
+        });
+
+        it('allows a legacy personal Work from explicit personal scope', async () => {
+            const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+            const result = await workScopedController(personalScope, {
+                id: workId,
+                userId: mkAuth().userId,
+                tenantId: null,
+                organizationId: null,
+            }).upload(mkAuth(), mkFile({}), workId);
+
+            expect(result.id).toMatch(/^[a-f0-9]{64}$/);
+        });
     });
 
     describe('GET /api/uploads/:userId/:filename', () => {
-        const everScope = {
-            tenantId: '11111111-1111-4111-8111-111111111111',
-            organizationId: '22222222-2222-4222-8222-222222222222',
-        };
-        const yoScope = {
-            tenantId: everScope.tenantId,
-            organizationId: '33333333-3333-4333-8333-333333333333',
-        };
-
         function guardedController(userUploads: { findOwnedByUser: jest.Mock }, scope: object) {
             return new UploadsController(
                 service,
@@ -305,6 +399,61 @@ describe('UploadsController', () => {
                 owner.userId,
                 personalScope,
             );
+            expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
+        });
+
+        it('opaque-404s an Ever upload whose same-user Work exists only in Yo before reading bytes', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const userUploads = {
+                findOwnedByUser: jest.fn().mockResolvedValue({
+                    sha256: stored.id,
+                    userId: owner.userId,
+                    workId,
+                    ...everScope,
+                }),
+            };
+            const scoped = workScopedController(
+                everScope,
+                { id: workId, userId: owner.userId, ...yoScope },
+                userUploads,
+            );
+            const readFile = jest.spyOn(service, 'readFile');
+            const { res } = mkRes();
+
+            await expect(
+                scoped.serve(owner, owner.userId, stored.filename, res, workId),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(readFile).not.toHaveBeenCalled();
+        });
+
+        it('serves a legacy personal upload associated with a legacy personal Work', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+            const userUploads = {
+                findOwnedByUser: jest.fn().mockResolvedValue({
+                    sha256: stored.id,
+                    userId: owner.userId,
+                    workId,
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            };
+            const scoped = workScopedController(
+                personalScope,
+                {
+                    id: workId,
+                    userId: owner.userId,
+                    tenantId: null,
+                    organizationId: null,
+                },
+                userUploads,
+            );
+            const { res, calls } = mkRes();
+
+            await scoped.serve(owner, owner.userId, stored.filename, res, workId);
+
             expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
         });
     });

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -658,37 +658,66 @@ export class UploadsController {
 
         const requested = this.scopeContext.getScope();
         if (!requested.organizationId) {
-            if (requested.tenantId && requested.tenantId !== (user.tenantId ?? null)) {
+            const userTenantId = user.tenantId ?? null;
+            if (requested.tenantId && requested.tenantId !== userTenantId) {
                 this.opaqueScopeNotFound();
             }
-            return { tenantId: user.tenantId ?? null, organizationId: null };
+
+            // ScopeResolverMiddleware leaves a headerless public request at
+            // EMPTY_SCOPE because @Public() skips SessionScopeGuard. Mirror
+            // that guard's default-Organization behavior here: a persisted
+            // default must still exist and retain exact roster access. An
+            // explicit personal scope already carries the user's tenant and
+            // therefore does not enter this fallback.
+            const defaultOrganizationId =
+                requested.tenantId === null ? (user.lastScopeOrganizationId ?? null) : null;
+            if (userTenantId && defaultOrganizationId) {
+                return this.requireAuthenticatedOrganizationScope(
+                    auth.userId,
+                    userTenantId,
+                    defaultOrganizationId,
+                );
+            }
+            return { tenantId: userTenantId, organizationId: null };
         }
 
         if (!requested.tenantId || user.tenantId !== requested.tenantId) {
             this.opaqueScopeNotFound();
         }
+        return this.requireAuthenticatedOrganizationScope(
+            auth.userId,
+            requested.tenantId,
+            requested.organizationId,
+        );
+    }
+
+    private async requireAuthenticatedOrganizationScope(
+        userId: string,
+        tenantId: string,
+        organizationId: string,
+    ): Promise<OwnershipScope> {
         const organization = this.organizationRepository
-            ? await this.organizationRepository.findById(requested.organizationId).catch(() => null)
+            ? await this.organizationRepository.findById(organizationId).catch(() => null)
             : null;
-        if (!organization || organization.tenantId !== requested.tenantId) {
+        if (!organization || organization.tenantId !== tenantId) {
             this.opaqueScopeNotFound();
         }
         const member = this.organizationMembers
             ? await this.organizationMembers
-                  .findByOrgAndUser(requested.organizationId, auth.userId)
+                  .findByOrgAndUser(organizationId, userId)
                   .catch(() => null)
             : null;
         const exactMember = Boolean(
-            member?.userId === auth.userId &&
-            member?.tenantId === requested.tenantId &&
-            member?.organizationId === requested.organizationId,
+            member?.userId === userId &&
+            member?.tenantId === tenantId &&
+            member?.organizationId === organizationId,
         );
         if (!exactMember) {
             const tenant = this.tenantRepository
-                ? await this.tenantRepository.findById(requested.tenantId).catch(() => null)
+                ? await this.tenantRepository.findById(tenantId).catch(() => null)
                 : null;
-            if (tenant?.ownerUserId !== auth.userId) this.opaqueScopeNotFound();
+            if (tenant?.ownerUserId !== userId) this.opaqueScopeNotFound();
         }
-        return { tenantId: requested.tenantId, organizationId: requested.organizationId };
+        return { tenantId, organizationId };
     }
 }

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -20,7 +20,7 @@ import {
     UploadedFile,
     UseInterceptors,
 } from '@nestjs/common';
-import { WorkRepository } from '@ever-works/agent/database';
+import { UserUploadRepository, WorkRepository } from '@ever-works/agent/database';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
@@ -33,6 +33,7 @@ import { AuthProvider } from '../auth/providers/auth-provider.abstract';
 import { toHeaders } from '../auth/providers/request-headers';
 import { UploadsService } from './uploads.service';
 import { PresignUploadDto } from './dto/presign-upload.dto';
+import { ScopeContextService } from '../scope/scope-context.service';
 
 const MAX_UPLOAD_BYTES = Number(process.env.UPLOADS_MAX_BYTES) || 5 * 1024 * 1024;
 
@@ -76,6 +77,8 @@ export class UploadsController {
         // for unit tests that don't exercise the workId path; the
         // module provides it in production.
         @Optional() private readonly workRepository?: WorkRepository,
+        @Optional() private readonly userUploads?: UserUploadRepository,
+        @Optional() private readonly scopeContext?: ScopeContextService,
     ) {}
 
     /**
@@ -471,6 +474,22 @@ export class UploadsController {
             // yours" is a small enumeration tell. Treat as not-found.
             res.status(HttpStatus.NOT_FOUND).json({ status: 'error', message: 'Not found' });
             return;
+        }
+        // The URL alone proves neither Organization nor Tenant ownership.
+        // Resolve the persisted upload row in the active request scope before
+        // touching storage; missing and wrong-scope hashes share the same
+        // opaque response. Legacy personal rows remain reachable through the
+        // centralized ownership predicate in UserUploadRepository.
+        if (this.userUploads) {
+            const match = /^([0-9a-f]{64})(?:\.|$)/i.exec(filename);
+            const scope = this.scopeContext?.getScope();
+            const upload = match
+                ? await this.userUploads.findOwnedByUser(match[1].toLowerCase(), userId, scope)
+                : null;
+            if (!upload || (upload.workId ?? null) !== (workId ?? null)) {
+                res.status(HttpStatus.NOT_FOUND).json({ status: 'error', message: 'Not found' });
+                return;
+            }
         }
         // EW-644 (Codex P1): when the caller passes a workId, verify
         // ownership before forwarding it to the backend — same gate as

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -20,7 +20,11 @@ import {
     UploadedFile,
     UseInterceptors,
 } from '@nestjs/common';
-import { UserUploadRepository, WorkRepository } from '@ever-works/agent/database';
+import {
+    UserUploadRepository,
+    WorkRepository,
+    ownershipScopeMatches,
+} from '@ever-works/agent/database';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
@@ -76,9 +80,16 @@ export class UploadsController {
         // victim's GitHub credentials. WorkRepository is `@Optional()`
         // for unit tests that don't exercise the workId path; the
         // module provides it in production.
-        @Optional() private readonly workRepository?: WorkRepository,
-        @Optional() private readonly userUploads?: UserUploadRepository,
-        @Optional() private readonly scopeContext?: ScopeContextService,
+        @Optional()
+        @Inject(WorkRepository)
+        private readonly workRepository: WorkRepository | undefined,
+        @Optional()
+        @Inject(UserUploadRepository)
+        private readonly userUploads: UserUploadRepository | undefined,
+        // Every authenticated attach/read path needs an authoritative request
+        // scope. Unlike the repositories above, this must fail Nest startup if
+        // request-scope plumbing is absent rather than degrading to user-only.
+        private readonly scopeContext: ScopeContextService,
     ) {}
 
     /**
@@ -229,7 +240,11 @@ export class UploadsController {
             });
         }
         const work = await this.workRepository.findById(workId);
-        if (!work || work.userId !== userId) {
+        if (
+            !work ||
+            work.userId !== userId ||
+            !ownershipScopeMatches(work, this.scopeContext.getScope())
+        ) {
             throw new NotFoundException({
                 status: 'error',
                 message: 'Work not found',
@@ -482,7 +497,7 @@ export class UploadsController {
         // centralized ownership predicate in UserUploadRepository.
         if (this.userUploads) {
             const match = /^([0-9a-f]{64})(?:\.|$)/i.exec(filename);
-            const scope = this.scopeContext?.getScope();
+            const scope = this.scopeContext.getScope();
             const upload = match
                 ? await this.userUploads.findOwnedByUser(match[1].toLowerCase(), userId, scope)
                 : null;

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -23,7 +23,12 @@ import {
 import {
     UserUploadRepository,
     WorkRepository,
+    UserRepository,
+    OrganizationRepository,
+    OrganizationMemberRepository,
+    TenantRepository,
     ownershipScopeMatches,
+    type OwnershipScope,
 } from '@ever-works/agent/database';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
@@ -90,6 +95,18 @@ export class UploadsController {
         // scope. Unlike the repositories above, this must fail Nest startup if
         // request-scope plumbing is absent rather than degrading to user-only.
         private readonly scopeContext: ScopeContextService,
+        @Optional()
+        @Inject(UserRepository)
+        private readonly userRepository?: UserRepository,
+        @Optional()
+        @Inject(OrganizationRepository)
+        private readonly organizationRepository?: OrganizationRepository,
+        @Optional()
+        @Inject(OrganizationMemberRepository)
+        private readonly organizationMembers?: OrganizationMemberRepository,
+        @Optional()
+        @Inject(TenantRepository)
+        private readonly tenantRepository?: TenantRepository,
     ) {}
 
     /**
@@ -137,7 +154,10 @@ export class UploadsController {
         if (workId) {
             await this.assertWorkAccess(auth.userId, workId);
         }
-        return this.uploads.saveImage(auth.userId, file, workId ? { workId } : undefined);
+        return this.uploads.saveImage(auth.userId, file, {
+            ...(workId ? { workId } : {}),
+            ownershipScope: this.scopeContext.getScope(),
+        });
     }
 
     @Post('image')
@@ -210,7 +230,10 @@ export class UploadsController {
         if (workId) {
             await this.assertWorkAccess(auth.userId, workId);
         }
-        return this.uploads.saveFile(auth.userId, file, workId ? { workId } : undefined);
+        return this.uploads.saveFile(auth.userId, file, {
+            ...(workId ? { workId } : {}),
+            ownershipScope: this.scopeContext.getScope(),
+        });
     }
 
     /**
@@ -302,9 +325,10 @@ export class UploadsController {
         // reach this point with `req.user` unset (because @Public() bypasses
         // AuthSessionGuard), an authenticated caller is supported as a
         // no-branch convenience.
-        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
+        const { userId, anonAccessToken, anonymousExpiresAt, ownershipScope } =
+            await this.resolveActingUser(req);
 
-        const result = await this.uploads.saveImage(userId, file);
+        const result = await this.uploads.saveImage(userId, file, { ownershipScope });
 
         // Note: `correlationHeader` is accepted but not yet propagated to
         // analytics. Hook it into the ZeroFrictionFunnel emit in a follow-up
@@ -377,9 +401,10 @@ export class UploadsController {
             });
         }
 
-        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
+        const { userId, anonAccessToken, anonymousExpiresAt, ownershipScope } =
+            await this.resolveActingUser(req);
 
-        const result = await this.uploads.saveFile(userId, file);
+        const result = await this.uploads.saveFile(userId, file, { ownershipScope });
 
         // The existing /anonymous endpoint takes an `x-correlation-id`
         // header for future telemetry; we omit it here until the
@@ -425,6 +450,10 @@ export class UploadsController {
         description: 'Backend does not support presign — use POST /api/uploads',
     })
     async presign(@Body() body: PresignUploadDto, @Req() req: AnonRequest) {
+        // Authenticate + hydrate ownership before touching even the backend
+        // capability surface. A revoked bearer must not receive a presign
+        // oracle or a key in a fallback personal scope.
+        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
         const backend = await this.uploads.getBackend();
         if (!backend.presignPut) {
             throw new NotImplementedException({
@@ -434,10 +463,6 @@ export class UploadsController {
                     'Active storage backend does not support presigned uploads — use POST /api/uploads with multipart form data instead.',
             });
         }
-
-        // Mint an anon user when no session is present, same as the anon
-        // upload route — direct-to-cloud uploads need an owner segment.
-        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
 
         const presign = await backend.presignPut({
             filename: body.filename,
@@ -558,24 +583,33 @@ export class UploadsController {
         userId: string;
         anonAccessToken: string | undefined;
         anonymousExpiresAt: string | null | undefined;
+        ownershipScope: OwnershipScope;
     }> {
-        // Codex P2 finding on PR #890: `@Public()` routes never have
-        // `req.user` populated (the guard short-circuits before it
-        // gets to bearer parsing), so the old `req.user?.userId`
-        // check was dead and every authenticated caller hitting
-        // /anonymous or /presign was getting re-anon-minted. Resolve
-        // the bearer here directly — same `authProvider.authenticate`
-        // path the guard would have taken. We swallow the error case:
-        // an unauthenticated request shouldn't fail the upload, it
-        // should fall through to the anon-mint branch.
-        const existing = await this.tryAuthenticate(req);
-        if (existing) {
+        const authorization = req.headers?.authorization;
+        const hasBearer = Array.isArray(authorization)
+            ? authorization.some((value) => value.trim().length > 0)
+            : typeof authorization === 'string' && authorization.trim().length > 0;
+
+        if (hasBearer) {
+            // @Public() skips the global session/scope guards, so reproduce
+            // their authoritative half here. A supplied-but-invalid bearer
+            // is never reinterpreted as an anonymous request.
+            const existing = await this.authenticateBearer(req);
+            const ownershipScope = await this.hydrateAuthenticatedScope(existing);
+            req.user = existing;
+            this.scopeContext.setScope(ownershipScope);
             return {
                 userId: existing.userId,
                 anonAccessToken: undefined,
                 anonymousExpiresAt: undefined,
+                ownershipScope,
             };
         }
+
+        // A genuinely anonymous request is always personal/null, regardless
+        // of any x-scope header the public middleware happened to resolve.
+        const ownershipScope: OwnershipScope = { tenantId: null, organizationId: null };
+        this.scopeContext.setScope(ownershipScope);
 
         const ipAddress =
             (typeof req.ip === 'string' && req.ip) ||
@@ -595,23 +629,66 @@ export class UploadsController {
             userId: anon.user.id,
             anonAccessToken: anon.access_token,
             anonymousExpiresAt: anon.user.anonymousExpiresAt ?? null,
+            ownershipScope,
         };
     }
 
-    /**
-     * Best-effort bearer resolution for `@Public()` upload routes.
-     * Returns the authenticated user when a valid session token is
-     * present, otherwise `null`. Never throws — an invalid/missing
-     * token falls through to anon-mint instead of 401-ing a route
-     * that's documented as accepting anonymous traffic.
-     */
-    private async tryAuthenticate(req: AnonRequest): Promise<AuthenticatedUser | null> {
-        const auth = req.headers?.authorization;
-        if (!auth) return null;
+    private opaqueScopeNotFound(): never {
+        throw new NotFoundException({ status: 'error', message: 'Resource not found' });
+    }
+
+    private async authenticateBearer(req: AnonRequest): Promise<AuthenticatedUser> {
         try {
-            return await this.authProvider.authenticate(toHeaders(req.headers || {}));
+            const authenticated = await this.authProvider.authenticate(
+                toHeaders(req.headers || {}),
+            );
+            if (!authenticated?.userId) this.opaqueScopeNotFound();
+            return authenticated;
         } catch {
-            return null;
+            this.opaqueScopeNotFound();
         }
+    }
+
+    /** Hydrate the exact scope a global SessionScopeGuard would authorize. */
+    private async hydrateAuthenticatedScope(auth: AuthenticatedUser): Promise<OwnershipScope> {
+        const user = this.userRepository
+            ? await this.userRepository.findById(auth.userId).catch(() => null)
+            : null;
+        if (!user?.isActive) this.opaqueScopeNotFound();
+
+        const requested = this.scopeContext.getScope();
+        if (!requested.organizationId) {
+            if (requested.tenantId && requested.tenantId !== (user.tenantId ?? null)) {
+                this.opaqueScopeNotFound();
+            }
+            return { tenantId: user.tenantId ?? null, organizationId: null };
+        }
+
+        if (!requested.tenantId || user.tenantId !== requested.tenantId) {
+            this.opaqueScopeNotFound();
+        }
+        const organization = this.organizationRepository
+            ? await this.organizationRepository.findById(requested.organizationId).catch(() => null)
+            : null;
+        if (!organization || organization.tenantId !== requested.tenantId) {
+            this.opaqueScopeNotFound();
+        }
+        const member = this.organizationMembers
+            ? await this.organizationMembers
+                  .findByOrgAndUser(requested.organizationId, auth.userId)
+                  .catch(() => null)
+            : null;
+        const exactMember = Boolean(
+            member?.userId === auth.userId &&
+            member?.tenantId === requested.tenantId &&
+            member?.organizationId === requested.organizationId,
+        );
+        if (!exactMember) {
+            const tenant = this.tenantRepository
+                ? await this.tenantRepository.findById(requested.tenantId).catch(() => null)
+                : null;
+            if (tenant?.ownerUserId !== auth.userId) this.opaqueScopeNotFound();
+        }
+        return { tenantId: requested.tenantId, organizationId: requested.organizationId };
     }
 }

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -47,10 +47,60 @@ const fakeFile = (
     originalname: overrides.originalname ?? 'probe.png',
 });
 
+const serviceWithMetadata = (backend: unknown) =>
+    new UploadsService(
+        backend as never,
+        undefined,
+        { record: jest.fn().mockResolvedValue({ id: 'upload-row' }) } as never,
+        { getScope: () => ({ tenantId: null, organizationId: null }) } as never,
+    );
+
 describe('UploadsService', () => {
     let root: string;
     let service: UploadsService;
     const userId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+    describe('authoritative scoped metadata', () => {
+        const everScope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+        const backend = {
+            providerName: 'metadata-test',
+            putObject: jest.fn(async (input: { ownerId: string; filename: string }) => ({
+                key: `${input.ownerId}/${input.filename}`,
+                url: 'ignored',
+            })),
+            getObject: jest.fn(),
+            deleteObject: jest.fn(),
+            isAvailable: jest.fn().mockResolvedValue(true),
+        };
+
+        it('records the active Ever scope before returning upload success', async () => {
+            const userUploads = { record: jest.fn().mockResolvedValue({ id: 'row-ever' }) };
+            const scoped = new (UploadsService as any)(backend, undefined, userUploads, {
+                getScope: () => everScope,
+            }) as UploadsService;
+
+            await expect(scoped.saveImage(userId, fakeFile({}))).resolves.toBeDefined();
+            expect(userUploads.record).toHaveBeenCalledWith(
+                expect.objectContaining({ userId, ...everScope }),
+            );
+        });
+
+        it('does not report success when authoritative metadata persistence fails', async () => {
+            const userUploads = {
+                record: jest.fn().mockRejectedValue(new Error('metadata database unavailable')),
+            };
+            const scoped = new (UploadsService as any)(backend, undefined, userUploads, {
+                getScope: () => everScope,
+            }) as UploadsService;
+
+            await expect(scoped.saveImage(userId, fakeFile({}))).rejects.toThrow(
+                /metadata database unavailable/,
+            );
+        });
+    });
 
     beforeEach(async () => {
         root = resolve(
@@ -65,7 +115,7 @@ describe('UploadsService', () => {
         // by passing the plugin directly to the service constructor.
         const backend = new LocalFsStoragePlugin();
         await backend.onLoad(stubContext('local-fs'));
-        service = new UploadsService(backend);
+        service = serviceWithMetadata(backend);
     });
 
     afterEach(async () => {
@@ -194,7 +244,7 @@ describe('UploadsService', () => {
             process.env.UPLOADS_MAX_BYTES = '100';
             const localBackend = new LocalFsStoragePlugin();
             await localBackend.onLoad(stubContext('local-fs'));
-            const s = new UploadsService(localBackend);
+            const s = serviceWithMetadata(localBackend);
             const big = Buffer.concat([TINY_PNG, Buffer.alloc(200)]);
             await expect(
                 s.saveImage(userId, {
@@ -277,7 +327,7 @@ describe('UploadsService', () => {
                     /* noop */
                 },
             };
-            svc = new UploadsService(spyBackend as never);
+            svc = serviceWithMetadata(spyBackend);
         });
 
         it('does not set workId on the backend by default', async () => {
@@ -389,7 +439,7 @@ describe('UploadsService', () => {
                     return `uploads/${ownerId}/${filename}`;
                 },
             };
-            const svc = new UploadsService(fakeBackend as never);
+            const svc = serviceWithMetadata(fakeBackend);
             const r = await svc.saveImage(userId, fakeFile({}));
 
             // Codex P1 #2: response URL is the API-routed path regardless of
@@ -428,7 +478,7 @@ describe('UploadsService', () => {
                 },
                 // intentionally NO deriveKey
             };
-            const svc = new UploadsService(backendNoDerive as never);
+            const svc = serviceWithMetadata(backendNoDerive);
             const r = await svc.saveImage(userId, fakeFile({}));
             await svc.readFile(userId, r.filename);
             expect(lastSeenKey).toEqual([`${userId}/${r.filename}`]);

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -100,6 +100,28 @@ describe('UploadsService', () => {
                 /metadata database unavailable/,
             );
         });
+
+        it.each(['saveImage', 'saveFile'] as const)(
+            'uses the explicit ownership scope for %s even when request ALS is stale',
+            async (method) => {
+                const yoScope = {
+                    tenantId: everScope.tenantId,
+                    organizationId: '33333333-3333-4333-8333-333333333333',
+                };
+                const userUploads = { record: jest.fn().mockResolvedValue({ id: 'row-ever' }) };
+                const scoped = new (UploadsService as any)(backend, undefined, userUploads, {
+                    getScope: () => yoScope,
+                }) as UploadsService;
+
+                await (scoped[method] as any)(userId, fakeFile({}), {
+                    ownershipScope: everScope,
+                });
+
+                expect(userUploads.record).toHaveBeenCalledWith(
+                    expect.objectContaining({ userId, ...everScope }),
+                );
+            },
+        );
     });
 
     beforeEach(async () => {

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -16,6 +16,7 @@ import type { WorkRepoResolver } from '@ever-works/github-storage-plugin';
 // UploadsModule binds the token to the real repo via `useExisting`.
 import type { UserUploadRepository } from '@ever-works/agent/database';
 import { getActiveStorageBackend } from './storage-backend.factory';
+import { ScopeContextService } from '../scope/scope-context.service';
 
 /**
  * DI token for the optional `UserUploadRepository`. The UploadsModule provides
@@ -267,14 +268,15 @@ export class UploadsService {
         @Optional()
         @Inject(WORK_REPO_RESOLVER)
         private readonly workRepoResolver?: WorkRepoResolver,
-        // Ownership index for plain uploads. `@Optional()` so the unit tests
-        // that construct `new UploadsService(backend)` still work; in
-        // production / E2E the UploadsModule binds USER_UPLOAD_REPOSITORY to the
-        // real repo, so every upload is recorded and attachments can validate
-        // ownership.
-        @Optional()
+        // Authoritative ownership index for plain uploads. Required in the
+        // Nest graph: returning success without this row would create bytes
+        // that no scoped attach/read path can authorize.
         @Inject(USER_UPLOAD_REPOSITORY)
         private readonly userUploads?: UserUploadRepository,
+        // Globally provided in the API. The default keeps direct unit
+        // construction ergonomic and represents explicit legacy-personal
+        // scope; Nest still resolves the real singleton in production.
+        private readonly scopeContext: ScopeContextService = new ScopeContextService(),
     ) {
         this.maxSize = Number(process.env.UPLOADS_MAX_BYTES) || DEFAULT_MAX_SIZE;
         if (backend) {
@@ -297,11 +299,10 @@ export class UploadsService {
     }
 
     /**
-     * Best-effort: index the upload's ownership (`userId`) + storage location in
-     * `user_uploads` so an attachment can later validate that its `uploadId`
-     * (the sha256) references a real, caller-owned upload. The bytes are already
-     * stored when this runs, so a failure here MUST NOT fail the upload — log
-     * and continue (deduped per `(userId, sha256)` in the repo).
+     * Persist the authoritative ownership row before reporting upload success.
+     * Storage writes happen first because the plugin contract has no shared DB
+     * transaction, but metadata failure is never swallowed: callers receive an
+     * error rather than a URL that every scoped attach/read path must reject.
      */
     private async recordUpload(input: {
         userId: string;
@@ -312,25 +313,22 @@ export class UploadsService {
         fileSize: number;
         workId?: string;
     }): Promise<void> {
-        if (!this.userUploads) return;
-        try {
-            await this.userUploads.record({
-                userId: input.userId,
-                sha256: input.sha256,
-                workId: input.workId ?? null,
-                storageProvider: (process.env.STORAGE_BACKEND || 'local-fs').toLowerCase(),
-                storagePath: input.key,
-                originalFilename: input.originalFilename ?? null,
-                mimeType: input.mimeType,
-                fileSize: input.fileSize,
-            });
-        } catch (err) {
-            this.logger.warn(
-                `Failed to record upload ownership (sha256=${input.sha256.slice(0, 12)}…): ${
-                    err instanceof Error ? err.message : String(err)
-                }`,
-            );
+        if (!this.userUploads) {
+            throw new Error('Upload metadata repository is not configured');
         }
+        const scope = this.scopeContext.getScope();
+        await this.userUploads.record({
+            userId: input.userId,
+            sha256: input.sha256,
+            workId: input.workId ?? null,
+            tenantId: scope.tenantId,
+            organizationId: scope.organizationId,
+            storageProvider: (process.env.STORAGE_BACKEND || 'local-fs').toLowerCase(),
+            storagePath: input.key,
+            originalFilename: input.originalFilename ?? null,
+            mimeType: input.mimeType,
+            fileSize: input.fileSize,
+        });
     }
 
     /**

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -14,7 +14,7 @@ import type { WorkRepoResolver } from '@ever-works/github-storage-plugin';
 // `@ever-works/agent/database` VALUE barrel into UploadsService would drag TypeORM
 // into the upload unit-test import graph (path-scurry-under-Jest crash). The
 // UploadsModule binds the token to the real repo via `useExisting`.
-import type { UserUploadRepository } from '@ever-works/agent/database';
+import type { OwnershipScope, UserUploadRepository } from '@ever-works/agent/database';
 import { getActiveStorageBackend } from './storage-backend.factory';
 import { ScopeContextService } from '../scope/scope-context.service';
 
@@ -52,6 +52,11 @@ export interface UploadResult {
      * can hand it back when submitting the prompt.
      */
     key?: string;
+}
+
+export interface SaveUploadOptions {
+    workId?: string;
+    ownershipScope?: OwnershipScope;
 }
 
 /**
@@ -312,11 +317,12 @@ export class UploadsService {
         mimeType: string;
         fileSize: number;
         workId?: string;
+        ownershipScope?: OwnershipScope;
     }): Promise<void> {
         if (!this.userUploads) {
             throw new Error('Upload metadata repository is not configured');
         }
-        const scope = this.scopeContext.getScope();
+        const scope = input.ownershipScope ?? this.scopeContext.getScope();
         await this.userUploads.record({
             userId: input.userId,
             sha256: input.sha256,
@@ -349,7 +355,7 @@ export class UploadsService {
     async saveImage(
         userId: string,
         file: Pick<Express.Multer.File, 'buffer' | 'mimetype' | 'size' | 'originalname'>,
-        opts?: { workId?: string },
+        opts?: SaveUploadOptions,
     ): Promise<UploadResult> {
         this.assertValidUserId(userId);
 
@@ -418,6 +424,7 @@ export class UploadsService {
             mimeType: sniffed.mime,
             fileSize: file.size,
             workId,
+            ownershipScope: opts?.ownershipScope,
         });
 
         // Codex P1 finding on PR #890: returning the plugin's backend-native
@@ -504,7 +511,7 @@ export class UploadsService {
     async saveFile(
         userId: string,
         file: Pick<Express.Multer.File, 'buffer' | 'mimetype' | 'size' | 'originalname'>,
-        opts?: { workId?: string },
+        opts?: SaveUploadOptions,
     ): Promise<UploadResult> {
         this.assertValidUserId(userId);
 
@@ -581,6 +588,7 @@ export class UploadsService {
                 mimeType: declared,
                 fileSize: file.size,
                 workId,
+                ownershipScope: opts?.ownershipScope,
             });
             const url = workId
                 ? `/api/uploads/${encodeURIComponent(userId)}/${filename}?workId=${encodeURIComponent(workId)}`
@@ -632,6 +640,7 @@ export class UploadsService {
                 mimeType: declared,
                 fileSize: file.size,
                 workId,
+                ownershipScope: opts?.ownershipScope,
             });
             const url = workId
                 ? `/api/uploads/${encodeURIComponent(userId)}/${filename}?workId=${encodeURIComponent(workId)}`

--- a/apps/api/src/works/org-memory.controller.ts
+++ b/apps/api/src/works/org-memory.controller.ts
@@ -535,7 +535,11 @@ export class OrgMemoryController {
             // Ownership is the lookup: `findOwnedByUser` scopes to the
             // caller, so a hash belonging to another user simply is not
             // found. No separate authorization check to forget.
-            const record = await this.userUploads.findOwnedByUser(attachmentId, auth.userId);
+            const record = await this.userUploads.findOwnedByUser(
+                attachmentId,
+                auth.userId,
+                this.scopeContext.getScope(),
+            );
             if (!record) {
                 results.push({ attachmentId, status: 'not_found' });
                 continue;

--- a/apps/api/src/works/org-memory.ingest-attachments.spec.ts
+++ b/apps/api/src/works/org-memory.ingest-attachments.spec.ts
@@ -36,7 +36,7 @@ describe('OrgMemoryController — ingest chat attachments into Memory', () => {
 
     let kb: { createOrgUpload: jest.Mock };
     let membership: { ensureMember: jest.Mock; ensureAdmin: jest.Mock };
-    let scopeContext: { getOrganizationId: jest.Mock };
+    let scopeContext: { getOrganizationId: jest.Mock; getScope: jest.Mock };
     let uploads: { readFile: jest.Mock };
     let userUploads: { findOwnedByUser: jest.Mock };
     let controller: OrgMemoryController;
@@ -52,7 +52,10 @@ describe('OrgMemoryController — ingest chat attachments into Memory', () => {
             ensureMember: jest.fn().mockResolvedValue({ id: 'org-1' }),
             ensureAdmin: jest.fn().mockResolvedValue({ id: 'org-1' }),
         };
-        scopeContext = { getOrganizationId: jest.fn().mockReturnValue('org-1') };
+        scopeContext = {
+            getOrganizationId: jest.fn().mockReturnValue('org-1'),
+            getScope: jest.fn().mockReturnValue({ tenantId: 'tenant-1', organizationId: 'org-1' }),
+        };
         uploads = {
             readFile: jest
                 .fn()
@@ -84,7 +87,10 @@ describe('OrgMemoryController — ingest chat attachments into Memory', () => {
     it('resolves each hash against the CALLER, so another user’s upload is never reachable', async () => {
         await controller.ingestAttachmentsIntoMemory(auth, { attachmentIds: [SHA] });
 
-        expect(userUploads.findOwnedByUser).toHaveBeenCalledWith(SHA, 'user-1');
+        expect(userUploads.findOwnedByUser).toHaveBeenCalledWith(SHA, 'user-1', {
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+        });
     });
 
     it('reports an unresolvable hash as not_found without touching storage', async () => {

--- a/packages/agent/src/agents/__tests__/agent-escalation.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-escalation.service.spec.ts
@@ -45,6 +45,7 @@ describe('AgentEscalationService (G3)', () => {
             listOpenForUser: jest.fn().mockResolvedValue([]),
             countOpenForWork: jest.fn().mockResolvedValue(0),
             resolve: jest.fn().mockResolvedValue(true),
+            resolveForTask: jest.fn().mockResolvedValue(true),
         };
     });
 
@@ -84,6 +85,24 @@ describe('AgentEscalationService (G3)', () => {
         expect(repository.listOpenForUser).toHaveBeenCalledWith('u1', expect.any(Date), 20);
         expect(repository.countOpenForWork).toHaveBeenCalledWith('work-1');
         expect(repository.resolve).toHaveBeenCalledWith('e1', 'u1', 'raised the budget');
+    });
+
+    it('delegates scoped Task resolution without dropping the route binding', async () => {
+        const scope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+        const svc = makeSvc();
+
+        await (svc as any).resolveForTask('e1', 'u1', 'task-1', scope, 'approved');
+
+        expect(repository.resolveForTask).toHaveBeenCalledWith(
+            'e1',
+            'u1',
+            'task-1',
+            scope,
+            'approved',
+        );
     });
 });
 

--- a/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
@@ -53,6 +53,8 @@ function makeAgent(over: Partial<Agent> = {}): Agent {
         toolsMd: '# Tools\nNone.',
         agentYml: 'version: 1\n',
         contentHash: 'abc123',
+        tenantId: null,
+        organizationId: null,
         createdAt: new Date('2026-01-01'),
         updatedAt: new Date('2026-01-01'),
         ...over,
@@ -228,7 +230,7 @@ describe('AgentExportService', () => {
         it('applies memoryRecallEnabled on the overwrite path, and omits it when absent', async () => {
             const existing = makeAgent({ id: 'existing-ceo' });
             agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
-            agents.findById.mockResolvedValueOnce(existing);
+            agents.findByIdAndUser.mockResolvedValueOnce(existing);
             const env = baseEnvelope();
             env.model.memoryRecallEnabled = false;
 
@@ -240,7 +242,7 @@ describe('AgentExportService', () => {
 
             agents.updateById.mockClear();
             agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
-            agents.findById.mockResolvedValueOnce(existing);
+            agents.findByIdAndUser.mockResolvedValueOnce(existing);
             await svc.importOne('u1', baseEnvelope(), { onConflict: 'overwrite' });
             expect('memoryRecallEnabled' in agents.updateById.mock.calls[0][1]).toBe(false);
         });
@@ -265,7 +267,7 @@ describe('AgentExportService', () => {
         it('conflict overwrite — patches existing row and returns conflictResolution=overwritten', async () => {
             const existing = makeAgent({ id: 'existing-ceo' });
             agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
-            agents.findById.mockResolvedValueOnce({
+            agents.findByIdAndUser.mockResolvedValueOnce({
                 ...existing,
                 name: baseEnvelope().identity.name,
                 soulMd: '# Hi',
@@ -276,6 +278,39 @@ describe('AgentExportService', () => {
                 'existing-ceo',
                 expect.objectContaining({ soulMd: '# Hi' }),
             );
+        });
+
+        it('does not overwrite the same logical slug in another active Organization', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            const hidden = makeAgent({
+                id: 'yo-ceo',
+                name: 'Yo CEO',
+                tenantId: everScope.tenantId,
+                organizationId: '33333333-3333-4333-8333-333333333333',
+            });
+            agents.findByUserIdAndSlug.mockImplementation(async (...args: unknown[]) =>
+                (args[4] as typeof everScope | undefined)?.organizationId ===
+                everScope.organizationId
+                    ? null
+                    : hidden,
+            );
+            agents.findByIdAndUser.mockResolvedValue(hidden);
+            agents.create.mockImplementation(async (partial: Partial<Agent>) => makeAgent(partial));
+
+            const result = await (svc.importOne as any)(
+                'u1',
+                baseEnvelope(),
+                { onConflict: 'overwrite' },
+                everScope,
+            );
+
+            expect(result.conflictResolution).toBe('none');
+            expect(result.created).toMatchObject(everScope);
+            expect(agents.updateById).not.toHaveBeenCalled();
+            expect(hidden.name).toBe('Yo CEO');
         });
 
         it('rejects secret in any file body', async () => {
@@ -321,7 +356,7 @@ describe('AgentExportService', () => {
             it('clamps permissions on the overwrite path too', async () => {
                 const existing = makeAgent({ id: 'existing-ceo' });
                 agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
-                agents.findById.mockResolvedValueOnce(existing);
+                agents.findByIdAndUser.mockResolvedValueOnce(existing);
                 await svc.importOne('u1', elevatedEnvelope(), { onConflict: 'overwrite' });
 
                 expect(agents.updateById).toHaveBeenCalledWith(
@@ -421,6 +456,39 @@ describe('AgentExportService', () => {
                 await svcWithRepo.importOne('u1', baseEnvelope());
                 expect(scopeCount).not.toHaveBeenCalled();
                 expect(agents.create).toHaveBeenCalled();
+            });
+
+            it('does not overwrite an Agent with an imported target from another Organization', async () => {
+                const everScope = {
+                    tenantId: '11111111-1111-4111-8111-111111111111',
+                    organizationId: '22222222-2222-4222-8222-222222222222',
+                };
+                const env = baseEnvelope();
+                env.runtime.targets = [{ type: 'work', id: 'work-yo' }];
+                const existing = makeAgent({ id: 'existing-ceo', ...everScope });
+                scopeCount.mockResolvedValue(0);
+                agents.findByUserIdAndSlug.mockResolvedValue(existing);
+                agents.findByIdAndUser.mockResolvedValue(existing);
+
+                await expect(
+                    (svcWithRepo.importOne as any)(
+                        'u1',
+                        env,
+                        { onConflict: 'overwrite' },
+                        everScope,
+                    ),
+                ).rejects.toBeInstanceOf(NotFoundException);
+                expect(agents.updateById).not.toHaveBeenCalled();
+                expect(scopeCount).toHaveBeenCalledWith({
+                    where: [
+                        expect.objectContaining({
+                            id: 'work-yo',
+                            userId: 'u1',
+                            tenantId: everScope.tenantId,
+                            organizationId: everScope.organizationId,
+                        }),
+                    ],
+                });
             });
         });
     });

--- a/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
@@ -179,6 +179,18 @@ describe('AgentExportService', () => {
             );
         });
 
+        it.each([[{ type: 'galaxy', id: 'target-1' }], [{ id: 'target-1' }], [null]])(
+            'rejects an imported malformed or unsupported target (%p)',
+            async (target) => {
+                const env = baseEnvelope();
+                env.runtime.targets = [target] as never;
+
+                await expect(svc.importOne('u1', env)).rejects.toThrow(BadRequestException);
+                expect(agents.create).not.toHaveBeenCalled();
+                expect(memberships.replaceForAgent).not.toHaveBeenCalled();
+            },
+        );
+
         it('rejects scope+ids mismatch (TENANT must not carry workId)', async () => {
             await expect(
                 svc.importOne('u1', baseEnvelope(), {

--- a/packages/agent/src/agents/__tests__/agent-run-sweeper-m6.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-sweeper-m6.spec.ts
@@ -56,6 +56,19 @@ describe('AgentRunSweeperService — state-aware policy (M6)', () => {
         };
     }
 
+    function persistedRun(over: Record<string, unknown> = {}) {
+        return {
+            id: 'r1',
+            agentId: 'a1',
+            userId: 'u1',
+            taskId: 'task-1',
+            workId: 'work-1',
+            tenantId: 'tenant-ever',
+            organizationId: 'org-ever',
+            ...over,
+        };
+    }
+
     beforeEach(() => {
         saved = {};
         for (const k of ENV_KEYS) {
@@ -68,7 +81,7 @@ describe('AgentRunSweeperService — state-aware policy (M6)', () => {
             parkStaleRunning: jest.fn().mockResolvedValue(0),
             findQueuedTooLong: jest.fn().mockResolvedValue([]),
             setAttention: jest.fn().mockResolvedValue(true),
-            findById: jest.fn().mockResolvedValue({ id: 'r1', userId: 'u1' }),
+            findById: jest.fn().mockResolvedValue(persistedRun()),
         };
         notifications = { notifyAgentRunQueuedTooLong: jest.fn().mockResolvedValue(undefined) };
         escalations = { record: jest.fn().mockResolvedValue({ id: 'e1' }) };
@@ -160,6 +173,75 @@ describe('AgentRunSweeperService — state-aware policy (M6)', () => {
                 expect.objectContaining({ reasonCode: 'run-parked', runId: 'r1', userId: 'u1' }),
             );
         });
+
+        it('uses the persisted Task and Organization scope for a parked escalation outside ALS', async () => {
+            runs.findStuckNonTerminal.mockResolvedValue([
+                row({
+                    status: 'running',
+                    taskId: undefined,
+                    tenantId: undefined,
+                    organizationId: undefined,
+                }),
+            ]);
+            runs.parkStaleRunning.mockResolvedValue(1);
+            runs.findById.mockResolvedValue(
+                persistedRun({
+                    taskId: 'task-ever',
+                    tenantId: 'tenant-ever',
+                    organizationId: 'org-ever',
+                }),
+            );
+
+            await makeSvc().sweepStuckRuns();
+
+            expect(escalations.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reasonCode: 'run-parked',
+                    runId: 'r1',
+                    taskId: 'task-ever',
+                    tenantId: 'tenant-ever',
+                    organizationId: 'org-ever',
+                }),
+            );
+        });
+
+        it('passes explicit personal null/null scope for a parked Task escalation outside ALS', async () => {
+            runs.findStuckNonTerminal.mockResolvedValue([row({ status: 'running' })]);
+            runs.parkStaleRunning.mockResolvedValue(1);
+            runs.findById.mockResolvedValue(
+                persistedRun({
+                    taskId: 'task-personal',
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            );
+
+            await makeSvc().sweepStuckRuns();
+
+            expect(escalations.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reasonCode: 'run-parked',
+                    taskId: 'task-personal',
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            );
+        });
+
+        it.each([
+            ['miss', null],
+            ['error', new Error('lookup failed')],
+        ])('keeps a parked sweep best-effort on full-run lookup %s', async (_case, result) => {
+            runs.findStuckNonTerminal.mockResolvedValue([row({ status: 'running' })]);
+            runs.parkStaleRunning.mockResolvedValue(1);
+            if (result instanceof Error) runs.findById.mockRejectedValue(result);
+            else runs.findById.mockResolvedValue(result);
+
+            await expect(makeSvc().sweepStuckRuns()).resolves.toEqual(
+                expect.objectContaining({ parked: 1, swept: 1 }),
+            );
+            expect(escalations.record).not.toHaveBeenCalled();
+        });
     });
 
     describe('queued-too-long → surface, never reap', () => {
@@ -231,5 +313,78 @@ describe('AgentRunSweeperService — state-aware policy (M6)', () => {
             expect(summary.flagged).toBe(2);
             expect(summary.notified).toBe(1);
         });
+
+        it('uses the persisted Organization scope for a queued Task escalation outside ALS', async () => {
+            runs.findQueuedTooLong.mockResolvedValue([
+                row({
+                    status: 'queued',
+                    taskId: 'task-ever',
+                    tenantId: undefined,
+                    organizationId: undefined,
+                }),
+            ]);
+            runs.findById.mockResolvedValue(
+                persistedRun({
+                    taskId: 'task-ever',
+                    tenantId: 'tenant-ever',
+                    organizationId: 'org-ever',
+                }),
+            );
+
+            await makeSvc().sweepQueuedTooLong();
+
+            expect(escalations.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reasonCode: 'queued-too-long',
+                    runId: 'r1',
+                    taskId: 'task-ever',
+                    tenantId: 'tenant-ever',
+                    organizationId: 'org-ever',
+                }),
+            );
+        });
+
+        it('passes explicit personal null/null scope for a queued Task escalation outside ALS', async () => {
+            runs.findQueuedTooLong.mockResolvedValue([
+                row({ status: 'queued', taskId: 'task-personal' }),
+            ]);
+            runs.findById.mockResolvedValue(
+                persistedRun({
+                    taskId: 'task-personal',
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            );
+
+            await makeSvc().sweepQueuedTooLong();
+
+            expect(escalations.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reasonCode: 'queued-too-long',
+                    taskId: 'task-personal',
+                    tenantId: null,
+                    organizationId: null,
+                }),
+            );
+        });
+
+        it.each([
+            ['miss', null],
+            ['error', new Error('lookup failed')],
+        ])(
+            'keeps a queued Task sweep best-effort on full-run lookup %s without filing guessed scope',
+            async (_case, result) => {
+                runs.findQueuedTooLong.mockResolvedValue([
+                    row({ status: 'queued', taskId: 'task-ever' }),
+                ]);
+                if (result instanceof Error) runs.findById.mockRejectedValue(result);
+                else runs.findById.mockResolvedValue(result);
+
+                await expect(makeSvc().sweepQueuedTooLong()).resolves.toEqual(
+                    expect.objectContaining({ flagged: 1, scanned: 1 }),
+                );
+                expect(escalations.record).not.toHaveBeenCalled();
+            },
+        );
     });
 });

--- a/packages/agent/src/agents/__tests__/agent-schedule-dispatcher.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-schedule-dispatcher.service.spec.ts
@@ -10,6 +10,11 @@ import {
 } from '../../entities/agent.entity';
 import type { Agent } from '../../entities/agent.entity';
 
+const everScope = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+
 function makeAgent(over: Partial<Agent> = {}): Agent {
     return {
         id: 'a1',
@@ -53,6 +58,8 @@ function makeAgent(over: Partial<Agent> = {}): Agent {
         toolsMd: null,
         agentYml: null,
         contentHash: null,
+        tenantId: null,
+        organizationId: null,
         createdAt: new Date('2026-01-01'),
         updatedAt: new Date('2026-01-01'),
         ...over,
@@ -107,6 +114,35 @@ describe('AgentScheduleDispatcherService', () => {
         );
         expect(trigger.enqueue).toHaveBeenCalledWith(
             expect.objectContaining({ agentId: 'a1', userId: 'u1', runId: 'run-1' }),
+        );
+    });
+
+    it('persists the due Agent tenant and Organization on its heartbeat run', async () => {
+        const agent = makeAgent({ ...everScope });
+        agentRepo.findDueForHeartbeat.mockResolvedValueOnce([agent]);
+        agentRepo.tryClaimForRun.mockResolvedValueOnce(agent.nextHeartbeatAt);
+
+        await svc.dispatchDue(trigger);
+
+        expect(runRepo.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({
+                agentId: 'a1',
+                userId: 'u1',
+                triggerKind: 'heartbeat',
+                ...everScope,
+            }),
+        );
+    });
+
+    it('keeps a legacy personal heartbeat run explicitly personal', async () => {
+        const agent = makeAgent({ tenantId: null, organizationId: null });
+        agentRepo.findDueForHeartbeat.mockResolvedValueOnce([agent]);
+        agentRepo.tryClaimForRun.mockResolvedValueOnce(agent.nextHeartbeatAt);
+
+        await svc.dispatchDue(trigger);
+
+        expect(runRepo.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({ tenantId: null, organizationId: null }),
         );
     });
 

--- a/packages/agent/src/agents/__tests__/agent-templates.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-templates.service.spec.ts
@@ -116,6 +116,35 @@ describe('AgentTemplatesService', () => {
         expect(input.missionId).toBeNull();
     });
 
+    it('keeps template parent validation and follow-up writes in the active Organization', async () => {
+        const { service, agents } = makeService();
+        const everScope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+        agents.create.mockImplementation(async (_userId, _input, scope) => {
+            if (scope?.organizationId !== everScope.organizationId) {
+                throw new NotFoundException('Mission mission-ever not found.');
+            }
+            return { ...CREATED, ...everScope };
+        });
+        agents.setGuardrails.mockImplementation(async (_userId, _id, _guardrails, scope) => {
+            if (scope?.organizationId !== everScope.organizationId) {
+                throw new NotFoundException('Agent agent-1 not found.');
+            }
+            return { ...AFTER_GUARDRAILS, ...everScope };
+        });
+
+        const result = await (service.createFromTemplate as any)(
+            'user-1',
+            'lead-researcher',
+            { scope: AgentScope.MISSION, missionId: 'mission-ever' },
+            everScope,
+        );
+
+        expect(result).toMatchObject(everScope);
+    });
+
     it('rejects unknown template slugs before creating anything', async () => {
         const { service, agents, files } = makeService();
 

--- a/packages/agent/src/agents/__tests__/agents.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agents.service.spec.ts
@@ -447,6 +447,17 @@ describe('AgentsService', () => {
     });
 
     describe('addTarget / removeTarget (assign an existing Agent to a Work)', () => {
+        it('rejects an unknown target discriminant instead of treating it as a wildcard', async () => {
+            const agent = makeAgent({ scope: AgentScope.TENANT, targets: null });
+            agents.findByIdAndUser.mockResolvedValue(agent);
+
+            await expect(
+                svc.addTarget('u1', 'a1', { type: 'galaxy', id: 'target-1' } as never),
+            ).rejects.toThrow(BadRequestException);
+            expect(agents.casUpdateTargets).not.toHaveBeenCalled();
+            expect(memberships.addMembership).not.toHaveBeenCalled();
+        });
+
         it('appends the target and materializes the membership row', async () => {
             const agent = makeAgent({ scope: AgentScope.TENANT, targets: null });
             agents.findByIdAndUser.mockResolvedValue(agent);

--- a/packages/agent/src/agents/__tests__/agents.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agents.service.spec.ts
@@ -648,6 +648,65 @@ describe('AgentsService', () => {
         });
     });
 
+    describe('addAttachment — canonical upload hashes', () => {
+        it('normalizes uppercase hashes before persistence and duplicate recovery', async () => {
+            const uppercaseSha256 = 'A'.repeat(64);
+            const canonicalSha256 = uppercaseSha256.toLowerCase();
+            const persisted: Array<{ id: string; agentId: string; uploadId: string }> = [];
+            const agentAttachments = {
+                add: jest.fn(async (agentId: string, uploadId: string) => {
+                    if (
+                        persisted.some(
+                            (attachment) =>
+                                attachment.agentId === agentId && attachment.uploadId === uploadId,
+                        )
+                    ) {
+                        throw new Error('duplicate key value violates unique constraint');
+                    }
+                    const attachment = {
+                        id: `attachment-${persisted.length + 1}`,
+                        agentId,
+                        uploadId,
+                    };
+                    persisted.push(attachment);
+                    return attachment;
+                }),
+                findByAgentId: jest.fn(async (agentId: string) =>
+                    persisted.filter((attachment) => attachment.agentId === agentId),
+                ),
+            };
+            const uploadsRepo = {
+                findOne: jest.fn().mockResolvedValue({ sha256: canonicalSha256 }),
+            };
+            agents.findByIdAndUser.mockResolvedValue(makeAgent());
+            svc = new AgentsService(
+                agents,
+                memberships,
+                budgets,
+                agentAttachments as never,
+                undefined,
+                undefined,
+                undefined,
+                uploadsRepo as never,
+            );
+
+            const first = await svc.addAttachment('u1', 'a1', uppercaseSha256);
+            const duplicate = await svc.addAttachment('u1', 'a1', canonicalSha256);
+
+            expect(persisted).toEqual([
+                expect.objectContaining({ agentId: 'a1', uploadId: canonicalSha256 }),
+            ]);
+            expect(first).toBe(duplicate);
+            expect(agentAttachments.add).toHaveBeenNthCalledWith(1, 'a1', canonicalSha256);
+            expect(agentAttachments.add).toHaveBeenNthCalledWith(2, 'a1', canonicalSha256);
+            expect(agentAttachments.findByAgentId).toHaveBeenCalledWith('a1');
+            expect(uploadsRepo.findOne).toHaveBeenCalledTimes(2);
+            for (const [options] of uploadsRepo.findOne.mock.calls) {
+                expect(options.where).toEqual(expect.objectContaining({ sha256: canonicalSha256 }));
+            }
+        });
+    });
+
     describe('assertCanAssignAcrossScope', () => {
         it('rejects cross-user assignment', async () => {
             const actor = makeAgent({ userId: 'u1', scope: AgentScope.TENANT });

--- a/packages/agent/src/agents/__tests__/run-steering.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-steering.service.spec.ts
@@ -14,6 +14,14 @@ import { RunSteeringService } from '../run-steering.service';
 describe('RunSteeringService', () => {
     const userId = 'user-1';
     const runId = 'run-1';
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    const yoScope = {
+        tenantId: everScope.tenantId,
+        organizationId: '33333333-3333-4333-8333-333333333333',
+    };
 
     let runs: any;
     let runLogs: any;
@@ -28,7 +36,7 @@ describe('RunSteeringService', () => {
             status: 'running',
             taskId: 'task-1',
             workId: 'work-1',
-            organizationId: 'org-1',
+            ...everScope,
             awaitingInput: false,
             terminalEndedReason: null,
             cliSessionId: null,
@@ -108,6 +116,31 @@ describe('RunSteeringService', () => {
             ).rejects.toBeInstanceOf(NotFoundException);
         });
 
+        it('loads the run inside the exact active Ever scope', async () => {
+            await makeSvc().steer({
+                runId,
+                userId,
+                message: 'ping',
+                ownershipScope: everScope,
+            });
+
+            expect(runs.findByIdAndUser).toHaveBeenCalledWith(runId, userId, everScope);
+        });
+
+        it('404s the same-user known run id when only Yo is active', async () => {
+            runs.findByIdAndUser.mockResolvedValue(null);
+
+            await expect(
+                makeSvc().steer({
+                    runId,
+                    userId,
+                    message: 'ping',
+                    ownershipScope: yoScope,
+                }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(runs.appendPendingInput).not.toHaveBeenCalled();
+        });
+
         it('rejects an empty message rather than queueing whitespace', async () => {
             await expect(makeSvc().steer({ runId, userId, message: '   ' })).rejects.toBeInstanceOf(
                 ConflictException,
@@ -157,6 +190,12 @@ describe('RunSteeringService', () => {
                 NotFoundException,
             );
         });
+
+        it('loads the interrupt target inside the exact active scope', async () => {
+            await makeSvc().interrupt(runId, userId, everScope);
+
+            expect(runs.findByIdAndUser).toHaveBeenCalledWith(runId, userId, everScope);
+        });
     });
 
     // ── resume ─────────────────────────────────────────────────────
@@ -185,6 +224,15 @@ describe('RunSteeringService', () => {
                 cliSessionId: 'cli-session-abc',
                 pendingInput: ['yes, ship it'],
             });
+        });
+
+        it('loads and recreates a resumed run in its exact persisted scope', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+
+            await makeSvc().resume(runId, userId, 'continue', everScope);
+
+            expect(runs.findByIdAndUser).toHaveBeenCalledWith(runId, userId, everScope);
+            expect(runs.createQueued).toHaveBeenCalledWith(expect.objectContaining(everScope));
         });
 
         it('resumes an awaiting-input run and clears its parked flag', async () => {
@@ -262,6 +310,53 @@ describe('RunSteeringService', () => {
         it('404s a run owned by another user', async () => {
             runs.findByIdAndUser.mockResolvedValue(null);
             await expect(makeSvc().resume(runId, userId)).rejects.toBeInstanceOf(NotFoundException);
+        });
+    });
+
+    describe('legacy personal compatibility', () => {
+        const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+        const legacyPersonal = (over: Record<string, unknown> = {}) =>
+            makeRun({ tenantId: null, organizationId: null, ...over });
+
+        it('steers a legacy personal run through the personal predicate', async () => {
+            runs.findByIdAndUser.mockResolvedValue(legacyPersonal());
+
+            await expect(
+                makeSvc().steer({
+                    runId,
+                    userId,
+                    message: 'personal note',
+                    ownershipScope: personalScope,
+                }),
+            ).resolves.toEqual(expect.objectContaining({ dispatched: 'injected' }));
+            expect(runs.findByIdAndUser).toHaveBeenCalledWith(runId, userId, personalScope);
+        });
+
+        it('interrupts a legacy personal run through the personal predicate', async () => {
+            runs.findByIdAndUser.mockResolvedValue(legacyPersonal());
+
+            await expect(makeSvc().interrupt(runId, userId, personalScope)).resolves.toEqual({
+                interrupted: true,
+                runId,
+            });
+            expect(runs.findByIdAndUser).toHaveBeenCalledWith(runId, userId, personalScope);
+        });
+
+        it('resumes a legacy personal run and preserves the legacy scope', async () => {
+            runs.findByIdAndUser.mockResolvedValue(
+                legacyPersonal({
+                    status: 'completed',
+                    terminalEndedReason: 'parked',
+                    cliSessionId: 'legacy-cli',
+                }),
+            );
+
+            await makeSvc().resume(runId, userId, null, personalScope);
+
+            expect(runs.findByIdAndUser).toHaveBeenCalledWith(runId, userId, personalScope);
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ tenantId: null, organizationId: null }),
+            );
         });
     });
 });

--- a/packages/agent/src/agents/agent-escalation.service.ts
+++ b/packages/agent/src/agents/agent-escalation.service.ts
@@ -10,6 +10,7 @@ import type { AgentEscalation } from '../entities/agent-escalation.entity';
 // Leaf token file — no runtime graph (see inbox-producer.port.ts).
 import { INBOX_PRODUCER, type InboxProducer } from '../inbox/inbox-producer.port';
 import { EscalationConfidenceService } from './escalation-confidence';
+import type { OwnershipScope } from '../database/ownership-scope';
 
 /**
  * Judgment layer G3 — the ONE place an agent's give-up becomes a record.
@@ -134,6 +135,16 @@ export class AgentEscalationService {
      */
     async resolve(id: string, userId: string, note?: string | null): Promise<boolean> {
         return this.repository.resolve(id, userId, note ?? null);
+    }
+
+    async resolveForTask(
+        id: string,
+        userId: string,
+        taskId: string,
+        scope: OwnershipScope,
+        note?: string | null,
+    ): Promise<boolean> {
+        return this.repository.resolveForTask(id, userId, taskId, scope, note ?? null);
     }
 
     /** Mirror one recorded escalation into the owner's inbox. Best-effort. */

--- a/packages/agent/src/agents/agent-export.service.ts
+++ b/packages/agent/src/agents/agent-export.service.ts
@@ -26,6 +26,11 @@ import { Mission } from '../entities/mission.entity';
 import { Work } from '../entities/work.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
 import { AgentRepository } from '../database/repositories/agent.repository';
+import {
+    ownershipStamp,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
 import { AgentBudgetRepository } from '../database/repositories/agent-budget.repository';
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
 import { ActivityLogService } from '../activity-log/activity-log.service';
@@ -222,8 +227,12 @@ export class AgentExportService {
         private readonly agentEntityRepo?: Repository<Agent>,
     ) {}
 
-    async exportOne(userId: string, agentId: string): Promise<AgentExportEnvelope> {
-        const agent = await this.agents.findByIdAndUser(agentId, userId);
+    async exportOne(
+        userId: string,
+        agentId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentExportEnvelope> {
+        const agent = await this.agents.findByIdAndUser(agentId, userId, ownershipScope);
         if (!agent) {
             throw new NotFoundException(`Agent ${agentId} not found.`);
         }
@@ -315,6 +324,7 @@ export class AgentExportService {
         userId: string,
         envelope: AgentExportEnvelope,
         options: AgentImportOptions = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<AgentImportResult> {
         this.assertValidEnvelope(envelope);
 
@@ -353,7 +363,8 @@ export class AgentExportService {
         // (id, userId) and 404 — same not-found shape either way — when it
         // is missing or owned by someone else. Tenant scope has no target
         // id, so it is unaffected.
-        await this.assertScopeOwned(userId, scope, { missionId, ideaId, workId });
+        await this.assertScopeOwned(userId, scope, { missionId, ideaId, workId }, ownershipScope);
+        await this.assertTargetsOwned(userId, envelope.runtime.targets, ownershipScope);
 
         // Secret-scan every file body BEFORE persisting — same hard-reject
         // posture as live edits via AgentFileService.write.
@@ -386,11 +397,13 @@ export class AgentExportService {
         const originalSlug = slugifyText(envelope.identity.name) || envelope.identity.slug;
         const mode = options.onConflict ?? 'rename';
 
-        const conflict = await this.agents.findByUserIdAndSlug(userId, scope, originalSlug, {
-            missionId,
-            ideaId,
-            workId,
-        });
+        const conflict = await this.agents.findByUserIdAndSlug(
+            userId,
+            scope,
+            originalSlug,
+            { missionId, ideaId, workId },
+            ownershipScope,
+        );
 
         let finalSlug = originalSlug;
         let conflictResolution: AgentImportResult['conflictResolution'] = 'none';
@@ -403,7 +416,11 @@ export class AgentExportService {
             } else if (mode === 'overwrite') {
                 await this.applyEnvelopeToExisting(conflict, envelope);
                 conflictResolution = 'overwritten';
-                const refreshed = (await this.agents.findById(conflict.id)) as Agent;
+                const refreshed = (await this.agents.findByIdAndUser(
+                    conflict.id,
+                    userId,
+                    ownershipScope,
+                )) as Agent;
                 await this.logActivity({
                     userId,
                     agentId: conflict.id,
@@ -417,11 +434,13 @@ export class AgentExportService {
                 };
             } else {
                 // rename
-                finalSlug = await this.deriveUniqueSlug(userId, scope, originalSlug, {
-                    missionId,
-                    ideaId,
-                    workId,
-                });
+                finalSlug = await this.deriveUniqueSlug(
+                    userId,
+                    scope,
+                    originalSlug,
+                    { missionId, ideaId, workId },
+                    ownershipScope,
+                );
                 conflictResolution = 'renamed';
             }
         }
@@ -448,6 +467,7 @@ export class AgentExportService {
 
         const created = await this.agents.create({
             userId,
+            ...ownershipStamp(ownershipScope),
             scope,
             missionId: scope === AgentScope.MISSION ? missionId : null,
             ideaId: scope === AgentScope.IDEA ? ideaId : null,
@@ -553,6 +573,7 @@ export class AgentExportService {
         userId: string,
         scope: AgentScope,
         ids: { missionId: string | null; ideaId: string | null; workId: string | null },
+        ownershipScope?: OwnershipScope,
     ): Promise<void> {
         // TENANT scope carries no target id — nothing to own-check.
         if (scope === AgentScope.TENANT) return;
@@ -582,19 +603,55 @@ export class AgentExportService {
             throw new BadRequestException(`Missing target id for ${scope}-scoped import.`);
         }
 
+        await this.assertEntityOwned(
+            userId,
+            entity,
+            targetId,
+            `${scope} ${targetId}`,
+            ownershipScope,
+        );
+    }
+
+    /** Imported bulk targets cannot bypass AgentsService.addTarget ownership checks. */
+    private async assertTargetsOwned(
+        userId: string,
+        targets: AgentTarget[] | null,
+        ownershipScope?: OwnershipScope,
+    ): Promise<void> {
+        for (const target of targets ?? []) {
+            if (target.type === 'wildcard') continue;
+            if (!target.id) {
+                throw new BadRequestException(`Imported ${target.type} target requires an id.`);
+            }
+            const entity: EntityTarget<ObjectLiteral> =
+                target.type === 'mission' ? Mission : target.type === 'idea' ? WorkProposal : Work;
+            await this.assertEntityOwned(
+                userId,
+                entity,
+                target.id,
+                `${target.type} ${target.id}`,
+                ownershipScope,
+            );
+        }
+    }
+
+    private async assertEntityOwned(
+        userId: string,
+        entity: EntityTarget<ObjectLiteral>,
+        id: string,
+        label: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<void> {
         // Skip only when the repo isn't wired (mock-only unit harnesses);
         // production resolves a live Repository<Agent> and its `.manager`
         // reaches every entity in the same DataSource.
         if (!this.agentEntityRepo) return;
 
-        // Existence-by-owner: count instead of hydrating a full row just to
-        // assert ownership.
-        const ownedCount = await this.agentEntityRepo.manager
-            .getRepository(entity)
-            .count({ where: { id: targetId, userId } });
+        const ownedCount = await this.agentEntityRepo.manager.getRepository(entity).count({
+            where: ownershipWhereWith<ObjectLiteral>(userId, ownershipScope, { id }),
+        });
         if (ownedCount === 0) {
-            // 404 (not 403) — don't leak existence of another user's scope.
-            throw new NotFoundException(`${scope} ${targetId} not found.`);
+            throw new NotFoundException(`${label} not found.`);
         }
     }
 
@@ -666,11 +723,18 @@ export class AgentExportService {
         scope: AgentScope,
         base: string,
         ids: { missionId: string | null; ideaId: string | null; workId: string | null },
+        ownershipScope?: OwnershipScope,
         maxAttempts = 200,
     ): Promise<string> {
         for (let i = 2; i <= maxAttempts; i++) {
             const candidate = `${base}-${i}`;
-            const existing = await this.agents.findByUserIdAndSlug(userId, scope, candidate, ids);
+            const existing = await this.agents.findByUserIdAndSlug(
+                userId,
+                scope,
+                candidate,
+                ids,
+                ownershipScope,
+            );
             if (!existing) return candidate;
         }
         throw new ConflictException(

--- a/packages/agent/src/agents/agent-export.service.ts
+++ b/packages/agent/src/agents/agent-export.service.ts
@@ -51,6 +51,11 @@ import { toAgentDto } from './types';
 // inline (and matched in value) to avoid coupling agent-export to
 // agent-file at the module-construction layer.
 const MAX_IMPORT_FILE_BYTES = 64 * 1024; // 64 KB per file (spec §5.10a / §5.6.6).
+const SUPPORTED_AGENT_TARGET_TYPES = new Set(['mission', 'idea', 'work', 'wildcard']);
+
+function isSupportedAgentTargetType(value: unknown): value is AgentTarget['type'] {
+    return typeof value === 'string' && SUPPORTED_AGENT_TARGET_TYPES.has(value);
+}
 
 /**
  * Review-fix I7: shared canonical-hash function. Mirrors the
@@ -553,6 +558,23 @@ export class AgentExportService {
                 `Envelope identity.scope is invalid: ${envelope.identity.scope}`,
             );
         }
+        if (!envelope.runtime || typeof envelope.runtime !== 'object') {
+            throw new BadRequestException('Envelope runtime is required.');
+        }
+        if (envelope.runtime.targets !== null && !Array.isArray(envelope.runtime.targets)) {
+            throw new BadRequestException('Envelope runtime.targets must be an array or null.');
+        }
+        for (const target of envelope.runtime.targets ?? []) {
+            if (!target || typeof target !== 'object' || !isSupportedAgentTargetType(target.type)) {
+                throw new BadRequestException('Envelope runtime.targets contains an invalid type.');
+            }
+            if (
+                target.type !== 'wildcard' &&
+                (typeof target.id !== 'string' || target.id.trim().length === 0)
+            ) {
+                throw new BadRequestException(`Imported ${target.type} target requires an id.`);
+            }
+        }
     }
 
     /**
@@ -619,12 +641,22 @@ export class AgentExportService {
         ownershipScope?: OwnershipScope,
     ): Promise<void> {
         for (const target of targets ?? []) {
-            if (target.type === 'wildcard') continue;
-            if (!target.id) {
-                throw new BadRequestException(`Imported ${target.type} target requires an id.`);
+            let entity: EntityTarget<ObjectLiteral>;
+            switch (target.type) {
+                case 'wildcard':
+                    continue;
+                case 'mission':
+                    entity = Mission;
+                    break;
+                case 'idea':
+                    entity = WorkProposal;
+                    break;
+                case 'work':
+                    entity = Work;
+                    break;
+                default:
+                    throw new BadRequestException('Imported Agent target type is invalid.');
             }
-            const entity: EntityTarget<ObjectLiteral> =
-                target.type === 'mission' ? Mission : target.type === 'idea' ? WorkProposal : Work;
             await this.assertEntityOwned(
                 userId,
                 entity,

--- a/packages/agent/src/agents/agent-run-sweeper.service.ts
+++ b/packages/agent/src/agents/agent-run-sweeper.service.ts
@@ -9,6 +9,7 @@ import {
 import { RunDispatchGateService } from './run-dispatch-gate.service';
 import { AgentEscalationService } from './agent-escalation.service';
 import { NotificationService } from '../notifications/notification.service';
+import type { AgentRun } from '../entities/agent-run.entity';
 
 /**
  * Error message prefix for a swept run.
@@ -395,13 +396,17 @@ export class AgentRunSweeperService {
         waitedMinutes: number,
     ): Promise<void> {
         if (!this.escalations) return;
+        const persisted = await this.findPersistedRunForEscalation(run.id);
+        if (!persisted) return;
         await this.escalations.record({
-            userId: run.userId,
+            userId: persisted.userId,
             reasonCode: 'queued-too-long',
-            runId: run.id,
-            taskId: run.taskId ?? null,
-            workId: run.workId ?? null,
-            agentId: run.agentId,
+            runId: persisted.id,
+            taskId: persisted.taskId ?? null,
+            workId: persisted.workId ?? null,
+            agentId: persisted.agentId,
+            tenantId: persisted.tenantId ?? null,
+            organizationId: persisted.organizationId ?? null,
             summary: `Run has been queued for ${waitedMinutes} minutes without starting.`,
             decisionNeeded:
                 'Decide whether to raise the concurrency limit for this Work/org, cancel the ' +
@@ -409,8 +414,8 @@ export class AgentRunSweeperService {
             attempted: [
                 {
                     label: 'dispatch',
-                    outcome: run.queuedReason
-                        ? `parked with reason '${run.queuedReason}'`
+                    outcome: persisted.queuedReason
+                        ? `parked with reason '${persisted.queuedReason}'`
                         : 'queued, never handed to the job runtime',
                 },
             ],
@@ -422,24 +427,17 @@ export class AgentRunSweeperService {
         cutoffMinutes: number,
     ): Promise<void> {
         if (!this.escalations) return;
-        // The stuck-scan projection is deliberately narrow (it does not
-        // select userId), so resolve the owner only when we actually have
-        // an escalation sink. A miss is not an error — the park itself
-        // already landed.
-        let userId: string | null = null;
-        try {
-            const full = await this.runs.findById(run.id);
-            userId = full?.userId ?? null;
-        } catch {
-            userId = null;
-        }
-        if (!userId) return;
+        const persisted = await this.findPersistedRunForEscalation(run.id);
+        if (!persisted) return;
         await this.escalations.record({
-            userId,
+            userId: persisted.userId,
             reasonCode: 'run-parked',
-            runId: run.id,
-            workId: run.workId ?? null,
-            agentId: run.agentId,
+            runId: persisted.id,
+            taskId: persisted.taskId ?? null,
+            workId: persisted.workId ?? null,
+            agentId: persisted.agentId,
+            tenantId: persisted.tenantId ?? null,
+            organizationId: persisted.organizationId ?? null,
             summary: `Run was parked after ${cutoffMinutes} minutes with no worker checkpoint.`,
             decisionNeeded:
                 'The conversation was kept and can be resumed. Decide whether to resume this ' +
@@ -451,6 +449,30 @@ export class AgentRunSweeperService {
                 },
             ],
         });
+    }
+
+    /**
+     * The sweeper projections intentionally omit ownership columns. Escalations
+     * are a best-effort side effect, so re-read the authoritative row and skip
+     * the card when it cannot be loaded instead of guessing a Task's scope.
+     */
+    private async findPersistedRunForEscalation(runId: string): Promise<AgentRun | null> {
+        try {
+            const run = await this.runs.findById(runId);
+            if (!run) {
+                this.logger.warn(
+                    `AgentRun escalation skipped for ${runId}: persisted run was not found.`,
+                );
+            }
+            return run;
+        } catch (error) {
+            this.logger.warn(
+                `AgentRun escalation skipped for ${runId}: persisted run lookup failed: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
     }
 }
 

--- a/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
+++ b/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
@@ -195,6 +195,8 @@ export class AgentScheduleDispatcherService {
                     agentId: agent.id,
                     userId: agent.userId,
                     triggerKind: 'heartbeat',
+                    tenantId: agent.tenantId ?? null,
+                    organizationId: agent.organizationId ?? null,
                 });
                 createdRun = run ?? null;
 
@@ -323,6 +325,8 @@ export class AgentScheduleDispatcherService {
                 agentId: agent.id,
                 userId: agent.userId,
                 triggerKind: 'manual',
+                tenantId: agent.tenantId ?? null,
+                organizationId: agent.organizationId ?? null,
             });
             createdRun = run ?? null;
             const handle = await trigger.enqueue({

--- a/packages/agent/src/agents/agent-templates.service.ts
+++ b/packages/agent/src/agents/agent-templates.service.ts
@@ -4,6 +4,7 @@ import { AgentsService } from './agents.service';
 import { AgentFileService } from './agent-file.service';
 import type { AgentDto } from './types';
 import { getAgentTemplate, listAgentTemplates, type AgentTemplate } from './agent-templates';
+import type { OwnershipScope } from '../database/ownership-scope';
 
 /**
  * Optional placement overrides accepted by {@link AgentTemplatesService.createFromTemplate}.
@@ -65,11 +66,12 @@ export class AgentTemplatesService {
         userId: string,
         slug: string,
         input: CreateAgentFromTemplateInput = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<AgentDto> {
         const template = this.get(slug);
         const scope = input.scope ?? AgentScope.TENANT;
 
-        const created = await this.agents.create(userId, {
+        const createInput = {
             scope,
             missionId: input.missionId ?? null,
             ideaId: input.ideaId ?? null,
@@ -78,7 +80,10 @@ export class AgentTemplatesService {
             title: template.title,
             capabilities: template.capabilities,
             permissions: template.defaultPermissions,
-        });
+        };
+        const created = ownershipScope
+            ? await this.agents.create(userId, createInput, ownershipScope)
+            : await this.agents.create(userId, createInput);
 
         // Persist the template's system prompt as the Agent's SOUL.md.
         // Best-effort ordering: the Agent row exists first, so a failed
@@ -97,6 +102,13 @@ export class AgentTemplatesService {
         }
 
         // Seed the review-before-act guardrails and return the fresh DTO.
-        return this.agents.setGuardrails(userId, created.id, template.defaultGuardrails);
+        return ownershipScope
+            ? this.agents.setGuardrails(
+                  userId,
+                  created.id,
+                  template.defaultGuardrails,
+                  ownershipScope,
+              )
+            : this.agents.setGuardrails(userId, created.id, template.defaultGuardrails);
     }
 }

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -49,6 +49,7 @@ import {
 // five canonical Agent files), so a secret-like value is hard-rejected
 // rather than redacted.
 import { assertNoSecrets } from '../utils/secret-scan';
+import { ownershipWhere, type OwnershipScope } from '../database/ownership-scope';
 
 // Upload IDs are SHA-256 hex strings (the `id` field returned by
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
@@ -258,22 +259,31 @@ export class AgentsService {
     async list(
         userId: string,
         filter: ListAgentsFilter = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<{
         rows: AgentDto[];
         total: number;
     }> {
-        const { rows, total } = await this.agents.findByUserIdScoped(userId, filter);
+        const { rows, total } = await this.agents.findByUserIdScoped(
+            userId,
+            filter,
+            ownershipScope,
+        );
         return { rows: rows.map(toAgentDto), total };
     }
 
-    async getOne(userId: string, id: string): Promise<AgentDto> {
-        const agent = await this.requireOwned(userId, id);
+    async getOne(userId: string, id: string, ownershipScope?: OwnershipScope): Promise<AgentDto> {
+        const agent = await this.requireOwned(userId, id, ownershipScope);
         return toAgentDto(agent);
     }
 
-    async create(userId: string, input: CreateAgentInput): Promise<AgentDto> {
+    async create(
+        userId: string,
+        input: CreateAgentInput,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentDto> {
         this.validateScopeOwnership(input);
-        await this.assertScopeParentExists(userId, input);
+        await this.assertScopeParentExists(userId, input, ownershipScope);
 
         const slug = slugifyText(input.name);
         // `slugifyText('---')` returns `-` (dash), not the empty string,
@@ -286,11 +296,17 @@ export class AgentsService {
             );
         }
 
-        const conflict = await this.agents.findByUserIdAndSlug(userId, input.scope, slug, {
-            missionId: input.scope === AgentScope.MISSION ? (input.missionId ?? null) : null,
-            ideaId: input.scope === AgentScope.IDEA ? (input.ideaId ?? null) : null,
-            workId: input.scope === AgentScope.WORK ? (input.workId ?? null) : null,
-        });
+        const conflict = await this.agents.findByUserIdAndSlug(
+            userId,
+            input.scope,
+            slug,
+            {
+                missionId: input.scope === AgentScope.MISSION ? (input.missionId ?? null) : null,
+                ideaId: input.scope === AgentScope.IDEA ? (input.ideaId ?? null) : null,
+                workId: input.scope === AgentScope.WORK ? (input.workId ?? null) : null,
+            },
+            ownershipScope,
+        );
         if (conflict) {
             throw new ConflictException(
                 `An Agent named "${input.name}" already exists in this scope.`,
@@ -958,8 +974,12 @@ export class AgentsService {
 
     // ── internals ─────────────────────────────────────────────────
 
-    private async requireOwned(userId: string, id: string): Promise<Agent> {
-        const agent = await this.agents.findByIdAndUser(id, userId);
+    private async requireOwned(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Agent> {
+        const agent = await this.agents.findByIdAndUser(id, userId, ownershipScope);
         if (!agent) {
             // 404 (not 403) — don't leak existence.
             throw new NotFoundException(`Agent ${id} not found.`);
@@ -1048,12 +1068,18 @@ export class AgentsService {
     private async assertScopeParentExists(
         userId: string,
         input: Pick<CreateAgentInput, 'scope' | 'missionId' | 'ideaId' | 'workId'>,
+        ownershipScope?: OwnershipScope,
     ): Promise<void> {
         switch (input.scope) {
             case AgentScope.WORK: {
                 if (!input.workId || !this.workRepo) return;
                 const work = await this.workRepo.findOne({
-                    where: { id: input.workId, userId },
+                    where: ownershipScope
+                        ? ownershipWhere<Work>(userId, ownershipScope).map((branch) => ({
+                              ...branch,
+                              id: input.workId,
+                          }))
+                        : { id: input.workId, userId },
                 });
                 if (!work) throw new NotFoundException(`Work ${input.workId} not found.`);
                 break;
@@ -1061,7 +1087,12 @@ export class AgentsService {
             case AgentScope.MISSION: {
                 if (!input.missionId || !this.missionRepo) return;
                 const mission = await this.missionRepo.findOne({
-                    where: { id: input.missionId, userId },
+                    where: ownershipScope
+                        ? ownershipWhere<Mission>(userId, ownershipScope).map((branch) => ({
+                              ...branch,
+                              id: input.missionId,
+                          }))
+                        : { id: input.missionId, userId },
                 });
                 if (!mission) throw new NotFoundException(`Mission ${input.missionId} not found.`);
                 break;
@@ -1069,7 +1100,12 @@ export class AgentsService {
             case AgentScope.IDEA: {
                 if (!input.ideaId || !this.ideaRepo) return;
                 const idea = await this.ideaRepo.findOne({
-                    where: { id: input.ideaId, userId },
+                    where: ownershipScope
+                        ? ownershipWhere<WorkProposal>(userId, ownershipScope).map((branch) => ({
+                              ...branch,
+                              id: input.ideaId,
+                          }))
+                        : { id: input.ideaId, userId },
                 });
                 if (!idea) throw new NotFoundException(`Idea ${input.ideaId} not found.`);
                 break;

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -49,7 +49,11 @@ import {
 // five canonical Agent files), so a secret-like value is hard-rejected
 // rather than redacted.
 import { assertNoSecrets } from '../utils/secret-scan';
-import { ownershipWhere, type OwnershipScope } from '../database/ownership-scope';
+import {
+    ownershipStamp,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
 
 // Upload IDs are SHA-256 hex strings (the `id` field returned by
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
@@ -284,6 +288,7 @@ export class AgentsService {
     ): Promise<AgentDto> {
         this.validateScopeOwnership(input);
         await this.assertScopeParentExists(userId, input, ownershipScope);
+        await this.assertTargetsExist(userId, input.targets, ownershipScope);
 
         const slug = slugifyText(input.name);
         // `slugifyText('---')` returns `-` (dash), not the empty string,
@@ -330,12 +335,13 @@ export class AgentsService {
         );
         this.validateHeartbeatCadence(input.heartbeatCadence ?? null);
         if (input.environmentId) {
-            await this.assertAssignableEnvironment(userId, input.environmentId);
+            await this.assertAssignableEnvironment(userId, input.environmentId, ownershipScope);
         }
 
         const created = await this.agents
             .create({
                 userId,
+                ...ownershipStamp(ownershipScope),
                 scope: input.scope,
                 missionId: input.scope === AgentScope.MISSION ? (input.missionId ?? null) : null,
                 ideaId: input.scope === AgentScope.IDEA ? (input.ideaId ?? null) : null,
@@ -401,8 +407,13 @@ export class AgentsService {
         return toAgentDto(created);
     }
 
-    async update(userId: string, id: string, input: UpdateAgentInput): Promise<AgentDto> {
-        const agent = await this.requireOwned(userId, id);
+    async update(
+        userId: string,
+        id: string,
+        input: UpdateAgentInput,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentDto> {
+        const agent = await this.requireOwned(userId, id, ownershipScope);
 
         const patch: Partial<Agent> = {};
 
@@ -414,11 +425,17 @@ export class AgentsService {
                 );
             }
             if (slug !== agent.slug) {
-                const conflict = await this.agents.findByUserIdAndSlug(userId, agent.scope, slug, {
-                    missionId: agent.missionId ?? null,
-                    ideaId: agent.ideaId ?? null,
-                    workId: agent.workId ?? null,
-                });
+                const conflict = await this.agents.findByUserIdAndSlug(
+                    userId,
+                    agent.scope,
+                    slug,
+                    {
+                        missionId: agent.missionId ?? null,
+                        ideaId: agent.ideaId ?? null,
+                        workId: agent.workId ?? null,
+                    },
+                    ownershipScope,
+                );
                 if (conflict && conflict.id !== agent.id) {
                     throw new ConflictException(
                         `An Agent named "${input.name}" already exists in this scope.`,
@@ -440,7 +457,7 @@ export class AgentsService {
         // tool/import callers can't bypass the UI filter).
         if (input.environmentId !== undefined) {
             if (input.environmentId !== null) {
-                await this.assertAssignableEnvironment(userId, input.environmentId);
+                await this.assertAssignableEnvironment(userId, input.environmentId, ownershipScope);
             }
             patch.environmentId = input.environmentId;
         }
@@ -471,12 +488,18 @@ export class AgentsService {
         }
 
         if (input.targets !== undefined) {
+            await this.assertTargetsExist(userId, input.targets, ownershipScope);
             patch.targets = input.targets;
         }
 
         if (input.reportsToAgentId !== undefined) {
             if (input.reportsToAgentId !== null) {
-                await this.assertValidReportsTo(userId, agent, input.reportsToAgentId);
+                await this.assertValidReportsTo(
+                    userId,
+                    agent,
+                    input.reportsToAgentId,
+                    ownershipScope,
+                );
             }
             patch.reportsToAgentId = input.reportsToAgentId;
         }
@@ -602,9 +625,14 @@ export class AgentsService {
      * to the parent it is ALREADY pinned to, which would record reach it
      * has by scope and then let `removeTarget` appear to revoke it.
      */
-    async addTarget(userId: string, id: string, target: AgentTarget): Promise<AgentDto> {
-        let agent = await this.requireOwned(userId, id);
-        await this.assertTargetExists(userId, target);
+    async addTarget(
+        userId: string,
+        id: string,
+        target: AgentTarget,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentDto> {
+        let agent = await this.requireOwned(userId, id, ownershipScope);
+        await this.assertTargetExists(userId, target, ownershipScope);
 
         for (let attempt = 0; attempt < AgentsService.TARGETS_CAS_ATTEMPTS; attempt++) {
             this.assertNotOwnScopeParent(agent, target);
@@ -643,7 +671,7 @@ export class AgentsService {
                 return true;
             });
             if (!won) {
-                agent = await this.requireOwned(userId, id);
+                agent = await this.requireOwned(userId, id, ownershipScope);
                 continue;
             }
 
@@ -661,8 +689,13 @@ export class AgentsService {
      * Remove ONE reach target from an Agent (idempotent — removing a
      * target the Agent never had is a no-op, not a 404).
      */
-    async removeTarget(userId: string, id: string, target: AgentTarget): Promise<AgentDto> {
-        let agent = await this.requireOwned(userId, id);
+    async removeTarget(
+        userId: string,
+        id: string,
+        target: AgentTarget,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentDto> {
+        let agent = await this.requireOwned(userId, id, ownershipScope);
 
         for (let attempt = 0; attempt < AgentsService.TARGETS_CAS_ATTEMPTS; attempt++) {
             const current = agent.targets ?? [];
@@ -701,7 +734,7 @@ export class AgentsService {
                 return true;
             });
             if (!won) {
-                agent = await this.requireOwned(userId, id);
+                agent = await this.requireOwned(userId, id, ownershipScope);
                 continue;
             }
 
@@ -738,30 +771,58 @@ export class AgentsService {
      * `findOne({ id, userId })` returning null is also how we avoid
      * confirming that another user's Work exists).
      */
-    private async assertTargetExists(userId: string, target: AgentTarget): Promise<void> {
+    private async assertTargetExists(
+        userId: string,
+        target: AgentTarget,
+        ownershipScope?: OwnershipScope,
+    ): Promise<void> {
         switch (target.type) {
             case 'work':
-                await this.assertScopeParentExists(userId, {
-                    scope: AgentScope.WORK,
-                    workId: target.id,
-                });
+                await this.assertScopeParentExists(
+                    userId,
+                    {
+                        scope: AgentScope.WORK,
+                        workId: target.id,
+                    },
+                    ownershipScope,
+                );
                 break;
             case 'mission':
-                await this.assertScopeParentExists(userId, {
-                    scope: AgentScope.MISSION,
-                    missionId: target.id,
-                });
+                await this.assertScopeParentExists(
+                    userId,
+                    {
+                        scope: AgentScope.MISSION,
+                        missionId: target.id,
+                    },
+                    ownershipScope,
+                );
                 break;
             case 'idea':
-                await this.assertScopeParentExists(userId, {
-                    scope: AgentScope.IDEA,
-                    ideaId: target.id,
-                });
+                await this.assertScopeParentExists(
+                    userId,
+                    {
+                        scope: AgentScope.IDEA,
+                        ideaId: target.id,
+                    },
+                    ownershipScope,
+                );
                 break;
             default:
                 // `wildcard` has no row to validate.
                 break;
         }
+    }
+
+    /** Bulk create/PATCH targets must pass the same exact-scope gate as addTarget. */
+    private async assertTargetsExist(
+        userId: string,
+        targets: AgentTarget[] | null | undefined,
+        ownershipScope?: OwnershipScope,
+    ): Promise<void> {
+        if (!targets?.length) return;
+        await Promise.all(
+            targets.map((target) => this.assertTargetExists(userId, target, ownershipScope)),
+        );
     }
 
     /**
@@ -777,8 +838,9 @@ export class AgentsService {
         userId: string,
         id: string,
         guardrails: AgentGuardrails | null,
+        ownershipScope?: OwnershipScope,
     ): Promise<AgentDto> {
-        await this.requireOwned(userId, id);
+        await this.requireOwned(userId, id, ownershipScope);
         if (guardrails !== null) {
             const violation = validateGuardrails(guardrails);
             if (violation) {
@@ -791,8 +853,13 @@ export class AgentsService {
         return toAgentDto(refreshed);
     }
 
-    async transition(userId: string, id: string, to: AgentStatus): Promise<AgentDto> {
-        const agent = await this.requireOwned(userId, id);
+    async transition(
+        userId: string,
+        id: string,
+        to: AgentStatus,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentDto> {
+        const agent = await this.requireOwned(userId, id, ownershipScope);
         const allowed = USER_TRANSITIONS[agent.status] ?? [];
         if (!allowed.includes(to)) {
             throw new BadRequestException(`Cannot transition Agent from ${agent.status} to ${to}.`);
@@ -824,12 +891,12 @@ export class AgentsService {
         return toAgentDto(refreshed);
     }
 
-    async pause(userId: string, id: string): Promise<AgentDto> {
-        return this.transition(userId, id, AgentStatus.PAUSED);
+    async pause(userId: string, id: string, ownershipScope?: OwnershipScope): Promise<AgentDto> {
+        return this.transition(userId, id, AgentStatus.PAUSED, ownershipScope);
     }
 
-    async resume(userId: string, id: string): Promise<AgentDto> {
-        return this.transition(userId, id, AgentStatus.ACTIVE);
+    async resume(userId: string, id: string, ownershipScope?: OwnershipScope): Promise<AgentDto> {
+        return this.transition(userId, id, AgentStatus.ACTIVE, ownershipScope);
     }
 
     /**
@@ -841,8 +908,12 @@ export class AgentsService {
      * heartbeats as a side effect of being pulled out of the archive —
      * the operator activates it deliberately afterwards.
      */
-    async unarchive(userId: string, id: string): Promise<AgentDto> {
-        const agent = await this.requireOwned(userId, id);
+    async unarchive(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentDto> {
+        const agent = await this.requireOwned(userId, id, ownershipScope);
         if (agent.status !== AgentStatus.ARCHIVED) {
             throw new BadRequestException('Only archived Agents can be unarchived.');
         }
@@ -855,14 +926,22 @@ export class AgentsService {
         return toAgentDto(refreshed);
     }
 
-    async archive(userId: string, id: string): Promise<{ archived: true }> {
-        await this.requireOwned(userId, id);
+    async archive(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<{ archived: true }> {
+        await this.requireOwned(userId, id, ownershipScope);
         await this.agents.archiveById(id);
         return { archived: true };
     }
 
-    async deleteHard(userId: string, id: string): Promise<{ deleted: true }> {
-        await this.requireOwned(userId, id);
+    async deleteHard(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<{ deleted: true }> {
+        await this.requireOwned(userId, id, ownershipScope);
         await this.budgets.deleteByAgentId(id).catch(() => undefined); // FK CASCADE handles it; tolerate
         await this.memberships.deleteByAgentId(id).catch(() => undefined);
         await this.agents.deleteById(id);
@@ -877,8 +956,12 @@ export class AgentsService {
      * after a page refresh (the client-side filename/MIME cache only
      * covers in-session uploads).
      */
-    async listAttachments(userId: string, id: string): Promise<AgentAttachmentListRow[]> {
-        await this.requireOwned(userId, id);
+    async listAttachments(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentAttachmentListRow[]> {
+        await this.requireOwned(userId, id, ownershipScope);
         if (!this.agentAttachments) return [];
         const rows = await this.agentAttachments.findByAgentId(id);
         if (rows.length === 0 || !this.uploadsRepo) return rows;
@@ -919,8 +1002,13 @@ export class AgentsService {
     }
 
     /** Attach an uploaded file to an Agent. Idempotent. */
-    async addAttachment(userId: string, id: string, uploadId: string): Promise<AgentAttachment> {
-        await this.requireOwned(userId, id);
+    async addAttachment(
+        userId: string,
+        id: string,
+        uploadId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentAttachment> {
+        await this.requireOwned(userId, id, ownershipScope);
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
@@ -959,8 +1047,9 @@ export class AgentsService {
         userId: string,
         id: string,
         attachmentId: string,
+        ownershipScope?: OwnershipScope,
     ): Promise<{ deleted: true }> {
-        await this.requireOwned(userId, id);
+        await this.requireOwned(userId, id, ownershipScope);
         if (!this.agentAttachments) {
             throw new NotFoundException(`Attachment not found`);
         }
@@ -999,11 +1088,12 @@ export class AgentsService {
         userId: string,
         agent: Agent,
         reportsToAgentId: string,
+        ownershipScope?: OwnershipScope,
     ): Promise<void> {
         if (reportsToAgentId === agent.id) {
             throw new ConflictException('An Agent cannot report to itself.');
         }
-        const manager = await this.agents.findByIdAndUser(reportsToAgentId, userId);
+        const manager = await this.agents.findByIdAndUser(reportsToAgentId, userId, ownershipScope);
         if (!manager) {
             throw new NotFoundException(`Agent ${reportsToAgentId} not found.`);
         }
@@ -1013,7 +1103,7 @@ export class AgentsService {
                 throw new ConflictException('This reporting line would create a cycle.');
             }
             cursor = cursor.reportsToAgentId
-                ? await this.agents.findByIdAndUser(cursor.reportsToAgentId, userId)
+                ? await this.agents.findByIdAndUser(cursor.reportsToAgentId, userId, ownershipScope)
                 : null;
         }
     }
@@ -1074,12 +1164,9 @@ export class AgentsService {
             case AgentScope.WORK: {
                 if (!input.workId || !this.workRepo) return;
                 const work = await this.workRepo.findOne({
-                    where: ownershipScope
-                        ? ownershipWhere<Work>(userId, ownershipScope).map((branch) => ({
-                              ...branch,
-                              id: input.workId,
-                          }))
-                        : { id: input.workId, userId },
+                    where: ownershipWhereWith<Work>(userId, ownershipScope, {
+                        id: input.workId,
+                    }),
                 });
                 if (!work) throw new NotFoundException(`Work ${input.workId} not found.`);
                 break;
@@ -1087,12 +1174,9 @@ export class AgentsService {
             case AgentScope.MISSION: {
                 if (!input.missionId || !this.missionRepo) return;
                 const mission = await this.missionRepo.findOne({
-                    where: ownershipScope
-                        ? ownershipWhere<Mission>(userId, ownershipScope).map((branch) => ({
-                              ...branch,
-                              id: input.missionId,
-                          }))
-                        : { id: input.missionId, userId },
+                    where: ownershipWhereWith<Mission>(userId, ownershipScope, {
+                        id: input.missionId,
+                    }),
                 });
                 if (!mission) throw new NotFoundException(`Mission ${input.missionId} not found.`);
                 break;
@@ -1100,12 +1184,9 @@ export class AgentsService {
             case AgentScope.IDEA: {
                 if (!input.ideaId || !this.ideaRepo) return;
                 const idea = await this.ideaRepo.findOne({
-                    where: ownershipScope
-                        ? ownershipWhere<WorkProposal>(userId, ownershipScope).map((branch) => ({
-                              ...branch,
-                              id: input.ideaId,
-                          }))
-                        : { id: input.ideaId, userId },
+                    where: ownershipWhereWith<WorkProposal>(userId, ownershipScope, {
+                        id: input.ideaId,
+                    }),
                 });
                 if (!idea) throw new NotFoundException(`Idea ${input.ideaId} not found.`);
                 break;
@@ -1150,6 +1231,7 @@ export class AgentsService {
     private async assertAssignableEnvironment(
         userId: string,
         environmentId: string,
+        ownershipScope?: OwnershipScope,
     ): Promise<void> {
         if (!this.environmentRepo) {
             // Hand-rolled unit-test surface without the repo wired;
@@ -1158,7 +1240,9 @@ export class AgentsService {
             return;
         }
         const environment = await this.environmentRepo.findOne({
-            where: { id: environmentId, userId },
+            where: ownershipWhereWith<Environment>(userId, ownershipScope, {
+                id: environmentId,
+            }),
         });
         if (!environment) {
             throw new NotFoundException('Environment not found');

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -1038,6 +1038,7 @@ export class AgentsService {
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
+        const canonicalUploadId = uploadId.toLowerCase();
         // Security: the uploadId must reference a real upload owned by the
         // caller — without this a ghost/foreign id persisted a dangling
         // attachment edge. `user_uploads` records every upload by (userId,
@@ -1047,7 +1048,7 @@ export class AgentsService {
             // accepts /i, so normalize before the ownership lookup.
             const owned = await this.uploadsRepo.findOne({
                 where: ownershipWhereWith<UserUpload>(userId, ownershipScope, {
-                    sha256: uploadId.toLowerCase(),
+                    sha256: canonicalUploadId,
                 }),
             });
             if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
@@ -1058,11 +1059,11 @@ export class AgentsService {
             );
         }
         try {
-            return await this.agentAttachments.add(id, uploadId);
+            return await this.agentAttachments.add(id, canonicalUploadId);
         } catch (err) {
             if (err instanceof Error && /duplicate key|unique constraint/i.test(err.message)) {
                 const existing = (await this.agentAttachments.findByAgentId(id)).find(
-                    (a) => a.uploadId === uploadId,
+                    (a) => a.uploadId === canonicalUploadId,
                 );
                 if (existing) return existing;
             }

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -59,6 +59,7 @@ import {
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
 // (Codex + Greptile P1 on PR #1044).
 const SHA256_RE = /^[0-9a-f]{64}$/i;
+const SUPPORTED_AGENT_TARGET_TYPES = new Set(['mission', 'idea', 'work', 'wildcard']);
 
 /**
  * Create-Agent input — writable subset of the entity. Validation
@@ -696,6 +697,7 @@ export class AgentsService {
         ownershipScope?: OwnershipScope,
     ): Promise<AgentDto> {
         let agent = await this.requireOwned(userId, id, ownershipScope);
+        this.assertTargetShape(target);
 
         for (let attempt = 0; attempt < AgentsService.TARGETS_CAS_ATTEMPTS; attempt++) {
             const current = agent.targets ?? [];
@@ -776,6 +778,7 @@ export class AgentsService {
         target: AgentTarget,
         ownershipScope?: OwnershipScope,
     ): Promise<void> {
+        this.assertTargetShape(target);
         switch (target.type) {
             case 'work':
                 await this.assertScopeParentExists(
@@ -807,9 +810,27 @@ export class AgentsService {
                     ownershipScope,
                 );
                 break;
-            default:
-                // `wildcard` has no row to validate.
+            case 'wildcard':
                 break;
+            default:
+                throw new BadRequestException('Agent target type is invalid.');
+        }
+    }
+
+    private assertTargetShape(target: AgentTarget): void {
+        if (
+            !target ||
+            typeof target !== 'object' ||
+            typeof target.type !== 'string' ||
+            !SUPPORTED_AGENT_TARGET_TYPES.has(target.type)
+        ) {
+            throw new BadRequestException('Agent target type is invalid.');
+        }
+        if (
+            target.type !== 'wildcard' &&
+            (typeof target.id !== 'string' || target.id.trim().length === 0)
+        ) {
+            throw new BadRequestException(`Agent ${target.type} target requires an id.`);
         }
     }
 

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -969,9 +969,14 @@ export class AgentsService {
         // already enforces the upload is owned by the caller, so the
         // owner-scoped lookup resolves every attachable upload.
         const uploads = await this.uploadsRepo.find({
-            where: { userId, sha256: In(rows.map((r) => r.uploadId)) },
+            where: ownershipWhereWith<UserUpload>(userId, ownershipScope, {
+                sha256: In(rows.map((r) => r.uploadId)),
+            }),
         });
         const bySha = new Map(uploads.map((u) => [u.sha256, u]));
+        if (new Set(rows.map((row) => row.uploadId)).size !== bySha.size) {
+            throw new NotFoundException(`Attachment not found`);
+        }
         return rows.map((r) => {
             const u = bySha.get(r.uploadId);
             if (!u) return r;
@@ -1020,7 +1025,9 @@ export class AgentsService {
             // sha256 is a case-insensitive content hash stored lowercase; the DTO
             // accepts /i, so normalize before the ownership lookup.
             const owned = await this.uploadsRepo.findOne({
-                where: { sha256: uploadId.toLowerCase(), userId },
+                where: ownershipWhereWith<UserUpload>(userId, ownershipScope, {
+                    sha256: uploadId.toLowerCase(),
+                }),
             });
             if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
         }

--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -22,6 +22,9 @@ import type {
 import { RunDispatchGateService } from './run-dispatch-gate.service';
 import { TerminalSessionLauncher } from './terminal-session-launcher.service';
 import { TaskReviewRejectionRepository } from '../database/repositories/task-review-rejection.repository';
+import type { OwnershipScope } from '../database/ownership-scope';
+
+type ScopedRunSteerInput = RunSteerInput & { ownershipScope?: OwnershipScope };
 
 /**
  * `terminalEndedReason` values that make a finished run resumable: the
@@ -196,9 +199,9 @@ export class RunSteeringService implements RunSteeringPort {
 
     // ── steer ──────────────────────────────────────────────────────
 
-    async steer(input: RunSteerInput): Promise<RunSteerOutcome> {
+    async steer(input: ScopedRunSteerInput): Promise<RunSteerOutcome> {
         const message = this.assertMessage(input.message);
-        const run = await this.requireOwnedRun(input.runId, input.userId);
+        const run = await this.requireOwnedRun(input.runId, input.userId, input.ownershipScope);
 
         if (!RunSteeringService.isLive(run)) {
             // Terminal run — nothing to inject into. The caller (task chat,
@@ -233,8 +236,12 @@ export class RunSteeringService implements RunSteeringPort {
 
     // ── interrupt ──────────────────────────────────────────────────
 
-    async interrupt(runId: string, userId: string): Promise<RunInterruptOutcome> {
-        const run = await this.requireOwnedRun(runId, userId);
+    async interrupt(
+        runId: string,
+        userId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<RunInterruptOutcome> {
+        const run = await this.requireOwnedRun(runId, userId, ownershipScope);
         if (!RunSteeringService.isLive(run)) {
             throw new ConflictException(
                 `AgentRun ${runId} is ${run.status} — only a queued or running run can be interrupted.`,
@@ -258,10 +265,11 @@ export class RunSteeringService implements RunSteeringPort {
         runId: string,
         userId: string,
         message?: string | null,
+        ownershipScope?: OwnershipScope,
     ): Promise<RunResumeOutcome> {
         const trimmed =
             message == null || message.trim().length === 0 ? null : this.assertMessage(message);
-        const run = await this.requireOwnedRun(runId, userId);
+        const run = await this.requireOwnedRun(runId, userId, ownershipScope);
 
         if (!RunSteeringService.isResumable(run)) {
             throw new ConflictException(
@@ -294,6 +302,7 @@ export class RunSteeringService implements RunSteeringPort {
                 triggerKind: 'task',
                 taskId: run.taskId!,
                 workId: run.workId ?? null,
+                tenantId: run.tenantId ?? null,
                 organizationId: run.organizationId ?? null,
                 runnerKind: run.runnerKind ?? null,
                 queuedReason: verdict.admitted ? null : (verdict.queuedReason ?? null),
@@ -483,8 +492,14 @@ export class RunSteeringService implements RunSteeringPort {
         }
     }
 
-    private async requireOwnedRun(runId: string, userId: string): Promise<AgentRun> {
-        const run = await this.runs.findByIdAndUser(runId, userId);
+    private async requireOwnedRun(
+        runId: string,
+        userId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<AgentRun> {
+        const run = ownershipScope
+            ? await this.runs.findByIdAndUser(runId, userId, ownershipScope)
+            : await this.runs.findByIdAndUser(runId, userId);
         if (!run) throw new NotFoundException(`AgentRun ${runId} not found.`);
         return run;
     }

--- a/packages/agent/src/agents/types.ts
+++ b/packages/agent/src/agents/types.ts
@@ -23,6 +23,8 @@ import type { AgentGuardrails } from './guardrails';
 export interface AgentDto {
     id: string;
     userId: string;
+    tenantId: string | null;
+    organizationId: string | null;
     scope: AgentScope;
     missionId: string | null;
     ideaId: string | null;
@@ -83,6 +85,8 @@ export function toAgentDto(agent: Agent): AgentDto {
     return {
         id: agent.id,
         userId: agent.userId,
+        tenantId: agent.tenantId ?? null,
+        organizationId: agent.organizationId ?? null,
         scope: agent.scope,
         missionId: agent.missionId ?? null,
         ideaId: agent.ideaId ?? null,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -1,6 +1,7 @@
 export * from './database-config.factory';
 export * from './database.config';
 export * from './database.module';
+export * from './ownership-scope';
 // Pricing Wave 9 M2 — run-cost settlement seam (token + contract).
 export * from './run-cost-settler';
 export * from './repositories/api-key.repository';

--- a/packages/agent/src/database/ownership-scope.ts
+++ b/packages/agent/src/database/ownership-scope.ts
@@ -1,0 +1,42 @@
+import { IsNull, type FindOptionsWhere } from 'typeorm';
+
+/** Request ownership selected by SessionScopeGuard / X-Scope-Slug. */
+export interface OwnershipScope {
+    tenantId: string | null;
+    organizationId: string | null;
+}
+
+/**
+ * User + request-scope predicates for Tier C entities.
+ *
+ * Personal scope includes rows stamped with the current Tenant and legacy
+ * rows that pre-date Tenant stamping, while excluding rows from every other
+ * Tenant and every Organization. An omitted scope preserves background-job
+ * and legacy service-call behavior; HTTP controllers always pass one.
+ */
+export function ownershipWhere<T>(userId: string, scope?: OwnershipScope): FindOptionsWhere<T>[] {
+    const base = { userId } as unknown as FindOptionsWhere<T>;
+    if (!scope) return [base];
+
+    if (scope.organizationId) {
+        return [
+            {
+                ...base,
+                tenantId: scope.tenantId ?? IsNull(),
+                organizationId: scope.organizationId,
+            } as FindOptionsWhere<T>,
+        ];
+    }
+
+    const personal = {
+        ...base,
+        organizationId: IsNull(),
+    } as FindOptionsWhere<T>;
+    if (!scope.tenantId) {
+        return [{ ...personal, tenantId: IsNull() } as FindOptionsWhere<T>];
+    }
+    return [
+        { ...personal, tenantId: scope.tenantId } as FindOptionsWhere<T>,
+        { ...personal, tenantId: IsNull() } as FindOptionsWhere<T>,
+    ];
+}

--- a/packages/agent/src/database/ownership-scope.ts
+++ b/packages/agent/src/database/ownership-scope.ts
@@ -6,6 +6,16 @@ export interface OwnershipScope {
     organizationId: string | null;
 }
 
+export interface OwnershipStamp {
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
+export interface OwnershipSqlPredicate {
+    clause: string;
+    parameters: Record<string, string>;
+}
+
 /**
  * User + request-scope predicates for Tier C entities.
  *
@@ -39,4 +49,63 @@ export function ownershipWhere<T>(userId: string, scope?: OwnershipScope): FindO
         { ...personal, tenantId: scope.tenantId } as FindOptionsWhere<T>,
         { ...personal, tenantId: IsNull() } as FindOptionsWhere<T>,
     ];
+}
+
+/** Add an entity-specific predicate without weakening either ownership branch. */
+export function ownershipWhereWith<T>(
+    userId: string,
+    scope: OwnershipScope | undefined,
+    where: FindOptionsWhere<T>,
+): FindOptionsWhere<T> | FindOptionsWhere<T>[] {
+    if (!scope) {
+        return { ...where, ...ownershipWhere<T>(userId)[0] };
+    }
+    return ownershipWhere<T>(userId, scope).map((branch) => ({ ...where, ...branch }));
+}
+
+/** Explicit scope columns for new Tier C rows; omitted legacy calls keep subscriber behavior. */
+export function ownershipStamp(scope?: OwnershipScope): OwnershipStamp {
+    return scope ? { tenantId: scope.tenantId, organizationId: scope.organizationId } : {};
+}
+
+/**
+ * QueryBuilder equivalent of {@link ownershipWhere}. The parameter prefix
+ * keeps the primitive safe to compose more than once in a single query.
+ */
+export function ownershipSqlPredicate(
+    alias: string,
+    scope?: OwnershipScope,
+    parameterPrefix = 'ownership',
+): OwnershipSqlPredicate | undefined {
+    if (!scope) return undefined;
+
+    const tenantParameter = `${parameterPrefix}TenantId`;
+    const organizationParameter = `${parameterPrefix}OrganizationId`;
+    const tenantColumn = `${alias}.tenantId`;
+    const organizationColumn = `${alias}.organizationId`;
+
+    if (scope.organizationId) {
+        const tenantClause = scope.tenantId
+            ? `${tenantColumn} = :${tenantParameter}`
+            : `${tenantColumn} IS NULL`;
+        return {
+            clause: `(${tenantClause} AND ${organizationColumn} = :${organizationParameter})`,
+            parameters: {
+                ...(scope.tenantId ? { [tenantParameter]: scope.tenantId } : {}),
+                [organizationParameter]: scope.organizationId,
+            },
+        };
+    }
+
+    if (!scope.tenantId) {
+        return {
+            clause: `(${organizationColumn} IS NULL AND ${tenantColumn} IS NULL)`,
+            parameters: {},
+        };
+    }
+
+    return {
+        clause: `(${organizationColumn} IS NULL AND (${tenantColumn} = :${tenantParameter} OR ${tenantColumn} IS NULL))`,
+        parameters: { [tenantParameter]: scope.tenantId },
+    };
 }

--- a/packages/agent/src/database/ownership-scope.ts
+++ b/packages/agent/src/database/ownership-scope.ts
@@ -11,6 +11,11 @@ export interface OwnershipStamp {
     organizationId?: string | null;
 }
 
+export interface OwnershipScopedRow {
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
 export interface OwnershipSqlPredicate {
     clause: string;
     parameters: Record<string, string>;
@@ -69,6 +74,33 @@ export function ownershipStamp(scope?: OwnershipScope): OwnershipStamp {
 }
 
 /**
+ * In-memory equivalent of {@link ownershipWhere} for rows already loaded by
+ * a legacy/custom repository. Keep this beside the TypeORM and SQL builders
+ * so service-level validation cannot drift from database-level filtering.
+ */
+export function ownershipScopeMatches(row: OwnershipScopedRow, scope?: OwnershipScope): boolean {
+    if (!scope) return true;
+
+    const tenantId = row.tenantId ?? null;
+    const organizationId = row.organizationId ?? null;
+    if (scope.organizationId) {
+        return tenantId === scope.tenantId && organizationId === scope.organizationId;
+    }
+    return (
+        organizationId === null &&
+        (tenantId === scope.tenantId || (scope.tenantId !== null && tenantId === null))
+    );
+}
+
+/** Scope persisted on a row, normalized away from optional/undefined fields. */
+export function ownershipScopeOf(row: OwnershipScopedRow): OwnershipScope {
+    return {
+        tenantId: row.tenantId ?? null,
+        organizationId: row.organizationId ?? null,
+    };
+}
+
+/**
  * QueryBuilder equivalent of {@link ownershipWhere}. The parameter prefix
  * keeps the primitive safe to compose more than once in a single query.
  */
@@ -81,8 +113,9 @@ export function ownershipSqlPredicate(
 
     const tenantParameter = `${parameterPrefix}TenantId`;
     const organizationParameter = `${parameterPrefix}OrganizationId`;
-    const tenantColumn = `${alias}.tenantId`;
-    const organizationColumn = `${alias}.organizationId`;
+    const columnPrefix = alias ? `${alias}.` : '';
+    const tenantColumn = `${columnPrefix}tenantId`;
+    const organizationColumn = `${columnPrefix}organizationId`;
 
     if (scope.organizationId) {
         const tenantClause = scope.tenantId

--- a/packages/agent/src/database/repositories/__tests__/task.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/task.repository.spec.ts
@@ -1,5 +1,43 @@
 import { TaskRepository } from '../task.repository';
 
+describe('TaskRepository ownership scope', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+
+    it('loads a known Task UUID with an exact user + tenant + Organization predicate', async () => {
+        const findOne = jest.fn().mockResolvedValue(null);
+        const tasks = new TaskRepository({ findOne } as never);
+
+        await (tasks.findByIdAndUser as any)('task-ever', 'user-1', everScope);
+
+        expect(findOne).toHaveBeenCalledWith({
+            where: [{ id: 'task-ever', userId: 'user-1', ...everScope }],
+        });
+    });
+
+    it('adds the active Organization predicate to list SQL before pagination', async () => {
+        const qb: any = {
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            orderBy: jest.fn().mockReturnThis(),
+            take: jest.fn().mockReturnThis(),
+            skip: jest.fn().mockReturnThis(),
+            getCount: jest.fn().mockResolvedValue(0),
+            getMany: jest.fn().mockResolvedValue([]),
+        };
+        const tasks = new TaskRepository({ createQueryBuilder: jest.fn(() => qb) } as never);
+
+        await (tasks.findByUserIdFiltered as any)('user-1', {}, everScope);
+
+        expect(qb.andWhere).toHaveBeenCalledWith(
+            expect.stringContaining('task.organizationId = :taskScopeOrganizationId'),
+            expect.objectContaining({ taskScopeOrganizationId: everScope.organizationId }),
+        );
+    });
+});
+
 describe('TaskRepository.wouldCreateCycle', () => {
     function makeSvc(parentChain: Record<string, string | null>) {
         const repo = {

--- a/packages/agent/src/database/repositories/agent-escalation.repository.scope.spec.ts
+++ b/packages/agent/src/database/repositories/agent-escalation.repository.scope.spec.ts
@@ -24,6 +24,32 @@ describe('AgentEscalationRepository Task resolution ownership', () => {
         };
     }
 
+    it('persists an explicit producer scope instead of relying on request ALS', async () => {
+        const orm = {
+            findOne: jest.fn().mockResolvedValue(null),
+            create: jest.fn((input: object) => input),
+            save: jest.fn(async (input: object) => ({ id: 'escalation-1', ...input })),
+        };
+        const repository = new AgentEscalationRepository(orm as never);
+
+        await repository.record({
+            userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            reasonCode: 'gate-exhausted',
+            summary: 'Checks remained red.',
+            decisionNeeded: 'Decide whether to retry.',
+            taskId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            tenantId: everScope.tenantId,
+            organizationId: everScope.organizationId,
+        });
+
+        expect(orm.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tenantId: everScope.tenantId,
+                organizationId: everScope.organizationId,
+            }),
+        );
+    });
+
     it('CAS-resolves only the exact user, routed Task, tenant and Organization', async () => {
         const { repository, qb } = build();
 

--- a/packages/agent/src/database/repositories/agent-escalation.repository.scope.spec.ts
+++ b/packages/agent/src/database/repositories/agent-escalation.repository.scope.spec.ts
@@ -1,0 +1,86 @@
+import { AgentEscalationRepository } from './agent-escalation.repository';
+
+describe('AgentEscalationRepository Task resolution ownership', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+
+    function build(affected: number | null = 1) {
+        const qb = {
+            update: jest.fn(),
+            set: jest.fn(),
+            where: jest.fn(),
+            andWhere: jest.fn(),
+            execute: jest.fn().mockResolvedValue({ affected }),
+        };
+        for (const method of ['update', 'set', 'where', 'andWhere'] as const) {
+            qb[method].mockReturnValue(qb);
+        }
+        const orm = { createQueryBuilder: jest.fn().mockReturnValue(qb) };
+        return {
+            repository: new AgentEscalationRepository(orm as never),
+            qb,
+        };
+    }
+
+    it('CAS-resolves only the exact user, routed Task, tenant and Organization', async () => {
+        const { repository, qb } = build();
+
+        await expect(
+            (repository as any).resolveForTask(
+                'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+                'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                everScope,
+                'approved',
+            ),
+        ).resolves.toBe(true);
+
+        expect(qb.andWhere).toHaveBeenCalledWith('taskId = :taskId', {
+            taskId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        });
+        expect(qb.andWhere).toHaveBeenCalledWith(
+            '(tenantId = :escalationOwnershipTenantId AND organizationId = :escalationOwnershipOrganizationId)',
+            {
+                escalationOwnershipTenantId: everScope.tenantId,
+                escalationOwnershipOrganizationId: everScope.organizationId,
+            },
+        );
+        expect(qb.andWhere).toHaveBeenCalledWith('status = :open', { open: 'open' });
+    });
+
+    it('uses explicit legacy-compatible personal ownership and preserves single-winner CAS', async () => {
+        const { repository, qb } = build();
+        qb.execute.mockResolvedValueOnce({ affected: 1 }).mockResolvedValueOnce({ affected: 0 });
+        const args = [
+            'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            { tenantId: everScope.tenantId, organizationId: null },
+            null,
+        ] as const;
+
+        await expect((repository as any).resolveForTask(...args)).resolves.toBe(true);
+        await expect((repository as any).resolveForTask(...args)).resolves.toBe(false);
+
+        expect(qb.andWhere).toHaveBeenCalledWith(
+            '(organizationId IS NULL AND (tenantId = :escalationOwnershipTenantId OR tenantId IS NULL))',
+            { escalationOwnershipTenantId: everScope.tenantId },
+        );
+    });
+
+    it('returns the same false result for a known Yo row excluded by the active Ever predicate', async () => {
+        const { repository } = build(0);
+
+        await expect(
+            (repository as any).resolveForTask(
+                'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+                'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                everScope,
+                null,
+            ),
+        ).resolves.toBe(false);
+    });
+});

--- a/packages/agent/src/database/repositories/agent-escalation.repository.ts
+++ b/packages/agent/src/database/repositories/agent-escalation.repository.ts
@@ -12,6 +12,7 @@ import {
     type AgentEscalationStatus,
 } from '@ever-works/contracts';
 import { AgentEscalation } from '../../entities/agent-escalation.entity';
+import { ownershipSqlPredicate, type OwnershipScope } from '../ownership-scope';
 
 export interface RecordEscalationInput {
     userId: string;
@@ -228,6 +229,40 @@ export class AgentEscalationRepository {
             .andWhere('userId = :userId', { userId })
             .andWhere('status = :open', { open: 'open' })
             .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Task-route resolution variant. The CAS binds not only the actor and
+     * open state, but the routed Task and its exact persisted ownership
+     * scope. A same-user escalation from another Organization is therefore
+     * indistinguishable from a missing or already-resolved row.
+     */
+    async resolveForTask(
+        id: string,
+        userId: string,
+        taskId: string,
+        scope: OwnershipScope,
+        resolutionNote?: string | null,
+    ): Promise<boolean> {
+        const ownership = ownershipSqlPredicate('', scope, 'escalationOwnership');
+        const query = this.repository
+            .createQueryBuilder()
+            .update(AgentEscalation)
+            .set({
+                status: 'resolved' as AgentEscalationStatus,
+                resolvedByUserId: userId,
+                resolutionNote: resolutionNote
+                    ? resolutionNote.slice(0, AGENT_ESCALATION_MAX_DECISION_CHARS)
+                    : null,
+                resolvedAt: new Date(),
+            })
+            .where('id = :id', { id })
+            .andWhere('userId = :userId', { userId })
+            .andWhere('taskId = :taskId', { taskId })
+            .andWhere('status = :open', { open: 'open' });
+        if (ownership) query.andWhere(ownership.clause, ownership.parameters);
+        const result = await query.execute();
         return (result.affected ?? 0) > 0;
     }
 }

--- a/packages/agent/src/database/repositories/agent-escalation.repository.ts
+++ b/packages/agent/src/database/repositories/agent-escalation.repository.ts
@@ -24,6 +24,7 @@ export interface RecordEscalationInput {
     workId?: string | null;
     agentId?: string | null;
     attempted?: AgentEscalationAttempt[] | null;
+    tenantId?: string | null;
     organizationId?: string | null;
     /**
      * Stable idempotency key. Omitted = derived from
@@ -105,6 +106,7 @@ export class AgentEscalationRepository {
             agentId: input.agentId ?? null,
             attempted: normalizeAttempts(input.attempted),
             dedupKey,
+            ...(input.tenantId !== undefined ? { tenantId: input.tenantId } : {}),
             ...(input.organizationId !== undefined ? { organizationId: input.organizationId } : {}),
             ...buildConfidencePatch(input.confidence, input.confidenceSource),
         });

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -22,9 +22,14 @@ describe('AgentRunRepository — terminal transitions', () => {
         getManyAndCount: jest.Mock;
         limit: jest.Mock;
         getMany: jest.Mock;
+        getOne: jest.Mock;
     };
     let repository: {
         findOne: jest.Mock;
+        find: jest.Mock;
+        count: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
         createQueryBuilder: jest.Mock;
     };
     let runs: AgentRunRepository;
@@ -52,10 +57,15 @@ describe('AgentRunRepository — terminal transitions', () => {
             getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
             limit: jest.fn().mockReturnThis(),
             getMany: jest.fn().mockResolvedValue([]),
+            getOne: jest.fn().mockResolvedValue(null),
         };
         repository = {
             // startedAt drives durationMs; null keeps the arithmetic out of the way.
             findOne: jest.fn().mockResolvedValue({ id: 'r1', startedAt: null }),
+            find: jest.fn().mockResolvedValue([]),
+            count: jest.fn().mockResolvedValue(0),
+            create: jest.fn((input) => input),
+            save: jest.fn(async (input) => input),
             createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
         };
         runs = new AgentRunRepository(repository as never);
@@ -231,6 +241,34 @@ describe('AgentRunRepository — terminal transitions', () => {
             repository.findOne.mockResolvedValue(null);
             await expect(runs.cancel('r1', 'u1')).resolves.toEqual({ found: false });
         });
+
+        it('keeps the terminal CAS inside the same active Organization scope', async () => {
+            const scope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+
+            await runs.cancel('00000000-0000-0000-0000-0000000000aa', 'u1', scope);
+
+            expect(repository.findOne).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: [
+                        expect.objectContaining({
+                            id: '00000000-0000-0000-0000-0000000000aa',
+                            userId: 'u1',
+                            ...scope,
+                        }),
+                    ],
+                }),
+            );
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                '(tenantId = :cancelRunTenantId AND organizationId = :cancelRunOrganizationId)',
+                {
+                    cancelRunTenantId: scope.tenantId,
+                    cancelRunOrganizationId: scope.organizationId,
+                },
+            );
+        });
     });
 
     describe('stuck-run sweep', () => {
@@ -284,7 +322,7 @@ describe('AgentRunRepository — terminal transitions', () => {
         };
 
         it('adds the exact active Organization to the authenticated-user predicate', async () => {
-            await (runs.listSessionsForUser as any)('u1', {}, 25, 0, everScope);
+            await runs.listSessionsForUser('u1', {}, 25, 0, everScope);
 
             expect(queryBuilder.where).toHaveBeenCalledWith('run.userId = :userId', {
                 userId: 'u1',
@@ -299,7 +337,7 @@ describe('AgentRunRepository — terminal transitions', () => {
         });
 
         it('keeps explicit personal scope separate from both Organizations', async () => {
-            await (runs.listSessionsForUser as any)('u1', {}, 25, 0, {
+            await runs.listSessionsForUser('u1', {}, 25, 0, {
                 tenantId: everScope.tenantId,
                 organizationId: null,
             });
@@ -308,6 +346,102 @@ describe('AgentRunRepository — terminal transitions', () => {
                 '(run.organizationId IS NULL AND (run.tenantId = :ownershipTenantId OR run.tenantId IS NULL))',
                 { ownershipTenantId: everScope.tenantId },
             );
+        });
+    });
+
+    describe('direct run ownership scope', () => {
+        const userId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        const agentId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+        const runId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+        const everScope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+        const yoScope = {
+            tenantId: everScope.tenantId,
+            organizationId: '33333333-3333-4333-8333-333333333333',
+        };
+
+        it('binds per-Agent list/count and direct get to the exact Ever scope', async () => {
+            await runs.findByAgentAndUser(agentId, userId, 25, 0, everScope);
+            await runs.countByAgentAndUser(agentId, userId, everScope);
+            await runs.findByIdAndUser(runId, userId, everScope);
+
+            const where = [
+                {
+                    agentId,
+                    userId,
+                    tenantId: everScope.tenantId,
+                    organizationId: everScope.organizationId,
+                },
+            ];
+            expect(repository.find).toHaveBeenCalledWith(expect.objectContaining({ where }));
+            expect(repository.count).toHaveBeenCalledWith({ where });
+            expect(repository.findOne).toHaveBeenLastCalledWith({
+                where: [{ id: runId, userId, ...everScope }],
+            });
+        });
+
+        it('uses a distinct predicate for the same-user known run UUID in Yo', async () => {
+            await runs.findByIdAndUser(runId, userId, yoScope);
+
+            expect(repository.findOne).toHaveBeenLastCalledWith({
+                where: [{ id: runId, userId, ...yoScope }],
+            });
+            expect(repository.findOne).not.toHaveBeenLastCalledWith({
+                where: [{ id: runId, userId, ...everScope }],
+            });
+        });
+
+        it('keeps current and legacy personal runs reachable without admitting either Org', async () => {
+            await runs.findByIdAndUser(runId, userId, {
+                tenantId: everScope.tenantId,
+                organizationId: null,
+            });
+
+            const where = repository.findOne.mock.calls.at(-1)?.[0]?.where as Array<
+                Record<string, unknown>
+            >;
+            expect(where).toHaveLength(2);
+            expect(where[0]).toMatchObject({
+                id: runId,
+                userId,
+                tenantId: everScope.tenantId,
+                organizationId: expect.objectContaining({ _type: 'isNull' }),
+            });
+            expect(where[1]).toMatchObject({
+                id: runId,
+                userId,
+                tenantId: expect.objectContaining({ _type: 'isNull' }),
+                organizationId: expect.objectContaining({ _type: 'isNull' }),
+            });
+        });
+
+        it('scopes same-task in-flight reuse to user + Organization', async () => {
+            await runs.findInFlightForTaskAgent(runId, agentId, userId, everScope);
+
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith('run.userId = :userId', {
+                userId,
+            });
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                '(run.tenantId = :inFlightRunTenantId AND run.organizationId = :inFlightRunOrganizationId)',
+                {
+                    inFlightRunTenantId: everScope.tenantId,
+                    inFlightRunOrganizationId: everScope.organizationId,
+                },
+            );
+        });
+
+        it('persists both ownership columns on an explicitly scoped queued run', async () => {
+            await runs.createQueued({
+                userId,
+                agentId,
+                triggerKind: 'task',
+                ...everScope,
+            });
+
+            expect(repository.create).toHaveBeenCalledWith(expect.objectContaining(everScope));
+            expect(repository.save).toHaveBeenCalledWith(expect.objectContaining(everScope));
         });
     });
 

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -17,6 +17,9 @@ describe('AgentRunRepository — terminal transitions', () => {
         // Sweep path: findStuckNonTerminal is a SELECT terminating in getMany.
         select: jest.Mock;
         orderBy: jest.Mock;
+        take: jest.Mock;
+        skip: jest.Mock;
+        getManyAndCount: jest.Mock;
         limit: jest.Mock;
         getMany: jest.Mock;
     };
@@ -44,6 +47,9 @@ describe('AgentRunRepository — terminal transitions', () => {
             execute: jest.fn().mockResolvedValue({ affected: 1 }),
             select: jest.fn().mockReturnThis(),
             orderBy: jest.fn().mockReturnThis(),
+            take: jest.fn().mockReturnThis(),
+            skip: jest.fn().mockReturnThis(),
+            getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
             limit: jest.fn().mockReturnThis(),
             getMany: jest.fn().mockResolvedValue([]),
         };
@@ -268,6 +274,40 @@ describe('AgentRunRepository — terminal transitions', () => {
             repository.createQueryBuilder.mockClear();
             await expect(runs.markStuckFailed([], 'stuck-timeout: x')).resolves.toBe(0);
             expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listSessionsForUser ownership scope', () => {
+        const everScope = {
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        };
+
+        it('adds the exact active Organization to the authenticated-user predicate', async () => {
+            await (runs.listSessionsForUser as any)('u1', {}, 25, 0, everScope);
+
+            expect(queryBuilder.where).toHaveBeenCalledWith('run.userId = :userId', {
+                userId: 'u1',
+            });
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                '(run.tenantId = :ownershipTenantId AND run.organizationId = :ownershipOrganizationId)',
+                {
+                    ownershipTenantId: everScope.tenantId,
+                    ownershipOrganizationId: everScope.organizationId,
+                },
+            );
+        });
+
+        it('keeps explicit personal scope separate from both Organizations', async () => {
+            await (runs.listSessionsForUser as any)('u1', {}, 25, 0, {
+                tenantId: everScope.tenantId,
+                organizationId: null,
+            });
+
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                '(run.organizationId IS NULL AND (run.tenantId = :ownershipTenantId OR run.tenantId IS NULL))',
+                { ownershipTenantId: everScope.tenantId },
+            );
         });
     });
 

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -336,6 +336,21 @@ describe('AgentRunRepository — terminal transitions', () => {
             );
         });
 
+        it('applies that same exact Organization predicate to scheduled heartbeat sessions', async () => {
+            await runs.listSessionsForUser('u1', { triggerKind: 'heartbeat' }, 25, 0, everScope);
+
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith('run.triggerKind = :triggerKind', {
+                triggerKind: 'heartbeat',
+            });
+            expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+                '(run.tenantId = :ownershipTenantId AND run.organizationId = :ownershipOrganizationId)',
+                {
+                    ownershipTenantId: everScope.tenantId,
+                    ownershipOrganizationId: everScope.organizationId,
+                },
+            );
+        });
+
         it('keeps explicit personal scope separate from both Organizations', async () => {
             await runs.listSessionsForUser('u1', {}, 25, 0, {
                 tenantId: everScope.tenantId,

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -408,6 +408,42 @@ describe('AgentRunRepository — terminal transitions', () => {
             });
         });
 
+        it('binds a batch embed lookup to the same user and exact Organization', async () => {
+            await (runs.findByIds as any)([runId], userId, everScope);
+
+            expect(repository.find).toHaveBeenLastCalledWith({
+                where: [
+                    expect.objectContaining({
+                        id: expect.objectContaining({ _type: 'in', _value: [runId] }),
+                        userId,
+                        ...everScope,
+                    }),
+                ],
+            });
+        });
+
+        it('keeps current and legacy personal batch embeds separate from Organization runs', async () => {
+            await (runs.findByIds as any)([runId], userId, {
+                tenantId: everScope.tenantId,
+                organizationId: null,
+            });
+
+            const where = repository.find.mock.calls.at(-1)?.[0]?.where as Array<
+                Record<string, unknown>
+            >;
+            expect(where).toHaveLength(2);
+            expect(where[0]).toMatchObject({
+                userId,
+                tenantId: everScope.tenantId,
+                organizationId: expect.objectContaining({ _type: 'isNull' }),
+            });
+            expect(where[1]).toMatchObject({
+                userId,
+                tenantId: expect.objectContaining({ _type: 'isNull' }),
+                organizationId: expect.objectContaining({ _type: 'isNull' }),
+            });
+        });
+
         it('keeps current and legacy personal runs reachable without admitting either Org', async () => {
             await runs.findByIdAndUser(runId, userId, {
                 tenantId: everScope.tenantId,

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -5,6 +5,7 @@ import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialE
 import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
 import { RUN_COST_SETTLER, type RunCostSettler } from '../run-cost-settler';
+import { ownershipSqlPredicate, type OwnershipScope } from '../ownership-scope';
 import type { SubAgentScope } from '@ever-works/contracts';
 
 /**
@@ -1272,10 +1273,15 @@ export class AgentRunRepository {
         },
         limit = 25,
         offset = 0,
+        ownershipScope?: OwnershipScope,
     ): Promise<[AgentRun[], number]> {
         const qb = this.repository
             .createQueryBuilder('run')
             .where('run.userId = :userId', { userId });
+        const ownership = ownershipSqlPredicate('run', ownershipScope);
+        if (ownership) {
+            qb.andWhere(ownership.clause, ownership.parameters);
+        }
         if (filters.attention === true) {
             qb.andWhere('(run.awaitingInput = :isAwaiting OR run.attentionReason IS NOT NULL)', {
                 isAwaiting: true,

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -111,16 +111,20 @@ export class AgentRunRepository {
      * Kanban run cockpit (Wave 2) — batch-load runs for the `includeRun`
      * list embed. One IN query, no N+1.
      *
-     * @internal Security: unscoped by design — callers MUST pass only ids
-     * derived server-side from rows the acting user already owns (the
-     * Tasks list hands over its own `latestRunId` pointers, never client
-     * input). HTTP handlers must not expose this with caller-supplied ids.
+     * Request-facing callers pass user + active scope so even a stale or
+     * malformed denormalized pointer cannot embed a same-user run from a
+     * different Organization. Omitted ownership preserves worker/internal
+     * callers that batch already-authoritative ids.
      */
-    async findByIds(ids: string[]): Promise<AgentRun[]> {
+    async findByIds(ids: string[], userId?: string, scope?: OwnershipScope): Promise<AgentRun[]> {
         // TypeORM renders `In([])` as invalid SQL on some drivers; and an
         // empty batch has an obvious answer anyway.
         if (ids.length === 0) return [];
-        return this.repository.find({ where: { id: In(ids) } });
+        const idPredicate = { id: In(ids) };
+        const where = userId
+            ? ownershipWhereWith<AgentRun>(userId, scope, idPredicate)
+            : idPredicate;
+        return this.repository.find({ where });
     }
 
     /**

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -5,7 +5,7 @@ import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialE
 import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
 import { RUN_COST_SETTLER, type RunCostSettler } from '../run-cost-settler';
-import { ownershipSqlPredicate, type OwnershipScope } from '../ownership-scope';
+import { ownershipSqlPredicate, ownershipWhereWith, type OwnershipScope } from '../ownership-scope';
 import type { SubAgentScope } from '@ever-works/contracts';
 
 /**
@@ -213,17 +213,24 @@ export class AgentRunRepository {
         userId: string,
         limit = 25,
         offset = 0,
+        scope?: OwnershipScope,
     ): Promise<AgentRun[]> {
         return this.repository.find({
-            where: { agentId, userId },
+            where: ownershipWhereWith<AgentRun>(userId, scope, { agentId }),
             order: { createdAt: 'DESC' },
             take: limit,
             skip: offset,
         });
     }
 
-    async countByAgentAndUser(agentId: string, userId: string): Promise<number> {
-        return this.repository.count({ where: { agentId, userId } });
+    async countByAgentAndUser(
+        agentId: string,
+        userId: string,
+        scope?: OwnershipScope,
+    ): Promise<number> {
+        return this.repository.count({
+            where: ownershipWhereWith<AgentRun>(userId, scope, { agentId }),
+        });
     }
 
     /**
@@ -231,8 +238,14 @@ export class AgentRunRepository {
      * ensures cross-user runs return null (controller maps that to 404
      * per architecture/security §9, no-existence-leak).
      */
-    async findByIdAndUser(runId: string, userId: string): Promise<AgentRun | null> {
-        return this.repository.findOne({ where: { id: runId, userId } });
+    async findByIdAndUser(
+        runId: string,
+        userId: string,
+        scope?: OwnershipScope,
+    ): Promise<AgentRun | null> {
+        return this.repository.findOne({
+            where: ownershipWhereWith<AgentRun>(userId, scope, { id: runId }),
+        });
     }
 
     /**
@@ -253,6 +266,7 @@ export class AgentRunRepository {
     async cancel(
         runId: string,
         userId: string,
+        scope?: OwnershipScope,
     ): Promise<{
         found: boolean;
         previousStatus?: AgentRunStatus;
@@ -271,8 +285,8 @@ export class AgentRunRepository {
         workId?: string | null;
     }> {
         const run = await this.repository.findOne({
-            where: { id: runId, userId },
-            select: ['id', 'status', 'triggerRunId', 'workId'],
+            where: ownershipWhereWith<AgentRun>(userId, scope, { id: runId }),
+            select: ['id', 'status', 'triggerRunId', 'workId', 'tenantId', 'organizationId'],
         });
         if (!run) return { found: false };
         if (run.status !== 'queued' && run.status !== 'running') {
@@ -283,7 +297,7 @@ export class AgentRunRepository {
                 workId: run.workId ?? null,
             };
         }
-        const result = await this.repository
+        const query = this.repository
             .createQueryBuilder()
             .update(AgentRun)
             .set({ status: 'cancelled', finishedAt: new Date() })
@@ -291,16 +305,20 @@ export class AgentRunRepository {
             .andWhere('userId = :userId', { userId })
             .andWhere('status IN (:...statuses)', {
                 statuses: ['queued', 'running'] satisfies AgentRunStatus[],
-            })
-            .execute();
+            });
+        const scopePredicate = ownershipSqlPredicate('', scope, 'cancelRun');
+        if (scopePredicate) {
+            query.andWhere(scopePredicate.clause, scopePredicate.parameters);
+        }
+        const result = await query.execute();
         // affected=0 ⇒ a concurrent worker flipped the row terminal
         // between our findOne and this CAS — surface that as a
         // graceful no-op so the controller responds 200/no-cancel
         // instead of 5xx.
         if ((result.affected ?? 0) === 0) {
             const fresh = await this.repository.findOne({
-                where: { id: runId },
-                select: ['id', 'status', 'triggerRunId'],
+                where: ownershipWhereWith<AgentRun>(userId, scope, { id: runId }),
+                select: ['id', 'status', 'triggerRunId', 'tenantId', 'organizationId'],
             });
             return {
                 found: true,
@@ -543,6 +561,7 @@ export class AgentRunRepository {
         queuedReason?: string | null;
         /** Wave 4 M1 — pipeline plugin id when known at creation. */
         runnerKind?: string | null;
+        tenantId?: string | null;
         organizationId?: string | null;
         /**
          * Streaming-terminal — this run wants a long-lived interactive
@@ -574,6 +593,7 @@ export class AgentRunRepository {
             ...(args.persistent === true ? { persistent: true } : {}),
             // Only stamp when explicitly provided — the ambient scope
             // subscriber (EW-657) remains the default writer.
+            ...(args.tenantId !== undefined ? { tenantId: args.tenantId } : {}),
             ...(args.organizationId !== undefined ? { organizationId: args.organizationId } : {}),
         });
         return this.repository.save(run);
@@ -947,16 +967,26 @@ export class AgentRunRepository {
      * same task + agent, the new mention appends context to the
      * in-flight run rather than dispatching a 2nd run.
      */
-    async findInFlightForTaskAgent(taskId: string, agentId: string): Promise<AgentRun | null> {
-        return this.repository
+    async findInFlightForTaskAgent(
+        taskId: string,
+        agentId: string,
+        userId?: string,
+        scope?: OwnershipScope,
+    ): Promise<AgentRun | null> {
+        const query = this.repository
             .createQueryBuilder('run')
             .where('run.taskId = :taskId', { taskId })
             .andWhere('run.agentId = :agentId', { agentId })
             .andWhere('run.status IN (:...statuses)', {
                 statuses: ['queued', 'running'] satisfies AgentRunStatus[],
             })
-            .orderBy('run.createdAt', 'DESC')
-            .getOne();
+            .orderBy('run.createdAt', 'DESC');
+        if (userId) query.andWhere('run.userId = :userId', { userId });
+        const scopePredicate = ownershipSqlPredicate('run', scope, 'inFlightRun');
+        if (scopePredicate) {
+            query.andWhere(scopePredicate.clause, scopePredicate.parameters);
+        }
+        return query.getOne();
     }
 
     /**

--- a/packages/agent/src/database/repositories/agent.repository.organization-scope-sql.integration.spec.ts
+++ b/packages/agent/src/database/repositories/agent.repository.organization-scope-sql.integration.spec.ts
@@ -1,0 +1,109 @@
+import { DataSource, type Repository } from 'typeorm';
+import { ENTITIES } from '../_entities-inventory';
+import { Agent, AgentScope, AgentStatus } from '../../entities/agent.entity';
+import { User } from '../../entities/user.entity';
+import { AgentRepository } from './agent.repository';
+
+const ORGANIZATION_ID = '22222222-2222-4222-8222-222222222222';
+const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('AgentRepository null-Tenant Organization SQL', () => {
+    describe('better-sqlite3 behavior', () => {
+        let dataSource: DataSource;
+        let agents: Repository<Agent>;
+        let userId: string;
+
+        beforeAll(async () => {
+            dataSource = new DataSource({
+                type: 'better-sqlite3',
+                database: ':memory:',
+                entities: ENTITIES,
+                synchronize: true,
+            });
+            await dataSource.initialize();
+
+            const users = dataSource.getRepository(User);
+            const user = await users.save(
+                users.create({
+                    username: 'null-tenant-agent-scope',
+                    email: 'null-tenant-agent-scope@example.com',
+                    password: 'x',
+                } as Partial<User>),
+            );
+            userId = user.id;
+            agents = dataSource.getRepository(Agent);
+            await agents.save([
+                agents.create({
+                    userId,
+                    tenantId: null,
+                    organizationId: ORGANIZATION_ID,
+                    scope: AgentScope.TENANT,
+                    name: 'Legacy Organization Agent',
+                    slug: 'legacy-organization-agent',
+                    status: AgentStatus.ACTIVE,
+                    permissions: {},
+                } as Partial<Agent>),
+                agents.create({
+                    userId,
+                    tenantId: TENANT_ID,
+                    organizationId: ORGANIZATION_ID,
+                    scope: AgentScope.TENANT,
+                    name: 'Tenant Organization Agent',
+                    slug: 'tenant-organization-agent',
+                    status: AgentStatus.ACTIVE,
+                    permissions: {},
+                } as Partial<Agent>),
+            ]);
+        });
+
+        afterAll(async () => {
+            if (dataSource?.isInitialized) await dataSource.destroy();
+        });
+
+        it('returns only the exact null-Tenant Organization row', async () => {
+            const repository = new AgentRepository(agents);
+
+            const result = await repository.findByUserIdScoped(
+                userId,
+                {},
+                { tenantId: null, organizationId: ORGANIZATION_ID },
+            );
+
+            expect(result.rows.map((row) => row.slug)).toEqual(['legacy-organization-agent']);
+            expect(result.total).toBe(1);
+        });
+    });
+
+    it('emits quoted PostgreSQL identifiers and never binds a null Tenant to equality', async () => {
+        const dataSource = new DataSource({
+            type: 'postgres',
+            host: '127.0.0.1',
+            username: 'unused',
+            password: 'unused',
+            database: 'unused',
+            entities: ENTITIES,
+        });
+        await (dataSource as unknown as { buildMetadatas(): Promise<void> }).buildMetadatas();
+        const orm = dataSource.getRepository(Agent);
+        const query = orm.createQueryBuilder('agent');
+        let emitted: [string, unknown[]] | undefined;
+        jest.spyOn(query, 'getCount').mockImplementation(async () => {
+            emitted = query.getQueryAndParameters();
+            return 0;
+        });
+        jest.spyOn(query, 'getMany').mockResolvedValue([]);
+        jest.spyOn(orm, 'createQueryBuilder').mockReturnValue(query);
+
+        await new AgentRepository(orm).findByUserIdScoped(
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            {},
+            { tenantId: null, organizationId: ORGANIZATION_ID },
+        );
+
+        expect(emitted).toBeDefined();
+        expect(emitted![0]).toContain('"agent"."tenantId" IS NULL');
+        expect(emitted![0]).toContain('"agent"."organizationId" =');
+        expect(emitted![1]).toContain(ORGANIZATION_ID);
+        expect(emitted![1]).not.toContain(null);
+    });
+});

--- a/packages/agent/src/database/repositories/agent.repository.organization-scope.spec.ts
+++ b/packages/agent/src/database/repositories/agent.repository.organization-scope.spec.ts
@@ -1,0 +1,67 @@
+import type { Repository } from 'typeorm';
+import type { Agent } from '../../entities/agent.entity';
+import { AgentRepository } from './agent.repository';
+
+const EVER_SCOPE = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+
+function queryHarness() {
+    const predicates: string[] = [];
+    const parameters: Record<string, unknown>[] = [];
+    const query = {
+        where: jest.fn((predicate: string, params?: Record<string, unknown>) => {
+            predicates.push(predicate);
+            if (params) parameters.push(params);
+            return query;
+        }),
+        andWhere: jest.fn((predicate: string, params?: Record<string, unknown>) => {
+            predicates.push(predicate);
+            if (params) parameters.push(params);
+            return query;
+        }),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getCount: jest.fn(async () => 0),
+        getMany: jest.fn(async () => []),
+    };
+    const repository = {
+        createQueryBuilder: jest.fn(() => query),
+    } as unknown as Repository<Agent>;
+    return { repository, predicates, parameters };
+}
+
+describe('AgentRepository Organization scope', () => {
+    it('constrains list queries to the exact active Tenant and Organization', async () => {
+        const harness = queryHarness();
+        const repository = new AgentRepository(harness.repository);
+
+        await repository.findByUserIdScoped('user-1', {}, EVER_SCOPE);
+
+        expect(harness.predicates.join('\n')).toContain('agent.tenantId = :scopeTenantId');
+        expect(harness.predicates.join('\n')).toContain(
+            'agent.organizationId = :scopeOrganizationId',
+        );
+        expect(Object.assign({}, ...harness.parameters)).toMatchObject({
+            scopeTenantId: EVER_SCOPE.tenantId,
+            scopeOrganizationId: EVER_SCOPE.organizationId,
+        });
+    });
+
+    it('personal scope includes current-Tenant and legacy rows but excludes other Tenants', async () => {
+        const harness = queryHarness();
+        const repository = new AgentRepository(harness.repository);
+
+        await repository.findByUserIdScoped('user-1', {}, {
+            tenantId: EVER_SCOPE.tenantId,
+            organizationId: null,
+        });
+
+        expect(harness.predicates.join('\n')).toContain('agent.organizationId IS NULL');
+        expect(harness.predicates.join('\n')).toContain(
+            '(agent.tenantId = :scopeTenantId OR agent.tenantId IS NULL)',
+        );
+    });
+});

--- a/packages/agent/src/database/repositories/agent.repository.organization-scope.spec.ts
+++ b/packages/agent/src/database/repositories/agent.repository.organization-scope.spec.ts
@@ -54,10 +54,14 @@ describe('AgentRepository Organization scope', () => {
         const harness = queryHarness();
         const repository = new AgentRepository(harness.repository);
 
-        await repository.findByUserIdScoped('user-1', {}, {
-            tenantId: EVER_SCOPE.tenantId,
-            organizationId: null,
-        });
+        await repository.findByUserIdScoped(
+            'user-1',
+            {},
+            {
+                tenantId: EVER_SCOPE.tenantId,
+                organizationId: null,
+            },
+        );
 
         expect(harness.predicates.join('\n')).toContain('agent.organizationId IS NULL');
         expect(harness.predicates.join('\n')).toContain(

--- a/packages/agent/src/database/repositories/agent.repository.organization-scope.spec.ts
+++ b/packages/agent/src/database/repositories/agent.repository.organization-scope.spec.ts
@@ -40,13 +40,13 @@ describe('AgentRepository Organization scope', () => {
 
         await repository.findByUserIdScoped('user-1', {}, EVER_SCOPE);
 
-        expect(harness.predicates.join('\n')).toContain('agent.tenantId = :scopeTenantId');
+        expect(harness.predicates.join('\n')).toContain('agent.tenantId = :ownershipTenantId');
         expect(harness.predicates.join('\n')).toContain(
-            'agent.organizationId = :scopeOrganizationId',
+            'agent.organizationId = :ownershipOrganizationId',
         );
         expect(Object.assign({}, ...harness.parameters)).toMatchObject({
-            scopeTenantId: EVER_SCOPE.tenantId,
-            scopeOrganizationId: EVER_SCOPE.organizationId,
+            ownershipTenantId: EVER_SCOPE.tenantId,
+            ownershipOrganizationId: EVER_SCOPE.organizationId,
         });
     });
 
@@ -65,7 +65,31 @@ describe('AgentRepository Organization scope', () => {
 
         expect(harness.predicates.join('\n')).toContain('agent.organizationId IS NULL');
         expect(harness.predicates.join('\n')).toContain(
-            '(agent.tenantId = :scopeTenantId OR agent.tenantId IS NULL)',
+            '(agent.tenantId = :ownershipTenantId OR agent.tenantId IS NULL)',
         );
+    });
+
+    it('uses IS NULL for a null-Tenant Organization scope instead of binding = NULL', async () => {
+        const harness = queryHarness();
+        const repository = new AgentRepository(harness.repository);
+
+        await repository.findByUserIdScoped(
+            'user-1',
+            {},
+            {
+                tenantId: null,
+                organizationId: EVER_SCOPE.organizationId,
+            },
+        );
+
+        const predicates = harness.predicates.join('\n');
+        const parameters = Object.assign({}, ...harness.parameters);
+        expect(predicates).toContain('agent.tenantId IS NULL');
+        expect(predicates).toContain('agent.organizationId = :ownershipOrganizationId');
+        expect(predicates).not.toContain('agent.tenantId = :');
+        expect(parameters).toEqual(
+            expect.objectContaining({ ownershipOrganizationId: EVER_SCOPE.organizationId }),
+        );
+        expect(parameters).not.toHaveProperty('ownershipTenantId');
     });
 });

--- a/packages/agent/src/database/repositories/agent.repository.ts
+++ b/packages/agent/src/database/repositories/agent.repository.ts
@@ -13,7 +13,7 @@ import {
 import { Agent, AgentScope, AgentStatus, type AgentTarget } from '../../entities/agent.entity';
 import { AgentMembership } from '../../entities/agent-membership.entity';
 import { buildCaseInsensitiveLikeClause, prepareCaseInsensitiveContainsPattern } from '../utils';
-import { ownershipWhere, type OwnershipScope } from '../ownership-scope';
+import { ownershipSqlPredicate, ownershipWhere, type OwnershipScope } from '../ownership-scope';
 
 /**
  * Filter shape for `findByUserIdScoped`. All fields optional — caller
@@ -129,23 +129,9 @@ export class AgentRepository {
             .createQueryBuilder('agent')
             .where('agent.userId = :userId', { userId });
 
-        if (ownershipScope?.organizationId) {
-            qb.andWhere(
-                'agent.tenantId = :scopeTenantId AND agent.organizationId = :scopeOrganizationId',
-                {
-                    scopeTenantId: ownershipScope.tenantId,
-                    scopeOrganizationId: ownershipScope.organizationId,
-                },
-            );
-        } else if (ownershipScope) {
-            qb.andWhere('agent.organizationId IS NULL');
-            if (ownershipScope.tenantId) {
-                qb.andWhere('(agent.tenantId = :scopeTenantId OR agent.tenantId IS NULL)', {
-                    scopeTenantId: ownershipScope.tenantId,
-                });
-            } else {
-                qb.andWhere('agent.tenantId IS NULL');
-            }
+        const ownership = ownershipSqlPredicate('agent', ownershipScope);
+        if (ownership) {
+            qb.andWhere(ownership.clause, ownership.parameters);
         }
 
         if (!wantsArchived) {

--- a/packages/agent/src/database/repositories/agent.repository.ts
+++ b/packages/agent/src/database/repositories/agent.repository.ts
@@ -13,6 +13,7 @@ import {
 import { Agent, AgentScope, AgentStatus, type AgentTarget } from '../../entities/agent.entity';
 import { AgentMembership } from '../../entities/agent-membership.entity';
 import { buildCaseInsensitiveLikeClause, prepareCaseInsensitiveContainsPattern } from '../utils';
+import { ownershipWhere, type OwnershipScope } from '../ownership-scope';
 
 /**
  * Filter shape for `findByUserIdScoped`. All fields optional — caller
@@ -66,8 +67,19 @@ export class AgentRepository {
         return this.repository.findOne({ where: { id } });
     }
 
-    async findByIdAndUser(id: string, userId: string): Promise<Agent | null> {
-        return this.repository.findOne({ where: { id, userId } });
+    async findByIdAndUser(
+        id: string,
+        userId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Agent | null> {
+        return this.repository.findOne({
+            where: ownershipScope
+                ? ownershipWhere<Agent>(userId, ownershipScope).map((branch) => ({
+                      ...branch,
+                      id,
+                  }))
+                : { id, userId },
+        });
     }
 
     /**
@@ -80,22 +92,29 @@ export class AgentRepository {
         scope: AgentScope,
         slug: string,
         opts: { missionId?: string | null; ideaId?: string | null; workId?: string | null } = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<Agent | null> {
+        const common: FindOptionsWhere<Agent> = {
+            scope,
+            slug,
+            missionId: opts.missionId ?? IsNull(),
+            ideaId: opts.ideaId ?? IsNull(),
+            workId: opts.workId ?? IsNull(),
+        };
         return this.repository.findOne({
-            where: {
-                userId,
-                scope,
-                slug,
-                missionId: opts.missionId ?? IsNull(),
-                ideaId: opts.ideaId ?? IsNull(),
-                workId: opts.workId ?? IsNull(),
-            },
+            where: ownershipScope
+                ? ownershipWhere<Agent>(userId, ownershipScope).map((branch) => ({
+                      ...branch,
+                      ...common,
+                  }))
+                : { userId, ...common },
         });
     }
 
     async findByUserIdScoped(
         userId: string,
         filter: ListAgentsFilter = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<{ rows: Agent[]; total: number }> {
         // Archived Agents are hidden from every catalog surface by
         // default — EXCEPT when the caller explicitly asks for them
@@ -109,6 +128,25 @@ export class AgentRepository {
         const qb = this.repository
             .createQueryBuilder('agent')
             .where('agent.userId = :userId', { userId });
+
+        if (ownershipScope?.organizationId) {
+            qb.andWhere(
+                'agent.tenantId = :scopeTenantId AND agent.organizationId = :scopeOrganizationId',
+                {
+                    scopeTenantId: ownershipScope.tenantId,
+                    scopeOrganizationId: ownershipScope.organizationId,
+                },
+            );
+        } else if (ownershipScope) {
+            qb.andWhere('agent.organizationId IS NULL');
+            if (ownershipScope.tenantId) {
+                qb.andWhere('(agent.tenantId = :scopeTenantId OR agent.tenantId IS NULL)', {
+                    scopeTenantId: ownershipScope.tenantId,
+                });
+            } else {
+                qb.andWhere('agent.tenantId IS NULL');
+            }
+        }
 
         if (!wantsArchived) {
             qb.andWhere('agent.status != :archived', { archived: AgentStatus.ARCHIVED });

--- a/packages/agent/src/database/repositories/mission-work.repository.organization-scope.spec.ts
+++ b/packages/agent/src/database/repositories/mission-work.repository.organization-scope.spec.ts
@@ -1,5 +1,6 @@
-import type { Repository } from 'typeorm';
-import type { MissionWork } from '../../entities/mission-work.entity';
+import { DataSource, type DeleteResult, type Repository } from 'typeorm';
+import { ENTITIES } from '../_entities-inventory';
+import { MissionWork } from '../../entities/mission-work.entity';
 import { MissionWorkRepository } from './mission-work.repository';
 
 const EVER_SCOPE = {
@@ -28,6 +29,9 @@ function queryHarness() {
             return query;
         }),
         orderBy: jest.fn().mockReturnThis(),
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        execute: jest.fn(async () => ({ affected: 1 })),
         getRawMany: jest.fn(async () => []),
     };
     const repository = {
@@ -86,5 +90,93 @@ describe('MissionWorkRepository Organization scope', () => {
         );
         expect(harness.predicates.join('\n')).toContain('mission.tenantId');
         expect(harness.predicates.join('\n')).toContain('mission.organizationId');
+    });
+
+    it('uses canonical IS NULL semantics for an Organization whose Tenant is null', async () => {
+        const harness = queryHarness();
+        const repository = new MissionWorkRepository(harness.repository);
+
+        await repository.listForMissionWithWork('mission-1', 'user-1', {
+            tenantId: null,
+            organizationId: EVER_SCOPE.organizationId,
+        });
+
+        const predicates = harness.predicates.join('\n');
+        const parameters = Object.assign({}, ...harness.parameters);
+        expect(predicates).toContain('rel.tenantId IS NULL');
+        expect(predicates).toContain('work.tenantId IS NULL');
+        expect(predicates).not.toContain('tenantId = :scopeTenantId');
+        expect(parameters).not.toHaveProperty('scopeTenantId');
+    });
+
+    it('builds scoped detach from portable property criteria with no scope object parameter', async () => {
+        const harness = queryHarness();
+        const repository = new MissionWorkRepository(harness.repository);
+
+        await repository.detach({
+            missionId: 'mission-1',
+            workId: 'work-1',
+            userId: 'user-1',
+            relation: 'created',
+            scope: EVER_SCOPE,
+        });
+
+        expect(harness.repository.createQueryBuilder).toHaveBeenCalledWith();
+        expect(
+            (harness.repository.createQueryBuilder as jest.Mock).mock.results[0].value.where,
+        ).toHaveBeenCalledWith([
+            {
+                missionId: 'mission-1',
+                workId: 'work-1',
+                userId: 'user-1',
+                relation: 'created',
+                ...EVER_SCOPE,
+            },
+        ]);
+    });
+
+    it('emits portable quoted PostgreSQL detach SQL with only scalar ownership parameters', async () => {
+        const dataSource = new DataSource({
+            type: 'postgres',
+            host: '127.0.0.1',
+            username: 'unused',
+            password: 'unused',
+            database: 'unused',
+            entities: ENTITIES,
+        });
+        await (dataSource as unknown as { buildMetadatas(): Promise<void> }).buildMetadatas();
+        const orm = dataSource.getRepository(MissionWork);
+        const query = orm.createQueryBuilder().delete().from(MissionWork);
+        let emitted: [string, unknown[]] | undefined;
+        let namedParameters: Record<string, unknown> | undefined;
+        jest.spyOn(query, 'execute').mockImplementation(async () => {
+            emitted = query.getQueryAndParameters();
+            namedParameters = query.getParameters();
+            return { affected: 1, raw: [] } as DeleteResult;
+        });
+        jest.spyOn(orm, 'createQueryBuilder').mockReturnValue({
+            delete: jest.fn(() => query),
+        } as never);
+
+        await new MissionWorkRepository(orm).detach({
+            missionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            workId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            relation: 'created',
+            scope: EVER_SCOPE,
+        });
+
+        expect(emitted).toBeDefined();
+        expect(emitted![0]).toContain('"missionId"');
+        expect(emitted![0]).toContain('"workId"');
+        expect(emitted![0]).toContain('"userId"');
+        expect(emitted![0]).toContain('"tenantId"');
+        expect(emitted![0]).toContain('"organizationId"');
+        expect(emitted![1]).toHaveLength(6);
+        expect(Object.values(namedParameters ?? {})).toHaveLength(6);
+        expect(Object.values(namedParameters ?? {})).not.toContainEqual(EVER_SCOPE);
+        expect(
+            Object.values(namedParameters ?? {}).every((value) => typeof value === 'string'),
+        ).toBe(true);
     });
 });

--- a/packages/agent/src/database/repositories/mission-work.repository.organization-scope.spec.ts
+++ b/packages/agent/src/database/repositories/mission-work.repository.organization-scope.spec.ts
@@ -1,0 +1,90 @@
+import type { Repository } from 'typeorm';
+import type { MissionWork } from '../../entities/mission-work.entity';
+import { MissionWorkRepository } from './mission-work.repository';
+
+const EVER_SCOPE = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+
+function queryHarness() {
+    const selected: string[] = [];
+    const predicates: string[] = [];
+    const parameters: Record<string, unknown>[] = [];
+    const query = {
+        leftJoin: jest.fn().mockReturnThis(),
+        select: jest.fn((columns: string[]) => {
+            selected.push(...columns);
+            return query;
+        }),
+        where: jest.fn((predicate: string, params?: Record<string, unknown>) => {
+            predicates.push(predicate);
+            if (params) parameters.push(params);
+            return query;
+        }),
+        andWhere: jest.fn((predicate: string, params?: Record<string, unknown>) => {
+            predicates.push(predicate);
+            if (params) parameters.push(params);
+            return query;
+        }),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn(async () => []),
+    };
+    const repository = {
+        createQueryBuilder: jest.fn(() => query),
+    } as unknown as Repository<MissionWork>;
+    return { repository, selected, predicates, parameters };
+}
+
+describe('MissionWorkRepository Organization scope', () => {
+    it('returns relation ownership and constrains both relation and Work to the active Organization', async () => {
+        const harness = queryHarness();
+        const repository = new MissionWorkRepository(harness.repository);
+
+        await (repository.listForMissionWithWork as any)('mission-1', 'user-1', EVER_SCOPE);
+
+        expect(harness.selected).toEqual(
+            expect.arrayContaining([
+                'rel.tenantId AS "tenantId"',
+                'rel.organizationId AS "organizationId"',
+            ]),
+        );
+        expect(harness.predicates.join('\n')).toContain('rel.tenantId');
+        expect(harness.predicates.join('\n')).toContain('rel.organizationId');
+        expect(harness.predicates.join('\n')).toContain('work.tenantId');
+        expect(harness.predicates.join('\n')).toContain('work.organizationId');
+        expect(Object.assign({}, ...harness.parameters)).toMatchObject({
+            scopeTenantId: EVER_SCOPE.tenantId,
+            scopeOrganizationId: EVER_SCOPE.organizationId,
+        });
+    });
+
+    it('keeps legacy personal relations visible but excludes every Organization relation', async () => {
+        const harness = queryHarness();
+        const repository = new MissionWorkRepository(harness.repository);
+
+        await (repository.listForMissionWithWork as any)('mission-1', 'user-1', {
+            tenantId: EVER_SCOPE.tenantId,
+            organizationId: null,
+        });
+
+        expect(harness.predicates.join('\n')).toContain('rel.organizationId IS NULL');
+        expect(harness.predicates.join('\n')).toContain('work.organizationId IS NULL');
+    });
+
+    it('constrains the reverse relation lookup and its Mission parent to the active Organization', async () => {
+        const harness = queryHarness();
+        const repository = new MissionWorkRepository(harness.repository);
+
+        await (repository.listForWorkWithMission as any)('work-1', 'user-1', EVER_SCOPE);
+
+        expect(harness.selected).toEqual(
+            expect.arrayContaining([
+                'rel.tenantId AS "tenantId"',
+                'rel.organizationId AS "organizationId"',
+            ]),
+        );
+        expect(harness.predicates.join('\n')).toContain('mission.tenantId');
+        expect(harness.predicates.join('\n')).toContain('mission.organizationId');
+    });
+});

--- a/packages/agent/src/database/repositories/mission-work.repository.ts
+++ b/packages/agent/src/database/repositories/mission-work.repository.ts
@@ -2,7 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { MissionWork, type MissionWorkRelation } from '../../entities/mission-work.entity';
-import { ownershipWhere, type OwnershipScope } from '../ownership-scope';
+import {
+    ownershipSqlPredicate,
+    ownershipWhere,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../ownership-scope';
 
 /** A mission_works row hydrated with the Work's display fields. */
 export interface MissionWorkWithWork {
@@ -75,16 +80,17 @@ export class MissionWorkRepository {
         scope?: OwnershipScope;
     }): Promise<boolean> {
         if (input.scope) {
-            const query = this.repository
-                .createQueryBuilder('rel')
+            const where = ownershipWhereWith<MissionWork>(input.userId, input.scope, {
+                missionId: input.missionId,
+                workId: input.workId,
+                relation: input.relation,
+            });
+            const res = await this.repository
+                .createQueryBuilder()
                 .delete()
                 .from(MissionWork)
-                .where(
-                    'missionId = :missionId AND workId = :workId AND userId = :userId AND relation = :relation',
-                    input,
-                );
-            this.applyOwnershipScope(query, ['mission_works'], input.scope, false);
-            const res = await query.execute();
+                .where(where)
+                .execute();
             return (res.affected ?? 0) > 0;
         }
         const res = await this.repository.delete({
@@ -170,30 +176,11 @@ export class MissionWorkRepository {
         query: { andWhere(predicate: string, parameters?: Record<string, unknown>): unknown },
         aliases: string[],
         scope?: OwnershipScope,
-        qualified = true,
     ): void {
         if (!scope) return;
-        const column = (alias: string, name: string) => (qualified ? `${alias}.${name}` : name);
         for (const alias of aliases) {
-            if (scope.organizationId) {
-                query.andWhere(
-                    `${column(alias, 'tenantId')} = :scopeTenantId AND ${column(alias, 'organizationId')} = :scopeOrganizationId`,
-                    {
-                        scopeTenantId: scope.tenantId,
-                        scopeOrganizationId: scope.organizationId,
-                    },
-                );
-            } else {
-                query.andWhere(`${column(alias, 'organizationId')} IS NULL`);
-                if (scope.tenantId) {
-                    query.andWhere(
-                        `(${column(alias, 'tenantId')} = :scopeTenantId OR ${column(alias, 'tenantId')} IS NULL)`,
-                        { scopeTenantId: scope.tenantId },
-                    );
-                } else {
-                    query.andWhere(`${column(alias, 'tenantId')} IS NULL`);
-                }
-            }
+            const ownership = ownershipSqlPredicate(alias, scope, 'scope');
+            if (ownership) query.andWhere(ownership.clause, ownership.parameters);
         }
     }
 }

--- a/packages/agent/src/database/repositories/mission-work.repository.ts
+++ b/packages/agent/src/database/repositories/mission-work.repository.ts
@@ -2,10 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { MissionWork, type MissionWorkRelation } from '../../entities/mission-work.entity';
+import { ownershipWhere, type OwnershipScope } from '../ownership-scope';
 
 /** A mission_works row hydrated with the Work's display fields. */
 export interface MissionWorkWithWork {
     id: string;
+    tenantId: string | null;
+    organizationId: string | null;
     missionId: string;
     workId: string;
     relation: MissionWorkRelation;
@@ -18,6 +21,8 @@ export interface MissionWorkWithWork {
  *  (reverse lookup — "which Missions relate to this Work"). */
 export interface MissionWorkWithMission {
     id: string;
+    tenantId: string | null;
+    organizationId: string | null;
     missionId: string;
     workId: string;
     relation: MissionWorkRelation;
@@ -67,7 +72,21 @@ export class MissionWorkRepository {
         workId: string;
         userId: string;
         relation: MissionWorkRelation;
+        scope?: OwnershipScope;
     }): Promise<boolean> {
+        if (input.scope) {
+            const query = this.repository
+                .createQueryBuilder('rel')
+                .delete()
+                .from(MissionWork)
+                .where(
+                    'missionId = :missionId AND workId = :workId AND userId = :userId AND relation = :relation',
+                    input,
+                );
+            this.applyOwnershipScope(query, ['mission_works'], input.scope, false);
+            const res = await query.execute();
+            return (res.affected ?? 0) > 0;
+        }
         const res = await this.repository.delete({
             missionId: input.missionId,
             workId: input.workId,
@@ -81,12 +100,15 @@ export class MissionWorkRepository {
     async listForMissionWithWork(
         missionId: string,
         userId: string,
+        scope?: OwnershipScope,
     ): Promise<MissionWorkWithWork[]> {
-        return this.repository
+        const query = this.repository
             .createQueryBuilder('rel')
             .leftJoin('rel.work', 'work')
             .select([
                 'rel.id AS "id"',
+                'rel.tenantId AS "tenantId"',
+                'rel.organizationId AS "organizationId"',
                 'rel.missionId AS "missionId"',
                 'rel.workId AS "workId"',
                 'rel.relation AS "relation"',
@@ -95,20 +117,24 @@ export class MissionWorkRepository {
                 'work.slug AS "workSlug"',
             ])
             .where('rel.missionId = :missionId AND rel.userId = :userId', { missionId, userId })
-            .orderBy('rel.createdAt', 'DESC')
-            .getRawMany<MissionWorkWithWork>();
+            .orderBy('rel.createdAt', 'DESC');
+        this.applyOwnershipScope(query, ['rel', 'work'], scope);
+        return query.getRawMany<MissionWorkWithWork>();
     }
 
     /** Reverse — relations touching one Work (owner-scoped), with Mission display fields. */
     async listForWorkWithMission(
         workId: string,
         userId: string,
+        scope?: OwnershipScope,
     ): Promise<MissionWorkWithMission[]> {
-        return this.repository
+        const query = this.repository
             .createQueryBuilder('rel')
             .leftJoin('rel.mission', 'mission')
             .select([
                 'rel.id AS "id"',
+                'rel.tenantId AS "tenantId"',
+                'rel.organizationId AS "organizationId"',
                 'rel.missionId AS "missionId"',
                 'rel.workId AS "workId"',
                 'rel.relation AS "relation"',
@@ -117,16 +143,57 @@ export class MissionWorkRepository {
                 'mission.status AS "missionStatus"',
             ])
             .where('rel.workId = :workId AND rel.userId = :userId', { workId, userId })
-            .orderBy('rel.createdAt', 'DESC')
-            .getRawMany<MissionWorkWithMission>();
+            .orderBy('rel.createdAt', 'DESC');
+        this.applyOwnershipScope(query, ['rel', 'mission'], scope);
+        return query.getRawMany<MissionWorkWithMission>();
     }
 
     /** Mission ids related to a Work (for the list endpoint's workId filter). */
-    async missionIdsForWork(workId: string, userId: string): Promise<string[]> {
+    async missionIdsForWork(
+        workId: string,
+        userId: string,
+        scope?: OwnershipScope,
+    ): Promise<string[]> {
         const rows = await this.repository.find({
-            where: { workId, userId },
+            where: scope
+                ? ownershipWhere<MissionWork>(userId, scope).map((branch) => ({
+                      ...branch,
+                      workId,
+                  }))
+                : { workId, userId },
             select: { missionId: true },
         });
         return [...new Set(rows.map((r) => r.missionId))];
+    }
+
+    private applyOwnershipScope(
+        query: { andWhere(predicate: string, parameters?: Record<string, unknown>): unknown },
+        aliases: string[],
+        scope?: OwnershipScope,
+        qualified = true,
+    ): void {
+        if (!scope) return;
+        const column = (alias: string, name: string) => (qualified ? `${alias}.${name}` : name);
+        for (const alias of aliases) {
+            if (scope.organizationId) {
+                query.andWhere(
+                    `${column(alias, 'tenantId')} = :scopeTenantId AND ${column(alias, 'organizationId')} = :scopeOrganizationId`,
+                    {
+                        scopeTenantId: scope.tenantId,
+                        scopeOrganizationId: scope.organizationId,
+                    },
+                );
+            } else {
+                query.andWhere(`${column(alias, 'organizationId')} IS NULL`);
+                if (scope.tenantId) {
+                    query.andWhere(
+                        `(${column(alias, 'tenantId')} = :scopeTenantId OR ${column(alias, 'tenantId')} IS NULL)`,
+                        { scopeTenantId: scope.tenantId },
+                    );
+                } else {
+                    query.andWhere(`${column(alias, 'tenantId')} IS NULL`);
+                }
+            }
+        }
     }
 }

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -7,6 +7,7 @@ import {
     prepareCaseInsensitiveContainsPattern,
     sanitizeLikePattern,
 } from '../utils';
+import { ownershipSqlPredicate, ownershipWhereWith, type OwnershipScope } from '../ownership-scope';
 
 export interface ListTasksFilter {
     status?: TaskStatus | TaskStatus[];
@@ -50,8 +51,14 @@ export class TaskRepository {
         return this.repository.findOne({ where: { id } });
     }
 
-    async findByIdAndUser(id: string, userId: string): Promise<Task | null> {
-        return this.repository.findOne({ where: { id, userId } });
+    async findByIdAndUser(
+        id: string,
+        userId: string,
+        scope?: OwnershipScope,
+    ): Promise<Task | null> {
+        return this.repository.findOne({
+            where: ownershipWhereWith<Task>(userId, scope, { id }),
+        });
     }
 
     async findBySlug(slug: string): Promise<Task | null> {
@@ -123,10 +130,16 @@ export class TaskRepository {
     async findByUserIdFiltered(
         userId: string,
         filter: ListTasksFilter = {},
+        scope?: OwnershipScope,
     ): Promise<{ rows: Task[]; total: number }> {
         const qb = this.repository
             .createQueryBuilder('task')
             .where('task.userId = :userId', { userId });
+
+        const scopePredicate = ownershipSqlPredicate('task', scope, 'taskScope');
+        if (scopePredicate) {
+            qb.andWhere(scopePredicate.clause, scopePredicate.parameters);
+        }
 
         if (filter.status) {
             if (Array.isArray(filter.status)) {
@@ -368,6 +381,8 @@ export class TaskRepository {
     async wouldCreateCycle(
         candidateChildId: string,
         proposedParentId: string,
+        userId?: string,
+        scope?: OwnershipScope,
         maxDepth = 200,
     ): Promise<boolean> {
         if (candidateChildId === proposedParentId) return true;
@@ -378,7 +393,9 @@ export class TaskRepository {
             seen.add(cursor);
             if (cursor === candidateChildId) return true;
             const next = await this.repository.findOne({
-                where: { id: cursor },
+                where: userId
+                    ? ownershipWhereWith<Task>(userId, scope, { id: cursor })
+                    : { id: cursor },
                 select: ['id', 'parentTaskId'],
             });
             cursor = next?.parentTaskId ?? null;

--- a/packages/agent/src/database/repositories/user-upload.repository.spec.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.spec.ts
@@ -1,0 +1,69 @@
+import { UserUploadRepository } from './user-upload.repository';
+
+describe('UserUploadRepository — ownership scope', () => {
+    const userId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const sha256 = 'b'.repeat(64);
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    const yoScope = {
+        tenantId: everScope.tenantId,
+        organizationId: '33333333-3333-4333-8333-333333333333',
+    };
+
+    let orm: { findOne: jest.Mock };
+    let uploads: UserUploadRepository;
+
+    beforeEach(() => {
+        orm = { findOne: jest.fn().mockResolvedValue(null) };
+        uploads = new UserUploadRepository(orm as never);
+    });
+
+    it('uses exact active Ever scope for a same-user known content hash', async () => {
+        await uploads.findOwnedByUser(sha256, userId, everScope);
+
+        expect(orm.findOne).toHaveBeenCalledWith({
+            where: [{ sha256, userId, ...everScope }],
+        });
+    });
+
+    it('does not collapse the same user + hash in Yo into Ever', async () => {
+        await uploads.findOwnedByUser(sha256, userId, yoScope);
+
+        expect(orm.findOne).toHaveBeenCalledWith({
+            where: [{ sha256, userId, ...yoScope }],
+        });
+        expect(orm.findOne).not.toHaveBeenCalledWith({
+            where: [{ sha256, userId, ...everScope }],
+        });
+    });
+
+    it('allows current and legacy personal uploads but no Organization row', async () => {
+        await uploads.findOwnedByUser(sha256, userId, {
+            tenantId: everScope.tenantId,
+            organizationId: null,
+        });
+
+        const where = orm.findOne.mock.calls[0][0].where as Array<Record<string, unknown>>;
+        expect(where).toHaveLength(2);
+        expect(where[0]).toMatchObject({
+            sha256,
+            userId,
+            tenantId: everScope.tenantId,
+            organizationId: expect.objectContaining({ _type: 'isNull' }),
+        });
+        expect(where[1]).toMatchObject({
+            sha256,
+            userId,
+            tenantId: expect.objectContaining({ _type: 'isNull' }),
+            organizationId: expect.objectContaining({ _type: 'isNull' }),
+        });
+    });
+
+    it('preserves the historical unscoped lookup only for non-request callers', async () => {
+        await uploads.findOwnedByUser(sha256, userId);
+
+        expect(orm.findOne).toHaveBeenCalledWith({ where: { sha256, userId } });
+    });
+});

--- a/packages/agent/src/database/repositories/user-upload.repository.spec.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.spec.ts
@@ -12,11 +12,15 @@ describe('UserUploadRepository — ownership scope', () => {
         organizationId: '33333333-3333-4333-8333-333333333333',
     };
 
-    let orm: { findOne: jest.Mock };
+    let orm: { findOne: jest.Mock; create: jest.Mock; save: jest.Mock };
     let uploads: UserUploadRepository;
 
     beforeEach(() => {
-        orm = { findOne: jest.fn().mockResolvedValue(null) };
+        orm = {
+            findOne: jest.fn().mockResolvedValue(null),
+            create: jest.fn((value) => value),
+            save: jest.fn(async (value) => ({ id: 'upload-row', ...value })),
+        };
         uploads = new UserUploadRepository(orm as never);
     });
 
@@ -65,5 +69,49 @@ describe('UserUploadRepository — ownership scope', () => {
         await uploads.findOwnedByUser(sha256, userId);
 
         expect(orm.findOne).toHaveBeenCalledWith({ where: { sha256, userId } });
+    });
+
+    it('dedupes identical bytes independently in Ever and Yo', async () => {
+        await uploads.record({
+            userId,
+            sha256,
+            ...everScope,
+            storageProvider: 'local-fs',
+            storagePath: `${userId}/${sha256}.png`,
+        });
+        await uploads.record({
+            userId,
+            sha256,
+            ...yoScope,
+            storageProvider: 'local-fs',
+            storagePath: `${userId}/${sha256}.png`,
+        });
+
+        expect(orm.findOne).toHaveBeenNthCalledWith(1, {
+            where: [{ userId, sha256, ...everScope }],
+        });
+        expect(orm.findOne).toHaveBeenNthCalledWith(2, {
+            where: [{ userId, sha256, ...yoScope }],
+        });
+        expect(orm.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('dedupes current and legacy personal uploads without matching an Organization row', async () => {
+        await uploads.record({
+            userId,
+            sha256,
+            tenantId: everScope.tenantId,
+            organizationId: null,
+            storageProvider: 'local-fs',
+            storagePath: `${userId}/${sha256}.png`,
+        });
+
+        const where = orm.findOne.mock.calls[0][0].where as Array<Record<string, unknown>>;
+        expect(where).toHaveLength(2);
+        expect(where[0]).toMatchObject({ userId, sha256, tenantId: everScope.tenantId });
+        expect(where[1]).toMatchObject({ userId, sha256 });
+        for (const branch of where) {
+            expect(branch.organizationId).toEqual(expect.objectContaining({ _type: 'isNull' }));
+        }
     });
 });

--- a/packages/agent/src/database/repositories/user-upload.repository.spec.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.spec.ts
@@ -114,4 +114,34 @@ describe('UserUploadRepository — ownership scope', () => {
             expect(branch.organizationId).toEqual(expect.objectContaining({ _type: 'isNull' }));
         }
     });
+
+    it('normalizes uppercase SHA-256 before scoped lookup and persistence', async () => {
+        const uppercaseSha256 = sha256.toUpperCase();
+
+        await uploads.record({
+            userId,
+            sha256: uppercaseSha256,
+            ...everScope,
+            storageProvider: 'local-fs',
+            storagePath: `${userId}/${sha256}.png`,
+        });
+
+        expect(orm.findOne).toHaveBeenCalledWith({
+            where: [{ userId, sha256, ...everScope }],
+        });
+        expect(orm.create).toHaveBeenCalledWith(
+            expect.objectContaining({ userId, sha256, ...everScope }),
+        );
+        expect(orm.create).not.toHaveBeenCalledWith(
+            expect.objectContaining({ sha256: uppercaseSha256 }),
+        );
+    });
+
+    it('normalizes uppercase SHA-256 on owned reads so it dedupes with lowercase rows', async () => {
+        await uploads.findOwnedByUser(sha256.toUpperCase(), userId, everScope);
+
+        expect(orm.findOne).toHaveBeenCalledWith({
+            where: [{ sha256, userId, ...everScope }],
+        });
+    });
 });

--- a/packages/agent/src/database/repositories/user-upload.repository.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.ts
@@ -4,6 +4,10 @@ import { Repository } from 'typeorm';
 import { UserUpload } from '../../entities/user-upload.entity';
 import { ownershipWhereWith, type OwnershipScope } from '../ownership-scope';
 
+function normalizeUploadSha256(sha256: string): string {
+    return sha256.toLowerCase();
+}
+
 export interface RecordUploadInput {
     userId?: string | null;
     sha256: string;
@@ -40,26 +44,30 @@ export class UserUploadRepository {
      * centralized ownership predicate.
      */
     async record(input: RecordUploadInput): Promise<UserUpload> {
-        const scope: OwnershipScope = {
-            tenantId: input.tenantId ?? null,
-            organizationId: input.organizationId ?? null,
+        const normalizedInput = {
+            ...input,
+            sha256: normalizeUploadSha256(input.sha256),
         };
-        const userId = input.userId ?? null;
+        const scope: OwnershipScope = {
+            tenantId: normalizedInput.tenantId ?? null,
+            organizationId: normalizedInput.organizationId ?? null,
+        };
+        const userId = normalizedInput.userId ?? null;
         const existing = await this.repo.findOne({
             where:
                 userId === null
                     ? {
                           userId: null,
-                          sha256: input.sha256,
+                          sha256: normalizedInput.sha256,
                           tenantId: scope.tenantId,
                           organizationId: scope.organizationId,
                       }
                     : ownershipWhereWith<UserUpload>(userId, scope, {
-                          sha256: input.sha256,
+                          sha256: normalizedInput.sha256,
                       }),
         });
         if (existing) return existing;
-        const entity = this.repo.create(input);
+        const entity = this.repo.create(normalizedInput);
         return this.repo.save(entity);
     }
 
@@ -70,7 +78,9 @@ export class UserUploadRepository {
         scope?: OwnershipScope,
     ): Promise<UserUpload | null> {
         return this.repo.findOne({
-            where: ownershipWhereWith<UserUpload>(userId, scope, { sha256 }),
+            where: ownershipWhereWith<UserUpload>(userId, scope, {
+                sha256: normalizeUploadSha256(sha256),
+            }),
         });
     }
 
@@ -125,7 +135,10 @@ export class UserUploadRepository {
         sha256: string,
         folderId: string | null,
     ): Promise<boolean> {
-        const result = await this.repo.update({ userId, sha256 }, { folderId });
+        const result = await this.repo.update(
+            { userId, sha256: normalizeUploadSha256(sha256) },
+            { folderId },
+        );
         return (result.affected ?? 0) > 0;
     }
 

--- a/packages/agent/src/database/repositories/user-upload.repository.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.ts
@@ -33,14 +33,30 @@ export class UserUploadRepository {
     ) {}
 
     /**
-     * Insert the upload-ownership record, deduped per `(userId, sha256)` — a
-     * repeat upload of the same file by the same user returns the existing row.
-     * Best-effort by contract: the bytes are already stored, so the caller must
-     * not let a failure here fail the upload (swallow + log).
+     * Insert the upload-ownership record, deduped within the exact persisted
+     * ownership scope. Organization uploads never collapse into another
+     * Organization merely because their bytes (and therefore sha256) match.
+     * Personal scope deliberately includes legacy null/null rows through the
+     * centralized ownership predicate.
      */
     async record(input: RecordUploadInput): Promise<UserUpload> {
+        const scope: OwnershipScope = {
+            tenantId: input.tenantId ?? null,
+            organizationId: input.organizationId ?? null,
+        };
+        const userId = input.userId ?? null;
         const existing = await this.repo.findOne({
-            where: { userId: input.userId ?? null, sha256: input.sha256 },
+            where:
+                userId === null
+                    ? {
+                          userId: null,
+                          sha256: input.sha256,
+                          tenantId: scope.tenantId,
+                          organizationId: scope.organizationId,
+                      }
+                    : ownershipWhereWith<UserUpload>(userId, scope, {
+                          sha256: input.sha256,
+                      }),
         });
         if (existing) return existing;
         const entity = this.repo.create(input);

--- a/packages/agent/src/database/repositories/user-upload.repository.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserUpload } from '../../entities/user-upload.entity';
+import { ownershipWhereWith, type OwnershipScope } from '../ownership-scope';
 
 export interface RecordUploadInput {
     userId?: string | null;
@@ -47,8 +48,14 @@ export class UserUploadRepository {
     }
 
     /** An upload with this `sha256` owned by `userId`, else null. */
-    async findOwnedByUser(sha256: string, userId: string): Promise<UserUpload | null> {
-        return this.repo.findOne({ where: { sha256, userId } });
+    async findOwnedByUser(
+        sha256: string,
+        userId: string,
+        scope?: OwnershipScope,
+    ): Promise<UserUpload | null> {
+        return this.repo.findOne({
+            where: ownershipWhereWith<UserUpload>(userId, scope, { sha256 }),
+        });
     }
 
     // ─── Memory Files (folder membership) ────────────────────────────────

--- a/packages/agent/src/entities/__tests__/ownership-observability.spec.ts
+++ b/packages/agent/src/entities/__tests__/ownership-observability.spec.ts
@@ -4,6 +4,10 @@ import type { Mission } from '../mission.entity';
 import { toAgentDto } from '../../agents/types';
 import { toGoalDto } from '../../goals/types';
 import { toMissionDto } from '../../missions/types';
+import type {
+    MissionWorkWithMission,
+    MissionWorkWithWork,
+} from '../../database/repositories/mission-work.repository';
 
 describe('organization ownership response contracts', () => {
     const ownership = {
@@ -17,5 +21,36 @@ describe('organization ownership response contracts', () => {
         ['AgentDto', () => toAgentDto({ ...ownership } as Agent)],
     ])('%s exposes the persisted tenant and Organization ids', (_name, project) => {
         expect(project()).toMatchObject(ownership);
+    });
+
+    it.each([
+        [
+            'MissionWorkWithWork',
+            {
+                id: 'relation-1',
+                ...ownership,
+                missionId: 'mission-1',
+                workId: 'work-1',
+                relation: 'created',
+                createdAt: new Date(0),
+                workName: 'Work',
+                workSlug: 'work',
+            } satisfies MissionWorkWithWork,
+        ],
+        [
+            'MissionWorkWithMission',
+            {
+                id: 'relation-1',
+                ...ownership,
+                missionId: 'mission-1',
+                workId: 'work-1',
+                relation: 'created',
+                createdAt: new Date(0),
+                missionTitle: 'Mission',
+                missionStatus: 'active',
+            } satisfies MissionWorkWithMission,
+        ],
+    ])('%s projects persisted ownership', (_name, projection) => {
+        expect(projection).toMatchObject(ownership);
     });
 });

--- a/packages/agent/src/entities/__tests__/ownership-observability.spec.ts
+++ b/packages/agent/src/entities/__tests__/ownership-observability.spec.ts
@@ -1,0 +1,21 @@
+import type { Agent } from '../agent.entity';
+import type { Goal } from '../goal.entity';
+import type { Mission } from '../mission.entity';
+import { toAgentDto } from '../../agents/types';
+import { toGoalDto } from '../../goals/types';
+import { toMissionDto } from '../../missions/types';
+
+describe('organization ownership response contracts', () => {
+    const ownership = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+
+    it.each([
+        ['MissionDto', () => toMissionDto({ ...ownership } as Mission)],
+        ['GoalDto', () => toGoalDto({ ...ownership } as Goal)],
+        ['AgentDto', () => toAgentDto({ ...ownership } as Agent)],
+    ])('%s exposes the persisted tenant and Organization ids', (_name, project) => {
+        expect(project()).toMatchObject(ownership);
+    });
+});

--- a/packages/agent/src/entities/user-upload.entity.ts
+++ b/packages/agent/src/entities/user-upload.entity.ts
@@ -35,6 +35,7 @@ import { User } from './user.entity';
  */
 @Entity({ name: 'user_uploads' })
 @Index('idx_user_uploads_user_sha', ['userId', 'sha256'])
+@Index('idx_user_uploads_user_scope_sha', ['userId', 'tenantId', 'organizationId', 'sha256'])
 @Index('idx_user_uploads_sha', ['sha256'])
 export class UserUpload {
     @PrimaryGeneratedColumn('uuid')

--- a/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
@@ -137,17 +137,25 @@ function build(overrides: { goal?: Partial<Goal> } = {}) {
         ),
     };
     const tasksService = {
-        create: jest.fn(async (userId: string, input: any) => {
-            const task = {
-                id: `task-${tasks._rows.length + 1}`,
-                slug: `T-${tasks._rows.length + 1}`,
-                userId,
-                createdAt: new Date(Date.now() + tasks._rows.length),
-                ...input,
-            };
-            tasks._rows.push(task);
-            return task;
-        }),
+        create: jest.fn(
+            async (
+                userId: string,
+                input: any,
+                scope?: { tenantId: string | null; organizationId: string | null },
+            ) => {
+                const task = {
+                    id: `task-${tasks._rows.length + 1}`,
+                    slug: `T-${tasks._rows.length + 1}`,
+                    userId,
+                    createdAt: new Date(Date.now() + tasks._rows.length),
+                    tenantId: scope?.tenantId ?? null,
+                    organizationId: scope?.organizationId ?? null,
+                    ...input,
+                };
+                tasks._rows.push(task);
+                return task;
+            },
+        ),
     };
     const transitions = {
         dispatchAgentRun: jest.fn(async () => ({
@@ -587,6 +595,7 @@ describe('GoalOrchestratorService — advance', () => {
                 agentId: 'agent-7',
                 labels: ['goal-iteration'],
             }),
+            { tenantId: null, organizationId: null },
         );
         // The brief handed to the agent is built from persisted state, so
         // the open criterion and the session budget must both be in it.
@@ -610,7 +619,7 @@ describe('GoalOrchestratorService — advance', () => {
 
     it('routes a pinned known Agent UUID only through the Goal persisted Ever scope', async () => {
         const assignedAgentId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
-        const { service, agents, transitions } = build({
+        const { service, agents, tasksService, transitions } = build({
             goal: {
                 loopStatus: 'running',
                 assignedAgentId,
@@ -622,9 +631,14 @@ describe('GoalOrchestratorService — advance', () => {
 
         expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', everScope);
         expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
-            expect.anything(),
+            expect.objectContaining(everScope),
             assignedAgentId,
             expect.anything(),
+        );
+        expect(tasksService.create).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ goalId: 'g1', agentId: assignedAgentId }),
+            everScope,
         );
     });
 

--- a/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
@@ -39,8 +39,13 @@ function matchesValue(actual: unknown, expected: unknown): boolean {
 function makeRepo(prefix: string) {
     const rows: AnyRow[] = [];
     let counter = 0;
-    const matches = (row: AnyRow, where: Record<string, unknown> = {}) =>
-        Object.entries(where).every(([k, v]) => matchesValue(row[k], v));
+    const matches = (
+        row: AnyRow,
+        where: Record<string, unknown> | Record<string, unknown>[] = {},
+    ): boolean => {
+        if (Array.isArray(where)) return where.some((branch) => matches(row, branch));
+        return Object.entries(where).every(([k, v]) => matchesValue(row[k], v));
+    };
     return {
         find: jest.fn(async (opts: any = {}) => {
             let result = rows.filter((r) => matches(r, opts.where));
@@ -123,7 +128,13 @@ function build(overrides: { goal?: Partial<Goal> } = {}) {
     goals._rows.push(goalRow(overrides.goal));
 
     const agents = {
-        findByIdAndUser: jest.fn(async (id: string) => ({ id, name: `Agent ${id}`, slug: id })),
+        findByIdAndUser: jest.fn(
+            async (
+                id: string,
+                _userId?: string,
+                _scope?: { tenantId: string | null; organizationId: string | null },
+            ) => ({ id, name: `Agent ${id}`, slug: id }),
+        ),
     };
     const tasksService = {
         create: jest.fn(async (userId: string, input: any) => {
@@ -259,6 +270,54 @@ describe('GoalOrchestratorService — ownership', () => {
 });
 
 describe('GoalOrchestratorService — limits', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    it('404s a same-user assigned Agent UUID outside the Goal active scope', async () => {
+        const { service, agents, goals } = build({ goal: everScope });
+        agents.findByIdAndUser.mockResolvedValueOnce(null as never);
+
+        await expect(
+            (service.updateLimits as any)(
+                'u1',
+                'g1',
+                { assignedAgentId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+                everScope,
+            ),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(goals.save).not.toHaveBeenCalled();
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            'u1',
+            everScope,
+        );
+    });
+
+    it('accepts a legacy personal Agent for a legacy personal Goal', async () => {
+        const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+        const { service, agents } = build({
+            goal: { tenantId: null, organizationId: null },
+        });
+        agents.findByIdAndUser.mockResolvedValueOnce({
+            id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            userId: 'u1',
+            tenantId: null,
+            organizationId: null,
+        } as never);
+
+        await expect(
+            (service.updateLimits as any)(
+                'u1',
+                'g1',
+                { assignedAgentId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' },
+                personalScope,
+            ),
+        ).resolves.toMatchObject({
+            assignedAgentId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        });
+    });
+
     it('persists every limit field and logs the change', async () => {
         const { service, goals, events } = build();
         const dto = await service.updateLimits('u1', 'g1', {
@@ -320,7 +379,7 @@ describe('GoalOrchestratorService — limits', () => {
         agents.findByIdAndUser.mockResolvedValueOnce(null as never);
         await expect(
             service.updateLimits('u1', 'g1', { assignedAgentId: 'foreign' }),
-        ).rejects.toBeInstanceOf(BadRequestException);
+        ).rejects.toBeInstanceOf(NotFoundException);
     });
 });
 
@@ -495,6 +554,15 @@ describe('GoalOrchestratorService — spend rollup', () => {
 });
 
 describe('GoalOrchestratorService — advance', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    const yoScope = {
+        tenantId: everScope.tenantId,
+        organizationId: '33333333-3333-4333-8333-333333333333',
+    };
+
     it('creates an iteration Task, dispatches it, and logs route + dispatch', async () => {
         const { service, tasksService, transitions, events, goals } = build({
             goal: {
@@ -538,6 +606,73 @@ describe('GoalOrchestratorService — advance', () => {
 
         expect(goals._rows[0].iteration).toBe(1);
         expect(goals._rows[0].activeAgentId).toBe('agent-7');
+    });
+
+    it('routes a pinned known Agent UUID only through the Goal persisted Ever scope', async () => {
+        const assignedAgentId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        const { service, agents, transitions } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId,
+                ...everScope,
+            },
+        });
+
+        await service.advance('u1', 'g1');
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', everScope);
+        expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
+            expect.anything(),
+            assignedAgentId,
+            expect.anything(),
+        );
+    });
+
+    it('does not route the same-user known Agent UUID when it exists only in Yo', async () => {
+        const assignedAgentId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+        const yoAgent = {
+            id: assignedAgentId,
+            userId: 'u1',
+            name: 'Yo Agent',
+            slug: 'yo-agent',
+            ...yoScope,
+        };
+        const { service, agents, transitions } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId,
+                ...everScope,
+            },
+        });
+        agents.findByIdAndUser.mockImplementation(
+            async (_id: string, _userId?: string, scope?: typeof everScope) =>
+                scope?.organizationId === yoAgent.organizationId ? yoAgent : null,
+        );
+
+        await service.advance('u1', 'g1');
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', everScope);
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+    });
+
+    it('keeps a legacy personal Goal pinned to a legacy personal Agent', async () => {
+        const assignedAgentId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+        const { service, agents, transitions } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId,
+                tenantId: null,
+                organizationId: null,
+            },
+        });
+
+        await service.advance('u1', 'g1');
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', {
+            tenantId: null,
+            organizationId: null,
+        });
+        expect(transitions.dispatchAgentRun).toHaveBeenCalled();
     });
 
     it('round-robins over the agents that have already worked the Goal', async () => {

--- a/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
@@ -326,6 +326,29 @@ describe('GoalOrchestratorService — limits', () => {
         });
     });
 
+    it('validates a pin against the persisted legacy Goal scope, not the broader request scope', async () => {
+        const personalRequestScope = { tenantId: everScope.tenantId, organizationId: null };
+        const { service, agents, goals } = build({
+            goal: { tenantId: null, organizationId: null },
+        });
+        agents.findByIdAndUser.mockResolvedValueOnce(null as never);
+
+        await expect(
+            service.updateLimits(
+                'u1',
+                'g1',
+                { assignedAgentId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' },
+                personalRequestScope,
+            ),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(
+            'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            'u1',
+            { tenantId: null, organizationId: null },
+        );
+        expect(goals.save).not.toHaveBeenCalled();
+    });
+
     it('persists every limit field and logs the change', async () => {
         const { service, goals, events } = build();
         const dto = await service.updateLimits('u1', 'g1', {

--- a/packages/agent/src/goals/__tests__/goals.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goals.service.spec.ts
@@ -27,8 +27,22 @@ interface AnyRow {
 function makeRepo(prefix: string) {
     const rows: AnyRow[] = [];
     let counter = 0;
-    const matches = (row: AnyRow, where: Record<string, unknown> = {}) =>
-        Object.entries(where).every(([k, v]) => row[k] === v);
+    const matches = (
+        row: AnyRow,
+        where: Record<string, unknown> | Record<string, unknown>[] = {},
+    ) => {
+        if (Array.isArray(where)) return where.some((branch) => matches(row, branch));
+        return Object.entries(where).every(([k, value]) => {
+            if (
+                typeof value === 'object' &&
+                value !== null &&
+                (value as { _type?: string })._type === 'isNull'
+            ) {
+                return row[k] == null;
+            }
+            return row[k] === value;
+        });
+    };
     const repo = {
         find: jest.fn(async (opts: any = {}) => {
             let result = rows.filter((r) => matches(r, opts.where));
@@ -388,6 +402,40 @@ describe('GoalsService', () => {
             await expect(service.linkToMission('u1', 'm1', 'ghost', false)).rejects.toBeInstanceOf(
                 NotFoundException,
             );
+        });
+
+        it('does not link a known Goal UUID from another active Organization', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            missionsRepo._rows[0] = { ...missionsRepo._rows[0], ...everScope };
+            goalsRepo._rows[0] = { ...goalsRepo._rows[0], ...everScope };
+            goalsRepo._rows[1] = {
+                ...goalsRepo._rows[1],
+                tenantId: everScope.tenantId,
+                organizationId: '33333333-3333-4333-8333-333333333333',
+            };
+
+            await expect(
+                (service.linkToMission as any)('u1', 'm1', 'gB', true, everScope),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(missionGoalsRepo._rows).toHaveLength(0);
+        });
+
+        it('stamps a Mission-Goal edge with the exact active Organization', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            missionsRepo._rows[0] = { ...missionsRepo._rows[0], ...everScope };
+            goalsRepo._rows[0] = { ...goalsRepo._rows[0], ...everScope };
+
+            const linked = await (service.linkToMission as any)('u1', 'm1', 'gA', true, everScope);
+
+            expect(missionGoalsRepo._rows[0]).toMatchObject(everScope);
+            expect(linked).toMatchObject(everScope);
+            expect(linked.goal).toMatchObject(everScope);
         });
     });
 });

--- a/packages/agent/src/goals/goal-orchestrator.service.ts
+++ b/packages/agent/src/goals/goal-orchestrator.service.ts
@@ -30,6 +30,11 @@ import { AGENT_RUN_CANCELLER, type AgentRunCanceller } from '../agents/agent-run
 import { TasksService } from '../tasks-domain/tasks.service';
 import { TaskTransitionService } from '../tasks-domain/task-transition.service';
 import {
+    ownershipScopeOf,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
+import {
     dodProgressSignature,
     normalizeDoDCriteria,
     summarizeDoD,
@@ -152,8 +157,9 @@ export class GoalOrchestratorService {
         userId: string,
         goalId: string,
         input: UpdateGoalLimitsInput,
+        scope?: OwnershipScope,
     ): Promise<GoalDto> {
-        const goal = await this.findOrThrow(userId, goalId);
+        const goal = await this.findOrThrow(userId, goalId, scope);
         const before = this.limitsSnapshot(goal);
 
         if (input.spendCapCents !== undefined) {
@@ -206,7 +212,11 @@ export class GoalOrchestratorService {
             goal.workerModelHint = this.normalizeHint(input.workerModelHint);
         }
         if (input.assignedAgentId !== undefined) {
-            goal.assignedAgentId = await this.resolveAssignedAgentId(userId, input.assignedAgentId);
+            goal.assignedAgentId = await this.resolveAssignedAgentId(
+                userId,
+                input.assignedAgentId,
+                scope,
+            );
         }
 
         const saved = await this.goals.save(goal);
@@ -908,8 +918,14 @@ export class GoalOrchestratorService {
 
     // ─── internals ──────────────────────────────────────────────────
 
-    private async findOrThrow(userId: string, goalId: string): Promise<Goal> {
-        const row = await this.goals.findOne({ where: { id: goalId, userId } });
+    private async findOrThrow(
+        userId: string,
+        goalId: string,
+        scope?: OwnershipScope,
+    ): Promise<Goal> {
+        const row = await this.goals.findOne({
+            where: ownershipWhereWith<Goal>(userId, scope, { id: goalId }),
+        });
         if (!row) {
             throw new NotFoundException(`Goal not found`);
         }
@@ -1019,9 +1035,10 @@ export class GoalOrchestratorService {
      */
     private async resolveCandidates(goal: Goal): Promise<GoalRoutingCandidate[]> {
         if (goal.assignedAgentId) {
+            const goalScope = ownershipScopeOf(goal);
             const agent = this.agents
                 ? await this.agents
-                      .findByIdAndUser(goal.assignedAgentId, goal.userId)
+                      .findByIdAndUser(goal.assignedAgentId, goal.userId, goalScope)
                       .catch(() => null)
                 : null;
             // With no Agent repository wired we cannot verify the pin, but
@@ -1042,8 +1059,11 @@ export class GoalOrchestratorService {
         const out = new Map<string, GoalRoutingCandidate>();
         for (const task of tasks) {
             if (!task.agentId || out.has(task.agentId)) continue;
+            const goalScope = ownershipScopeOf(goal);
             const agent = this.agents
-                ? await this.agents.findByIdAndUser(task.agentId, goal.userId).catch(() => null)
+                ? await this.agents
+                      .findByIdAndUser(task.agentId, goal.userId, goalScope)
+                      .catch(() => null)
                 : null;
             if (this.agents && !agent) continue;
             out.set(task.agentId, {
@@ -1151,15 +1171,15 @@ export class GoalOrchestratorService {
     private async resolveAssignedAgentId(
         userId: string,
         agentId: string | null,
+        scope?: OwnershipScope,
     ): Promise<string | null> {
         if (agentId === null) return null;
         if (this.agents) {
-            const agent = await this.agents.findByIdAndUser(agentId, userId).catch(() => null);
+            const agent = await this.agents
+                .findByIdAndUser(agentId, userId, scope)
+                .catch(() => null);
             if (!agent) {
-                // 400, not 404, and no existence leak: from the caller's
-                // side an id they do not own and one that never existed are
-                // the same unusable input (the TasksService idiom).
-                throw new BadRequestException(`Agent ${agentId} not found.`);
+                throw new NotFoundException(`Agent ${agentId} not found.`);
             }
         }
         return agentId;

--- a/packages/agent/src/goals/goal-orchestrator.service.ts
+++ b/packages/agent/src/goals/goal-orchestrator.service.ts
@@ -816,17 +816,21 @@ export class GoalOrchestratorService {
             metadata: { reasonCode: decision.reasonCode },
         });
 
-        const task = await this.tasksService.create(goal.userId, {
-            title: `[Goal] ${goal.title} — iteration ${iteration}`,
-            description: this.buildIterationBrief(goal, iteration),
-            status: TaskStatus.TODO,
-            priority: TaskPriority.P2,
-            labels: [GOAL_ITERATION_LABEL],
-            goalId: goal.id,
-            agentId,
-            createdByType: 'user',
-            createdById: goal.userId,
-        });
+        const task = await this.tasksService.create(
+            goal.userId,
+            {
+                title: `[Goal] ${goal.title} — iteration ${iteration}`,
+                description: this.buildIterationBrief(goal, iteration),
+                status: TaskStatus.TODO,
+                priority: TaskPriority.P2,
+                labels: [GOAL_ITERATION_LABEL],
+                goalId: goal.id,
+                agentId,
+                createdByType: 'user',
+                createdById: goal.userId,
+            },
+            ownershipScopeOf(goal),
+        );
 
         const dispatch = await this.transitions.dispatchAgentRun(task, agentId, {
             // Keyed on the iteration, so a double tick of the cron cannot

--- a/packages/agent/src/goals/goal-orchestrator.service.ts
+++ b/packages/agent/src/goals/goal-orchestrator.service.ts
@@ -215,7 +215,7 @@ export class GoalOrchestratorService {
             goal.assignedAgentId = await this.resolveAssignedAgentId(
                 userId,
                 input.assignedAgentId,
-                scope,
+                ownershipScopeOf(goal),
             );
         }
 

--- a/packages/agent/src/goals/goals.service.ts
+++ b/packages/agent/src/goals/goals.service.ts
@@ -14,6 +14,7 @@ import { MissionGoal } from '../entities/mission-goal.entity';
 import { Mission } from '../entities/mission.entity';
 import { GoalEvaluationService } from './goal-evaluation.service';
 import { validateGoalJudgment } from './goal-criteria';
+import { ownershipWhere, type OwnershipScope } from '../database/ownership-scope';
 import {
     DEFAULT_CHECK_FREQUENCY_MINUTES,
     MIN_CHECK_FREQUENCY_MINUTES,
@@ -90,9 +91,15 @@ export class GoalsService {
 
     // ─── CRUD ───────────────────────────────────────────────────────
 
-    async listForUser(userId: string, filter: ListGoalsFilter = {}): Promise<GoalDto[]> {
-        const where: FindOptionsWhere<Goal> = {
-            userId,
+    async listForUser(
+        userId: string,
+        filter: ListGoalsFilter = {},
+        scope?: OwnershipScope,
+    ): Promise<GoalDto[]> {
+        const whereBranches: FindOptionsWhere<Goal>[] = (
+            scope ? ownershipWhere<Goal>(userId, scope) : [{ userId }]
+        ).map((branch) => ({
+            ...branch,
             ...(filter.status ? { status: filter.status } : {}),
             // Archive is a VIEW, not a deletion: the default catalog hides
             // archived Goals, `archived: true` shows only those, and
@@ -101,7 +108,10 @@ export class GoalsService {
             // them and the catalog is unchanged for anyone who never
             // archives anything.
             ...this.archivedPredicate(filter.archived),
-        };
+        }));
+        const where: FindOptionsWhere<Goal> | FindOptionsWhere<Goal>[] = scope
+            ? whereBranches
+            : whereBranches[0];
         const rows = await this.goals.find({
             where,
             order: { updatedAt: 'DESC' },
@@ -111,8 +121,8 @@ export class GoalsService {
         return rows.map(toGoalDto);
     }
 
-    async getForUser(userId: string, goalId: string): Promise<GoalDto> {
-        return toGoalDto(await this.findOrThrow(userId, goalId));
+    async getForUser(userId: string, goalId: string, scope?: OwnershipScope): Promise<GoalDto> {
+        return toGoalDto(await this.findOrThrow(userId, goalId, scope));
     }
 
     /**
@@ -409,8 +419,19 @@ export class GoalsService {
         return archived === true ? { archivedAt: Not(IsNull()) } : { archivedAt: IsNull() };
     }
 
-    private async findOrThrow(userId: string, goalId: string): Promise<Goal> {
-        const row = await this.goals.findOne({ where: { id: goalId, userId } });
+    private async findOrThrow(
+        userId: string,
+        goalId: string,
+        scope?: OwnershipScope,
+    ): Promise<Goal> {
+        const row = await this.goals.findOne({
+            where: scope
+                ? ownershipWhere<Goal>(userId, scope).map((branch) => ({
+                      ...branch,
+                      id: goalId,
+                  }))
+                : { id: goalId, userId },
+        });
         if (!row) {
             throw new NotFoundException(`Goal not found`);
         }

--- a/packages/agent/src/goals/goals.service.ts
+++ b/packages/agent/src/goals/goals.service.ts
@@ -14,7 +14,12 @@ import { MissionGoal } from '../entities/mission-goal.entity';
 import { Mission } from '../entities/mission.entity';
 import { GoalEvaluationService } from './goal-evaluation.service';
 import { validateGoalJudgment } from './goal-criteria';
-import { ownershipWhere, type OwnershipScope } from '../database/ownership-scope';
+import {
+    ownershipStamp,
+    ownershipWhere,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
 import {
     DEFAULT_CHECK_FREQUENCY_MINUTES,
     MIN_CHECK_FREQUENCY_MINUTES,
@@ -129,8 +134,13 @@ export class GoalsService {
      * Append-only observation history (progress sparkline / audit).
      * Newest-first; `limit` defaults to 100.
      */
-    async listSamples(userId: string, goalId: string, limit = 100): Promise<GoalMetricSampleDto[]> {
-        await this.findOrThrow(userId, goalId);
+    async listSamples(
+        userId: string,
+        goalId: string,
+        limit = 100,
+        scope?: OwnershipScope,
+    ): Promise<GoalMetricSampleDto[]> {
+        await this.findOrThrow(userId, goalId, scope);
         const rows = await this.samples.find({
             where: { goalId },
             order: { sampledAt: 'DESC' },
@@ -139,7 +149,7 @@ export class GoalsService {
         return rows.map(toGoalMetricSampleDto);
     }
 
-    async create(userId: string, input: CreateGoalInput): Promise<GoalDto> {
+    async create(userId: string, input: CreateGoalInput, scope?: OwnershipScope): Promise<GoalDto> {
         const metricSource = this.validateMetricSource(input.metricSource, {
             requireProvider: false,
         });
@@ -151,6 +161,7 @@ export class GoalsService {
         const saved = await this.goals.save(
             this.goals.create({
                 userId,
+                ...ownershipStamp(scope),
                 title: input.title.trim().slice(0, 200),
                 description: input.description?.trim() || null,
                 metricSource,
@@ -181,8 +192,13 @@ export class GoalsService {
      * writing `outcome: null` clears an auto-set outcome without
      * changing status (re-open via activate).
      */
-    async update(userId: string, goalId: string, input: UpdateGoalInput): Promise<GoalDto> {
-        const existing = await this.findOrThrow(userId, goalId);
+    async update(
+        userId: string,
+        goalId: string,
+        input: UpdateGoalInput,
+        scope?: OwnershipScope,
+    ): Promise<GoalDto> {
+        const existing = await this.findOrThrow(userId, goalId, scope);
 
         if (input.title !== undefined) existing.title = input.title.trim().slice(0, 200);
         if (input.description !== undefined) {
@@ -254,8 +270,12 @@ export class GoalsService {
         return toGoalDto(await this.goals.save(existing));
     }
 
-    async delete(userId: string, goalId: string): Promise<{ deleted: true }> {
-        const existing = await this.findOrThrow(userId, goalId);
+    async delete(
+        userId: string,
+        goalId: string,
+        scope?: OwnershipScope,
+    ): Promise<{ deleted: true }> {
+        const existing = await this.findOrThrow(userId, goalId, scope);
         // DB-level cascades remove samples + mission_goals edges.
         await this.goals.remove(existing);
         return { deleted: true };
@@ -271,8 +291,8 @@ export class GoalsService {
      * `nextCheckAt` is set to "now" so the next dispatcher tick
      * evaluates immediately.
      */
-    async activate(userId: string, goalId: string): Promise<GoalDto> {
-        const existing = await this.findOrThrow(userId, goalId);
+    async activate(userId: string, goalId: string, scope?: OwnershipScope): Promise<GoalDto> {
+        const existing = await this.findOrThrow(userId, goalId, scope);
         if (!ACTIVATABLE_STATUSES.includes(existing.status)) {
             throw new BadRequestException(
                 `Goal cannot be activated from status "${existing.status}". Allowed: ${ACTIVATABLE_STATUSES.join(', ')}.`,
@@ -286,8 +306,8 @@ export class GoalsService {
     }
 
     /** ACTIVE → PAUSED; clears `nextCheckAt` so the dispatcher skips it. */
-    async pause(userId: string, goalId: string): Promise<GoalDto> {
-        const existing = await this.findOrThrow(userId, goalId);
+    async pause(userId: string, goalId: string, scope?: OwnershipScope): Promise<GoalDto> {
+        const existing = await this.findOrThrow(userId, goalId, scope);
         if (!PAUSABLE_STATUSES.includes(existing.status)) {
             throw new BadRequestException(
                 `Goal cannot be paused from status "${existing.status}". Allowed: ${PAUSABLE_STATUSES.join(', ')}.`,
@@ -308,29 +328,36 @@ export class GoalsService {
     async evaluateNow(
         userId: string,
         goalId: string,
+        scope?: OwnershipScope,
     ): Promise<{ entry: GoalEvaluationEntry; goal: GoalDto }> {
-        const existing = await this.findOrThrow(userId, goalId);
+        const existing = await this.findOrThrow(userId, goalId, scope);
         if (existing.status !== GoalStatus.ACTIVE) {
             throw new BadRequestException(
                 `Goal must be active to evaluate now (status is "${existing.status}").`,
             );
         }
         const entry = await this.evaluationService.evaluateOne(existing);
-        const fresh = await this.findOrThrow(userId, goalId);
+        const fresh = await this.findOrThrow(userId, goalId, scope);
         return { entry, goal: toGoalDto(fresh) };
     }
 
     // ─── Mission ↔ Goal links ───────────────────────────────────────
 
-    async listForMission(userId: string, missionId: string): Promise<MissionGoalLinkDto[]> {
-        await this.findMissionOrThrow(userId, missionId);
+    async listForMission(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<MissionGoalLinkDto[]> {
+        await this.findMissionOrThrow(userId, missionId, scope);
         const links = await this.missionGoals.find({
-            where: { missionId },
+            where: ownershipWhereWith<MissionGoal>(userId, scope, { missionId }),
             order: { createdAt: 'ASC' },
         });
         if (links.length === 0) return [];
         const goalRows = await this.goals.find({
-            where: { id: In(links.map((l) => l.goalId)) },
+            where: ownershipWhereWith<Goal>(userId, scope, {
+                id: In(links.map((l) => l.goalId)),
+            }),
         });
         const byId = new Map(goalRows.map((g) => [g.id, g]));
         return links.map((link) => toMissionGoalLinkDto(link, byId.get(link.goalId) ?? null));
@@ -352,17 +379,30 @@ export class GoalsService {
         missionId: string,
         goalId: string,
         isPrimary = false,
+        scope?: OwnershipScope,
     ): Promise<MissionGoalLinkDto> {
-        await this.findMissionOrThrow(userId, missionId);
-        const goal = await this.findOrThrow(userId, goalId);
+        await this.findMissionOrThrow(userId, missionId, scope);
+        const goal = await this.findOrThrow(userId, goalId, scope);
 
         if (isPrimary) {
             // Demote-before-promote so the Postgres partial unique
             // index never sees two primaries.
-            await this.missionGoals.update({ missionId, isPrimary: true }, { isPrimary: false });
+            const currentPrimaries = await this.missionGoals.find({
+                where: ownershipWhereWith<MissionGoal>(userId, scope, {
+                    missionId,
+                    isPrimary: true,
+                }),
+            });
+            await Promise.all(
+                currentPrimaries.map((primary) => {
+                    primary.isPrimary = false;
+                    return this.missionGoals.save(primary);
+                }),
+            );
         }
 
-        let link = await this.missionGoals.findOne({ where: { missionId, goalId } });
+        const linkWhere = ownershipWhereWith<MissionGoal>(userId, scope, { missionId, goalId });
+        let link = await this.missionGoals.findOne({ where: linkWhere });
         if (link) {
             if (link.isPrimary !== isPrimary) {
                 link.isPrimary = isPrimary;
@@ -373,14 +413,20 @@ export class GoalsService {
 
         try {
             link = await this.missionGoals.save(
-                this.missionGoals.create({ missionId, goalId, userId, isPrimary }),
+                this.missionGoals.create({
+                    missionId,
+                    goalId,
+                    userId,
+                    isPrimary,
+                    ...ownershipStamp(scope),
+                }),
             );
         } catch (err) {
             // Duplicate (missionId, goalId) race — re-read and apply
             // the isPrimary intent (mirrors the MissionAttachment
             // idempotency contract).
             if (err instanceof Error && /duplicate key|unique constraint/i.test(err.message)) {
-                const existing = await this.missionGoals.findOne({ where: { missionId, goalId } });
+                const existing = await this.missionGoals.findOne({ where: linkWhere });
                 if (existing) {
                     if (existing.isPrimary !== isPrimary) {
                         existing.isPrimary = isPrimary;
@@ -402,9 +448,13 @@ export class GoalsService {
         userId: string,
         missionId: string,
         goalId: string,
+        scope?: OwnershipScope,
     ): Promise<{ deleted: true }> {
-        await this.findMissionOrThrow(userId, missionId);
-        const link = await this.missionGoals.findOne({ where: { missionId, goalId } });
+        await this.findMissionOrThrow(userId, missionId, scope);
+        await this.findOrThrow(userId, goalId, scope);
+        const link = await this.missionGoals.findOne({
+            where: ownershipWhereWith<MissionGoal>(userId, scope, { missionId, goalId }),
+        });
         if (!link) {
             throw new NotFoundException(`Goal link not found`);
         }
@@ -425,12 +475,7 @@ export class GoalsService {
         scope?: OwnershipScope,
     ): Promise<Goal> {
         const row = await this.goals.findOne({
-            where: scope
-                ? ownershipWhere<Goal>(userId, scope).map((branch) => ({
-                      ...branch,
-                      id: goalId,
-                  }))
-                : { id: goalId, userId },
+            where: ownershipWhereWith<Goal>(userId, scope, { id: goalId }),
         });
         if (!row) {
             throw new NotFoundException(`Goal not found`);
@@ -438,8 +483,14 @@ export class GoalsService {
         return row;
     }
 
-    private async findMissionOrThrow(userId: string, missionId: string): Promise<Mission> {
-        const row = await this.missions.findOne({ where: { id: missionId, userId } });
+    private async findMissionOrThrow(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<Mission> {
+        const row = await this.missions.findOne({
+            where: ownershipWhereWith<Mission>(userId, scope, { id: missionId }),
+        });
         if (!row) {
             throw new NotFoundException(`Mission not found`);
         }

--- a/packages/agent/src/goals/types.ts
+++ b/packages/agent/src/goals/types.ts
@@ -35,6 +35,8 @@ export const DEFAULT_CHECK_FREQUENCY_MINUTES = 60;
  */
 export interface GoalDto {
     id: string;
+    tenantId: string | null;
+    organizationId: string | null;
     title: string;
     description: string | null;
     metricSource: GoalMetricSource;
@@ -85,6 +87,8 @@ export interface GoalDto {
 export function toGoalDto(goal: Goal): GoalDto {
     return {
         id: goal.id,
+        tenantId: goal.tenantId ?? null,
+        organizationId: goal.organizationId ?? null,
         title: goal.title,
         description: goal.description ?? null,
         metricSource: goal.metricSource,

--- a/packages/agent/src/goals/types.ts
+++ b/packages/agent/src/goals/types.ts
@@ -152,6 +152,8 @@ export function toGoalMetricSampleDto(sample: GoalMetricSample): GoalMetricSampl
 /** Mission ↔ Goal edge, expanded with the Goal projection. */
 export interface MissionGoalLinkDto {
     id: string;
+    tenantId: string | null;
+    organizationId: string | null;
     missionId: string;
     goalId: string;
     isPrimary: boolean;
@@ -163,6 +165,8 @@ export function toMissionGoalLinkDto(link: MissionGoal, goal?: Goal | null): Mis
     const resolved = goal ?? link.goal ?? null;
     return {
         id: link.id,
+        tenantId: link.tenantId ?? null,
+        organizationId: link.organizationId ?? null,
         missionId: link.missionId,
         goalId: link.goalId,
         isPrimary: link.isPrimary,

--- a/packages/agent/src/missions/__tests__/mission-clone.service.spec.ts
+++ b/packages/agent/src/missions/__tests__/mission-clone.service.spec.ts
@@ -1,5 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
-import type { Repository } from 'typeorm';
+import type { FindOptionsWhere, Repository } from 'typeorm';
 import { MissionCloneService } from '../mission-clone.service';
 import { Mission, MissionStatus, MissionType } from '../../entities/mission.entity';
 import {
@@ -44,29 +44,61 @@ function makeStore() {
         } as WorkProposal;
     }
 
+    function matchesWhere(
+        row: Record<string, unknown>,
+        where:
+            | FindOptionsWhere<Record<string, unknown>>
+            | FindOptionsWhere<Record<string, unknown>>[],
+    ): boolean {
+        if (Array.isArray(where)) return where.some((branch) => matchesWhere(row, branch));
+        return Object.entries(where).every(([key, expected]) => {
+            if (
+                typeof expected === 'object' &&
+                expected !== null &&
+                (expected as { _type?: string })._type === 'isNull'
+            ) {
+                return row[key] == null;
+            }
+            if (
+                typeof expected === 'object' &&
+                expected !== null &&
+                (expected as { _type?: string })._type === 'not'
+            ) {
+                return row[key] !== (expected as { _value?: unknown })._value;
+            }
+            return row[key] === expected;
+        });
+    }
+
     const txManager = {
-        findOne: jest.fn(async (entity: unknown, opts: { where: Record<string, unknown> }) => {
-            if (entity === Mission) {
-                return (
-                    missions.find((m) =>
-                        Object.entries(opts.where).every(
-                            ([k, v]) => (m as unknown as Record<string, unknown>)[k] === v,
-                        ),
-                    ) ?? null
-                );
-            }
-            return null;
-        }),
-        find: jest.fn(async (entity: unknown, opts: { where: Record<string, unknown> }) => {
-            if (entity === WorkProposal) {
-                return proposals.filter((p) =>
-                    Object.entries(opts.where).every(
-                        ([k, v]) => (p as unknown as Record<string, unknown>)[k] === v,
-                    ),
-                );
-            }
-            return [];
-        }),
+        findOne: jest.fn(
+            async (
+                entity: unknown,
+                opts: {
+                    where: FindOptionsWhere<Mission> | FindOptionsWhere<Mission>[];
+                },
+            ) => {
+                if (entity === Mission) {
+                    return (
+                        missions.find((m) => matchesWhere(m as never, opts.where as never)) ?? null
+                    );
+                }
+                return null;
+            },
+        ),
+        find: jest.fn(
+            async (
+                entity: unknown,
+                opts: {
+                    where: FindOptionsWhere<WorkProposal> | FindOptionsWhere<WorkProposal>[];
+                },
+            ) => {
+                if (entity === WorkProposal) {
+                    return proposals.filter((p) => matchesWhere(p as never, opts.where as never));
+                }
+                return [];
+            },
+        ),
         create: jest.fn((entity: unknown, partial: Partial<Mission | WorkProposal>) => {
             if (entity === Mission) return createMissionEntity(partial as Partial<Mission>);
             if (entity === WorkProposal)
@@ -96,6 +128,7 @@ function makeStore() {
         missions,
         proposals,
         txManager,
+        matchesWhere,
         seedMission(partial: Partial<Mission> & { userId: string }): Mission {
             const m: Mission = createMissionEntity({
                 title: 'src title',
@@ -143,14 +176,12 @@ function makeRepos(store: ReturnType<typeof makeStore>) {
                 return cb(store.txManager);
             }),
         },
-        count: jest.fn(async (opts: { where: { sourceMissionId?: string; userId?: string } }) => {
-            return store.missions.filter(
-                (m) =>
-                    m.sourceMissionId === opts.where.sourceMissionId &&
-                    (opts.where.userId === undefined || m.userId === opts.where.userId) &&
-                    m.id !== opts.where.sourceMissionId,
-            ).length;
-        }),
+        count: jest.fn(
+            async (opts: { where: FindOptionsWhere<Mission> | FindOptionsWhere<Mission>[] }) =>
+                store.missions.filter((mission) =>
+                    store.matchesWhere(mission as never, opts.where as never),
+                ).length,
+        ),
     };
     const proposalRepo = {};
     return { missionRepo, proposalRepo };
@@ -319,6 +350,51 @@ describe('MissionCloneService', () => {
             await expect(
                 service.cloneForUser('u1', '00000000-0000-0000-0000-000000000000'),
             ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('does not clone a known Mission UUID from another active Organization', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            const source = store.seedMission({
+                userId: 'u1',
+                tenantId: everScope.tenantId,
+                organizationId: '33333333-3333-4333-8333-333333333333',
+            });
+
+            await expect(
+                (service.cloneForUser as any)('u1', source.id, {}, everScope),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(store.missions).toEqual([source]);
+        });
+
+        it('copies only Ideas from the active Organization and stamps the clone exactly', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            const source = store.seedMission({ userId: 'u1', ...everScope });
+            store.seedProposal({
+                userId: 'u1',
+                missionId: source.id,
+                title: 'Ever idea',
+                ...everScope,
+            });
+            store.seedProposal({
+                userId: 'u1',
+                missionId: source.id,
+                title: 'Yo idea',
+                tenantId: everScope.tenantId,
+                organizationId: '33333333-3333-4333-8333-333333333333',
+            });
+
+            const result = await (service.cloneForUser as any)('u1', source.id, {}, everScope);
+            const copies = store.proposals.filter((idea) => idea.missionId === result.mission.id);
+
+            expect(result.mission).toMatchObject(everScope);
+            expect(copies).toHaveLength(1);
+            expect(copies[0]).toMatchObject({ title: 'Ever idea', ...everScope });
         });
     });
 

--- a/packages/agent/src/missions/__tests__/missions.service.spec.ts
+++ b/packages/agent/src/missions/__tests__/missions.service.spec.ts
@@ -521,6 +521,8 @@ describe('MissionsService', () => {
                 const rows: MissionWorkWithWork[] = [
                     {
                         id: 'mw1',
+                        tenantId: null,
+                        organizationId: null,
                         missionId: id,
                         workId: 'w1',
                         relation: 'created',
@@ -572,6 +574,8 @@ describe('MissionsService', () => {
                 const refreshed: MissionWorkWithWork[] = [
                     {
                         id: 'mw1',
+                        tenantId: null,
+                        organizationId: null,
                         missionId: id,
                         workId: 'w1',
                         relation: 'operates',
@@ -635,6 +639,8 @@ describe('MissionsService', () => {
                 const rows: MissionWorkWithMission[] = [
                     {
                         id: 'mw2',
+                        tenantId: null,
+                        organizationId: null,
                         missionId: 'm9',
                         workId: 'w1',
                         relation: 'markets',

--- a/packages/agent/src/missions/mission-clone.service.ts
+++ b/packages/agent/src/missions/mission-clone.service.ts
@@ -9,6 +9,11 @@ import {
 } from '../entities/work-proposal.entity';
 import { parseCron } from './cron-matcher';
 import { toMissionDto, type MissionDto } from './types';
+import {
+    ownershipStamp,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
 
 /**
  * Optional caller-supplied overrides for the cloned Mission.
@@ -117,6 +122,7 @@ export class MissionCloneService {
         userId: string,
         sourceMissionId: string,
         overrides: CloneMissionOverrides = {},
+        scope?: OwnershipScope,
     ): Promise<CloneMissionResult> {
         // The whole clone runs inside a single transaction so the
         // "new Mission + N copied Ideas" pair is atomic — partial
@@ -126,7 +132,7 @@ export class MissionCloneService {
         // TypeORM's data source is configured for.
         return this.missions.manager.transaction(async (tx) => {
             const source = await tx.findOne(Mission, {
-                where: { id: sourceMissionId, userId },
+                where: ownershipWhereWith<Mission>(userId, scope, { id: sourceMissionId }),
             });
             if (!source) {
                 throw new NotFoundException(`Mission not found`);
@@ -165,6 +171,7 @@ export class MissionCloneService {
             const newMission = await tx.save(
                 tx.create(Mission, {
                     userId,
+                    ...ownershipStamp(scope),
                     title: clonedTitle,
                     description: source.description,
                     type: source.type,
@@ -193,7 +200,9 @@ export class MissionCloneService {
             // metric below (just DISMISSED), so the caller can
             // surface a "we skipped N dismissed Ideas" hint.
             const sourceIdeas = await tx.find(WorkProposal, {
-                where: { missionId: source.id, userId },
+                where: ownershipWhereWith<WorkProposal>(userId, scope, {
+                    missionId: source.id,
+                }),
             });
             const eligible = sourceIdeas.filter(
                 (idea) => idea.status !== WorkProposalStatus.DISMISSED,
@@ -204,6 +213,7 @@ export class MissionCloneService {
                 const newIdeaRows = eligible.map((src) =>
                     tx.create(WorkProposal, {
                         userId,
+                        ...ownershipStamp(scope),
                         missionId: newMission.id,
                         // Fresh-slate status + cleared failure cols + no
                         // acceptedWorkId. The clone is a new chance, not
@@ -257,13 +267,16 @@ export class MissionCloneService {
      * FK schema permits them but the writer never sets them, and
      * counting them would be misleading.
      */
-    async countClonesOf(userId: string, sourceMissionId: string): Promise<number> {
+    async countClonesOf(
+        userId: string,
+        sourceMissionId: string,
+        scope?: OwnershipScope,
+    ): Promise<number> {
         return this.missions.count({
-            where: {
-                userId,
+            where: ownershipWhereWith<Mission>(userId, scope, {
                 sourceMissionId,
                 id: Not(sourceMissionId),
-            },
+            }),
         });
     }
 }

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -6,7 +6,7 @@ import {
     Optional,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ILike, Repository, type FindOptionsWhere } from 'typeorm';
+import { ILike, In, Repository, type FindOptionsWhere } from 'typeorm';
 import {
     Mission,
     MissionOutcome,
@@ -543,7 +543,17 @@ export class MissionsService {
     ): Promise<MissionAttachment[]> {
         await this.findOrThrow(userId, missionId, scope);
         if (!this.missionAttachments) return [];
-        return this.missionAttachments.findByMissionId(missionId);
+        const rows = await this.missionAttachments.findByMissionId(missionId);
+        if (rows.length === 0 || !this.uploadsRepo) return rows;
+        const uploads = await this.uploadsRepo.find({
+            where: ownershipWhereWith<UserUpload>(userId, scope, {
+                sha256: In(rows.map((row) => row.uploadId)),
+            }),
+        });
+        if (new Set(rows.map((row) => row.uploadId)).size !== uploads.length) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        return rows;
     }
 
     /**
@@ -567,7 +577,9 @@ export class MissionsService {
         // attachment edge the hunt found.
         if (this.uploadsRepo) {
             const owned = await this.uploadsRepo.findOne({
-                where: { sha256: uploadId.toLowerCase(), userId },
+                where: ownershipWhereWith<UserUpload>(userId, scope, {
+                    sha256: uploadId.toLowerCase(),
+                }),
             });
             if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
         }

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -34,6 +34,7 @@ import { toMissionDto, type MissionDto } from './types';
 // validate full-URL forms of `missionTemplateRepo` so a malicious value can
 // never be persisted for the Phase 8 scaffolder to clone/fetch.
 import { isSafeWebhookUrl } from '../utils';
+import { ownershipWhere, type OwnershipScope } from '../database/ownership-scope';
 
 // Upload IDs are SHA-256 hex strings (the `id` field returned by
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
@@ -212,18 +213,26 @@ export class MissionsService {
      * PR H adds filter + pagination; PR R (Phase 6 frontend) drives
      * the design for which controls land where.
      */
-    async listForUser(userId: string, filter: ListMissionsFilter = {}): Promise<MissionDto[]> {
-        const baseWhere: FindOptionsWhere<Mission> = {
-            userId,
-            ...(filter.status ? { status: filter.status } : {}),
-        };
+    async listForUser(
+        userId: string,
+        filter: ListMissionsFilter = {},
+        scope?: OwnershipScope,
+    ): Promise<MissionDto[]> {
+        const baseWhere = (scope ? ownershipWhere<Mission>(userId, scope) : [{ userId }]).map(
+            (branch) => ({
+                ...branch,
+                ...(filter.status ? { status: filter.status } : {}),
+            }),
+        );
         const search = filter.search?.trim();
         const where: FindOptionsWhere<Mission> | FindOptionsWhere<Mission>[] = search
-            ? [
-                  { ...baseWhere, title: ILike(`%${search}%`) },
-                  { ...baseWhere, description: ILike(`%${search}%`) },
-              ]
-            : baseWhere;
+            ? baseWhere.flatMap((branch) => [
+                  { ...branch, title: ILike(`%${search}%`) },
+                  { ...branch, description: ILike(`%${search}%`) },
+              ])
+            : scope
+              ? baseWhere
+              : baseWhere[0];
         const rows = await this.missions.find({
             where,
             order: { updatedAt: 'DESC' },
@@ -240,8 +249,12 @@ export class MissionsService {
      * response shape either way so the API doesn't leak whether
      * the id exists.
      */
-    async getForUser(userId: string, missionId: string): Promise<MissionDto> {
-        const row = await this.findOrThrow(userId, missionId);
+    async getForUser(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<MissionDto> {
+        const row = await this.findOrThrow(userId, missionId, scope);
         return toMissionDto(row);
     }
 
@@ -579,10 +592,16 @@ export class MissionsService {
      * `mission_works` edge; review §8.1). Ownership-gated on the
      * Mission; empty when the repo isn't wired (hand-rolled tests).
      */
-    async listWorks(userId: string, missionId: string): Promise<MissionWorkWithWork[]> {
-        await this.findOrThrow(userId, missionId);
+    async listWorks(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<MissionWorkWithWork[]> {
+        await this.findOrThrow(userId, missionId, scope);
         if (!this.missionWorks) return [];
-        return this.missionWorks.listForMissionWithWork(missionId, userId);
+        return scope
+            ? this.missionWorks.listForMissionWithWork(missionId, userId, scope)
+            : this.missionWorks.listForMissionWithWork(missionId, userId);
     }
 
     /**
@@ -597,8 +616,9 @@ export class MissionsService {
         missionId: string,
         workId: string,
         relation: MissionWorkRelation,
+        scope?: OwnershipScope,
     ): Promise<MissionWorkWithWork[]> {
-        await this.findOrThrow(userId, missionId);
+        await this.findOrThrow(userId, missionId, scope);
         if (!MISSION_WORK_RELATIONS.includes(relation)) {
             throw new BadRequestException(
                 `Invalid relation "${relation}". Allowed: ${MISSION_WORK_RELATIONS.join(', ')}.`,
@@ -609,12 +629,18 @@ export class MissionsService {
                 `MissionWorkRepository is not wired — attach the provider before calling attachWork`,
             );
         }
-        const work = await this.worksRepo.findOne({ where: { id: workId, userId } });
+        const work = await this.worksRepo.findOne({
+            where: scope
+                ? ownershipWhere<Work>(userId, scope).map((branch) => ({ ...branch, id: workId }))
+                : { id: workId, userId },
+        });
         if (!work) {
             throw new NotFoundException(`Work not found`);
         }
         await this.missionWorks.attach({ missionId, workId, userId, relation });
-        return this.missionWorks.listForMissionWithWork(missionId, userId);
+        return scope
+            ? this.missionWorks.listForMissionWithWork(missionId, userId, scope)
+            : this.missionWorks.listForMissionWithWork(missionId, userId);
     }
 
     /**
@@ -626,12 +652,19 @@ export class MissionsService {
         missionId: string,
         workId: string,
         relation: MissionWorkRelation,
+        scope?: OwnershipScope,
     ): Promise<{ deleted: true }> {
-        await this.findOrThrow(userId, missionId);
+        await this.findOrThrow(userId, missionId, scope);
         if (!this.missionWorks) {
             throw new NotFoundException(`Relation not found`);
         }
-        const removed = await this.missionWorks.detach({ missionId, workId, userId, relation });
+        const removed = await this.missionWorks.detach({
+            missionId,
+            workId,
+            userId,
+            relation,
+            ...(scope ? { scope } : {}),
+        });
         if (!removed) {
             throw new NotFoundException(`Relation not found`);
         }
@@ -642,15 +675,41 @@ export class MissionsService {
      * PR-2 — reverse lookup: the Missions related to one of the
      * caller's Works (drives the Work-detail "Missions" panel).
      */
-    async listMissionsForWork(userId: string, workId: string): Promise<MissionWorkWithMission[]> {
+    async listMissionsForWork(
+        userId: string,
+        workId: string,
+        scope?: OwnershipScope,
+    ): Promise<MissionWorkWithMission[]> {
+        if (scope && this.worksRepo) {
+            const work = await this.worksRepo.findOne({
+                where: ownershipWhere<Work>(userId, scope).map((branch) => ({
+                    ...branch,
+                    id: workId,
+                })),
+            });
+            if (!work) throw new NotFoundException(`Work not found`);
+        }
         if (!this.missionWorks) return [];
-        return this.missionWorks.listForWorkWithMission(workId, userId);
+        return scope
+            ? this.missionWorks.listForWorkWithMission(workId, userId, scope)
+            : this.missionWorks.listForWorkWithMission(workId, userId);
     }
 
     // ─── internals ──────────────────────────────────────────────────
 
-    private async findOrThrow(userId: string, missionId: string): Promise<Mission> {
-        const row = await this.missions.findOne({ where: { id: missionId, userId } });
+    private async findOrThrow(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<Mission> {
+        const row = await this.missions.findOne({
+            where: scope
+                ? ownershipWhere<Mission>(userId, scope).map((branch) => ({
+                      ...branch,
+                      id: missionId,
+                  }))
+                : { id: missionId, userId },
+        });
         if (!row) {
             throw new NotFoundException(`Mission not found`);
         }

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -34,7 +34,12 @@ import { toMissionDto, type MissionDto } from './types';
 // validate full-URL forms of `missionTemplateRepo` so a malicious value can
 // never be persisted for the Phase 8 scaffolder to clone/fetch.
 import { isSafeWebhookUrl } from '../utils';
-import { ownershipWhere, type OwnershipScope } from '../database/ownership-scope';
+import {
+    ownershipStamp,
+    ownershipWhere,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
 
 // Upload IDs are SHA-256 hex strings (the `id` field returned by
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
@@ -268,7 +273,11 @@ export class MissionsService {
      * title from the description automatically when the caller
      * doesn't supply one. For now title is required.
      */
-    async create(userId: string, input: CreateMissionInput): Promise<MissionDto> {
+    async create(
+        userId: string,
+        input: CreateMissionInput,
+        scope?: OwnershipScope,
+    ): Promise<MissionDto> {
         this.assertScheduleConsistency(input.type, input.schedule);
         const description = input.description.trim();
         // Phase 3 PR I — when the caller doesn't pass a title (or
@@ -289,6 +298,7 @@ export class MissionsService {
         const saved = await this.missions.save(
             this.missions.create({
                 userId,
+                ...ownershipStamp(scope),
                 title,
                 description,
                 type: input.type,
@@ -321,8 +331,9 @@ export class MissionsService {
         userId: string,
         missionId: string,
         input: UpdateMissionInput,
+        scope?: OwnershipScope,
     ): Promise<MissionDto> {
-        const existing = await this.findOrThrow(userId, missionId);
+        const existing = await this.findOrThrow(userId, missionId, scope);
 
         const nextType = input.type ?? existing.type;
         const nextSchedule =
@@ -364,13 +375,15 @@ export class MissionsService {
      *   - 400 BadRequest when the current status doesn't allow the
      *     transition (e.g. pause-ing an already-PAUSED Mission).
      */
-    async pause(userId: string, missionId: string): Promise<MissionDto> {
+    async pause(userId: string, missionId: string, scope?: OwnershipScope): Promise<MissionDto> {
         const dto = await this.transition(
             userId,
             missionId,
             PAUSABLE_STATUSES,
             MissionStatus.PAUSED,
             'pause',
+            undefined,
+            scope,
         );
         await this.recordActivity(userId, ActivityActionType.MISSION_PAUSED, 'pause', {
             missionId,
@@ -378,13 +391,15 @@ export class MissionsService {
         return dto;
     }
 
-    async resume(userId: string, missionId: string): Promise<MissionDto> {
+    async resume(userId: string, missionId: string, scope?: OwnershipScope): Promise<MissionDto> {
         const dto = await this.transition(
             userId,
             missionId,
             RESUMABLE_STATUSES,
             MissionStatus.ACTIVE,
             'resume',
+            undefined,
+            scope,
         );
         await this.recordActivity(userId, ActivityActionType.MISSION_RESUMED, 'resume', {
             missionId,
@@ -406,6 +421,7 @@ export class MissionsService {
         userId: string,
         missionId: string,
         outcome?: MissionOutcome | null,
+        scope?: OwnershipScope,
     ): Promise<MissionDto> {
         if (outcome != null && !Object.values(MissionOutcome).includes(outcome)) {
             throw new BadRequestException(
@@ -422,6 +438,7 @@ export class MissionsService {
                 m.outcome = outcome ?? null;
                 m.completedAt = new Date();
             },
+            scope,
         );
         await this.recordActivity(userId, ActivityActionType.MISSION_COMPLETED, 'complete', {
             missionId,
@@ -442,8 +459,12 @@ export class MissionsService {
      * Returns `{ deleted: true }` on success, 404 when the Mission
      * doesn't exist for this user.
      */
-    async delete(userId: string, missionId: string): Promise<{ deleted: true }> {
-        const existing = await this.findOrThrow(userId, missionId);
+    async delete(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<{ deleted: true }> {
+        const existing = await this.findOrThrow(userId, missionId, scope);
         await this.missions.remove(existing);
         await this.recordActivity(userId, ActivityActionType.MISSION_DELETED, 'delete', {
             missionId,
@@ -472,6 +493,7 @@ export class MissionsService {
     async runNow(
         userId: string,
         missionId: string,
+        scope?: OwnershipScope,
     ): Promise<{
         status:
             | 'noop-placeholder'
@@ -486,7 +508,7 @@ export class MissionsService {
         ideasQueued?: number;
         message?: string;
     }> {
-        const mission = await this.findOrThrow(userId, missionId);
+        const mission = await this.findOrThrow(userId, missionId, scope);
         if (!RUNNABLE_STATUSES.includes(mission.status)) {
             throw new BadRequestException(
                 `Mission cannot be run from status "${mission.status}". Allowed: ${RUNNABLE_STATUSES.join(', ')}.`,
@@ -514,8 +536,12 @@ export class MissionsService {
      * Returns an empty array when the attachments repo isn't wired
      * (hand-rolled tests) — same defensive shape as the tick service.
      */
-    async listAttachments(userId: string, missionId: string): Promise<MissionAttachment[]> {
-        await this.findOrThrow(userId, missionId);
+    async listAttachments(
+        userId: string,
+        missionId: string,
+        scope?: OwnershipScope,
+    ): Promise<MissionAttachment[]> {
+        await this.findOrThrow(userId, missionId, scope);
         if (!this.missionAttachments) return [];
         return this.missionAttachments.findByMissionId(missionId);
     }
@@ -530,8 +556,9 @@ export class MissionsService {
         userId: string,
         missionId: string,
         uploadId: string,
+        scope?: OwnershipScope,
     ): Promise<MissionAttachment> {
-        await this.findOrThrow(userId, missionId);
+        await this.findOrThrow(userId, missionId, scope);
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
@@ -574,8 +601,9 @@ export class MissionsService {
         userId: string,
         missionId: string,
         attachmentId: string,
+        scope?: OwnershipScope,
     ): Promise<{ deleted: true }> {
-        await this.findOrThrow(userId, missionId);
+        await this.findOrThrow(userId, missionId, scope);
         if (!this.missionAttachments) {
             throw new NotFoundException(`Attachment not found`);
         }
@@ -703,12 +731,7 @@ export class MissionsService {
         scope?: OwnershipScope,
     ): Promise<Mission> {
         const row = await this.missions.findOne({
-            where: scope
-                ? ownershipWhere<Mission>(userId, scope).map((branch) => ({
-                      ...branch,
-                      id: missionId,
-                  }))
-                : { id: missionId, userId },
+            where: ownershipWhereWith<Mission>(userId, scope, { id: missionId }),
         });
         if (!row) {
             throw new NotFoundException(`Mission not found`);
@@ -723,8 +746,9 @@ export class MissionsService {
         target: MissionStatus,
         verb: string,
         mutate?: (mission: Mission) => void,
+        scope?: OwnershipScope,
     ): Promise<MissionDto> {
-        const existing = await this.findOrThrow(userId, missionId);
+        const existing = await this.findOrThrow(userId, missionId, scope);
         if (!allowedFrom.includes(existing.status)) {
             throw new BadRequestException(
                 `Mission cannot be ${verb}d from status "${existing.status}". Allowed: ${allowedFrom.join(', ')}.`,

--- a/packages/agent/src/missions/types.ts
+++ b/packages/agent/src/missions/types.ts
@@ -15,6 +15,8 @@ import type {
  */
 export interface MissionDto {
     id: string;
+    tenantId: string | null;
+    organizationId: string | null;
     title: string;
     description: string;
     type: MissionType;
@@ -43,6 +45,8 @@ export interface MissionDto {
 export function toMissionDto(mission: Mission): MissionDto {
     return {
         id: mission.id,
+        tenantId: mission.tenantId ?? null,
+        organizationId: mission.organizationId ?? null,
         title: mission.title,
         description: mission.description,
         type: mission.type,

--- a/packages/agent/src/organization-ownership-scoping.spec.ts
+++ b/packages/agent/src/organization-ownership-scoping.spec.ts
@@ -202,6 +202,221 @@ function agent(overrides: Partial<Agent>): Agent {
 }
 
 describe('Organization ownership scoping', () => {
+    const uploadSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    describe('Agent and Mission attachment upload scope', () => {
+        it('404s when an Ever Agent is given the same user upload hash from Yo', async () => {
+            const ownedAgent = agent({ id: 'agent-ever', ...EVER_SCOPE });
+            const foreignUpload = {
+                sha256: uploadSha,
+                userId: 'user-1',
+                storagePath: uploadSha,
+                ...OTHER_SCOPE,
+            };
+            const edges = {
+                add: jest.fn(async () => ({
+                    id: 'edge-1',
+                    agentId: ownedAgent.id,
+                    uploadId: uploadSha,
+                })),
+                findByAgentId: jest.fn(async () => []),
+            };
+            const uploads = {
+                findOne: jest.fn(
+                    async (options: { where?: FindOptionsWhere<typeof foreignUpload> }) =>
+                        matchesWhere(foreignUpload, options.where) ? foreignUpload : null,
+                ),
+            };
+            const service = new AgentsService(
+                { findByIdAndUser: jest.fn(async () => ownedAgent) } as never,
+                {} as never,
+                {} as never,
+                edges as never,
+                undefined,
+                undefined,
+                undefined,
+                uploads as never,
+            );
+
+            await expect(
+                service.addAttachment('user-1', ownedAgent.id, uploadSha, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(edges.add).not.toHaveBeenCalled();
+        });
+
+        it('does not expose metadata or a URL for a Yo upload through an Ever Agent edge', async () => {
+            const ownedAgent = agent({ id: 'agent-ever', ...EVER_SCOPE });
+            const foreignUpload = {
+                sha256: uploadSha,
+                userId: 'user-1',
+                storagePath: `${uploadSha}.txt`,
+                originalFilename: 'yo-secret.txt',
+                mimeType: 'text/plain',
+                fileSize: 9,
+                ...OTHER_SCOPE,
+            };
+            const edges = {
+                findByAgentId: jest.fn(async () => [
+                    { id: 'edge-1', agentId: ownedAgent.id, uploadId: uploadSha },
+                ]),
+            };
+            const uploads = {
+                find: jest.fn(
+                    async (options: { where?: FindOptionsWhere<typeof foreignUpload> }) =>
+                        matchesWhere(foreignUpload, options.where) ? [foreignUpload] : [],
+                ),
+            };
+            const service = new AgentsService(
+                { findByIdAndUser: jest.fn(async () => ownedAgent) } as never,
+                {} as never,
+                {} as never,
+                edges as never,
+                undefined,
+                undefined,
+                undefined,
+                uploads as never,
+            );
+
+            await expect(
+                service.listAttachments('user-1', ownedAgent.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('404s an Ever Mission attachment whose upload hash belongs to Yo', async () => {
+            const ownedMission = mission({ id: 'mission-ever', ...EVER_SCOPE });
+            const attachments = { add: jest.fn() };
+            const foreignUpload = {
+                sha256: uploadSha,
+                userId: 'user-1',
+                ...OTHER_SCOPE,
+            };
+            const uploads = {
+                findOne: jest.fn(
+                    async (options: { where?: FindOptionsWhere<typeof foreignUpload> }) =>
+                        matchesWhere(foreignUpload, options.where) ? foreignUpload : null,
+                ),
+            };
+            const service = new MissionsService(
+                { findOne: jest.fn(async () => ownedMission) } as never,
+                new TitlerService(),
+                undefined,
+                attachments as never,
+                uploads as never,
+            );
+
+            await expect(
+                service.addAttachment('user-1', ownedMission.id, uploadSha, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(attachments.add).not.toHaveBeenCalled();
+        });
+
+        it('does not expose a Mission attachment edge backed by the same-user Yo hash', async () => {
+            const ownedMission = mission({ id: 'mission-ever', ...EVER_SCOPE });
+            const attachments = {
+                findByMissionId: jest.fn(async () => [
+                    { id: 'edge-yo', missionId: ownedMission.id, uploadId: uploadSha },
+                ]),
+            };
+            const foreignUpload = {
+                sha256: uploadSha,
+                userId: 'user-1',
+                ...OTHER_SCOPE,
+            };
+            const uploads = {
+                find: jest.fn(
+                    async (options: { where?: FindOptionsWhere<typeof foreignUpload> }) =>
+                        matchesWhere(foreignUpload, options.where) ? [foreignUpload] : [],
+                ),
+            };
+            const service = new MissionsService(
+                { findOne: jest.fn(async () => ownedMission) } as never,
+                new TitlerService(),
+                undefined,
+                attachments as never,
+                uploads as never,
+            );
+
+            await expect(
+                service.listAttachments('user-1', ownedMission.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('keeps legacy personal Agent attachment metadata and URL readable', async () => {
+            const legacyAgent = agent({
+                id: 'agent-personal',
+                tenantId: null,
+                organizationId: null,
+            });
+            const edges = {
+                findByAgentId: jest.fn(async () => [
+                    { id: 'edge-personal', agentId: legacyAgent.id, uploadId: uploadSha },
+                ]),
+            };
+            const uploads = {
+                find: jest.fn(async () => [
+                    {
+                        sha256: uploadSha,
+                        userId: 'user-1',
+                        storagePath: `${uploadSha}.txt`,
+                        originalFilename: 'legacy.txt',
+                        mimeType: 'text/plain',
+                        fileSize: 9,
+                        tenantId: null,
+                        organizationId: null,
+                    },
+                ]),
+            };
+            const service = new AgentsService(
+                { findByIdAndUser: jest.fn(async () => legacyAgent) } as never,
+                {} as never,
+                {} as never,
+                edges as never,
+                undefined,
+                undefined,
+                undefined,
+                uploads as never,
+            );
+
+            await expect(
+                service.listAttachments('user-1', legacyAgent.id, PERSONAL_SCOPE),
+            ).resolves.toEqual([
+                expect.objectContaining({
+                    filename: 'legacy.txt',
+                    url: `/api/uploads/user-1/${uploadSha}.txt`,
+                }),
+            ]);
+        });
+
+        it('keeps a legacy personal Mission and upload compatible with personal scope', async () => {
+            const legacyMission = mission({
+                id: 'mission-personal',
+                tenantId: null,
+                organizationId: null,
+            });
+            const edge = { id: 'edge-personal', missionId: legacyMission.id, uploadId: uploadSha };
+            const attachments = { add: jest.fn(async () => edge) };
+            const uploads = {
+                findOne: jest.fn(async () => ({
+                    sha256: uploadSha,
+                    userId: 'user-1',
+                    tenantId: null,
+                    organizationId: null,
+                })),
+            };
+            const service = new MissionsService(
+                { findOne: jest.fn(async () => legacyMission) } as never,
+                new TitlerService(),
+                undefined,
+                attachments as never,
+                uploads as never,
+            );
+
+            await expect(
+                service.addAttachment('user-1', legacyMission.id, uploadSha, PERSONAL_SCOPE),
+            ).resolves.toEqual(edge);
+        });
+    });
+
     describe('MissionsService', () => {
         function makeService(rows: Mission[]) {
             const repo = {

--- a/packages/agent/src/organization-ownership-scoping.spec.ts
+++ b/packages/agent/src/organization-ownership-scoping.spec.ts
@@ -1,0 +1,576 @@
+import { NotFoundException } from '@nestjs/common';
+import type { FindOptionsWhere, Repository } from 'typeorm';
+import { AgentsService } from './agents/agents.service';
+import {
+    Agent,
+    AgentAvatarMode,
+    AgentIdleBehavior,
+    AgentScope,
+    AgentStatus,
+} from './entities/agent.entity';
+import { Goal, GoalStatus } from './entities/goal.entity';
+import type { GoalMetricSample } from './entities/goal-metric-sample.entity';
+import type { MissionGoal } from './entities/mission-goal.entity';
+import { Mission, MissionStatus, MissionType } from './entities/mission.entity';
+import type { Work } from './entities/work.entity';
+import { GoalsService } from './goals/goals.service';
+import type { GoalEvaluationService } from './goals/goal-evaluation.service';
+import { MissionsService } from './missions/missions.service';
+import { TitlerService } from './titler/titler.service';
+
+const EVER_SCOPE = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+const OTHER_SCOPE = {
+    tenantId: EVER_SCOPE.tenantId,
+    organizationId: '33333333-3333-4333-8333-333333333333',
+};
+const FOREIGN_SCOPE = {
+    tenantId: '44444444-4444-4444-8444-444444444444',
+    organizationId: '55555555-5555-4555-8555-555555555555',
+};
+const PERSONAL_SCOPE = { tenantId: EVER_SCOPE.tenantId, organizationId: null };
+
+type OwnershipScope = typeof EVER_SCOPE | typeof PERSONAL_SCOPE;
+
+function isNullOperator(value: unknown): boolean {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        (value as { _type?: string })._type === 'isNull'
+    );
+}
+
+function matchesWhere<T extends Record<string, unknown>>(
+    row: T,
+    where: FindOptionsWhere<T> | FindOptionsWhere<T>[] | undefined,
+): boolean {
+    if (!where) return true;
+    if (Array.isArray(where)) return where.some((branch) => matchesWhere(row, branch));
+    return Object.entries(where).every(([key, expected]) => {
+        if (isNullOperator(expected)) return row[key] == null;
+        return row[key] === expected;
+    });
+}
+
+function scopedRows<
+    T extends { userId: string; tenantId?: string | null; organizationId?: string | null },
+>(rows: T[], userId: string, scope?: OwnershipScope): T[] {
+    return rows.filter((row) => {
+        if (row.userId !== userId) return false;
+        if (!scope) return true;
+        if (scope.organizationId === null) {
+            return (
+                row.organizationId == null &&
+                (row.tenantId == null || row.tenantId === scope.tenantId)
+            );
+        }
+        return row.tenantId === scope.tenantId && row.organizationId === scope.organizationId;
+    });
+}
+
+function mission(overrides: Partial<Mission>): Mission {
+    return {
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        userId: 'user-1',
+        title: 'Mission',
+        description: 'Mission description',
+        type: MissionType.ONE_SHOT,
+        status: MissionStatus.ACTIVE,
+        outcome: null,
+        completedAt: null,
+        schedule: null,
+        autoBuildWorks: false,
+        outstandingIdeasCap: null,
+        guardrailsOverride: null,
+        missionTemplateRepo: null,
+        missionRepo: null,
+        sourceMissionId: null,
+        tenantId: null,
+        organizationId: null,
+        createdAt: new Date('2026-08-22T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-22T00:00:00.000Z'),
+        ...overrides,
+    };
+}
+
+function goal(overrides: Partial<Goal>): Goal {
+    return {
+        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        userId: 'user-1',
+        title: 'Goal',
+        description: null,
+        metricSource: { pluginId: 'stripe', metricId: 'income' },
+        comparator: 'gte',
+        targetValue: 100,
+        unit: 'usd',
+        window: 'month',
+        baselineValue: null,
+        currentValue: null,
+        currentValueAt: null,
+        deadline: null,
+        checkFrequencyMinutes: 60,
+        nextCheckAt: null,
+        status: GoalStatus.DRAFT,
+        outcome: null,
+        criteria: null,
+        constraints: null,
+        resolvedScore: null,
+        dodCriteria: null,
+        spendCapCents: null,
+        spentCents: 0,
+        wallClockLimitHours: null,
+        stuckThresholdIterations: null,
+        sessionBudgetMinutes: null,
+        gracePeriodMinutes: null,
+        executionTarget: null,
+        plannerModelHint: null,
+        workerModelHint: null,
+        iteration: 0,
+        lastProgressIteration: 0,
+        activeAgentId: null,
+        assignedAgentId: null,
+        loopStatus: null,
+        loopStartedAt: null,
+        archivedAt: null,
+        tenantId: null,
+        organizationId: null,
+        createdAt: new Date('2026-08-22T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-22T00:00:00.000Z'),
+        ...overrides,
+    } as Goal;
+}
+
+function agent(overrides: Partial<Agent>): Agent {
+    return {
+        id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+        userId: 'user-1',
+        scope: AgentScope.TENANT,
+        missionId: null,
+        ideaId: null,
+        workId: null,
+        name: 'Agent',
+        slug: 'agent',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: null,
+        environmentId: null,
+        maxSkillContextTokens: 4000,
+        memoryRecallEnabled: true,
+        status: AgentStatus.DRAFT,
+        permissions: {
+            canCreateAgents: false,
+            canAssignTasks: false,
+            canEditSkills: false,
+            canEditAgentFiles: false,
+            canSpend: false,
+            canCommitToRepo: false,
+            canOpenPullRequests: false,
+            canCallExternalTools: false,
+        },
+        targets: null,
+        guardrails: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        committerName: null,
+        committerEmail: null,
+        reportsToAgentId: null,
+        scorecard: null,
+        initScript: null,
+        soulMd: null,
+        agentsMd: null,
+        heartbeatMd: null,
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        tenantId: null,
+        organizationId: null,
+        createdAt: new Date('2026-08-22T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-22T00:00:00.000Z'),
+        ...overrides,
+    } as Agent;
+}
+
+describe('Organization ownership scoping', () => {
+    describe('MissionsService', () => {
+        function makeService(rows: Mission[]) {
+            const repo = {
+                find: jest.fn(
+                    async (options: {
+                        where?: FindOptionsWhere<Mission> | FindOptionsWhere<Mission>[];
+                    }) =>
+                        rows.filter((row) =>
+                            matchesWhere(
+                                row as unknown as Record<string, unknown>,
+                                options.where as never,
+                            ),
+                        ),
+                ),
+                findOne: jest.fn(
+                    async (options: {
+                        where?: FindOptionsWhere<Mission> | FindOptionsWhere<Mission>[];
+                    }) =>
+                        rows.find((row) =>
+                            matchesWhere(
+                                row as unknown as Record<string, unknown>,
+                                options.where as never,
+                            ),
+                        ) ?? null,
+                ),
+                create: jest.fn((partial: Partial<Mission>) => mission(partial)),
+                save: jest.fn(async (row: Mission) => {
+                    row.tenantId = EVER_SCOPE.tenantId;
+                    row.organizationId = EVER_SCOPE.organizationId;
+                    const index = rows.findIndex((candidate) => candidate.id === row.id);
+                    if (index === -1) rows.push(row);
+                    else rows[index] = row;
+                    return row;
+                }),
+            };
+            return {
+                repo,
+                service: new MissionsService(
+                    repo as unknown as Repository<Mission>,
+                    new TitlerService(),
+                ),
+            };
+        }
+
+        it('lists only the active Organization and keeps personal scope compatible with legacy rows', async () => {
+            const rows = [
+                mission({ id: 'ever', ...EVER_SCOPE }),
+                mission({ id: 'other', ...OTHER_SCOPE }),
+                mission({
+                    id: 'personal-current',
+                    tenantId: EVER_SCOPE.tenantId,
+                    organizationId: null,
+                }),
+                mission({ id: 'personal-legacy', tenantId: null, organizationId: null }),
+                mission({
+                    id: 'personal-foreign',
+                    tenantId: FOREIGN_SCOPE.tenantId,
+                    organizationId: null,
+                }),
+            ];
+            const { service } = makeService(rows);
+
+            const ever = await (service.listForUser as any)('user-1', {}, EVER_SCOPE);
+            const personal = await (service.listForUser as any)('user-1', {}, PERSONAL_SCOPE);
+
+            expect(ever.map((row: { id: string }) => row.id)).toEqual(['ever']);
+            expect(personal.map((row: { id: string }) => row.id)).toEqual([
+                'personal-current',
+                'personal-legacy',
+            ]);
+        });
+
+        it.each([
+            ['another Organization', mission({ id: 'hidden-org', ...OTHER_SCOPE })],
+            ['another tenant', mission({ id: 'hidden-tenant', ...FOREIGN_SCOPE })],
+        ])('returns the same 404 for a lookup in %s', async (_label, hidden) => {
+            const { service } = makeService([hidden]);
+            await expect(
+                (service.getForUser as any)('user-1', hidden.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('create response and subsequent scoped read expose the same ownership', async () => {
+            const { service } = makeService([]);
+            const created = await service.create('user-1', {
+                title: 'Build Ever Works',
+                description: 'Build Ever Works safely',
+                type: MissionType.ONE_SHOT,
+            });
+            const read = await (service.getForUser as any)('user-1', created.id, EVER_SCOPE);
+            expect(created).toMatchObject(EVER_SCOPE);
+            expect(read).toMatchObject(EVER_SCOPE);
+        });
+    });
+
+    describe('GoalsService', () => {
+        function makeService(rows: Goal[]) {
+            const goalsRepo = {
+                find: jest.fn(
+                    async (options: {
+                        where?: FindOptionsWhere<Goal> | FindOptionsWhere<Goal>[];
+                    }) =>
+                        rows.filter((row) =>
+                            matchesWhere(
+                                row as unknown as Record<string, unknown>,
+                                options.where as never,
+                            ),
+                        ),
+                ),
+                findOne: jest.fn(
+                    async (options: {
+                        where?: FindOptionsWhere<Goal> | FindOptionsWhere<Goal>[];
+                    }) =>
+                        rows.find((row) =>
+                            matchesWhere(
+                                row as unknown as Record<string, unknown>,
+                                options.where as never,
+                            ),
+                        ) ?? null,
+                ),
+                create: jest.fn((partial: Partial<Goal>) => goal(partial)),
+                save: jest.fn(async (row: Goal) => {
+                    row.tenantId = EVER_SCOPE.tenantId;
+                    row.organizationId = EVER_SCOPE.organizationId;
+                    const index = rows.findIndex((candidate) => candidate.id === row.id);
+                    if (index === -1) rows.push(row);
+                    else rows[index] = row;
+                    return row;
+                }),
+            };
+            const emptyRepo = { find: jest.fn(async () => []), findOne: jest.fn(async () => null) };
+            return new GoalsService(
+                goalsRepo as unknown as Repository<Goal>,
+                emptyRepo as unknown as Repository<GoalMetricSample>,
+                emptyRepo as unknown as Repository<MissionGoal>,
+                emptyRepo as unknown as Repository<Mission>,
+                { evaluateOne: jest.fn() } as unknown as GoalEvaluationService,
+            );
+        }
+
+        it('lists only the active Organization and keeps personal scope compatible with legacy rows', async () => {
+            const service = makeService([
+                goal({ id: 'ever', ...EVER_SCOPE }),
+                goal({ id: 'other', ...OTHER_SCOPE }),
+                goal({
+                    id: 'personal-current',
+                    tenantId: EVER_SCOPE.tenantId,
+                    organizationId: null,
+                }),
+                goal({ id: 'personal-legacy', tenantId: null, organizationId: null }),
+                goal({
+                    id: 'personal-foreign',
+                    tenantId: FOREIGN_SCOPE.tenantId,
+                    organizationId: null,
+                }),
+            ]);
+
+            const ever = await (service.listForUser as any)('user-1', {}, EVER_SCOPE);
+            const personal = await (service.listForUser as any)('user-1', {}, PERSONAL_SCOPE);
+
+            expect(ever.map((row: { id: string }) => row.id)).toEqual(['ever']);
+            expect(personal.map((row: { id: string }) => row.id)).toEqual([
+                'personal-current',
+                'personal-legacy',
+            ]);
+        });
+
+        it.each([
+            ['another Organization', goal({ id: 'hidden-org', ...OTHER_SCOPE })],
+            ['another tenant', goal({ id: 'hidden-tenant', ...FOREIGN_SCOPE })],
+        ])('returns the same 404 for a lookup in %s', async (_label, hidden) => {
+            const service = makeService([hidden]);
+            await expect(
+                (service.getForUser as any)('user-1', hidden.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('create response and subsequent scoped read expose the same ownership', async () => {
+            const service = makeService([]);
+            const created = await service.create('user-1', {
+                title: 'Ship ownership proof',
+                metricSource: { pluginId: 'stripe', metricId: 'income' },
+                comparator: 'gte',
+                targetValue: 1,
+                unit: 'proof',
+                window: 'point',
+            });
+            const read = await (service.getForUser as any)('user-1', created.id, EVER_SCOPE);
+            expect(created).toMatchObject(EVER_SCOPE);
+            expect(read).toMatchObject(EVER_SCOPE);
+        });
+    });
+
+    describe('AgentsService', () => {
+        function makeService(rows: Agent[]) {
+            const agents = {
+                findByUserIdScoped: jest.fn(
+                    async (userId: string, _filter: unknown, scope?: OwnershipScope) => {
+                        const owned = scopedRows(rows, userId, scope);
+                        return { rows: owned, total: owned.length };
+                    },
+                ),
+                findByIdAndUser: jest.fn(
+                    async (id: string, userId: string, scope?: OwnershipScope) =>
+                        scopedRows(rows, userId, scope).find((row) => row.id === id) ?? null,
+                ),
+                findByUserIdAndSlug: jest.fn(async () => null),
+                create: jest.fn(async (partial: Partial<Agent>) => {
+                    const saved = agent({ ...partial, ...EVER_SCOPE });
+                    rows.push(saved);
+                    return saved;
+                }),
+            };
+            return new AgentsService(agents as never, {} as never, {} as never);
+        }
+
+        it('lists only the active Organization and keeps personal scope compatible with legacy rows', async () => {
+            const service = makeService([
+                agent({ id: 'ever', ...EVER_SCOPE }),
+                agent({ id: 'other', ...OTHER_SCOPE }),
+                agent({
+                    id: 'personal-current',
+                    tenantId: EVER_SCOPE.tenantId,
+                    organizationId: null,
+                }),
+                agent({ id: 'personal-legacy', tenantId: null, organizationId: null }),
+                agent({
+                    id: 'personal-foreign',
+                    tenantId: FOREIGN_SCOPE.tenantId,
+                    organizationId: null,
+                }),
+            ]);
+
+            const ever = await (service.list as any)('user-1', {}, EVER_SCOPE);
+            const personal = await (service.list as any)('user-1', {}, PERSONAL_SCOPE);
+
+            expect(ever.rows.map((row: { id: string }) => row.id)).toEqual(['ever']);
+            expect(personal.rows.map((row: { id: string }) => row.id)).toEqual([
+                'personal-current',
+                'personal-legacy',
+            ]);
+        });
+
+        it.each([
+            ['another Organization', agent({ id: 'hidden-org', ...OTHER_SCOPE })],
+            ['another tenant', agent({ id: 'hidden-tenant', ...FOREIGN_SCOPE })],
+        ])('returns the same 404 for a lookup in %s', async (_label, hidden) => {
+            const service = makeService([hidden]);
+            await expect(
+                (service.getOne as any)('user-1', hidden.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('create response and subsequent scoped read expose the same ownership', async () => {
+            const service = makeService([]);
+            const created = await (service.create as any)(
+                'user-1',
+                { scope: AgentScope.TENANT, name: 'Ownership verifier' },
+                EVER_SCOPE,
+            );
+            const read = await (service.getOne as any)('user-1', created.id, EVER_SCOPE);
+            expect(created).toMatchObject(EVER_SCOPE);
+            expect(read).toMatchObject(EVER_SCOPE);
+        });
+    });
+
+    it('rejects attaching a Work from another Organization without leaking whether it exists', async () => {
+        const missionRows = [mission({ id: 'mission-ever', ...EVER_SCOPE })];
+        const missionRepo = {
+            findOne: jest.fn(
+                async (options: { where?: FindOptionsWhere<Mission> }) =>
+                    missionRows.find((row) =>
+                        matchesWhere(
+                            row as unknown as Record<string, unknown>,
+                            options.where as never,
+                        ),
+                    ) ?? null,
+            ),
+        };
+        const foreignWork = {
+            id: 'work-other',
+            userId: 'user-1',
+            ...OTHER_SCOPE,
+        } as Work;
+        const worksRepo = {
+            findOne: jest.fn(async (options: { where?: FindOptionsWhere<Work> }) =>
+                matchesWhere(
+                    foreignWork as unknown as Record<string, unknown>,
+                    options.where as never,
+                )
+                    ? foreignWork
+                    : null,
+            ),
+        };
+        const relations = {
+            attach: jest.fn(),
+            listForMissionWithWork: jest.fn(async () => []),
+        };
+        const service = new MissionsService(
+            missionRepo as unknown as Repository<Mission>,
+            new TitlerService(),
+            undefined,
+            undefined,
+            undefined,
+            relations as never,
+            worksRepo as unknown as Repository<Work>,
+        );
+
+        await expect(
+            (service.attachWork as any)(
+                'user-1',
+                'mission-ever',
+                'work-other',
+                'operates',
+                EVER_SCOPE,
+            ),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(relations.attach).not.toHaveBeenCalled();
+    });
+
+    it('returns the subscriber-stamped relation ownership and the subsequent scoped read agrees', async () => {
+        const ownedMission = mission({ id: 'mission-ever', ...EVER_SCOPE });
+        const ownedWork = { id: 'work-ever', userId: 'user-1', ...EVER_SCOPE } as Work;
+        const rows: Array<Record<string, unknown>> = [];
+        const missionRepo = {
+            findOne: jest.fn(async () => ownedMission),
+        };
+        const worksRepo = {
+            findOne: jest.fn(async () => ownedWork),
+        };
+        const relations = {
+            attach: jest.fn(async (input: Record<string, unknown>) => {
+                rows.push({ id: 'relation-ever', ...input, ...EVER_SCOPE });
+            }),
+            listForMissionWithWork: jest.fn(
+                async (_missionId: string, _userId: string, activeScope?: OwnershipScope) =>
+                    scopedRows(
+                        rows as Array<
+                            Record<string, unknown> & {
+                                userId: string;
+                                tenantId: string | null;
+                                organizationId: string | null;
+                            }
+                        >,
+                        'user-1',
+                        activeScope,
+                    ),
+            ),
+        };
+        const service = new MissionsService(
+            missionRepo as unknown as Repository<Mission>,
+            new TitlerService(),
+            undefined,
+            undefined,
+            undefined,
+            relations as never,
+            worksRepo as unknown as Repository<Work>,
+        );
+
+        const created = await (service.attachWork as any)(
+            'user-1',
+            ownedMission.id,
+            ownedWork.id,
+            'operates',
+            EVER_SCOPE,
+        );
+        const read = await (service.listWorks as any)('user-1', ownedMission.id, EVER_SCOPE);
+
+        expect(created[0]).toMatchObject(EVER_SCOPE);
+        expect(read[0]).toMatchObject(EVER_SCOPE);
+    });
+});

--- a/packages/agent/src/organization-ownership-scoping.spec.ts
+++ b/packages/agent/src/organization-ownership-scoping.spec.ts
@@ -295,6 +295,22 @@ describe('Organization ownership scoping', () => {
             expect(created).toMatchObject(EVER_SCOPE);
             expect(read).toMatchObject(EVER_SCOPE);
         });
+
+        it('does not update a known Mission UUID from another active Organization', async () => {
+            const hidden = mission({ id: 'mission-yo', title: 'Yo Mission', ...OTHER_SCOPE });
+            const { repo, service } = makeService([hidden]);
+
+            await expect(
+                (service.update as any)(
+                    'user-1',
+                    hidden.id,
+                    { title: 'Ever overwrite' },
+                    EVER_SCOPE,
+                ),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(repo.save).not.toHaveBeenCalled();
+            expect(hidden.title).toBe('Yo Mission');
+        });
     });
 
     describe('GoalsService', () => {
@@ -393,6 +409,16 @@ describe('Organization ownership scoping', () => {
             expect(created).toMatchObject(EVER_SCOPE);
             expect(read).toMatchObject(EVER_SCOPE);
         });
+
+        it('does not activate a known Goal UUID from another active Organization', async () => {
+            const hidden = goal({ id: 'goal-yo', title: 'Yo Goal', ...OTHER_SCOPE });
+            const service = makeService([hidden]);
+
+            await expect(
+                (service.activate as any)('user-1', hidden.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(hidden.status).toBe(GoalStatus.DRAFT);
+        });
     });
 
     describe('AgentsService', () => {
@@ -414,6 +440,7 @@ describe('Organization ownership scoping', () => {
                     rows.push(saved);
                     return saved;
                 }),
+                archiveById: jest.fn(),
             };
             return new AgentsService(agents as never, {} as never, {} as never);
         }
@@ -465,6 +492,153 @@ describe('Organization ownership scoping', () => {
             const read = await (service.getOne as any)('user-1', created.id, EVER_SCOPE);
             expect(created).toMatchObject(EVER_SCOPE);
             expect(read).toMatchObject(EVER_SCOPE);
+        });
+
+        it('does not archive a known Agent UUID from another active Organization', async () => {
+            const hidden = agent({ id: 'agent-yo', name: 'Yo Agent', ...OTHER_SCOPE });
+            const service = makeService([hidden]);
+
+            await expect(
+                (service.archive as any)('user-1', hidden.id, EVER_SCOPE),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('does not create an Agent with a bulk target from another Organization', async () => {
+            const foreignWork = {
+                id: 'work-yo',
+                userId: 'user-1',
+                ...OTHER_SCOPE,
+            } as Work;
+            const agents = {
+                findByUserIdAndSlug: jest.fn(async () => null),
+                create: jest.fn(async (partial: Partial<Agent>) => agent(partial)),
+            };
+            const memberships = { replaceForAgent: jest.fn(async () => undefined) };
+            const workRepo = {
+                findOne: jest.fn(
+                    async (options: {
+                        where?: FindOptionsWhere<Work> | FindOptionsWhere<Work>[];
+                    }) =>
+                        matchesWhere(
+                            foreignWork as unknown as Record<string, unknown>,
+                            options.where as never,
+                        )
+                            ? foreignWork
+                            : null,
+                ),
+            };
+            const service = new AgentsService(
+                agents as never,
+                memberships as never,
+                {} as never,
+                undefined,
+                workRepo as unknown as Repository<Work>,
+            );
+
+            await expect(
+                (service.create as any)(
+                    'user-1',
+                    {
+                        scope: AgentScope.TENANT,
+                        name: 'Ever operator',
+                        targets: [{ type: 'work', id: foreignWork.id }],
+                    },
+                    EVER_SCOPE,
+                ),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(agents.create).not.toHaveBeenCalled();
+        });
+
+        it('does not replace Agent targets with a known Work from another Organization', async () => {
+            const ownedAgent = agent({ id: 'agent-ever', ...EVER_SCOPE });
+            const foreignWork = {
+                id: 'work-yo',
+                userId: 'user-1',
+                ...OTHER_SCOPE,
+            } as Work;
+            const agents = {
+                findByIdAndUser: jest.fn(async () => ownedAgent),
+                findById: jest.fn(async () => ownedAgent),
+                updateById: jest.fn(async () => undefined),
+            };
+            const memberships = { replaceForAgent: jest.fn(async () => undefined) };
+            const workRepo = {
+                findOne: jest.fn(
+                    async (options: {
+                        where?: FindOptionsWhere<Work> | FindOptionsWhere<Work>[];
+                    }) =>
+                        matchesWhere(
+                            foreignWork as unknown as Record<string, unknown>,
+                            options.where as never,
+                        )
+                            ? foreignWork
+                            : null,
+                ),
+            };
+            const service = new AgentsService(
+                agents as never,
+                memberships as never,
+                {} as never,
+                undefined,
+                workRepo as unknown as Repository<Work>,
+            );
+
+            await expect(
+                (service.update as any)(
+                    'user-1',
+                    ownedAgent.id,
+                    { targets: [{ type: 'work', id: foreignWork.id }] },
+                    EVER_SCOPE,
+                ),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(agents.updateById).not.toHaveBeenCalled();
+            expect(memberships.replaceForAgent).not.toHaveBeenCalled();
+        });
+
+        it('does not assign an Environment from another Organization', async () => {
+            const ownedAgent = agent({ id: 'agent-ever', ...EVER_SCOPE });
+            const foreignEnvironment = {
+                id: 'environment-yo',
+                userId: 'user-1',
+                status: 'published',
+                ...OTHER_SCOPE,
+            };
+            const agents = {
+                findByIdAndUser: jest.fn(async () => ownedAgent),
+                findById: jest.fn(async () => ownedAgent),
+                updateById: jest.fn(async () => undefined),
+            };
+            const environmentRepo = {
+                findOne: jest.fn(
+                    async (options: {
+                        where?:
+                            | FindOptionsWhere<typeof foreignEnvironment>
+                            | FindOptionsWhere<typeof foreignEnvironment>[];
+                    }) =>
+                        matchesWhere(foreignEnvironment, options.where) ? foreignEnvironment : null,
+                ),
+            };
+            const service = new AgentsService(
+                agents as never,
+                { replaceForAgent: jest.fn() } as never,
+                {} as never,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                environmentRepo as never,
+            );
+
+            await expect(
+                (service.update as any)(
+                    'user-1',
+                    ownedAgent.id,
+                    { environmentId: foreignEnvironment.id },
+                    EVER_SCOPE,
+                ),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(agents.updateById).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
@@ -72,6 +72,7 @@ describe('TaskTransitionService.dispatchAgentRun — the one dispatch path', () 
     let dispatcher: any;
     let runDenorm: any;
     let dispatchGate: any;
+    let agents: any;
 
     beforeEach(() => {
         tasks = { casUpdateStatus: jest.fn().mockResolvedValue(true), findById: jest.fn() };
@@ -89,6 +90,13 @@ describe('TaskTransitionService.dispatchAgentRun — the one dispatch path', () 
             recordTerminal: jest.fn().mockResolvedValue(undefined),
         };
         dispatchGate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+        agents = {
+            findByIdAndUser: jest.fn(async (id: string, userId: string, scope: unknown) => ({
+                id,
+                userId,
+                ...(scope as object),
+            })),
+        };
     });
 
     const makeSvc = () =>
@@ -102,6 +110,9 @@ describe('TaskTransitionService.dispatchAgentRun — the one dispatch path', () 
             undefined,
             runDenorm,
             dispatchGate,
+            undefined,
+            undefined,
+            agents,
         );
 
     it('consults the dispatch gate, creates the queued run, mirrors it on the board and enqueues', async () => {

--- a/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { TaskTransitionService } from '../task-transition.service';
 import {
     TasksService,
@@ -10,6 +10,15 @@ import {
 } from '../tasks.service';
 import { TaskStatus, TaskPriority } from '../../entities/task.entity';
 import type { Task } from '../../entities/task.entity';
+
+const everScope = {
+    tenantId: '11111111-1111-4111-8111-111111111111',
+    organizationId: '22222222-2222-4222-8222-222222222222',
+};
+const yoScope = {
+    tenantId: everScope.tenantId,
+    organizationId: '33333333-3333-4333-8333-333333333333',
+};
 
 /**
  * Board dispatch (kanban M3 / M4).
@@ -45,6 +54,8 @@ function makeTask(over: Partial<Task> = {}): Task {
         completedAt: null,
         isRecurring: false,
         recurrenceOccurredCount: 0,
+        tenantId: null,
+        organizationId: null,
         createdAt: new Date('2026-01-01'),
         updatedAt: new Date('2026-01-01'),
         ...over,
@@ -114,6 +125,19 @@ describe('TaskTransitionService.dispatchAgentRun — the one dispatch path', () 
         expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
         expect(runs.setTriggerRunId).toHaveBeenCalledWith('r1', 'trd-1');
         expect(result).toEqual({ runId: 'r1', dispatched: true, parked: false });
+    });
+
+    it('persists the Task tenant and Organization on the queued AgentRun', async () => {
+        await makeSvc().dispatchAgentRun(makeTask({ workId: 'w1', ...everScope }), 'agent-ever');
+
+        expect(runs.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({
+                agentId: 'agent-ever',
+                taskId: 't1',
+                workId: 'w1',
+                ...everScope,
+            }),
+        );
     });
 
     it('parks the run WITHOUT enqueuing when the concurrency gate refuses', async () => {
@@ -237,6 +261,57 @@ describe('TasksService.runTask — board dispatch', () => {
         expect(result).toMatchObject({ taskId: 't1', agentId: 'agent-x', dispatched: true });
     });
 
+    it('opaque-404s a same-user known Task UUID from Yo in the active Ever scope', async () => {
+        taskRepo.findByIdAndUser.mockResolvedValueOnce(makeTask({ ...yoScope }));
+
+        await expect(
+            (build().runTask as any)('u1', 't1', { agentId: 'agent-x' }, everScope),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+    });
+
+    it('rejects a same-user known Yo Agent UUID in the active Ever scope', async () => {
+        taskRepo.findByIdAndUser.mockResolvedValue(makeTask({ ...everScope }));
+        const yoAgent = { id: 'agent-yo', userId: 'u1', name: 'Yo Agent', ...yoScope };
+        agents.findByIdAndUser.mockImplementation(
+            async (_id: string, _userId: string, scope?: typeof everScope) =>
+                !scope || scope.organizationId === yoScope.organizationId ? yoAgent : null,
+        );
+
+        const error = await (build().runTask as any)(
+            'u1',
+            't1',
+            { agentId: 'agent-yo' },
+            everScope,
+        ).catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(BadRequestException);
+        expect((error as BadRequestException).getResponse()).toMatchObject({
+            code: RUN_AGENT_NOT_FOUND,
+        });
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith('agent-yo', 'u1', everScope);
+        expect(agentRuns.findInFlightForTaskAgent).not.toHaveBeenCalled();
+    });
+
+    it('uses user + exact scope for same-Task in-flight dedup', async () => {
+        taskRepo.findByIdAndUser.mockResolvedValue(makeTask({ ...everScope }));
+        agents.findByIdAndUser.mockResolvedValue({
+            id: 'agent-ever',
+            userId: 'u1',
+            name: 'Ever Agent',
+            ...everScope,
+        });
+
+        await (build().runTask as any)('u1', 't1', { agentId: 'agent-ever' }, everScope);
+
+        expect(agentRuns.findInFlightForTaskAgent).toHaveBeenCalledWith(
+            't1',
+            'agent-ever',
+            'u1',
+            everScope,
+        );
+    });
+
     it('refuses with 409 RUN_ALREADY_IN_FLIGHT when that (task, agent) pair is already running', async () => {
         agentRuns.findInFlightForTaskAgent.mockResolvedValue({ id: 'run-live', status: 'running' });
         const error = await build()
@@ -275,6 +350,7 @@ describe('TasksService.runTask — board dispatch', () => {
         expect(agents.findByUserIdScoped).toHaveBeenCalledWith(
             'u1',
             expect.objectContaining({ workId: 'w1' }),
+            undefined,
         );
         expect(result.agentId).toBe('agent-work');
     });
@@ -362,13 +438,35 @@ describe('TasksService.listRunCandidates', () => {
             build(taskRepo, assignees, agents).listRunCandidates('u1', 't1'),
         ).resolves.toEqual([]);
     });
+
+    it('does not offer same-user Yo assignees as Ever run candidates', async () => {
+        const taskRepo = {
+            findByIdAndUser: jest.fn().mockResolvedValue(makeTask({ ...everScope })),
+        };
+        const assignees = {
+            findAgentAssignees: jest.fn().mockResolvedValue([{ assigneeId: 'agent-yo' }]),
+        };
+        const yoAgent = { id: 'agent-yo', userId: 'u1', name: 'Yo Agent', ...yoScope };
+        const agents = {
+            findByIdAndUser: jest.fn(
+                async (_id: string, _userId: string, scope?: typeof everScope) =>
+                    !scope || scope.organizationId === yoScope.organizationId ? yoAgent : null,
+            ),
+            findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+        };
+
+        await expect(
+            (build(taskRepo, assignees, agents).listRunCandidates as any)('u1', 't1', everScope),
+        ).resolves.toEqual([]);
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith('agent-yo', 'u1', everScope);
+    });
 });
 
 describe('TasksService.runTasksBatch', () => {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    const build = () =>
+    const build = (taskRepo: any = { findByIdAndUser: jest.fn().mockResolvedValue(makeTask()) }) =>
         new TasksService(
-            { findByIdAndUser: jest.fn().mockResolvedValue(makeTask()) } as any,
+            taskRepo,
             { findAgentAssignees: jest.fn().mockResolvedValue([]) } as any,
             {} as any,
             {} as any,
@@ -420,5 +518,20 @@ describe('TasksService.runTasksBatch', () => {
         await expect(service.runTasksBatch('u1', tooMany)).rejects.toBeInstanceOf(
             BadRequestException,
         );
+    });
+
+    it('keeps every batch item inside the same active Ever scope', async () => {
+        const taskRepo = {
+            findByIdAndUser: jest.fn().mockResolvedValue(makeTask({ ...yoScope })),
+        };
+        const service = build(taskRepo);
+
+        const { results } = await (service.runTasksBatch as any)(
+            'u1',
+            [{ taskId: 't1', agentId: 'agent-ever' }],
+            everScope,
+        );
+
+        expect(results[0]).toMatchObject({ taskId: 't1', ok: false });
     });
 });

--- a/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
@@ -3,6 +3,10 @@ import { TaskChatService } from '../task-chat.service';
 import { ActivityActionType } from '../../entities/activity-log.types';
 
 describe('TaskChatService', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
     let tasks: any;
     let messages: any;
     let kbMentions: any;
@@ -26,6 +30,35 @@ describe('TaskChatService', () => {
     });
 
     describe('post', () => {
+        it('requires the parent Task through the exact active scope for list, post, and edit', async () => {
+            tasks.findByIdAndUser.mockResolvedValue({ id: 't1', userId: 'u1', ...everScope });
+            messages.create.mockResolvedValue({ id: 'm1' });
+            messages.findById
+                .mockResolvedValueOnce({
+                    id: 'm1',
+                    taskId: 't1',
+                    authorType: 'user',
+                    authorId: 'u1',
+                    body: 'old',
+                    createdAt: new Date(),
+                })
+                .mockResolvedValueOnce({ id: 'm1', taskId: 't1', body: 'new' });
+
+            await (svc.list as any)('u1', 't1', {}, everScope);
+            await (svc.post as any)(
+                'u1',
+                { taskId: 't1', authorType: 'user', authorId: 'u1', body: 'hello' },
+                {},
+                everScope,
+            );
+            await (svc.edit as any)('u1', 'm1', 'new', {}, everScope);
+
+            expect(tasks.findByIdAndUser).toHaveBeenCalledTimes(3);
+            for (const call of tasks.findByIdAndUser.mock.calls) {
+                expect(call).toEqual(['t1', 'u1', everScope]);
+            }
+        });
+
         it('404s for a cross-user Task', async () => {
             tasks.findByIdAndUser.mockResolvedValueOnce(null);
             await expect(
@@ -123,7 +156,7 @@ describe('TaskChatService', () => {
                 runs as any,
                 chatDispatcher,
             );
-            tasks.findByIdAndUser.mockResolvedValueOnce({ id: 't1' });
+            tasks.findByIdAndUser.mockResolvedValueOnce({ id: 't1', userId: 'u1', ...everScope });
             messages.create.mockImplementationOnce((d: any) => Promise.resolve({ id: 'm1', ...d }));
 
             await dispatchingSvc.post(
@@ -145,6 +178,7 @@ describe('TaskChatService', () => {
                     triggerKind: 'chat',
                     taskId: 't1',
                     chatMessageId: 'm1',
+                    ...everScope,
                 }),
             );
             expect(chatDispatcher.enqueue).toHaveBeenCalledWith(

--- a/packages/agent/src/tasks-domain/__tests__/task-recurrence-dispatcher.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-recurrence-dispatcher.service.spec.ts
@@ -59,7 +59,10 @@ describe('TaskRecurrenceDispatcherService', () => {
     });
 
     it('happy path — claims template, advances nextOccurrenceAt, spawns instance with fresh slug', async () => {
-        const template = makeTemplate();
+        const template = makeTemplate({
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        });
         tasks.findDueRecurringTemplates.mockResolvedValueOnce([template]);
         tasks.casClaimRecurrence.mockResolvedValueOnce(true);
         tasks.create.mockResolvedValueOnce({ id: 'inst-1', slug: 'T-42' });
@@ -74,12 +77,26 @@ describe('TaskRecurrenceDispatcherService', () => {
                 slug: 'T-42',
                 parentRecurringTaskId: 'tmpl-1',
                 isRecurring: false,
+                tenantId: template.tenantId,
+                organizationId: template.organizationId,
             }),
         );
         // CAS-claim advanced nextOccurrenceAt to a future Date.
         const casArgs = tasks.casClaimRecurrence.mock.calls[0];
         expect(casArgs[0]).toBe('tmpl-1');
         expect(casArgs[1]).toEqual(template.nextOccurrenceAt);
+    });
+
+    it('preserves a legacy personal template as personal', async () => {
+        const template = makeTemplate({ tenantId: null, organizationId: null });
+        tasks.findDueRecurringTemplates.mockResolvedValueOnce([template]);
+        tasks.create.mockResolvedValueOnce({ id: 'inst-personal', slug: 'T-42' });
+
+        await svc.dispatchDue();
+
+        expect(tasks.create).toHaveBeenCalledWith(
+            expect.objectContaining({ tenantId: null, organizationId: null }),
+        );
     });
 
     it('CAS-claim loss → outcome=skipped, no spawn', async () => {

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -37,6 +37,7 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
     let assignees: any;
     let runs: any;
     let dispatcher: any;
+    let agents: any;
 
     beforeEach(() => {
         tasks = {
@@ -52,11 +53,52 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
             setTriggerRunId: jest.fn().mockResolvedValue(undefined),
         };
         dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+        agents = {
+            findByIdAndUser: jest.fn(async (id: string, userId: string, scope: unknown) => ({
+                id,
+                userId,
+                ...(scope as object),
+            })),
+        };
     });
 
     function makeSvc() {
-        return new TaskTransitionService(tasks, blocks, approvers, assignees, runs, dispatcher);
+        return new (TaskTransitionService as any)(
+            tasks,
+            blocks,
+            approvers,
+            assignees,
+            runs,
+            dispatcher,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            agents,
+        ) as TaskTransitionService;
     }
+
+    it('fails closed before creating a run when Agent ownership validation is unavailable', async () => {
+        const serviceWithoutAgents = new TaskTransitionService(
+            tasks,
+            blocks,
+            approvers,
+            assignees,
+            runs,
+            dispatcher,
+        );
+
+        await expect(
+            serviceWithoutAgents.dispatchAgentRun(makeTask(), 'agent-a'),
+        ).resolves.toMatchObject({
+            runId: null,
+            dispatched: false,
+            error: 'agent-not-found',
+        });
+        expect(runs.createQueued).not.toHaveBeenCalled();
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
 
     it('does NOT fan out when there are no Agent assignees', async () => {
         const svc = makeSvc();
@@ -83,6 +125,49 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         expect(firstCall.taskId).toBe('t1');
         expect(firstCall.dedupKey).toMatch(/t1:agent-[ab]:1/);
         expect(firstCall.runId).toBe('r1');
+    });
+
+    it('drops known same-user Agent assignees outside the persisted Task Organization', async () => {
+        const svc = makeSvc();
+        const task = makeTask({
+            status: TaskStatus.TODO,
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        });
+        tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+        assignees.findAgentAssignees.mockResolvedValueOnce([
+            { assigneeType: 'agent', assigneeId: 'agent-yo' },
+        ]);
+        agents.findByIdAndUser.mockResolvedValueOnce(null);
+
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith('agent-yo', 'u1', {
+            tenantId: task.tenantId,
+            organizationId: task.organizationId,
+        });
+        expect(runs.createQueued).not.toHaveBeenCalled();
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('validates task.agentId in the persisted Task scope before fallback dispatch', async () => {
+        const svc = makeSvc();
+        const task = makeTask({
+            status: TaskStatus.TODO,
+            agentId: 'agent-yo',
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+        });
+        tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+        assignees.findAgentAssignees.mockResolvedValueOnce([]);
+        agents.findByIdAndUser.mockResolvedValueOnce(null);
+
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+
+        expect(runs.createQueued).not.toHaveBeenCalled();
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
     });
 
     it('pre-creates a queued AgentRun row before enqueuing the Trigger.dev run', async () => {
@@ -243,6 +328,9 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
                 undefined, // notifications
                 undefined, // runDenorm
                 gate,
+                undefined, // works
+                undefined, // terminalSessions
+                agents,
             );
 
         const toInProgress = async (svc: TaskTransitionService, taskOver: Partial<Task> = {}) => {
@@ -325,6 +413,12 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
             assignees,
             undefined,
             dispatcher,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            agents,
         );
         dispatcher.enqueue.mockRejectedValueOnce(new Error('Trigger.dev down'));
         const task = makeTask({ status: TaskStatus.TODO });
@@ -367,6 +461,7 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
                 undefined,
                 undefined,
                 terminalSessions as never,
+                agents,
             );
         }
 
@@ -420,6 +515,7 @@ describe('TaskTransitionService — owner-column agent fallback (kanban/detail-p
     let assignees: any;
     let runs: any;
     let dispatcher: any;
+    let agents: any;
 
     beforeEach(() => {
         tasks = { casUpdateStatus: jest.fn().mockResolvedValue(true), findById: jest.fn() };
@@ -432,10 +528,30 @@ describe('TaskTransitionService — owner-column agent fallback (kanban/detail-p
             setTriggerRunId: jest.fn().mockResolvedValue(undefined),
         };
         dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+        agents = {
+            findByIdAndUser: jest.fn(async (id: string, userId: string, scope: unknown) => ({
+                id,
+                userId,
+                ...(scope as object),
+            })),
+        };
     });
 
     const makeSvc = () =>
-        new TaskTransitionService(tasks, blocks, approvers, assignees, runs, dispatcher);
+        new (TaskTransitionService as any)(
+            tasks,
+            blocks,
+            approvers,
+            assignees,
+            runs,
+            dispatcher,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            agents,
+        ) as TaskTransitionService;
 
     it('dispatches the Task OWN agent (task.agentId) when there are no assignee rows', async () => {
         // The Task detail page assigns an Agent by writing task.agentId — it

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.schedule.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.schedule.spec.ts
@@ -83,8 +83,9 @@ describe('TasksService.scheduleTask / unscheduleTask', () => {
     it('schedules a future one-shot and clears any stale claim', async () => {
         const { service, repos } = makeService();
         const task = makeTask({ scheduleClaimedAt: new Date() });
-        repos.tasks.findByIdAndUser.mockResolvedValue(task);
-        repos.tasks.findById.mockResolvedValue(makeTask({ scheduledAt: FUTURE }));
+        repos.tasks.findByIdAndUser
+            .mockResolvedValueOnce(task)
+            .mockResolvedValueOnce(makeTask({ scheduledAt: FUTURE }));
 
         const out = await service.scheduleTask('user-1', 'task-1', FUTURE);
 
@@ -136,8 +137,9 @@ describe('TasksService.scheduleTask / unscheduleTask', () => {
 
     it('unschedule clears both schedule columns', async () => {
         const { service, repos } = makeService();
-        repos.tasks.findByIdAndUser.mockResolvedValue(makeTask({ scheduledAt: FUTURE }));
-        repos.tasks.findById.mockResolvedValue(makeTask());
+        repos.tasks.findByIdAndUser
+            .mockResolvedValueOnce(makeTask({ scheduledAt: FUTURE }))
+            .mockResolvedValueOnce(makeTask());
 
         await service.unscheduleTask('user-1', 'task-1');
 

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
@@ -47,10 +47,15 @@ function makeService(overrides: Record<string, any> = {}) {
             wouldCreateCycle: jest.fn().mockResolvedValue(false),
         },
         assignees: {
+            add: jest.fn().mockResolvedValue({ id: 'assignee-row' }),
             removeForTask: jest.fn(),
         },
-        reviewers: {},
-        approvers: {},
+        reviewers: {
+            add: jest.fn().mockResolvedValue({ id: 'reviewer-row' }),
+        },
+        approvers: {
+            add: jest.fn().mockResolvedValue({ id: 'approver-row' }),
+        },
         blocks: {
             removeForTask: jest.fn(),
         },
@@ -90,10 +95,22 @@ function makeService(overrides: Record<string, any> = {}) {
         agentRuns: {
             findByIds: jest.fn(),
         },
+        notifications: {
+            emit: jest.fn().mockResolvedValue(undefined),
+        },
+        users: {
+            findById: jest.fn(),
+        },
+        organizationMembers: {
+            findByOrgAndUser: jest.fn(),
+        },
+        tenants: {
+            findById: jest.fn(),
+        },
         ...overrides,
     };
 
-    const service = new TasksService(
+    const service = new (TasksService as any)(
         repos.tasks as any,
         repos.assignees as any,
         repos.reviewers as any,
@@ -105,7 +122,7 @@ function makeService(overrides: Record<string, any> = {}) {
         undefined,
         repos.attachments as any,
         repos.agents as any,
-        undefined,
+        repos.notifications as any,
         repos.workUploads as any,
         repos.works as any,
         repos.missions as any,
@@ -113,6 +130,9 @@ function makeService(overrides: Record<string, any> = {}) {
         repos.teams as any,
         repos.goals as any,
         repos.agentRuns as any,
+        repos.users as any,
+        repos.organizationMembers as any,
+        repos.tenants as any,
     );
 
     return { service, repos };
@@ -127,6 +147,167 @@ describe('TasksService authorization guardrails', () => {
         tenantId: everScope.tenantId,
         organizationId: '33333333-3333-4333-8333-333333333333',
     };
+
+    const taskOwnerId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const everMemberId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const yoMemberId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+    const actorCases = [
+        {
+            label: 'assignee',
+            invoke: (
+                service: TasksService,
+                taskId: string,
+                actorId: string,
+                scope: typeof everScope,
+            ) => service.addAssignee(taskOwnerId, taskId, 'user', actorId, scope),
+            inserted: (repos: ReturnType<typeof makeService>['repos']) => repos.assignees.add,
+        },
+        {
+            label: 'reviewer',
+            invoke: (
+                service: TasksService,
+                taskId: string,
+                actorId: string,
+                scope: typeof everScope,
+            ) => service.addReviewer(taskOwnerId, taskId, 'user', actorId, scope),
+            inserted: (repos: ReturnType<typeof makeService>['repos']) => repos.reviewers.add,
+        },
+        {
+            label: 'approver',
+            invoke: (
+                service: TasksService,
+                taskId: string,
+                actorId: string,
+                scope: typeof everScope,
+            ) => service.addApprover(taskOwnerId, taskId, 'user', actorId, scope),
+            inserted: (repos: ReturnType<typeof makeService>['repos']) => repos.approvers.add,
+        },
+    ] as const;
+
+    it.each(actorCases)(
+        'rejects a known same-Tenant Yo user as an Ever Task $label without inserting or notifying',
+        async ({ invoke, inserted }) => {
+            const task = makeTask({ userId: taskOwnerId, ...everScope });
+            const { service, repos } = makeService();
+            repos.tasks.findByIdAndUser.mockResolvedValueOnce(task);
+            repos.users.findById.mockResolvedValueOnce({
+                id: yoMemberId,
+                tenantId: everScope.tenantId,
+                isActive: true,
+            });
+            // Even a repository bug returning the known Yo roster row must
+            // not weaken the exact Organization comparison in the service.
+            repos.organizationMembers.findByOrgAndUser.mockResolvedValueOnce({
+                userId: yoMemberId,
+                tenantId: yoScope.tenantId,
+                organizationId: yoScope.organizationId,
+            });
+            repos.tenants.findById.mockResolvedValueOnce({
+                id: everScope.tenantId,
+                ownerUserId: taskOwnerId,
+            });
+
+            await expect(invoke(service, task.id, yoMemberId, everScope)).rejects.toThrow(
+                BadRequestException,
+            );
+            expect(inserted(repos)).not.toHaveBeenCalled();
+            expect(repos.notifications.emit).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(actorCases)(
+        'rejects a revoked Ever user as a Task $label with the same opaque failure',
+        async ({ invoke, inserted }) => {
+            const task = makeTask({ userId: taskOwnerId, ...everScope });
+            const { service, repos } = makeService();
+            repos.tasks.findByIdAndUser.mockResolvedValueOnce(task);
+            repos.users.findById.mockResolvedValueOnce({
+                id: everMemberId,
+                tenantId: everScope.tenantId,
+                isActive: true,
+            });
+            repos.organizationMembers.findByOrgAndUser.mockResolvedValueOnce(null);
+            repos.tenants.findById.mockResolvedValueOnce({
+                id: everScope.tenantId,
+                ownerUserId: taskOwnerId,
+            });
+
+            await expect(invoke(service, task.id, everMemberId, everScope)).rejects.toThrow(
+                BadRequestException,
+            );
+            expect(inserted(repos)).not.toHaveBeenCalled();
+            expect(repos.notifications.emit).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(actorCases)(
+        'accepts an active exact-roster Ever user as a Task $label',
+        async ({ invoke, inserted }) => {
+            const task = makeTask({ userId: taskOwnerId, ...everScope });
+            const { service, repos } = makeService();
+            repos.tasks.findByIdAndUser.mockResolvedValueOnce(task);
+            repos.users.findById.mockResolvedValueOnce({
+                id: everMemberId,
+                tenantId: everScope.tenantId,
+                isActive: true,
+            });
+            repos.organizationMembers.findByOrgAndUser.mockResolvedValueOnce({
+                userId: everMemberId,
+                organizationId: everScope.organizationId,
+                tenantId: everScope.tenantId,
+            });
+
+            await expect(invoke(service, task.id, everMemberId, everScope)).resolves.toBeDefined();
+            expect(inserted(repos)).toHaveBeenCalled();
+        },
+    );
+
+    it('allows the tenant owner without a roster row on an Ever Task', async () => {
+        const task = makeTask({ userId: taskOwnerId, ...everScope });
+        const { service, repos } = makeService();
+        repos.tasks.findByIdAndUser.mockResolvedValueOnce(task);
+        repos.users.findById.mockResolvedValueOnce({
+            id: taskOwnerId,
+            tenantId: everScope.tenantId,
+            isActive: true,
+        });
+        repos.organizationMembers.findByOrgAndUser.mockResolvedValueOnce(null);
+        repos.tenants.findById.mockResolvedValueOnce({
+            id: everScope.tenantId,
+            ownerUserId: taskOwnerId,
+        });
+
+        await expect(
+            service.addAssignee(taskOwnerId, task.id, 'user', taskOwnerId, everScope),
+        ).resolves.toBeDefined();
+    });
+
+    it('keeps personal Task user actors limited to the personal owner', async () => {
+        const personalScope = { tenantId: everScope.tenantId, organizationId: null };
+        const task = makeTask({ userId: taskOwnerId, ...personalScope });
+        const { service, repos } = makeService();
+        repos.tasks.findByIdAndUser.mockResolvedValue(task);
+        repos.users.findById
+            .mockResolvedValueOnce({
+                id: taskOwnerId,
+                tenantId: everScope.tenantId,
+                isActive: true,
+            })
+            .mockResolvedValueOnce({
+                id: everMemberId,
+                tenantId: everScope.tenantId,
+                isActive: true,
+            });
+
+        await expect(
+            service.addReviewer(taskOwnerId, task.id, 'user', taskOwnerId, personalScope),
+        ).resolves.toBeDefined();
+        await expect(
+            service.addReviewer(taskOwnerId, task.id, 'user', everMemberId, personalScope),
+        ).rejects.toThrow(BadRequestException);
+        expect(repos.reviewers.add).toHaveBeenCalledTimes(1);
+    });
 
     it('scopes the includeRun batch lookup instead of trusting a Task latestRunId pointer', async () => {
         const knownRunId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
@@ -77,6 +77,15 @@ function makeService(overrides: Record<string, any> = {}) {
         ideas: {
             findByIdForUser: jest.fn(),
         },
+        agents: {
+            findByIdAndUser: jest.fn(),
+        },
+        teams: {
+            findOne: jest.fn(),
+        },
+        goals: {
+            findOne: jest.fn(),
+        },
         ...overrides,
     };
 
@@ -91,12 +100,14 @@ function makeService(overrides: Record<string, any> = {}) {
         repos.transitions as any,
         undefined,
         repos.attachments as any,
-        undefined,
+        repos.agents as any,
         undefined,
         repos.workUploads as any,
         repos.works as any,
         repos.missions as any,
         repos.ideas as any,
+        repos.teams as any,
+        repos.goals as any,
     );
 
     return { service, repos };
@@ -201,6 +212,48 @@ describe('TasksService authorization guardrails', () => {
         expect(repos.tasks.create).toHaveBeenCalledWith(
             expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
         );
+    });
+
+    it('stamps an explicit Goal background scope and validates its Agent in that same scope', async () => {
+        const created = makeTask({ id: 'task-created', goalId: 'goal-ever', ...everScope });
+        const { service, repos } = makeService();
+        repos.goals.findOne.mockResolvedValueOnce({
+            id: 'goal-ever',
+            userId: 'user-1',
+            ...everScope,
+        });
+        repos.agents.findByIdAndUser.mockResolvedValueOnce({
+            id: 'agent-ever',
+            userId: 'user-1',
+            ...everScope,
+        });
+        repos.tasks.create.mockResolvedValueOnce(created);
+
+        await expect(
+            service.create(
+                'user-1',
+                {
+                    title: 'Goal iteration',
+                    goalId: 'goal-ever',
+                    agentId: 'agent-ever',
+                    createdByType: 'user',
+                    createdById: 'user-1',
+                },
+                everScope,
+            ),
+        ).resolves.toEqual(created);
+
+        expect(repos.agents.findByIdAndUser).toHaveBeenCalledWith(
+            'agent-ever',
+            'user-1',
+            everScope,
+        );
+        expect(repos.goals.findOne).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: [{ id: 'goal-ever', userId: 'user-1', ...everScope }],
+            }),
+        );
+        expect(repos.tasks.create).toHaveBeenCalledWith(expect.objectContaining(everScope));
     });
 
     it('rejects Mission-scoped task creation when the Mission is not owned by the user', async () => {

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
@@ -103,6 +103,72 @@ function makeService(overrides: Record<string, any> = {}) {
 }
 
 describe('TasksService authorization guardrails', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    const yoScope = {
+        tenantId: everScope.tenantId,
+        organizationId: '33333333-3333-4333-8333-333333333333',
+    };
+
+    it('404s a same-user Task UUID from another active Organization', async () => {
+        const hidden = makeTask({
+            id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            tenantId: yoScope.tenantId,
+            organizationId: yoScope.organizationId,
+        });
+        const { service, repos } = makeService();
+        repos.tasks.findByIdAndUser.mockResolvedValueOnce(hidden);
+
+        await expect(
+            (service.getOne as any)('user-1', hidden.id, everScope),
+        ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('404s when the Task row matches but its Work belongs to Yo', async () => {
+        const hiddenWorkTask = makeTask({
+            id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            workId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            ...everScope,
+        });
+        const { service, repos } = makeService();
+        repos.tasks.findByIdAndUser.mockResolvedValueOnce(hiddenWorkTask);
+        repos.works.findById.mockResolvedValueOnce({
+            id: hiddenWorkTask.workId,
+            userId: 'user-1',
+            ...yoScope,
+        });
+
+        await expect(
+            (service.getOne as any)('user-1', hiddenWorkTask.id, everScope),
+        ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('keeps legacy personal Task and Work rows reachable in personal scope', async () => {
+        const legacy = makeTask({
+            id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+            workId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+            tenantId: null,
+            organizationId: null,
+        });
+        const { service, repos } = makeService();
+        repos.tasks.findByIdAndUser.mockResolvedValueOnce(legacy);
+        repos.works.findById.mockResolvedValueOnce({
+            id: legacy.workId,
+            userId: 'user-1',
+            tenantId: null,
+            organizationId: null,
+        });
+
+        await expect(
+            (service.getOne as any)('user-1', legacy.id, {
+                tenantId: everScope.tenantId,
+                organizationId: null,
+            }),
+        ).resolves.toBe(legacy);
+    });
+
     it('rejects Work-scoped task creation when the Work is not owned by the user', async () => {
         const { service, repos } = makeService();
         repos.works.findById.mockResolvedValueOnce({ id: 'work-1', userId: 'other-user' });

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
@@ -41,6 +41,7 @@ function makeService(overrides: Record<string, any> = {}) {
         tasks: {
             findByIdAndUser: jest.fn(),
             findById: jest.fn(),
+            findByUserIdFiltered: jest.fn(),
             create: jest.fn(),
             updateById: jest.fn().mockResolvedValue(undefined),
             wouldCreateCycle: jest.fn().mockResolvedValue(false),
@@ -86,6 +87,9 @@ function makeService(overrides: Record<string, any> = {}) {
         goals: {
             findOne: jest.fn(),
         },
+        agentRuns: {
+            findByIds: jest.fn(),
+        },
         ...overrides,
     };
 
@@ -108,6 +112,7 @@ function makeService(overrides: Record<string, any> = {}) {
         repos.ideas as any,
         repos.teams as any,
         repos.goals as any,
+        repos.agentRuns as any,
     );
 
     return { service, repos };
@@ -123,6 +128,18 @@ describe('TasksService authorization guardrails', () => {
         organizationId: '33333333-3333-4333-8333-333333333333',
     };
 
+    it('scopes the includeRun batch lookup instead of trusting a Task latestRunId pointer', async () => {
+        const knownRunId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+        const task = makeTask({ latestRunId: knownRunId, ...everScope });
+        const { service, repos } = makeService();
+        repos.tasks.findByUserIdFiltered.mockResolvedValueOnce({ rows: [task], total: 1 });
+        repos.agentRuns.findByIds.mockResolvedValueOnce([]);
+
+        await service.list('user-1', {}, { includeRun: true }, everScope);
+
+        expect(repos.agentRuns.findByIds).toHaveBeenCalledWith([knownRunId], 'user-1', everScope);
+    });
+
     it('404s a same-user Task UUID from another active Organization', async () => {
         const hidden = makeTask({
             id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
@@ -135,6 +152,7 @@ describe('TasksService authorization guardrails', () => {
         await expect(
             (service.getOne as any)('user-1', hidden.id, everScope),
         ).rejects.toBeInstanceOf(NotFoundException);
+        expect(repos.tasks.findByIdAndUser).toHaveBeenCalledWith(hidden.id, 'user-1', everScope);
     });
 
     it('404s when the Task row matches but its Work belongs to Yo', async () => {
@@ -332,12 +350,19 @@ describe('TasksService authorization guardrails', () => {
         const parent = makeTask({ id: 'parent-1' });
         const refreshed = makeTask({ parentTaskId: parent.id });
         const { service, repos } = makeService();
-        repos.tasks.findByIdAndUser.mockResolvedValueOnce(task).mockResolvedValueOnce(parent);
-        repos.tasks.findById.mockResolvedValueOnce(refreshed);
+        repos.tasks.findByIdAndUser
+            .mockResolvedValueOnce(task)
+            .mockResolvedValueOnce(parent)
+            .mockResolvedValueOnce(refreshed);
 
         await service.update('user-1', task.id, { parentTaskId: parent.id });
 
-        expect(repos.tasks.wouldCreateCycle).toHaveBeenCalledWith(task.id, parent.id);
+        expect(repos.tasks.wouldCreateCycle).toHaveBeenCalledWith(
+            task.id,
+            parent.id,
+            'user-1',
+            undefined,
+        );
         expect(repos.tasks.updateById).toHaveBeenCalledWith(task.id, { parentTaskId: parent.id });
     });
 

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.subtasks.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.subtasks.spec.ts
@@ -107,6 +107,7 @@ describe('TasksService.listSubtasks', () => {
         expect(repos.tasks.findByUserIdFiltered).toHaveBeenCalledWith(
             'user-1',
             expect.objectContaining({ parentTaskId: 'task-1' }),
+            undefined,
         );
         expect(out.rows.map((row) => row.id)).toEqual(['c1', 'c2']);
         expect(out.total).toBe(2);

--- a/packages/agent/src/tasks-domain/recurrence.ts
+++ b/packages/agent/src/tasks-domain/recurrence.ts
@@ -169,6 +169,8 @@ export function computeNextTemplateOccurrence(ctx: TemplateCadenceContext): Date
 export function cloneRecurringTaskAsInstance(template: Task): Partial<Task> {
     return {
         userId: template.userId,
+        tenantId: template.tenantId ?? null,
+        organizationId: template.organizationId ?? null,
         title: template.title,
         description: template.description ?? null,
         status: TaskStatus.TODO,

--- a/packages/agent/src/tasks-domain/task-chat.service.ts
+++ b/packages/agent/src/tasks-domain/task-chat.service.ts
@@ -13,8 +13,9 @@ import {
 } from '../database/repositories/task-side.repositories';
 import { TaskRepository } from '../database/repositories/task.repository';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { ownershipScopeOf, type OwnershipScope } from '../database/ownership-scope';
 import type { TaskChatMessage } from '../entities/task-chat-message.entity';
-import type { TaskActorType } from '../entities/task.entity';
+import type { Task, TaskActorType } from '../entities/task.entity';
 import { ActivityLogService } from '../activity-log/activity-log.service';
 import { ActivityActionType, ActivityStatus } from '../entities/activity-log.types';
 import { assertNoSecrets } from '../utils/secret-scan';
@@ -97,8 +98,9 @@ export class TaskChatService {
         userId: string,
         taskId: string,
         opts: { limit?: number; offset?: number } = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<TaskChatMessage[]> {
-        await this.requireOwnedTask(userId, taskId);
+        await this.requireOwnedTask(userId, taskId, ownershipScope);
         return this.messages.findByTaskId(taskId, opts.limit ?? 50, opts.offset ?? 0);
     }
 
@@ -106,8 +108,9 @@ export class TaskChatService {
         userId: string,
         input: PostChatInput,
         lookups: MentionLookups = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<TaskChatMessage> {
-        const task = await this.requireOwnedTask(userId, input.taskId);
+        const task = await this.requireOwnedTask(userId, input.taskId, ownershipScope);
         this.assertBody(input.body);
 
         const mentions = this.parseMentions(input.body, lookups);
@@ -163,7 +166,15 @@ export class TaskChatService {
             for (const mention of agentMentions) {
                 const dedupKey = `${task.id}:${mention.id}:${row.id}`;
                 void (async () => {
-                    if (await this.trySteerLiveRun(task.id, mention.id, userId, input.body)) {
+                    if (
+                        await this.trySteerLiveRun(
+                            task.id,
+                            mention.id,
+                            userId,
+                            input.body,
+                            ownershipScopeOf(task),
+                        )
+                    ) {
                         return;
                     }
                     let run: { id: string } | null = null;
@@ -190,6 +201,8 @@ export class TaskChatService {
                                       // chat-triggered runs count toward (and show
                                       // under) their Work like task runs do.
                                       workId: task.workId ?? null,
+                                      tenantId: task.tenantId ?? null,
+                                      organizationId: task.organizationId ?? null,
                                       queuedReason: verdict.admitted
                                           ? null
                                           : (verdict.queuedReason ?? null),
@@ -295,11 +308,12 @@ export class TaskChatService {
         messageId: string,
         newBody: string,
         lookups: MentionLookups = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<TaskChatMessage> {
         const msg = await this.messages.findById(messageId);
         if (!msg) throw new NotFoundException(`Chat message ${messageId} not found.`);
 
-        await this.requireOwnedTask(userId, msg.taskId);
+        await this.requireOwnedTask(userId, msg.taskId, ownershipScope);
 
         // Authorship — only the original author can edit (when author
         // is a user; agent-authored messages are not user-editable).
@@ -415,10 +429,16 @@ export class TaskChatService {
         agentId: string,
         userId: string,
         body: string,
+        ownershipScope: OwnershipScope,
     ): Promise<boolean> {
         if (!this.steering || !this.runs) return false;
         try {
-            const live = await this.runs.findInFlightForTaskAgent(taskId, agentId);
+            const live = await this.runs.findInFlightForTaskAgent(
+                taskId,
+                agentId,
+                userId,
+                ownershipScope,
+            );
             if (!live) return false;
             const outcome = await this.steering.steer({ runId: live.id, userId, message: body });
             if (outcome.dispatched !== 'injected') return false;
@@ -434,8 +454,12 @@ export class TaskChatService {
         }
     }
 
-    private async requireOwnedTask(userId: string, taskId: string) {
-        const task = await this.tasks.findByIdAndUser(taskId, userId);
+    private async requireOwnedTask(
+        userId: string,
+        taskId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Task> {
+        const task = await this.tasks.findByIdAndUser(taskId, userId, ownershipScope);
         if (!task) throw new NotFoundException(`Task ${taskId} not found.`);
         return task;
     }

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -17,6 +17,8 @@ import {
     TaskApproverRepository,
 } from '../database/repositories/task-side.repositories';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { AgentRepository } from '../database/repositories/agent.repository';
+import { ownershipScopeOf } from '../database/ownership-scope';
 import {
     AGENT_TASK_EXECUTE_DISPATCHER,
     JOB_RUNTIME_NOT_CONFIGURED_REASON,
@@ -126,6 +128,10 @@ export class TaskTransitionService {
         @Optional()
         @Inject(TERMINAL_SESSION_STARTER)
         private readonly terminalSessions?: TerminalSessionStarter,
+        // Ownership is enforced at the single dispatch choke point so
+        // transition fan-out, recurrence, delegation, and manual dispatch
+        // cannot drift into different Agent-scope rules.
+        @Optional() private readonly agents?: AgentRepository,
     ) {}
 
     /**
@@ -365,6 +371,17 @@ export class TaskTransitionService {
     }> {
         if (!this.dispatcher) {
             return { runId: null, dispatched: false, parked: false, error: 'no-dispatcher' };
+        }
+        const agent = await this.agents
+            ?.findByIdAndUser(agentId, task.userId, ownershipScopeOf(task))
+            .catch(() => null);
+        if (!agent) {
+            return {
+                runId: null,
+                dispatched: false,
+                parked: false,
+                error: 'agent-not-found',
+            };
         }
         const generation = opts.generation ?? (task.recurrenceOccurredCount ?? 0) + 1;
         const dedupKey = opts.dedupKey ?? `${task.id}:${agentId}:${generation}`;

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -398,6 +398,8 @@ export class TaskTransitionService {
                               triggerKind: 'task',
                               taskId: task.id,
                               workId: task.workId ?? null,
+                              tenantId: task.tenantId ?? null,
+                              organizationId: task.organizationId ?? null,
                               queuedReason: verdict.admitted
                                   ? null
                                   : (verdict.queuedReason ?? 'concurrency-limit'),

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -56,6 +56,7 @@ import { PolicyModule } from '../policy/policy.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { AgentsModule } from '../agents/agents.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { DatabaseModule } from '../database/database.module';
 
 /**
  * Tasks feature — Phases 11 + 12 + 13.
@@ -66,6 +67,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
  */
 @Module({
     imports: [
+        DatabaseModule,
         TypeOrmModule.forFeature([
             Task,
             TaskAssignee,

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -42,6 +42,7 @@ import { TaskNotificationService } from './task-notification.service';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkProposalRepository } from '../user-research/work-proposal.repository';
+import { ownershipScopeMatches, type OwnershipScope } from '../database/ownership-scope';
 
 export interface CreateTaskInput {
     title: string;
@@ -375,9 +376,22 @@ export class TasksService {
         return { rows: withRuns, total };
     }
 
-    async getOne(userId: string, id: string): Promise<Task> {
+    async getOne(userId: string, id: string, scope?: OwnershipScope): Promise<Task> {
         const task = await this.tasks.findByIdAndUser(id, userId);
-        if (!task) throw new NotFoundException(`Task ${id} not found.`);
+        if (!task || !ownershipScopeMatches(task, scope)) {
+            throw new NotFoundException(`Task ${id} not found.`);
+        }
+
+        // A Work-scoped Task carries two authoritative scope rows. Both must
+        // agree with the active request; accepting the Task row alone lets a
+        // stale/malformed cross-Organization workId dispatch in the wrong
+        // workspace. Fail closed when the Work repository is unavailable.
+        if (scope && task.workId) {
+            const work = this.works ? await this.works.findById(task.workId) : null;
+            if (!work || work.userId !== userId || !ownershipScopeMatches(work, scope)) {
+                throw new NotFoundException(`Task ${id} not found.`);
+            }
+        }
         return task;
     }
 

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -37,6 +37,9 @@ import {
 import { AgentRepository } from '../database/repositories/agent.repository';
 import type { Agent } from '../entities/agent.entity';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { UserRepository } from '../database/repositories/user.repository';
+import { OrganizationMemberRepository } from '../database/repositories/organization-member.repository';
+import { TenantRepository } from '../database/repositories/tenant.repository';
 import type { AgentRunStatus } from '../entities/agent-run.entity';
 import { TaskNotificationService } from './task-notification.service';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
@@ -44,6 +47,7 @@ import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkProposalRepository } from '../user-research/work-proposal.repository';
 import {
     ownershipScopeMatches,
+    ownershipScopeOf,
     ownershipStamp,
     ownershipWhereWith,
     type OwnershipScope,
@@ -292,34 +296,71 @@ export class TasksService {
         // test fixtures keep compiling and graphs without the Agents module
         // simply skip the embed.
         @Optional() private readonly agentRuns?: AgentRunRepository,
+        @Optional() private readonly users?: UserRepository,
+        @Optional() private readonly organizationMembers?: OrganizationMemberRepository,
+        @Optional() private readonly tenants?: TenantRepository,
     ) {}
 
     /**
      * Review-fix I4: shared validator for assignee / reviewer / approver
-     * add paths. For `agent` actor type, the Agent must belong to the
-     * acting user (cross-user is rejected with a 400). For `user` actor
-     * type we just sanity-check the id is a non-empty string — full
-     * user-existence validation requires a UserRepository in this graph
-     * and is deferred to the API layer's @CurrentUser() resolution.
+     * add paths. The persisted Task scope is authoritative: an Agent must
+     * exist in that exact scope, and a user actor must be an active member
+     * of the exact Organization roster (or the Tenant owner). Personal
+     * Tasks can only point back to their owner. Every mismatch shares one
+     * response so a known UUID is not an Organization-roster oracle.
      */
     private async assertActorIsValid(
         userId: string,
         actorType: TaskActorType,
         actorId: string,
-        ownershipScope?: OwnershipScope,
+        task: Task,
     ): Promise<void> {
         if (!actorId || actorId.trim().length === 0) {
             throw new BadRequestException(`${actorType} id is required.`);
         }
+        const taskScope = ownershipScopeOf(task);
         if (actorType === 'agent' && this.agents) {
             const agent = await this.agents
-                .findByIdAndUser(actorId, userId, ownershipScope)
+                .findByIdAndUser(actorId, userId, taskScope)
                 .catch(() => null);
             if (!agent) {
-                throw new BadRequestException(
-                    `Agent ${actorId} is not reachable for this user — cannot assign.`,
-                );
+                throw new BadRequestException('Task actor is not reachable in this Task scope.');
             }
+            return;
+        }
+
+        if (actorType !== 'user') return;
+        const actor = this.users ? await this.users.findById(actorId).catch(() => null) : null;
+        let reachable = Boolean(actor?.isActive);
+
+        if (reachable && taskScope.organizationId) {
+            reachable = actor?.tenantId === taskScope.tenantId;
+            if (reachable && taskScope.tenantId) {
+                const member = this.organizationMembers
+                    ? await this.organizationMembers
+                          .findByOrgAndUser(taskScope.organizationId, actorId)
+                          .catch(() => null)
+                    : null;
+                reachable = Boolean(
+                    member?.organizationId === taskScope.organizationId &&
+                    member?.tenantId === taskScope.tenantId &&
+                    member?.userId === actorId,
+                );
+                if (!reachable) {
+                    const tenant = this.tenants
+                        ? await this.tenants.findById(taskScope.tenantId).catch(() => null)
+                        : null;
+                    reachable = tenant?.ownerUserId === actorId;
+                }
+            } else {
+                reachable = false;
+            }
+        } else if (reachable) {
+            reachable = actorId === task.userId;
+        }
+
+        if (!reachable) {
+            throw new BadRequestException('Task actor is not reachable in this Task scope.');
         }
     }
 
@@ -1214,7 +1255,7 @@ export class TasksService {
     ) {
         const task = await this.getOne(userId, taskId, ownershipScope);
         // Review-fix I4: validate the actor exists / belongs to user.
-        await this.assertActorIsValid(userId, assigneeType, assigneeId, ownershipScope);
+        await this.assertActorIsValid(userId, assigneeType, assigneeId, task);
         const row = await this.insertOrConflict(
             () => this.assignees.add(taskId, assigneeType, assigneeId),
             `Task ${taskId} already has assignee ${assigneeId}.`,
@@ -1273,9 +1314,9 @@ export class TasksService {
         reviewerId: string,
         ownershipScope?: OwnershipScope,
     ) {
-        await this.getOne(userId, taskId, ownershipScope);
+        const task = await this.getOne(userId, taskId, ownershipScope);
         // Review-fix I4: validate the actor exists / belongs to user.
-        await this.assertActorIsValid(userId, reviewerType, reviewerId, ownershipScope);
+        await this.assertActorIsValid(userId, reviewerType, reviewerId, task);
         return this.insertOrConflict(
             () => this.reviewers.add(taskId, reviewerType, reviewerId),
             `Task ${taskId} already has reviewer ${reviewerId}.`,
@@ -1289,9 +1330,9 @@ export class TasksService {
         approverId: string,
         ownershipScope?: OwnershipScope,
     ) {
-        await this.getOne(userId, taskId, ownershipScope);
+        const task = await this.getOne(userId, taskId, ownershipScope);
         // Review-fix I4: validate the actor exists / belongs to user.
-        await this.assertActorIsValid(userId, approverType, approverId, ownershipScope);
+        await this.assertActorIsValid(userId, approverType, approverId, task);
         return this.insertOrConflict(
             () => this.approvers.add(taskId, approverType, approverId),
             `Task ${taskId} already has approver ${approverId}.`,

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -306,12 +306,15 @@ export class TasksService {
         userId: string,
         actorType: TaskActorType,
         actorId: string,
+        ownershipScope?: OwnershipScope,
     ): Promise<void> {
         if (!actorId || actorId.trim().length === 0) {
             throw new BadRequestException(`${actorType} id is required.`);
         }
         if (actorType === 'agent' && this.agents) {
-            const agent = await this.agents.findByIdAndUser(actorId, userId).catch(() => null);
+            const agent = await this.agents
+                .findByIdAndUser(actorId, userId, ownershipScope)
+                .catch(() => null);
             if (!agent) {
                 throw new BadRequestException(
                     `Agent ${actorId} is not reachable for this user — cannot assign.`,
@@ -324,8 +327,13 @@ export class TasksService {
         userId: string,
         filter: ListTasksFilter = {},
         opts: { includeRun?: boolean } = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<{ rows: TaskWithRun[]; total: number }> {
-        const { rows, total } = await this.tasks.findByUserIdFiltered(userId, filter);
+        const { rows, total } = await this.tasks.findByUserIdFiltered(
+            userId,
+            filter,
+            ownershipScope,
+        );
         if (!opts.includeRun || rows.length === 0 || !this.agentRuns) {
             return { rows, total };
         }
@@ -352,7 +360,7 @@ export class TasksService {
         }
         let runsById = new Map<string, TaskRunEmbed>();
         try {
-            const runs = await this.agentRuns.findByIds(runIds);
+            const runs = await this.agentRuns.findByIds(runIds, userId, ownershipScope);
             runsById = new Map(
                 runs.map((run) => [
                     run.id,
@@ -382,7 +390,7 @@ export class TasksService {
     }
 
     async getOne(userId: string, id: string, scope?: OwnershipScope): Promise<Task> {
-        const task = await this.tasks.findByIdAndUser(id, userId);
+        const task = await this.tasks.findByIdAndUser(id, userId, scope);
         if (!task || !ownershipScopeMatches(task, scope)) {
             throw new NotFoundException(`Task ${id} not found.`);
         }
@@ -414,12 +422,20 @@ export class TasksService {
      * first, so a foreign parent 404s before any side row is read, and
      * the child rows come from the user-scoped list query.
      */
-    async listSubtasks(userId: string, parentTaskId: string): Promise<TaskSubtasksProjection> {
-        await this.getOne(userId, parentTaskId);
-        const { rows, total } = await this.tasks.findByUserIdFiltered(userId, {
-            parentTaskId,
-            limit: SUBTASKS_PAGE_SIZE,
-        });
+    async listSubtasks(
+        userId: string,
+        parentTaskId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<TaskSubtasksProjection> {
+        await this.getOne(userId, parentTaskId, ownershipScope);
+        const { rows, total } = await this.tasks.findByUserIdFiltered(
+            userId,
+            {
+                parentTaskId,
+                limit: SUBTASKS_PAGE_SIZE,
+            },
+            ownershipScope,
+        );
 
         const ids = rows.map((row) => row.id);
         const [assigneeRows, approverRows] = await Promise.all([
@@ -491,7 +507,11 @@ export class TasksService {
         // impossible for a brand-new id, but a malformed parent chain
         // pointing into existing-cyclic data would propagate downstream.
         if (input.parentTaskId) {
-            const parent = await this.tasks.findByIdAndUser(input.parentTaskId, userId);
+            const parent = await this.tasks.findByIdAndUser(
+                input.parentTaskId,
+                userId,
+                ownershipScope,
+            );
             if (!parent) {
                 throw new BadRequestException(`Parent Task ${input.parentTaskId} not found.`);
             }
@@ -528,7 +548,7 @@ export class TasksService {
                     );
                 }
                 seen.add(cursor);
-                const ancestor = await this.tasks.findByIdAndUser(cursor, userId);
+                const ancestor = await this.tasks.findByIdAndUser(cursor, userId, ownershipScope);
                 if (!ancestor) break;
                 cursor = ancestor.parentTaskId ?? null;
                 hops += 1;
@@ -577,8 +597,13 @@ export class TasksService {
         return created;
     }
 
-    async update(userId: string, id: string, input: UpdateTaskInput): Promise<Task> {
-        const task = await this.getOne(userId, id);
+    async update(
+        userId: string,
+        id: string,
+        input: UpdateTaskInput,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Task> {
+        const task = await this.getOne(userId, id, ownershipScope);
         const patch: Partial<Task> = {};
 
         if (input.title !== undefined) {
@@ -641,9 +666,13 @@ export class TasksService {
         const ownersChanged = Object.keys(ownerPatch).length > 0;
 
         if (ownersChanged) {
-            await this.assertScopeReachable(userId, {
-                ...ownerPatch,
-            } as CreateTaskInput);
+            await this.assertScopeReachable(
+                userId,
+                {
+                    ...ownerPatch,
+                } as CreateTaskInput,
+                ownershipScope,
+            );
 
             // Re-filing a Task must not break the sub-task hierarchy. The
             // create path enforces "a child agrees with its parent on every
@@ -657,7 +686,11 @@ export class TasksService {
             const effectiveParentId =
                 input.parentTaskId !== undefined ? input.parentTaskId : task.parentTaskId;
             if (effectiveParentId) {
-                const parent = await this.tasks.findByIdAndUser(effectiveParentId, userId);
+                const parent = await this.tasks.findByIdAndUser(
+                    effectiveParentId,
+                    userId,
+                    ownershipScope,
+                );
                 if (parent) {
                     this.assertParentScopeMatches(nextOwners, parent);
                 }
@@ -667,10 +700,14 @@ export class TasksService {
             // which cannot be fixed by validating this row alone. Refuse
             // rather than leave the tree inconsistent — the caller can move
             // the children first, or detach them.
-            const { total: childCount } = await this.tasks.findByUserIdFiltered(userId, {
-                parentTaskId: id,
-                limit: 1,
-            });
+            const { total: childCount } = await this.tasks.findByUserIdFiltered(
+                userId,
+                {
+                    parentTaskId: id,
+                    limit: 1,
+                },
+                ownershipScope,
+            );
             if (childCount > 0) {
                 throw new BadRequestException(
                     `Task ${id} has ${childCount} sub-task(s); re-file or detach them before changing its owners so parent and child scopes cannot diverge.`,
@@ -684,7 +721,11 @@ export class TasksService {
             if (input.parentTaskId === null) {
                 patch.parentTaskId = null;
             } else {
-                const parent = await this.tasks.findByIdAndUser(input.parentTaskId, userId);
+                const parent = await this.tasks.findByIdAndUser(
+                    input.parentTaskId,
+                    userId,
+                    ownershipScope,
+                );
                 if (!parent) {
                     throw new BadRequestException(`Parent Task ${input.parentTaskId} not found.`);
                 }
@@ -694,7 +735,12 @@ export class TasksService {
                 // block approved the move, then this check compared the OLD
                 // owners against the NEW parent and threw.
                 this.assertParentScopeMatches(nextOwners, parent);
-                const isCycle = await this.tasks.wouldCreateCycle(id, input.parentTaskId);
+                const isCycle = await this.tasks.wouldCreateCycle(
+                    id,
+                    input.parentTaskId,
+                    userId,
+                    ownershipScope,
+                );
                 if (isCycle) {
                     throw new ConflictException(
                         `Cannot set parent — would create a sub-task cycle.`,
@@ -705,7 +751,7 @@ export class TasksService {
         }
 
         await this.tasks.updateById(id, patch);
-        const refreshed = (await this.tasks.findById(id)) as Task;
+        const refreshed = await this.getOne(userId, id, ownershipScope);
         await this.logActivity({
             userId,
             taskId: id,
@@ -715,8 +761,12 @@ export class TasksService {
         return refreshed;
     }
 
-    async remove(userId: string, id: string): Promise<{ deleted: true }> {
-        const task = await this.getOne(userId, id);
+    async remove(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<{ deleted: true }> {
+        const task = await this.getOne(userId, id, ownershipScope);
         await this.tasks.deleteById(id);
         await this.logActivity({
             userId,
@@ -748,8 +798,9 @@ export class TasksService {
             recurrenceEndsAt?: Date | null;
             recurrenceMaxOccurrences?: number | null;
         },
+        ownershipScope?: OwnershipScope,
     ): Promise<Task> {
-        await this.getOne(userId, id);
+        await this.getOne(userId, id, ownershipScope);
         const hasRule = !!input.recurrenceRule;
         const hasCron = !!input.recurrenceCron;
         if (hasRule === hasCron) {
@@ -797,13 +848,17 @@ export class TasksService {
             recurrenceEndsAt: input.recurrenceEndsAt ?? null,
             recurrenceMaxOccurrences: input.recurrenceMaxOccurrences ?? null,
         });
-        return (await this.tasks.findById(id)) as Task;
+        return this.getOne(userId, id, ownershipScope);
     }
 
     /** Phase 17.2 — turn off recurrence on a template. Existing
      * spawned instances are untouched. */
-    async clearRecurring(userId: string, id: string): Promise<Task> {
-        await this.getOne(userId, id);
+    async clearRecurring(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Task> {
+        await this.getOne(userId, id, ownershipScope);
         await this.tasks.updateById(id, {
             isRecurring: false,
             recurrenceRule: null,
@@ -812,7 +867,7 @@ export class TasksService {
             recurrenceEndsAt: null,
             recurrenceMaxOccurrences: null,
         });
-        return (await this.tasks.findById(id)) as Task;
+        return this.getOne(userId, id, ownershipScope);
     }
 
     // ── Schedule mode "Scheduled" (one-shot) ──────────────────────
@@ -823,8 +878,13 @@ export class TasksService {
      * the dispatcher picks up the NEW time. Mutually exclusive with
      * recurrence — a recurring template already has a cadence.
      */
-    async scheduleTask(userId: string, id: string, runAt: Date): Promise<Task> {
-        const task = await this.getOne(userId, id);
+    async scheduleTask(
+        userId: string,
+        id: string,
+        runAt: Date,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Task> {
+        const task = await this.getOne(userId, id, ownershipScope);
         this.assertFutureSchedule(runAt);
         if (task.isRecurring) {
             throw new BadRequestException(
@@ -838,12 +898,16 @@ export class TasksService {
             actionType: ActivityActionType.TASK_UPDATED,
             details: { scheduledAt: runAt.toISOString() },
         });
-        return (await this.tasks.findById(id)) as Task;
+        return this.getOne(userId, id, ownershipScope);
     }
 
     /** Remove the one-shot schedule (mode back to Run Once). */
-    async unscheduleTask(userId: string, id: string): Promise<Task> {
-        await this.getOne(userId, id);
+    async unscheduleTask(
+        userId: string,
+        id: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Task> {
+        await this.getOne(userId, id, ownershipScope);
         await this.tasks.updateById(id, { scheduledAt: null, scheduleClaimedAt: null });
         await this.logActivity({
             userId,
@@ -851,7 +915,7 @@ export class TasksService {
             actionType: ActivityActionType.TASK_UPDATED,
             details: { scheduledAt: null },
         });
-        return (await this.tasks.findById(id)) as Task;
+        return this.getOne(userId, id, ownershipScope);
     }
 
     private assertFutureSchedule(runAt: Date): void {
@@ -1106,8 +1170,9 @@ export class TasksService {
         // red-gate review refusal in TaskTransitionService; human/API
         // callers omit it and are unaffected.
         opts: TransitionOptions = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<Task> {
-        const task = await this.getOne(userId, id);
+        const task = await this.getOne(userId, id, ownershipScope);
         const from = task.status;
         const result = await this.transitions.transition(task, to, opts);
         await this.logActivity({
@@ -1145,10 +1210,11 @@ export class TasksService {
         taskId: string,
         assigneeType: TaskActorType,
         assigneeId: string,
+        ownershipScope?: OwnershipScope,
     ) {
-        const task = await this.getOne(userId, taskId);
+        const task = await this.getOne(userId, taskId, ownershipScope);
         // Review-fix I4: validate the actor exists / belongs to user.
-        await this.assertActorIsValid(userId, assigneeType, assigneeId);
+        await this.assertActorIsValid(userId, assigneeType, assigneeId, ownershipScope);
         const row = await this.insertOrConflict(
             () => this.assignees.add(taskId, assigneeType, assigneeId),
             `Task ${taskId} already has assignee ${assigneeId}.`,
@@ -1180,8 +1246,13 @@ export class TasksService {
         return row;
     }
 
-    async removeAssignee(userId: string, taskId: string, assigneeId: string) {
-        await this.getOne(userId, taskId);
+    async removeAssignee(
+        userId: string,
+        taskId: string,
+        assigneeId: string,
+        ownershipScope?: OwnershipScope,
+    ) {
+        await this.getOne(userId, taskId, ownershipScope);
         const removed = await this.assignees.removeForTask(taskId, assigneeId);
         if (!removed) {
             throw new NotFoundException(`Assignee ${assigneeId} not found.`);
@@ -1200,10 +1271,11 @@ export class TasksService {
         taskId: string,
         reviewerType: TaskActorType,
         reviewerId: string,
+        ownershipScope?: OwnershipScope,
     ) {
-        await this.getOne(userId, taskId);
+        await this.getOne(userId, taskId, ownershipScope);
         // Review-fix I4: validate the actor exists / belongs to user.
-        await this.assertActorIsValid(userId, reviewerType, reviewerId);
+        await this.assertActorIsValid(userId, reviewerType, reviewerId, ownershipScope);
         return this.insertOrConflict(
             () => this.reviewers.add(taskId, reviewerType, reviewerId),
             `Task ${taskId} already has reviewer ${reviewerId}.`,
@@ -1215,22 +1287,28 @@ export class TasksService {
         taskId: string,
         approverType: TaskActorType,
         approverId: string,
+        ownershipScope?: OwnershipScope,
     ) {
-        await this.getOne(userId, taskId);
+        await this.getOne(userId, taskId, ownershipScope);
         // Review-fix I4: validate the actor exists / belongs to user.
-        await this.assertActorIsValid(userId, approverType, approverId);
+        await this.assertActorIsValid(userId, approverType, approverId, ownershipScope);
         return this.insertOrConflict(
             () => this.approvers.add(taskId, approverType, approverId),
             `Task ${taskId} already has approver ${approverId}.`,
         );
     }
 
-    async addBlocker(userId: string, taskId: string, blockedByTaskId: string) {
-        await this.getOne(userId, taskId);
+    async addBlocker(
+        userId: string,
+        taskId: string,
+        blockedByTaskId: string,
+        ownershipScope?: OwnershipScope,
+    ) {
+        await this.getOne(userId, taskId, ownershipScope);
         if (taskId === blockedByTaskId) {
             throw new BadRequestException('Task cannot block itself.');
         }
-        const blocker = await this.tasks.findByIdAndUser(blockedByTaskId, userId);
+        const blocker = await this.tasks.findByIdAndUser(blockedByTaskId, userId, ownershipScope);
         if (!blocker) {
             throw new BadRequestException(`Blocking Task ${blockedByTaskId} not found.`);
         }
@@ -1258,8 +1336,13 @@ export class TasksService {
         return row;
     }
 
-    async removeBlocker(userId: string, taskId: string, blockId: string) {
-        await this.getOne(userId, taskId);
+    async removeBlocker(
+        userId: string,
+        taskId: string,
+        blockId: string,
+        ownershipScope?: OwnershipScope,
+    ) {
+        await this.getOne(userId, taskId, ownershipScope);
         const removed = await this.blocks.removeForTask(taskId, blockId);
         if (!removed) {
             throw new NotFoundException(`Blocker ${blockId} not found.`);
@@ -1281,13 +1364,14 @@ export class TasksService {
         taskId: string,
         relatedTaskId: string,
         kind: 'related' | 'duplicates' | 'follow-up',
+        ownershipScope?: OwnershipScope,
     ) {
-        await this.getOne(userId, taskId);
+        await this.getOne(userId, taskId, ownershipScope);
         // A task cannot relate to itself (mirrors the addBlocker self-guard).
         if (taskId === relatedTaskId) {
             throw new BadRequestException('Task cannot relate to itself.');
         }
-        const related = await this.tasks.findByIdAndUser(relatedTaskId, userId);
+        const related = await this.tasks.findByIdAndUser(relatedTaskId, userId, ownershipScope);
         if (!related) {
             throw new BadRequestException(`Related Task ${relatedTaskId} not found.`);
         }
@@ -1302,8 +1386,8 @@ export class TasksService {
 
     // ── Phase 13.5 — attachments ──────────────────────────────────
 
-    async listAttachments(userId: string, taskId: string) {
-        await this.getOne(userId, taskId);
+    async listAttachments(userId: string, taskId: string, ownershipScope?: OwnershipScope) {
+        await this.getOne(userId, taskId, ownershipScope);
         if (!this.attachments) return [];
         return this.attachments.findByTaskId(taskId);
     }
@@ -1321,8 +1405,9 @@ export class TasksService {
         taskId: string,
         uploadId: string,
         role: 'initial' | 'result' = 'initial',
+        ownershipScope?: OwnershipScope,
     ) {
-        const task = await this.getOne(userId, taskId);
+        const task = await this.getOne(userId, taskId, ownershipScope);
         if (!uploadId) throw new BadRequestException('uploadId is required.');
         if (role !== 'initial' && role !== 'result') {
             throw new BadRequestException(`Invalid attachment role: ${role}`);
@@ -1356,8 +1441,13 @@ export class TasksService {
         }
     }
 
-    async removeAttachment(userId: string, taskId: string, attachmentId: string) {
-        await this.getOne(userId, taskId);
+    async removeAttachment(
+        userId: string,
+        taskId: string,
+        attachmentId: string,
+        ownershipScope?: OwnershipScope,
+    ) {
+        await this.getOne(userId, taskId, ownershipScope);
         if (!this.attachments) {
             throw new BadRequestException('Attachment repository not wired in this context.');
         }

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -42,7 +42,12 @@ import { TaskNotificationService } from './task-notification.service';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkProposalRepository } from '../user-research/work-proposal.repository';
-import { ownershipScopeMatches, type OwnershipScope } from '../database/ownership-scope';
+import {
+    ownershipScopeMatches,
+    ownershipStamp,
+    ownershipWhereWith,
+    type OwnershipScope,
+} from '../database/ownership-scope';
 
 export interface CreateTaskInput {
     title: string;
@@ -467,12 +472,16 @@ export class TasksService {
         };
     }
 
-    async create(userId: string, input: CreateTaskInput): Promise<Task> {
+    async create(
+        userId: string,
+        input: CreateTaskInput,
+        ownershipScope?: OwnershipScope,
+    ): Promise<Task> {
         // Ownership is deliberately NOT exclusive. A Task may belong to a
         // Work and a Team and have been raised by a Mission at the same
         // time; the previous "exactly zero or one of missionId/ideaId/workId"
         // rule made that impossible to express.
-        await this.assertScopeReachable(userId, input);
+        await this.assertScopeReachable(userId, input, ownershipScope);
         this.assertTitle(input.title);
         if (input.description) assertNoSecrets(input.description, 'task.description');
 
@@ -533,6 +542,7 @@ export class TasksService {
 
         const created = await this.tasks.create({
             userId,
+            ...ownershipStamp(ownershipScope),
             slug,
             title: input.title.trim(),
             description: input.description ?? null,
@@ -867,8 +877,12 @@ export class TasksService {
      * failure degrades to the candidates gathered so far, so the picker
      * still opens with whatever is knowable).
      */
-    async listRunCandidates(userId: string, taskId: string): Promise<RunCandidateAgent[]> {
-        const task = await this.getOne(userId, taskId);
+    async listRunCandidates(
+        userId: string,
+        taskId: string,
+        ownershipScope?: OwnershipScope,
+    ): Promise<RunCandidateAgent[]> {
+        const task = await this.getOne(userId, taskId, ownershipScope);
         const out = new Map<string, RunCandidateAgent>();
 
         const push = (id: string, source: RunCandidateAgent['source'], agent?: Agent | null) => {
@@ -886,7 +900,9 @@ export class TasksService {
             const assigned = await this.assignees.findAgentAssignees(taskId);
             for (const row of assigned) {
                 const agent = this.agents
-                    ? await this.agents.findByIdAndUser(row.assigneeId, userId).catch(() => null)
+                    ? await this.agents
+                          .findByIdAndUser(row.assigneeId, userId, ownershipScope)
+                          .catch(() => null)
                     : null;
                 // An assignee row whose Agent is gone (or belongs to
                 // someone else) is not a candidate — the picker must
@@ -898,16 +914,22 @@ export class TasksService {
         }
 
         if (task.agentId && this.agents) {
-            const agent = await this.agents.findByIdAndUser(task.agentId, userId).catch(() => null);
+            const agent = await this.agents
+                .findByIdAndUser(task.agentId, userId, ownershipScope)
+                .catch(() => null);
             if (agent) push(task.agentId, 'task', agent);
         }
 
         if (task.workId && this.agents) {
             try {
-                const { rows } = await this.agents.findByUserIdScoped(userId, {
-                    workId: task.workId,
-                    limit: 25,
-                });
+                const { rows } = await this.agents.findByUserIdScoped(
+                    userId,
+                    {
+                        workId: task.workId,
+                        limit: 25,
+                    },
+                    ownershipScope,
+                );
                 for (const agent of rows) push(agent.id, 'work-default', agent);
             } catch (err) {
                 this.logger.warn(`Run candidates: Work-agent lookup failed for ${taskId}: ${err}`);
@@ -936,13 +958,19 @@ export class TasksService {
         userId: string,
         taskId: string,
         opts: { agentId?: string | null } = {},
+        ownershipScope?: OwnershipScope,
     ): Promise<RunTaskResult> {
-        const task = await this.getOne(userId, taskId);
-        const agentId = await this.resolveRunAgentId(userId, taskId, opts.agentId ?? null);
+        const task = await this.getOne(userId, taskId, ownershipScope);
+        const agentId = await this.resolveRunAgentId(
+            userId,
+            taskId,
+            opts.agentId ?? null,
+            ownershipScope,
+        );
 
         if (this.agentRuns) {
             const inFlight = await this.agentRuns
-                .findInFlightForTaskAgent(taskId, agentId)
+                .findInFlightForTaskAgent(taskId, agentId, userId, ownershipScope)
                 .catch(() => null);
             if (inFlight) {
                 throw new ConflictException({
@@ -991,6 +1019,7 @@ export class TasksService {
     async runTasksBatch(
         userId: string,
         items: { taskId: string; agentId?: string | null }[],
+        ownershipScope?: OwnershipScope,
     ): Promise<{ results: RunBatchItemResult[] }> {
         if (!Array.isArray(items) || items.length === 0) {
             throw new BadRequestException('At least one task is required.');
@@ -1003,7 +1032,12 @@ export class TasksService {
         const results: RunBatchItemResult[] = [];
         for (const item of items) {
             try {
-                const run = await this.runTask(userId, item.taskId, { agentId: item.agentId });
+                const run = await this.runTask(
+                    userId,
+                    item.taskId,
+                    { agentId: item.agentId },
+                    ownershipScope,
+                );
                 results.push({ taskId: item.taskId, ok: true, run });
             } catch (err) {
                 results.push({
@@ -1024,13 +1058,18 @@ export class TasksService {
         userId: string,
         taskId: string,
         explicitAgentId: string | null,
+        ownershipScope?: OwnershipScope,
     ): Promise<string> {
         if (explicitAgentId) {
             if (!this.agents) {
                 throw new BadRequestException('Agent repository not wired in this context.');
             }
-            const agent = await this.agents.findByIdAndUser(explicitAgentId, userId);
-            if (!agent) {
+            const agent = await this.agents.findByIdAndUser(
+                explicitAgentId,
+                userId,
+                ownershipScope,
+            );
+            if (!agent || !ownershipScopeMatches(agent, ownershipScope)) {
                 // 400 (not 404) and no existence leak: from the caller's
                 // side an id they do not own and an id that never existed
                 // are the same unusable input.
@@ -1042,7 +1081,7 @@ export class TasksService {
             return explicitAgentId;
         }
 
-        const candidates = await this.listRunCandidates(userId, taskId);
+        const candidates = await this.listRunCandidates(userId, taskId, ownershipScope);
         if (candidates.length === 1) return candidates[0].id;
         if (candidates.length === 0) {
             throw new BadRequestException({
@@ -1340,13 +1379,17 @@ export class TasksService {
         }
     }
 
-    private async assertScopeReachable(userId: string, input: CreateTaskInput): Promise<void> {
+    private async assertScopeReachable(
+        userId: string,
+        input: CreateTaskInput,
+        ownershipScope?: OwnershipScope,
+    ): Promise<void> {
         if (input.workId) {
             if (!this.works) {
                 throw new BadRequestException('Work repository not wired in this context.');
             }
             const work = await this.works.findById(input.workId);
-            if (!work || work.userId !== userId) {
+            if (!work || work.userId !== userId || !ownershipScopeMatches(work, ownershipScope)) {
                 throw new BadRequestException(`Work ${input.workId} not found.`);
             }
         }
@@ -1355,7 +1398,9 @@ export class TasksService {
                 throw new BadRequestException('Mission repository not wired in this context.');
             }
             const mission = await this.missions.findOne({
-                where: { id: input.missionId, userId },
+                where: ownershipWhereWith<Mission>(userId, ownershipScope, {
+                    id: input.missionId,
+                }),
                 select: ['id', 'userId'],
             });
             if (!mission) {
@@ -1367,7 +1412,7 @@ export class TasksService {
                 throw new BadRequestException('Idea repository not wired in this context.');
             }
             const idea = await this.ideas.findByIdForUser(input.ideaId, userId);
-            if (!idea) {
+            if (!idea || !ownershipScopeMatches(idea, ownershipScope)) {
                 throw new BadRequestException(`Idea ${input.ideaId} not found.`);
             }
         }
@@ -1382,7 +1427,7 @@ export class TasksService {
                 throw new BadRequestException('Team repository not wired in this context.');
             }
             const team = await this.teams.findOne({
-                where: { id: input.teamId, userId },
+                where: ownershipWhereWith<Team>(userId, ownershipScope, { id: input.teamId }),
                 select: ['id'],
             });
             if (!team) {
@@ -1393,8 +1438,8 @@ export class TasksService {
             if (!this.agents) {
                 throw new BadRequestException('Agent repository not wired in this context.');
             }
-            const agent = await this.agents.findByIdAndUser(input.agentId, userId);
-            if (!agent) {
+            const agent = await this.agents.findByIdAndUser(input.agentId, userId, ownershipScope);
+            if (!agent || !ownershipScopeMatches(agent, ownershipScope)) {
                 throw new BadRequestException(`Agent ${input.agentId} not found.`);
             }
         }
@@ -1403,7 +1448,7 @@ export class TasksService {
                 throw new BadRequestException('Goal repository not wired in this context.');
             }
             const goal = await this.goals.findOne({
-                where: { id: input.goalId, userId },
+                where: ownershipWhereWith<Goal>(userId, ownershipScope, { id: input.goalId }),
                 select: ['id'],
             });
             if (!goal) {

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -614,6 +614,10 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
 
     describe('quality gates (Wave 3 M2+M3) — dispatch-freeze + PR gate', () => {
         const WORK_ID = '88888888-8888-4888-8888-888888888888';
+        const EVER_SCOPE = {
+            tenantId: '99999999-9999-4999-8999-999999999999',
+            organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        };
         const WORKSPACE = {
             cwd: '/workspaces/task-1',
             branch: 'task/owned-task',
@@ -630,7 +634,9 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
         };
 
         /** Point the owned task at a Work so the gate path can resolve it. */
-        const useWorkTask = () => {
+        const useWorkTask = (
+            scope: { tenantId: string | null; organizationId: string | null } = EVER_SCOPE,
+        ) => {
             tasks.getOne.mockImplementation(async (userId: string, taskId: string) => {
                 if (userId === OWNER && taskId === OWNED_TASK_ID) {
                     return {
@@ -644,6 +650,7 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                         missionId: null,
                         ideaId: null,
                         workId: WORK_ID,
+                        ...scope,
                     };
                 }
                 throw new Error(`Task ${taskId} not found.`);
@@ -1092,8 +1099,10 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 ],
             };
 
-            const useExhaustedGate = () => {
-                useWorkTask();
+            const useExhaustedGate = (
+                scope: { tenantId: string | null; organizationId: string | null } = EVER_SCOPE,
+            ) => {
+                useWorkTask(scope);
                 taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
                 resolveAcceptanceChecksMock.mockReturnValue([BUILD_CHECK]);
                 resolveChecksPolicyMock.mockReturnValue('required');
@@ -1115,8 +1124,24 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                         reasonCode: 'gate-exhausted',
                         taskId: OWNED_TASK_ID,
                         workId: WORK_ID,
+                        tenantId: EVER_SCOPE.tenantId,
+                        organizationId: EVER_SCOPE.organizationId,
                         decisionNeeded: expect.stringContaining('Decide'),
                         attempted: [expect.objectContaining({ label: 'build', detail: 'boom' })],
+                    }),
+                );
+            });
+
+            it('explicitly persists personal null ownership outside request ALS', async () => {
+                useExhaustedGate({ tenantId: null, organizationId: null });
+
+                await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+                expect(escalations.record).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        taskId: OWNED_TASK_ID,
+                        tenantId: null,
+                        organizationId: null,
                     }),
                 );
             });

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -990,6 +990,12 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                             taskId: payload.taskId,
                             workId: taskRow.workId ?? null,
                             agentId: agent.id,
+                            // Trigger/internal-RPC execution has no request
+                            // ALS. Carry the persisted Task scope explicitly
+                            // so the escalation can later be resolved by the
+                            // exact Task-bound ownership CAS.
+                            tenantId: taskRow.tenantId ?? null,
+                            organizationId: taskRow.organizationId ?? null,
                             summary,
                             decisionNeeded: judgeEscalated
                                 ? `Every acceptance check passed, but the acceptance review says the task is not done: ${


### PR DESCRIPTION
## Summary
- expose persisted tenantId and organizationId on Mission, Goal, Agent, and Mission-Work response projections
- apply active request Tenant/Organization filtering to list/get queries while retaining current-Tenant and legacy-null personal rows
- validate both Mission-Work endpoints in the active Organization and return uniform 404s for cross-scope lookups
- keep creates subscriber-stamped; no client-supplied ownership fields or migration

## Verification
- 134 focused Agent package tests passed (7 suites)
- 3 API controller wiring tests passed
- @ever-works/agent type-check and build passed
- ever-works-api type-check and build passed
- OpenAPI generation passed (593 paths)
- git diff --check passed

## Safety
- code/tests only; no production API calls, data changes, migrations, deletes, deployment, merge, or cascade
- preserves unscoped service-call compatibility and all existing records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access Control**
  * Organization and tenant ownership checks now apply consistently across agents, missions, goals, runs, attachments, targets, and relationships.
  * Cross-organization access is blocked with consistent not-found responses.
  * Revoked or unauthorized organization sessions can no longer fall back to personal access.

* **Data Visibility**
  * Agent, mission, goal, and run responses now include tenant and organization ownership details.

* **Bug Fixes**
  * Prevented cross-organization updates, imports, assignments, cloning, attachments, and run controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->