### PR TITLE
fix(agent): certify data with runtime YAML parser

### DIFF
--- a/packages/agent/src/generators/data-generator/data-generator.service.spec.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GitFacadeService } from '../../facades/git.facade';
+import { Work } from '../../entities/work.entity';
+import { User } from '../../entities/user.entity';
+import { GenerationMethod } from '../../items-generator/dto';
+import { PipelineOrchestratorService } from '../../pipeline';
+import { WorkOperationsService } from '../../work-operations';
+import { CategoryIconService } from '../../services/category-icon';
+import { WorksConfigWriterService } from '../../works-config/services/works-config-writer.service';
+import { DataGeneratorService } from './data-generator.service';
+import { DataRepository, RuntimeYamlCompatibilityError } from './data-repository';
+
+describe('DataGeneratorService runtime YAML certification', () => {
+    let service: DataGeneratorService;
+    let gitFacade: { cloneOrPull: jest.Mock };
+    let pipelineOrchestrator: { execute: jest.Mock; resumeOrExecute: jest.Mock };
+
+    const owner = { id: 'owner-1' } as User;
+    const user = { id: 'user-1' } as User;
+    const work = {
+        id: 'work-1',
+        name: 'Runtime YAML Test',
+        slug: 'runtime-yaml-test',
+        user: owner,
+        gitProvider: 'github',
+        getDataRepo: () => 'runtime-yaml-test-data',
+        getRepoOwner: () => 'ever-works',
+        resolveCommitter: () => ({ name: 'Test User', email: 'test@example.com' }),
+    } as unknown as Work;
+
+    beforeEach(async () => {
+        gitFacade = {
+            cloneOrPull: jest.fn().mockResolvedValue('C:/tmp/runtime-yaml-test-data'),
+        };
+        pipelineOrchestrator = {
+            execute: jest.fn(),
+            resumeOrExecute: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                DataGeneratorService,
+                { provide: GitFacadeService, useValue: gitFacade },
+                { provide: PipelineOrchestratorService, useValue: pipelineOrchestrator },
+                { provide: WorkOperationsService, useValue: {} },
+                { provide: WorksConfigWriterService, useValue: {} },
+                { provide: CategoryIconService, useValue: {} },
+            ],
+        }).compile();
+
+        service = module.get(DataGeneratorService);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('stops update generation before the pipeline when the existing corpus is runtime-incompatible', async () => {
+        const compatibilityError = new RuntimeYamlCompatibilityError(
+            'data/broken/broken.yml',
+            'Map keys must be unique',
+        );
+        const assertRuntimeCompatible = jest.fn().mockRejectedValue(compatibilityError);
+        jest.spyOn(DataRepository, 'create').mockResolvedValue({
+            assertRuntimeCompatible,
+            getCategories: jest.fn().mockResolvedValue([]),
+            getTags: jest.fn().mockResolvedValue([]),
+            getCollections: jest.fn().mockResolvedValue([]),
+            getReferences: jest.fn().mockResolvedValue([]),
+            getItems: jest.fn().mockResolvedValue([]),
+            getConfig: jest.fn().mockResolvedValue(null),
+        } as unknown as DataRepository);
+
+        await expect(
+            service.initialize(work, user, {
+                name: work.name,
+                prompt: 'Update the directory',
+                generation_method: GenerationMethod.CREATE_UPDATE,
+            } as any),
+        ).resolves.toMatchObject({
+            success: false,
+            error: {
+                code: 'DATA_REPO_FAILED',
+                cause: compatibilityError,
+            },
+        });
+
+        expect(assertRuntimeCompatible).toHaveBeenCalledTimes(1);
+        expect(pipelineOrchestrator.execute).not.toHaveBeenCalled();
+        expect(pipelineOrchestrator.resumeOrExecute).not.toHaveBeenCalled();
+    });
+
+    it('keeps ordinary item reads tolerant by skipping generation certification', async () => {
+        const assertRuntimeCompatible = jest.fn();
+        const items = [{ slug: 'legacy-item', name: 'Legacy Item' }];
+        jest.spyOn(DataRepository, 'create').mockResolvedValue({
+            assertRuntimeCompatible,
+            getCategories: jest.fn().mockResolvedValue([]),
+            getTags: jest.fn().mockResolvedValue([]),
+            getCollections: jest.fn().mockResolvedValue([]),
+            getReferences: jest.fn().mockResolvedValue([]),
+            getItems: jest.fn().mockResolvedValue(items),
+            getConfig: jest.fn().mockResolvedValue(null),
+        } as unknown as DataRepository);
+
+        await expect(service.getItems(work, user)).resolves.toEqual(items);
+        expect(assertRuntimeCompatible).not.toHaveBeenCalled();
+    });
+
+    it('allows recreate generation to replace a malformed legacy corpus', async () => {
+        const compatibilityError = new RuntimeYamlCompatibilityError(
+            'data/broken/broken.yml',
+            'Map keys must be unique',
+        );
+        const assertRuntimeCompatible = jest.fn().mockRejectedValue(compatibilityError);
+        jest.spyOn(DataRepository, 'create').mockResolvedValue({
+            assertRuntimeCompatible,
+            getCategories: jest.fn().mockResolvedValue([]),
+            getTags: jest.fn().mockResolvedValue([]),
+            getCollections: jest.fn().mockResolvedValue([]),
+            getReferences: jest.fn().mockResolvedValue([]),
+            getItems: jest.fn().mockResolvedValue([]),
+            getConfig: jest.fn().mockResolvedValue(null),
+        } as unknown as DataRepository);
+        pipelineOrchestrator.execute.mockResolvedValue(undefined);
+
+        await expect(
+            service.initialize(work, user, {
+                name: work.name,
+                prompt: 'Replace the directory',
+                generation_method: GenerationMethod.RECREATE,
+            } as any),
+        ).resolves.toMatchObject({
+            success: false,
+            error: { code: 'GENERATION_FAILED' },
+        });
+
+        expect(assertRuntimeCompatible).not.toHaveBeenCalled();
+        expect(pipelineOrchestrator.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops imported-data updates before reading or writing an incompatible corpus', async () => {
+        const compatibilityError = new RuntimeYamlCompatibilityError(
+            'data/broken/broken.yml',
+            'Implicit keys need to be on a single line',
+        );
+        const assertRuntimeCompatible = jest.fn().mockRejectedValue(compatibilityError);
+        const getItems = jest.fn();
+        jest.spyOn(DataRepository, 'create').mockResolvedValue({
+            assertRuntimeCompatible,
+            getItems,
+            ensureWorksExist: jest.fn(),
+            ensureDefaultConfig: jest.fn(),
+        } as unknown as DataRepository);
+
+        await expect(
+            service.updateWithImportedData(work, user, {
+                items: [],
+                categories: [],
+                tags: [],
+            }),
+        ).resolves.toMatchObject({
+            success: false,
+            error: {
+                code: 'DATA_REPO_FAILED',
+                cause: compatibilityError,
+            },
+        });
+
+        expect(assertRuntimeCompatible).toHaveBeenCalledTimes(1);
+        expect(getItems).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/generators/data-generator/data-generator.service.spec.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.spec.ts
@@ -90,6 +90,26 @@ describe('DataGeneratorService runtime YAML certification', () => {
         expect(pipelineOrchestrator.resumeOrExecute).not.toHaveBeenCalled();
     });
 
+    it('fails closed before the pipeline when strict preflight cannot clone the corpus', async () => {
+        gitFacade.cloneOrPull.mockRejectedValue(
+            Object.assign(new Error('permission denied while cloning'), { code: 'EACCES' }),
+        );
+
+        await expect(
+            service.initialize(work, user, {
+                name: work.name,
+                prompt: 'Update the directory',
+                generation_method: GenerationMethod.CREATE_UPDATE,
+            } as any),
+        ).resolves.toMatchObject({
+            success: false,
+            error: { code: 'DATA_REPO_FAILED' },
+        });
+
+        expect(pipelineOrchestrator.execute).not.toHaveBeenCalled();
+        expect(pipelineOrchestrator.resumeOrExecute).not.toHaveBeenCalled();
+    });
+
     it('keeps ordinary item reads tolerant by skipping generation certification', async () => {
         const assertRuntimeCompatible = jest.fn();
         const items = [{ slug: 'legacy-item', name: 'Legacy Item' }];
@@ -165,6 +185,37 @@ describe('DataGeneratorService runtime YAML certification', () => {
                 code: 'DATA_REPO_FAILED',
                 cause: compatibilityError,
             },
+        });
+
+        expect(assertRuntimeCompatible).toHaveBeenCalledTimes(1);
+        expect(getItems).not.toHaveBeenCalled();
+    });
+
+    it('classifies imported-data certification I/O failures as data-repository failures', async () => {
+        const certificationError = Object.assign(
+            new Error('permission denied while reading YAML'),
+            {
+                code: 'EACCES',
+            },
+        );
+        const assertRuntimeCompatible = jest.fn().mockRejectedValue(certificationError);
+        const getItems = jest.fn();
+        jest.spyOn(DataRepository, 'create').mockResolvedValue({
+            assertRuntimeCompatible,
+            getItems,
+            ensureWorksExist: jest.fn(),
+            ensureDefaultConfig: jest.fn(),
+        } as unknown as DataRepository);
+
+        await expect(
+            service.updateWithImportedData(work, user, {
+                items: [],
+                categories: [],
+                tags: [],
+            }),
+        ).resolves.toMatchObject({
+            success: false,
+            error: { code: 'DATA_REPO_FAILED' },
         });
 
         expect(assertRuntimeCompatible).toHaveBeenCalledTimes(1);

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { GitFacadeService } from '../../facades/git.facade';
 import { Work } from '../../entities/work.entity';
 import { User } from '../../entities/user.entity';
-import { DataRepository } from './data-repository';
+import { DataRepository, RuntimeYamlCompatibilityError } from './data-repository';
 import type { IDataConfig, PRUpdate } from './data-repository';
 import { slugifyText } from '../../utils/text.utils';
 import type { Identifiable, ItemData, Category, Collection, Tag } from '@ever-works/contracts';
@@ -211,13 +211,35 @@ export class DataGeneratorService {
         };
         let existingItemsBeforeGeneration: ItemData[] = [];
 
-        // Get existing data if available
-        // get existing data only if we are in update mode
-        if (createItemsGeneratorDto.generation_method === GenerationMethod.CREATE_UPDATE) {
-            existingData = await this.getExistingData(work, user);
-            existingItemsBeforeGeneration = existingData.existingItems;
-        } else if (createItemsGeneratorDto.generation_method === GenerationMethod.RECREATE) {
-            existingItemsBeforeGeneration = (await this.getExistingData(work, user)).existingItems;
+        // Get existing data if available. Generation must use the strict YAML
+        // contract of the generated website even though ordinary legacy reads
+        // remain tolerant of duplicate keys.
+        try {
+            if (createItemsGeneratorDto.generation_method === GenerationMethod.CREATE_UPDATE) {
+                existingData = await this.getExistingData(work, user, {
+                    requireRuntimeCompatibility: true,
+                });
+                existingItemsBeforeGeneration = existingData.existingItems;
+            } else if (createItemsGeneratorDto.generation_method === GenerationMethod.RECREATE) {
+                // Recreate intentionally replaces the old corpus, so retain
+                // tolerant reads here to keep it available as a repair path.
+                existingItemsBeforeGeneration = (await this.getExistingData(work, user))
+                    .existingItems;
+            }
+        } catch (error) {
+            if (error instanceof RuntimeYamlCompatibilityError) {
+                this.logger.error('Data repository failed runtime YAML certification', error);
+                return {
+                    success: false,
+                    error: {
+                        code: 'DATA_REPO_FAILED',
+                        message: error.message,
+                        cause: error,
+                    },
+                    warnings: [],
+                };
+            }
+            throw error;
         }
 
         throwIfCancelled();
@@ -1452,7 +1474,11 @@ export class DataGeneratorService {
     /**
      * Gets existing data from the repository if it exists, otherwise returns empty data
      */
-    private async getExistingData(work: Work, user: User) {
+    private async getExistingData(
+        work: Work,
+        user: User,
+        options: { requireRuntimeCompatibility?: boolean } = {},
+    ) {
         const workOwner = this.getWorkOwner(work);
         const committer = work.resolveCommitter(user);
         const repo = work.getDataRepo();
@@ -1467,6 +1493,10 @@ export class DataGeneratorService {
                 },
             );
             const data = await DataRepository.create(dest, getWorkDefaultDataConfig(work));
+
+            if (options.requireRuntimeCompatibility) {
+                await data.assertRuntimeCompatible();
+            }
 
             const [categories, tags, collections, references, existingItems, config] =
                 await Promise.all([
@@ -1486,7 +1516,10 @@ export class DataGeneratorService {
                 existingReferences: references,
                 existingConfig: config,
             };
-        } catch {
+        } catch (error) {
+            if (error instanceof RuntimeYamlCompatibilityError) {
+                throw error;
+            }
             return {
                 existingItems: [],
                 existingCategories: [],
@@ -1906,6 +1939,7 @@ export class DataGeneratorService {
             );
 
             const data = await DataRepository.create(dest, getWorkDefaultDataConfig(work));
+            await data.assertRuntimeCompatible();
             await data.ensureWorksExist();
             await data.ensureDefaultConfig();
 
@@ -2090,7 +2124,10 @@ export class DataGeneratorService {
             return {
                 success: false,
                 error: {
-                    code: 'GENERATION_FAILED',
+                    code:
+                        error instanceof RuntimeYamlCompatibilityError
+                            ? 'DATA_REPO_FAILED'
+                            : 'GENERATION_FAILED',
                     // Security (info-leak): guard the untyped throw so a non-Error
                     // value can't surface `message: undefined` or serialize a raw
                     // internal object (paths/stack) into the API result `cause`.

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -184,6 +184,19 @@ export class DataGeneratorService {
         return getWorkOwner(work);
     }
 
+    private runtimeCertificationFailure(error: unknown): InitializeError {
+        const cause = error instanceof Error ? error : new Error(String(error));
+
+        return {
+            code: 'DATA_REPO_FAILED',
+            message:
+                error instanceof RuntimeYamlCompatibilityError
+                    ? error.message
+                    : 'Failed to certify data repository for runtime compatibility',
+            cause,
+        };
+    }
+
     async initialize(
         work: Work,
         user: User,
@@ -227,19 +240,12 @@ export class DataGeneratorService {
                     .existingItems;
             }
         } catch (error) {
-            if (error instanceof RuntimeYamlCompatibilityError) {
-                this.logger.error('Data repository failed runtime YAML certification', error);
-                return {
-                    success: false,
-                    error: {
-                        code: 'DATA_REPO_FAILED',
-                        message: error.message,
-                        cause: error,
-                    },
-                    warnings: [],
-                };
-            }
-            throw error;
+            this.logger.error('Data repository failed runtime YAML certification', error);
+            return {
+                success: false,
+                error: this.runtimeCertificationFailure(error),
+                warnings: [],
+            };
         }
 
         throwIfCancelled();
@@ -1517,7 +1523,7 @@ export class DataGeneratorService {
                 existingConfig: config,
             };
         } catch (error) {
-            if (error instanceof RuntimeYamlCompatibilityError) {
+            if (options.requireRuntimeCompatibility) {
                 throw error;
             }
             return {
@@ -1928,6 +1934,7 @@ export class DataGeneratorService {
         const committer = work.resolveCommitter(user);
         const repoName = work.getDataRepo();
         const repoOwner = work.getRepoOwner();
+        let runtimeCertificationComplete = false;
 
         try {
             this.logger.log(`Syncing imported data for: ${repoOwner}/${repoName}`);
@@ -1940,6 +1947,7 @@ export class DataGeneratorService {
 
             const data = await DataRepository.create(dest, getWorkDefaultDataConfig(work));
             await data.assertRuntimeCompatible();
+            runtimeCertificationComplete = true;
             await data.ensureWorksExist();
             await data.ensureDefaultConfig();
 
@@ -2123,18 +2131,19 @@ export class DataGeneratorService {
             this.logger.error('Failed to sync with imported data', error);
             return {
                 success: false,
-                error: {
-                    code:
-                        error instanceof RuntimeYamlCompatibilityError
-                            ? 'DATA_REPO_FAILED'
-                            : 'GENERATION_FAILED',
-                    // Security (info-leak): guard the untyped throw so a non-Error
-                    // value can't surface `message: undefined` or serialize a raw
-                    // internal object (paths/stack) into the API result `cause`.
-                    message:
-                        error instanceof Error ? error.message : 'Failed to sync data repository',
-                    cause: error instanceof Error ? error : new Error(String(error)),
-                },
+                error: !runtimeCertificationComplete
+                    ? this.runtimeCertificationFailure(error)
+                    : {
+                          code: 'GENERATION_FAILED',
+                          // Security (info-leak): guard the untyped throw so a non-Error
+                          // value can't surface `message: undefined` or serialize a raw
+                          // internal object (paths/stack) into the API result `cause`.
+                          message:
+                              error instanceof Error
+                                  ? error.message
+                                  : 'Failed to sync data repository',
+                          cause: error instanceof Error ? error : new Error(String(error)),
+                      },
             };
         }
     }

--- a/packages/agent/src/generators/data-generator/data-repository.spec.ts
+++ b/packages/agent/src/generators/data-generator/data-repository.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { DataRepository } from './data-repository';
+import { DataRepository, RuntimeYamlCompatibilityError } from './data-repository';
 
 describe('DataRepository', () => {
     afterEach(async () => {
@@ -43,6 +43,11 @@ describe('DataRepository', () => {
         });
         expect(warnSpy).toHaveBeenCalledTimes(1);
 
+        await expect(repository.assertRuntimeCompatible()).rejects.toMatchObject({
+            name: RuntimeYamlCompatibilityError.name,
+            relativePath: 'data/box/box.yml',
+        });
+
         await fs.rm(repoDir, { recursive: true, force: true });
     });
 
@@ -71,6 +76,27 @@ describe('DataRepository', () => {
 
         await expect(repository.countItems()).resolves.toBe(1);
         await expect(repository.getItem('broken-item')).rejects.toThrow();
+        await expect(repository.assertRuntimeCompatible()).rejects.toMatchObject({
+            name: RuntimeYamlCompatibilityError.name,
+            relativePath: 'data/broken-item/broken-item.yml',
+        });
+
+        await fs.rm(repoDir, { recursive: true, force: true });
+    });
+
+    it('certifies item YAML only when the strict runtime parser accepts the corpus', async () => {
+        const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'data-repository-spec-'));
+
+        await fs.mkdir(path.join(repoDir, 'data', 'valid-item'), { recursive: true });
+        await fs.writeFile(
+            path.join(repoDir, 'data', 'valid-item', 'valid-item.yml'),
+            ['name: Valid Item', 'description: Runtime-compatible YAML', ''].join('\n'),
+            'utf-8',
+        );
+
+        const repository = await DataRepository.create(repoDir);
+
+        await expect(repository.assertRuntimeCompatible()).resolves.toBeUndefined();
 
         await fs.rm(repoDir, { recursive: true, force: true });
     });

--- a/packages/agent/src/generators/data-generator/data-repository.ts
+++ b/packages/agent/src/generators/data-generator/data-repository.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import * as yaml from 'yaml';
 import mergeWith from 'lodash/mergeWith';
 import { format } from 'date-fns';
@@ -33,6 +34,21 @@ export type PRUpdate = {
     number?: number;
     url?: string;
 };
+
+/**
+ * Raised when a data corpus cannot be parsed by the generated website's
+ * strict YAML runtime. The repository-relative path is safe to surface in a
+ * generation result and gives the owner an actionable source file to repair.
+ */
+export class RuntimeYamlCompatibilityError extends Error {
+    constructor(
+        public readonly relativePath: string,
+        public readonly parserMessage: string,
+    ) {
+        super(`Runtime-incompatible YAML in ${relativePath}: ${parserMessage}`);
+        this.name = RuntimeYamlCompatibilityError.name;
+    }
+}
 
 export interface SettingsHeaderConfig {
     submit_enabled?: boolean;
@@ -497,6 +513,60 @@ export class DataRepository {
             });
 
         return Promise.all(promises).then((items) => items.filter(Boolean));
+    }
+
+    /**
+     * Certify the item corpus with the same strict yaml parser contract used
+     * by generated websites. Files are read and parsed sequentially so this
+     * preflight does not recreate the catalogue-sized memory spike it guards.
+     *
+     * Ordinary getItem/getItems calls intentionally remain tolerant of
+     * duplicate keys for backwards-compatible legacy reads.
+     */
+    async assertRuntimeCompatible(): Promise<void> {
+        const pendingDirectories = [this.dataDir];
+
+        while (pendingDirectories.length > 0) {
+            const currentDir = pendingDirectories.shift()!;
+            let entries: Dirent[];
+
+            try {
+                entries = await fs.readdir(currentDir, { withFileTypes: true });
+            } catch (error) {
+                if (
+                    currentDir === this.dataDir &&
+                    (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT'
+                ) {
+                    return;
+                }
+                throw error;
+            }
+
+            entries.sort((left, right) => left.name.localeCompare(right.name));
+
+            for (const entry of entries) {
+                const filepath = path.join(currentDir, entry.name);
+                if (entry.isDirectory()) {
+                    pendingDirectories.push(filepath);
+                    continue;
+                }
+                if (!entry.isFile() || !/\.ya?ml$/i.test(entry.name)) {
+                    continue;
+                }
+
+                const content = await fs.readFile(filepath, 'utf-8');
+                try {
+                    yaml.parse(content);
+                } catch (error) {
+                    const relativePath = path
+                        .relative(this.dir, filepath)
+                        .split(path.sep)
+                        .join('/');
+                    const parserMessage = error instanceof Error ? error.message : String(error);
+                    throw new RuntimeYamlCompatibilityError(relativePath, parserMessage);
+                }
+            }
+        }
     }
 
     async countItems(): Promise<number> {


### PR DESCRIPTION
# Summary

Aligns Ever Works generation certification with the generated website runtime's strict `yaml@2.8.3` contract, while preserving tolerant legacy reads and the full-recreate repair path.

## Description

`DataRepository.getItem/getItems` still retry duplicate-key YAML with `uniqueKeys: false` for backward-compatible inspection. Update generation and imported-data updates now run a sequential strict item-corpus preflight before the pipeline or writes, returning `DATA_REPO_FAILED` with a safe repository-relative path when runtime parsing would fail. Full recreate remains tolerant so it can replace malformed legacy data.

## Changes Made

- Add `RuntimeYamlCompatibilityError` and sequential `assertRuntimeCompatible()` item-corpus validation.
- Stop update/import generation before pipeline/write when strict runtime YAML fails.
- Add focused coverage for duplicate keys, orphan scalars, valid corpora, tolerant reads, strict update/import behavior, and recreate compatibility.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change addressing an issue)
- [x] 🧪 Test addition or modification

## Testing Instructions

1. `pnpm exec jest src/generators/data-generator/data-repository.spec.ts src/generators/data-generator/data-generator.service.spec.ts --runInBand` — 13/13 pass.
2. `pnpm type-check` in `packages/agent` — exit 0.
3. `pnpm build` in `packages/agent` — 1,371 files compiled, zero type issues.
4. Strict `yaml@2.8.3` sweep of 14 current data corpora — 16,210/16,210 files parse.

## Deployment Notes

Source-only PR. No Work generation, data mutation, branch promotion, or live rollout is included. Runtime rollout remains blocked on review and a separate maintenance claim.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] My code follows the established code style of the project
- [x] I have commented my code, particularly in hard-to-understand areas

## Additional Context

Compatibility impact is intentionally narrow: ordinary reads and recreate remain tolerant; only operations that would certify or extend an existing corpus require strict runtime compatibility.