### PR TITLE
fix(k8s): make generated-site rollouts memory-safe

### DIFF
--- a/docs/specs/k8s-generated-site-memory-safety/implementation-plan.md
+++ b/docs/specs/k8s-generated-site-memory-safety/implementation-plan.md
@@ -1,0 +1,64 @@
+# Kubernetes Generated-Site Memory Safety Implementation Plan
+
+> **For Codex:** Use `superpowers:test-driven-development` for each behavior change and `superpowers:verification-before-completion` before claiming completion.
+
+**Goal:** Make future generated-site Deployments advertise realistic memory, roll a single replica without a temporary duplicate, probe a lightweight health endpoint, and spread replicas across nodes.
+
+**Scope:** Renderer and Kubernetes plugin settings only. Existing Work rows, generated repositories, live Deployments, routes, clusters, and node sizing are explicitly out of scope for this code change.
+
+**Design:** The renderer defaults memory requests to a `512Mi` admission floor, the smallest request above the measured roughly 468–499 MiB low-water working sets. This floor is not a sufficiency claim for sites measured in the 0.4–0.8 GiB range; those need higher measured per-Work requests. Platform-managed sources normalize legacy explicit requests below `512Mi` during deploy only after validating the effective request/limit pair; custom clusters retain their values and the full Kubernetes quantity syntax. A settings hook rejects malformed managed quantities, request-over-limit, and new managed request/limit values below the floor. Single-replica Deployments use a surge-free `0/1` rollout, explicitly accepting a brief outage while the replacement becomes Ready; startup keeps `/` to warm the catalogue, readiness/liveness use `/api/health`, and a soft hostname topology spread preference applies to the existing pod selector.
+
+## Task 1: Lock renderer behavior with failing tests
+
+**Files:**
+
+- Modify: `packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts`
+
+1. Add tests for the `512Mi` default and explicit override.
+2. Add tests for single-replica `maxSurge: 0` / `maxUnavailable: 1`, its intentional brief-outage tradeoff, and multi-replica `1/0`.
+3. Add tests that startup keeps `/` for catalogue warm-up while readiness and liveness use `/api/health`.
+4. Add a test for a soft hostname topology spread preference using the Deployment selector, avoiding tainted-control-plane hard-constraint deadlocks.
+5. Run `pnpm test -- src/__tests__/manifest.renderer.spec.ts` and confirm the new assertions fail for the expected missing behavior.
+
+## Task 2: Implement renderer safety defaults
+
+**Files:**
+
+- Modify: `packages/plugins/k8s/src/manifest.renderer.ts`
+
+1. Render `512Mi` when no memory request is supplied.
+2. Render a surge-free strategy for one replica while retaining ordinary rolling availability for multiple replicas.
+3. Preserve the startup probe on `/` and point readiness/liveness at `/api/health`.
+4. Add a hostname topology spread preference with `maxSkew: 1`, `ScheduleAnyway`, and the existing selector.
+5. Re-run the renderer test and confirm it passes.
+
+## Task 3: Lock managed-cluster settings behavior with failing tests
+
+**Files:**
+
+- Modify: `packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts`
+
+1. Assert schema defaults without restricting Kubernetes' DecimalSI, BinarySI, or exponent syntax.
+2. Assert validation accepts `512Mi`, `0.5Gi`, and exponent forms on managed sources and preserves valid custom-cluster quantities.
+3. Assert validation rejects malformed managed quantities, request greater than limit, and managed request/limit values below `512Mi`.
+4. Assert deploy normalizes a legacy managed `256Mi` override to `512Mi`, fails before any API write when the effective limit is too low, and preserves a custom-cluster `256Mi` override.
+5. Run `pnpm test -- src/__tests__/k8s.plugin.spec.ts` and confirm the new assertions fail for the expected missing behavior.
+
+## Task 4: Implement settings validation and legacy normalization
+
+**Files:**
+
+- Modify: `packages/plugins/k8s/src/k8s.plugin.ts`
+
+1. Add exact Kubernetes DecimalSI, BinarySI, and DecimalExponent quantity parsing for managed-floor comparisons.
+2. Add schema defaults without a syntax-narrowing pattern.
+3. Add `validateSettings()` for managed quantity syntax, request/limit ordering, and managed-source minimum request/limit values while leaving custom-cluster validation to its API server.
+4. Normalize legacy sub-minimum managed requests at deploy render time without changing stored Work settings, but fail safely before any API write if the effective limit cannot cover the request.
+5. Re-run the focused tests and confirm they pass.
+
+## Task 5: Verify the complete plugin change
+
+1. Run `pnpm test -- src/__tests__/manifest.renderer.spec.ts src/__tests__/k8s.plugin.spec.ts`.
+2. Run the package typecheck/build commands exposed by `packages/plugins/k8s/package.json`.
+3. Run `git diff --check` and inspect the rendered manifest diff for one- and two-replica inputs.
+4. Record rollback as reverting the renderer/plugin commit; no live resource changes are part of this code commit.

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -179,7 +179,7 @@ describe('KubernetesPlugin metadata', () => {
 
 	it('publishes measured memory defaults without narrowing Kubernetes quantity syntax', () => {
 		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
-		expect(props.memoryRequest?.default).toBe('512Mi');
+		expect(props.memoryRequest?.default).toBeUndefined();
 		expect(props.memoryLimit?.default).toBe('2Gi');
 		expect(props.memoryRequest?.pattern).toBeUndefined();
 		expect(props.memoryLimit?.pattern).toBeUndefined();
@@ -626,6 +626,24 @@ describe('KubernetesPlugin.deploy (mocked api)', () => {
 					githubOwner: 'acme',
 					websiteRepoIsPrivate: false,
 					settingsOverride: { clusterSource: 'custom-kubeconfig', memoryRequest: '256Mi' }
+				}
+			},
+			VALID
+		);
+
+		const manifest = vi.mocked(api.applyDeployment).mock.calls[0]?.[1] as Record<string, any>;
+		expect(manifest.spec.template.spec.containers[0].resources.requests.memory).toBe('256Mi');
+	});
+
+	it('preserves the historical 256Mi fallback for a custom cluster without an override', async () => {
+		await plugin.deploy(
+			{
+				projectName: 'work-1',
+				sourceDir: '.',
+				options: {
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					settingsOverride: { clusterSource: 'custom-kubeconfig' }
 				}
 			},
 			VALID

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -177,6 +177,14 @@ describe('KubernetesPlugin metadata', () => {
 		expect(ic?.['x-widget']).toBe('cluster-ingress-class');
 	});
 
+	it('publishes measured memory defaults without narrowing Kubernetes quantity syntax', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.memoryRequest?.default).toBe('512Mi');
+		expect(props.memoryLimit?.default).toBe('2Gi');
+		expect(props.memoryRequest?.pattern).toBeUndefined();
+		expect(props.memoryLimit?.pattern).toBeUndefined();
+	});
+
 	it('manifest hints verifiesOnSave so the UI labels the save button "Save & verify" and shows cluster info on success', () => {
 		const m = plugin.getManifest();
 		expect(m.uiHints?.verifiesOnSave).toBe(true);
@@ -187,6 +195,113 @@ describe('KubernetesPlugin metadata', () => {
 		expect(m.uiHints?.includeInOnboarding).toBe(true);
 		expect(m.uiHints?.onboardingPriority).toBe(4);
 		expect(m.uiHints?.onboardingDescription).toBeDefined();
+	});
+});
+
+describe('KubernetesPlugin.validateSettings', () => {
+	const plugin = new KubernetesPlugin();
+
+	it('accepts the managed minimum and preserves smaller requests for custom clusters', () => {
+		expect(
+			plugin.validateSettings({ clusterSource: 'k8s-works', memoryRequest: '512Mi', memoryLimit: '2Gi' })
+		).toEqual({ valid: true });
+		expect(
+			plugin.validateSettings({ clusterSource: 'k8s-works', memoryRequest: '0.5Gi', memoryLimit: '1e9' })
+		).toEqual({ valid: true });
+		expect(
+			plugin.validateSettings({ clusterSource: 'custom-kubeconfig', memoryRequest: '256Mi', memoryLimit: '2Gi' })
+		).toEqual({ valid: true });
+		expect(
+			plugin.validateSettings({ clusterSource: 'custom-kubeconfig', memoryRequest: '500M', memoryLimit: '1G' })
+		).toEqual({ valid: true });
+	});
+
+	it('rejects malformed memory quantities on a platform-managed cluster', () => {
+		const result = plugin.validateSettings({
+			clusterSource: 'k8s-works',
+			memoryRequest: 'not-a-quantity',
+			memoryLimit: '2Gi'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: 'memoryRequest', code: 'INVALID_MEMORY_QUANTITY' })
+			])
+		);
+	});
+
+	it('rejects unsupported quantity suffixes on a platform-managed cluster', () => {
+		const result = plugin.validateSettings({
+			clusterSource: 'k8s-works',
+			memoryRequest: '500K',
+			memoryLimit: '2Gi'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: 'memoryRequest', code: 'INVALID_MEMORY_QUANTITY' })
+			])
+		);
+	});
+
+	it('rejects a request larger than the limit', () => {
+		const result = plugin.validateSettings({
+			clusterSource: 'k8s-works',
+			memoryRequest: '3Gi',
+			memoryLimit: '2Gi'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: 'memoryRequest', code: 'MEMORY_REQUEST_EXCEEDS_LIMIT' })
+			])
+		);
+	});
+
+	it('rejects new sub-512Mi requests on platform-managed clusters', () => {
+		const result = plugin.validateSettings({
+			clusterSource: 'k8s-works-shared',
+			memoryRequest: '256Mi',
+			memoryLimit: '2Gi'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: 'memoryRequest', code: 'MANAGED_MEMORY_REQUEST_TOO_LOW' })
+			])
+		);
+	});
+
+	it('validates a legacy low request and low limit as one invalid managed pair', () => {
+		const result = plugin.validateSettings({
+			clusterSource: 'k8s-works',
+			memoryRequest: '256Mi',
+			memoryLimit: '384Mi'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: 'memoryRequest', code: 'MANAGED_MEMORY_REQUEST_TOO_LOW' }),
+				expect.objectContaining({ path: 'memoryLimit', code: 'MANAGED_MEMORY_LIMIT_TOO_LOW' })
+			])
+		);
+	});
+
+	it('recognizes valid DecimalSI quantities while applying the managed admission floor', () => {
+		const result = plugin.validateSettings({
+			clusterSource: 'k8s-works',
+			memoryRequest: '500M',
+			memoryLimit: '1G'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: 'memoryRequest', code: 'MANAGED_MEMORY_REQUEST_TOO_LOW' })
+			])
+		);
+		expect(result.errors).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ code: 'INVALID_MEMORY_QUANTITY' })])
+		);
 	});
 });
 
@@ -458,6 +573,66 @@ describe('KubernetesPlugin.deploy (mocked api)', () => {
 		);
 		expect(result.status).toBe('error');
 		expect(result.error).not.toContain('leak-12345');
+	});
+
+	it('normalizes a legacy managed 256Mi request to the 512Mi admission floor', async () => {
+		await plugin.deploy(
+			{
+				projectName: 'work-1',
+				sourceDir: '.',
+				options: {
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					settingsOverride: { clusterSource: 'k8s-works', memoryRequest: '256Mi' }
+				}
+			},
+			VALID
+		);
+
+		const manifest = vi.mocked(api.applyDeployment).mock.calls[0]?.[1] as Record<string, any>;
+		expect(manifest.spec.template.spec.containers[0].resources.requests.memory).toBe('512Mi');
+	});
+
+	it('fails before any API write when a legacy managed limit is below the normalized request floor', async () => {
+		const result = await plugin.deploy(
+			{
+				projectName: 'work-1',
+				sourceDir: '.',
+				options: {
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					settingsOverride: {
+						clusterSource: 'k8s-works',
+						memoryRequest: '256Mi',
+						memoryLimit: '384Mi'
+					}
+				}
+			},
+			VALID
+		);
+
+		expect(result.status).toBe('error');
+		expect(result.error).toMatch(/limit.*512Mi admission floor/i);
+		expect(api.ensureNamespace).not.toHaveBeenCalled();
+		expect(api.applyDeployment).not.toHaveBeenCalled();
+	});
+
+	it('preserves an explicit 256Mi request for a custom cluster', async () => {
+		await plugin.deploy(
+			{
+				projectName: 'work-1',
+				sourceDir: '.',
+				options: {
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					settingsOverride: { clusterSource: 'custom-kubeconfig', memoryRequest: '256Mi' }
+				}
+			},
+			VALID
+		);
+
+		const manifest = vi.mocked(api.applyDeployment).mock.calls[0]?.[1] as Record<string, any>;
+		expect(manifest.spec.template.spec.containers[0].resources.requests.memory).toBe('256Mi');
 	});
 });
 

--- a/packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts
@@ -39,9 +39,9 @@ describe('buildDeployment', () => {
 		expect(c.readinessProbe).toBeDefined();
 	});
 
-	it('uses a 512Mi admission floor by default and preserves explicit sizing', () => {
+	it('preserves the provider-neutral 256Mi fallback and explicit sizing', () => {
 		const defaults = buildDeployment(baseInput) as Record<string, any>;
-		expect(defaults.spec.template.spec.containers[0].resources.requests.memory).toBe('512Mi');
+		expect(defaults.spec.template.spec.containers[0].resources.requests.memory).toBe('256Mi');
 
 		const explicit = buildDeployment({ ...baseInput, memoryRequest: '768Mi' }) as Record<string, any>;
 		expect(explicit.spec.template.spec.containers[0].resources.requests.memory).toBe('768Mi');

--- a/packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/manifest.renderer.spec.ts
@@ -39,6 +39,41 @@ describe('buildDeployment', () => {
 		expect(c.readinessProbe).toBeDefined();
 	});
 
+	it('uses a 512Mi admission floor by default and preserves explicit sizing', () => {
+		const defaults = buildDeployment(baseInput) as Record<string, any>;
+		expect(defaults.spec.template.spec.containers[0].resources.requests.memory).toBe('512Mi');
+
+		const explicit = buildDeployment({ ...baseInput, memoryRequest: '768Mi' }) as Record<string, any>;
+		expect(explicit.spec.template.spec.containers[0].resources.requests.memory).toBe('768Mi');
+	});
+
+	it('trades one-replica availability for no temporary surge and keeps multi-replica availability', () => {
+		const single = buildDeployment({ ...baseInput, replicas: 1 }) as Record<string, any>;
+		expect(single.spec.strategy.rollingUpdate).toEqual({ maxSurge: 0, maxUnavailable: 1 });
+
+		const multiple = buildDeployment(baseInput) as Record<string, any>;
+		expect(multiple.spec.strategy.rollingUpdate).toEqual({ maxSurge: 1, maxUnavailable: 0 });
+	});
+
+	it('preserves the homepage startup warm-up before ongoing health probes begin', () => {
+		const d = buildDeployment(baseInput) as Record<string, any>;
+		const c = d.spec.template.spec.containers[0];
+		expect(c.startupProbe.httpGet.path).toBe('/');
+	});
+
+	it('softly spreads replicas without letting an untolerated control-plane domain strand a rollout', () => {
+		const d = buildDeployment(baseInput) as Record<string, any>;
+		expect(d.spec.template.spec.topologySpreadConstraints).toEqual([
+			{
+				maxSkew: 1,
+				topologyKey: 'kubernetes.io/hostname',
+				whenUnsatisfiable: 'ScheduleAnyway',
+				labelSelector: { matchLabels: { 'app.kubernetes.io/name': 'my-site' } }
+			}
+		]);
+		expect(d.spec.template.spec.topologySpreadConstraints[0].nodeTaintsPolicy).toBeUndefined();
+	});
+
 	it('omits imagePullSecrets when no pull secret name is provided', () => {
 		const d = buildDeployment(baseInput) as Record<string, any>;
 		expect(d.spec.template.spec.imagePullSecrets).toBeUndefined();

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -11,7 +11,9 @@ import type {
 	PluginCategory,
 	PluginContext,
 	PluginHealthCheck,
-	PluginManifest
+	PluginManifest,
+	ValidationError,
+	ValidationResult
 } from '@ever-works/plugin';
 
 import { createHash } from 'node:crypto';
@@ -68,6 +70,113 @@ function hashRuntimeEnv(env: Record<string, string>): string {
 const DEFAULT_NAMESPACE = 'ever-works';
 const DEFAULT_REPLICAS = 1;
 const CONTAINER_PORT = 3000;
+const DEFAULT_MEMORY_REQUEST = '512Mi';
+const DEFAULT_MEMORY_LIMIT = '2Gi';
+
+interface ParsedQuantity {
+	numerator: bigint;
+	denominator: bigint;
+}
+
+const MANAGED_MEMORY_REQUEST_MINIMUM = parseKubernetesQuantity(DEFAULT_MEMORY_REQUEST)!;
+
+function isPlatformManagedClusterSource(source: ClusterSource | undefined): boolean {
+	return source === 'k8s-works' || source === 'k8s-works-shared';
+}
+
+/**
+ * Parse Kubernetes' DecimalSI, BinarySI, and DecimalExponent quantity forms
+ * into an exact rational number. Custom clusters keep passing their strings
+ * through untouched; this parser is only used to enforce managed-cluster
+ * memory invariants before an API write.
+ */
+function parseKubernetesQuantity(value: unknown): ParsedQuantity | undefined {
+	if (typeof value !== 'string') return undefined;
+	const match = /^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:(?:[eE]([+-]?\d+))|(Ki|Mi|Gi|Ti|Pi|Ei|[numkMGTPE]))?$/.exec(
+		value
+	);
+	if (!match) return undefined;
+
+	const integer = match[2] ?? '0';
+	const fraction = match[3] ?? match[4] ?? '';
+	let numerator = BigInt(`${integer}${fraction}` || '0');
+	let denominator = 10n ** BigInt(fraction.length);
+	if (match[1] === '-') numerator = -numerator;
+
+	const exponentText = match[5];
+	const suffix = match[6] ?? '';
+	if (exponentText !== undefined) {
+		const exponent = Number(exponentText);
+		// Kubernetes resources are bounded far below this; the guard prevents
+		// an adversarial settings string from allocating an enormous BigInt.
+		if (!Number.isSafeInteger(exponent) || Math.abs(exponent) > 100) return undefined;
+		if (exponent >= 0) numerator *= 10n ** BigInt(exponent);
+		else denominator *= 10n ** BigInt(-exponent);
+	}
+
+	const decimalPowers: Record<string, number> = {
+		n: -9,
+		u: -6,
+		m: -3,
+		'': 0,
+		k: 3,
+		M: 6,
+		G: 9,
+		T: 12,
+		P: 15,
+		E: 18
+	};
+	const binaryPowers: Record<string, number> = { Ki: 10, Mi: 20, Gi: 30, Ti: 40, Pi: 50, Ei: 60 };
+
+	if (suffix in binaryPowers) {
+		numerator *= 1n << BigInt(binaryPowers[suffix]);
+	} else {
+		const power = decimalPowers[suffix];
+		if (power === undefined) return undefined;
+		if (power >= 0) numerator *= 10n ** BigInt(power);
+		else denominator *= 10n ** BigInt(-power);
+	}
+
+	return { numerator, denominator };
+}
+
+function compareQuantities(left: ParsedQuantity, right: ParsedQuantity): number {
+	const leftScaled = left.numerator * right.denominator;
+	const rightScaled = right.numerator * left.denominator;
+	return leftScaled < rightScaled ? -1 : leftScaled > rightScaled ? 1 : 0;
+}
+
+function effectiveMemorySizing(settings: KubernetesSettings): {
+	memoryRequest: string | undefined;
+	memoryLimit: string | undefined;
+} {
+	if (!isPlatformManagedClusterSource(settings.clusterSource)) {
+		return { memoryRequest: settings.memoryRequest, memoryLimit: settings.memoryLimit };
+	}
+
+	const requested = settings.memoryRequest ?? DEFAULT_MEMORY_REQUEST;
+	const limited = settings.memoryLimit ?? DEFAULT_MEMORY_LIMIT;
+	const requestQuantity = parseKubernetesQuantity(requested);
+	const limitQuantity = parseKubernetesQuantity(limited);
+	if (requestQuantity === undefined || limitQuantity === undefined) {
+		throw new K8sPluginError(
+			'UNKNOWN',
+			'Managed Kubernetes memory request and limit must use valid Kubernetes resource quantities.'
+		);
+	}
+
+	const belowFloor = compareQuantities(requestQuantity, MANAGED_MEMORY_REQUEST_MINIMUM) < 0;
+	const memoryRequest = belowFloor ? DEFAULT_MEMORY_REQUEST : requested;
+	const effectiveRequestQuantity = belowFloor ? MANAGED_MEMORY_REQUEST_MINIMUM : requestQuantity;
+	if (compareQuantities(limitQuantity, effectiveRequestQuantity) < 0) {
+		throw new K8sPluginError(
+			'UNKNOWN',
+			'Managed Kubernetes memory limit must cover the effective request (the 512Mi admission floor or a larger configured request).'
+		);
+	}
+
+	return { memoryRequest, memoryLimit: limited };
+}
 
 interface DeployOptions {
 	/** Short git SHA (or any deterministic version tag). */
@@ -295,7 +404,9 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			memoryRequest: {
 				type: 'string',
 				title: 'Memory request',
-				description: "Kubernetes quantity, e.g. '256Mi'."
+				default: DEFAULT_MEMORY_REQUEST,
+				description:
+					"Kubernetes quantity, e.g. '512Mi' or '500M'. Platform-managed clusters use 512Mi only as an admission floor; set a larger measured value for each heavier catalogue."
 			},
 			cpuLimit: {
 				type: 'string',
@@ -305,6 +416,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			memoryLimit: {
 				type: 'string',
 				title: 'Memory limit',
+				default: DEFAULT_MEMORY_LIMIT,
 				description:
 					"Kubernetes quantity, e.g. '2Gi'. Must fit the target node: a limit larger than a node's allocatable memory schedules fine (requests are small) and then OOM-kills the pod climbing toward a ceiling that does not exist."
 			}
@@ -363,6 +475,68 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			message: 'Kubernetes plugin is ready (cluster reachability is per-token)',
 			checkedAt: Date.now()
 		};
+	}
+
+	validateSettings(settings: Record<string, unknown>): ValidationResult {
+		const errors: ValidationError[] = [];
+		const clusterSource = isClusterSource(settings.clusterSource) ? settings.clusterSource : undefined;
+		// Kubernetes accepts DecimalSI, BinarySI, and exponent quantities. Do
+		// not narrow syntax for a customer's own cluster; its API server remains
+		// authoritative. Managed clusters need local parsing only because the
+		// platform enforces an admission floor before it writes any resource.
+		if (!isPlatformManagedClusterSource(clusterSource)) return { valid: true };
+
+		const memoryRequest = settings.memoryRequest ?? DEFAULT_MEMORY_REQUEST;
+		const memoryLimit = settings.memoryLimit ?? DEFAULT_MEMORY_LIMIT;
+		const requestQuantity = parseKubernetesQuantity(memoryRequest);
+		const limitQuantity = parseKubernetesQuantity(memoryLimit);
+
+		if (requestQuantity === undefined) {
+			errors.push({
+				path: 'memoryRequest',
+				code: 'INVALID_MEMORY_QUANTITY',
+				message: "Memory request must be a valid Kubernetes quantity such as '512Mi', '500M', or '1e9'."
+			});
+		}
+
+		if (limitQuantity === undefined) {
+			errors.push({
+				path: 'memoryLimit',
+				code: 'INVALID_MEMORY_QUANTITY',
+				message: "Memory limit must be a valid Kubernetes quantity such as '2Gi' or '2G'."
+			});
+		}
+
+		if (
+			requestQuantity !== undefined &&
+			limitQuantity !== undefined &&
+			compareQuantities(requestQuantity, limitQuantity) > 0
+		) {
+			errors.push({
+				path: 'memoryRequest',
+				code: 'MEMORY_REQUEST_EXCEEDS_LIMIT',
+				message: 'Memory request must not exceed the memory limit.'
+			});
+		}
+
+		if (requestQuantity !== undefined && compareQuantities(requestQuantity, MANAGED_MEMORY_REQUEST_MINIMUM) < 0) {
+			errors.push({
+				path: 'memoryRequest',
+				code: 'MANAGED_MEMORY_REQUEST_TOO_LOW',
+				message:
+					'Platform-managed clusters require a 512Mi admission floor; heavier sites need a larger measured request.'
+			});
+		}
+
+		if (limitQuantity !== undefined && compareQuantities(limitQuantity, MANAGED_MEMORY_REQUEST_MINIMUM) < 0) {
+			errors.push({
+				path: 'memoryLimit',
+				code: 'MANAGED_MEMORY_LIMIT_TOO_LOW',
+				message: 'Platform-managed memory limit must cover the 512Mi admission floor.'
+			});
+		}
+
+		return errors.length > 0 ? { valid: false, errors } : { valid: true };
 	}
 
 	getManifest(): PluginManifest {
@@ -541,6 +715,11 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		let pullSecretName: string | undefined;
 
 		try {
+			// Resolve request and limit as a pair before the first write. A legacy
+			// managed Work may combine a sub-floor request with an even lower
+			// limit; raising only the request would make an invalid Deployment.
+			const memorySizing = effectiveMemorySizing(settings);
+
 			// Idempotently ensure the namespace exists. Without this, the
 			// SSA patches below 404 against a fresh cluster (e.g. the
 			// default `ever-works` namespace on a brand-new EKS cluster).
@@ -597,9 +776,12 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				// Per-Work sizing, resolved through the same settings merge as the
 				// rest (settingsOverride layers the work tier over the plugin's own).
 				cpuRequest: settings.cpuRequest,
-				memoryRequest: settings.memoryRequest,
+				// Stored legacy managed settings may still say 256Mi. Normalize the
+				// request only after validating it against the effective limit, and
+				// never mutate the Work row as a side effect of deployment.
+				memoryRequest: memorySizing.memoryRequest,
 				cpuLimit: settings.cpuLimit,
-				memoryLimit: settings.memoryLimit,
+				memoryLimit: memorySizing.memoryLimit,
 				// Makes the pod template differ between deploys of the same branch.
 				// The image tag is a mutable alias, so without this the manifest is
 				// identical every time and server-side apply rolls nothing.

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -404,7 +404,6 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			memoryRequest: {
 				type: 'string',
 				title: 'Memory request',
-				default: DEFAULT_MEMORY_REQUEST,
 				description:
 					"Kubernetes quantity, e.g. '512Mi' or '500M'. Platform-managed clusters use 512Mi only as an admission floor; set a larger measured value for each heavier catalogue."
 			},

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -26,6 +26,18 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 	const selector = SELECTOR_LABELS(input.workSlug);
 
 	const podSpec: Record<string, unknown> = {
+		// Prefer spreading replicas across failure domains when the cluster has
+		// them. This stays soft: older clusters do not understand
+		// nodeTaintsPolicy, and a hard constraint can count an untolerated
+		// control-plane as an empty domain and strand the next replica.
+		topologySpreadConstraints: [
+			{
+				maxSkew: 1,
+				topologyKey: 'kubernetes.io/hostname',
+				whenUnsatisfiable: 'ScheduleAnyway',
+				labelSelector: { matchLabels: selector }
+			}
+		],
 		containers: [
 			{
 				name: 'app',
@@ -43,6 +55,8 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				// gets a realistic timeout; a startupProbe absorbs the cold start so
 				// liveness never kills a warming container and loses its cache.
 				startupProbe: {
+					// Keep startup on the homepage: its successful render is what warms
+					// the catalogue cache before ongoing cheap health checks begin.
 					httpGet: { path: '/', port: 'http' },
 					periodSeconds: 10,
 					timeoutSeconds: 10,
@@ -72,12 +86,15 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				// exist. A Work genuinely needing more (mcp-servers) needs a bigger
 				// node or a smaller footprint, not a bigger number here.
 				//
-				// Requests stay small so scheduling is cheap. All four are overridable
-				// per Work via plugin settings.
+				// A 512Mi admission floor stops several roughly 500Mi processes from
+				// being advertised as 256Mi pods. It is NOT a sufficiency claim for
+				// sites measured in the 0.4–0.8Gi range: heavier catalogues still need
+				// an explicit measured per-Work request. All four values remain
+				// configurable through plugin settings.
 				resources: {
 					requests: {
 						cpu: input.cpuRequest ?? '100m',
-						memory: input.memoryRequest ?? '256Mi'
+						memory: input.memoryRequest ?? '512Mi'
 					},
 					limits: {
 						cpu: input.cpuLimit ?? '2',
@@ -109,7 +126,16 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 		spec: {
 			replicas: input.replicas,
 			selector: { matchLabels: selector },
-			strategy: { type: 'RollingUpdate', rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } },
+			// A single-replica rollout must not briefly double the site's memory
+			// footprint on a constrained node. The explicit tradeoff is a brief
+			// outage while the old pod stops and the replacement becomes Ready;
+			// this is NOT a zero-downtime strategy. Multi-replica Works retain
+			// their availability-first rollout.
+			strategy: {
+				type: 'RollingUpdate',
+				rollingUpdate:
+					input.replicas === 1 ? { maxSurge: 0, maxUnavailable: 1 } : { maxSurge: 1, maxUnavailable: 0 }
+			},
 			template: {
 				// Without a per-deploy annotation the rendered Deployment is
 				// byte-identical between deploys of the same branch (the tag is a

--- a/packages/plugins/k8s/src/manifest.renderer.ts
+++ b/packages/plugins/k8s/src/manifest.renderer.ts
@@ -94,7 +94,9 @@ export function buildDeployment(input: ManifestRenderInputs): Record<string, unk
 				resources: {
 					requests: {
 						cpu: input.cpuRequest ?? '100m',
-						memory: input.memoryRequest ?? '512Mi'
+						// Managed deployments pass their 512Mi floor explicitly; BYOC
+						// keeps this provider-neutral historical fallback.
+						memory: input.memoryRequest ?? '256Mi'
 					},
 					limits: {
 						cpu: input.cpuLimit ?? '2',


### PR DESCRIPTION
## Summary
- raise the generated-site managed-cluster request admission floor to 512Mi while keeping heavier Works explicitly measurable/configurable
- validate managed request+limit as one pair before any Kubernetes write and preserve full quantity syntax/custom-cluster passthrough
- use surge-free 0/1 replacement for one replica and soft hostname spreading
- retain #2153's proven probe split: startup / warms the catalogue; readiness/liveness use /api/health

## Important tradeoffs
- 512Mi is an admission floor, not a sufficiency claim for sites measured at 0.4-0.8Gi
- maxSurge=0/maxUnavailable=1 intentionally permits a brief outage for a one-replica Work; this is not zero downtime
- topology spreading is ScheduleAnyway so an untolerated control-plane domain cannot strand a rollout

## Verification
- full @ever-works/k8s-plugin suite: 10 files / 171 tests pass
- focused renderer/settings suite: 66 tests pass
- type-check passes
- CJS/ESM/DTS package build passes
- independent review found no remaining Critical/Important issue after request-limit, topology, quantity-syntax, and outage-semantics corrections

This PR is intentionally stacked on #2153 so it does not duplicate or regress that probe change. It changes no Work row, Deployment, route, data, VM size, or live cluster state by itself.