### PR TITLE
fix(k8s): probe health endpoint after startup

### DIFF
--- a/packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts
@@ -48,6 +48,14 @@ describe('buildDeployment', () => {
 		const d = buildDeployment({ ...baseInput, pullSecretName: 'my-site-pull' }) as Record<string, any>;
 		expect(d.spec.template.spec.imagePullSecrets).toEqual([{ name: 'my-site-pull' }]);
 	});
+
+	it('uses the cheap health endpoint for ongoing readiness and liveness probes', () => {
+		const d = buildDeployment(baseInput) as Record<string, any>;
+		const container = d.spec.template.spec.containers[0];
+
+		expect(container.readinessProbe.httpGet.path).toBe('/api/health');
+		expect(container.livenessProbe.httpGet.path).toBe('/api/health');
+	});
 });
 
 describe('buildService', () => {

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -49,13 +49,13 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 					failureThreshold: input.startupFailureThreshold ?? 30
 				},
 				readinessProbe: {
-					httpGet: { path: '/', port: 'http' },
+					httpGet: { path: '/api/health', port: 'http' },
 					periodSeconds: 10,
 					timeoutSeconds: 5,
 					failureThreshold: 3
 				},
 				livenessProbe: {
-					httpGet: { path: '/', port: 'http' },
+					httpGet: { path: '/api/health', port: 'http' },
 					periodSeconds: 20,
 					timeoutSeconds: 10,
 					failureThreshold: 6


### PR DESCRIPTION
## Summary
- keep the homepage startup probe so directory content warms before readiness
- use the cheap /api/health endpoint for ongoing readiness and liveness
- prevent a slow catalogue render from removing the only Service endpoint and returning ingress 503

## Verification
- RED: manifest renderer test received / instead of /api/health
- GREEN: focused renderer spec (10/10)
- full @ever-works/k8s-plugin suite (156/156)
- @ever-works/k8s-plugin type-check after building @ever-works/contracts and @ever-works/plugin