### PR TITLE
fix(scope): persist Organization workspace selection

### DIFF
--- a/apps/api/src/organizations/organizations.module.ts
+++ b/apps/api/src/organizations/organizations.module.ts
@@ -32,6 +32,8 @@ import { OrgTemplatesController } from './org-templates.controller';
 import { CompanyImportService } from './company-import.service';
 import { CompanyImportController } from './company-import.controller';
 import { WorkRegisteredListener } from './work-registered.listener';
+import { UserScopeController } from '../users/controllers/user-scope.controller';
+import { ActiveScopeService } from '../users/services/active-scope.service';
 
 /**
  * EW-658 (Tenants & Organizations Phase 6) — Organizations module.
@@ -89,6 +91,7 @@ import { WorkRegisteredListener } from './work-registered.listener';
         // feature modules with `:orgId` routes (e.g. WorksModule's
         // OrgKbController) share one audited implementation.
         OrganizationMembershipService,
+        ActiveScopeService,
         // EW-711 (security-audit C2) — fail-closed `CanActivate` wrapper over
         // OrganizationMembershipService so raw `:orgId` routes are authorized
         // declaratively/by-default (closes the "a future route forgets the
@@ -114,6 +117,7 @@ import { WorkRegisteredListener } from './work-registered.listener';
         OrgTemplatesController,
         CompanyImportController,
         OrganizationInvitationsController,
+        UserScopeController,
     ],
     exports: [
         OrganizationService,

--- a/apps/api/src/scope/__tests__/scope-resolver.middleware.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-resolver.middleware.spec.ts
@@ -63,6 +63,18 @@ describe('ScopeResolverMiddleware (EW-659 Phase 7)', () => {
             expect(userRepository.findBySlug).not.toHaveBeenCalled();
         });
 
+        it('recognizes the collision-proof personal sentinel without a slug lookup', async () => {
+            const { scope, nextCalled } = await runWithCapture({
+                params: {},
+                headers: { 'x-scope-slug': '@personal' },
+            });
+
+            expect(nextCalled).toBe(true);
+            expect(scope).toEqual({ tenantId: null, organizationId: null });
+            expect(organizationRepository.findBySlug).not.toHaveBeenCalled();
+            expect(userRepository.findBySlug).not.toHaveBeenCalled();
+        });
+
         it('treats whitespace-only slug as missing (EMPTY_SCOPE pass-through)', async () => {
             const { scope, nextCalled } = await runWithCapture({
                 params: { slug: '   ' },

--- a/apps/api/src/scope/__tests__/scope-stamping.creation-paths.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-stamping.creation-paths.spec.ts
@@ -32,17 +32,26 @@ describe('Scope stamping across Mission/Goal/Work/Agent creation paths', () => {
 
     it.each(TIER_C_ENTITIES)(
         '%s exposes the real nullable scope columns and is stamped through the subscriber',
-        (domain, Entity) => {
-            const columns = getMetadataArgsStorage()
-                .filterColumns(Entity)
-                .map((column) => column.propertyName);
-            expect(columns).toEqual(expect.arrayContaining(['tenantId', 'organizationId']));
+        (domain, entityClass) => {
+            const columns = getMetadataArgsStorage().filterColumns(entityClass);
+            expect(columns).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        propertyName: 'tenantId',
+                        options: expect.objectContaining({ nullable: true }),
+                    }),
+                    expect.objectContaining({
+                        propertyName: 'organizationId',
+                        options: expect.objectContaining({ nullable: true }),
+                    }),
+                ]),
+            );
 
             // Use an actual entity prototype so this is a runtime contract, not
             // a source-signature search tied to a service method's formatting.
-            const row = Object.assign(Object.create(Entity.prototype), {
+            const row = Object.assign(Object.create(entityClass.prototype), {
                 id: `${domain.toLowerCase()}-1`,
-            }) as InstanceType<typeof Entity> & {
+            }) as InstanceType<typeof entityClass> & {
                 tenantId?: string | null;
                 organizationId?: string | null;
             };

--- a/apps/api/src/scope/__tests__/scope-stamping.creation-paths.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-stamping.creation-paths.spec.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { DataSource, EntityMetadata, InsertEvent } from 'typeorm';
+import { ScopeContextService } from '../scope-context.service';
+import { ScopeStampingSubscriber } from '../scope-stamping.subscriber';
+
+const REPOSITORY_ROOT = resolve(__dirname, '../../../../..');
+
+interface CreationPath {
+    domain: string;
+    entityFile: string;
+    serviceFile: string;
+    createStart: string;
+    createEnd: string;
+    requiredInsertTokens: string[];
+    supportingFile?: string;
+    supportingStart?: string;
+    supportingEnd?: string;
+}
+
+const CREATION_PATHS: CreationPath[] = [
+    {
+        domain: 'Mission',
+        entityFile: 'packages/agent/src/entities/mission.entity.ts',
+        serviceFile: 'packages/agent/src/missions/missions.service.ts',
+        createStart: '    async create(userId: string, input: CreateMissionInput)',
+        createEnd: '    async update(',
+        requiredInsertTokens: ['this.missions.create({', 'this.missions.save('],
+    },
+    {
+        domain: 'Goal',
+        entityFile: 'packages/agent/src/entities/goal.entity.ts',
+        serviceFile: 'packages/agent/src/goals/goals.service.ts',
+        createStart: '    async create(userId: string, input: CreateGoalInput)',
+        createEnd: '    async update(',
+        requiredInsertTokens: ['this.goals.create({', 'this.goals.save('],
+    },
+    {
+        domain: 'Work',
+        entityFile: 'packages/agent/src/entities/work.entity.ts',
+        serviceFile: 'packages/agent/src/database/repositories/work.repository.ts',
+        createStart: '    async create(dto: Partial<Work>, user: User)',
+        createEnd: '    async createOrUpdate(',
+        requiredInsertTokens: ['this.repository.create(dto)', 'this.repository.save(work)'],
+    },
+    {
+        domain: 'Agent',
+        entityFile: 'packages/agent/src/entities/agent.entity.ts',
+        serviceFile: 'packages/agent/src/agents/agents.service.ts',
+        createStart: '    async create(userId: string, input: CreateAgentInput)',
+        createEnd: '    async update(',
+        requiredInsertTokens: ['this.agents', '.create({'],
+        supportingFile: 'packages/agent/src/database/repositories/agent.repository.ts',
+        supportingStart: '    async create(data: Partial<Agent>)',
+        supportingEnd: '    async updateById(',
+    },
+];
+
+function source(relativePath: string): string {
+    return readFileSync(resolve(REPOSITORY_ROOT, relativePath), 'utf8');
+}
+
+function section(text: string, start: string, end: string): string {
+    const startIndex = text.indexOf(start);
+    expect(startIndex).toBeGreaterThanOrEqual(0);
+    const endIndex = text.indexOf(end, startIndex + start.length);
+    expect(endIndex).toBeGreaterThan(startIndex);
+    return text.slice(startIndex, endIndex);
+}
+
+function makeEvent(entity: Record<string, unknown>): InsertEvent<unknown> {
+    return {
+        entity,
+        metadata: {
+            columns: ['id', 'tenantId', 'organizationId'].map((propertyName) => ({
+                propertyName,
+            })),
+        } as unknown as EntityMetadata,
+    } as InsertEvent<unknown>;
+}
+
+describe('Scope stamping across Mission/Goal/Work/Agent creation paths', () => {
+    const tenantId = 'tenant-ever';
+    const organizationId = 'organization-ever';
+
+    it.each(CREATION_PATHS)(
+        '$domain is a Tier-C entity whose real create path leaves scope implicit for the subscriber',
+        (path) => {
+            const entitySource = source(path.entityFile);
+            expect(entitySource).toMatch(
+                /@Column\([^)]*nullable:\s*true[^)]*\)[\s\S]*tenantId\??:/,
+            );
+            expect(entitySource).toMatch(
+                /@Column\([^)]*nullable:\s*true[^)]*\)[\s\S]*organizationId\??:/,
+            );
+
+            const createPath = section(source(path.serviceFile), path.createStart, path.createEnd);
+            for (const token of path.requiredInsertTokens) expect(createPath).toContain(token);
+            expect(createPath).not.toMatch(/\b(?:tenantId|organizationId)\s*:/);
+
+            if (path.supportingFile && path.supportingStart && path.supportingEnd) {
+                const supportingPath = section(
+                    source(path.supportingFile),
+                    path.supportingStart,
+                    path.supportingEnd,
+                );
+                expect(supportingPath).toContain('this.repository.create(data)');
+                expect(supportingPath).toContain('this.repository.save(entity)');
+                expect(supportingPath).not.toMatch(/\b(?:tenantId|organizationId)\s*:/);
+            }
+
+            const scopeContext = new ScopeContextService();
+            const subscriber = new ScopeStampingSubscriber(
+                { subscribers: [] } as unknown as DataSource,
+                scopeContext,
+            );
+            const row: Record<string, unknown> = { id: `${path.domain.toLowerCase()}-1` };
+            scopeContext.runWith({ tenantId, organizationId }, () => {
+                subscriber.beforeInsert(makeEvent(row));
+            });
+
+            expect(row).toMatchObject({ tenantId, organizationId });
+        },
+    );
+});

--- a/apps/api/src/scope/__tests__/scope-stamping.creation-paths.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-stamping.creation-paths.spec.ts
@@ -1,74 +1,21 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import type { DataSource, EntityMetadata, InsertEvent } from 'typeorm';
+import { Agent, Goal, Mission, Work } from '@ever-works/agent/entities';
+import {
+    getMetadataArgsStorage,
+    type DataSource,
+    type EntityMetadata,
+    type InsertEvent,
+} from 'typeorm';
 import { ScopeContextService } from '../scope-context.service';
 import { ScopeStampingSubscriber } from '../scope-stamping.subscriber';
 
-const REPOSITORY_ROOT = resolve(__dirname, '../../../../..');
+const TIER_C_ENTITIES = [
+    ['Mission', Mission],
+    ['Goal', Goal],
+    ['Work', Work],
+    ['Agent', Agent],
+] as const;
 
-interface CreationPath {
-    domain: string;
-    entityFile: string;
-    serviceFile: string;
-    createStart: string;
-    createEnd: string;
-    requiredInsertTokens: string[];
-    supportingFile?: string;
-    supportingStart?: string;
-    supportingEnd?: string;
-}
-
-const CREATION_PATHS: CreationPath[] = [
-    {
-        domain: 'Mission',
-        entityFile: 'packages/agent/src/entities/mission.entity.ts',
-        serviceFile: 'packages/agent/src/missions/missions.service.ts',
-        createStart: '    async create(userId: string, input: CreateMissionInput)',
-        createEnd: '    async update(',
-        requiredInsertTokens: ['this.missions.create({', 'this.missions.save('],
-    },
-    {
-        domain: 'Goal',
-        entityFile: 'packages/agent/src/entities/goal.entity.ts',
-        serviceFile: 'packages/agent/src/goals/goals.service.ts',
-        createStart: '    async create(userId: string, input: CreateGoalInput)',
-        createEnd: '    async update(',
-        requiredInsertTokens: ['this.goals.create({', 'this.goals.save('],
-    },
-    {
-        domain: 'Work',
-        entityFile: 'packages/agent/src/entities/work.entity.ts',
-        serviceFile: 'packages/agent/src/database/repositories/work.repository.ts',
-        createStart: '    async create(dto: Partial<Work>, user: User)',
-        createEnd: '    async createOrUpdate(',
-        requiredInsertTokens: ['this.repository.create(dto)', 'this.repository.save(work)'],
-    },
-    {
-        domain: 'Agent',
-        entityFile: 'packages/agent/src/entities/agent.entity.ts',
-        serviceFile: 'packages/agent/src/agents/agents.service.ts',
-        createStart: '    async create(userId: string, input: CreateAgentInput)',
-        createEnd: '    async update(',
-        requiredInsertTokens: ['this.agents', '.create({'],
-        supportingFile: 'packages/agent/src/database/repositories/agent.repository.ts',
-        supportingStart: '    async create(data: Partial<Agent>)',
-        supportingEnd: '    async updateById(',
-    },
-];
-
-function source(relativePath: string): string {
-    return readFileSync(resolve(REPOSITORY_ROOT, relativePath), 'utf8');
-}
-
-function section(text: string, start: string, end: string): string {
-    const startIndex = text.indexOf(start);
-    expect(startIndex).toBeGreaterThanOrEqual(0);
-    const endIndex = text.indexOf(end, startIndex + start.length);
-    expect(endIndex).toBeGreaterThan(startIndex);
-    return text.slice(startIndex, endIndex);
-}
-
-function makeEvent(entity: Record<string, unknown>): InsertEvent<unknown> {
+function makeEvent(entity: object): InsertEvent<unknown> {
     return {
         entity,
         metadata: {
@@ -83,38 +30,28 @@ describe('Scope stamping across Mission/Goal/Work/Agent creation paths', () => {
     const tenantId = 'tenant-ever';
     const organizationId = 'organization-ever';
 
-    it.each(CREATION_PATHS)(
-        '$domain is a Tier-C entity whose real create path leaves scope implicit for the subscriber',
-        (path) => {
-            const entitySource = source(path.entityFile);
-            expect(entitySource).toMatch(
-                /@Column\([^)]*nullable:\s*true[^)]*\)[\s\S]*tenantId\??:/,
-            );
-            expect(entitySource).toMatch(
-                /@Column\([^)]*nullable:\s*true[^)]*\)[\s\S]*organizationId\??:/,
-            );
+    it.each(TIER_C_ENTITIES)(
+        '%s exposes the real nullable scope columns and is stamped through the subscriber',
+        (domain, Entity) => {
+            const columns = getMetadataArgsStorage()
+                .filterColumns(Entity)
+                .map((column) => column.propertyName);
+            expect(columns).toEqual(expect.arrayContaining(['tenantId', 'organizationId']));
 
-            const createPath = section(source(path.serviceFile), path.createStart, path.createEnd);
-            for (const token of path.requiredInsertTokens) expect(createPath).toContain(token);
-            expect(createPath).not.toMatch(/\b(?:tenantId|organizationId)\s*:/);
-
-            if (path.supportingFile && path.supportingStart && path.supportingEnd) {
-                const supportingPath = section(
-                    source(path.supportingFile),
-                    path.supportingStart,
-                    path.supportingEnd,
-                );
-                expect(supportingPath).toContain('this.repository.create(data)');
-                expect(supportingPath).toContain('this.repository.save(entity)');
-                expect(supportingPath).not.toMatch(/\b(?:tenantId|organizationId)\s*:/);
-            }
-
+            // Use an actual entity prototype so this is a runtime contract, not
+            // a source-signature search tied to a service method's formatting.
+            const row = Object.assign(Object.create(Entity.prototype), {
+                id: `${domain.toLowerCase()}-1`,
+            }) as InstanceType<typeof Entity> & {
+                tenantId?: string | null;
+                organizationId?: string | null;
+            };
             const scopeContext = new ScopeContextService();
             const subscriber = new ScopeStampingSubscriber(
                 { subscribers: [] } as unknown as DataSource,
                 scopeContext,
             );
-            const row: Record<string, unknown> = { id: `${path.domain.toLowerCase()}-1` };
+
             scopeContext.runWith({ tenantId, organizationId }, () => {
                 subscriber.beforeInsert(makeEvent(row));
             });

--- a/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
+++ b/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
@@ -10,7 +10,10 @@ import { SessionScopeGuard } from '../session-scope.guard';
  * `getType()` returns 'http' by default; `switchToHttp().getRequest()`
  * returns the `request` object we pass in.
  */
-function makeContext(request: { user?: unknown }): ExecutionContext {
+function makeContext(request: {
+    user?: unknown;
+    headers?: Record<string, string | string[] | undefined>;
+}): ExecutionContext {
     return {
         getType: () => 'http',
         switchToHttp: () => ({
@@ -110,7 +113,7 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
         expect(findById).not.toHaveBeenCalled();
     });
 
-    it('seeds { tenantId, organizationId } for a user with both set', async () => {
+    it('treats a headerless unprefixed request as personal and never reads the mutable pointer', async () => {
         findById.mockResolvedValue({ tenantId: 't-1', lastScopeOrganizationId: 'o-1' });
         const ctx = makeContext({ user: { userId: 'u-1' } });
 
@@ -123,7 +126,25 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
         );
 
         expect(findById).toHaveBeenCalledWith('u-1');
-        expect(observed).toEqual({ tenantId: 't-1', organizationId: 'o-1' });
+        expect(observed).toEqual({ tenantId: 't-1', organizationId: null });
+    });
+
+    it('keeps explicit @personal personal even when another tab persisted an Organization', async () => {
+        findById.mockResolvedValue({ tenantId: 't-1', lastScopeOrganizationId: 'o-yo' });
+        const ctx = makeContext({
+            user: { userId: 'u-1' },
+            headers: { 'x-scope-slug': '@personal' },
+        });
+
+        const observed = await scopeContext.runWith(
+            { tenantId: null, organizationId: null },
+            async () => {
+                await guard.canActivate(ctx);
+                return scopeContext.getScope();
+            },
+        );
+
+        expect(observed).toEqual({ tenantId: 't-1', organizationId: null });
     });
 
     it('seeds { tenantId, organizationId: null } when lastScopeOrganizationId is null', async () => {
@@ -277,7 +298,7 @@ describe('SessionScopeGuard + ScopeOwnershipGuard pipeline (EW-664 regression)',
         } as unknown as ExecutionContext;
     }
 
-    it('legacy route: session guard seeds scope + hydrates user, ownership guard then allows', async () => {
+    it('personal route: session guard seeds bare scope + hydrates user, ownership guard then allows', async () => {
         const scopeContext = new ScopeContextService();
         const findById = jest
             .fn()
@@ -301,7 +322,7 @@ describe('SessionScopeGuard + ScopeOwnershipGuard pipeline (EW-664 regression)',
 
         // Before the fix this threw 403 in ownershipGuard.
         expect(allowed).toBe(true);
-        expect(observed).toEqual({ tenantId: 't-1', organizationId: 'o-1' });
+        expect(observed).toEqual({ tenantId: 't-1', organizationId: null });
     });
 
     it('slug route to OWN tenant: ownership guard allows after hydration', async () => {

--- a/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
+++ b/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
@@ -235,25 +235,38 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
         });
     });
 
-    it('does not silently fall back to personal scope after the last-active membership is revoked', async () => {
+    it('a revoked last-active membership never affects a headerless request: personal scope, no roster lookup', async () => {
         findById.mockResolvedValue({
             tenantId: 't-1',
             lastScopeOrganizationId: 'o-ever',
         });
+        const organizationRepository = {
+            findById: jest.fn().mockResolvedValue({ id: 'o-ever', tenantId: 't-1' }),
+        };
+        const organizationMembers = { findByOrgAndUser: jest.fn().mockResolvedValue(null) };
         const membershipGuard = new SessionScopeGuard(
             scopeContext,
             { findById } as never,
-            { findById: jest.fn().mockResolvedValue({ id: 'o-ever', tenantId: 't-1' }) } as never,
-            { findByOrgAndUser: jest.fn().mockResolvedValue(null) } as never,
+            organizationRepository as never,
+            organizationMembers as never,
             { findById: jest.fn().mockResolvedValue({ ownerUserId: 'tenant-owner' }) } as never,
         );
         const ctx = makeContext({ user: { userId: 'u-1' } });
 
-        await expect(
-            scopeContext.runWith({ tenantId: null, organizationId: null }, () =>
-                membershipGuard.canActivate(ctx),
-            ),
-        ).rejects.toMatchObject({ status: 404, message: 'Organization not found' });
+        const observed = await scopeContext.runWith(
+            { tenantId: null, organizationId: null },
+            async () => {
+                await membershipGuard.canActivate(ctx);
+                return scopeContext.getScope();
+            },
+        );
+
+        // The mutable pointer is a fresh-login navigation default only; it is
+        // never read as request authority, so revocation cannot lock the user
+        // out of their own personal scope and no Organization lookup happens.
+        expect(observed).toEqual({ tenantId: 't-1', organizationId: null });
+        expect(organizationRepository.findById).not.toHaveBeenCalled();
+        expect(organizationMembers.findByOrgAndUser).not.toHaveBeenCalled();
     });
 
     it('keeps Tenant-owner access even though owners intentionally have no roster row', async () => {

--- a/apps/api/src/scope/scope-resolver.middleware.ts
+++ b/apps/api/src/scope/scope-resolver.middleware.ts
@@ -22,6 +22,7 @@ type NextFn = (err?: unknown) => void;
  * are embedded in log lines so they cannot forge extra entries.
  */
 const CONTROL_CHARS = new RegExp('[\\u0000-\\u001F\\u007F-\\u009F]+', 'g');
+const PERSONAL_SCOPE_SENTINEL = '@personal';
 
 /**
  * EW-659 (Tenants & Organizations Phase 7) — slug routing middleware.
@@ -77,7 +78,7 @@ export class ScopeResolverMiddleware implements NestMiddleware {
     async use(req: MiddlewareRequest, _res: unknown, next: NextFn): Promise<void> {
         const slug = this.extractSlug(req);
 
-        if (!slug) {
+        if (!slug || slug === PERSONAL_SCOPE_SENTINEL) {
             // Legacy un-prefixed route, or an exempt path. Run under
             // EMPTY_SCOPE so the subscriber's beforeInsert hook sees
             // `null` for both fields and doesn't stamp anything.

--- a/apps/api/src/scope/session-scope.guard.ts
+++ b/apps/api/src/scope/session-scope.guard.ts
@@ -24,18 +24,20 @@ import { ScopeContextService } from './scope-context.service';
  * under `EMPTY_SCOPE` (both fields `null`).
  *
  * That's wrong for an authenticated user who HAS been upgraded to a
- * Tenant: their legacy-route requests should operate in their default
- * scope (their Tenant + last-active Org), not the empty scope. Otherwise
+ * Tenant: their unprefixed requests should operate in their bare personal
+ * scope (their Tenant, no Organization), not the empty scope. Otherwise
  * the Phase 5b [`ScopeStampingSubscriber`](./scope-stamping.subscriber.ts)
  * stamps NULLs on rows they create, and scope-filtered reads miss their
- * own data.
+ * own data. The mutable `users.lastScopeOrganizationId` preference is a
+ * fresh-login navigation default only — it is never read here as request
+ * authorization (see `ActiveScopeService` / PR #2152).
  *
  * The middleware can't fix this itself: it runs BEFORE `AuthSessionGuard`
  * populates `request.user`, so it has no user to read `tenantId` /
  * `lastScopeOrganizationId` from. This guard runs AFTER `AuthSessionGuard`
  * (guards execute in `providers`-array registration order — see
  * `api.module.ts`) and does TWO things: hydrates `req.user.tenantId`
- * and, on legacy routes, seeds the default scope in place via
+ * and, on unprefixed personal routes, seeds bare personal scope in place via
  * [`ScopeContextService.setScope`](./scope-context.service.ts).
  *
  * **Behavior:**
@@ -48,9 +50,9 @@ import { ScopeContextService } from './scope-context.service';
  *   - An Organization scope must still have an exact roster membership;
  *     the Tenant owner is the sole row-less exception. A revoked/missing
  *     Organization is an opaque 404.
- *   - Then SEED scope only if no slug already resolved one
+ *   - Then SEED personal scope only if no Organization slug resolved one
  *     (`scope.tenantId === null`) AND the user has a Tenant →
- *     `{ tenantId, organizationId: lastScopeOrganizationId ?? null }`.
+ *     `{ tenantId, organizationId: null }`.
  *     A user with no Tenant leaves `EMPTY_SCOPE`.
  *
  * **Why hydrate on slug routes too (not just legacy):** the next guard,
@@ -111,10 +113,10 @@ export class SessionScopeGuard implements CanActivate {
         // reads it.
         user.tenantId = tenantId;
 
-        // Seed the default scope ONLY on legacy routes (no slug resolved
-        // a scope). Slug routes keep the middleware-resolved scope; the
-        // ownership guard then verifies it belongs to this user's
-        // hydrated tenant.
+        // An unprefixed request is the personal route contract. Never read the
+        // user's mutable last-Organization preference here: that value is only
+        // a fresh-login navigation default, not request authorization. This is
+        // what keeps simultaneous Ever and Yo tabs isolated.
         const scope = this.scopeContext.getScope();
         if (
             scope.organizationId !== null &&
@@ -124,21 +126,13 @@ export class SessionScopeGuard implements CanActivate {
             await this.requireActiveOrganization(user.userId, scope.tenantId, scope.organizationId);
         }
         if (scope.tenantId === null && tenantId !== null) {
-            // Security: validate that lastScopeOrganizationId still belongs to
-            // this user's tenant before seeding it as the active scope.
-            // Missing, foreign, or revoked last-active Organizations fail with
-            // the same opaque 404 as an explicit slug request. Falling back to
-            // bare personal scope here would make revocation grant a different
-            // data surface that the caller did not explicitly select.
-            const resolvedOrganizationId: string | null = dbUser?.lastScopeOrganizationId ?? null;
-            if (resolvedOrganizationId !== null) {
-                await this.requireActiveOrganization(user.userId, tenantId, resolvedOrganizationId);
-            }
             this.scopeContext.setScope({
                 tenantId,
-                organizationId: resolvedOrganizationId,
+                organizationId: null,
             });
-            this.logger.debug(`Seeded session scope for user ${user.userId}: tenantId=${tenantId}`);
+            this.logger.debug(
+                `Seeded personal scope for user ${user.userId}: tenantId=${tenantId}`,
+            );
         }
 
         return true;

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -357,28 +357,29 @@ describe('UploadsController', () => {
             expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
         });
 
-        it('hydrates and validates the persisted Ever default for a bearer with no explicit scope', async () => {
+        it('resolves a headerless bearer to bare personal scope and never reads the persisted Organization pointer', async () => {
             const ctx = publicController({
                 activeScope: { tenantId: null, organizationId: null },
                 bearer: true,
                 user: {
                     id: bearerUserId,
                     tenantId: everScope.tenantId,
+                    // Another tab may have persisted Ever as the login default;
+                    // that preference is never request authority.
                     lastScopeOrganizationId: everScope.organizationId,
                     isActive: true,
                 },
             });
+            const personalScope = { tenantId: everScope.tenantId, organizationId: null };
 
             await ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined);
 
-            expect(ctx.members.findByOrgAndUser).toHaveBeenCalledWith(
-                everScope.organizationId,
-                bearerUserId,
-            );
+            expect(ctx.organizations.findById).not.toHaveBeenCalled();
+            expect(ctx.members.findByOrgAndUser).not.toHaveBeenCalled();
             expect(ctx.uploads.saveImage).toHaveBeenCalledWith(bearerUserId, expect.anything(), {
-                ownershipScope: everScope,
+                ownershipScope: personalScope,
             });
-            expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(everScope);
+            expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(personalScope);
         });
 
         it.each([
@@ -396,7 +397,7 @@ describe('UploadsController', () => {
                     ),
             ],
         ] as const)(
-            'hydrates and validates the persisted Ever default before a headerless %s',
+            'keeps a headerless %s in bare personal scope even when the persisted default is revoked or unknown',
             async (label, invoke) => {
                 const ctx = publicController({
                     activeScope: { tenantId: null, organizationId: null },
@@ -407,88 +408,44 @@ describe('UploadsController', () => {
                         lastScopeOrganizationId: everScope.organizationId,
                         isActive: true,
                     },
+                    // A revoked roster row / missing Organization must be
+                    // irrelevant: the pointer is not consulted at all.
+                    member: null,
+                    organization: null,
+                    tenant: { id: everScope.tenantId, ownerUserId: 'other' },
                 });
+                const personalScope = { tenantId: everScope.tenantId, organizationId: null };
 
                 await invoke(ctx);
 
-                expect(ctx.members.findByOrgAndUser).toHaveBeenCalledWith(
-                    everScope.organizationId,
-                    bearerUserId,
-                );
+                expect(ctx.organizations.findById).not.toHaveBeenCalled();
+                expect(ctx.members.findByOrgAndUser).not.toHaveBeenCalled();
                 if (label === 'file') {
                     expect(ctx.uploads.saveFile).toHaveBeenCalledWith(
                         bearerUserId,
                         expect.anything(),
-                        { ownershipScope: everScope },
+                        { ownershipScope: personalScope },
                     );
                 } else {
                     expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
                 }
-                expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(everScope);
+                expect(ctx.scopeContext.setScope).toHaveBeenCalledWith(personalScope);
             },
         );
 
-        it.each([
-            [
-                'image',
-                (ctx: ReturnType<typeof publicController>) =>
-                    ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined),
-            ],
-            [
-                'file',
-                (ctx: ReturnType<typeof publicController>) =>
-                    ctx.controller.uploadAnonymousFile(mkFile({}), ctx.req),
-            ],
-        ] as const)(
-            'opaquely rejects a revoked persisted Ever default before a headerless %s upload',
-            async (_label, invoke) => {
-                const ctx = publicController({
-                    activeScope: { tenantId: null, organizationId: null },
-                    bearer: true,
-                    user: {
-                        id: bearerUserId,
-                        tenantId: everScope.tenantId,
-                        lastScopeOrganizationId: everScope.organizationId,
-                        isActive: true,
-                    },
-                    member: null,
-                    tenant: { id: everScope.tenantId, ownerUserId: 'other' },
-                });
+        it('still requires exact roster access when the bearer explicitly selects Ever', async () => {
+            const ctx = publicController({
+                activeScope: everScope,
+                bearer: true,
+                member: null,
+                tenant: { id: everScope.tenantId, ownerUserId: 'other' },
+            });
 
-                await expect(invoke(ctx)).rejects.toBeInstanceOf(NotFoundException);
-                expect(ctx.uploads.saveImage).not.toHaveBeenCalled();
-                expect(ctx.uploads.saveFile).not.toHaveBeenCalled();
-            },
-        );
-
-        it.each([
-            ['revoked', { member: null }],
-            ['unknown', { organization: null }],
-        ] as const)(
-            'opaquely rejects a bearer whose persisted Ever default is %s before presigning',
-            async (_label, overrides) => {
-                const ctx = publicController({
-                    activeScope: { tenantId: null, organizationId: null },
-                    bearer: true,
-                    user: {
-                        id: bearerUserId,
-                        tenantId: everScope.tenantId,
-                        lastScopeOrganizationId: everScope.organizationId,
-                        isActive: true,
-                    },
-                    tenant: { id: everScope.tenantId, ownerUserId: 'other' },
-                    ...overrides,
-                });
-
-                await expect(
-                    ctx.controller.presign(
-                        { filename: 'direct.png', mimeType: 'image/png', size: 100 },
-                        ctx.req,
-                    ),
-                ).rejects.toBeInstanceOf(NotFoundException);
-                expect(ctx.uploads.getBackend).not.toHaveBeenCalled();
-            },
-        );
+            await expect(
+                ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(ctx.uploads.saveImage).not.toHaveBeenCalled();
+        });
 
         it.each([
             [

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -663,21 +663,13 @@ export class UploadsController {
                 this.opaqueScopeNotFound();
             }
 
-            // ScopeResolverMiddleware leaves a headerless public request at
-            // EMPTY_SCOPE because @Public() skips SessionScopeGuard. Mirror
-            // that guard's default-Organization behavior here: a persisted
-            // default must still exist and retain exact roster access. An
-            // explicit personal scope already carries the user's tenant and
-            // therefore does not enter this fallback.
-            const defaultOrganizationId =
-                requested.tenantId === null ? (user.lastScopeOrganizationId ?? null) : null;
-            if (userTenantId && defaultOrganizationId) {
-                return this.requireAuthenticatedOrganizationScope(
-                    auth.userId,
-                    userTenantId,
-                    defaultOrganizationId,
-                );
-            }
+            // ScopeResolverMiddleware leaves a headerless (or explicit
+            // `@personal`) public request at EMPTY_SCOPE because @Public()
+            // skips SessionScopeGuard. Mirror that guard exactly: the request
+            // resolves to the user's bare personal scope. The mutable
+            // `users.lastScopeOrganizationId` preference is a fresh-login
+            // navigation default only and is never read as request authority;
+            // an Organization must be selected explicitly via `X-Scope-Slug`.
             return { tenantId: userTenantId, organizationId: null };
         }
 

--- a/apps/api/src/users/controllers/user-scope.controller.spec.ts
+++ b/apps/api/src/users/controllers/user-scope.controller.spec.ts
@@ -1,0 +1,41 @@
+import type { AuthenticatedUser } from '../../auth/types/auth.types';
+import { ActiveScopeService } from '../services/active-scope.service';
+import { UserScopeController } from './user-scope.controller';
+
+describe('UserScopeController', () => {
+    const auth = { userId: 'user-1' } as AuthenticatedUser;
+    let activeScope: jest.Mocked<Pick<ActiveScopeService, 'getActiveScope' | 'updateActiveScope'>>;
+    let controller: UserScopeController;
+
+    beforeEach(() => {
+        activeScope = {
+            getActiveScope: jest.fn(),
+            updateActiveScope: jest.fn(),
+        };
+        controller = new UserScopeController(activeScope as unknown as ActiveScopeService);
+    });
+
+    it('returns the authenticated user persisted active scope', async () => {
+        activeScope.getActiveScope.mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-ever',
+            organizationSlug: 'ever',
+        });
+
+        await expect(controller.get(auth)).resolves.toMatchObject({ organizationSlug: 'ever' });
+        expect(activeScope.getActiveScope).toHaveBeenCalledWith('user-1');
+    });
+
+    it('persists the requested Organization before returning it', async () => {
+        activeScope.updateActiveScope.mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-ever',
+            organizationSlug: 'ever',
+        });
+
+        await expect(controller.update(auth, { organizationSlug: 'ever' })).resolves.toMatchObject({
+            organizationId: 'org-ever',
+        });
+        expect(activeScope.updateActiveScope).toHaveBeenCalledWith('user-1', 'ever');
+    });
+});

--- a/apps/api/src/users/controllers/user-scope.controller.spec.ts
+++ b/apps/api/src/users/controllers/user-scope.controller.spec.ts
@@ -1,3 +1,4 @@
+import { Test, TestingModule } from '@nestjs/testing';
 import type { AuthenticatedUser } from '../../auth/types/auth.types';
 import { ActiveScopeService } from '../services/active-scope.service';
 import { UserScopeController } from './user-scope.controller';
@@ -6,13 +7,22 @@ describe('UserScopeController', () => {
     const auth = { userId: 'user-1' } as AuthenticatedUser;
     let activeScope: jest.Mocked<Pick<ActiveScopeService, 'getActiveScope' | 'updateActiveScope'>>;
     let controller: UserScopeController;
+    let moduleRef: TestingModule;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         activeScope = {
             getActiveScope: jest.fn(),
             updateActiveScope: jest.fn(),
         };
-        controller = new UserScopeController(activeScope as unknown as ActiveScopeService);
+        moduleRef = await Test.createTestingModule({
+            controllers: [UserScopeController],
+            providers: [{ provide: ActiveScopeService, useValue: activeScope }],
+        }).compile();
+        controller = moduleRef.get(UserScopeController);
+    });
+
+    afterEach(async () => {
+        await moduleRef.close();
     });
 
     it('returns the authenticated user persisted active scope', async () => {

--- a/apps/api/src/users/controllers/user-scope.controller.ts
+++ b/apps/api/src/users/controllers/user-scope.controller.ts
@@ -1,19 +1,10 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ACTIVE_SCOPE_RESPONSE_SCHEMA, type ActiveScopeResponse } from '@ever-works/contracts/api';
 import { CurrentUser } from '../../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../../auth/types/auth.types';
 import { UpdateActiveScopeDto } from '../dto/update-active-scope.dto';
-import { ActiveScopeResponse, ActiveScopeService } from '../services/active-scope.service';
-
-const ACTIVE_SCOPE_SCHEMA = {
-    type: 'object',
-    properties: {
-        tenantId: { type: 'string', format: 'uuid', nullable: true },
-        organizationId: { type: 'string', format: 'uuid', nullable: true },
-        organizationSlug: { type: 'string', nullable: true },
-    },
-    required: ['tenantId', 'organizationId', 'organizationSlug'],
-};
+import { ActiveScopeService } from '../services/active-scope.service';
 
 @ApiTags('Users')
 @ApiBearerAuth('JWT-auth')
@@ -23,7 +14,7 @@ export class UserScopeController {
 
     @Get()
     @ApiOperation({ summary: 'Get the authenticated user active Organization scope' })
-    @ApiResponse({ status: 200, schema: ACTIVE_SCOPE_SCHEMA })
+    @ApiResponse({ status: 200, schema: ACTIVE_SCOPE_RESPONSE_SCHEMA })
     get(@CurrentUser() auth: AuthenticatedUser): Promise<ActiveScopeResponse> {
         return this.activeScopeService.getActiveScope(auth.userId);
     }
@@ -31,7 +22,7 @@ export class UserScopeController {
     @Post()
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Persist the authenticated user active Organization scope' })
-    @ApiResponse({ status: 200, schema: ACTIVE_SCOPE_SCHEMA })
+    @ApiResponse({ status: 200, schema: ACTIVE_SCOPE_RESPONSE_SCHEMA })
     @ApiResponse({ status: 404, description: 'Organization not found for this user' })
     update(
         @CurrentUser() auth: AuthenticatedUser,

--- a/apps/api/src/users/controllers/user-scope.controller.ts
+++ b/apps/api/src/users/controllers/user-scope.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../../auth/types/auth.types';
+import { UpdateActiveScopeDto } from '../dto/update-active-scope.dto';
+import { ActiveScopeResponse, ActiveScopeService } from '../services/active-scope.service';
+
+const ACTIVE_SCOPE_SCHEMA = {
+    type: 'object',
+    properties: {
+        tenantId: { type: 'string', format: 'uuid', nullable: true },
+        organizationId: { type: 'string', format: 'uuid', nullable: true },
+        organizationSlug: { type: 'string', nullable: true },
+    },
+    required: ['tenantId', 'organizationId', 'organizationSlug'],
+};
+
+@ApiTags('Users')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/users/me/scope')
+export class UserScopeController {
+    constructor(private readonly activeScopeService: ActiveScopeService) {}
+
+    @Get()
+    @ApiOperation({ summary: 'Get the authenticated user active Organization scope' })
+    @ApiResponse({ status: 200, schema: ACTIVE_SCOPE_SCHEMA })
+    get(@CurrentUser() auth: AuthenticatedUser): Promise<ActiveScopeResponse> {
+        return this.activeScopeService.getActiveScope(auth.userId);
+    }
+
+    @Post()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Persist the authenticated user active Organization scope' })
+    @ApiResponse({ status: 200, schema: ACTIVE_SCOPE_SCHEMA })
+    @ApiResponse({ status: 404, description: 'Organization not found for this user' })
+    update(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: UpdateActiveScopeDto,
+    ): Promise<ActiveScopeResponse> {
+        return this.activeScopeService.updateActiveScope(auth.userId, body.organizationSlug);
+    }
+}

--- a/apps/api/src/users/dto/update-active-scope.dto.spec.ts
+++ b/apps/api/src/users/dto/update-active-scope.dto.spec.ts
@@ -1,0 +1,33 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateActiveScopeDto } from './update-active-scope.dto';
+
+describe('UpdateActiveScopeDto', () => {
+    it('accepts and trims a valid Organization slug', async () => {
+        const dto = plainToInstance(UpdateActiveScopeDto, { organizationSlug: '  ever  ' });
+
+        await expect(validate(dto)).resolves.toHaveLength(0);
+        expect(dto.organizationSlug).toBe('ever');
+    });
+
+    it('accepts explicit null for personal/bare-Tenant scope', async () => {
+        const dto = plainToInstance(UpdateActiveScopeDto, { organizationSlug: null });
+
+        await expect(validate(dto)).resolves.toHaveLength(0);
+    });
+
+    it('rejects an omitted selection', async () => {
+        const dto = plainToInstance(UpdateActiveScopeDto, {});
+
+        await expect(validate(dto)).resolves.not.toHaveLength(0);
+    });
+
+    it.each(['', 'Ever', '-ever', 'ever-', 'ever works'])(
+        'rejects invalid slug %j',
+        async (slug) => {
+            const dto = plainToInstance(UpdateActiveScopeDto, { organizationSlug: slug });
+
+            await expect(validate(dto)).resolves.not.toHaveLength(0);
+        },
+    );
+});

--- a/apps/api/src/users/dto/update-active-scope.dto.ts
+++ b/apps/api/src/users/dto/update-active-scope.dto.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+import { IsDefined, IsString, Length, Matches, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateActiveScopeDto {
+    @ApiProperty({
+        type: String,
+        nullable: true,
+        example: 'ever',
+        description:
+            'Organization slug to make active. Explicit null selects personal/bare-Tenant scope.',
+    })
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    @ValidateIf((_object, value) => value !== null)
+    @IsDefined()
+    @IsString()
+    @Length(1, 64)
+    @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+    organizationSlug: string | null;
+}

--- a/apps/api/src/users/services/active-scope.service.spec.ts
+++ b/apps/api/src/users/services/active-scope.service.spec.ts
@@ -62,14 +62,13 @@ describe('ActiveScopeService', () => {
         expect(users.update).not.toHaveBeenCalled();
     });
 
-    it('returns bare-Tenant scope for a stale persisted pointer without mutating on GET', async () => {
+    it('returns an opaque 404 for a revoked persisted login default without mutating on GET', async () => {
         users.findById.mockResolvedValue(user as never);
         membership.ensureMember.mockRejectedValue(new NotFoundException('not found'));
 
-        await expect(service.getActiveScope(user.id)).resolves.toEqual({
-            tenantId: 'tenant-1',
-            organizationId: null,
-            organizationSlug: null,
+        await expect(service.getActiveScope(user.id)).rejects.toMatchObject({
+            status: 404,
+            message: 'Organization not found',
         });
         expect(users.update).not.toHaveBeenCalled();
     });

--- a/apps/api/src/users/services/active-scope.service.spec.ts
+++ b/apps/api/src/users/services/active-scope.service.spec.ts
@@ -58,18 +58,25 @@ describe('ActiveScopeService', () => {
             organizationId: 'org-ever',
             organizationSlug: 'ever',
         });
-        expect(membership.ensureMember).toHaveBeenCalledWith(ever.id, user.id);
+        expect(membership.ensureMember).toHaveBeenCalledTimes(1);
+        expect(membership.ensureMember).toHaveBeenCalledWith(user.lastScopeOrganizationId, user.id);
+        expect(organizations.findById).not.toHaveBeenCalled();
+        expect(organizations.findBySlug).not.toHaveBeenCalled();
         expect(users.update).not.toHaveBeenCalled();
     });
 
     it('returns an opaque 404 for a revoked persisted login default without mutating on GET', async () => {
         users.findById.mockResolvedValue(user as never);
-        membership.ensureMember.mockRejectedValue(new NotFoundException('not found'));
+        membership.ensureMember.mockRejectedValue(new NotFoundException('membership revoked'));
 
         await expect(service.getActiveScope(user.id)).rejects.toMatchObject({
             status: 404,
             message: 'Organization not found',
         });
+        expect(membership.ensureMember).toHaveBeenCalledTimes(1);
+        expect(membership.ensureMember).toHaveBeenCalledWith(user.lastScopeOrganizationId, user.id);
+        expect(organizations.findById).not.toHaveBeenCalled();
+        expect(organizations.findBySlug).not.toHaveBeenCalled();
         expect(users.update).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/users/services/active-scope.service.spec.ts
+++ b/apps/api/src/users/services/active-scope.service.spec.ts
@@ -1,4 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
 import { OrganizationMembershipService } from '../../organizations/organization-membership.service';
 import { ActiveScopeService } from './active-scope.service';
@@ -8,6 +9,7 @@ describe('ActiveScopeService', () => {
     let users: jest.Mocked<Pick<UserRepository, 'findById' | 'update'>>;
     let organizations: jest.Mocked<Pick<OrganizationRepository, 'findById' | 'findBySlug'>>;
     let membership: jest.Mocked<Pick<OrganizationMembershipService, 'ensureMember'>>;
+    let moduleRef: TestingModule;
 
     const user = {
         id: 'user-1',
@@ -20,7 +22,7 @@ describe('ActiveScopeService', () => {
         slug: 'ever',
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         users = {
             findById: jest.fn(),
             update: jest.fn(),
@@ -32,11 +34,19 @@ describe('ActiveScopeService', () => {
         membership = {
             ensureMember: jest.fn(),
         };
-        service = new ActiveScopeService(
-            users as unknown as UserRepository,
-            organizations as unknown as OrganizationRepository,
-            membership as unknown as OrganizationMembershipService,
-        );
+        moduleRef = await Test.createTestingModule({
+            providers: [
+                ActiveScopeService,
+                { provide: UserRepository, useValue: users },
+                { provide: OrganizationRepository, useValue: organizations },
+                { provide: OrganizationMembershipService, useValue: membership },
+            ],
+        }).compile();
+        service = moduleRef.get(ActiveScopeService);
+    });
+
+    afterEach(async () => {
+        await moduleRef.close();
     });
 
     it('returns the persisted active Organization for a same-Tenant pointer', async () => {

--- a/apps/api/src/users/services/active-scope.service.spec.ts
+++ b/apps/api/src/users/services/active-scope.service.spec.ts
@@ -109,9 +109,10 @@ describe('ActiveScopeService', () => {
         users.findById.mockResolvedValue(user as never);
         organizations.findBySlug.mockResolvedValue(null);
 
-        await expect(service.updateActiveScope(user.id, 'missing')).rejects.toBeInstanceOf(
-            NotFoundException,
-        );
+        await expect(service.updateActiveScope(user.id, 'missing')).rejects.toMatchObject({
+            status: 404,
+            message: 'Organization not found',
+        });
         expect(users.update).not.toHaveBeenCalled();
     });
 
@@ -126,9 +127,9 @@ describe('ActiveScopeService', () => {
         membership.ensureMember.mockRejectedValue(new NotFoundException('not found'));
 
         const rejection = service.updateActiveScope(user.id, 'foreign');
-        await expect(rejection).rejects.toBeInstanceOf(NotFoundException);
         await expect(rejection).rejects.toMatchObject({
-            response: expect.objectContaining({ message: "Organization 'foreign' not found" }),
+            status: 404,
+            message: 'Organization not found',
         });
         expect(users.update).not.toHaveBeenCalled();
     });

--- a/apps/api/src/users/services/active-scope.service.spec.ts
+++ b/apps/api/src/users/services/active-scope.service.spec.ts
@@ -1,0 +1,147 @@
+import { NotFoundException } from '@nestjs/common';
+import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import { OrganizationMembershipService } from '../../organizations/organization-membership.service';
+import { ActiveScopeService } from './active-scope.service';
+
+describe('ActiveScopeService', () => {
+    let service: ActiveScopeService;
+    let users: jest.Mocked<Pick<UserRepository, 'findById' | 'update'>>;
+    let organizations: jest.Mocked<Pick<OrganizationRepository, 'findById' | 'findBySlug'>>;
+    let membership: jest.Mocked<Pick<OrganizationMembershipService, 'ensureMember'>>;
+
+    const user = {
+        id: 'user-1',
+        tenantId: 'tenant-1',
+        lastScopeOrganizationId: 'org-ever',
+    };
+    const ever = {
+        id: 'org-ever',
+        tenantId: 'tenant-1',
+        slug: 'ever',
+    };
+
+    beforeEach(() => {
+        users = {
+            findById: jest.fn(),
+            update: jest.fn(),
+        };
+        organizations = {
+            findById: jest.fn(),
+            findBySlug: jest.fn(),
+        };
+        membership = {
+            ensureMember: jest.fn(),
+        };
+        service = new ActiveScopeService(
+            users as unknown as UserRepository,
+            organizations as unknown as OrganizationRepository,
+            membership as unknown as OrganizationMembershipService,
+        );
+    });
+
+    it('returns the persisted active Organization for a same-Tenant pointer', async () => {
+        users.findById.mockResolvedValue(user as never);
+        membership.ensureMember.mockResolvedValue(ever as never);
+
+        await expect(service.getActiveScope(user.id)).resolves.toEqual({
+            tenantId: 'tenant-1',
+            organizationId: 'org-ever',
+            organizationSlug: 'ever',
+        });
+        expect(membership.ensureMember).toHaveBeenCalledWith(ever.id, user.id);
+        expect(users.update).not.toHaveBeenCalled();
+    });
+
+    it('returns bare-Tenant scope for a stale persisted pointer without mutating on GET', async () => {
+        users.findById.mockResolvedValue(user as never);
+        membership.ensureMember.mockRejectedValue(new NotFoundException('not found'));
+
+        await expect(service.getActiveScope(user.id)).resolves.toEqual({
+            tenantId: 'tenant-1',
+            organizationId: null,
+            organizationSlug: null,
+        });
+        expect(users.update).not.toHaveBeenCalled();
+    });
+
+    it('persists a same-Tenant Organization selected by slug', async () => {
+        users.findById.mockResolvedValue(user as never);
+        organizations.findBySlug.mockResolvedValue(ever as never);
+        membership.ensureMember.mockResolvedValue(ever as never);
+        users.update.mockResolvedValue({ ...user, lastScopeOrganizationId: ever.id } as never);
+
+        await expect(service.updateActiveScope(user.id, ever.slug)).resolves.toEqual({
+            tenantId: 'tenant-1',
+            organizationId: 'org-ever',
+            organizationSlug: 'ever',
+        });
+        expect(users.update).toHaveBeenCalledWith(user.id, {
+            lastScopeOrganizationId: ever.id,
+        });
+        expect(membership.ensureMember).toHaveBeenCalledWith(ever.id, user.id);
+    });
+
+    it('supports the product contract for explicit personal/bare-Tenant scope', async () => {
+        users.findById.mockResolvedValue(user as never);
+        users.update.mockResolvedValue({ ...user, lastScopeOrganizationId: null } as never);
+
+        await expect(service.updateActiveScope(user.id, null)).resolves.toEqual({
+            tenantId: 'tenant-1',
+            organizationId: null,
+            organizationSlug: null,
+        });
+        expect(organizations.findBySlug).not.toHaveBeenCalled();
+        expect(users.update).toHaveBeenCalledWith(user.id, {
+            lastScopeOrganizationId: null,
+        });
+    });
+
+    it('rejects an unknown slug without changing the prior active scope', async () => {
+        users.findById.mockResolvedValue(user as never);
+        organizations.findBySlug.mockResolvedValue(null);
+
+        await expect(service.updateActiveScope(user.id, 'missing')).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(users.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a foreign-Tenant Organization with the same response and no partial update', async () => {
+        users.findById.mockResolvedValue(user as never);
+        organizations.findBySlug.mockResolvedValue({
+            ...ever,
+            id: 'org-foreign',
+            tenantId: 'tenant-foreign',
+            slug: 'foreign',
+        } as never);
+        membership.ensureMember.mockRejectedValue(new NotFoundException('not found'));
+
+        const rejection = service.updateActiveScope(user.id, 'foreign');
+        await expect(rejection).rejects.toBeInstanceOf(NotFoundException);
+        await expect(rejection).rejects.toMatchObject({
+            response: expect.objectContaining({ message: "Organization 'foreign' not found" }),
+        });
+        expect(users.update).not.toHaveBeenCalled();
+    });
+
+    it('propagates an unexpected membership lookup failure without changing scope', async () => {
+        users.findById.mockResolvedValue(user as never);
+        organizations.findBySlug.mockResolvedValue(ever as never);
+        membership.ensureMember.mockRejectedValue(new Error('membership database unavailable'));
+
+        await expect(service.updateActiveScope(user.id, ever.slug)).rejects.toThrow(
+            'membership database unavailable',
+        );
+        expect(users.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing authenticated user without writing', async () => {
+        users.findById.mockResolvedValue(null);
+
+        await expect(service.updateActiveScope('missing-user', 'ever')).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(organizations.findBySlug).not.toHaveBeenCalled();
+        expect(users.update).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/users/services/active-scope.service.ts
+++ b/apps/api/src/users/services/active-scope.service.ts
@@ -52,7 +52,7 @@ export class ActiveScopeService {
 
         const organization = await this.organizationRepository.findBySlug(organizationSlug);
         if (!organization) {
-            throw new NotFoundException(`Organization '${organizationSlug}' not found`);
+            throw new NotFoundException('Organization not found');
         }
 
         let authorizedOrganization: Organization;
@@ -60,7 +60,7 @@ export class ActiveScopeService {
             authorizedOrganization = await this.membership.ensureMember(organization.id, user.id);
         } catch (error) {
             if (error instanceof NotFoundException) {
-                throw new NotFoundException(`Organization '${organizationSlug}' not found`);
+                throw new NotFoundException('Organization not found');
             }
             throw error;
         }

--- a/apps/api/src/users/services/active-scope.service.ts
+++ b/apps/api/src/users/services/active-scope.service.ts
@@ -1,13 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
 import type { Organization } from '@ever-works/agent/entities';
+import type { ActiveScopeResponse } from '@ever-works/contracts/api';
 import { OrganizationMembershipService } from '../../organizations/organization-membership.service';
-
-export interface ActiveScopeResponse {
-    tenantId: string | null;
-    organizationId: string | null;
-    organizationSlug: string | null;
-}
 
 @Injectable()
 export class ActiveScopeService {

--- a/apps/api/src/users/services/active-scope.service.ts
+++ b/apps/api/src/users/services/active-scope.service.ts
@@ -25,7 +25,9 @@ export class ActiveScopeService {
         try {
             organization = await this.membership.ensureMember(organizationId, user.id);
         } catch (error) {
-            if (error instanceof NotFoundException) return this.bareTenantScope(tenantId);
+            if (error instanceof NotFoundException) {
+                throw new NotFoundException('Organization not found');
+            }
             throw error;
         }
 

--- a/apps/api/src/users/services/active-scope.service.ts
+++ b/apps/api/src/users/services/active-scope.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import type { Organization } from '@ever-works/agent/entities';
+import { OrganizationMembershipService } from '../../organizations/organization-membership.service';
+
+export interface ActiveScopeResponse {
+    tenantId: string | null;
+    organizationId: string | null;
+    organizationSlug: string | null;
+}
+
+@Injectable()
+export class ActiveScopeService {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly organizationRepository: OrganizationRepository,
+        private readonly membership: OrganizationMembershipService,
+    ) {}
+
+    async getActiveScope(userId: string): Promise<ActiveScopeResponse> {
+        const user = await this.requireUser(userId);
+        const tenantId = user.tenantId ?? null;
+        const organizationId = user.lastScopeOrganizationId ?? null;
+
+        if (tenantId === null || organizationId === null) {
+            return this.bareTenantScope(tenantId);
+        }
+
+        let organization: Organization;
+        try {
+            organization = await this.membership.ensureMember(organizationId, user.id);
+        } catch (error) {
+            if (error instanceof NotFoundException) return this.bareTenantScope(tenantId);
+            throw error;
+        }
+
+        return {
+            tenantId,
+            organizationId: organization.id,
+            organizationSlug: organization.slug,
+        };
+    }
+
+    async updateActiveScope(
+        userId: string,
+        organizationSlug: string | null,
+    ): Promise<ActiveScopeResponse> {
+        const user = await this.requireUser(userId);
+        const tenantId = user.tenantId ?? null;
+
+        if (organizationSlug === null) {
+            await this.userRepository.update(user.id, { lastScopeOrganizationId: null });
+            return this.bareTenantScope(tenantId);
+        }
+
+        const organization = await this.organizationRepository.findBySlug(organizationSlug);
+        if (!organization) {
+            throw new NotFoundException(`Organization '${organizationSlug}' not found`);
+        }
+
+        let authorizedOrganization: Organization;
+        try {
+            authorizedOrganization = await this.membership.ensureMember(organization.id, user.id);
+        } catch (error) {
+            if (error instanceof NotFoundException) {
+                throw new NotFoundException(`Organization '${organizationSlug}' not found`);
+            }
+            throw error;
+        }
+
+        await this.userRepository.update(user.id, {
+            lastScopeOrganizationId: authorizedOrganization.id,
+        });
+        return {
+            tenantId: authorizedOrganization.tenantId,
+            organizationId: authorizedOrganization.id,
+            organizationSlug: authorizedOrganization.slug,
+        };
+    }
+
+    private async requireUser(userId: string) {
+        const user = await this.userRepository.findById(userId);
+        if (!user) {
+            throw new NotFoundException('User not found');
+        }
+        return user;
+    }
+
+    private bareTenantScope(tenantId: string | null): ActiveScopeResponse {
+        return {
+            tenantId,
+            organizationId: null,
+            organizationSlug: null,
+        };
+    }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { DatabaseModule, OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import { DatabaseModule, UserRepository } from '@ever-works/agent/database';
 import { UsersController } from './controllers/users.controller';
 import { UsernameAllocatorService } from './services/username-allocator.service';
 
@@ -18,7 +18,7 @@ import { UsernameAllocatorService } from './services/username-allocator.service'
  */
 @Module({
     imports: [DatabaseModule],
-    providers: [UserRepository, OrganizationRepository, UsernameAllocatorService],
+    providers: [UserRepository, UsernameAllocatorService],
     controllers: [UsersController],
     exports: [UsernameAllocatorService],
 })

--- a/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
+++ b/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
@@ -1,7 +1,12 @@
-import { test, expect, type APIRequestContext } from '@playwright/test';
+import { test, expect, type APIRequestContext, type BrowserContext } from '@playwright/test';
 import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
-import { createOrganizationViaAPI, listOrganizationsViaAPI } from './helpers/organizations';
-import { loadSeededTestUser } from './helpers/seeded-test-user';
+import { loginViaUI } from './helpers/auth';
+import {
+    createOrganizationViaAPI,
+    gotoDashboardWithSwitcher,
+    listOrganizationsViaAPI,
+    selectOrganizationInSwitcher,
+} from './helpers/organizations';
 
 /**
  * ORG SWITCH -> CONTEXT PROPAGATION (deep integration)
@@ -14,9 +19,7 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  * spoofing is rejected.
  *
  * ──────────────────────────────────────────────────────────────────────────
- * THE REAL SWITCH MECHANISM (probed live against the sqlite in-memory CI
- * driver on 2026-06-01 — NOT what the task title's "/switch endpoint, cookie,
- * x-organization-id header" wording assumes; those do NOT exist in this build):
+ * THE REAL SWITCH MECHANISM:
  *
  *   - There is NO `POST /api/organizations/switch` and NO
  *     `GET /api/organizations/current` route. The organizations controller
@@ -29,23 +32,19 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *       PATCH  /api/organizations/:id
  *       POST   /api/organizations/:id/upgrade-from-account
  *
+ *   - The switcher POSTs the chosen slug to `/api/users/me/scope`; the API
+ *     validates ownership and persists `users.lastScopeOrganizationId`.
  *   - The active scope is resolved SERVER-SIDE by ScopeResolverMiddleware
- *     (apps/api/src/scope/scope-resolver.middleware.ts):
- *       1. `X-Scope-Slug: <orgSlug>` request header  <-- the SPA's fetch
- *          wrapper sets this from the active-org cookie/localStorage. THIS is
- *          the programmatic "switch active org" knob the web client uses.
+ *     plus SessionScopeGuard:
+ *       1. `X-Scope-Slug: <orgSlug>` request header for explicit API clients.
  *       2. else the first `/{slug}/...` URL path segment.
- *       3. else EMPTY_SCOPE, and SessionScopeGuard
- *          (apps/api/src/scope/session-scope.guard.ts) seeds the user's default
- *          scope { tenantId, organizationId: lastScopeOrganizationId }.
+ *       3. else SessionScopeGuard seeds the persisted Organization scope.
  *     An UNKNOWN slug in X-Scope-Slug -> middleware throws NotFoundException
  *     -> 404. A slug belonging to ANOTHER tenant -> resolves, but the
  *     ScopeOwnershipGuard rejects it for this user -> 403.
  *
- *   - `users.lastScopeOrganizationId` (packages/agent/src/entities/user.entity.ts)
- *     is set to the FIRST org on first-org create (organization.service.ts) and
- *     persists across logout/login. There is no API to re-point it; the SPA
- *     re-points the *active* scope per-request via `X-Scope-Slug`.
+ *   - Explicit `X-Scope-Slug` remains supported for API clients, but the real
+ *     browser switch no longer relies on synthetic localStorage plumbing.
  *
  * PROBED FACTS the assertions below rely on (ALL verified live, 2026-06-01):
  *   - POST /api/works (X-Scope-Slug: A) -> 200 { status:'success',
@@ -75,7 +74,7 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *
  * GOTCHAS honoured: mutations run on FRESH registerUserViaAPI() users (cross-
  * spec isolation); the seeded user (storageState) is only touched for the
- * UI/localStorage flow; unique Date.now suffixes; assert toContain/membership,
+ * UI flow; unique Date.now suffixes; assert toContain/membership,
  * never exact counts; flow- filename is safe vs the no-auth testIgnore regex.
  */
 
@@ -125,6 +124,33 @@ async function listWorksUnderScope(
     const res = await request.get(`${API_BASE}/api/works`, { headers });
     expect(res.status(), `list works body=${await res.text().catch(() => '')}`).toBe(200);
     return res.json();
+}
+
+interface ActiveScope {
+    tenantId: string | null;
+    organizationId: string | null;
+    organizationSlug: string | null;
+}
+
+async function setActiveScope(
+    request: APIRequestContext,
+    token: string,
+    organizationSlug: string | null,
+): Promise<ActiveScope> {
+    const response = await request.post(`${API_BASE}/api/users/me/scope`, {
+        headers: authedHeaders(token),
+        data: { organizationSlug },
+    });
+    expect(response.status(), `set scope body=${await response.text().catch(() => '')}`).toBe(200);
+    return response.json();
+}
+
+async function getActiveScope(request: APIRequestContext, token: string): Promise<ActiveScope> {
+    const response = await request.get(`${API_BASE}/api/users/me/scope`, {
+        headers: authedHeaders(token),
+    });
+    expect(response.status(), `get scope body=${await response.text().catch(() => '')}`).toBe(200);
+    return response.json();
 }
 
 test.describe('Org switch -> context propagation', () => {
@@ -290,11 +316,10 @@ test.describe('Org switch -> context propagation', () => {
         expect((await resolve.json()).id).toBe(orgA.id);
     });
 
-    test('lastScopeOrganizationId + org membership persist across a fresh login; login DTO rejects extra fields', async ({
+    test('selected Organization persists across a fresh login and stamps headerless writes', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
-        // First org create pins lastScopeOrganizationId = orgA on the User row.
         const orgA = await createOrganizationViaAPI(
             request,
             user.access_token,
@@ -306,9 +331,12 @@ test.describe('Org switch -> context propagation', () => {
             `Persist B ${Date.now()}`,
         );
 
-        // A work stamped with A's scope before re-login.
-        const wA = await createWorkUnderScope(request, user.access_token, orgA.slug, 'persist-A');
-        expect(wA.organizationId).toBe(orgA.id);
+        const selected = await setActiveScope(request, user.access_token, orgB.slug);
+        expect(selected).toEqual({
+            tenantId: orgB.tenantId,
+            organizationId: orgB.id,
+            organizationSlug: orgB.slug,
+        });
 
         // Re-login: the login DTO is whitelisted to { email, password } ONLY.
         const badLogin = await request.post(`${API_BASE}/api/auth/login`, {
@@ -329,78 +357,107 @@ test.describe('Org switch -> context propagation', () => {
         expect(orgIds).toContain(orgA.id);
         expect(orgIds).toContain(orgB.id);
 
-        // On the fresh token, the previously-A-stamped work is still readable by
-        // id and still carries A — the persisted scope wasn't reset by re-login.
-        const reread = await request.get(`${API_BASE}/api/works/${wA.id}`, {
-            headers: authedHeaders(freshToken),
-        });
-        expect(reread.status()).toBe(200);
-        expect(((await reread.json())?.work as WorkRow)?.organizationId).toBe(orgA.id);
+        expect(await getActiveScope(request, freshToken)).toEqual(selected);
 
-        // And the fresh session can still switch scope to A and write into A.
-        const wA2 = await createWorkUnderScope(request, freshToken, orgA.slug, 'persist-A-2');
-        expect(wA2.organizationId).toBe(orgA.id);
+        // No X-Scope-Slug: SessionScopeGuard must seed the persisted scope.
+        const wB = await createWorkUnderScope(request, freshToken, null, 'persist-B-headerless');
+        expect(wB.organizationId).toBe(orgB.id);
+        expect(wB.tenantId).toBe(orgB.tenantId);
     });
 
-    test('UI active-org switch: the SPA stores the active org slug and the propagated X-Scope-Slug WRITE stamps the matching org (A<->B)', async ({
-        page,
+    test('unknown and foreign scope selection fail closed without changing the persisted Organization', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const owned = await createOrganizationViaAPI(
+            request,
+            owner.access_token,
+            `Owned ${Date.now()}`,
+        );
+        await setActiveScope(request, owner.access_token, owned.slug);
+
+        const unknown = await request.post(`${API_BASE}/api/users/me/scope`, {
+            headers: authedHeaders(owner.access_token),
+            data: { organizationSlug: `unknown-${Date.now().toString(36)}` },
+        });
+        expect(unknown.status()).toBe(404);
+        expect(await getActiveScope(request, owner.access_token)).toMatchObject({
+            organizationId: owned.id,
+            organizationSlug: owned.slug,
+        });
+
+        const stranger = await registerUserViaAPI(request);
+        const foreign = await createOrganizationViaAPI(
+            request,
+            stranger.access_token,
+            `Foreign ${Date.now()}`,
+        );
+        const rejected = await request.post(`${API_BASE}/api/users/me/scope`, {
+            headers: authedHeaders(owner.access_token),
+            data: { organizationSlug: foreign.slug },
+        });
+        expect(rejected.status()).toBe(404);
+        expect(await getActiveScope(request, owner.access_token)).toMatchObject({
+            organizationId: owned.id,
+            organizationSlug: owned.slug,
+        });
+    });
+
+    test('real WorkspaceSwitcher click persists, safely resolves the slug URL, and governs a headerless write', async ({
+        browser,
         request,
         baseURL,
     }) => {
-        // Seed two orgs through the SEEDED user so the browser session and the API
-        // session line up.
-        const s = loadSeededTestUser();
-        const login = await request.post(`${API_BASE}/api/auth/login`, {
-            data: { email: s.email, password: s.password },
+        test.setTimeout(120_000);
+        const fresh = await registerUserViaAPI(request);
+        const token = fresh.access_token;
+        await request
+            .post(`${API_BASE}/api/onboarding/dismiss`, { headers: authedHeaders(token) })
+            .catch(() => {});
+        const orgA = await createOrganizationViaAPI(request, token, `UI A ${Date.now()}`);
+        const orgB = await createOrganizationViaAPI(request, token, `UI B ${Date.now()}`);
+        await setActiveScope(request, token, orgA.slug);
+
+        const context: BrowserContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
         });
-        expect(login.status(), `seeded login body=${await login.text().catch(() => '')}`).toBe(200);
-        const { access_token } = await login.json();
-        expect(access_token).toBeTruthy();
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: fresh.email, password: fresh.password });
+            await gotoDashboardWithSwitcher(page, baseURL);
 
-        const orgA = await createOrganizationViaAPI(request, access_token, `UI A ${Date.now()}`);
-        const orgB = await createOrganizationViaAPI(request, access_token, `UI B ${Date.now()}`);
+            const persistedRequest = page.waitForRequest(
+                (candidate) =>
+                    candidate.method() === 'POST' &&
+                    new URL(candidate.url()).pathname === '/api/users/me/scope',
+            );
+            const compatibilityNavigation = page.waitForRequest(
+                (candidate) =>
+                    candidate.method() === 'GET' &&
+                    new URL(candidate.url()).pathname === `/${orgB.slug}/dashboard`,
+            );
+            await selectOrganizationInSwitcher(page, orgB.displayName);
 
-        const myOrgIds = (await listOrganizationsViaAPI(request, access_token)).map((o) => o.id);
-        expect(myOrgIds).toContain(orgA.id);
-        expect(myOrgIds).toContain(orgB.id);
+            expect((await persistedRequest).postDataJSON()).toEqual({
+                organizationSlug: orgB.slug,
+            });
+            await compatibilityNavigation;
+            await expect(page).toHaveURL(/\/$/, { timeout: 90_000 });
+            await expect(
+                page
+                    .getByRole('button', { name: 'Switch Organization' })
+                    .getByText(orgB.displayName),
+            ).toBeVisible();
 
-        // Load the app (authenticated via storageState) and simulate the
-        // switcher's effect: the SPA persists the active org slug in localStorage,
-        // from which its fetch wrapper derives X-Scope-Slug (see
-        // scope-resolver.middleware.ts docblock).
-        const origin = new URL(baseURL ?? 'http://localhost:3000').origin;
-        await page.goto(origin + '/', { waitUntil: 'domcontentloaded' });
-
-        await page.evaluate(
-            (slug) => window.localStorage.setItem('activeOrgSlug', slug),
-            orgA.slug,
-        );
-        const storedA = await page.evaluate(() => window.localStorage.getItem('activeOrgSlug'));
-        expect(storedA).toBe(orgA.slug);
-
-        // A write using that stored slug as the propagated header is stamped with A.
-        const wA = await createWorkUnderScope(request, access_token, storedA, 'ui-A');
-        expect(wA.organizationId).toBe(orgA.id);
-
-        // Re-point the switcher to B in the browser and confirm propagation flips:
-        // the next write is stamped with B.
-        await page.evaluate(
-            (slug) => window.localStorage.setItem('activeOrgSlug', slug),
-            orgB.slug,
-        );
-        const storedB = await page.evaluate(() => window.localStorage.getItem('activeOrgSlug'));
-        expect(storedB).toBe(orgB.slug);
-        const wB = await createWorkUnderScope(request, access_token, storedB, 'ui-B');
-        expect(wB.organizationId).toBe(orgB.id);
-        expect(wB.organizationId).not.toBe(wA.organizationId);
-
-        // Best-effort: a native org switcher control may be present in the shell
-        // (the deep dropdown interaction is owned by organization-create-switch.spec.ts).
-        const switcher = page.getByRole('button', { name: 'Switch Organization' }).first();
-        if (await switcher.count()) {
-            await expect(switcher)
-                .toBeVisible({ timeout: 15000 })
-                .catch(() => {});
+            expect(await getActiveScope(request, token)).toMatchObject({
+                organizationId: orgB.id,
+                organizationSlug: orgB.slug,
+            });
+            const scoped = await createWorkUnderScope(request, token, null, 'ui-real-switch');
+            expect(scoped.organizationId).toBe(orgB.id);
+            expect(scoped.organizationId).not.toBe(orgA.id);
+        } finally {
+            await context.close();
         }
     });
 });

--- a/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
+++ b/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
@@ -216,7 +216,6 @@ test.describe('Organization workspace request authority', () => {
             await everPage.goto(`/org/${ever.slug}/missions/new`, {
                 waitUntil: 'load',
             });
-            await everPage.locator('#new-mission-title').fill(missionTitle);
             await everPage
                 .locator('#new-mission-description')
                 .fill('This Mission must remain stamped in the Ever workspace.');
@@ -224,6 +223,11 @@ test.describe('Organization workspace request authority', () => {
                 '[data-testid="new-mission-form"] button[type="submit"]',
             );
             await expect(createMissionButton).toBeEnabled({ timeout: 30_000 });
+            // The enabled state is a user-visible hydration signal for this
+            // controlled form. Enter the title afterwards so a cold page load
+            // cannot leave only the DOM value updated while React state stays
+            // empty and the API derives a different title.
+            await everPage.locator('#new-mission-title').fill(missionTitle);
             await createMissionButton.click();
             await expect(everPage).toHaveURL(
                 new RegExp(`/org/${ever.slug}/missions/[0-9a-f-]+$`, 'i'),

--- a/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
+++ b/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type APIRequestContext, type BrowserContext } from '@playwright/test';
+import { expect, test, type APIRequestContext, type BrowserContext } from '@playwright/test';
 import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
 import { loginViaUI } from './helpers/auth';
 import {
@@ -6,125 +6,10 @@ import {
     gotoDashboardWithSwitcher,
     listOrganizationsViaAPI,
     selectOrganizationInSwitcher,
+    type Organization,
 } from './helpers/organizations';
 
-/**
- * ORG SWITCH -> CONTEXT PROPAGATION (deep integration)
- *
- * Theme: switching the active Organization must propagate into every
- * subsequent scoped WRITE (the new resource is stamped with the active org);
- * a resource stamped under A carries A's org id while B-scoped writes carry
- * B's; switching back resumes A-stamping; and the user's
- * `lastScopeOrganizationId` persists across a fresh login. Cross-tenant scope
- * spoofing is rejected.
- *
- * ──────────────────────────────────────────────────────────────────────────
- * THE REAL SWITCH MECHANISM:
- *
- *   - There is NO `POST /api/organizations/switch` and NO
- *     `GET /api/organizations/current` route. The organizations controller
- *     (apps/api/src/organizations/organizations.controller.ts) exposes ONLY:
- *       POST   /api/organizations               { name, slug? } -> 201
- *       POST   /api/organizations/register-company
- *       GET    /api/organizations               -> 200 [orgs in caller's Tenant]
- *       GET    /api/organizations/check-slug
- *       GET    /api/organizations/:slug         -> 200 GLOBAL resolver (any authed user)
- *       PATCH  /api/organizations/:id
- *       POST   /api/organizations/:id/upgrade-from-account
- *
- *   - The switcher POSTs the chosen slug to `/api/users/me/scope`; the API
- *     validates ownership and persists `users.lastScopeOrganizationId`.
- *   - The active scope is resolved SERVER-SIDE by ScopeResolverMiddleware
- *     plus SessionScopeGuard:
- *       1. `X-Scope-Slug: <orgSlug>` request header for explicit API clients.
- *       2. else the first `/{slug}/...` URL path segment.
- *       3. else SessionScopeGuard seeds the persisted Organization scope.
- *     An UNKNOWN slug in X-Scope-Slug -> middleware throws NotFoundException
- *     -> 404. A slug belonging to ANOTHER tenant -> resolves, but the
- *     ScopeOwnershipGuard rejects it for this user -> 403.
- *
- *   - Explicit `X-Scope-Slug` remains supported for API clients, but the real
- *     browser switch no longer relies on synthetic localStorage plumbing.
- *
- * PROBED FACTS the assertions below rely on (ALL verified live, 2026-06-01):
- *   - POST /api/works (X-Scope-Slug: A) -> 200 { status:'success',
- *       work:{ id, organizationId === A.id, tenantId === A.tenantId } }.
- *       With X-Scope-Slug: B the new work's organizationId === B.id. Switching
- *       back to A stamps A again. THIS is the propagation contract.
- *   - GET /api/works is OWNER-scoped, NOT org-filtered: under ANY active scope
- *       it returns ALL of the owner's works (both A's and B's). So the
- *       per-org "invisibility" lives in each row's stamped organizationId, not
- *       in a filtered list. (Truthful probed behavior — see DEVIATION below.)
- *   - GET /api/works/:id is OWNER-scoped: 200 across any active scope, org id
- *       on the row is unchanged by the switch (the resource is not re-homed).
- *   - A FOREIGN user (different tenant) sending org A's slug in X-Scope-Slug
- *       -> 403 (ScopeOwnershipGuard) — cross-tenant scope spoofing is blocked.
- *   - An UNKNOWN X-Scope-Slug -> 404 (ScopeResolverMiddleware NotFoundException).
- *   - GET /api/organizations/:slug is a GLOBAL resolver -> 200 for any authed user.
- *   - login DTO accepts ONLY { email, password } (extra { name } -> 400);
- *     lastScopeOrganizationId + org membership survive a fresh login.
- *
- * TRUTHFUL DEVIATION (probed, asserted as-is, NOT a fictional contract):
- *   The task title implies that "resources created under org A are invisible
- *   under org B" via a filtered list. In THIS build the works LIST is purely
- *   owner-scoped and does NOT filter by the active org, so two same-owner orgs
- *   share one visible list. The genuine org-isolation signal is the per-row
- *   `organizationId` stamp (verified) plus the cross-TENANT 403. This spec
- *   asserts the real signal and never claims a non-existent list filter.
- *
- * GOTCHAS honoured: mutations run on FRESH registerUserViaAPI() users (cross-
- * spec isolation); the seeded user (storageState) is only touched for the
- * UI flow; unique Date.now suffixes; assert toContain/membership,
- * never exact counts; flow- filename is safe vs the no-auth testIgnore regex.
- */
-
-interface WorkRow {
-    id: string;
-    organizationId: string | null;
-    tenantId: string | null;
-    userId?: string;
-}
-
-const works = (body: unknown): WorkRow[] =>
-    (body as { works?: WorkRow[] })?.works ?? (Array.isArray(body) ? (body as WorkRow[]) : []);
-const workIds = (body: unknown): string[] =>
-    works(body)
-        .map((w) => w.id)
-        .filter(Boolean);
-
-/** POST /api/works under a given active org scope (via X-Scope-Slug). */
-async function createWorkUnderScope(
-    request: APIRequestContext,
-    token: string,
-    scopeSlug: string | null,
-    name: string,
-): Promise<WorkRow> {
-    const headers: Record<string, string> = { ...authedHeaders(token) };
-    if (scopeSlug) headers['X-Scope-Slug'] = scopeSlug;
-    const slug = `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-    const res = await request.post(`${API_BASE}/api/works`, {
-        headers,
-        data: { name, slug, description: `e2e ${name}`, organization: false },
-    });
-    // Probed: POST /api/works returns 200 (not 201) with { status:'success', work:{…} }.
-    expect(res.status(), `create work body=${await res.text().catch(() => '')}`).toBe(200);
-    const body = await res.json();
-    expect(body.status).toBe('success');
-    return body.work as WorkRow;
-}
-
-/** GET /api/works under a given active org scope (via X-Scope-Slug). */
-async function listWorksUnderScope(
-    request: APIRequestContext,
-    token: string,
-    scopeSlug: string | null,
-): Promise<unknown> {
-    const headers: Record<string, string> = { ...authedHeaders(token) };
-    if (scopeSlug) headers['X-Scope-Slug'] = scopeSlug;
-    const res = await request.get(`${API_BASE}/api/works`, { headers });
-    expect(res.status(), `list works body=${await res.text().catch(() => '')}`).toBe(200);
-    return res.json();
-}
+const PERSONAL_SCOPE = '@personal';
 
 interface ActiveScope {
     tenantId: string | null;
@@ -132,7 +17,21 @@ interface ActiveScope {
     organizationSlug: string | null;
 }
 
-async function setActiveScope(
+interface MissionRow {
+    id: string;
+    title: string;
+    tenantId: string | null;
+    organizationId: string | null;
+}
+
+function scopedHeaders(token: string, scope: string | null): Record<string, string> {
+    return {
+        ...authedHeaders(token),
+        ...(scope === null ? {} : { 'X-Scope-Slug': scope }),
+    };
+}
+
+async function setLoginDefault(
     request: APIRequestContext,
     token: string,
     organizationSlug: string | null,
@@ -145,7 +44,7 @@ async function setActiveScope(
     return response.json();
 }
 
-async function getActiveScope(request: APIRequestContext, token: string): Promise<ActiveScope> {
+async function getLoginDefault(request: APIRequestContext, token: string): Promise<ActiveScope> {
     const response = await request.get(`${API_BASE}/api/users/me/scope`, {
         headers: authedHeaders(token),
     });
@@ -153,219 +52,227 @@ async function getActiveScope(request: APIRequestContext, token: string): Promis
     return response.json();
 }
 
-test.describe('Org switch -> context propagation', () => {
-    test('switching active org via X-Scope-Slug propagates into subsequent scoped WRITES (A -> B -> A)', async ({
+async function createMission(
+    request: APIRequestContext,
+    token: string,
+    scope: string | null,
+    title: string,
+): Promise<MissionRow> {
+    const response = await request.post(`${API_BASE}/api/me/missions`, {
+        headers: scopedHeaders(token, scope),
+        data: {
+            title,
+            description: `Workspace isolation coverage for ${title}`,
+            type: 'one-shot',
+        },
+    });
+    expect(
+        response.status(),
+        `create Mission (${String(scope)}) body=${await response.text().catch(() => '')}`,
+    ).toBe(201);
+    return response.json();
+}
+
+async function findMission(
+    request: APIRequestContext,
+    token: string,
+    scope: string,
+    title: string,
+): Promise<MissionRow | undefined> {
+    const response = await request.get(`${API_BASE}/api/me/missions`, {
+        headers: scopedHeaders(token, scope),
+    });
+    expect(response.status(), `list Mission body=${await response.text().catch(() => '')}`).toBe(
+        200,
+    );
+    const rows = (await response.json()) as MissionRow[];
+    return rows.find((row) => row.title === title);
+}
+
+async function expectSwitcherSelection(
+    context: BrowserContext,
+    page: Awaited<ReturnType<BrowserContext['newPage']>>,
+    displayName: string,
+): Promise<void> {
+    await expect(
+        page.getByRole('button', { name: 'Switch Organization' }).getByText(displayName),
+    ).toBeVisible({ timeout: 30_000 });
+    expect(context.pages()).toContain(page);
+}
+
+test.describe('Organization workspace request authority', () => {
+    test.describe.configure({ timeout: 150_000 });
+
+    test('parallel Ever, Yo, personal, and headerless creates keep exact request-local stamps', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
-        const orgA = await createOrganizationViaAPI(
-            request,
-            user.access_token,
-            `Switch A ${Date.now()}`,
-        );
-        const orgB = await createOrganizationViaAPI(
-            request,
-            user.access_token,
-            `Switch B ${Date.now()}`,
-        );
-        expect(orgA.id).not.toBe(orgB.id);
-        // Both orgs share the one lazily-minted tenant.
-        expect(orgA.tenantId).toBeTruthy();
-        expect(orgB.tenantId).toBe(orgA.tenantId);
+        const suffix = Date.now().toString(36);
+        const ever = await createOrganizationViaAPI(request, user.access_token, `Ever ${suffix}`);
+        const yo = await createOrganizationViaAPI(request, user.access_token, `Yo ${suffix}`);
 
-        // Switch active org -> A: a write is stamped with A.
-        const wA = await createWorkUnderScope(request, user.access_token, orgA.slug, 'work-in-A');
-        expect(wA.organizationId).toBe(orgA.id);
-        expect(wA.tenantId).toBe(orgA.tenantId);
+        // Deliberately make the mutable preference disagree with the first
+        // request. It is a future-login default, never request authority.
+        await setLoginDefault(request, user.access_token, yo.slug);
+        const sharedTitle = `parallel-same-title-${suffix}`;
 
-        // Switch active org -> B: the very next write is stamped with B, not A.
-        const wB = await createWorkUnderScope(request, user.access_token, orgB.slug, 'work-in-B');
-        expect(wB.organizationId).toBe(orgB.id);
-        expect(wB.organizationId).not.toBe(orgA.id);
+        const [everMission, yoMission, personalMission, headerlessMission] = await Promise.all([
+            createMission(request, user.access_token, ever.slug, sharedTitle),
+            createMission(request, user.access_token, yo.slug, sharedTitle),
+            createMission(request, user.access_token, PERSONAL_SCOPE, sharedTitle),
+            createMission(request, user.access_token, null, sharedTitle),
+        ]);
 
-        // Switch back -> A: writes resume being stamped with A.
-        const wA2 = await createWorkUnderScope(
-            request,
-            user.access_token,
-            orgA.slug,
-            'work-in-A-again',
-        );
-        expect(wA2.organizationId).toBe(orgA.id);
+        expect(everMission).toMatchObject({
+            tenantId: ever.tenantId,
+            organizationId: ever.id,
+        });
+        expect(yoMission).toMatchObject({ tenantId: yo.tenantId, organizationId: yo.id });
+        expect(personalMission).toMatchObject({
+            tenantId: ever.tenantId,
+            organizationId: null,
+        });
+        expect(headerlessMission).toMatchObject({
+            tenantId: ever.tenantId,
+            organizationId: null,
+        });
+        expect(
+            new Set([everMission.id, yoMission.id, personalMission.id, headerlessMission.id]),
+        ).toHaveLength(4);
     });
 
-    test('per-row org stamping is the isolation signal: A-scoped and B-scoped resources keep their own org id; switch-back stamps A again', async ({
+    test('two browser sessions stay isolated when Yo changes the login default and Ever mutates later', async ({
+        browser,
+        request,
+        baseURL,
+    }) => {
+        const user = await registerUserViaAPI(request);
+        const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+        await request
+            .post(`${API_BASE}/api/onboarding/dismiss`, {
+                headers: authedHeaders(user.access_token),
+            })
+            .catch(() => {});
+        const ever = await createOrganizationViaAPI(
+            request,
+            user.access_token,
+            `Ever Session ${suffix}`,
+        );
+        const yo = await createOrganizationViaAPI(
+            request,
+            user.access_token,
+            `Yo Session ${suffix}`,
+        );
+        await setLoginDefault(request, user.access_token, ever.slug);
+
+        const everContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const yoContext = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const everPage = await everContext.newPage();
+        const yoPage = await yoContext.newPage();
+
+        try {
+            await loginViaUI(everPage, { email: user.email, password: user.password });
+            await loginViaUI(yoPage, { email: user.email, password: user.password });
+            await expect(everPage).toHaveURL(`/org/${ever.slug}/dashboard`);
+            await expect(yoPage).toHaveURL(`/org/${ever.slug}/dashboard`);
+            await gotoDashboardWithSwitcher(everPage, baseURL, '/dashboard');
+            await gotoDashboardWithSwitcher(yoPage, baseURL, '/dashboard');
+
+            const persistedRequest = yoPage.waitForRequest(
+                (candidate) =>
+                    candidate.method() === 'POST' &&
+                    new URL(candidate.url()).pathname === '/api/users/me/scope',
+            );
+            const canonicalNavigation = yoPage.waitForRequest(
+                (candidate) =>
+                    candidate.method() === 'GET' &&
+                    new URL(candidate.url()).pathname === `/org/${yo.slug}/dashboard`,
+            );
+            await selectOrganizationInSwitcher(yoPage, yo.displayName);
+
+            const persisted = await persistedRequest;
+            expect(persisted.postDataJSON()).toEqual({ organizationSlug: yo.slug });
+            expect(persisted.headers()['x-ever-workspace']).toBe(`org:${ever.slug}`);
+            await canonicalNavigation;
+            await expect(yoPage).toHaveURL(`/org/${yo.slug}/dashboard`);
+            await expectSwitcherSelection(yoContext, yoPage, yo.displayName);
+
+            // The account-wide preference changed, but the other session's
+            // visible URL remains authoritative, including after a reload.
+            await expect(everPage).toHaveURL(`/org/${ever.slug}/dashboard`);
+            await everPage.reload({ waitUntil: 'domcontentloaded' });
+            await expect(everPage).toHaveURL(`/org/${ever.slug}/dashboard`);
+            await expectSwitcherSelection(everContext, everPage, ever.displayName);
+            expect(await getLoginDefault(request, user.access_token)).toMatchObject({
+                organizationId: yo.id,
+                organizationSlug: yo.slug,
+            });
+
+            // A server-action mutation from the old Ever session must use the
+            // current request path, not the now-Yo login preference.
+            const missionTitle = `ever-after-yo-switch-${suffix}`;
+            await everPage.goto(`/org/${ever.slug}/missions/new`, {
+                waitUntil: 'domcontentloaded',
+            });
+            await everPage.locator('#new-mission-title').fill(missionTitle);
+            await everPage
+                .locator('#new-mission-description')
+                .fill('This Mission must remain stamped in the Ever workspace.');
+            await everPage
+                .locator('[data-testid="new-mission-form"] button[type="submit"]')
+                .click();
+            await expect(everPage).toHaveURL(
+                new RegExp(`/org/${ever.slug}/missions/[0-9a-f-]+$`, 'i'),
+                { timeout: 90_000 },
+            );
+
+            await expect
+                .poll(
+                    async () =>
+                        (await findMission(request, user.access_token, ever.slug, missionTitle))
+                            ?.organizationId,
+                    { timeout: 30_000 },
+                )
+                .toBe(ever.id);
+            await expect(yoPage).toHaveURL(`/org/${yo.slug}/dashboard`);
+        } finally {
+            await Promise.all([everContext.close(), yoContext.close()]);
+        }
+    });
+
+    test('fresh login hydrates the preference, while explicit personal remains personal', async ({
+        browser,
         request,
     }) => {
         const user = await registerUserViaAPI(request);
-        const orgA = await createOrganizationViaAPI(
+        const org = await createOrganizationViaAPI(
             request,
             user.access_token,
-            `Iso A ${Date.now()}`,
+            `Login ${Date.now()}`,
         );
-        const orgB = await createOrganizationViaAPI(
+        await setLoginDefault(request, user.access_token, org.slug);
+
+        const personal = await createMission(
             request,
             user.access_token,
-            `Iso B ${Date.now()}`,
+            PERSONAL_SCOPE,
+            `personal-after-${org.slug}`,
         );
+        expect(personal).toMatchObject({ tenantId: org.tenantId, organizationId: null });
 
-        const wA = await createWorkUnderScope(request, user.access_token, orgA.slug, 'iso-A');
-        const wB = await createWorkUnderScope(request, user.access_token, orgB.slug, 'iso-B');
-        const wA2 = await createWorkUnderScope(request, user.access_token, orgA.slug, 'iso-A-2');
-
-        // Each resource carries the org that was active when it was written.
-        expect(wA.organizationId).toBe(orgA.id);
-        expect(wB.organizationId).toBe(orgB.id);
-        expect(wA2.organizationId).toBe(orgA.id); // switch-back resumed A-stamping
-        // A-scoped rows are distinguishable from B-scoped rows by org id.
-        expect(wA.organizationId).not.toBe(wB.organizationId);
-
-        // The owner's list (owner-scoped, NOT org-filtered) contains all three;
-        // the org boundary is visible PER ROW, not by the list omitting rows.
-        const all = await listWorksUnderScope(request, user.access_token, orgA.slug);
-        const rows = works(all);
-        const byId = new Map(rows.map((w) => [w.id, w]));
-        expect(byId.get(wA.id)?.organizationId).toBe(orgA.id);
-        expect(byId.get(wB.id)?.organizationId).toBe(orgB.id);
-        expect(byId.get(wA2.id)?.organizationId).toBe(orgA.id);
-
-        // Switching the active scope does NOT re-home already-written rows:
-        // re-reading the same set under scope B leaves every org id unchanged.
-        const allUnderB = await listWorksUnderScope(request, user.access_token, orgB.slug);
-        const byIdB = new Map(works(allUnderB).map((w) => [w.id, w]));
-        expect(byIdB.get(wA.id)?.organizationId).toBe(orgA.id);
-        expect(byIdB.get(wB.id)?.organizationId).toBe(orgB.id);
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: user.email, password: user.password });
+            await expect(page).toHaveURL(`/org/${org.slug}/dashboard`);
+        } finally {
+            await context.close();
+        }
     });
 
-    test('a work stays readable BY ID across org switches and keeps its original org id (findOne is owner-scoped)', async ({
-        request,
-    }) => {
-        const user = await registerUserViaAPI(request);
-        const orgA = await createOrganizationViaAPI(
-            request,
-            user.access_token,
-            `ById A ${Date.now()}`,
-        );
-        const orgB = await createOrganizationViaAPI(
-            request,
-            user.access_token,
-            `ById B ${Date.now()}`,
-        );
-
-        const wA = await createWorkUnderScope(request, user.access_token, orgA.slug, 'byid');
-        expect(wA.organizationId).toBe(orgA.id);
-
-        // A direct GET /works/:id is owner-scoped and resolves even with B as the
-        // active scope; its organizationId stays A — the switch never re-homes it.
-        const byId = await request.get(`${API_BASE}/api/works/${wA.id}`, {
-            headers: { ...authedHeaders(user.access_token), 'X-Scope-Slug': orgB.slug },
-        });
-        expect(byId.status()).toBe(200);
-        const fetched = await byId.json();
-        const work = (fetched?.work ?? fetched) as WorkRow;
-        expect(work.id).toBe(wA.id);
-        expect(work.organizationId).toBe(orgA.id);
-
-        // And reading it back under A's scope gives the identical org id.
-        const byIdA = await request.get(`${API_BASE}/api/works/${wA.id}`, {
-            headers: { ...authedHeaders(user.access_token), 'X-Scope-Slug': orgA.slug },
-        });
-        expect(byIdA.status()).toBe(200);
-        expect(((await byIdA.json())?.work as WorkRow)?.organizationId).toBe(orgA.id);
-    });
-
-    test('cross-tenant scope spoofing is rejected (403); unknown scope slug is 404; get-by-slug stays a global 200', async ({
-        request,
-    }) => {
-        // Owner builds an org with a scoped resource.
-        const owner = await registerUserViaAPI(request);
-        const orgA = await createOrganizationViaAPI(
-            request,
-            owner.access_token,
-            `Foreign A ${Date.now()}`,
-        );
-        const wA = await createWorkUnderScope(request, owner.access_token, orgA.slug, 'foreign-A');
-        expect(wA.organizationId).toBe(orgA.id);
-
-        // A different user (different tenant) tries to "switch into" orgA via its
-        // slug. The slug resolves (global namespace) but ScopeOwnershipGuard sees
-        // it belongs to another tenant -> 403. Cross-tenant spoofing blocked.
-        const stranger = await registerUserViaAPI(request);
-        const spoof = await request.get(`${API_BASE}/api/works`, {
-            headers: { ...authedHeaders(stranger.access_token), 'X-Scope-Slug': orgA.slug },
-        });
-        expect(spoof.status()).toBe(403);
-
-        // An UNKNOWN scope slug doesn't resolve at all -> the middleware 404s.
-        const unknown = await request.get(`${API_BASE}/api/works`, {
-            headers: {
-                ...authedHeaders(stranger.access_token),
-                'X-Scope-Slug': `no-such-org-${Date.now().toString(36)}`,
-            },
-        });
-        expect(unknown.status()).toBe(404);
-
-        // GET /api/organizations/:slug, however, IS a global resolver -> 200 even
-        // for the stranger (it backs the Phase-7 slug middleware + deep links).
-        // The real authorization boundary is the SCOPED request (403 above), not
-        // get-by-slug.
-        const resolve = await request.get(
-            `${API_BASE}/api/organizations/${encodeURIComponent(orgA.slug)}`,
-            { headers: authedHeaders(stranger.access_token) },
-        );
-        expect(resolve.status()).toBe(200);
-        expect((await resolve.json()).id).toBe(orgA.id);
-    });
-
-    test('selected Organization persists across a fresh login and stamps headerless writes', async ({
-        request,
-    }) => {
-        const user = await registerUserViaAPI(request);
-        const orgA = await createOrganizationViaAPI(
-            request,
-            user.access_token,
-            `Persist A ${Date.now()}`,
-        );
-        const orgB = await createOrganizationViaAPI(
-            request,
-            user.access_token,
-            `Persist B ${Date.now()}`,
-        );
-
-        const selected = await setActiveScope(request, user.access_token, orgB.slug);
-        expect(selected).toEqual({
-            tenantId: orgB.tenantId,
-            organizationId: orgB.id,
-            organizationSlug: orgB.slug,
-        });
-
-        // Re-login: the login DTO is whitelisted to { email, password } ONLY.
-        const badLogin = await request.post(`${API_BASE}/api/auth/login`, {
-            data: { email: user.email, password: user.password, name: 'nope' },
-        });
-        expect(badLogin.status(), 'extra {name} on login DTO must 400').toBe(400);
-
-        const relogin = await request.post(`${API_BASE}/api/auth/login`, {
-            data: { email: user.email, password: user.password },
-        });
-        expect(relogin.status()).toBe(200);
-        const freshToken = (await relogin.json()).access_token;
-        expect(freshToken).toBeTruthy();
-
-        // Org membership survives the new session (the Tenant + both orgs outlived it).
-        const orgsAfter = await listOrganizationsViaAPI(request, freshToken);
-        const orgIds = orgsAfter.map((o) => o.id);
-        expect(orgIds).toContain(orgA.id);
-        expect(orgIds).toContain(orgB.id);
-
-        expect(await getActiveScope(request, freshToken)).toEqual(selected);
-
-        // No X-Scope-Slug: SessionScopeGuard must seed the persisted scope.
-        const wB = await createWorkUnderScope(request, freshToken, null, 'persist-B-headerless');
-        expect(wB.organizationId).toBe(orgB.id);
-        expect(wB.tenantId).toBe(orgB.tenantId);
-    });
-
-    test('unknown and foreign scope selection fail closed without changing the persisted Organization', async ({
+    test('unknown and foreign selections share opaque 404 parity and do not change the default', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
@@ -374,17 +281,7 @@ test.describe('Org switch -> context propagation', () => {
             owner.access_token,
             `Owned ${Date.now()}`,
         );
-        await setActiveScope(request, owner.access_token, owned.slug);
-
-        const unknown = await request.post(`${API_BASE}/api/users/me/scope`, {
-            headers: authedHeaders(owner.access_token),
-            data: { organizationSlug: `unknown-${Date.now().toString(36)}` },
-        });
-        expect(unknown.status()).toBe(404);
-        expect(await getActiveScope(request, owner.access_token)).toMatchObject({
-            organizationId: owned.id,
-            organizationSlug: owned.slug,
-        });
+        await setLoginDefault(request, owner.access_token, owned.slug);
 
         const stranger = await registerUserViaAPI(request);
         const foreign = await createOrganizationViaAPI(
@@ -392,72 +289,29 @@ test.describe('Org switch -> context propagation', () => {
             stranger.access_token,
             `Foreign ${Date.now()}`,
         );
-        const rejected = await request.post(`${API_BASE}/api/users/me/scope`, {
-            headers: authedHeaders(owner.access_token),
-            data: { organizationSlug: foreign.slug },
-        });
+        const [unknown, rejected] = await Promise.all([
+            request.post(`${API_BASE}/api/users/me/scope`, {
+                headers: authedHeaders(owner.access_token),
+                data: { organizationSlug: `unknown-${Date.now().toString(36)}` },
+            }),
+            request.post(`${API_BASE}/api/users/me/scope`, {
+                headers: authedHeaders(owner.access_token),
+                data: { organizationSlug: foreign.slug },
+            }),
+        ]);
+
+        expect(unknown.status()).toBe(404);
         expect(rejected.status()).toBe(404);
-        expect(await getActiveScope(request, owner.access_token)).toMatchObject({
+        expect((await unknown.json()).message).toBe((await rejected.json()).message);
+        expect(await getLoginDefault(request, owner.access_token)).toMatchObject({
             organizationId: owned.id,
             organizationSlug: owned.slug,
         });
-    });
 
-    test('real WorkspaceSwitcher click persists, safely resolves the slug URL, and governs a headerless write', async ({
-        browser,
-        request,
-        baseURL,
-    }) => {
-        test.setTimeout(120_000);
-        const fresh = await registerUserViaAPI(request);
-        const token = fresh.access_token;
-        await request
-            .post(`${API_BASE}/api/onboarding/dismiss`, { headers: authedHeaders(token) })
-            .catch(() => {});
-        const orgA = await createOrganizationViaAPI(request, token, `UI A ${Date.now()}`);
-        const orgB = await createOrganizationViaAPI(request, token, `UI B ${Date.now()}`);
-        await setActiveScope(request, token, orgA.slug);
-
-        const context: BrowserContext = await browser.newContext({
-            storageState: { cookies: [], origins: [] },
-        });
-        const page = await context.newPage();
-        try {
-            await loginViaUI(page, { email: fresh.email, password: fresh.password });
-            await gotoDashboardWithSwitcher(page, baseURL);
-
-            const persistedRequest = page.waitForRequest(
-                (candidate) =>
-                    candidate.method() === 'POST' &&
-                    new URL(candidate.url()).pathname === '/api/users/me/scope',
-            );
-            const compatibilityNavigation = page.waitForRequest(
-                (candidate) =>
-                    candidate.method() === 'GET' &&
-                    new URL(candidate.url()).pathname === `/${orgB.slug}/dashboard`,
-            );
-            await selectOrganizationInSwitcher(page, orgB.displayName);
-
-            expect((await persistedRequest).postDataJSON()).toEqual({
-                organizationSlug: orgB.slug,
-            });
-            await compatibilityNavigation;
-            await expect(page).toHaveURL(/\/$/, { timeout: 90_000 });
-            await expect(
-                page
-                    .getByRole('button', { name: 'Switch Organization' })
-                    .getByText(orgB.displayName),
-            ).toBeVisible();
-
-            expect(await getActiveScope(request, token)).toMatchObject({
-                organizationId: orgB.id,
-                organizationSlug: orgB.slug,
-            });
-            const scoped = await createWorkUnderScope(request, token, null, 'ui-real-switch');
-            expect(scoped.organizationId).toBe(orgB.id);
-            expect(scoped.organizationId).not.toBe(orgA.id);
-        } finally {
-            await context.close();
-        }
+        const visible = await listOrganizationsViaAPI(request, owner.access_token);
+        expect(visible.map((organization: Organization) => organization.id)).toContain(owned.id);
+        expect(visible.map((organization: Organization) => organization.id)).not.toContain(
+            foreign.id,
+        );
     });
 });

--- a/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
+++ b/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
@@ -214,15 +214,17 @@ test.describe('Organization workspace request authority', () => {
             // current request path, not the now-Yo login preference.
             const missionTitle = `ever-after-yo-switch-${suffix}`;
             await everPage.goto(`/org/${ever.slug}/missions/new`, {
-                waitUntil: 'domcontentloaded',
+                waitUntil: 'load',
             });
             await everPage.locator('#new-mission-title').fill(missionTitle);
             await everPage
                 .locator('#new-mission-description')
                 .fill('This Mission must remain stamped in the Ever workspace.');
-            await everPage
-                .locator('[data-testid="new-mission-form"] button[type="submit"]')
-                .click();
+            const createMissionButton = everPage.locator(
+                '[data-testid="new-mission-form"] button[type="submit"]',
+            );
+            await expect(createMissionButton).toBeEnabled({ timeout: 30_000 });
+            await createMissionButton.click();
             await expect(everPage).toHaveURL(
                 new RegExp(`/org/${ever.slug}/missions/[0-9a-f-]+$`, 'i'),
                 { timeout: 90_000 },

--- a/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
+++ b/apps/web/e2e/flow-org-switch-context-propagation.spec.ts
@@ -137,8 +137,8 @@ test.describe('Organization workspace request authority', () => {
             organizationId: null,
         });
         expect(
-            new Set([everMission.id, yoMission.id, personalMission.id, headerlessMission.id]),
-        ).toHaveLength(4);
+            new Set([everMission.id, yoMission.id, personalMission.id, headerlessMission.id]).size,
+        ).toBe(4);
     });
 
     test('two browser sessions stay isolated when Yo changes the login default and Ever mutates later', async ({
@@ -216,13 +216,17 @@ test.describe('Organization workspace request authority', () => {
             await everPage.goto(`/org/${ever.slug}/missions/new`, {
                 waitUntil: 'load',
             });
-            await everPage
-                .locator('#new-mission-description')
-                .fill('This Mission must remain stamped in the Ever workspace.');
+            const missionDescription = everPage.locator('#new-mission-description');
             const createMissionButton = everPage.locator(
                 '[data-testid="new-mission-form"] button[type="submit"]',
             );
-            await expect(createMissionButton).toBeEnabled({ timeout: 30_000 });
+            await expect(async () => {
+                await missionDescription.fill('');
+                await missionDescription.fill(
+                    'This Mission must remain stamped in the Ever workspace.',
+                );
+                await expect(createMissionButton).toBeEnabled({ timeout: 1_000 });
+            }).toPass({ timeout: 30_000 });
             // The enabled state is a user-visible hydration signal for this
             // controlled form. Enter the title afterwards so a cold page load
             // cannot leave only the DOM value updated while React state stays

--- a/apps/web/e2e/helpers/organizations.ts
+++ b/apps/web/e2e/helpers/organizations.ts
@@ -20,7 +20,7 @@ import { API_BASE, authedHeaders } from './api';
  *     "Move your existing items?" dialog — we pick "Start empty" → "Continue"
  *     (the default "Move existing items" hits a Postgres-only endpoint that
  *     500s on sqlite). 2nd+ orgs persist the scope, visit the validated
- *     /{slug}/dashboard compatibility route, then redirect to the legacy root.
+ *     canonical /org/{slug}/dashboard route and remain in that namespace.
  */
 
 export interface Organization {
@@ -73,7 +73,11 @@ export async function gotoDashboardWithSwitcher(
         { name: 'sidebar-collapsed', value: '0', url: origin },
         { name: 'chat-panel-open', value: '0', url: origin },
     ]);
-    await page.goto(route, { waitUntil: 'domcontentloaded' });
+    const currentPath = new URL(page.url()).pathname;
+    const organizationPrefix = /^\/org\/[^/]+/.exec(currentPath)?.[0] ?? '';
+    const destination =
+        organizationPrefix && !route.startsWith('/org/') ? `${organizationPrefix}${route}` : route;
+    await page.goto(destination, { waitUntil: 'domcontentloaded' });
     await expect(switcherTrigger(page)).toBeVisible({ timeout: 30_000 });
 }
 
@@ -99,7 +103,7 @@ export async function openWorkspaceSwitcher(page: Page): Promise<void> {
 /**
  * Create an Organization through the UI switcher → modal flow. Handles the
  * first-org "Start empty" branch and the 2nd+-org direct-navigation branch.
- * Returns once the validated slug navigation has resolved to the legacy root.
+ * Returns once the canonical Organization navigation has resolved.
  */
 export async function createOrganizationViaUI(page: Page, name: string): Promise<void> {
     await openWorkspaceSwitcher(page);
@@ -121,27 +125,27 @@ export async function createOrganizationViaUI(page: Page, name: string): Promise
         await blank.click();
     }
 
-    // Observe the compatibility navigation so a redirect to `/` cannot make a
-    // broken switch look green merely because the final route happens to load.
-    const compatibilityNavigation = page.waitForRequest((candidate) => {
+    // Observe the canonical navigation so a stale/personal route cannot make a
+    // broken switch look green merely because some dashboard happens to load.
+    const canonicalNavigation = page.waitForRequest((candidate) => {
         return (
             candidate.method() === 'GET' &&
-            /^\/[^/]+\/dashboard$/.test(new URL(candidate.url()).pathname)
+            /^\/org\/[^/]+\/dashboard$/.test(new URL(candidate.url()).pathname)
         );
     });
 
     // Submit via the stable testid (the button label is locale-dependent).
     await page.getByTestId('org-create-submit').click();
 
-    await compatibilityNavigation;
-    await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
+    const request = await canonicalNavigation;
+    const pathname = new URL(request.url()).pathname;
+    await page.waitForURL((url) => url.pathname === pathname, { timeout: 30_000 });
 }
 
 /**
  * Select an existing Organization from the switcher dropdown. The switcher
- * persists the choice before navigating through the validated slug-dashboard
- * compatibility route. The route redirects to `/`; the persisted scope keeps
- * the selected Organization active on the legacy dashboard tree.
+ * persists the preference before navigating to the canonical Organization
+ * dashboard. Correctness comes from that visible per-tab URL, not the write.
  */
 export async function selectOrganizationInSwitcher(page: Page, displayName: string): Promise<void> {
     await openWorkspaceSwitcher(page);

--- a/apps/web/e2e/helpers/organizations.ts
+++ b/apps/web/e2e/helpers/organizations.ts
@@ -19,7 +19,8 @@ import { API_BASE, authedHeaders } from './api';
  *     "Name", submit "Create"). The FIRST org also shows the
  *     "Move your existing items?" dialog — we pick "Start empty" → "Continue"
  *     (the default "Move existing items" hits a Postgres-only endpoint that
- *     500s on sqlite). 2nd+ orgs skip it and navigate to /{slug}/dashboard.
+ *     500s on sqlite). 2nd+ orgs persist the scope, visit the validated
+ *     /{slug}/dashboard compatibility route, then redirect to the legacy root.
  */
 
 export interface Organization {
@@ -98,7 +99,7 @@ export async function openWorkspaceSwitcher(page: Page): Promise<void> {
 /**
  * Create an Organization through the UI switcher → modal flow. Handles the
  * first-org "Start empty" branch and the 2nd+-org direct-navigation branch.
- * Returns once the browser lands on the new org's /{slug}/dashboard.
+ * Returns once the validated slug navigation has resolved to the legacy root.
  */
 export async function createOrganizationViaUI(page: Page, name: string): Promise<void> {
     await openWorkspaceSwitcher(page);
@@ -120,17 +121,27 @@ export async function createOrganizationViaUI(page: Page, name: string): Promise
         await blank.click();
     }
 
+    // Observe the compatibility navigation so a redirect to `/` cannot make a
+    // broken switch look green merely because the final route happens to load.
+    const compatibilityNavigation = page.waitForRequest((candidate) => {
+        return (
+            candidate.method() === 'GET' &&
+            /^\/[^/]+\/dashboard$/.test(new URL(candidate.url()).pathname)
+        );
+    });
+
     // Submit via the stable testid (the button label is locale-dependent).
     await page.getByTestId('org-create-submit').click();
 
-    await page.waitForURL(/\/[^/]+\/dashboard(\?|$)/, { timeout: 30_000 });
+    await compatibilityNavigation;
+    await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
 }
 
 /**
  * Select an existing Organization from the switcher dropdown. The switcher
- * routes to the org's slug-scoped URL (`/{slug}/…`). NB: the slug-scoped
- * dashboard page itself is Phase-7-pending web-side (see use-active-scope.ts),
- * so callers should assert the URL slug, not the destination page content.
+ * persists the choice before navigating through the validated slug-dashboard
+ * compatibility route. The route redirects to `/`; the persisted scope keeps
+ * the selected Organization active on the legacy dashboard tree.
  */
 export async function selectOrganizationInSwitcher(page: Page, displayName: string): Promise<void> {
     await openWorkspaceSwitcher(page);

--- a/apps/web/e2e/organization-create-switch.spec.ts
+++ b/apps/web/e2e/organization-create-switch.spec.ts
@@ -17,16 +17,16 @@ import {
  * the site header." This drives the real WorkspaceSwitcher end-to-end: create
  * two orgs through the modal and confirm both become selectable entries in the
  * header switcher (the "switch" affordance), cross-checked against
- * GET /api/organizations. Selecting an org routes to its slug-scoped URL.
+ * GET /api/organizations. Selecting an org persists the scope and safely
+ * resolves the slug-scoped compatibility URL back to the legacy dashboard.
  *
  * Scope notes:
  *  - Creating the first Organization runs a tenantId backfill that used
  *    Postgres-only `$n` placeholders → 500 under the sqlite e2e DB. Fixed in
  *    organization.service.ts (query-builder placeholders); without it this
  *    flow is impossible on the e2e stack.
- *  - The slug-scoped dashboard page (`/{slug}/dashboard`) is Phase-7-pending
- *    web-side (see apps/web/src/lib/hooks/use-active-scope.ts), so we assert
- *    the switcher LISTS + routes to each org, not the destination page.
+ *  - The narrow slug-scoped compatibility page validates the persisted scope
+ *    and redirects to `/`, keeping the unprefixed dashboard tree stable.
  *  - Runs as a FRESH, isolated user (its own empty-storageState context) rather
  *    than the shared seeded storageState user. The header WorkspaceSwitcher
  *    lists EVERY org the current user owns in a single `overflow-hidden`,
@@ -107,15 +107,22 @@ test.describe('Organizations — create + switch via header', () => {
             expect(names).toContain(alpha);
             expect(names).toContain(beta);
 
-            // 6. Selecting an org from the header routes to that org's slug-scoped URL.
-            await selectOrganizationInSwitcher(page, alpha);
+            // 6. Selection persists before visiting the validated slug route.
             const alphaSlug = (await listOrganizationsViaAPI(request, token)).find(
                 (o) => o.displayName === alpha,
             )?.slug;
             expect(alphaSlug, 'alpha should have a slug').toBeTruthy();
-            // Client soft-nav (router.push) — poll the URL rather than waiting on a
-            // load event.
-            await expect(page).toHaveURL(new RegExp(`/${alphaSlug}(/|$)`), { timeout: 90_000 });
+            const slugNavigation = page.waitForRequest(
+                (candidate) =>
+                    candidate.method() === 'GET' &&
+                    new URL(candidate.url()).pathname === `/${alphaSlug}/dashboard`,
+            );
+            await selectOrganizationInSwitcher(page, alpha);
+            await slugNavigation;
+            await expect(page).toHaveURL(/\/$/, { timeout: 90_000 });
+            await expect(
+                page.getByRole('button', { name: 'Switch Organization' }).getByText(alpha),
+            ).toBeVisible();
         } finally {
             await context.close();
         }

--- a/apps/web/e2e/organization-create-switch.spec.ts
+++ b/apps/web/e2e/organization-create-switch.spec.ts
@@ -18,15 +18,15 @@ import {
  * two orgs through the modal and confirm both become selectable entries in the
  * header switcher (the "switch" affordance), cross-checked against
  * GET /api/organizations. Selecting an org persists the scope and safely
- * resolves the slug-scoped compatibility URL back to the legacy dashboard.
+ * navigates to the canonical Organization dashboard namespace.
  *
  * Scope notes:
  *  - Creating the first Organization runs a tenantId backfill that used
  *    Postgres-only `$n` placeholders → 500 under the sqlite e2e DB. Fixed in
  *    organization.service.ts (query-builder placeholders); without it this
  *    flow is impossible on the e2e stack.
- *  - The narrow slug-scoped compatibility page validates the persisted scope
- *    and redirects to `/`, keeping the unprefixed dashboard tree stable.
+ *  - The visible `/org/{slug}` URL is the per-tab workspace authority; the
+ *    persisted selection is only a future-login default.
  *  - Runs as a FRESH, isolated user (its own empty-storageState context) rather
  *    than the shared seeded storageState user. The header WorkspaceSwitcher
  *    lists EVERY org the current user owns in a single `overflow-hidden`,
@@ -107,19 +107,19 @@ test.describe('Organizations — create + switch via header', () => {
             expect(names).toContain(alpha);
             expect(names).toContain(beta);
 
-            // 6. Selection persists before visiting the validated slug route.
+            // 6. Selection persists before visiting the canonical slug route.
             const alphaSlug = (await listOrganizationsViaAPI(request, token)).find(
                 (o) => o.displayName === alpha,
             )?.slug;
             expect(alphaSlug, 'alpha should have a slug').toBeTruthy();
-            const slugNavigation = page.waitForRequest(
+            const canonicalNavigation = page.waitForRequest(
                 (candidate) =>
                     candidate.method() === 'GET' &&
-                    new URL(candidate.url()).pathname === `/${alphaSlug}/dashboard`,
+                    new URL(candidate.url()).pathname === `/org/${alphaSlug}/dashboard`,
             );
             await selectOrganizationInSwitcher(page, alpha);
-            await slugNavigation;
-            await expect(page).toHaveURL(/\/$/, { timeout: 90_000 });
+            await canonicalNavigation;
+            await expect(page).toHaveURL(`/org/${alphaSlug}/dashboard`, { timeout: 90_000 });
             await expect(
                 page.getByRole('button', { name: 'Switch Organization' }).getByText(alpha),
             ).toBeVisible();

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -95,6 +95,11 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
     output: BUILD_OUTPUT as NextConfig['output'],
+    // Keep the proxy's validated request-origin rewrite intact. Without this,
+    // Next normalizes next-intl's rewrite back to its internal `localhost`
+    // origin; behind a differently named listener/reverse proxy that becomes
+    // an external rewrite and re-enters the proxy.
+    skipProxyUrlNormalize: true,
     // Dev-only (Next ignores this in production builds): let the e2e/CI
     // harness reach the dev server over 127.0.0.1. The self-hosted CI
     // runner resolves `localhost` to IPv6 `::1`, where the dev servers

--- a/apps/web/src/app/[locale]/[slug]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/[slug]/dashboard/page.tsx
@@ -1,34 +1,17 @@
 import { notFound, redirect } from 'next/navigation';
-import type { ActiveScopeResponse } from '@ever-works/contracts/api';
-import { ApiResponseError, serverFetch } from '@/lib/api/server-api';
+import { LOCALES } from '@/lib/constants';
+import { getLegacyOrganizationDashboardRedirect } from '@/lib/workspace-scope';
 
 interface OrganizationDashboardCompatibilityPageProps {
     params: Promise<{ slug: string }>;
 }
 
-/**
- * Compatibility entry point for the canonical Organization dashboard URL.
- * The switch mutation already happened through POST /api/users/me/scope;
- * this GET only validates that persisted state before entering legacy routes.
- */
+/** Server fallback for bookmarks that bypassed the canonical proxy redirect. */
 export default async function OrganizationDashboardCompatibilityPage({
     params,
 }: OrganizationDashboardCompatibilityPageProps) {
     const { slug } = await params;
-
-    let activeScope: ActiveScopeResponse;
-    try {
-        activeScope = await serverFetch<ActiveScopeResponse>('/users/me/scope');
-    } catch (error) {
-        if (error instanceof ApiResponseError && error.statusCode === 404) {
-            notFound();
-        }
-        throw error;
-    }
-
-    if (!activeScope.organizationId || activeScope.organizationSlug !== slug) {
-        notFound();
-    }
-
-    redirect('/');
+    const target = getLegacyOrganizationDashboardRedirect(`/${slug}/dashboard`, LOCALES);
+    if (target === null) notFound();
+    redirect(target);
 }

--- a/apps/web/src/app/[locale]/[slug]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/[slug]/dashboard/page.tsx
@@ -1,11 +1,6 @@
 import { notFound, redirect } from 'next/navigation';
-import { serverFetch } from '@/lib/api/server-api';
-
-interface ActiveScopeResponse {
-    tenantId: string | null;
-    organizationId: string | null;
-    organizationSlug: string | null;
-}
+import type { ActiveScopeResponse } from '@ever-works/contracts/api';
+import { ApiResponseError, serverFetch } from '@/lib/api/server-api';
 
 interface OrganizationDashboardCompatibilityPageProps {
     params: Promise<{ slug: string }>;
@@ -24,8 +19,11 @@ export default async function OrganizationDashboardCompatibilityPage({
     let activeScope: ActiveScopeResponse;
     try {
         activeScope = await serverFetch<ActiveScopeResponse>('/users/me/scope');
-    } catch {
-        notFound();
+    } catch (error) {
+        if (error instanceof ApiResponseError && error.statusCode === 404) {
+            notFound();
+        }
+        throw error;
     }
 
     if (!activeScope.organizationId || activeScope.organizationSlug !== slug) {

--- a/apps/web/src/app/[locale]/[slug]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/[slug]/dashboard/page.tsx
@@ -1,0 +1,36 @@
+import { notFound, redirect } from 'next/navigation';
+import { serverFetch } from '@/lib/api/server-api';
+
+interface ActiveScopeResponse {
+    tenantId: string | null;
+    organizationId: string | null;
+    organizationSlug: string | null;
+}
+
+interface OrganizationDashboardCompatibilityPageProps {
+    params: Promise<{ slug: string }>;
+}
+
+/**
+ * Compatibility entry point for the canonical Organization dashboard URL.
+ * The switch mutation already happened through POST /api/users/me/scope;
+ * this GET only validates that persisted state before entering legacy routes.
+ */
+export default async function OrganizationDashboardCompatibilityPage({
+    params,
+}: OrganizationDashboardCompatibilityPageProps) {
+    const { slug } = await params;
+
+    let activeScope: ActiveScopeResponse;
+    try {
+        activeScope = await serverFetch<ActiveScopeResponse>('/users/me/scope');
+    } catch {
+        notFound();
+    }
+
+    if (!activeScope.organizationId || activeScope.organizationSlug !== slug) {
+        notFound();
+    }
+
+    redirect('/');
+}

--- a/apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts
+++ b/apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { redirectMock, notFoundMock } = vi.hoisted(() => ({
+    redirectMock: vi.fn(() => {
+        throw new Error('NEXT_REDIRECT');
+    }),
+    notFoundMock: vi.fn(() => {
+        throw new Error('NEXT_NOT_FOUND');
+    }),
+}));
+
+vi.mock('next/navigation', () => ({
+    redirect: redirectMock,
+    notFound: notFoundMock,
+}));
+
+vi.mock('@/lib/api/server-api', () => ({
+    serverFetch: vi.fn(),
+}));
+
+import { serverFetch } from '@/lib/api/server-api';
+import OrganizationDashboardCompatibilityPage from './page';
+
+function renderSlug(slug: string) {
+    return OrganizationDashboardCompatibilityPage({ params: Promise.resolve({ slug }) });
+}
+
+describe('/[slug]/dashboard compatibility route', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('validates the persisted active Organization and redirects to the existing root dashboard', async () => {
+        vi.mocked(serverFetch).mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-ever',
+            organizationSlug: 'ever',
+        });
+
+        await expect(renderSlug('ever')).rejects.toThrow('NEXT_REDIRECT');
+        expect(serverFetch).toHaveBeenCalledWith('/users/me/scope');
+        expect(redirectMock).toHaveBeenCalledWith('/');
+        expect(notFoundMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['another Organization is persisted', 'yo-inc'],
+        ['personal scope is persisted', null],
+    ])('fails closed when %s', async (_label, organizationSlug) => {
+        vi.mocked(serverFetch).mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: organizationSlug ? 'another-org' : null,
+            organizationSlug,
+        });
+
+        await expect(renderSlug('ever')).rejects.toThrow('NEXT_NOT_FOUND');
+        expect(notFoundMock).toHaveBeenCalledTimes(1);
+        expect(redirectMock).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the active-scope API cannot validate the session', async () => {
+        vi.mocked(serverFetch).mockRejectedValue(new Error('Unauthorized'));
+
+        await expect(renderSlug('ever')).rejects.toThrow('NEXT_NOT_FOUND');
+        expect(notFoundMock).toHaveBeenCalledTimes(1);
+        expect(redirectMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts
+++ b/apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts
@@ -1,15 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { ApiResponseErrorMock, redirectMock, notFoundMock } = vi.hoisted(() => ({
-    ApiResponseErrorMock: class ApiResponseError extends Error {
-        constructor(
-            message: string,
-            public readonly statusCode: number,
-        ) {
-            super(message);
-            this.name = 'ApiResponseError';
-        }
-    },
+const { redirectMock, notFoundMock } = vi.hoisted(() => ({
     redirectMock: vi.fn(() => {
         throw new Error('NEXT_REDIRECT');
     }),
@@ -18,17 +9,8 @@ const { ApiResponseErrorMock, redirectMock, notFoundMock } = vi.hoisted(() => ({
     }),
 }));
 
-vi.mock('next/navigation', () => ({
-    redirect: redirectMock,
-    notFound: notFoundMock,
-}));
+vi.mock('next/navigation', () => ({ redirect: redirectMock, notFound: notFoundMock }));
 
-vi.mock('@/lib/api/server-api', () => ({
-    ApiResponseError: ApiResponseErrorMock,
-    serverFetch: vi.fn(),
-}));
-
-import { ApiResponseError, serverFetch } from '@/lib/api/server-api';
 import OrganizationDashboardCompatibilityPage from './page';
 
 function renderSlug(slug: string) {
@@ -36,55 +18,19 @@ function renderSlug(slug: string) {
 }
 
 describe('/[slug]/dashboard compatibility route', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+    beforeEach(() => vi.clearAllMocks());
 
-    it('validates the persisted active Organization and redirects to the existing root dashboard', async () => {
-        vi.mocked(serverFetch).mockResolvedValue({
-            tenantId: 'tenant-1',
-            organizationId: 'org-ever',
-            organizationSlug: 'ever',
-        });
-
+    it('redirects an unambiguous legacy slug to the canonical namespaced dashboard', async () => {
         await expect(renderSlug('ever')).rejects.toThrow('NEXT_REDIRECT');
-        expect(serverFetch).toHaveBeenCalledWith('/users/me/scope');
-        expect(redirectMock).toHaveBeenCalledWith('/');
+        expect(redirectMock).toHaveBeenCalledWith('/org/ever/dashboard');
         expect(notFoundMock).not.toHaveBeenCalled();
     });
 
-    it.each([
-        ['another Organization is persisted', 'yo-inc'],
-        ['personal scope is persisted', null],
-    ])('fails closed when %s', async (_label, organizationSlug) => {
-        vi.mocked(serverFetch).mockResolvedValue({
-            tenantId: 'tenant-1',
-            organizationId: organizationSlug ? 'another-org' : null,
-            organizationSlug,
-        });
-
-        await expect(renderSlug('ever')).rejects.toThrow('NEXT_NOT_FOUND');
-        expect(notFoundMock).toHaveBeenCalledTimes(1);
-        expect(redirectMock).not.toHaveBeenCalled();
-    });
-
-    it('renders not found when the active scope no longer exists', async () => {
-        vi.mocked(serverFetch).mockRejectedValue(new ApiResponseError('Scope not found', 404));
-
-        await expect(renderSlug('ever')).rejects.toThrow('NEXT_NOT_FOUND');
-        expect(notFoundMock).toHaveBeenCalledTimes(1);
-        expect(redirectMock).not.toHaveBeenCalled();
-    });
-
-    it.each([
-        ['an unauthorized session', new ApiResponseError('Unauthorized', 401)],
-        ['an upstream failure', new ApiResponseError('Unavailable', 503)],
-        ['a network failure', new Error('socket disconnected')],
-    ])('rethrows %s instead of disguising it as a missing route', async (_label, error) => {
-        vi.mocked(serverFetch).mockRejectedValue(error);
-
-        await expect(renderSlug('ever')).rejects.toBe(error);
-        expect(notFoundMock).not.toHaveBeenCalled();
-        expect(redirectMock).not.toHaveBeenCalled();
-    });
+    it.each(['en', 'fr', 'settings', 'org', 'api', '@personal', 'bad/slug'])(
+        'does not reinterpret locale, reserved, or malformed slug %s as an Organization',
+        async (slug) => {
+            await expect(renderSlug(slug)).rejects.toThrow('NEXT_NOT_FOUND');
+            expect(redirectMock).not.toHaveBeenCalled();
+        },
+    );
 });

--- a/apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts
+++ b/apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { redirectMock, notFoundMock } = vi.hoisted(() => ({
+const { ApiResponseErrorMock, redirectMock, notFoundMock } = vi.hoisted(() => ({
+    ApiResponseErrorMock: class ApiResponseError extends Error {
+        constructor(
+            message: string,
+            public readonly statusCode: number,
+        ) {
+            super(message);
+            this.name = 'ApiResponseError';
+        }
+    },
     redirectMock: vi.fn(() => {
         throw new Error('NEXT_REDIRECT');
     }),
@@ -15,10 +24,11 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/lib/api/server-api', () => ({
+    ApiResponseError: ApiResponseErrorMock,
     serverFetch: vi.fn(),
 }));
 
-import { serverFetch } from '@/lib/api/server-api';
+import { ApiResponseError, serverFetch } from '@/lib/api/server-api';
 import OrganizationDashboardCompatibilityPage from './page';
 
 function renderSlug(slug: string) {
@@ -58,11 +68,23 @@ describe('/[slug]/dashboard compatibility route', () => {
         expect(redirectMock).not.toHaveBeenCalled();
     });
 
-    it('fails closed when the active-scope API cannot validate the session', async () => {
-        vi.mocked(serverFetch).mockRejectedValue(new Error('Unauthorized'));
+    it('renders not found when the active scope no longer exists', async () => {
+        vi.mocked(serverFetch).mockRejectedValue(new ApiResponseError('Scope not found', 404));
 
         await expect(renderSlug('ever')).rejects.toThrow('NEXT_NOT_FOUND');
         expect(notFoundMock).toHaveBeenCalledTimes(1);
+        expect(redirectMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['an unauthorized session', new ApiResponseError('Unauthorized', 401)],
+        ['an upstream failure', new ApiResponseError('Unavailable', 503)],
+        ['a network failure', new Error('socket disconnected')],
+    ])('rethrows %s instead of disguising it as a missing route', async (_label, error) => {
+        vi.mocked(serverFetch).mockRejectedValue(error);
+
+        await expect(renderSlug('ever')).rejects.toBe(error);
+        expect(notFoundMock).not.toHaveBeenCalled();
         expect(redirectMock).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/app/actions/auth-unverified.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-unverified.unit.spec.ts
@@ -33,6 +33,7 @@ const {
 }));
 
 vi.mock('@/lib/api', () => ({
+    getLoginDefaultWorkspaceHref: vi.fn(async () => '/'),
     authAPI: {
         register: registerMock,
         redeemMagicLink: redeemMagicLinkApiMock,

--- a/apps/web/src/app/actions/auth-unverified.unit.spec.ts
+++ b/apps/web/src/app/actions/auth-unverified.unit.spec.ts
@@ -22,18 +22,20 @@ const {
     registerMock,
     redeemMagicLinkApiMock,
     setAuthCookiesMock,
+    getLoginDefaultWorkspaceHrefMock,
     getRedirectUrlMock,
     redirectMock,
 } = vi.hoisted(() => ({
     registerMock: vi.fn(),
     redeemMagicLinkApiMock: vi.fn(),
     setAuthCookiesMock: vi.fn(),
+    getLoginDefaultWorkspaceHrefMock: vi.fn(),
     getRedirectUrlMock: vi.fn(),
     redirectMock: vi.fn(),
 }));
 
 vi.mock('@/lib/api', () => ({
-    getLoginDefaultWorkspaceHref: vi.fn(async () => '/'),
+    getLoginDefaultWorkspaceHref: getLoginDefaultWorkspaceHrefMock,
     authAPI: {
         register: registerMock,
         redeemMagicLink: redeemMagicLinkApiMock,
@@ -157,6 +159,7 @@ describe('EW-080 — a magic-link sign-in says the address is still unconfirmed'
     beforeEach(() => {
         redeemMagicLinkApiMock.mockReset();
         setAuthCookiesMock.mockReset();
+        getLoginDefaultWorkspaceHrefMock.mockReset().mockResolvedValue('/');
         getRedirectUrlMock.mockReset();
         redirectMock.mockReset();
         vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -201,6 +204,44 @@ describe('EW-080 — a magic-link sign-in says the address is still unconfirmed'
         expect(noticeParam(redirectedHref())).toBeNull();
     });
 
+    it('uses the persisted Organization only as the fresh-login navigation default', async () => {
+        const response = authResponse(true);
+        redeemMagicLinkApiMock.mockResolvedValue(response);
+        getLoginDefaultWorkspaceHrefMock.mockResolvedValue('/org/ever/dashboard');
+        getRedirectUrlMock.mockImplementation(async (_r: unknown, href: string) => href);
+
+        const { redeemMagicLink } = await import('./auth');
+        const result = await redeemMagicLink('a'.repeat(64), null);
+
+        expect(setAuthCookiesMock).toHaveBeenCalledWith('tok-1');
+        expect(getLoginDefaultWorkspaceHrefMock).toHaveBeenCalledTimes(1);
+        expect(getRedirectUrlMock).toHaveBeenCalledWith(response, '/org/ever/dashboard');
+        expect(redirectedHref()).toBe('/org/ever/dashboard');
+        expect(result).toEqual({ success: true });
+    });
+
+    it.each([
+        ['a transient scope API failure', new Error('scope API unavailable')],
+        ['a malformed persisted Organization slug', new Error('Invalid workspace scope')],
+    ])(
+        'preserves successful redemption and falls back to personal for %s',
+        async (_scenario, lookupError) => {
+            const response = authResponse(true);
+            redeemMagicLinkApiMock.mockResolvedValue(response);
+            getLoginDefaultWorkspaceHrefMock.mockRejectedValue(lookupError);
+            getRedirectUrlMock.mockImplementation(async (_r: unknown, href: string) => href);
+
+            const { redeemMagicLink } = await import('./auth');
+            const result = await redeemMagicLink('a'.repeat(64), null);
+
+            expect(setAuthCookiesMock).toHaveBeenCalledWith('tok-1');
+            expect(getLoginDefaultWorkspaceHrefMock).toHaveBeenCalledTimes(1);
+            expect(getRedirectUrlMock).toHaveBeenCalledWith(response, '/');
+            expect(redirectedHref()).toBe('/');
+            expect(result).toEqual({ success: true });
+        },
+    );
+
     it('does not decorate an allowlisted absolute redirect target', async () => {
         // `ALLOWED_REDIRECT_URLS` defaults to `localhost,127.0.0.1`, so this is
         // a host the redirect guard actually honours. An external page has no
@@ -223,5 +264,6 @@ describe('EW-080 — a magic-link sign-in says the address is still unconfirmed'
         expect(result.success).toBe(false);
         expect(redirectMock).not.toHaveBeenCalled();
         expect(setAuthCookiesMock).not.toHaveBeenCalled();
+        expect(getLoginDefaultWorkspaceHrefMock).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -85,6 +85,21 @@ function isAccountLockedError(error: unknown): boolean {
     return /account .*lock|temporarily locked/i.test(message);
 }
 
+/**
+ * Workspace preference resolution is post-authentication navigation only.
+ * Once the API has authenticated the user and the session cookie is written,
+ * a stale preference, revoked membership, or transient scope lookup failure
+ * must not turn that successful authentication into an action error.
+ */
+async function resolveLoginDefaultWorkspaceHref(): Promise<string> {
+    try {
+        return await getLoginDefaultWorkspaceHref();
+    } catch (error) {
+        console.error('Unable to resolve the login workspace default', error);
+        return ROUTES.DASHBOARD;
+    }
+}
+
 export async function login(identifier: string, password: string, redirectUrl: string | null) {
     const t = await getTranslations('validation.auth');
     // `validation.auth` has no key for an unverified email; the message already
@@ -163,7 +178,7 @@ export async function login(identifier: string, password: string, redirectUrl: s
     } else if (authResponse) {
         // The mutable preference is navigation convenience only. Resolve it
         // once after authentication, then let an explicit redirect cookie win.
-        href = await getLoginDefaultWorkspaceHref();
+        href = await resolveLoginDefaultWorkspaceHref();
         href = await getRedirectUrl(authResponse, href);
     }
 
@@ -668,7 +683,7 @@ export async function redeemMagicLink(token: string, redirectUrl: string | null)
     ) {
         href = redirectUrl;
     } else if (authResponse) {
-        href = await getLoginDefaultWorkspaceHref();
+        href = await resolveLoginDefaultWorkspaceHref();
         href = await getRedirectUrl(authResponse, href);
     }
 

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -4,7 +4,12 @@ import { z } from 'zod';
 import { removeAuthAccessCookies, setOAuthStateCookie, setAuthCookies } from '@/lib/auth';
 import { ALLOWED_REDIRECT_URLS, ROUTES, withAppUrl } from '@/lib/constants';
 import { PASSWORD_RULES, VALIDATION_RULES } from './validation';
-import { authAPI, AuthResponse, type TermsAcceptanceClaim } from '@/lib/api';
+import {
+    authAPI,
+    AuthResponse,
+    getLoginDefaultWorkspaceHref,
+    type TermsAcceptanceClaim,
+} from '@/lib/api';
 import { redirect } from '@/i18n/navigation';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { isValidRedirectUrl } from '@/lib/utils';
@@ -156,7 +161,9 @@ export async function login(identifier: string, password: string, redirectUrl: s
     ) {
         href = redirectUrl;
     } else if (authResponse) {
-        // Check if we have a redirect URL in a cookie
+        // The mutable preference is navigation convenience only. Resolve it
+        // once after authentication, then let an explicit redirect cookie win.
+        href = await getLoginDefaultWorkspaceHref();
         href = await getRedirectUrl(authResponse, href);
     }
 
@@ -661,6 +668,7 @@ export async function redeemMagicLink(token: string, redirectUrl: string | null)
     ) {
         href = redirectUrl;
     } else if (authResponse) {
+        href = await getLoginDefaultWorkspaceHref();
         href = await getRedirectUrl(authResponse, href);
     }
 

--- a/apps/web/src/app/actions/auth.unit.spec.ts
+++ b/apps/web/src/app/actions/auth.unit.spec.ts
@@ -182,6 +182,9 @@ describe('login — which failure the user is told about', () => {
         const result = await login('someone@example.com', 'wrong', null);
 
         expect(result).toEqual({ success: false, error: 'invalidCredentials' });
+        expect(setAuthCookiesMock).not.toHaveBeenCalled();
+        expect(getLoginDefaultWorkspaceHrefMock).not.toHaveBeenCalled();
+        expect(redirectMock).not.toHaveBeenCalled();
     });
 
     it('still reports a suspended account', async () => {
@@ -221,6 +224,27 @@ describe('login — which failure the user is told about', () => {
             href: '/org/ever/dashboard',
         });
     });
+
+    it.each([
+        ['a transient scope API failure', new Error('scope API unavailable')],
+        ['a malformed persisted Organization slug', new Error('Invalid workspace scope')],
+    ])(
+        'preserves successful authentication and falls back to personal for %s',
+        async (_scenario, lookupError) => {
+            const authResponse = { access_token: 'token', user: {} };
+            loginMock.mockResolvedValue(authResponse);
+            getLoginDefaultWorkspaceHrefMock.mockRejectedValue(lookupError);
+
+            const { login } = await import('./auth');
+            const result = await login('someone@example.com', 'correct-horse', null);
+
+            expect(setAuthCookiesMock).toHaveBeenCalledWith('token');
+            expect(getLoginDefaultWorkspaceHrefMock).toHaveBeenCalledTimes(1);
+            expect(getRedirectUrlMock).toHaveBeenCalledWith(authResponse, '/');
+            expect(redirectMock).toHaveBeenCalledWith({ locale: 'en', href: '/' });
+            expect(result).toEqual({ success: true });
+        },
+    );
 
     it('does not let the mutable preference override an explicit login redirect', async () => {
         loginMock.mockResolvedValue({ access_token: 'token', user: {} });

--- a/apps/web/src/app/actions/auth.unit.spec.ts
+++ b/apps/web/src/app/actions/auth.unit.spec.ts
@@ -14,17 +14,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 // Hoisted because vi.mock factory runs before regular module code.
-const { setOAuthStateCookieMock, getOAuthAuthUrlMock, loginMock } = vi.hoisted(() => ({
+const {
+    setOAuthStateCookieMock,
+    setAuthCookiesMock,
+    getOAuthAuthUrlMock,
+    getLoginDefaultWorkspaceHrefMock,
+    getRedirectUrlMock,
+    loginMock,
+    redirectMock,
+} = vi.hoisted(() => ({
     setOAuthStateCookieMock: vi.fn(),
+    setAuthCookiesMock: vi.fn(),
     getOAuthAuthUrlMock: vi.fn(),
+    getLoginDefaultWorkspaceHrefMock: vi.fn(),
+    getRedirectUrlMock: vi.fn(),
     loginMock: vi.fn(),
+    redirectMock: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
     setOAuthStateCookie: setOAuthStateCookieMock,
     // unused by connectProvider but exported by the barrel
     removeAuthAccessCookies: vi.fn(),
-    setAuthCookies: vi.fn(),
+    setAuthCookies: setAuthCookiesMock,
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -34,7 +46,10 @@ vi.mock('@/lib/api', () => ({
         register: vi.fn(),
         logout: vi.fn(),
     },
+    getLoginDefaultWorkspaceHref: getLoginDefaultWorkspaceHrefMock,
 }));
+
+vi.mock('@/lib/auth/redirect', () => ({ getRedirectUrl: getRedirectUrlMock }));
 
 vi.mock('next-intl/server', () => ({
     getTranslations: async () => (key: string) => key,
@@ -42,7 +57,7 @@ vi.mock('next-intl/server', () => ({
 }));
 
 vi.mock('@/i18n/navigation', () => ({
-    redirect: vi.fn(),
+    redirect: redirectMock,
 }));
 
 describe('connectProvider — C-03 state round-trip', () => {
@@ -130,6 +145,10 @@ describe('connectProvider — C-03 state round-trip', () => {
 describe('login — which failure the user is told about', () => {
     beforeEach(() => {
         loginMock.mockReset();
+        setAuthCookiesMock.mockReset();
+        getLoginDefaultWorkspaceHrefMock.mockReset().mockResolvedValue('/');
+        getRedirectUrlMock.mockReset().mockImplementation(async (_auth, href) => href);
+        redirectMock.mockReset();
     });
 
     afterEach(() => {
@@ -183,5 +202,34 @@ describe('login — which failure the user is told about', () => {
         const result = await login('someone@example.com', 'correct-horse', null);
 
         expect(result).toEqual({ success: false, error: 'invalidCredentials' });
+    });
+
+    it('uses the persisted Organization only as the fresh-login navigation default', async () => {
+        loginMock.mockResolvedValue({ access_token: 'token', user: {} });
+        getLoginDefaultWorkspaceHrefMock.mockResolvedValue('/org/ever/dashboard');
+
+        const { login } = await import('./auth');
+        await login('someone@example.com', 'correct-horse', null);
+
+        expect(getLoginDefaultWorkspaceHrefMock).toHaveBeenCalledTimes(1);
+        expect(getRedirectUrlMock).toHaveBeenCalledWith(
+            expect.objectContaining({ access_token: 'token' }),
+            '/org/ever/dashboard',
+        );
+        expect(redirectMock).toHaveBeenCalledWith({
+            locale: 'en',
+            href: '/org/ever/dashboard',
+        });
+    });
+
+    it('does not let the mutable preference override an explicit login redirect', async () => {
+        loginMock.mockResolvedValue({ access_token: 'token', user: {} });
+
+        const { login } = await import('./auth');
+        await login('someone@example.com', 'correct-horse', '/missions');
+
+        expect(getLoginDefaultWorkspaceHrefMock).not.toHaveBeenCalled();
+        expect(getRedirectUrlMock).not.toHaveBeenCalled();
+        expect(redirectMock).toHaveBeenCalledWith({ locale: 'en', href: '/missions' });
     });
 });

--- a/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/attach-token/route.ts
+++ b/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/attach-token/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 type RouteContext = { params: Promise<{ id: string; runId: string }> };
 
@@ -38,11 +39,21 @@ export async function POST(request: NextRequest, ctx: RouteContext) {
     // from being the place a new role could be smuggled in.
     const roleQuery = request.nextUrl.searchParams.get('role') === 'viewer' ? '?role=viewer' : '';
 
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
+
     const upstream = await fetch(
         `${API_URL}/agents/${id}/runs/${runId}/terminal/attach-token${roleQuery}`,
         {
             method: 'POST',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers,
             cache: 'no-store',
         },
     );

--- a/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/start/route.ts
+++ b/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/start/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 type RouteContext = { params: Promise<{ id: string; runId: string }> };
 
@@ -19,7 +20,7 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
  * No request body is forwarded: the session argv is operator configuration
  * resolved server-side, never something the browser gets to choose.
  */
-export async function POST(_request: NextRequest, ctx: RouteContext) {
+export async function POST(request: NextRequest, ctx: RouteContext) {
     const { id, runId } = await ctx.params;
     if (!UUID.test(id) || !UUID.test(runId)) {
         return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
@@ -30,9 +31,19 @@ export async function POST(_request: NextRequest, ctx: RouteContext) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
+
     const upstream = await fetch(`${API_URL}/agents/${id}/runs/${runId}/terminal/start`, {
         method: 'POST',
-        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        headers,
         cache: 'no-store',
     });
 

--- a/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/start/route.unit.spec.ts
+++ b/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/start/route.unit.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { POST } from './route';
+
+const AGENT = '11111111-2222-4333-8444-555555555555';
+const RUN = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
+
+function request(selector?: string) {
+    const headers = new Headers({ 'x-scope-slug': 'attacker-supplied-yo' });
+    if (selector) headers.set('x-ever-workspace', selector);
+    return new Request('http://web.example/api/agents/a/runs/r/terminal/start', {
+        method: 'POST',
+        headers,
+    }) as Parameters<typeof POST>[0];
+}
+
+function context() {
+    return { params: Promise.resolve({ id: AGENT, runId: RUN }) };
+}
+
+describe('POST Agent terminal start workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('overwrites spoofing and forwards the explicit per-tab Organization selector', async () => {
+        const response = await POST(request('org:ever'), context());
+
+        expect(response.status).toBe(200);
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('ever');
+        expect(new Headers(init.headers).get('x-ever-workspace')).toBeNull();
+    });
+
+    it('fails closed before upstream when the browser selector is absent', async () => {
+        const response = await POST(request(), context());
+
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/transcript/route.ts
+++ b/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/transcript/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 type RouteContext = { params: Promise<{ id: string; runId: string }> };
 
@@ -41,11 +42,21 @@ export async function GET(request: NextRequest, ctx: RouteContext) {
     }
     const suffix = query.toString() ? `?${query.toString()}` : '';
 
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
+
     const upstream = await fetch(
         `${API_URL}/agents/${id}/runs/${runId}/terminal/transcript${suffix}`,
         {
             method: 'GET',
-            headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+            headers,
             cache: 'no-store',
         },
     );

--- a/apps/web/src/app/api/org-templates/route.ts
+++ b/apps/web/src/app/api/org-templates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Teams & Prebuilt Companies (spec §6) — web BFF proxy for
@@ -10,14 +11,20 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * ANY failure returns `[]` so the modal simply skips its template step
  * (guaranteed no-regression fallback, same posture as agent templates).
  */
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
     const token = await getAuthAccessCookie();
     if (!token) {
         return NextResponse.json([], { status: 200 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         const upstream = await fetch(`${API_URL}/org-templates`, {

--- a/apps/web/src/app/api/organizations/[id]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * PR-6 (domain-model evolution) — web BFF proxy for
@@ -31,9 +32,15 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
-    headers.set('Content-Type', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         const upstream = await fetch(`${API_URL}/organizations/${encodeURIComponent(id)}`, {

--- a/apps/web/src/app/api/organizations/[id]/upgrade-from-account/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/upgrade-from-account/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
@@ -12,7 +13,7 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * with `UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS` — we pass that body
  * through verbatim so the dialog can surface the right copy.
  */
-export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
     const token = await getAuthAccessCookie();
     if (!token) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -23,9 +24,15 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
         return NextResponse.json({ error: 'Missing organization id' }, { status: 400 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
-    headers.set('Content-Type', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         const upstream = await fetch(

--- a/apps/web/src/app/api/organizations/import-company/route.ts
+++ b/apps/web/src/app/api/organizations/import-company/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Teams & Prebuilt Companies (spec §6.2) — web BFF proxy for
@@ -23,9 +24,15 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
-    headers.set('Content-Type', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         // Generous deadline: an import materializes up to ~100 files + rows.

--- a/apps/web/src/app/api/organizations/register-company/route.ts
+++ b/apps/web/src/app/api/organizations/register-company/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * EW-662 (Tenants & Organizations Phase 10) — web BFF proxy for
@@ -26,9 +27,15 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
-    headers.set('Content-Type', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         const upstream = await fetch(`${API_URL}/organizations/register-company`, {

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * EW-660 (Tenants & Organizations Phase 8) — web BFF proxy for
@@ -15,14 +16,20 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * `useOrganizations()` hook can surface a sensible `error` value without
  * mistaking the auth-failure for an empty-orgs list.
  */
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
     const token = await getAuthAccessCookie();
     if (!token) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         const upstream = await fetch(`${API_URL}/organizations`, {
@@ -71,9 +78,15 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
-    headers.set('Content-Type', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     try {
         const upstream = await fetch(`${API_URL}/organizations`, {

--- a/apps/web/src/app/api/organizations/route.unit.spec.ts
+++ b/apps/web/src/app/api/organizations/route.unit.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { GET } from './route';
+
+function request(selector?: string) {
+    const headers = new Headers({ 'x-scope-slug': 'attacker-supplied-yo' });
+    if (selector) headers.set('x-ever-workspace', selector);
+    return new Request('http://web.example/api/organizations', { headers }) as Parameters<
+        typeof GET
+    >[0];
+}
+
+describe('GET /api/organizations workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify([]), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('overwrites spoofing and forwards the explicit per-tab Organization selector', async () => {
+        const response = await GET(request('org:ever'));
+
+        expect(response.status).toBe(200);
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('ever');
+        expect(new Headers(init.headers).get('x-ever-workspace')).toBeNull();
+    });
+
+    it('fails closed before upstream when the browser selector is absent', async () => {
+        const response = await GET(request());
+
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/users/me/scope/route.ts
+++ b/apps/web/src/app/api/users/me/scope/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+export async function GET(_request: NextRequest) {
+    return proxyActiveScope('GET');
+}
+
+export async function POST(request: NextRequest) {
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    return proxyActiveScope('POST', body);
+}
+
+async function proxyActiveScope(method: 'GET' | 'POST', body?: unknown) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    if (method === 'POST') {
+        headers.set('Content-Type', 'application/json');
+    }
+
+    try {
+        const upstream = await fetch(`${API_URL}/users/me/scope`, {
+            method,
+            headers,
+            body: method === 'POST' ? JSON.stringify(body) : undefined,
+            cache: 'no-store',
+        });
+        const text = await upstream.text();
+
+        return new NextResponse(text || null, {
+            status: upstream.status,
+            headers: {
+                'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+            },
+        });
+    } catch (error) {
+        console.error(`Failed to proxy ${method} /api/users/me/scope:`, error);
+        return NextResponse.json({ error: 'Failed to access active scope' }, { status: 500 });
+    }
+}

--- a/apps/web/src/app/api/users/me/scope/route.ts
+++ b/apps/web/src/app/api/users/me/scope/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
-export async function GET(_request: NextRequest) {
-    return proxyActiveScope('GET');
+export async function GET(request: NextRequest) {
+    return proxyActiveScope(request, 'GET');
 }
 
 export async function POST(request: NextRequest) {
@@ -14,19 +15,26 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
     }
 
-    return proxyActiveScope('POST', body);
+    return proxyActiveScope(request, 'POST', body);
 }
 
-async function proxyActiveScope(method: 'GET' | 'POST', body?: unknown) {
+async function proxyActiveScope(request: NextRequest, method: 'GET' | 'POST', body?: unknown) {
     const token = await getAuthAccessCookie();
     if (!token) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const headers = new Headers();
-    headers.set('Authorization', `Bearer ${token}`);
+    const baseHeaders = new Headers();
+    baseHeaders.set('Authorization', `Bearer ${token}`);
     if (method === 'POST') {
-        headers.set('Content-Type', 'application/json');
+        baseHeaders.set('Content-Type', 'application/json');
+    }
+
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, baseHeaders);
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
     }
 
     try {

--- a/apps/web/src/app/api/users/me/scope/route.unit.spec.ts
+++ b/apps/web/src/app/api/users/me/scope/route.unit.spec.ts
@@ -11,10 +11,16 @@ vi.mock('@/lib/constants', () => ({
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
 import { GET, POST } from './route';
 
-function makeRequest(body?: string) {
+function makeRequest(body?: string, selector: string | null = 'personal', referer?: string) {
+    const headers = new Headers(
+        body === undefined ? undefined : { 'content-type': 'application/json' },
+    );
+    if (selector !== null) headers.set('x-ever-workspace', selector);
+    if (referer) headers.set('referer', referer);
+    headers.set('x-scope-slug', 'attacker-supplied');
     return new Request('http://web.example/api/users/me/scope', {
         method: body === undefined ? 'GET' : 'POST',
-        headers: body === undefined ? undefined : { 'content-type': 'application/json' },
+        headers,
         body,
     }) as Parameters<typeof POST>[0];
 }
@@ -51,6 +57,8 @@ describe('/api/users/me/scope BFF', () => {
         expect(url).toBe('http://api.example/users/me/scope');
         expect(init.method).toBe('GET');
         expect((init.headers as Headers).get('authorization')).toBe('Bearer access-token');
+        expect((init.headers as Headers).get('x-scope-slug')).toBe('@personal');
+        expect((init.headers as Headers).get('x-ever-workspace')).toBeNull();
     });
 
     it('POST forwards the selection and returns the persisted active scope', async () => {
@@ -78,6 +86,27 @@ describe('/api/users/me/scope BFF', () => {
         await expect(response.json()).resolves.toEqual({
             message: "Organization 'foreign' not found",
         });
+    });
+
+    it('accepts an explicit Organization selector without Referer and overwrites spoofing', async () => {
+        const response = await POST(
+            makeRequest(JSON.stringify({ organizationSlug: 'ever' }), 'org:ever'),
+        );
+
+        expect(response.status).toBe(200);
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect((init.headers as Headers).get('x-scope-slug')).toBe('ever');
+    });
+
+    it('fails closed on a missing or stale browser selector', async () => {
+        const missing = await POST(makeRequest('{}', null));
+        expect(missing.status).toBe(400);
+
+        const stale = await POST(
+            makeRequest('{}', 'org:ever', 'http://web.example/org/yo/dashboard'),
+        );
+        expect(stale.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('returns 401 without making an upstream request when the auth cookie is absent', async () => {

--- a/apps/web/src/app/api/users/me/scope/route.unit.spec.ts
+++ b/apps/web/src/app/api/users/me/scope/route.unit.spec.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { GET, POST } from './route';
+
+function makeRequest(body?: string) {
+    return new Request('http://web.example/api/users/me/scope', {
+        method: body === undefined ? 'GET' : 'POST',
+        headers: body === undefined ? undefined : { 'content-type': 'application/json' },
+        body,
+    }) as Parameters<typeof POST>[0];
+}
+
+describe('/api/users/me/scope BFF', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.mocked(getAuthAccessCookie).mockResolvedValue('access-token');
+        fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    tenantId: 'tenant-1',
+                    organizationId: 'org-ever',
+                    organizationSlug: 'ever',
+                }),
+                { status: 200, headers: { 'content-type': 'application/json' } },
+            ),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('GET forwards the encrypted-cookie token only as a bearer header', async () => {
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ organizationSlug: 'ever' });
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://api.example/users/me/scope');
+        expect(init.method).toBe('GET');
+        expect((init.headers as Headers).get('authorization')).toBe('Bearer access-token');
+    });
+
+    it('POST forwards the selection and returns the persisted active scope', async () => {
+        const response = await POST(makeRequest(JSON.stringify({ organizationSlug: 'ever' })));
+
+        expect(response.status).toBe(200);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://api.example/users/me/scope');
+        expect(init.method).toBe('POST');
+        expect(init.body).toBe(JSON.stringify({ organizationSlug: 'ever' }));
+        expect((init.headers as Headers).get('authorization')).toBe('Bearer access-token');
+    });
+
+    it('passes an upstream rejection through without changing its status or body', async () => {
+        fetchMock.mockResolvedValueOnce(
+            new Response(JSON.stringify({ message: "Organization 'foreign' not found" }), {
+                status: 404,
+                headers: { 'content-type': 'application/json' },
+            }),
+        );
+
+        const response = await POST(makeRequest(JSON.stringify({ organizationSlug: 'foreign' })));
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            message: "Organization 'foreign' not found",
+        });
+    });
+
+    it('returns 401 without making an upstream request when the auth cookie is absent', async () => {
+        vi.mocked(getAuthAccessCookie).mockResolvedValueOnce(undefined);
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(401);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid JSON locally without making an upstream request', async () => {
+        const response = await POST(makeRequest('{'));
+
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Building2, Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { toast } from 'sonner';
 import { useRouter } from '@/i18n/navigation';
 import { cn } from '@/lib/utils/cn';
 import {
@@ -100,8 +101,9 @@ export function WorkspaceSwitcher({
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
-    const { activeOrganization } = useActiveScope();
+    const { activeOrganization, setActiveOrganization } = useActiveScope();
     const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [pendingOrganizationSlug, setPendingOrganizationSlug] = useState<string | null>(null);
 
     const hasOrgs = organizations.length > 0;
     // Pick the trigger label org — use the active one (from URL slug) if
@@ -111,8 +113,32 @@ export function WorkspaceSwitcher({
         ? (activeOrganization ?? organizations[0])
         : null;
 
-    const handleSelectOrg = (org: OrganizationResponse) => {
-        router.push(`/${org.slug}/dashboard`);
+    const handleSelectOrg = async (org: OrganizationResponse) => {
+        if (pendingOrganizationSlug !== null) return;
+
+        setPendingOrganizationSlug(org.slug);
+        try {
+            const response = await fetch('/api/users/me/scope', {
+                method: 'POST',
+                credentials: 'include',
+                cache: 'no-store',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ organizationSlug: org.slug }),
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to persist active Organization (${response.status})`);
+            }
+            const persisted = (await response.json()) as { organizationSlug?: string | null };
+            if (persisted.organizationSlug !== org.slug) {
+                throw new Error('The persisted active Organization did not match the selection');
+            }
+            setActiveOrganization(org);
+            router.push(`/${org.slug}/dashboard`);
+        } catch {
+            toast.error('Could not switch Organization. Please try again.');
+        } finally {
+            setPendingOrganizationSlug(null);
+        }
     };
 
     const handleCreateOrg = () => {
@@ -180,6 +206,7 @@ export function WorkspaceSwitcher({
                                     key={org.id}
                                     onClick={() => handleSelectOrg(org)}
                                     className="cursor-pointer"
+                                    disabled={pendingOrganizationSlug !== null}
                                 >
                                     <div className="flex items-center gap-2 w-full">
                                         <OrgAvatar org={org} size="xs" />

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -20,6 +20,7 @@ import { FaviconEverWorkImage, LogoEverWorkImage } from '../logos';
 import { CreateOrganizationModal } from '../organizations/CreateOrganizationModal';
 import type { WorkConfig } from '@/lib/api';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 interface WorkspaceSwitcherProps {
     /** Site config passed through to the inline logo / favicon. */
@@ -101,7 +102,7 @@ export function WorkspaceSwitcher({
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
-    const { activeOrganization, setActiveOrganization } = useActiveScope();
+    const { activeOrganization } = useActiveScope();
     const [isCreateOpen, setIsCreateOpen] = useState(false);
     const [pendingOrganizationSlug, setPendingOrganizationSlug] = useState<string | null>(null);
 
@@ -118,7 +119,7 @@ export function WorkspaceSwitcher({
 
         setPendingOrganizationSlug(org.slug);
         try {
-            const response = await fetch('/api/users/me/scope', {
+            const response = await browserApiFetch('/api/users/me/scope', {
                 method: 'POST',
                 credentials: 'include',
                 cache: 'no-store',
@@ -132,8 +133,7 @@ export function WorkspaceSwitcher({
             if (persisted.organizationSlug !== org.slug) {
                 throw new Error('The persisted active Organization did not match the selection');
             }
-            setActiveOrganization(org);
-            router.push(`/${org.slug}/dashboard`);
+            router.push(`/org/${org.slug}/dashboard`);
         } catch {
             toast.error('Could not switch Organization. Please try again.');
         } finally {

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Building2, Check, ChevronsUpDown, Plus } from 'lucide-react';
 import { toast } from 'sonner';
-import { useRouter } from '@/i18n/navigation';
 import { cn } from '@/lib/utils/cn';
 import {
     DropdownMenu,
@@ -21,6 +20,7 @@ import { CreateOrganizationModal } from '../organizations/CreateOrganizationModa
 import type { WorkConfig } from '@/lib/api';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 import { browserApiFetch } from '@/lib/api/browser-api';
+import { navigateToWorkspaceDashboard } from '@/lib/workspace-navigation';
 
 interface WorkspaceSwitcherProps {
     /** Site config passed through to the inline logo / favicon. */
@@ -100,7 +100,6 @@ export function WorkspaceSwitcher({
     isCollapsed = false,
 }: WorkspaceSwitcherProps) {
     const t = useTranslations('organizations.switcher');
-    const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
     const { activeOrganization } = useActiveScope();
     const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -133,7 +132,7 @@ export function WorkspaceSwitcher({
             if (persisted.organizationSlug !== org.slug) {
                 throw new Error('The persisted active Organization did not match the selection');
             }
-            router.push(`/org/${org.slug}/dashboard`);
+            navigateToWorkspaceDashboard({ kind: 'organization', slug: org.slug });
         } catch {
             toast.error('Could not switch Organization. Please try again.');
         } finally {

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -26,6 +26,13 @@ vi.mock('@/i18n/navigation', () => ({
     useRouter: () => ({ push: routerPushMock }),
 }));
 
+const { navigateToWorkspaceDashboardMock } = vi.hoisted(() => ({
+    navigateToWorkspaceDashboardMock: vi.fn(),
+}));
+vi.mock('@/lib/workspace-navigation', () => ({
+    navigateToWorkspaceDashboard: navigateToWorkspaceDashboardMock,
+}));
+
 // Mock the image-only logo variants to simple sentinels — we don't want
 // to render real Next.js Image components in jsdom, and we want stable
 // test selectors for the empty-state assertion.
@@ -69,6 +76,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     beforeEach(() => {
         __resetOrganizationsStoreForTests();
         routerPushMock.mockReset();
+        navigateToWorkspaceDashboardMock.mockReset();
         pathnameMock.mockReset().mockReturnValue('/dashboard');
         vi.stubGlobal(
             'fetch',
@@ -280,7 +288,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         );
         const switchHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
         expect(switchHeaders.get('x-ever-workspace')).toBe('org:yo-inc');
-        expect(routerPushMock).not.toHaveBeenCalled();
+        expect(navigateToWorkspaceDashboardMock).not.toHaveBeenCalled();
 
         resolveSwitch({
             ok: true,
@@ -292,6 +300,12 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
             }),
         });
 
-        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/org/ever/dashboard'));
+        await waitFor(() =>
+            expect(navigateToWorkspaceDashboardMock).toHaveBeenCalledWith({
+                kind: 'organization',
+                slug: 'ever',
+            }),
+        );
+        expect(routerPushMock).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
 // next-intl — return the key path verbatim so assertions can match
@@ -70,10 +70,23 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         __resetOrganizationsStoreForTests();
         routerPushMock.mockReset();
         paramsMock.mockReset().mockReturnValue({});
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    tenantId: 't-1',
+                    organizationId: null,
+                    organizationSlug: null,
+                }),
+            }),
+        );
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
     });
 
     /**
@@ -222,5 +235,60 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         // After opening, the org list row + create row both show.
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    it('persists the selected Organization before navigating to its compatibility dashboard', async () => {
+        const yo = makeOrg({ id: 'o-yo', slug: 'yo-inc', displayName: 'Yo Incorporated' });
+        const ever = makeOrg({ id: 'o-ever', slug: 'ever', displayName: 'Ever' });
+        __seedOrganizationsStoreForTests({
+            data: [yo, ever],
+            isLoading: false,
+            error: null,
+        });
+
+        let resolveSwitch!: (response: unknown) => void;
+        const switchResponse = new Promise((resolve) => {
+            resolveSwitch = resolve;
+        });
+        const fetchMock = vi.mocked(fetch);
+        fetchMock.mockImplementation((_input, init) => {
+            if (init?.method === 'POST') {
+                return switchResponse as Promise<Response>;
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    tenantId: 't-1',
+                    organizationId: 'o-yo',
+                    organizationSlug: 'yo-inc',
+                }),
+            } as Response);
+        });
+
+        render(<WorkspaceSwitcher />);
+        fireEvent.click(screen.getAllByRole('button')[0]);
+        fireEvent.click(screen.getByText('Ever'));
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/api/users/me/scope',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ organizationSlug: 'ever' }),
+            }),
+        );
+        expect(routerPushMock).not.toHaveBeenCalled();
+
+        resolveSwitch({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                tenantId: 't-1',
+                organizationId: 'o-ever',
+                organizationSlug: 'ever',
+            }),
+        });
+
+        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/ever/dashboard'));
     });
 });

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -11,10 +11,10 @@ vi.mock('next-intl', () => ({
 
 // next/navigation — `useParams()` returns the URL slug. We mock it
 // per-test via `paramsMock`.
-const paramsMock = vi.fn<() => { slug?: string }>();
-paramsMock.mockReturnValue({});
+const pathnameMock = vi.fn<() => string>();
+pathnameMock.mockReturnValue('/dashboard');
 vi.mock('next/navigation', () => ({
-    useParams: () => paramsMock(),
+    usePathname: () => pathnameMock(),
 }));
 
 // i18n navigation — `useRouter().push()` for the switch-on-click flow.
@@ -69,7 +69,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     beforeEach(() => {
         __resetOrganizationsStoreForTests();
         routerPushMock.mockReset();
-        paramsMock.mockReset().mockReturnValue({});
+        pathnameMock.mockReset().mockReturnValue('/dashboard');
         vi.stubGlobal(
             'fetch',
             vi.fn().mockResolvedValue({
@@ -237,7 +237,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 
-    it('persists the selected Organization before navigating to its compatibility dashboard', async () => {
+    it('persists from the current tab scope before navigating to the canonical dashboard', async () => {
         const yo = makeOrg({ id: 'o-yo', slug: 'yo-inc', displayName: 'Yo Incorporated' });
         const ever = makeOrg({ id: 'o-ever', slug: 'ever', displayName: 'Ever' });
         __seedOrganizationsStoreForTests({
@@ -251,6 +251,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
             resolveSwitch = resolve;
         });
         const fetchMock = vi.mocked(fetch);
+        window.history.replaceState({}, '', '/org/yo-inc/dashboard');
         fetchMock.mockImplementation((_input, init) => {
             if (init?.method === 'POST') {
                 return switchResponse as Promise<Response>;
@@ -277,6 +278,8 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
                 body: JSON.stringify({ organizationSlug: 'ever' }),
             }),
         );
+        const switchHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
+        expect(switchHeaders.get('x-ever-workspace')).toBe('org:yo-inc');
         expect(routerPushMock).not.toHaveBeenCalled();
 
         resolveSwitch({
@@ -289,6 +292,6 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
             }),
         });
 
-        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/ever/dashboard'));
+        await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/org/ever/dashboard'));
     });
 });

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -21,7 +21,10 @@ import {
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
 import { browserApiFetch } from '@/lib/api/browser-api';
-import { navigateToWorkspaceDashboard } from '@/lib/workspace-navigation';
+import {
+    navigateToWorkspaceDashboard,
+    persistActiveOrganization,
+} from '@/lib/workspace-navigation';
 
 /**
  * Mirror of `User.deriveSlugIfMissing` (and the server-side
@@ -47,23 +50,6 @@ const MAX_NAME_LENGTH = 200;
  * their own tighter ~2000-char injection cap.
  */
 const MAX_VISION_LENGTH = 5000;
-
-async function persistActiveOrganization(organizationSlug: string): Promise<void> {
-    const response = await browserApiFetch('/api/users/me/scope', {
-        method: 'POST',
-        credentials: 'include',
-        cache: 'no-store',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ organizationSlug }),
-    });
-    if (!response.ok) {
-        throw new Error(`Failed to persist active Organization (${response.status})`);
-    }
-    const persisted = (await response.json()) as { organizationSlug?: string | null };
-    if (persisted.organizationSlug !== organizationSlug) {
-        throw new Error('The persisted active Organization did not match the selection');
-    }
-}
 
 /**
  * Teams & Prebuilt Companies (spec §4.4/§6) — one catalog entry from

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -47,6 +47,23 @@ const MAX_NAME_LENGTH = 200;
  */
 const MAX_VISION_LENGTH = 5000;
 
+async function persistActiveOrganization(organizationSlug: string): Promise<void> {
+    const response = await fetch('/api/users/me/scope', {
+        method: 'POST',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ organizationSlug }),
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to persist active Organization (${response.status})`);
+    }
+    const persisted = (await response.json()) as { organizationSlug?: string | null };
+    if (persisted.organizationSlug !== organizationSlug) {
+        throw new Error('The persisted active Organization did not match the selection');
+    }
+}
+
 /**
  * Teams & Prebuilt Companies (spec §4.4/§6) — one catalog entry from
  * `GET /api/org-templates` (BFF proxy of the ever-works/orgs manifest).
@@ -314,11 +331,12 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
                         setCreatedOrg(org);
                         setShowUpgradeDialog(true);
                     } else {
-                        onOpenChange(false);
                         // Security: validate slug matches expected alphanumeric-dash
                         // pattern before interpolating into the router path to prevent
                         // an open redirect if the API ever returns a malformed slug.
                         if (/^[a-z0-9-]+$/.test(org.slug)) {
+                            await persistActiveOrganization(org.slug);
+                            onOpenChange(false);
                             router.push(`/${org.slug}/dashboard`);
                         }
                     }

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -363,27 +363,24 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
     );
 
     const handleUpgradeDialogClose = useCallback(
-        (didUpgrade: boolean) => {
-            setShowUpgradeDialog(false);
+        async (didUpgrade: boolean) => {
             const target = createdOrg;
-            // Reset modal state then close the outer dialog. Navigation
-            // happens after close so a route change doesn't fight the
-            // transition.
+            if (!target || !/^[a-z0-9-]+$/.test(target.slug)) {
+                throw new Error(t('errors.generic'));
+            }
+
+            // Do not close or navigate until the server confirms the new
+            // Organization is the user's persisted active workspace.
+            await persistActiveOrganization(target.slug);
+            setShowUpgradeDialog(false);
             setCreatedOrg(null);
             onOpenChange(false);
-            if (target) {
-                // Security: validate slug matches expected alphanumeric-dash
-                // pattern before interpolating into the router path to prevent
-                // an open redirect if the API ever returns a malformed slug.
-                if (/^[a-z0-9-]+$/.test(target.slug)) {
-                    router.push(`/${target.slug}/dashboard`);
-                }
-                // Pull the freshly-upgraded org list (tenantId is now set
-                // on the user, so subsequent fetches reflect that).
-                if (didUpgrade) void mutate();
-            }
+            router.push(`/${target.slug}/dashboard`);
+            // Pull the freshly-upgraded org list (tenantId is now set on
+            // the user, so subsequent fetches reflect that).
+            if (didUpgrade) void mutate();
         },
-        [createdOrg, mutate, onOpenChange, router],
+        [createdOrg, mutate, onOpenChange, router, t],
     );
 
     // Hide the modal panel while the upgrade dialog is visible so the

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -18,10 +18,10 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { useRouter } from '@/i18n/navigation';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
 import { browserApiFetch } from '@/lib/api/browser-api';
+import { navigateToWorkspaceDashboard } from '@/lib/workspace-navigation';
 
 /**
  * Mirror of `User.deriveSlugIfMissing` (and the server-side
@@ -111,16 +111,15 @@ type SlugStatus =
  *   - First Org (organizations.length === 0 before submit) → hands off
  *     to `<UpgradeOrCreateDialog>` so the user can choose the upgrade
  *     vs empty branch.
- *   - 2nd+ Org → close modal and navigate to `/{slug}/dashboard`
+ *   - 2nd+ Org → close modal and navigate to `/org/{slug}/dashboard`
  *     directly. Subsequent Orgs skip the upgrade dialog entirely
  *     (spec §5.3).
  *
  * Wires into `useOrganizations().mutate()` on success so the
- * `<WorkspaceSwitcher>` populates without a full page reload.
+ * `<WorkspaceSwitcher>` has fresh data before the workspace reload.
  */
 export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizationModalProps) {
     const t = useTranslations('organizations.create');
-    const router = useRouter();
     const { organizations, mutate } = useOrganizations();
 
     const [name, setName] = useState('');
@@ -338,7 +337,10 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
                         if (/^[a-z0-9-]+$/.test(org.slug)) {
                             await persistActiveOrganization(org.slug);
                             onOpenChange(false);
-                            router.push(`/org/${org.slug}/dashboard`);
+                            navigateToWorkspaceDashboard({
+                                kind: 'organization',
+                                slug: org.slug,
+                            });
                         }
                     }
                 } catch (err) {
@@ -346,7 +348,7 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
                 }
             })();
         });
-    }, [name, vision, selectedTemplate, organizations.length, mutate, onOpenChange, router, t]);
+    }, [name, vision, selectedTemplate, organizations.length, mutate, onOpenChange, t]);
 
     const handlePickTemplate = useCallback(
         (slug: string | null) => {
@@ -376,12 +378,12 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
             setShowUpgradeDialog(false);
             setCreatedOrg(null);
             onOpenChange(false);
-            router.push(`/org/${target.slug}/dashboard`);
+            navigateToWorkspaceDashboard({ kind: 'organization', slug: target.slug });
             // Pull the freshly-upgraded org list (tenantId is now set on
             // the user, so subsequent fetches reflect that).
             if (didUpgrade) void mutate();
         },
-        [createdOrg, mutate, onOpenChange, router, t],
+        [createdOrg, mutate, onOpenChange, t],
     );
 
     // Hide the modal panel while the upgrade dialog is visible so the

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -21,6 +21,7 @@ import {
 import { useRouter } from '@/i18n/navigation';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 /**
  * Mirror of `User.deriveSlugIfMissing` (and the server-side
@@ -48,7 +49,7 @@ const MAX_NAME_LENGTH = 200;
 const MAX_VISION_LENGTH = 5000;
 
 async function persistActiveOrganization(organizationSlug: string): Promise<void> {
-    const response = await fetch('/api/users/me/scope', {
+    const response = await browserApiFetch('/api/users/me/scope', {
         method: 'POST',
         credentials: 'include',
         cache: 'no-store',
@@ -171,7 +172,7 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
         const controller = new AbortController();
         void (async () => {
             try {
-                const res = await fetch('/api/org-templates', {
+                const res = await browserApiFetch('/api/org-templates', {
                     method: 'GET',
                     signal: controller.signal,
                     cache: 'no-store',
@@ -200,7 +201,7 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
         const timer = setTimeout(() => {
             void (async () => {
                 try {
-                    const res = await fetch(
+                    const res = await browserApiFetch(
                         `/api/organizations/check-slug?value=${encodeURIComponent(trimmed)}`,
                         {
                             method: 'GET',
@@ -266,7 +267,7 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
         startTransition(() => {
             void (async () => {
                 try {
-                    const res = await fetch(
+                    const res = await browserApiFetch(
                         importing ? '/api/organizations/import-company' : '/api/organizations',
                         {
                             method: 'POST',
@@ -337,7 +338,7 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
                         if (/^[a-z0-9-]+$/.test(org.slug)) {
                             await persistActiveOrganization(org.slug);
                             onOpenChange(false);
-                            router.push(`/${org.slug}/dashboard`);
+                            router.push(`/org/${org.slug}/dashboard`);
                         }
                     }
                 } catch (err) {
@@ -375,7 +376,7 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
             setShowUpgradeDialog(false);
             setCreatedOrg(null);
             onOpenChange(false);
-            router.push(`/${target.slug}/dashboard`);
+            router.push(`/org/${target.slug}/dashboard`);
             // Pull the freshly-upgraded org list (tenantId is now set on
             // the user, so subsequent fetches reflect that).
             if (didUpgrade) void mutate();

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -236,4 +236,115 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         // No navigation yet — that happens after upgrade choice.
         expect(routerPushMock).not.toHaveBeenCalled();
     });
+
+    it('persists a first Organization as active before closing and navigating', async () => {
+        const newOrg = org({ id: 'o-first', slug: 'first-org', displayName: 'First Org' });
+        const events: string[] = [];
+        routerPushMock.mockImplementation((path: string) => events.push(`navigate:${path}`));
+        const onOpenChange = vi.fn((next: boolean) => events.push(`modal:${next}`));
+        const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/org-templates') {
+                return new Response('[]', { status: 200 });
+            }
+            if (u.includes('/api/organizations/check-slug')) {
+                return new Response(JSON.stringify({ available: true, normalized: newOrg.slug }), {
+                    status: 200,
+                });
+            }
+            if (u === '/api/organizations' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            if (u === '/api/organizations') {
+                return new Response(JSON.stringify([newOrg]), { status: 200 });
+            }
+            if (u.endsWith('/upgrade-from-account') && init?.method === 'POST') {
+                events.push('upgrade');
+                return new Response('{}', { status: 200 });
+            }
+            if (u === '/api/users/me/scope' && init?.method === 'POST') {
+                events.push('scope');
+                return new Response(
+                    JSON.stringify({
+                        tenantId: newOrg.tenantId,
+                        organizationId: newOrg.id,
+                        organizationSlug: newOrg.slug,
+                    }),
+                    { status: 200 },
+                );
+            }
+            throw new Error(`Unexpected fetch: ${u}`);
+        });
+
+        render(<CreateOrganizationModal open={true} onOpenChange={onOpenChange} />);
+        fireEvent.change(screen.getByPlaceholderText('organizations.create.namePlaceholder'), {
+            target: { value: 'First Org' },
+        });
+        fireEvent.click(screen.getByText('organizations.create.submit'));
+        await screen.findByText('organizations.upgrade.title');
+        fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
+
+        await waitFor(() => {
+            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+        });
+        const scopeCall = fetchMock.mock.calls.find(
+            ([url, init]) =>
+                String(url) === '/api/users/me/scope' &&
+                (init as RequestInit | undefined)?.method === 'POST',
+        );
+        expect(scopeCall).toBeDefined();
+        expect(JSON.parse((scopeCall![1] as RequestInit).body as string)).toEqual({
+            organizationSlug: newOrg.slug,
+        });
+        expect(events.indexOf('scope')).toBeLessThan(events.indexOf('modal:false'));
+        expect(events.indexOf('scope')).toBeLessThan(
+            events.indexOf(`navigate:/${newOrg.slug}/dashboard`),
+        );
+    });
+
+    it('keeps the upgrade dialog open when first-Organization scope persistence fails', async () => {
+        const newOrg = org({ id: 'o-first', slug: 'first-org', displayName: 'First Org' });
+        const onOpenChange = vi.fn();
+        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/org-templates') {
+                return new Response('[]', { status: 200 });
+            }
+            if (u.includes('/api/organizations/check-slug')) {
+                return new Response(JSON.stringify({ available: true, normalized: newOrg.slug }), {
+                    status: 200,
+                });
+            }
+            if (u === '/api/organizations' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            if (u === '/api/organizations') {
+                return new Response(JSON.stringify([newOrg]), { status: 200 });
+            }
+            if (u.endsWith('/upgrade-from-account') && init?.method === 'POST') {
+                return new Response('{}', { status: 200 });
+            }
+            if (u === '/api/users/me/scope' && init?.method === 'POST') {
+                return new Response('{}', { status: 503 });
+            }
+            throw new Error(`Unexpected fetch: ${u}`);
+        });
+
+        render(<CreateOrganizationModal open={true} onOpenChange={onOpenChange} />);
+        fireEvent.change(screen.getByPlaceholderText('organizations.create.namePlaceholder'), {
+            target: { value: 'First Org' },
+        });
+        fireEvent.click(screen.getByText('organizations.create.submit'));
+        await screen.findByText('organizations.upgrade.title');
+        fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent(
+                'Failed to persist active Organization (503)',
+            );
+        });
+        expect(screen.getByText('organizations.upgrade.title')).toBeInTheDocument();
+        expect(onOpenChange).not.toHaveBeenCalledWith(false);
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
 });

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -35,6 +35,13 @@ vi.mock('@/i18n/navigation', () => ({
     getPathname: ({ href }: { href: string }) => href,
 }));
 
+const { navigateToWorkspaceDashboardMock } = vi.hoisted(() => ({
+    navigateToWorkspaceDashboardMock: vi.fn(),
+}));
+vi.mock('@/lib/workspace-navigation', () => ({
+    navigateToWorkspaceDashboard: navigateToWorkspaceDashboardMock,
+}));
+
 // next-intl `Dialog` uses Headless UI's Transition.show — render the
 // real dialog so we can drive the form. No additional mock needed.
 
@@ -68,6 +75,7 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         __resetOrganizationsStoreForTests();
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
         routerPushMock.mockReset();
+        navigateToWorkspaceDashboardMock.mockReset();
     });
 
     afterEach(() => {
@@ -156,7 +164,10 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
             // Modal closed.
             expect(onOpenChange).toHaveBeenCalledWith(false);
             // Navigated to the new Org's dashboard.
-            expect(routerPushMock).toHaveBeenCalledWith(`/org/${newOrg.slug}/dashboard`);
+            expect(navigateToWorkspaceDashboardMock).toHaveBeenCalledWith({
+                kind: 'organization',
+                slug: newOrg.slug,
+            });
         });
 
         // POST request body carried the trimmed name.
@@ -237,13 +248,15 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
             expect(screen.queryByText('organizations.create.submit')).toBeNull();
         });
         // No navigation yet — that happens after upgrade choice.
-        expect(routerPushMock).not.toHaveBeenCalled();
+        expect(navigateToWorkspaceDashboardMock).not.toHaveBeenCalled();
     });
 
     it('persists a first Organization as active before closing and navigating', async () => {
         const newOrg = org({ id: 'o-first', slug: 'first-org', displayName: 'First Org' });
         const events: string[] = [];
-        routerPushMock.mockImplementation((path: string) => events.push(`navigate:${path}`));
+        navigateToWorkspaceDashboardMock.mockImplementation(({ slug }: { slug: string }) =>
+            events.push(`navigate:/org/${slug}/dashboard`),
+        );
         const onOpenChange = vi.fn((next: boolean) => events.push(`modal:${next}`));
         const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
             const u = String(url);
@@ -288,7 +301,10 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
 
         await waitFor(() => {
-            expect(routerPushMock).toHaveBeenCalledWith(`/org/${newOrg.slug}/dashboard`);
+            expect(navigateToWorkspaceDashboardMock).toHaveBeenCalledWith({
+                kind: 'organization',
+                slug: newOrg.slug,
+            });
         });
         const scopeCall = fetchMock.mock.calls.find(
             ([url, init]) =>
@@ -348,6 +364,6 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         });
         expect(screen.getByText('organizations.upgrade.title')).toBeInTheDocument();
         expect(onOpenChange).not.toHaveBeenCalledWith(false);
-        expect(routerPushMock).not.toHaveBeenCalled();
+        expect(navigateToWorkspaceDashboardMock).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -124,6 +124,16 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
                     headers: { 'Content-Type': 'application/json' },
                 });
             }
+            if (u === '/api/users/me/scope' && init?.method === 'POST') {
+                return new Response(
+                    JSON.stringify({
+                        tenantId: newOrg.tenantId,
+                        organizationId: newOrg.id,
+                        organizationSlug: newOrg.slug,
+                    }),
+                    { status: 200, headers: { 'Content-Type': 'application/json' } },
+                );
+            }
             if (u === '/api/organizations') {
                 return new Response(JSON.stringify([newOrg]), {
                     status: 200,
@@ -158,6 +168,16 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         expect(postCall).toBeDefined();
         const body = JSON.parse((postCall![1] as RequestInit).body as string);
         expect(body).toEqual({ name: 'Globex LLC' });
+
+        const scopeCall = fetchMock.mock.calls.find(
+            ([url, init]) =>
+                String(url) === '/api/users/me/scope' &&
+                (init as RequestInit | undefined)?.method === 'POST',
+        );
+        expect(scopeCall).toBeDefined();
+        expect(JSON.parse((scopeCall![1] as RequestInit).body as string)).toEqual({
+            organizationSlug: newOrg.slug,
+        });
     });
 
     /**

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -156,7 +156,7 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
             // Modal closed.
             expect(onOpenChange).toHaveBeenCalledWith(false);
             // Navigated to the new Org's dashboard.
-            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+            expect(routerPushMock).toHaveBeenCalledWith(`/org/${newOrg.slug}/dashboard`);
         });
 
         // POST request body carried the trimmed name.
@@ -168,6 +168,9 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         expect(postCall).toBeDefined();
         const body = JSON.parse((postCall![1] as RequestInit).body as string);
         expect(body).toEqual({ name: 'Globex LLC' });
+        expect(new Headers((postCall![1] as RequestInit).headers).get('x-ever-workspace')).toBe(
+            'personal',
+        );
 
         const scopeCall = fetchMock.mock.calls.find(
             ([url, init]) =>
@@ -285,7 +288,7 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
 
         await waitFor(() => {
-            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+            expect(routerPushMock).toHaveBeenCalledWith(`/org/${newOrg.slug}/dashboard`);
         });
         const scopeCall = fetchMock.mock.calls.find(
             ([url, init]) =>
@@ -298,7 +301,7 @@ describe('CreateOrganizationModal — EW-661 Phase 9', () => {
         });
         expect(events.indexOf('scope')).toBeLessThan(events.indexOf('modal:false'));
         expect(events.indexOf('scope')).toBeLessThan(
-            events.indexOf(`navigate:/${newOrg.slug}/dashboard`),
+            events.indexOf(`navigate:/org/${newOrg.slug}/dashboard`),
         );
     });
 

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -38,7 +38,8 @@ vi.mock('@/i18n/navigation', () => ({
 const { navigateToWorkspaceDashboardMock } = vi.hoisted(() => ({
     navigateToWorkspaceDashboardMock: vi.fn(),
 }));
-vi.mock('@/lib/workspace-navigation', () => ({
+vi.mock('@/lib/workspace-navigation', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/lib/workspace-navigation')>()),
     navigateToWorkspaceDashboard: navigateToWorkspaceDashboardMock,
 }));
 

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
@@ -14,8 +14,12 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { useRouter } from '@/i18n/navigation';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
+import {
+    navigateToWorkspaceDashboard,
+    persistActiveOrganization,
+} from '@/lib/workspace-navigation';
 import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
 
 const MAX_NAME_LENGTH = 200;
@@ -42,7 +46,8 @@ export interface RegisterCompanyDialogProps {
  *  - First Org (`organizations.length === 0` pre-submit) → hands off
  *    to `<UpgradeOrCreateDialog>` so the user can choose Upgrade vs
  *    Empty.
- *  - 2nd+ Org → close + navigate to `/${org.slug}/dashboard`.
+ *  - 2nd+ Org → persist membership-validated scope, then cross to the
+ *    canonical `/org/{slug}/dashboard` in a fresh document.
  *
  * The full Stripe Atlas form (paperwork inputs, jurisdiction picker,
  * etc.) is intentionally out of scope here — the chip's value in v1
@@ -52,7 +57,6 @@ export interface RegisterCompanyDialogProps {
  */
 export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDialogProps) {
     const t = useTranslations('organizations.registerCompany');
-    const router = useRouter();
     const { organizations, isLoading, error: orgsError, mutate } = useOrganizations();
 
     const [name, setName] = useState('');
@@ -127,7 +131,7 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
         setIsSubmitting(true);
 
         try {
-            const res = await fetch('/api/organizations/register-company', {
+            const res = await browserApiFetch('/api/organizations/register-company', {
                 method: 'POST',
                 credentials: 'include',
                 cache: 'no-store',
@@ -164,8 +168,9 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                 setCreatedOrg(org);
                 setShowUpgradeDialog(true);
             } else {
+                await persistActiveOrganization(org.slug);
                 onOpenChange(false);
-                router.push(`/${org.slug}/dashboard`);
+                navigateToWorkspaceDashboard({ kind: 'organization', slug: org.slug });
             }
         } catch (err) {
             setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
@@ -181,22 +186,24 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
         organizations.length,
         mutate,
         onOpenChange,
-        router,
         t,
     ]);
 
     const handleUpgradeDialogClose = useCallback(
-        (didUpgrade: boolean) => {
-            setShowUpgradeDialog(false);
+        async (didUpgrade: boolean) => {
             const target = createdOrg;
+            if (!target) {
+                throw new Error(t('errors.generic'));
+            }
+
+            await persistActiveOrganization(target.slug);
+            setShowUpgradeDialog(false);
             setCreatedOrg(null);
             onOpenChange(false);
-            if (target) {
-                router.push(`/${target.slug}/dashboard`);
-                if (didUpgrade) void mutate();
-            }
+            navigateToWorkspaceDashboard({ kind: 'organization', slug: target.slug });
+            if (didUpgrade) void mutate();
         },
-        [createdOrg, mutate, onOpenChange, router],
+        [createdOrg, mutate, onOpenChange, t],
     );
 
     const showCreatePanel = !showUpgradeDialog;

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
@@ -34,7 +34,26 @@ vi.mock('@/i18n/navigation', () => ({
     getPathname: ({ href }: { href: string }) => href,
 }));
 
+const { navigateToWorkspaceDashboardMock } = vi.hoisted(() => ({
+    navigateToWorkspaceDashboardMock: vi.fn(),
+}));
+vi.mock('@/lib/workspace-navigation', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/lib/workspace-navigation')>()),
+    navigateToWorkspaceDashboard: navigateToWorkspaceDashboardMock,
+}));
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/lib/constants')>()),
+    API_URL: 'http://api.example',
+}));
+
 import { RegisterCompanyDialog } from './RegisterCompanyDialog';
+import { POST as registerCompanyPost } from '@/app/api/organizations/register-company/route';
+import { POST as persistScopePost } from '@/app/api/users/me/scope/route';
 import {
     __resetOrganizationsStoreForTests,
     __seedOrganizationsStoreForTests,
@@ -59,15 +78,90 @@ function org(overrides: Partial<OrganizationResponse> = {}): OrganizationRespons
     };
 }
 
+interface UpstreamCall {
+    kind: 'register' | 'persist';
+    init: RequestInit;
+}
+
+function installRealBffBoundary(
+    newOrganization: OrganizationResponse,
+    options: { persistStatus?: number; events?: string[] } = {},
+) {
+    const upstreamCalls: UpstreamCall[] = [];
+    const events = options.events ?? [];
+
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+            if (url === '/api/organizations/register-company' && init?.method === 'POST') {
+                const headers = new Headers(init.headers);
+                // A hostile browser may try to send the internal API header.
+                // The actual BFF handler below must overwrite it from the
+                // browser selector derived from the visible URL.
+                headers.set('x-scope-slug', 'spoofed-yo');
+                return registerCompanyPost(
+                    new Request('http://web.example/api/organizations/register-company', {
+                        ...init,
+                        headers,
+                    }) as Parameters<typeof registerCompanyPost>[0],
+                );
+            }
+            if (url === '/api/users/me/scope' && init?.method === 'POST') {
+                const headers = new Headers(init.headers);
+                headers.set('x-scope-slug', 'spoofed-yo');
+                return persistScopePost(
+                    new Request('http://web.example/api/users/me/scope', {
+                        ...init,
+                        headers,
+                    }) as Parameters<typeof persistScopePost>[0],
+                );
+            }
+            if (url === '/api/organizations' && init?.method === 'GET') {
+                return Response.json([newOrganization]);
+            }
+            if (url === 'http://api.example/organizations/register-company') {
+                events.push('register');
+                upstreamCalls.push({ kind: 'register', init: init ?? {} });
+                return Response.json(newOrganization, { status: 201 });
+            }
+            if (url === 'http://api.example/users/me/scope') {
+                events.push('persist');
+                upstreamCalls.push({ kind: 'persist', init: init ?? {} });
+                const status = options.persistStatus ?? 200;
+                if (status !== 200) {
+                    return Response.json({ error: 'Membership revoked' }, { status });
+                }
+                return Response.json({
+                    tenantId: newOrganization.tenantId,
+                    organizationId: newOrganization.id,
+                    organizationSlug: newOrganization.slug,
+                });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        }),
+    );
+
+    navigateToWorkspaceDashboardMock.mockImplementation(() => {
+        events.push('navigate');
+    });
+
+    return { upstreamCalls, events };
+}
+
 describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
     beforeEach(() => {
         __resetOrganizationsStoreForTests();
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
         routerPushMock.mockReset();
+        navigateToWorkspaceDashboardMock.mockReset();
+        window.history.replaceState({}, '', '/dashboard');
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
     });
 
     it('disables submit when name is empty and never fires the POST', () => {
@@ -102,27 +196,15 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
      * register-company endpoint, navigates to the new Org's dashboard,
      * and closes the modal.
      */
-    it('calls POST /api/organizations/register-company and navigates after success (2nd Org)', async () => {
+    it('uses the visible Organization scope, persists, then canonically navigates after a later-Org create', async () => {
         __seedOrganizationsStoreForTests({
             data: [org({ id: 'o-existing', slug: 'existing' })],
             isLoading: false,
             error: null,
         });
+        window.history.replaceState({}, '', '/org/ever/works');
         const newOrg = org({ id: 'o-2', slug: 'globex', displayName: 'Globex LLC' });
-        const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-            const u = String(url);
-            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
-                return new Response(JSON.stringify(newOrg), {
-                    status: 201,
-                    headers: { 'Content-Type': 'application/json' },
-                });
-            }
-            if (u === '/api/organizations') {
-                // best-effort `mutate()` after success.
-                return new Response(JSON.stringify([newOrg]), { status: 200 });
-            }
-            throw new Error(`Unexpected fetch: ${u}`);
-        });
+        const { upstreamCalls, events } = installRealBffBoundary(newOrg);
 
         const onOpenChange = vi.fn();
         render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
@@ -137,19 +219,25 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
 
         await waitFor(() => {
             expect(onOpenChange).toHaveBeenCalledWith(false);
-            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+            expect(navigateToWorkspaceDashboardMock).toHaveBeenCalledWith({
+                kind: 'organization',
+                slug: newOrg.slug,
+            });
         });
 
-        const postCall = fetchMock.mock.calls.find(
-            ([u, init]) =>
-                String(u) === '/api/organizations/register-company' &&
-                (init as RequestInit | undefined)?.method === 'POST',
-        );
-        expect(postCall).toBeDefined();
-        const body = JSON.parse((postCall![1] as RequestInit).body as string);
+        expect(routerPushMock).not.toHaveBeenCalled();
+        expect(events).toEqual(['register', 'persist', 'navigate']);
+        const registerCall = upstreamCalls.find((call) => call.kind === 'register');
+        const persistCall = upstreamCalls.find((call) => call.kind === 'persist');
+        expect(new Headers(registerCall?.init.headers).get('x-scope-slug')).toBe('ever');
+        expect(new Headers(persistCall?.init.headers).get('x-scope-slug')).toBe('ever');
+        const body = JSON.parse(String(registerCall?.init.body));
         // countryCode is sent raw; the server normalizes (single source of
         // truth — Greptile P2 on PR #1071).
         expect(body).toEqual({ name: 'Globex LLC', countryCode: 'de' });
+        expect(JSON.parse(String(persistCall?.init.body))).toEqual({
+            organizationSlug: newOrg.slug,
+        });
     });
 
     /**
@@ -181,13 +269,7 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
     it('chains into the UpgradeOrCreateDialog when this is the user first Org', async () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
         const newOrg = org({ id: 'o-first', slug: 'first-co', displayName: 'First Company' });
-        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-            const u = String(url);
-            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
-                return new Response(JSON.stringify(newOrg), { status: 201 });
-            }
-            return new Response(JSON.stringify([newOrg]), { status: 200 });
-        });
+        installRealBffBoundary(newOrg);
 
         render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
 
@@ -204,6 +286,99 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
         expect(routerPushMock).not.toHaveBeenCalled();
     });
 
+    it('persists personal scope before completing a first-Org empty create and navigating', async () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        window.history.replaceState({}, '', '/dashboard');
+        const newOrg = org({ id: 'o-first', slug: 'first-co', displayName: 'First Company' });
+        const { upstreamCalls, events } = installRealBffBoundary(newOrg);
+        const onOpenChange = vi.fn();
+        render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'First Company' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+        await screen.findByText('organizations.upgrade.title');
+        fireEvent.click(document.getElementById('upgrade-or-create-empty') as HTMLInputElement);
+        fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
+
+        await waitFor(() =>
+            expect(navigateToWorkspaceDashboardMock).toHaveBeenCalledWith({
+                kind: 'organization',
+                slug: newOrg.slug,
+            }),
+        );
+        expect(events).toEqual(['register', 'persist', 'navigate']);
+        for (const call of upstreamCalls) {
+            expect(new Headers(call.init.headers).get('x-scope-slug')).toBe('@personal');
+        }
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
+
+    it('does not close or navigate when active-Organization persistence rejects membership', async () => {
+        __seedOrganizationsStoreForTests({
+            data: [org({ id: 'o-existing', slug: 'ever' })],
+            isLoading: false,
+            error: null,
+        });
+        window.history.replaceState({}, '', '/org/ever/works');
+        const newOrg = org({ id: 'o-revoked', slug: 'revoked-co' });
+        const { events } = installRealBffBoundary(newOrg, { persistStatus: 404 });
+        const onOpenChange = vi.fn();
+        render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Revoked Company' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+
+        await screen.findByText('Failed to persist active Organization (404)');
+        expect(events).toEqual(['register', 'persist']);
+        expect(navigateToWorkspaceDashboardMock).not.toHaveBeenCalled();
+        expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it('keeps the first-Org completion dialog open when persistence fails', async () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        const newOrg = org({ id: 'o-first', slug: 'first-co' });
+        const { events } = installRealBffBoundary(newOrg, { persistStatus: 404 });
+        const onOpenChange = vi.fn();
+        render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'First Company' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+        await screen.findByText('organizations.upgrade.title');
+        fireEvent.click(document.getElementById('upgrade-or-create-empty') as HTMLInputElement);
+        fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
+
+        await screen.findByText('Failed to persist active Organization (404)');
+        expect(events).toEqual(['register', 'persist']);
+        expect(screen.getByText('organizations.upgrade.title')).toBeInTheDocument();
+        expect(navigateToWorkspaceDashboardMock).not.toHaveBeenCalled();
+        expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it('proves register-company BFF rejects a missing browser selector before upstream', async () => {
+        const newOrg = org();
+        const { upstreamCalls } = installRealBffBoundary(newOrg);
+        const response = await registerCompanyPost(
+            new Request('http://web.example/api/organizations/register-company', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-scope-slug': 'spoofed-yo',
+                },
+                body: JSON.stringify({ name: 'Must fail closed' }),
+            }) as Parameters<typeof registerCompanyPost>[0],
+        );
+
+        expect(response.status).toBe(400);
+        expect(upstreamCalls).toHaveLength(0);
+    });
+
     /**
      * Regression — when the org-list GET errored, `organizations` is `[]`
      * but unreliable, so the user must NOT be treated as first-org (which
@@ -218,13 +393,7 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
             error: new Error('GET /api/organizations failed'),
         });
         const newOrg = org({ id: 'o-3', slug: 'initech', displayName: 'Initech' });
-        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-            const u = String(url);
-            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
-                return new Response(JSON.stringify(newOrg), { status: 201 });
-            }
-            return new Response(JSON.stringify([newOrg]), { status: 200 });
-        });
+        installRealBffBoundary(newOrg);
 
         const onOpenChange = vi.fn();
         render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
@@ -236,7 +405,10 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
 
         await waitFor(() => {
             expect(onOpenChange).toHaveBeenCalledWith(false);
-            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+            expect(navigateToWorkspaceDashboardMock).toHaveBeenCalledWith({
+                kind: 'organization',
+                slug: newOrg.slug,
+            });
         });
         // The upgrade dialog (first-org path) must NOT appear.
         expect(screen.queryByText('organizations.upgrade.title')).toBeNull();

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
@@ -14,6 +14,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 type UpgradeChoice = 'upgrade' | 'empty';
 
@@ -92,7 +93,7 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
         startTransition(async () => {
             try {
                 if (!upgradeCompleted) {
-                    const res = await fetch(
+                    const res = await browserApiFetch(
                         `/api/organizations/${encodeURIComponent(organization.id)}/upgrade-from-account`,
                         {
                             method: 'POST',

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
@@ -24,9 +24,10 @@ export interface UpgradeOrCreateDialogProps {
      * Fired when the dialog finishes (either branch completes, or the
      * user cancels). `didUpgrade=true` means the upgrade API call ran
      * and succeeded — the caller may want to refresh data tied to the
-     * promoted Tenant.
+     * promoted Tenant. Async callers are awaited; rejection leaves this
+     * dialog open and surfaces the error so completion can be retried.
      */
-    onClose: (didUpgrade: boolean) => void;
+    onClose: (didUpgrade: boolean) => void | Promise<void>;
 }
 
 /**
@@ -54,6 +55,7 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
     const t = useTranslations('organizations.upgrade');
     const [choice, setChoice] = useState<UpgradeChoice>('upgrade');
     const [error, setError] = useState<string | null>(null);
+    const [upgradeCompleted, setUpgradeCompleted] = useState(false);
     const [pending, startTransition] = useTransition();
     const upgradeRadioRef = useRef<HTMLInputElement>(null);
 
@@ -64,6 +66,7 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
         if (open) {
             setChoice('upgrade');
             setError(null);
+            setUpgradeCompleted(false);
             const id = window.setTimeout(() => {
                 upgradeRadioRef.current?.focus();
             }, 0);
@@ -73,14 +76,22 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
 
     const handleConfirm = () => {
         setError(null);
-        if (choice === 'empty') {
-            // No API call — just close. Parent handles navigation.
-            onClose(false);
+        if (choice === 'empty' && !upgradeCompleted) {
+            // No upgrade API call — the parent still persists active scope
+            // before it closes and navigates.
+            startTransition(async () => {
+                try {
+                    await onClose(false);
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : t('errors.generic'));
+                }
+            });
             return;
         }
-        startTransition(() => {
-            void (async () => {
-                try {
+
+        startTransition(async () => {
+            try {
+                if (!upgradeCompleted) {
                     const res = await fetch(
                         `/api/organizations/${encodeURIComponent(organization.id)}/upgrade-from-account`,
                         {
@@ -107,17 +118,25 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
                         }
                         return;
                     }
-                    onClose(true);
-                } catch (err) {
-                    setError(err instanceof Error ? err.message : t('errors.generic'));
+                    setUpgradeCompleted(true);
                 }
-            })();
+                await onClose(true);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : t('errors.generic'));
+            }
         });
     };
 
     const handleCancel = () => {
         if (pending) return;
-        onClose(false);
+        setError(null);
+        startTransition(async () => {
+            try {
+                await onClose(upgradeCompleted);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : t('errors.generic'));
+            }
+        });
     };
 
     return (
@@ -139,7 +158,7 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
                         onChange={() => setChoice('upgrade')}
                         label={t('upgradeOption')}
                         help={t('upgradeHelp')}
-                        disabled={pending}
+                        disabled={pending || upgradeCompleted}
                     />
                     <ChoiceRow
                         id="upgrade-or-create-empty"
@@ -147,7 +166,7 @@ export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOr
                         onChange={() => setChoice('empty')}
                         label={t('emptyOption')}
                         help={t('emptyHelp')}
-                        disabled={pending}
+                        disabled={pending || upgradeCompleted}
                     />
                 </div>
 

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
@@ -131,6 +131,8 @@ describe('UpgradeOrCreateDialog — EW-661 Phase 9', () => {
             );
             expect(onClose).toHaveBeenCalledWith(true);
         });
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-ever-workspace')).toBe('personal');
     });
 
     it('keeps the dialog open and reports a parent completion failure', async () => {

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
@@ -133,6 +133,22 @@ describe('UpgradeOrCreateDialog — EW-661 Phase 9', () => {
         });
     });
 
+    it('keeps the dialog open and reports a parent completion failure', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+        );
+        const onClose = vi.fn().mockRejectedValue(new Error('Active scope was not persisted'));
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        fireEvent.click(screen.getByText('organizations.upgrade.confirm'));
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent('Active scope was not persisted');
+        });
+        expect(onClose).toHaveBeenCalledWith(true);
+        expect(screen.getByText('organizations.upgrade.title')).toBeInTheDocument();
+    });
+
     /**
      * 409 UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS — first-Org-only
      * guard fired on the API side. The dialog surfaces a generic

--- a/apps/web/src/components/settings/OrganizationSettings.tsx
+++ b/apps/web/src/components/settings/OrganizationSettings.tsx
@@ -9,6 +9,7 @@ import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { ShowDateTime } from '@/components/ui/show-datetime';
 import { MergePolicyCard } from '@/components/policy/MergePolicyCard';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { OrganizationMembersSection } from './OrganizationMembersSection';
 
@@ -93,16 +94,19 @@ export function OrganizationSettings() {
         startTransition(() => {
             void (async () => {
                 try {
-                    const res = await fetch(`/api/organizations/${encodeURIComponent(orgId)}`, {
-                        method: 'PATCH',
-                        credentials: 'include',
-                        cache: 'no-store',
-                        headers: { 'Content-Type': 'application/json' },
-                        // Empty textarea = clear the vision (explicit null —
-                        // the column is nullable and NULL means "never set /
-                        // no vision context for agents").
-                        body: JSON.stringify({ vision: trimmed.length > 0 ? trimmed : null }),
-                    });
+                    const res = await browserApiFetch(
+                        `/api/organizations/${encodeURIComponent(orgId)}`,
+                        {
+                            method: 'PATCH',
+                            credentials: 'include',
+                            cache: 'no-store',
+                            headers: { 'Content-Type': 'application/json' },
+                            // Empty textarea = clear the vision (explicit null —
+                            // the column is nullable and NULL means "never set /
+                            // no vision context for agents").
+                            body: JSON.stringify({ vision: trimmed.length > 0 ? trimmed : null }),
+                        },
+                    );
                     if (!res.ok) {
                         setSaveError(t('errors.generic'));
                         return;
@@ -143,7 +147,7 @@ export function OrganizationSettings() {
         async (next: MergePolicyOverride | null) => {
             if (!selectedOrg) return { success: false, error: t('errors.generic') };
             try {
-                const res = await fetch(
+                const res = await browserApiFetch(
                     `/api/organizations/${encodeURIComponent(selectedOrg.id)}`,
                     {
                         method: 'PATCH',

--- a/apps/web/src/components/settings/OrganizationSettings.unit.spec.tsx
+++ b/apps/web/src/components/settings/OrganizationSettings.unit.spec.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ResolvedMergePolicy } from '@ever-works/contracts';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+}));
+
+vi.mock('./OrganizationMembersSection', () => ({
+    OrganizationMembersSection: () => null,
+}));
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/lib/constants')>()),
+    API_URL: 'http://api.example',
+}));
+
+import { PATCH } from '@/app/api/organizations/[id]/route';
+import { OrganizationSettings } from './OrganizationSettings';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+const ORGANIZATION: OrganizationResponse = {
+    id: 'org-ever',
+    tenantId: 'tenant-ever',
+    slug: 'ever',
+    legalName: 'Ever Co',
+    displayName: 'Ever',
+    countryCode: 'ES',
+    registrationProvider: 'manual',
+    registrationStatus: 'registered',
+    linkedWorkId: null,
+    vision: null,
+    visionUpdatedAt: null,
+    mergePolicy: null,
+    createdAt: '2026-08-23T00:00:00.000Z',
+    updatedAt: '2026-08-23T00:00:00.000Z',
+};
+
+const RESOLUTION: ResolvedMergePolicy = {
+    policy: {
+        allowAgentMerge: true,
+        requireGreenGate: true,
+        requireHumanApproval: false,
+        allowedMergeMethods: ['squash'],
+        protectedBranches: ['main'],
+    },
+    source: 'default',
+    chain: [{ scope: 'default', id: null, fields: [] }],
+};
+
+interface UpstreamCall {
+    url: string;
+    init: RequestInit;
+}
+
+function installRealOrganizationPatchBoundary() {
+    const upstreamCalls: UpstreamCall[] = [];
+
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+            if (url.startsWith('/api/merge-policy/resolve?')) {
+                return Response.json(RESOLUTION);
+            }
+            if (url === '/api/organizations' && init?.method === 'GET') {
+                return Response.json([ORGANIZATION]);
+            }
+            if (url === `/api/organizations/${ORGANIZATION.id}` && init?.method === 'PATCH') {
+                const headers = new Headers(init.headers);
+                // Simulate a hostile browser-supplied internal API header. The
+                // real BFF must discard it in favour of the visible tab scope.
+                headers.set('x-scope-slug', 'yo');
+                return PATCH(
+                    new Request(`http://web.example${url}`, { ...init, headers }) as Parameters<
+                        typeof PATCH
+                    >[0],
+                    { params: Promise.resolve({ id: ORGANIZATION.id }) },
+                );
+            }
+            if (url === `http://api.example/organizations/${ORGANIZATION.id}`) {
+                const call = { url, init: init ?? {} };
+                upstreamCalls.push(call);
+                const body = JSON.parse(String(init?.body)) as Partial<OrganizationResponse>;
+                return Response.json({ ...ORGANIZATION, ...body }, { status: 200 });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        }),
+    );
+
+    return upstreamCalls;
+}
+
+async function renderLoadedSettings() {
+    render(<OrganizationSettings />);
+    await waitFor(() => expect(screen.getByTestId('organization-settings')).toBeInTheDocument());
+    await waitFor(() =>
+        expect(screen.getByTestId('organization-merge-policy-summary')).not.toHaveTextContent(
+            'Loading the effective policy',
+        ),
+    );
+}
+
+describe('OrganizationSettings scoped BFF writes', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        __seedOrganizationsStoreForTests({
+            data: [ORGANIZATION],
+            isLoading: false,
+            error: null,
+        });
+        window.history.replaceState({}, '', '/org/ever/settings/organization');
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('saves Vision through the real BFF with visible scope overriding spoofed scope', async () => {
+        const upstreamCalls = installRealOrganizationPatchBoundary();
+        await renderLoadedSettings();
+
+        fireEvent.change(screen.getByTestId('organization-settings-vision-input'), {
+            target: { value: 'Build humane autonomous companies.' },
+        });
+        fireEvent.click(screen.getByTestId('organization-settings-vision-save'));
+
+        await waitFor(() => expect(upstreamCalls).toHaveLength(1));
+        expect(new Headers(upstreamCalls[0].init.headers).get('x-scope-slug')).toBe('ever');
+        expect(JSON.parse(String(upstreamCalls[0].init.body))).toEqual({
+            vision: 'Build humane autonomous companies.',
+        });
+    });
+
+    it('saves merge policy through the same real scoped BFF boundary', async () => {
+        const upstreamCalls = installRealOrganizationPatchBoundary();
+        await renderLoadedSettings();
+
+        fireEvent.click(screen.getByTestId('organization-merge-policy-requireHumanApproval'));
+
+        await waitFor(() => expect(upstreamCalls).toHaveLength(1));
+        expect(new Headers(upstreamCalls[0].init.headers).get('x-scope-slug')).toBe('ever');
+        expect(JSON.parse(String(upstreamCalls[0].init.body))).toEqual({
+            mergePolicy: { requireHumanApproval: true },
+        });
+    });
+
+    it('proves the real BFF fails closed when a browser selector is absent', async () => {
+        const upstreamCalls = installRealOrganizationPatchBoundary();
+        const response = await PATCH(
+            new Request(`http://web.example/api/organizations/${ORGANIZATION.id}`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-scope-slug': 'yo',
+                },
+                body: JSON.stringify({ vision: 'Must not cross the boundary' }),
+            }) as Parameters<typeof PATCH>[0],
+            { params: Promise.resolve({ id: ORGANIZATION.id }) },
+        );
+
+        expect(response.status).toBe(400);
+        expect(upstreamCalls).toHaveLength(0);
+    });
+});

--- a/apps/web/src/components/terminal/AgentTerminalClient.tsx
+++ b/apps/web/src/components/terminal/AgentTerminalClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { TerminalPane } from './TerminalPane';
 
 interface RunRow {
@@ -45,9 +46,12 @@ export function AgentTerminalClient({
         setStarting(true);
         setStartError(null);
         try {
-            const res = await fetch(`/api/agents/${agentId}/runs/${selected}/terminal/start`, {
-                method: 'POST',
-            });
+            const res = await browserApiFetch(
+                `/api/agents/${agentId}/runs/${selected}/terminal/start`,
+                {
+                    method: 'POST',
+                },
+            );
             if (!res.ok) {
                 // The API's 409 messages ("already live", "run has finished")
                 // are the useful ones — surface them verbatim when present.

--- a/apps/web/src/components/terminal/AgentTerminalClient.unit.spec.tsx
+++ b/apps/web/src/components/terminal/AgentTerminalClient.unit.spec.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('./TerminalPane', () => ({
+    TerminalPane: () => <div data-testid="terminal-pane" />,
+}));
+
+import { AgentTerminalClient } from './AgentTerminalClient';
+
+describe('AgentTerminalClient workspace selector', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('stamps start-session from the visible Organization route', async () => {
+        window.history.replaceState({}, '', '/org/ever/agents/agent-1');
+        const fetchMock = vi.fn(
+            async (_input: RequestInfo | URL, _init?: RequestInit) =>
+                new Response('{}', { status: 200 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <AgentTerminalClient
+                agentId="11111111-2222-4333-8444-555555555555"
+                initialRunId="2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f"
+                runs={[
+                    {
+                        id: '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f',
+                        status: 'running',
+                        triggerKind: 'manual',
+                        createdAt: '2026-08-23T00:00:00.000Z',
+                        summary: null,
+                    },
+                ]}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('terminal-start-session'));
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
+    });
+});

--- a/apps/web/src/components/terminal/TerminalPane.unit.spec.tsx
+++ b/apps/web/src/components/terminal/TerminalPane.unit.spec.tsx
@@ -8,6 +8,7 @@ vi.mock('next-intl', () => ({
 
 import { TerminalPane } from './TerminalPane';
 import type { TerminalRenderer } from './terminal-renderer';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
 
 /**
  * Injected-seam suite: a fake renderer (never mount real xterm in
@@ -136,6 +137,42 @@ describe('TerminalPane', () => {
         );
         return renderer;
     }
+
+    it('stamps the default transcript and attach transport from the visible Organization route', async () => {
+        window.history.replaceState({}, '', '/org/ever/agents/agent-1');
+        const fetchMock = vi.fn(
+            async (input: RequestInfo | URL, _init?: RequestInit) =>
+                new Response(
+                    String(input).includes('/attach-token')
+                        ? JSON.stringify({
+                              token: 'tok',
+                              wsUrl: 'ws://x/ws/terminal/r',
+                              role: 'driver',
+                              expiresInSec: 60,
+                          })
+                        : JSON.stringify({ chunks: [], lastSeq: null, hasMore: false, total: 0 }),
+                    { status: 200 },
+                ),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <TerminalPane
+                agentId={AGENT}
+                runId={RUN}
+                createRenderer={async () => makeFakeRenderer()}
+                attachDeps={{ webSocketImpl: ScriptedSocket as unknown as typeof WebSocket }}
+            />,
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        for (const call of fetchMock.mock.calls) {
+            const init = call[1] as RequestInit;
+            expect(new Headers(init.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
+        }
+        window.history.replaceState({}, '', '/');
+        vi.unstubAllGlobals();
+    });
 
     it('reaches attached, keeps the mount node React-child-free, and renders live bytes', async () => {
         const renderer = renderPane(okTokenFetch());

--- a/apps/web/src/components/terminal/use-terminal-attach.ts
+++ b/apps/web/src/components/terminal/use-terminal-attach.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 /**
  * Terminal attach hook (streaming-terminal M7).
@@ -101,7 +102,7 @@ export function useTerminalAttach(
     useEffect(() => {
         let cancelled = false;
         let socket: WebSocket | null = null;
-        const doFetch = deps.fetchImpl ?? fetch;
+        const doFetch = deps.fetchImpl ?? browserApiFetch;
         const WS = deps.webSocketImpl ?? WebSocket;
 
         setState('starting');

--- a/apps/web/src/i18n/navigation-base.ts
+++ b/apps/web/src/i18n/navigation-base.ts
@@ -1,0 +1,5 @@
+import { createNavigation } from 'next-intl/navigation';
+import { routing } from './routing';
+
+/** Raw next-intl navigation primitives shared by the client wrapper and server exports. */
+export const navigationBase = createNavigation(routing);

--- a/apps/web/src/i18n/navigation-base.ts
+++ b/apps/web/src/i18n/navigation-base.ts
@@ -1,5 +1,5 @@
 import { createNavigation } from 'next-intl/navigation';
-import { routing } from './routing';
+import { routing } from '@/i18n/routing';
 
 /** Raw next-intl navigation primitives shared by the client wrapper and server exports. */
 export const navigationBase = createNavigation(routing);

--- a/apps/web/src/i18n/navigation-client.tsx
+++ b/apps/web/src/i18n/navigation-client.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { forwardRef, useMemo, type ComponentProps, type ComponentRef } from 'react';
+import { buildWorkspaceHref, parseWorkspacePath } from '@/lib/workspace-scope';
+import { navigationBase } from './navigation-base';
+
+type LinkProps = ComponentProps<typeof navigationBase.Link>;
+type LinkHref = LinkProps['href'];
+
+type ObjectHref = {
+    pathname: string;
+    [key: string]: unknown;
+};
+
+export type WorkspaceNavigableHref = string | ObjectHref;
+
+const PERSONAL_EXIT_PATHS = [
+    '/auth',
+    '/claim',
+    '/forgot-password',
+    '/login',
+    '/logout',
+    '/org-invite',
+    '/register',
+    '/reset-password',
+    '/verify-email',
+] as const;
+
+function isPersonalExit(pathname: string): boolean {
+    return PERSONAL_EXIT_PATHS.some(
+        (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    );
+}
+
+/**
+ * Keep ordinary in-app navigation in the Organization namespace visible in
+ * the current tab. Explicit canonical destinations, auth/public exits,
+ * external URLs, fragments, and query-only changes retain their exact href.
+ */
+export function withWorkspaceHref<T extends WorkspaceNavigableHref>(
+    href: T,
+    currentPathname: string,
+): T {
+    let pathname: string;
+    if (typeof href === 'string') {
+        pathname = href;
+    } else {
+        pathname = href.pathname;
+    }
+
+    if (
+        !pathname.startsWith('/') ||
+        pathname.startsWith('//') ||
+        pathname === '/org' ||
+        pathname.startsWith('/org/') ||
+        isPersonalExit(pathname)
+    ) {
+        return href;
+    }
+
+    let currentScope;
+    try {
+        currentScope = parseWorkspacePath(currentPathname);
+    } catch {
+        return href;
+    }
+    if (currentScope.kind !== 'organization') return href;
+
+    const scopedPathname = buildWorkspaceHref(currentScope, pathname);
+    return (
+        typeof href === 'string'
+            ? scopedPathname
+            : { ...(href as ObjectHref), pathname: scopedPathname }
+    ) as T;
+}
+
+/** Workspace-aware drop-in replacement for next-intl's Link. */
+export const Link = forwardRef<ComponentRef<typeof navigationBase.Link>, LinkProps>(
+    function WorkspaceLink({ href, ...props }, ref) {
+        const pathname = navigationBase.usePathname();
+        const scopedHref = withWorkspaceHref(href as WorkspaceNavigableHref, pathname) as LinkHref;
+        return <navigationBase.Link ref={ref} href={scopedHref} {...props} />;
+    },
+);
+
+/** Workspace-aware drop-in replacement for next-intl's client router. */
+export function useRouter(): ReturnType<typeof navigationBase.useRouter> {
+    const router = navigationBase.useRouter();
+    const pathname = navigationBase.usePathname();
+
+    return useMemo(() => {
+        type Router = ReturnType<typeof navigationBase.useRouter>;
+        const push: Router['push'] = ((href: WorkspaceNavigableHref, options?: unknown) =>
+            router.push(
+                withWorkspaceHref(href, pathname) as never,
+                options as never,
+            )) as Router['push'];
+        const replace: Router['replace'] = ((href: WorkspaceNavigableHref, options?: unknown) =>
+            router.replace(
+                withWorkspaceHref(href, pathname) as never,
+                options as never,
+            )) as Router['replace'];
+        const prefetch: Router['prefetch'] = ((href: WorkspaceNavigableHref, options?: unknown) =>
+            router.prefetch(
+                withWorkspaceHref(href, pathname) as never,
+                options as never,
+            )) as Router['prefetch'];
+
+        return { ...router, push, replace, prefetch };
+    }, [pathname, router]);
+}
+
+export const usePathname = navigationBase.usePathname;

--- a/apps/web/src/i18n/navigation-client.unit.spec.tsx
+++ b/apps/web/src/i18n/navigation-client.unit.spec.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigationMocks = vi.hoisted(() => ({
+    pathname: '/org/ever/dashboard',
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+}));
+
+vi.mock('next-intl/navigation', () => ({
+    createNavigation: () => ({
+        Link: ({ href, children, ...props }: React.ComponentProps<'a'> & { href: unknown }) => (
+            <a
+                {...props}
+                href={
+                    typeof href === 'string'
+                        ? href
+                        : String((href as unknown as { pathname?: string }).pathname ?? '')
+                }
+            >
+                {children}
+            </a>
+        ),
+        getPathname: vi.fn(),
+        redirect: vi.fn(),
+        usePathname: () => navigationMocks.pathname,
+        useRouter: () => ({
+            back: vi.fn(),
+            forward: vi.fn(),
+            refresh: vi.fn(),
+            push: navigationMocks.push,
+            replace: navigationMocks.replace,
+            prefetch: navigationMocks.prefetch,
+        }),
+    }),
+}));
+
+vi.mock('next-intl/routing', () => ({
+    defineRouting: (value: unknown) => value,
+}));
+
+import { Link, useRouter, withWorkspaceHref } from './navigation-client';
+
+function RouterProbe() {
+    const router = useRouter();
+    return (
+        <>
+            <button onClick={() => router.push('/missions')}>push</button>
+            <button onClick={() => router.replace('/goals')}>replace</button>
+            <button onClick={() => router.prefetch('/agents')}>prefetch</button>
+        </>
+    );
+}
+
+describe('workspace-aware navigation', () => {
+    beforeEach(() => {
+        navigationMocks.pathname = '/org/ever/dashboard';
+        vi.clearAllMocks();
+    });
+
+    it('keeps a relative app destination in the current Organization namespace', () => {
+        expect(withWorkspaceHref('/agents', '/org/ever/missions')).toBe('/org/ever/agents');
+    });
+
+    it('keeps UrlObject query state while adding the Organization namespace', () => {
+        expect(
+            withWorkspaceHref(
+                { pathname: '/goals', query: { view: 'archived' } },
+                '/org/yo/dashboard',
+            ),
+        ).toEqual({ pathname: '/org/yo/goals', query: { view: 'archived' } });
+    });
+
+    it('does not double-prefix an already canonical Organization destination', () => {
+        expect(withWorkspaceHref('/org/yo/agents', '/org/ever/missions')).toBe('/org/yo/agents');
+    });
+
+    it.each(['/login', '/register', '/auth/error', '/org-invite/token', '/claim/token'])(
+        'leaves the personal/public exit %s outside the Organization namespace',
+        (href) => {
+            expect(withWorkspaceHref(href, '/org/ever/dashboard')).toBe(href);
+        },
+    );
+
+    it('leaves external, fragment, query-only, and explicitly personal navigation unchanged', () => {
+        expect(withWorkspaceHref('https://example.com', '/org/ever/dashboard')).toBe(
+            'https://example.com',
+        );
+        expect(withWorkspaceHref('#details', '/org/ever/dashboard')).toBe('#details');
+        expect(withWorkspaceHref('?tab=runs', '/org/ever/dashboard')).toBe('?tab=runs');
+        expect(withWorkspaceHref('/agents', '/agents')).toBe('/agents');
+    });
+
+    it('applies the workspace transform through the exported Link', () => {
+        render(<Link href="/agents">Agents</Link>);
+        expect(screen.getByRole('link', { name: 'Agents' })).toHaveAttribute(
+            'href',
+            '/org/ever/agents',
+        );
+    });
+
+    it('applies the workspace transform through push, replace, and prefetch', () => {
+        render(<RouterProbe />);
+        fireEvent.click(screen.getByRole('button', { name: 'push' }));
+        fireEvent.click(screen.getByRole('button', { name: 'replace' }));
+        fireEvent.click(screen.getByRole('button', { name: 'prefetch' }));
+
+        expect(navigationMocks.push).toHaveBeenCalledWith('/org/ever/missions', undefined);
+        expect(navigationMocks.replace).toHaveBeenCalledWith('/org/ever/goals', undefined);
+        expect(navigationMocks.prefetch).toHaveBeenCalledWith('/org/ever/agents', undefined);
+    });
+});

--- a/apps/web/src/i18n/navigation.ts
+++ b/apps/web/src/i18n/navigation.ts
@@ -1,4 +1,4 @@
-import { navigationBase } from './navigation-base';
+import { navigationBase } from '@/i18n/navigation-base';
 
-export { Link, usePathname, useRouter } from './navigation-client';
+export { Link, usePathname, useRouter } from '@/i18n/navigation-client';
 export const { redirect, getPathname } = navigationBase;

--- a/apps/web/src/i18n/navigation.ts
+++ b/apps/web/src/i18n/navigation.ts
@@ -1,4 +1,4 @@
-import { createNavigation } from 'next-intl/navigation';
-import { routing } from './routing';
+import { navigationBase } from './navigation-base';
 
-export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);
+export { Link, usePathname, useRouter } from './navigation-client';
+export const { redirect, getPathname } = navigationBase;

--- a/apps/web/src/lib/api/bff-scope.ts
+++ b/apps/web/src/lib/api/bff-scope.ts
@@ -1,0 +1,45 @@
+import {
+    API_SCOPE_HEADER,
+    BROWSER_WORKSPACE_SCOPE_HEADER,
+    parseWorkspacePath,
+    parseWorkspaceSelector,
+    toApiScopeHeader,
+    type WorkspaceScope,
+} from '../workspace-scope';
+
+function scopesMatch(left: WorkspaceScope, right: WorkspaceScope): boolean {
+    return (
+        left.kind === right.kind &&
+        (left.kind === 'personal' || (right.kind === 'organization' && left.slug === right.slug))
+    );
+}
+
+/**
+ * Convert the browser's explicit, per-tab selector into the API contract.
+ * Referer is optional, but when present it must be same-origin and agree with
+ * the selector. Both browser and API scope headers are always overwritten.
+ */
+export function applyBffWorkspaceScope(request: Request, baseHeaders: HeadersInit): Headers {
+    try {
+        const selected = parseWorkspaceSelector(
+            request.headers.get(BROWSER_WORKSPACE_SCOPE_HEADER),
+        );
+        const referer = request.headers.get('referer');
+        if (referer) {
+            const refererUrl = new URL(referer);
+            if (refererUrl.origin !== new URL(request.url).origin) {
+                throw new Error('Cross-origin Referer');
+            }
+            if (!scopesMatch(selected, parseWorkspacePath(refererUrl.pathname))) {
+                throw new Error('Stale workspace selector');
+            }
+        }
+
+        const upstream = new Headers(baseHeaders);
+        upstream.delete(BROWSER_WORKSPACE_SCOPE_HEADER);
+        upstream.set(API_SCOPE_HEADER, toApiScopeHeader(selected));
+        return upstream;
+    } catch {
+        throw new Error('Invalid workspace scope');
+    }
+}

--- a/apps/web/src/lib/api/bff-scope.unit.spec.ts
+++ b/apps/web/src/lib/api/bff-scope.unit.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+    API_SCOPE_HEADER,
+    BROWSER_WORKSPACE_SCOPE_HEADER,
+    PERSONAL_SCOPE_SENTINEL,
+} from '../workspace-scope';
+import { applyBffWorkspaceScope } from './bff-scope';
+
+function request(selector?: string, referer?: string): Request {
+    const headers = new Headers({
+        [API_SCOPE_HEADER]: 'attacker-supplied-yo',
+    });
+    if (selector !== undefined) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    if (referer !== undefined) headers.set('referer', referer);
+    return new Request('https://app.example/api/missions', { method: 'POST', headers });
+}
+
+describe('BFF workspace scope boundary', () => {
+    it('accepts an explicit Organization selector without Referer and overwrites the API header', () => {
+        const upstream = applyBffWorkspaceScope(request('org:ever'), {
+            Authorization: 'Bearer test',
+        });
+
+        expect(upstream.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(upstream.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+        expect(upstream.get('authorization')).toBe('Bearer test');
+    });
+
+    it('accepts explicit personal only with an unprefixed same-origin Referer', () => {
+        const upstream = applyBffWorkspaceScope(
+            request('personal', 'https://app.example/missions/new'),
+            {},
+        );
+
+        expect(upstream.get(API_SCOPE_HEADER)).toBe(PERSONAL_SCOPE_SENTINEL);
+    });
+
+    it.each([
+        ['missing selector', request(undefined, 'https://app.example/org/ever/missions')],
+        ['invalid selector', request('org:@personal', 'https://app.example/org/ever/missions')],
+        ['stale tab selector', request('org:ever', 'https://app.example/org/yo/missions')],
+        ['personal downgrade', request('personal', 'https://app.example/org/ever/missions')],
+        ['cross-origin Referer', request('org:ever', 'https://evil.example/org/ever/missions')],
+    ] as const)('fails closed for %s', (_label, input) => {
+        expect(() => applyBffWorkspaceScope(input, {})).toThrow('Invalid workspace scope');
+    });
+});

--- a/apps/web/src/lib/api/browser-api.ts
+++ b/apps/web/src/lib/api/browser-api.ts
@@ -1,0 +1,26 @@
+import {
+    BROWSER_WORKSPACE_SCOPE_HEADER,
+    parseWorkspacePath,
+    serializeWorkspaceScope,
+} from '../workspace-scope';
+
+/**
+ * Browser-to-BFF transport. Scope is re-derived for every call from the
+ * visible tab URL, so it cannot race with another tab's persisted preference.
+ */
+export function browserApiFetch(
+    input: RequestInfo | URL,
+    init: RequestInit = {},
+): Promise<Response> {
+    if (typeof window === 'undefined') {
+        throw new Error('browserApiFetch requires a browser workspace path');
+    }
+
+    const headers = new Headers(init.headers);
+    headers.set(
+        BROWSER_WORKSPACE_SCOPE_HEADER,
+        serializeWorkspaceScope(parseWorkspacePath(window.location.pathname)),
+    );
+
+    return fetch(input, { ...init, headers });
+}

--- a/apps/web/src/lib/api/browser-api.unit.spec.ts
+++ b/apps/web/src/lib/api/browser-api.unit.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '../workspace-scope';
+import { browserApiFetch } from './browser-api';
+
+describe('browserApiFetch workspace selector', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('derives the Organization selector at call time so two tabs do not share preference state', async () => {
+        const observed: string[] = [];
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+                observed.push(new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER) ?? '');
+                return new Response(null, { status: 204 });
+            }),
+        );
+
+        window.history.replaceState({}, '', '/org/ever/missions/new');
+        await browserApiFetch('/api/missions', { method: 'POST' });
+        window.history.replaceState({}, '', '/org/yo/missions/new');
+        await browserApiFetch('/api/missions', { method: 'POST' });
+
+        expect(observed).toEqual(['org:ever', 'org:yo']);
+    });
+
+    it('emits explicit personal scope only from a genuinely unprefixed route', async () => {
+        const fetchMock = vi.fn(
+            async (_input: RequestInfo | URL, _init?: RequestInit) =>
+                new Response(null, { status: 204 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+        window.history.replaceState({}, '', '/missions/new');
+
+        await browserApiFetch('/api/missions', { method: 'POST' });
+
+        const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('personal');
+    });
+
+    it('overwrites a caller-supplied selector and re-derives after navigation', async () => {
+        const fetchMock = vi.fn(
+            async (_input: RequestInfo | URL, _init?: RequestInit) =>
+                new Response(null, { status: 204 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+        window.history.replaceState({}, '', '/org/ever/dashboard');
+
+        await browserApiFetch('/api/missions', {
+            method: 'POST',
+            headers: { [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:yo' },
+        });
+        window.history.replaceState({}, '', '/dashboard');
+        await browserApiFetch('/api/missions', { method: 'POST' });
+
+        expect(
+            fetchMock.mock.calls.map((call) =>
+                new Headers(call[1]?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER),
+            ),
+        ).toEqual(['org:ever', 'personal']);
+    });
+});

--- a/apps/web/src/lib/api/server-api.ts
+++ b/apps/web/src/lib/api/server-api.ts
@@ -1,8 +1,16 @@
 import 'server-only';
-import { ALLOWED_REDIRECT_URLS, API_URL, WEB_URL } from '../constants';
+import { ALLOWED_REDIRECT_URLS, API_URL, ROUTES, WEB_URL } from '../constants';
 import { headers } from 'next/headers';
 import { getAuthAccessCookie } from '../auth/cookies';
 import { getTranslations } from 'next-intl/server';
+import {
+    API_SCOPE_HEADER,
+    BROWSER_WORKSPACE_SCOPE_HEADER,
+    isOrganizationSlug,
+    parseWorkspaceSelector,
+    toApiScopeHeader,
+} from '../workspace-scope';
+import type { ActiveScopeResponse } from '@ever-works/contracts/api';
 
 export class ApiResponseError extends Error {
     constructor(
@@ -93,19 +101,23 @@ export async function serverFetch<T>(
     endpoint: string,
     options: ServerFetchOptions = {},
 ): Promise<T> {
+    const requestHeaders = await headers();
+    const selectedScope = parseWorkspaceSelector(
+        requestHeaders.get(BROWSER_WORKSPACE_SCOPE_HEADER),
+    );
     const frontendUrl = await getFrontendUrl();
     const t = await getTranslations('api.errors');
     const { rawResponse, ...fetchOptions } = options;
 
     const doFetch = async (authToken?: string) => {
-        const reqHeaders: Record<string, string> = {
-            'Content-Type': 'application/json',
-            'X-Frontend-URL': frontendUrl,
-            ...((fetchOptions.headers as Record<string, string>) || {}),
-        };
+        const reqHeaders = new Headers(fetchOptions.headers);
+        if (!reqHeaders.has('Content-Type')) reqHeaders.set('Content-Type', 'application/json');
+        reqHeaders.set('X-Frontend-URL', frontendUrl);
+        reqHeaders.delete(BROWSER_WORKSPACE_SCOPE_HEADER);
+        reqHeaders.set(API_SCOPE_HEADER, toApiScopeHeader(selectedScope));
 
         if (authToken) {
-            reqHeaders['Authorization'] = `Bearer ${authToken}`;
+            reqHeaders.set('Authorization', `Bearer ${authToken}`);
         }
 
         return fetch(`${API_URL}${endpoint}`, {
@@ -211,6 +223,16 @@ export async function serverFetch<T>(
     } catch {
         return text as T;
     }
+}
+
+/** Resolve the mutable preference exactly once: as a fresh-login destination. */
+export async function getLoginDefaultWorkspaceHref(): Promise<string> {
+    const scope = await serverFetch<ActiveScopeResponse>('/users/me/scope', { method: 'GET' });
+    if (scope.organizationSlug === null) return ROUTES.DASHBOARD;
+    if (!isOrganizationSlug(scope.organizationSlug)) {
+        throw new Error('Invalid workspace scope');
+    }
+    return `/org/${scope.organizationSlug}/dashboard`;
 }
 
 // Type-safe server-side mutations (for use in server actions)

--- a/apps/web/src/lib/api/server-api.unit.spec.ts
+++ b/apps/web/src/lib/api/server-api.unit.spec.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '../workspace-scope';
+
+const { getAuthAccessCookieMock, headersMock, translationsMock } = vi.hoisted(() => ({
+    getAuthAccessCookieMock: vi.fn(),
+    headersMock: vi.fn(),
+    translationsMock: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock('next/headers', () => ({ headers: headersMock }));
+vi.mock('../auth/cookies', () => ({ getAuthAccessCookie: getAuthAccessCookieMock }));
+vi.mock('next-intl/server', () => ({ getTranslations: translationsMock }));
+vi.mock('../constants', () => ({
+    ALLOWED_REDIRECT_URLS: ['app.example'],
+    API_URL: 'https://api.example',
+    ROUTES: { DASHBOARD: '/' },
+    WEB_URL: 'https://app.example',
+}));
+
+import { getLoginDefaultWorkspaceHref, serverFetch } from './server-api';
+
+describe('serverFetch workspace scope transport', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthAccessCookieMock.mockResolvedValue('access-token');
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(JSON.stringify({ ok: true }), {
+                        status: 200,
+                        headers: { 'content-type': 'application/json' },
+                    }),
+            ),
+        );
+    });
+
+    it.each([
+        ['org:ever', 'ever'],
+        ['personal', '@personal'],
+    ])('overwrites caller scope from the proxy selector %s', async (selector, expected) => {
+        headersMock.mockResolvedValue(
+            new Headers({
+                host: 'app.example',
+                [BROWSER_WORKSPACE_SCOPE_HEADER]: selector,
+            }),
+        );
+
+        await serverFetch('/me/missions', {
+            method: 'POST',
+            headers: { [API_SCOPE_HEADER]: 'attacker-yo' },
+            body: '{}',
+        });
+
+        const init = vi.mocked(fetch).mock.calls[0][1];
+        const sent = new Headers(init?.headers);
+        expect(sent.get(API_SCOPE_HEADER)).toBe(expected);
+        expect(sent.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+    });
+
+    it('fails closed when a server mutation has no trusted proxy selector', async () => {
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+
+        await expect(serverFetch('/me/missions', { method: 'POST', body: '{}' })).rejects.toThrow(
+            'Invalid workspace scope',
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['ever', '/org/ever/dashboard'],
+        [null, '/'],
+    ])(
+        'hydrates the fresh-login default %s without changing request authority',
+        async (slug, href) => {
+            headersMock.mockResolvedValue(
+                new Headers({ host: 'app.example', [BROWSER_WORKSPACE_SCOPE_HEADER]: 'personal' }),
+            );
+            vi.mocked(fetch).mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        tenantId: 'tenant-1',
+                        organizationId: slug ? 'org-ever' : null,
+                        organizationSlug: slug,
+                    }),
+                    { status: 200, headers: { 'content-type': 'application/json' } },
+                ),
+            );
+
+            await expect(getLoginDefaultWorkspaceHref()).resolves.toBe(href);
+        },
+    );
+
+    it('does not downgrade a revoked login default to personal', async () => {
+        headersMock.mockResolvedValue(
+            new Headers({ host: 'app.example', [BROWSER_WORKSPACE_SCOPE_HEADER]: 'personal' }),
+        );
+        vi.mocked(fetch).mockResolvedValueOnce(
+            new Response(JSON.stringify({ message: 'Organization not found' }), {
+                status: 404,
+                headers: { 'content-type': 'application/json' },
+            }),
+        );
+
+        await expect(getLoginDefaultWorkspaceHref()).rejects.toMatchObject({ statusCode: 404 });
+    });
+});

--- a/apps/web/src/lib/hooks/use-active-scope.ts
+++ b/apps/web/src/lib/hooks/use-active-scope.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 import { useOrganizations } from './use-organizations';
@@ -20,6 +21,14 @@ export interface UseActiveScopeResult {
      * because the API only returns orgs the user can see).
      */
     activeOrganization: OrganizationResponse | null;
+    /** Update the local view only after the server confirms a persisted switch. */
+    setActiveOrganization: (organization: OrganizationResponse | null) => void;
+}
+
+interface ActiveScopeResponse {
+    tenantId: string | null;
+    organizationId: string | null;
+    organizationSlug: string | null;
 }
 
 /**
@@ -37,13 +46,49 @@ export interface UseActiveScopeResult {
 export function useActiveScope(): UseActiveScopeResult {
     const params = useParams<{ slug?: string | string[] }>();
     const { organizations } = useOrganizations();
+    const [persistedSlug, setPersistedSlug] = useState<string | null>(null);
+    const selectionVersion = useRef(0);
 
     const rawSlug = params?.slug;
-    const slug = Array.isArray(rawSlug) ? (rawSlug[0] ?? null) : (rawSlug ?? null);
+    const routeSlug = Array.isArray(rawSlug) ? (rawSlug[0] ?? null) : (rawSlug ?? null);
+
+    useEffect(() => {
+        if (routeSlug) return;
+
+        let cancelled = false;
+        const versionAtRequestStart = selectionVersion.current;
+        void (async () => {
+            try {
+                const response = await fetch('/api/users/me/scope', {
+                    method: 'GET',
+                    credentials: 'include',
+                    cache: 'no-store',
+                });
+                if (!response.ok) return;
+                const body = (await response.json()) as ActiveScopeResponse;
+                if (!cancelled && selectionVersion.current === versionAtRequestStart) {
+                    setPersistedSlug(body.organizationSlug ?? null);
+                }
+            } catch {
+                // Keep the current local selection on transient BFF/network failures.
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [routeSlug]);
+
+    const setActiveOrganization = useCallback((organization: OrganizationResponse | null) => {
+        selectionVersion.current += 1;
+        setPersistedSlug(organization?.slug ?? null);
+    }, []);
+
+    const slug = routeSlug ?? persistedSlug;
 
     const activeOrganization = slug
         ? (organizations.find((org) => org.slug === slug) ?? null)
         : null;
 
-    return { slug, activeOrganization };
+    return { slug, activeOrganization, setActiveOrganization };
 }

--- a/apps/web/src/lib/hooks/use-active-scope.ts
+++ b/apps/web/src/lib/hooks/use-active-scope.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
-import type { OrganizationResponse } from '@ever-works/contracts/api';
+import type { ActiveScopeResponse, OrganizationResponse } from '@ever-works/contracts/api';
 import { useOrganizations } from './use-organizations';
 
 export interface UseActiveScopeResult {
@@ -23,12 +23,6 @@ export interface UseActiveScopeResult {
     activeOrganization: OrganizationResponse | null;
     /** Update the local view only after the server confirms a persisted switch. */
     setActiveOrganization: (organization: OrganizationResponse | null) => void;
-}
-
-interface ActiveScopeResponse {
-    tenantId: string | null;
-    organizationId: string | null;
-    organizationSlug: string | null;
 }
 
 /**

--- a/apps/web/src/lib/hooks/use-active-scope.ts
+++ b/apps/web/src/lib/hooks/use-active-scope.ts
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'next/navigation';
-import type { ActiveScopeResponse, OrganizationResponse } from '@ever-works/contracts/api';
+import { usePathname } from 'next/navigation';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
 import { useOrganizations } from './use-organizations';
+import { parseWorkspacePath } from '../workspace-scope';
 
 export interface UseActiveScopeResult {
     /**
@@ -21,8 +21,6 @@ export interface UseActiveScopeResult {
      * because the API only returns orgs the user can see).
      */
     activeOrganization: OrganizationResponse | null;
-    /** Update the local view only after the server confirms a persisted switch. */
-    setActiveOrganization: (organization: OrganizationResponse | null) => void;
 }
 
 /**
@@ -38,51 +36,14 @@ export interface UseActiveScopeResult {
  * empty-state logo.
  */
 export function useActiveScope(): UseActiveScopeResult {
-    const params = useParams<{ slug?: string | string[] }>();
+    const pathname = usePathname();
     const { organizations } = useOrganizations();
-    const [persistedSlug, setPersistedSlug] = useState<string | null>(null);
-    const selectionVersion = useRef(0);
-
-    const rawSlug = params?.slug;
-    const routeSlug = Array.isArray(rawSlug) ? (rawSlug[0] ?? null) : (rawSlug ?? null);
-
-    useEffect(() => {
-        if (routeSlug) return;
-
-        let cancelled = false;
-        const versionAtRequestStart = selectionVersion.current;
-        void (async () => {
-            try {
-                const response = await fetch('/api/users/me/scope', {
-                    method: 'GET',
-                    credentials: 'include',
-                    cache: 'no-store',
-                });
-                if (!response.ok) return;
-                const body = (await response.json()) as ActiveScopeResponse;
-                if (!cancelled && selectionVersion.current === versionAtRequestStart) {
-                    setPersistedSlug(body.organizationSlug ?? null);
-                }
-            } catch {
-                // Keep the current local selection on transient BFF/network failures.
-            }
-        })();
-
-        return () => {
-            cancelled = true;
-        };
-    }, [routeSlug]);
-
-    const setActiveOrganization = useCallback((organization: OrganizationResponse | null) => {
-        selectionVersion.current += 1;
-        setPersistedSlug(organization?.slug ?? null);
-    }, []);
-
-    const slug = routeSlug ?? persistedSlug;
+    const workspace = parseWorkspacePath(pathname);
+    const slug = workspace.kind === 'organization' ? workspace.slug : null;
 
     const activeOrganization = slug
         ? (organizations.find((org) => org.slug === slug) ?? null)
         : null;
 
-    return { slug, activeOrganization, setActiveOrganization };
+    return { slug, activeOrganization };
 }

--- a/apps/web/src/lib/hooks/use-active-scope.unit.spec.tsx
+++ b/apps/web/src/lib/hooks/use-active-scope.unit.spec.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+const paramsMock = vi.fn<() => { slug?: string }>();
+vi.mock('next/navigation', () => ({
+    useParams: () => paramsMock(),
+}));
+
+import { useActiveScope } from './use-active-scope';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from './use-organizations';
+
+const ever = {
+    id: 'org-ever',
+    tenantId: 'tenant-1',
+    slug: 'ever',
+    displayName: 'Ever',
+} as OrganizationResponse;
+const yo = {
+    id: 'org-yo',
+    tenantId: 'tenant-1',
+    slug: 'yo-inc',
+    displayName: 'Yo Incorporated',
+} as OrganizationResponse;
+
+describe('useActiveScope', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        __seedOrganizationsStoreForTests({ data: [yo, ever], isLoading: false, error: null });
+        paramsMock.mockReset().mockReturnValue({});
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    tenantId: 'tenant-1',
+                    organizationId: 'org-yo',
+                    organizationSlug: 'yo-inc',
+                }),
+            }),
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('uses the route slug as the canonical active scope when one is present', () => {
+        paramsMock.mockReturnValue({ slug: 'ever' });
+
+        const { result } = renderHook(() => useActiveScope());
+
+        expect(result.current.activeOrganization?.id).toBe('org-ever');
+        expect(result.current.slug).toBe('ever');
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('restores the persisted Organization on an unprefixed legacy route', async () => {
+        const { result } = renderHook(() => useActiveScope());
+
+        await waitFor(() => expect(result.current.activeOrganization?.id).toBe('org-yo'));
+        expect(fetch).toHaveBeenCalledWith(
+            '/api/users/me/scope',
+            expect.objectContaining({ method: 'GET' }),
+        );
+    });
+
+    it('reflects a successfully persisted switch immediately without localStorage', async () => {
+        const { result } = renderHook(() => useActiveScope());
+        await waitFor(() => expect(result.current.activeOrganization?.id).toBe('org-yo'));
+
+        act(() => result.current.setActiveOrganization(ever));
+
+        expect(result.current.activeOrganization?.id).toBe('org-ever');
+        expect(result.current.slug).toBe('ever');
+    });
+});

--- a/apps/web/src/lib/hooks/use-active-scope.unit.spec.tsx
+++ b/apps/web/src/lib/hooks/use-active-scope.unit.spec.tsx
@@ -1,10 +1,10 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
-const paramsMock = vi.fn<() => { slug?: string }>();
+const pathnameMock = vi.fn<() => string>();
 vi.mock('next/navigation', () => ({
-    useParams: () => paramsMock(),
+    usePathname: () => pathnameMock(),
 }));
 
 import { useActiveScope } from './use-active-scope';
@@ -30,7 +30,7 @@ describe('useActiveScope', () => {
     beforeEach(() => {
         __resetOrganizationsStoreForTests();
         __seedOrganizationsStoreForTests({ data: [yo, ever], isLoading: false, error: null });
-        paramsMock.mockReset().mockReturnValue({});
+        pathnameMock.mockReset().mockReturnValue('/dashboard');
         vi.stubGlobal(
             'fetch',
             vi.fn().mockResolvedValue({
@@ -50,7 +50,7 @@ describe('useActiveScope', () => {
     });
 
     it('uses the route slug as the canonical active scope when one is present', () => {
-        paramsMock.mockReturnValue({ slug: 'ever' });
+        pathnameMock.mockReturnValue('/org/ever/dashboard');
 
         const { result } = renderHook(() => useActiveScope());
 
@@ -59,23 +59,27 @@ describe('useActiveScope', () => {
         expect(fetch).not.toHaveBeenCalled();
     });
 
-    it('restores the persisted Organization on an unprefixed legacy route', async () => {
+    it('keeps an unprefixed route explicitly personal without reading persisted preference', () => {
         const { result } = renderHook(() => useActiveScope());
 
-        await waitFor(() => expect(result.current.activeOrganization?.id).toBe('org-yo'));
-        expect(fetch).toHaveBeenCalledWith(
-            '/api/users/me/scope',
-            expect.objectContaining({ method: 'GET' }),
-        );
+        expect(result.current.activeOrganization).toBeNull();
+        expect(result.current.slug).toBeNull();
+        expect(fetch).not.toHaveBeenCalled();
     });
 
-    it('reflects a successfully persisted switch immediately without localStorage', async () => {
-        const { result } = renderHook(() => useActiveScope());
-        await waitFor(() => expect(result.current.activeOrganization?.id).toBe('org-yo'));
-
-        act(() => result.current.setActiveOrganization(ever));
-
+    it('re-derives from the visible URL after navigation without shared module cache', () => {
+        pathnameMock.mockReturnValue('/org/ever/dashboard');
+        const { result, rerender, unmount } = renderHook(() => useActiveScope());
         expect(result.current.activeOrganization?.id).toBe('org-ever');
-        expect(result.current.slug).toBe('ever');
+
+        pathnameMock.mockReturnValue('/org/yo-inc/dashboard');
+        rerender();
+        expect(result.current.activeOrganization?.id).toBe('org-yo');
+
+        unmount();
+        pathnameMock.mockReturnValue('/dashboard');
+        const fresh = renderHook(() => useActiveScope());
+        expect(fresh.result.current.activeOrganization).toBeNull();
+        expect(fetch).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/lib/hooks/use-organizations.ts
+++ b/apps/web/src/lib/hooks/use-organizations.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { browserApiFetch } from '../api/browser-api';
 
 /**
  * EW-660 (Tenants & Organizations Phase 8) — client-side hook fetching
@@ -76,7 +77,7 @@ async function fetchOrganizations(): Promise<void> {
     if (inFlight) return inFlight;
     inFlight = (async () => {
         try {
-            const response = await fetch('/api/organizations', {
+            const response = await browserApiFetch('/api/organizations', {
                 method: 'GET',
                 credentials: 'include',
                 cache: 'no-store',

--- a/apps/web/src/lib/hooks/use-organizations.unit.spec.tsx
+++ b/apps/web/src/lib/hooks/use-organizations.unit.spec.tsx
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '../workspace-scope';
+import { __resetOrganizationsStoreForTests, useOrganizations } from './use-organizations';
+
+describe('useOrganizations workspace selector', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        window.history.replaceState({}, '', '/org/ever/settings');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('derives the selector from the current tab when it loads memberships', async () => {
+        const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+            Promise.resolve(
+                new Response(JSON.stringify([]), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+            ),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        renderHook(() => useOrganizations());
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
+    });
+});

--- a/apps/web/src/lib/workspace-navigation.ts
+++ b/apps/web/src/lib/workspace-navigation.ts
@@ -1,6 +1,33 @@
 import { buildWorkspaceHref, isOrganizationSlug, type WorkspaceScope } from './workspace-scope';
+import { browserApiFetch } from './api/browser-api';
 
 type WorkspaceLocation = Pick<Location, 'origin' | 'assign'>;
+
+/**
+ * Persist the user's fresh-login default only after the membership-validated
+ * scope endpoint confirms the exact Organization selected by this tab.
+ */
+export async function persistActiveOrganization(organizationSlug: string): Promise<void> {
+    if (!isOrganizationSlug(organizationSlug)) {
+        throw new Error('Invalid Organization workspace');
+    }
+
+    const response = await browserApiFetch('/api/users/me/scope', {
+        method: 'POST',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ organizationSlug }),
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to persist active Organization (${response.status})`);
+    }
+
+    const persisted = (await response.json()) as { organizationSlug?: string | null };
+    if (persisted.organizationSlug !== organizationSlug) {
+        throw new Error('The persisted active Organization did not match the selection');
+    }
+}
 
 /**
  * Cross a workspace boundary with a fresh document. This deliberately avoids

--- a/apps/web/src/lib/workspace-navigation.ts
+++ b/apps/web/src/lib/workspace-navigation.ts
@@ -1,0 +1,25 @@
+import { buildWorkspaceHref, isOrganizationSlug, type WorkspaceScope } from './workspace-scope';
+
+type WorkspaceLocation = Pick<Location, 'origin' | 'assign'>;
+
+/**
+ * Cross a workspace boundary with a fresh document. This deliberately avoids
+ * the client router so scope-sensitive caches and BFF requests are recreated
+ * from the canonical visible pathname.
+ */
+export function navigateToWorkspaceDashboard(
+    scope: WorkspaceScope,
+    location: WorkspaceLocation = window.location,
+): void {
+    if (scope.kind === 'organization' && !isOrganizationSlug(scope.slug)) {
+        throw new Error('Invalid Organization workspace');
+    }
+
+    const pathname = buildWorkspaceHref(scope, '/dashboard');
+    const target = new URL(pathname, location.origin);
+    if (target.origin !== location.origin) {
+        throw new Error('Workspace navigation must remain same-origin');
+    }
+
+    location.assign(target.href);
+}

--- a/apps/web/src/lib/workspace-navigation.unit.spec.ts
+++ b/apps/web/src/lib/workspace-navigation.unit.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { navigateToWorkspaceDashboard } from './workspace-navigation';
+
+describe('navigateToWorkspaceDashboard', () => {
+    it('performs a canonical same-origin document navigation for an Organization', () => {
+        const assign = vi.fn();
+
+        navigateToWorkspaceDashboard(
+            { kind: 'organization', slug: 'ever' },
+            { origin: 'https://works.example', assign },
+        );
+
+        expect(assign).toHaveBeenCalledWith('https://works.example/org/ever/dashboard');
+    });
+
+    it('uses the explicit unprefixed personal dashboard contract', () => {
+        const assign = vi.fn();
+
+        navigateToWorkspaceDashboard(
+            { kind: 'personal' },
+            { origin: 'https://works.example', assign },
+        );
+
+        expect(assign).toHaveBeenCalledWith('https://works.example/dashboard');
+    });
+});

--- a/apps/web/src/lib/workspace-navigation.unit.spec.ts
+++ b/apps/web/src/lib/workspace-navigation.unit.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { navigateToWorkspaceDashboard } from './workspace-navigation';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { navigateToWorkspaceDashboard, persistActiveOrganization } from './workspace-navigation';
 
 describe('navigateToWorkspaceDashboard', () => {
     it('performs a canonical same-origin document navigation for an Organization', () => {
@@ -22,5 +22,48 @@ describe('navigateToWorkspaceDashboard', () => {
         );
 
         expect(assign).toHaveBeenCalledWith('https://works.example/dashboard');
+    });
+});
+
+describe('persistActiveOrganization', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('persists the exact Organization slug with the scoped browser transport', async () => {
+        window.history.replaceState({}, '', '/org/ever/works');
+        const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+            Response.json({ organizationSlug: 'new-company' }, { status: 200 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        await persistActiveOrganization('new-company');
+
+        const [url, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        expect(url).toBe('/api/users/me/scope');
+        expect(new Headers(init.headers).get('x-ever-workspace')).toBe('org:ever');
+        expect(JSON.parse(String(init.body))).toEqual({ organizationSlug: 'new-company' });
+    });
+
+    it('rejects a failed membership-validated persistence response', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => Response.json({ error: 'Not found' }, { status: 404 })),
+        );
+
+        await expect(persistActiveOrganization('revoked-company')).rejects.toThrow(
+            'Failed to persist active Organization (404)',
+        );
+    });
+
+    it('rejects a response that persisted a different Organization', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => Response.json({ organizationSlug: 'yo' }, { status: 200 })),
+        );
+
+        await expect(persistActiveOrganization('ever')).rejects.toThrow(
+            'The persisted active Organization did not match the selection',
+        );
     });
 });

--- a/apps/web/src/lib/workspace-scope.ts
+++ b/apps/web/src/lib/workspace-scope.ts
@@ -1,0 +1,109 @@
+// Runtime twins of the public `@ever-works/contracts/api` constants. Keeping
+// the tiny web boundary self-contained avoids loading the server contract
+// package into browser chunks; the contract spec pins the exact same values.
+export const PERSONAL_SCOPE_SENTINEL = '@personal' as const;
+export const API_SCOPE_HEADER = 'x-scope-slug' as const;
+export const BROWSER_WORKSPACE_SCOPE_HEADER = 'x-ever-workspace' as const;
+
+const ORGANIZATION_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const CANONICAL_ORGANIZATION_PREFIX = '/org/';
+
+/** First path segments owned by the application rather than an Organization. */
+const RESERVED_LEGACY_ORGANIZATION_SLUGS = new Set([
+    'api',
+    'auth',
+    'dashboard',
+    'login',
+    'logout',
+    'onboarding',
+    'org',
+    'organizations',
+    'profile',
+    'register',
+    'settings',
+    'signup',
+    'verify-email',
+]);
+
+export type WorkspaceScope =
+    | { readonly kind: 'personal' }
+    | { readonly kind: 'organization'; readonly slug: string };
+
+function splitPathSuffix(value: string): { pathname: string; suffix: string } {
+    const suffixIndex = value.search(/[?#]/);
+    return suffixIndex === -1
+        ? { pathname: value, suffix: '' }
+        : { pathname: value.slice(0, suffixIndex), suffix: value.slice(suffixIndex) };
+}
+
+/**
+ * Parse the visible browser pathname. The URL is the request authority: this
+ * function deliberately has no access to cookies, local storage, or the user's
+ * persisted last-Organization preference.
+ */
+export function parseWorkspacePath(value: string): WorkspaceScope {
+    const { pathname } = splitPathSuffix(value);
+    if (pathname === '/org' || pathname.startsWith(CANONICAL_ORGANIZATION_PREFIX)) {
+        const segments = pathname.split('/');
+        const slug = segments[2] ?? '';
+        if (!ORGANIZATION_SLUG.test(slug)) {
+            throw new Error('Invalid Organization workspace path');
+        }
+        return { kind: 'organization', slug };
+    }
+
+    return { kind: 'personal' };
+}
+
+export function toApiScopeHeader(scope: WorkspaceScope): string {
+    return scope.kind === 'organization' ? scope.slug : PERSONAL_SCOPE_SENTINEL;
+}
+
+export function serializeWorkspaceScope(scope: WorkspaceScope): string {
+    return scope.kind === 'organization' ? `org:${scope.slug}` : 'personal';
+}
+
+export function parseWorkspaceSelector(value: string | null): WorkspaceScope {
+    if (value === 'personal') return { kind: 'personal' };
+    if (value?.startsWith('org:')) {
+        const slug = value.slice('org:'.length);
+        if (ORGANIZATION_SLUG.test(slug)) {
+            return { kind: 'organization', slug };
+        }
+    }
+    throw new Error('Invalid workspace scope');
+}
+
+/** Build a canonical workspace-aware app href from an existing unprefixed href. */
+export function buildWorkspaceHref(scope: WorkspaceScope, href: string): string {
+    if (!href.startsWith('/') || href.startsWith('//')) {
+        throw new Error('Workspace href must be an absolute same-origin path');
+    }
+    if (scope.kind === 'personal') return href;
+    if (href.startsWith(CANONICAL_ORGANIZATION_PREFIX)) return href;
+    return `${CANONICAL_ORGANIZATION_PREFIX}${scope.slug}${href}`;
+}
+
+/**
+ * Return the sole supported compatibility redirect. It accepts exactly
+ * `/{slug}/dashboard`, excludes locale and reserved app segments, and can only
+ * construct a same-origin relative target.
+ */
+export function getLegacyOrganizationDashboardRedirect(
+    value: string,
+    locales: readonly string[],
+): string | null {
+    const { pathname, suffix } = splitPathSuffix(value);
+    const match = /^\/([a-z0-9]+(?:-[a-z0-9]+)*)\/dashboard\/?$/.exec(pathname);
+    if (!match) return null;
+
+    const slug = match[1];
+    if (RESERVED_LEGACY_ORGANIZATION_SLUGS.has(slug) || locales.includes(slug)) {
+        return null;
+    }
+    return `/org/${slug}/dashboard${suffix}`;
+}
+
+export function isOrganizationSlug(value: string): boolean {
+    return ORGANIZATION_SLUG.test(value);
+}

--- a/apps/web/src/lib/workspace-scope.unit.spec.ts
+++ b/apps/web/src/lib/workspace-scope.unit.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+    PERSONAL_SCOPE_SENTINEL,
+    buildWorkspaceHref,
+    getLegacyOrganizationDashboardRedirect,
+    parseWorkspacePath,
+    toApiScopeHeader,
+} from './workspace-scope';
+
+describe('workspace URL contract', () => {
+    it.each([
+        ['/org/ever/dashboard', { kind: 'organization', slug: 'ever' }],
+        ['/org/yo/missions/new?from=template#details', { kind: 'organization', slug: 'yo' }],
+        ['/org/en/dashboard', { kind: 'organization', slug: 'en' }],
+        ['/dashboard', { kind: 'personal' }],
+        ['/missions/new', { kind: 'personal' }],
+    ] as const)('parses %s without consulting global preference state', (pathname, expected) => {
+        expect(parseWorkspacePath(pathname)).toEqual(expected);
+    });
+
+    it.each([
+        '/org//dashboard',
+        '/org/../dashboard',
+        '/org/%2F/dashboard',
+        '/org/@personal/dashboard',
+    ])('rejects malformed canonical Organization path %s', (pathname) => {
+        expect(() => parseWorkspacePath(pathname)).toThrow('Invalid Organization workspace path');
+    });
+
+    it('uses a reserved personal sentinel that cannot collide with an Organization slug', () => {
+        expect(PERSONAL_SCOPE_SENTINEL).toBe('@personal');
+        expect(toApiScopeHeader({ kind: 'personal' })).toBe(PERSONAL_SCOPE_SENTINEL);
+        expect(toApiScopeHeader({ kind: 'organization', slug: 'ever' })).toBe('ever');
+        expect(PERSONAL_SCOPE_SENTINEL).not.toMatch(/^[a-z0-9-]+$/);
+    });
+
+    it.each([
+        ['/ever/dashboard', '/org/ever/dashboard'],
+        ['/yo/dashboard?tab=agents', '/org/yo/dashboard?tab=agents'],
+    ] as const)('redirects only an unambiguous legacy Organization dashboard %s', (from, to) => {
+        expect(getLegacyOrganizationDashboardRedirect(from, ['en', 'fr'])).toBe(to);
+    });
+
+    it.each([
+        '/en/dashboard',
+        '/fr/dashboard',
+        '/org/dashboard',
+        '/settings/dashboard',
+        '/api/dashboard',
+        '/ever/missions',
+        '/https:%2F%2Fevil.example/dashboard',
+    ])(
+        'does not reinterpret reserved, locale, non-dashboard, or redirect-like path %s',
+        (pathname) => {
+            expect(getLegacyOrganizationDashboardRedirect(pathname, ['en', 'fr'])).toBeNull();
+        },
+    );
+
+    it('prefixes app paths for an Organization but leaves personal paths unprefixed', () => {
+        expect(
+            buildWorkspaceHref({ kind: 'organization', slug: 'ever' }, '/missions/new?x=1#two'),
+        ).toBe('/org/ever/missions/new?x=1#two');
+        expect(buildWorkspaceHref({ kind: 'personal' }, '/missions/new?x=1#two')).toBe(
+            '/missions/new?x=1#two',
+        );
+    });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import createMiddleware from 'next-intl/middleware';
 import { routing } from './i18n/routing';
 import { NextRequest, NextResponse } from 'next/server';
-import { LOCALES, PUBLIC_ROUTES, ROUTES } from './lib/constants';
+import { ALLOWED_REDIRECT_URLS, LOCALES, PUBLIC_ROUTES, ROUTES } from './lib/constants';
 import { AUTH_COOKIE_NAME } from './lib/auth/cookies';
 import { match } from 'path-to-regexp';
 import { getAuthFromRequest } from './lib/auth';
@@ -123,6 +123,58 @@ function isPublicRoute(pathname: string): boolean {
 }
 
 /**
+ * next-intl emits an absolute `x-middleware-rewrite` URL. Behind a reverse
+ * proxy (and in the IPv4 E2E harness), Next's internal request origin can be
+ * `localhost` while the browser origin is a different host. Next then treats
+ * the locale rewrite as external and performs a second proxy request, losing
+ * the original Organization URL rewrite. Locale targets are app-internal by
+ * contract, so align their origin with the validated request authority while
+ * preserving next-intl's path/query.
+ */
+const SAFE_REQUEST_HOST = /^(?:\[[0-9a-f:.]+\]|[a-z0-9.-]+)(?::\d{1,5})?$/i;
+
+function isAllowedRequestHostname(hostname: string): boolean {
+    const normalized = hostname.toLowerCase();
+    return ALLOWED_REDIRECT_URLS.some((allowed) => {
+        const candidate = allowed
+            .replace(/^https?:\/\//, '')
+            .toLowerCase()
+            .trim();
+        if (candidate.startsWith('*.')) {
+            const domain = candidate.slice(2);
+            return normalized !== domain && normalized.endsWith(`.${domain}`);
+        }
+        return normalized === candidate;
+    });
+}
+
+function alignLocaleRewriteOrigin(req: NextRequest, response: NextResponse): NextResponse {
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    if (!rewrite) return response;
+
+    const target = new URL(rewrite, 'http://internal.invalid');
+    const locale = target.pathname.split('/').filter(Boolean)[0];
+    if (locale && LOCALE_SET.has(locale)) {
+        const requestHost = req.headers.get('host')?.trim();
+        const requestOrigin = new URL(req.nextUrl.origin);
+        if (requestHost && SAFE_REQUEST_HOST.test(requestHost)) {
+            try {
+                const authority = new URL(`${requestOrigin.protocol}//${requestHost}`);
+                if (isAllowedRequestHostname(authority.hostname)) {
+                    requestOrigin.host = authority.host;
+                }
+            } catch {
+                // Keep Next's parsed request origin for an invalid authority.
+            }
+        }
+        target.protocol = requestOrigin.protocol;
+        target.host = requestOrigin.host;
+        response.headers.set('x-middleware-rewrite', target.toString());
+    }
+    return response;
+}
+
+/**
  * Strip a legacy `/<locale>/...` prefix from a pathname.
  *
  * Until 2026-05 the app served every route under `/<locale>/...` (default
@@ -205,13 +257,18 @@ export default async function proxy(req: NextRequest) {
         const prefix = `/org/${selectedScope.slug}`;
         const internalPath = pathname.slice(prefix.length);
         scopedRequest.nextUrl.pathname =
-            internalPath === '' || internalPath === '/' ? '/' : internalPath;
+            internalPath === '' ||
+            internalPath === '/' ||
+            internalPath === '/dashboard' ||
+            internalPath === '/dashboard/'
+                ? '/'
+                : internalPath;
     }
 
     // 2) Let next-intl resolve the locale from the cookie / Accept-Language.
     //    In `localePrefix: 'never'` mode this rewrites the request
     //    internally (the visible URL stays unprefixed).
-    const intlResponse = await nextIntlMiddleware(scopedRequest);
+    const intlResponse = alignLocaleRewriteOrigin(req, await nextIntlMiddleware(scopedRequest));
 
     // 3) Public routes need no auth check.
     if (isPublicRoute(pathname)) {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,6 +5,12 @@ import { LOCALES, PUBLIC_ROUTES, ROUTES } from './lib/constants';
 import { AUTH_COOKIE_NAME } from './lib/auth/cookies';
 import { match } from 'path-to-regexp';
 import { getAuthFromRequest } from './lib/auth';
+import {
+    BROWSER_WORKSPACE_SCOPE_HEADER,
+    getLegacyOrganizationDashboardRedirect,
+    parseWorkspacePath,
+    serializeWorkspaceScope,
+} from './lib/workspace-scope';
 
 const nextIntlMiddleware = createMiddleware(routing);
 
@@ -169,10 +175,43 @@ export default async function proxy(req: NextRequest) {
         return applySecurityHeaders(response);
     }
 
+    // Safe compatibility for the one Organization URL shape shipped before
+    // the canonical namespace. Locale and reserved app segments never enter
+    // this branch, so `/en/dashboard` remains a locale compatibility URL.
+    const organizationLegacyTarget = getLegacyOrganizationDashboardRedirect(
+        `${pathname}${req.nextUrl.search}`,
+        LOCALES,
+    );
+    if (organizationLegacyTarget) {
+        const target = new URL(organizationLegacyTarget, req.url);
+        const response = NextResponse.redirect(target, 307);
+        response.headers.set('Cache-Control', 'no-store');
+        return applySecurityHeaders(response);
+    }
+
+    // The visible URL is the per-tab authority. Overwrite any inbound selector
+    // and strip the canonical `/org/{slug}` prefix only for the internal App
+    // Router match. next-intl then applies its locale rewrite to that request.
+    let selectedScope;
+    try {
+        selectedScope = parseWorkspacePath(pathname);
+    } catch {
+        return applySecurityHeaders(new NextResponse(null, { status: 404 }));
+    }
+    const scopedHeaders = new Headers(req.headers);
+    scopedHeaders.set(BROWSER_WORKSPACE_SCOPE_HEADER, serializeWorkspaceScope(selectedScope));
+    const scopedRequest = new NextRequest(req, { headers: scopedHeaders });
+    if (selectedScope.kind === 'organization') {
+        const prefix = `/org/${selectedScope.slug}`;
+        const internalPath = pathname.slice(prefix.length);
+        scopedRequest.nextUrl.pathname =
+            internalPath === '' || internalPath === '/' ? '/' : internalPath;
+    }
+
     // 2) Let next-intl resolve the locale from the cookie / Accept-Language.
     //    In `localePrefix: 'never'` mode this rewrites the request
     //    internally (the visible URL stays unprefixed).
-    const intlResponse = await nextIntlMiddleware(req);
+    const intlResponse = await nextIntlMiddleware(scopedRequest);
 
     // 3) Public routes need no auth check.
     if (isPublicRoute(pathname)) {

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -26,7 +26,7 @@ describe('canonical Organization workspace proxy', () => {
 
     it.each([
         ['/org/ever/missions?status=active', '/missions', 'org:ever'],
-        ['/org/en/dashboard', '/dashboard', 'org:en'],
+        ['/org/en/dashboard', '/', 'org:en'],
         ['/missions', '/missions', 'personal'],
     ])(
         'rewrites %s internally and overwrites the trusted selector',
@@ -56,6 +56,48 @@ describe('canonical Organization workspace proxy', () => {
         expect(response.status).toBe(307);
         expect(response.headers.get('location')).toBe('https://app.example/dashboard');
         expect(intlMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps next-intl rewrites internal when the runtime request host differs', async () => {
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: {
+                    'x-middleware-rewrite': 'http://localhost:3000/en/missions?status=active',
+                },
+            }),
+        );
+        const runtimeRequest = new NextRequest(
+            'http://localhost:3000/org/ever/missions?status=active',
+            {
+                headers: {
+                    host: '127.0.0.1:3000',
+                    [BROWSER_WORKSPACE_SCOPE_HEADER]: 'attacker-supplied',
+                },
+            },
+        );
+
+        const response = await proxy(runtimeRequest);
+
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+            'http://127.0.0.1:3000/en/missions?status=active',
+        );
+    });
+
+    it('does not align an internal rewrite to a non-allowlisted Host header', async () => {
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: { 'x-middleware-rewrite': 'http://localhost:3000/en/login' },
+            }),
+        );
+        const hostileRequest = new NextRequest('http://localhost:3000/login', {
+            headers: { host: 'malicious.invalid' },
+        });
+
+        const response = await proxy(hostileRequest);
+
+        expect(response.headers.get('x-middleware-rewrite')).toBe('http://localhost:3000/en/login');
     });
 
     it.each(['/settings/dashboard', '/org/dashboard'])(

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from './lib/workspace-scope';
+
+const { getAuthFromRequestMock, intlMock } = vi.hoisted(() => ({
+    getAuthFromRequestMock: vi.fn(),
+    intlMock: vi.fn(async (_request: unknown) => new Response(null, { status: 200 })),
+}));
+
+vi.mock('next-intl/middleware', () => ({ default: () => intlMock }));
+vi.mock('./lib/auth', () => ({ getAuthFromRequest: getAuthFromRequestMock }));
+
+import proxy from './proxy';
+
+function request(path: string, selector = 'attacker-supplied'): NextRequest {
+    return new NextRequest(`https://app.example${path}`, {
+        headers: { [BROWSER_WORKSPACE_SCOPE_HEADER]: selector },
+    });
+}
+
+describe('canonical Organization workspace proxy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthFromRequestMock.mockResolvedValue({ isAuthenticated: true, isExpired: false });
+    });
+
+    it.each([
+        ['/org/ever/missions?status=active', '/missions', 'org:ever'],
+        ['/org/en/dashboard', '/dashboard', 'org:en'],
+        ['/missions', '/missions', 'personal'],
+    ])(
+        'rewrites %s internally and overwrites the trusted selector',
+        async (path, internal, scope) => {
+            await proxy(request(path));
+
+            const scopedRequest = intlMock.mock.calls[0][0] as NextRequest;
+            expect(scopedRequest.nextUrl.pathname).toBe(internal);
+            expect(scopedRequest.nextUrl.search).toBe(path.includes('?') ? '?status=active' : '');
+            expect(scopedRequest.headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe(scope);
+        },
+    );
+
+    it('redirects only an unambiguous legacy Organization dashboard URL', async () => {
+        const response = await proxy(request('/ever/dashboard?tab=agents'));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get('location')).toBe(
+            'https://app.example/org/ever/dashboard?tab=agents',
+        );
+        expect(intlMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps the existing locale compatibility redirect distinct from Organization routing', async () => {
+        const response = await proxy(request('/en/dashboard'));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get('location')).toBe('https://app.example/dashboard');
+        expect(intlMock).not.toHaveBeenCalled();
+    });
+
+    it.each(['/settings/dashboard', '/org/dashboard'])(
+        'does not reinterpret reserved or locale route %s as a legacy Organization',
+        async (path) => {
+            await proxy(request(path));
+            expect(intlMock).toHaveBeenCalledTimes(1);
+        },
+    );
+});

--- a/docs/internal/2026-08-22-organization-switch-scope-plan.md
+++ b/docs/internal/2026-08-22-organization-switch-scope-plan.md
@@ -1,0 +1,125 @@
+# Organization Switch Scope Persistence Implementation Plan
+
+> **For Codex:** Execute this plan in `E:\Coding\_worktrees\ever-works-org-switch-scope` on
+> `codex/fix-organization-switch-scope`. Follow test-driven development and do not merge or deploy.
+
+**Goal:** Make the real WorkspaceSwitcher persist the selected Organization before navigation, make
+`/{organizationSlug}/dashboard` load safely, and prove subsequent Mission, Goal, Work, and Agent writes
+inherit that persisted Organization through the existing session-scope guard.
+
+**Architecture:** Add an authenticated `GET/POST /api/users/me/scope` API that validates the requested
+Organization against the caller's Tenant before updating `users.lastScopeOrganizationId`. Proxy it through a
+Next.js BFF so the browser never receives the bearer token. The client hook reads the persisted selection on
+legacy routes, while the switcher POSTs before navigating. A narrow slug-dashboard compatibility Server
+Component validates that its slug equals the persisted active Organization and redirects to the existing root
+dashboard without mutating on GET. Existing unprefixed API calls remain unchanged: `SessionScopeGuard` seeds
+their request scope from the persisted column.
+
+**Tech Stack:** NestJS 11, TypeORM, Next.js 16 App Router, React 19, Vitest/Testing Library, Jest, Playwright.
+
+---
+
+## Task 1: Lock the authenticated active-scope API contract
+
+**Files:**
+
+- Create: `apps/api/src/users/dto/update-active-scope.dto.ts`
+- Create: `apps/api/src/users/services/active-scope.service.ts`
+- Create: `apps/api/src/users/services/active-scope.service.spec.ts`
+- Create: `apps/api/src/users/controllers/user-scope.controller.ts`
+- Create: `apps/api/src/users/controllers/user-scope.controller.spec.ts`
+- Modify: `apps/api/src/users/users.module.ts`
+
+1. Write service tests that fail because no active-scope service exists. Cover:
+    - returning the persisted Organization;
+    - persisting a same-Tenant slug;
+    - explicit `null` personal/bare-Tenant scope, required by the existing product contract;
+    - unknown and foreign slugs returning the same not-found outcome;
+    - `UserRepository.update` never being called for either rejection;
+    - a stale persisted pointer returning bare-Tenant scope without mutating during GET.
+2. Run the focused Jest test and capture the expected RED failure.
+3. Implement the minimum service, DTO, controller, and module wiring.
+4. Add thin controller tests for GET/POST delegation and run the focused suite GREEN.
+
+## Task 2: Lock the browser-to-BFF switch contract
+
+**Files:**
+
+- Create: `apps/web/src/app/api/users/me/scope/route.ts`
+- Create: `apps/web/src/app/api/users/me/scope/route.unit.spec.ts`
+- Modify: `apps/web/src/components/layout/WorkspaceSwitcher.tsx`
+- Modify: `apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx`
+
+1. Add a failing component test that opens the real switcher row, clicks a second Organization, and proves:
+    - `POST /api/users/me/scope` receives `{ organizationSlug }`;
+    - navigation does not happen before persistence resolves;
+    - successful persistence navigates to `/{slug}/dashboard`;
+    - failed persistence leaves the route and active label unchanged.
+2. Add failing BFF route tests for authenticated forwarding, unauthenticated 401, invalid JSON, and upstream
+   status/body propagation.
+3. Run both tests RED.
+4. Implement the route handler and asynchronous switcher flow. Disable duplicate selection while pending and
+   surface a safe error without navigating.
+5. Run both focused Vitest files GREEN.
+
+## Task 3: Restore persisted active scope on legacy routes
+
+**Files:**
+
+- Create: `apps/web/src/lib/hooks/use-active-scope.unit.spec.tsx`
+- Modify: `apps/web/src/lib/hooks/use-active-scope.ts`
+- Modify: `apps/web/src/components/layout/WorkspaceSwitcher.tsx`
+
+1. Write failing hook tests proving URL slug precedence, persisted-scope fallback on `/`, and an immediate
+   in-component selection update after a successful switch.
+2. Run the hook test RED.
+3. Add a request-local client hook state that GETs the BFF when no slug is present and exposes a setter for a
+   successful switch. Do not use localStorage as an authority.
+4. Run hook and switcher tests GREEN.
+
+## Task 4: Make the slug dashboard URL safe without GET mutation
+
+**Files:**
+
+- Create: `apps/web/src/app/[locale]/[slug]/dashboard/page.tsx`
+- Create: `apps/web/src/app/[locale]/[slug]/dashboard/page.unit.spec.ts`
+
+1. Write failing Server Component contract tests proving:
+    - a slug matching `GET /users/me/scope` redirects to `/`;
+    - a mismatched, personal, failed, or unknown active scope produces not-found;
+    - the route performs GET only and never changes active scope.
+2. Run the route test RED.
+3. Implement the narrow async-`params` App Router page using `serverFetch`, `redirect`, and `notFound`.
+4. Run the route test GREEN.
+
+## Task 5: Replace the fake end-to-end propagation proof
+
+**Files:**
+
+- Modify: `apps/web/e2e/flow-org-switch-context-propagation.spec.ts`
+- Modify: `apps/web/e2e/organization-create-switch.spec.ts`
+- Modify only if needed: `apps/web/e2e/helpers/organizations.ts`
+
+1. Replace the localStorage/manual-header UI test with a real browser click that observes the BFF POST,
+   successfully traverses the compatibility URL, returns to the dashboard, and shows the selected Organization.
+2. Add API integration coverage that POSTs the active scope and then uses a fresh login with no
+   `X-Scope-Slug` header. Prove GET returns the same Organization.
+3. Prove unknown and foreign Organization slugs do not change the previously selected scope.
+4. Through the real API paths, create isolated test Mission, Goal, Work, and Agent rows after selection without
+   a scope header and assert each response is stamped with the selected `organizationId` and `tenantId`.
+   Do not use production data and do not add Fleet behavior in this task.
+5. Update the older switch test to expect the validated compatibility redirect rather than a permanent slug URL.
+6. Run the focused Playwright spec against the local e2e stack. If environment services are unavailable,
+   preserve the runnable contract and report that constraint separately from unit/integration evidence.
+
+## Task 6: Verify, review, and hand off without rollout
+
+1. Run focused Jest and Vitest suites fresh.
+2. Run API/web type-check and lint for the changed applications.
+3. Run API/web builds proportional to the cross-boundary change.
+4. Inspect the diff for secrets, migrations, plugin/Fleet files, deletion, and accidental scope expansion.
+5. Run the repository's applicable React quality checklist after TSX edits.
+6. Commit with a conventional semantic message and push only `codex/fix-organization-switch-scope`.
+7. Open a PR to `develop` if permitted, but do not merge or deploy while the existing rollout claim is active.
+8. Keep the maintenance claim active for review/rollout, update its heartbeat accurately, and report exact
+   commands, branch/PR, remaining rollout gate, and rollback (`revert` the feature commit/PR).

--- a/packages/contracts/src/api/active-scope.spec.ts
+++ b/packages/contracts/src/api/active-scope.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { ACTIVE_SCOPE_RESPONSE_SCHEMA, type ActiveScopeResponse } from './active-scope.js';
+
+describe('active scope response contract', () => {
+	it('defines the shared runtime schema used by API documentation and consumers', () => {
+		expect(ACTIVE_SCOPE_RESPONSE_SCHEMA).toEqual({
+			type: 'object',
+			properties: {
+				tenantId: { type: 'string', format: 'uuid', nullable: true },
+				organizationId: { type: 'string', format: 'uuid', nullable: true },
+				organizationSlug: { type: 'string', nullable: true }
+			},
+			required: ['tenantId', 'organizationId', 'organizationSlug']
+		});
+
+		expectTypeOf<ActiveScopeResponse>().toEqualTypeOf<{
+			tenantId: string | null;
+			organizationId: string | null;
+			organizationSlug: string | null;
+		}>();
+	});
+});

--- a/packages/contracts/src/api/active-scope.spec.ts
+++ b/packages/contracts/src/api/active-scope.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import { ACTIVE_SCOPE_RESPONSE_SCHEMA, type ActiveScopeResponse } from './active-scope.js';
+import {
+	ACTIVE_SCOPE_API_HEADER,
+	ACTIVE_SCOPE_BROWSER_HEADER,
+	ACTIVE_SCOPE_PERSONAL_SENTINEL,
+	ACTIVE_SCOPE_RESPONSE_SCHEMA,
+	type ActiveScopeResponse
+} from './active-scope.js';
 
 describe('active scope response contract', () => {
 	it('defines the shared runtime schema used by API documentation and consumers', () => {
@@ -18,5 +24,11 @@ describe('active scope response contract', () => {
 			organizationId: string | null;
 			organizationSlug: string | null;
 		}>();
+	});
+
+	it('defines a reserved personal selector and canonical transport headers', () => {
+		expect(ACTIVE_SCOPE_PERSONAL_SENTINEL).toBe('@personal');
+		expect(ACTIVE_SCOPE_API_HEADER).toBe('x-scope-slug');
+		expect(ACTIVE_SCOPE_BROWSER_HEADER).toBe('x-ever-workspace');
 	});
 });

--- a/packages/contracts/src/api/active-scope.ts
+++ b/packages/contracts/src/api/active-scope.ts
@@ -4,6 +4,11 @@ type NullableStringSchemaProperty = {
 	nullable: true;
 };
 
+/** Reserved transport contract; Organization slugs can never collide with this value. */
+export const ACTIVE_SCOPE_PERSONAL_SENTINEL = '@personal' as const;
+export const ACTIVE_SCOPE_API_HEADER = 'x-scope-slug' as const;
+export const ACTIVE_SCOPE_BROWSER_HEADER = 'x-ever-workspace' as const;
+
 const ACTIVE_SCOPE_RESPONSE_PROPERTIES = {
 	tenantId: { type: 'string', format: 'uuid', nullable: true },
 	organizationId: { type: 'string', format: 'uuid', nullable: true },

--- a/packages/contracts/src/api/active-scope.ts
+++ b/packages/contracts/src/api/active-scope.ts
@@ -1,0 +1,25 @@
+type NullableStringSchemaProperty = {
+	type: 'string';
+	format?: 'uuid';
+	nullable: true;
+};
+
+const ACTIVE_SCOPE_RESPONSE_PROPERTIES = {
+	tenantId: { type: 'string', format: 'uuid', nullable: true },
+	organizationId: { type: 'string', format: 'uuid', nullable: true },
+	organizationSlug: { type: 'string', nullable: true }
+} satisfies Record<string, NullableStringSchemaProperty>;
+
+type ActiveScopeResponseKey = keyof typeof ACTIVE_SCOPE_RESPONSE_PROPERTIES;
+
+/** Runtime OpenAPI schema and source of truth for the active-scope response keys. */
+export const ACTIVE_SCOPE_RESPONSE_SCHEMA = {
+	type: 'object' as const,
+	properties: ACTIVE_SCOPE_RESPONSE_PROPERTIES,
+	required: Object.keys(ACTIVE_SCOPE_RESPONSE_PROPERTIES) as ActiveScopeResponseKey[]
+};
+
+/** Wire response shared by the API and every active-scope consumer. */
+export type ActiveScopeResponse = {
+	[Key in ActiveScopeResponseKey]: string | null;
+};

--- a/packages/contracts/src/api/index.ts
+++ b/packages/contracts/src/api/index.ts
@@ -22,6 +22,9 @@ export * from './data-sync/index.js';
 // upgrade-from-account API wire-types.
 export * from './organization/index.js';
 
+// EW-660 persisted Tenant / Organization workspace selection.
+export * from './active-scope.js';
+
 // EW-693 Dynamic plugin distribution — install state, catalog, allowlist
 // wire-types for `/plugins/catalog`, `/plugins/:id/install*`, and
 // `/admin/plugins/allowlist*`.


### PR DESCRIPTION
## Summary
- add an authenticated, membership-validated active Organization scope API that persists `users.lastScopeOrganizationId` without a migration
- switch workspaces through a same-origin web BFF before navigating, restore persisted scope on legacy routes, and safely redirect validated `/{slug}/dashboard` URLs to the existing dashboard
- replace the localStorage-only browser contract with real switcher/BFF coverage and add Mission/Goal/Work/Agent scope-stamping regression coverage

## Safety and behavior
- unknown and foreign Organization slugs return an opaque 404 and do not partially update the user
- explicit personal scope remains supported by the existing product contract
- no live entity, production API, database, Kubernetes, ArgoCD, or deployment was touched
- no migration and no delete/removal
- unprefixed routes remain supported

## Verification
- `pnpm --dir apps/api test -- src/users/services/active-scope.service.spec.ts src/users/controllers/user-scope.controller.spec.ts src/users/dto/update-active-scope.dto.spec.ts src/scope/__tests__/scope-stamping.creation-paths.spec.ts` (focused API suites; consolidated run: 6 suites / 43 tests; final service resilience rerun: 8 tests)
- `pnpm --dir apps/web exec vitest run src/components/layout/WorkspaceSwitcher.unit.spec.tsx src/components/organizations/CreateOrganizationModal.unit.spec.tsx src/lib/hooks/use-active-scope.unit.spec.tsx 'src/app/[locale]/[slug]/dashboard/page.unit.spec.ts' src/app/api/users/me/scope/route.unit.spec.ts` (5 files / 24 tests)
- `pnpm exec turbo run build --filter=ever-works-api^... --filter=ever-works-web^...` (14/14 dependency packages)
- `pnpm --dir apps/api type-check`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/api build` (893 files, 0 TypeScript issues)
- `pnpm --dir apps/web build` (42 routes, including the new compatibility route and BFF)
- isolated local production-build E2E with in-memory SQLite: `pnpm --dir apps/web exec playwright test flow-org-switch-context-propagation organization-create-switch --project=chromium --workers=1` (9 passed)
- changed-file web lint clean; the modal's two whole-file `react-hooks/set-state-in-effect` findings are unchanged and reproduce identically on `origin/develop`

## Rollout gate
Do not merge, cascade, or deploy this PR while the active Ever Works plugin rollout claim owns `develop -> stage -> main` and resulting rollouts. The maintenance claim remains active through review/rollout coordination.

## Rollback
Revert this PR commit before deployment. The change is additive and has no schema or data migration; no production data rollback is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-backed active workspace selection for organizations and personal scope.
  * Organization routes now use canonical `/org/{slug}/dashboard` URLs.
  * Workspace switching persists selections before navigation and restores the configured workspace after login.
  * Added workspace-aware navigation and scope handling for organization, creation, and terminal workflows.

* **Bug Fixes**
  * Invalid, inaccessible, stale, or mismatched workspace selections now fail safely.
  * Personal routes no longer inherit an organization unintentionally.

* **Tests**
  * Expanded coverage for switching, routing, authorization, persistence, and scope propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->