### PR TITLE
chore(release): cascade develop -> stage (Ever Works billing on the shared Stripe account)

### DIFF
--- a/apps/api/src/billing/dto/plan-checkout.dto.ts
+++ b/apps/api/src/billing/dto/plan-checkout.dto.ts
@@ -1,4 +1,14 @@
-import { IsEnum, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+import {
+    IsEnum,
+    IsIn,
+    IsInt,
+    IsOptional,
+    IsString,
+    Matches,
+    Max,
+    MaxLength,
+    Min,
+} from 'class-validator';
 import { SubscriptionPlanCode } from '@ever-works/agent/entities';
 
 /**
@@ -23,6 +33,34 @@ export class CreatePlanCheckoutDto {
     @IsString()
     @MaxLength(64)
     organizationId?: string;
+
+    /**
+     * Which billing period to buy. Defaults to `monthly`, which is what every caller sent before
+     * this field existed.
+     *
+     * 🛑 This names a PERIOD, not a price. The amount for the resulting SKU is still read from the
+     * server catalog, so asking for `lifetime` on a plan that has no lifetime price is a 400 rather
+     * than a cheaper subscription. Only the self-hosted Pro Edition sells a `lifetime` licence, and
+     * it is bought as a one-off payment — never inferred from a marketing toggle position.
+     */
+    @IsOptional()
+    @IsIn(['monthly', 'annual', 'lifetime'])
+    interval?: 'monthly' | 'annual' | 'lifetime';
+
+    /**
+     * TOTAL seats (employees OR agents) the buyer wants, inclusive of the plan's included
+     * allowance — not the number of extra ones.
+     *
+     * The service clamps this against the plan row and bills only the excess, so this number can
+     * only ever cost the buyer MORE, never less: under-reporting just buys fewer seats. The upper
+     * bound is a sanity limit on a public, throttled endpoint, not a product limit; a genuinely
+     * larger deployment buys Enterprise Option 1, which is unbounded and meters nothing.
+     */
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(100_000)
+    seats?: number;
 }
 
 /**

--- a/apps/api/src/billing/plan-checkout.controller.ts
+++ b/apps/api/src/billing/plan-checkout.controller.ts
@@ -111,6 +111,11 @@ export class PlanCheckoutController {
             const session = await this.planSubscriptionService.startPlanCheckout({
                 userId: auth.userId,
                 planCode: body.planCode,
+                // Period and seat count are the only two things the caller may steer, and neither
+                // can lower the bill: an interval the plan does not sell is a 400, and seats are
+                // clamped against the plan's own allowance on the server.
+                interval: body.interval ?? 'monthly',
+                seats: body.seats ?? null,
                 // The provider appends its own session identifier — see
                 // the `successUrl` contract on `PlanCheckoutRequest`.
                 successUrl: `${base}/settings/billing?plan=success`,

--- a/apps/api/src/migrations/1786940000000-AddPlanHostingSeatsAndCredits.ts
+++ b/apps/api/src/migrations/1786940000000-AddPlanHostingSeatsAndCredits.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Hosting, annual/one-time pricing, seats and credit allowance on the subscription plan
+ * (owner directive 2026-08-22 — align Ever Works pricing with Ever Gauzy / Ever Teams).
+ *
+ * `subscription_plans` could describe exactly one shape of plan: a flat monthly price on cloud
+ * hosting. The agreed model needs three more axes, so the six columns below give the plan row
+ * somewhere to hold them:
+ *
+ *  - `hosting`          — `cloud` or `selfhosted`. Paid self-hosted editions sell a commercial
+ *                         licence that lifts the buyer's AGPLv3 obligations. Together with the
+ *                         tier this derives the plan's Stripe `lookup_key` in the shared account.
+ *  - `annualPrice`      — charged once per YEAR. The marketing site quotes annual per month, so
+ *                         cloud Pro displays "$17/mo" and stores 204.00. `0` ⇒ no annual option,
+ *                         which is exactly right for every pre-existing row.
+ *  - `lifetimePrice`    — one-time perpetual commercial licence. NULL on every plan not sold that
+ *                         way. 🛑 A row with this set is bought in Stripe `mode: payment`, never
+ *                         `subscription`.
+ *  - `seatsIncluded`    — seats (employees OR agents, interchangeably) before per-seat billing
+ *                         starts. NULL ⇒ UNBOUNDED, and an unbounded plan never emits a seat line.
+ *  - `seatMonthlyPrice` — price per ADDITIONAL seat per month. The annual rate is 12x this;
+ *                         additional seats carry no annual discount, matching Gauzy's flat
+ *                         "$5 per month" wording.
+ *  - `monthlyCredits`   — platform-billed AI credits per month, on top of the universal daily free
+ *                         grant. A SEPARATE axis from seats: self-hosting is free, but a
+ *                         self-hosted deployment using Ever-hosted AI still spends credits.
+ *
+ * Entity: `packages/agent/src/entities/subscription-plan.entity.ts`.
+ *
+ * Nothing is backfilled and nothing is dropped. Every pre-existing row keeps `hosting='cloud'`,
+ * `annualPrice=0`, and NULL seats/lifetime — i.e. precisely the behaviour it had before this
+ * change. The new values arrive through `SubscriptionService.seedPlans()`, which upserts on
+ * `code` at boot; the three new `selfhosted_*` codes create their own rows there.
+ *
+ * 🛑 `subscription_plans.code` is NOT touched. `free` / `standard` / `premium` are stored verbatim
+ * in `user_subscriptions.planCode` and in Stripe metadata on every subscription ever created.
+ * Standard and Premium are now DISPLAYED as "Pro" and "Enterprise", which is a `displayName`
+ * change in the seed, not a code change.
+ *
+ * Forward-only with per-step guards (house pattern, mirrors
+ * `1784720000000-AddBillingSubscriptionLifecycleColumns`), so it is safe on both the SQLite demo
+ * deployment and the Postgres stage/prod ones, and safe to re-run.
+ */
+export class AddPlanHostingSeatsAndCredits1786940000000 implements MigrationInterface {
+    name = 'AddPlanHostingSeatsAndCredits1786940000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('subscription_plans');
+        if (!table) return;
+
+        const addColumn = async (name: string, ddl: string) => {
+            if (!table.findColumnByName(name)) {
+                await queryRunner.query(`ALTER TABLE "subscription_plans" ADD COLUMN ${ddl}`);
+            }
+        };
+
+        await addColumn('hosting', `"hosting" varchar(32) NOT NULL DEFAULT 'cloud'`);
+        await addColumn('annualPrice', `"annualPrice" decimal(10,2) NOT NULL DEFAULT 0`);
+        await addColumn('lifetimePrice', `"lifetimePrice" decimal(10,2)`);
+        await addColumn('seatsIncluded', `"seatsIncluded" integer`);
+        await addColumn('seatMonthlyPrice', `"seatMonthlyPrice" decimal(10,2)`);
+        await addColumn('monthlyCredits', `"monthlyCredits" integer NOT NULL DEFAULT 0`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('subscription_plans');
+        if (!table) return;
+
+        for (const col of [
+            'hosting',
+            'annualPrice',
+            'lifetimePrice',
+            'seatsIncluded',
+            'seatMonthlyPrice',
+            'monthlyCredits',
+        ]) {
+            if (table.findColumnByName(col)) {
+                await queryRunner.query(`ALTER TABLE "subscription_plans" DROP COLUMN "${col}"`);
+            }
+        }
+    }
+}

--- a/packages/agent/src/entities/__tests__/types.spec.ts
+++ b/packages/agent/src/entities/__tests__/types.spec.ts
@@ -27,17 +27,40 @@ describe('entities/types', () => {
             ['FREE', 'free'],
             ['STANDARD', 'standard'],
             ['PREMIUM', 'premium'],
+            ['SELFHOSTED_COMMUNITY', 'selfhosted_community'],
+            ['SELFHOSTED_PRO', 'selfhosted_pro'],
+            ['SELFHOSTED_ENTERPRISE', 'selfhosted_enterprise'],
         ] as const)('%s → %s', (key, value) => {
             expect(SubscriptionPlanCode[key]).toBe(value);
         });
 
-        it('has exactly 3 plan codes', () => {
+        it('has exactly 6 plan codes', () => {
             const literals = Object.values(SubscriptionPlanCode).filter(
                 (v) => typeof v === 'string',
             );
-            expect(literals).toHaveLength(3);
-            // Pinned ascending tier order: free → standard → premium.
-            expect(literals).toEqual(['free', 'standard', 'premium']);
+            expect(literals).toHaveLength(6);
+            // Pinned order: the three cloud tiers ascending, then the three self-hosted editions.
+            // The self-hosted trio was added 2026-08-22 when Ever Works gained paid self-hosted
+            // editions; a commercial licence lifts the buyer's AGPLv3 obligations.
+            expect(literals).toEqual([
+                'free',
+                'standard',
+                'premium',
+                'selfhosted_community',
+                'selfhosted_pro',
+                'selfhosted_enterprise',
+            ]);
+        });
+
+        it('never renames the three original codes', () => {
+            // 🛑 These three strings are stored verbatim in `subscription_plans.code`, in
+            // `user_subscriptions.planCode`, and in Stripe metadata on every subscription ever
+            // created. Renaming one orphans live subscriptions. Their DISPLAY names moved to the
+            // marketing tiers ('standard' shows as "Pro", 'premium' as "Enterprise") — that is a
+            // `displayName` change in the plan seed, never a change here.
+            expect(SubscriptionPlanCode.FREE).toBe('free');
+            expect(SubscriptionPlanCode.STANDARD).toBe('standard');
+            expect(SubscriptionPlanCode.PREMIUM).toBe('premium');
         });
     });
 

--- a/packages/agent/src/entities/subscription-plan.entity.ts
+++ b/packages/agent/src/entities/subscription-plan.entity.ts
@@ -7,7 +7,12 @@ import {
     OneToMany,
     Index,
 } from 'typeorm';
-import type { ClassToObject, WorkScheduleCadence, SubscriptionPlanCode } from './types';
+import type {
+    ClassToObject,
+    WorkScheduleCadence,
+    SubscriptionPlanCode,
+    SubscriptionPlanHosting,
+} from './types';
 import { UserSubscription } from './user-subscription.entity';
 
 @Index(['code'], { unique: true })
@@ -37,6 +42,67 @@ export class SubscriptionPlan {
 
     @Column({ type: 'varchar', default: 'usd' })
     currency: string;
+
+    /* ---------------------------------------------------------------------- *
+     *  Added 2026-08-22 — hosting, annual/one-time pricing, seats, credits.
+     *
+     *  Every column below is nullable or defaulted, so the migration needs no
+     *  backfill and a pre-existing row keeps behaving exactly as it did: cloud
+     *  hosting, no annual price, no seat metering, no credit allowance.
+     * ---------------------------------------------------------------------- */
+
+    /**
+     * `cloud` or `selfhosted`. Together with the marketing tier this derives the plan's Stripe
+     * `lookup_key` in the shared account — see
+     * `packages/agent/src/subscriptions/billing/stripe-catalog.ts`.
+     */
+    @Column({ type: 'varchar', default: 'cloud' })
+    hosting: SubscriptionPlanHosting;
+
+    /**
+     * Charged once per YEAR, in the plan currency. The marketing site quotes annual per month; this
+     * is the yearly figure. Cloud Pro displays "$17/mo" and stores 204.00.
+     *
+     * `0` means the plan has no annual option.
+     */
+    @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+    annualPrice: string;
+
+    /**
+     * One-time perpetual commercial licence, in the plan currency, lifting the buyer's AGPLv3
+     * obligations. NULL on every plan that is not sold this way — which is all of them except the
+     * self-hosted Pro Edition.
+     *
+     * 🛑 A row with a `lifetimePrice` is bought in Stripe `mode: payment`, never `subscription`.
+     * Never infer that from a marketing toggle position — read it from this column.
+     */
+    @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+    lifetimePrice: string | null;
+
+    /**
+     * Seats — employees OR agents, interchangeably — included before per-seat billing starts.
+     * NULL means UNBOUNDED (the Community Edition, and Enterprise "Option 1": one organization with
+     * unlimited employees and agents). An unbounded plan never emits a seat line item.
+     */
+    @Column({ type: 'int', nullable: true })
+    seatsIncluded: number | null;
+
+    /**
+     * Price per ADDITIONAL seat per month, in the plan currency. NULL where seats are unbounded or
+     * the plan is free. The annual rate is exactly 12x this — additional seats carry no annual
+     * discount, matching Ever Gauzy's flat "$5 per month" wording.
+     */
+    @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+    seatMonthlyPrice: string | null;
+
+    /**
+     * Platform-billed AI credits granted per month on this plan, on top of the universal daily free
+     * grant. Credits are a SEPARATE axis from seats and apply on every hosting mode: self-hosting
+     * is free, but a self-hosted deployment using Ever-hosted AI still spends credits. Runs on the
+     * customer's own model keys spend nothing, on any plan.
+     */
+    @Column({ type: 'int', default: 0 })
+    monthlyCredits: number;
 
     @Column({ type: 'boolean', default: true })
     active: boolean;

--- a/packages/agent/src/entities/types.ts
+++ b/packages/agent/src/entities/types.ts
@@ -37,10 +37,42 @@ export type GenerateStatus = {
     recentLogs?: GenerationStepLog[];
 };
 
+/**
+ * Where a plan runs. Ever's shared Stripe catalog uses the same two values across every product, so
+ * this string is part of a plan's `lookup_key` and must not drift.
+ */
+export type SubscriptionPlanHosting = 'cloud' | 'selfhosted';
+
+/**
+ * The purchasable plans, one code per (hosting, tier) pair.
+ *
+ * 🛑 The first three codes are LOAD-BEARING and must never be renamed or removed: they are stored
+ * verbatim in `subscription_plans.code`, in `user_subscriptions.planCode`, and in Stripe session
+ * metadata on every subscription ever created. Their DISPLAY names moved to the marketing tiers
+ * (Standard is shown as "Pro", Premium as "Enterprise") — that is a `displayName` change in the
+ * plan seed, not a code change.
+ *
+ * The three `SELFHOSTED_*` codes were added 2026-08-22 when Ever Works gained paid self-hosted
+ * editions. A self-hosted commercial licence lifts the buyer's AGPLv3 obligations; the free
+ * Community Edition needs a row so the plan switcher can show it, but it is never bought and has no
+ * Stripe object.
+ *
+ * Hosting is a separate column rather than being parsed out of the code — see
+ * `subscription-plan.entity.ts`. The code is the identity; the columns describe it.
+ */
 export enum SubscriptionPlanCode {
+    /** Cloud, Free — 1 seat, 50 credits/day, never purchasable through checkout. */
     FREE = 'free',
+    /** Cloud, shown as "Pro" — $25/mo or $204/yr, 10 seats, 3,000 credits/mo. */
     STANDARD = 'standard',
+    /** Cloud, shown as "Enterprise" — $199/mo or $1,668/yr, 10 seats, 25,000 credits/mo. */
     PREMIUM = 'premium',
+    /** Self-hosted Community Edition — free AGPLv3 download, unlimited seats, no Stripe object. */
+    SELFHOSTED_COMMUNITY = 'selfhosted_community',
+    /** Self-hosted Pro Edition — $49/mo, $408/yr, or a $99 one-time perpetual commercial licence. */
+    SELFHOSTED_PRO = 'selfhosted_pro',
+    /** Self-hosted Enterprise Edition — $199/mo or $1,668/yr commercial licence. */
+    SELFHOSTED_ENTERPRISE = 'selfhosted_enterprise',
 }
 
 /**

--- a/packages/agent/src/subscriptions/billing/billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.ts
@@ -93,8 +93,53 @@ export interface BillingPlanDescriptor {
     /** Recurring price in cents, from the server plan row. */
     readonly priceCents: number;
     readonly currency: string;
-    /** Only monthly today; widened here so the seam does not need a bump. */
+    /**
+     * The recurrence, for a recurring plan. Ignored entirely when {@link mode} is `payment` — a
+     * perpetual licence does not recur.
+     */
     readonly interval: 'month' | 'year';
+
+    /**
+     * How the plan is bought. `subscription` (the default, and what every caller sent before this
+     * field existed) recurs; `payment` is a one-off perpetual commercial licence that lifts the
+     * buyer's AGPLv3 obligations.
+     *
+     * 🛑 Read this from the SKU, never from a marketing toggle position: on self-hosted, the
+     * "annual" slot is a yearly subscription on one tier and a one-time licence on another.
+     */
+    readonly mode?: 'subscription' | 'payment' | null;
+
+    /**
+     * Catalog `lookup_key` for this plan, e.g. `ever_works_cloud_pro_monthly`.
+     *
+     * When set AND resolvable in the provider account, the provider bills the CATALOG price object
+     * instead of minting an ad-hoc one from {@link priceCents}. That is what puts Ever Works on the
+     * same shared Stripe account and the same lookup-key convention as every other Ever product,
+     * and it is what makes a charge auditable after the fact: the invoice line carries a key that
+     * maps back to a reviewed commit rather than to a number that happened to be in a plan row.
+     *
+     * 🛑 Optional on purpose. A deployment whose catalog has not been synced — a self-hoster, CI,
+     * local dev — leaves this unset (or sets a key the account does not have) and the provider
+     * falls back to the existing inline-price path. Billing must not stop working because a catalog
+     * sync has not been run.
+     */
+    readonly lookupKey?: string | null;
+
+    /**
+     * Catalog `lookup_key` for this plan's per-additional-seat price, e.g.
+     * `ever_works_cloud_pro_seat_monthly`. Ignored unless {@link extraSeats} is greater than zero.
+     *
+     * A seat is an employee OR an agent — the two are interchangeable in Ever Works. Mirrors Ever
+     * Gauzy / Ever Teams, which include 10 and bill per additional one.
+     */
+    readonly seatLookupKey?: string | null;
+
+    /**
+     * Seats to bill BEYOND the plan's included allowance. Already net of `seatsIncluded`; the
+     * provider does not subtract anything. Zero, absent, or a plan with unbounded seats all mean
+     * "no seat line item".
+     */
+    readonly extraSeats?: number | null;
 }
 
 /**

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -22,11 +22,37 @@ import { SubscriptionStatus } from '@src/entities/user-subscription.entity';
  *     the return route) grants the same tier once.
  */
 
+// Mirrors what `SubscriptionService.seedPlans()` actually writes: code 'standard' is the tier the
+// marketing site calls "Pro", at Ever Gauzy / Ever Teams cloud Small Business pricing.
 const STANDARD_PLAN = {
     id: 'plan-standard',
     code: 'standard',
-    displayName: 'Standard',
-    monthlyPrice: '29',
+    displayName: 'Pro',
+    hosting: 'cloud',
+    monthlyPrice: '25',
+    // The YEARLY charge, not the "$17/mo" the marketing site displays.
+    annualPrice: '204',
+    lifetimePrice: null,
+    seatsIncluded: 10,
+    seatMonthlyPrice: '5',
+    monthlyCredits: 3000,
+    currency: 'usd',
+    active: true,
+};
+
+// The only row sold as a one-off perpetual commercial licence — and the only one whose "annual"
+// slot and one-time slot both exist, which is precisely the pair the catalog has to keep apart.
+const SELFHOSTED_PRO_PLAN = {
+    id: 'plan-selfhosted-pro',
+    code: 'selfhosted_pro',
+    displayName: 'Pro Edition',
+    hosting: 'selfhosted',
+    monthlyPrice: '49',
+    annualPrice: '408',
+    lifetimePrice: '99',
+    seatsIncluded: 10,
+    seatMonthlyPrice: '5',
+    monthlyCredits: 3000,
     currency: 'usd',
     active: true,
 };
@@ -154,16 +180,161 @@ describe('startPlanCheckout — the server prices everything', () => {
             url: 'https://pay.example/cs_plan_1',
             sessionId: 'cs_plan_1',
             planCode: 'standard',
-            priceCents: 2900,
+            priceCents: 2500,
             currency: 'usd',
         });
         const request = provider.createPlanCheckoutSession.mock.calls[0][0];
-        // $29.00 → 2900 cents, straight from `subscription_plans`.
+        // $25.00 → 2500 cents. The row and the shared-account catalog agree; neither comes from the body.
         expect(request.plan).toEqual(
-            expect.objectContaining({ code: 'standard', priceCents: 2900, interval: 'month' }),
+            expect.objectContaining({ code: 'standard', priceCents: 2500, interval: 'month' }),
         );
         // Server-authored correlation id, echoed back on the signed event.
         expect(request.referenceId).toBe('u1:standard');
+    });
+
+    it('names the shared-account catalog price so the invoice traces back to a reviewed commit', async () => {
+        const { service, provider } = build();
+
+        await service.startPlanCheckout(checkoutOptions);
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        // Plan code 'standard' is sold as the "Pro" tier; the fixture has no hosting, which the
+        // resolver reads as cloud — the same default the migration gives every pre-existing row.
+        expect(request.plan.lookupKey).toBe('ever_works_cloud_pro_monthly');
+        // priceCents is still carried: the provider falls back to it when the account has no
+        // catalog price, so removing it would break every unsynced deployment. Here the catalog
+        // and the seeded row agree, which is the invariant stripe-catalog.spec.ts guards.
+        expect(request.plan.priceCents).toBe(2500);
+    });
+
+    it('bills no seat line when the buyer stays inside the plan allowance', async () => {
+        const { service, provider } = build();
+
+        // Pro includes 10. Asking for 10 is not an upsell.
+        await service.startPlanCheckout({ ...checkoutOptions, seats: 10 });
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.extraSeats).toBe(0);
+        expect(request.plan.seatLookupKey).toBeNull();
+    });
+
+    it('bills only the seats beyond the allowance, on the matching seat price', async () => {
+        const { service, provider } = build();
+
+        await service.startPlanCheckout({ ...checkoutOptions, seats: 27 });
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        // 27 requested - 10 included = 17 billable, NOT 27.
+        expect(request.plan.extraSeats).toBe(17);
+        expect(request.plan.seatLookupKey).toBe('ever_works_cloud_pro_seat_monthly');
+    });
+
+    it('clamps a hostile seat count on the server rather than trusting it', async () => {
+        // The clamp lives against the PLAN row, so a caller cannot under- or over-report its way
+        // into a wrong bill. Negative and non-finite values must produce no seat charge at all.
+        for (const seats of [-100, 0, Number.NaN]) {
+            const { service, provider } = build();
+            await service.startPlanCheckout({ ...checkoutOptions, seats });
+            const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+            expect(request.plan.extraSeats).toBe(0);
+            expect(request.plan.seatLookupKey).toBeNull();
+        }
+    });
+
+    it('omits the seat count entirely when the caller does not ask for seats', async () => {
+        const { service, provider } = build();
+
+        await service.startPlanCheckout(checkoutOptions);
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.extraSeats).toBe(0);
+    });
+
+    it('defaults to the monthly period when the caller does not name one', async () => {
+        const { service, provider } = build();
+
+        await service.startPlanCheckout(checkoutOptions);
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.interval).toBe('month');
+        expect(request.plan.lookupKey).toBe('ever_works_cloud_pro_monthly');
+    });
+
+    it('buys the annual SKU as a YEARLY subscription when asked for one', async () => {
+        const { service, provider } = build();
+
+        await service.startPlanCheckout({ ...checkoutOptions, interval: 'annual' });
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.interval).toBe('year');
+        expect(request.plan.lookupKey).toBe('ever_works_cloud_pro_annual');
+        // The seat line has to follow the plan's period — a monthly seat price cannot ride on a
+        // yearly subscription, Stripe rejects mixed intervals in one subscription.
+        expect(request.plan.seatLookupKey).toBeNull();
+    });
+
+    it('matches the seat period to the plan period on an annual purchase', async () => {
+        const { service, provider } = build();
+
+        await service.startPlanCheckout({ ...checkoutOptions, interval: 'annual', seats: 12 });
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.extraSeats).toBe(2);
+        expect(request.plan.seatLookupKey).toBe('ever_works_cloud_pro_seat_annual');
+    });
+
+    it('sells a perpetual licence as a ONE-OFF payment, never a subscription', async () => {
+        const { service, provider } = build({
+            planRepository: makePlanRepository({
+                findByCode: jest.fn().mockResolvedValue(SELFHOSTED_PRO_PLAN),
+            }),
+        });
+
+        const started = await service.startPlanCheckout({
+            ...checkoutOptions,
+            planCode: 'selfhosted_pro',
+            interval: 'lifetime',
+        });
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.mode).toBe('payment');
+        expect(request.plan.lookupKey).toBe('ever_works_selfhosted_pro_lifetime');
+        // $99 once. Fulfilment (issuing the licence document) is MANUAL for now.
+        expect(request.plan.priceCents).toBe(9900);
+        expect(started.priceCents).toBe(9900);
+        // A one-off purchase cannot carry a recurring seat line.
+        expect(request.plan.seatLookupKey).toBeNull();
+    });
+
+    it('never sells a recurring period as a one-off, or the reverse', async () => {
+        const { service, provider } = build({
+            planRepository: makePlanRepository({
+                findByCode: jest.fn().mockResolvedValue(SELFHOSTED_PRO_PLAN),
+            }),
+        });
+
+        // The self-hosted "annual" slot is a yearly SUBSCRIPTION on this tier even though the same
+        // tier also sells a one-time licence — the exact confusion the catalog exists to prevent.
+        await service.startPlanCheckout({
+            ...checkoutOptions,
+            planCode: 'selfhosted_pro',
+            interval: 'annual',
+        });
+        const annual = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(annual.plan.mode).toBe('subscription');
+        expect(annual.plan.interval).toBe('year');
+        expect(annual.plan.priceCents).toBe(40800);
+    });
+
+    it('refuses a period the plan does not sell rather than downgrading to one it does', async () => {
+        // Cloud Pro has no lifetime price. Selling the monthly one instead would take money for
+        // the wrong thing entirely.
+        const { service, provider } = build();
+
+        await expect(
+            service.startPlanCheckout({ ...checkoutOptions, interval: 'lifetime' }),
+        ).rejects.toBeInstanceOf(PlanNotPurchasableError);
+        expect(provider.createPlanCheckoutSession).not.toHaveBeenCalled();
     });
 
     it('lazily creates the provider customer + billing profile', async () => {

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -15,6 +15,7 @@ import {
     BillingProviderNotConfiguredError,
     type BillingWebhookEvent,
 } from './billing.provider';
+import { billableSeats, resolveSkuForPlanRow, type CatalogInterval } from './stripe-catalog';
 
 /** A checkout was asked for with a plan code that is not sellable. */
 export class UnknownSubscriptionPlanError extends Error {
@@ -56,6 +57,21 @@ export interface StartPlanCheckoutOptions {
     cancelUrl: string;
     organizationId?: string | null;
     tenantId?: string | null;
+    /**
+     * Total seats (employees OR agents) the buyer wants, INCLUSIVE of the plan allowance. The
+     * service clamps this against the plan row and bills only the excess, so a caller cannot
+     * under-report to pay less. Absent means "just the included allowance".
+     */
+    seats?: number | null;
+    /**
+     * Which billing period to buy. Defaults to `monthly` — the only period this path supported
+     * before the shared catalog existed.
+     *
+     * An interval the resolved plan does not sell is refused, never silently downgraded to one it
+     * does: quietly selling a monthly subscription to someone who asked for a perpetual licence is
+     * worse than a 400.
+     */
+    interval?: CatalogInterval | null;
 }
 
 export interface PlanCheckoutStarted {
@@ -140,8 +156,20 @@ export class PlanSubscriptionService {
             throw new BillingProviderNotConfiguredError();
         }
 
-        const plan = await this.resolveSellablePlan(options.planCode);
-        const priceCents = planPriceCents(plan);
+        const interval: CatalogInterval = options.interval ?? 'monthly';
+
+        const plan = await this.resolveSellablePlan(options.planCode, interval);
+        const catalogSku = resolveSkuForPlanRow({
+            code: plan.code,
+            hosting: plan.hosting,
+            interval,
+        });
+        // What the buyer will actually be charged. The catalog wins because the catalog price is
+        // what the provider bills; the row is the fallback for an unsynced deployment. Reading the
+        // row first would echo 0 for any period the row has no column value for — showing someone
+        // "$0" on a confirmation screen for a charge that is about to be 204.00.
+        const priceCents =
+            catalogSku?.price.amountCents ?? planPriceCentsForInterval(plan, interval);
 
         const user = await this.userRepository.findById(options.userId);
         const existing = await this.billingProfileRepository.findByUserId(options.userId);
@@ -169,7 +197,15 @@ export class PlanSubscriptionService {
                 label: `${plan.displayName} plan`,
                 priceCents,
                 currency: plan.currency || this.billingProvider.getDefaultCurrency(),
-                interval: 'month',
+                interval: interval === 'annual' ? 'year' : 'month',
+                // A `lifetime` SKU is bought outright. Decided from the catalog SKU, never from
+                // the interval name alone — see `resolveCatalogSku`.
+                mode: catalogSku?.mode ?? (interval === 'lifetime' ? 'payment' : 'subscription'),
+                // Prefer the catalog price in the shared Stripe account over the row's own amount,
+                // so the invoice line carries a lookup_key that maps back to a reviewed commit.
+                // `null` here is normal on a deployment whose catalog has not been synced — the
+                // provider falls back to billing `priceCents` exactly as it did before.
+                ...this.catalogKeysFor(plan, interval, options.seats ?? null),
             },
             successUrl: options.successUrl,
             cancelUrl: options.cancelUrl,
@@ -182,6 +218,34 @@ export class PlanSubscriptionService {
             planCode: plan.code,
             priceCents,
             currency: plan.currency,
+        };
+    }
+
+    /**
+     * The catalog fields for a plan row: which shared-account price to bill, which per-seat price
+     * to add, and how many seats are actually billable.
+     *
+     * Seats are clamped against the PLAN's own allowance, on the server, from the stored row — a
+     * caller cannot ask for a seat count that bills less than it should, and a plan with unbounded
+     * seats (the Community Edition, and Enterprise "Option 1") always yields zero extras.
+     *
+     * Returns empty when the catalog does not know this plan, which leaves the descriptor exactly
+     * as it was before the shared account existed.
+     */
+    private catalogKeysFor(
+        plan: SubscriptionPlan,
+        interval: CatalogInterval,
+        requestedSeats: number | null,
+    ): { lookupKey?: string; seatLookupKey?: string | null; extraSeats?: number } {
+        const sku = resolveSkuForPlanRow({ code: plan.code, hosting: plan.hosting, interval });
+        if (!sku) return {};
+
+        const extraSeats = requestedSeats === null ? 0 : billableSeats(sku.plan, requestedSeats);
+
+        return {
+            lookupKey: sku.lookupKey,
+            seatLookupKey: extraSeats > 0 ? sku.seatLookupKey : null,
+            extraSeats,
         };
     }
 
@@ -391,15 +455,28 @@ export class PlanSubscriptionService {
 
     // ── Resolution helpers ───────────────────────────────────────────
 
-    private async resolveSellablePlan(planCode: string): Promise<SubscriptionPlan> {
+    private async resolveSellablePlan(
+        planCode: string,
+        interval: CatalogInterval = 'monthly',
+    ): Promise<SubscriptionPlan> {
         const plan = await this.findPlanByCode(planCode);
         if (!plan || !plan.active) {
             throw new UnknownSubscriptionPlanError(String(planCode));
         }
+        // A free tier is free on every period, so this stays keyed on the monthly price: it is the
+        // "is this plan sold at all?" question, not "does it sell this period?".
         if (planPriceCents(plan) <= 0) {
             throw new PlanNotPurchasableError(
                 'Free plans do not require checkout — switch to them directly',
             );
+        }
+        // A period the plan does not sell must be refused, never downgraded to one it does. Both
+        // sources have to agree: the catalog decides what Stripe can charge, the row decides what
+        // an unsynced deployment charges, and selling a period only one of them knows about would
+        // bill the wrong amount on half the fleet.
+        const sku = resolveSkuForPlanRow({ code: plan.code, hosting: plan.hosting, interval });
+        if (!sku && planPriceCentsForInterval(plan, interval) <= 0) {
+            throw new PlanNotPurchasableError(`This plan is not sold on a ${interval} basis`);
         }
         return plan;
     }
@@ -457,6 +534,28 @@ function planPriceCents(plan: SubscriptionPlan): number {
         return 0;
     }
     return Math.round(price * 100);
+}
+
+/**
+ * The plan row's own price for one billing period, in cents.
+ *
+ * This is the FALLBACK amount — what gets billed on a deployment whose Stripe catalog has not been
+ * synced. When the catalog resolves, the provider bills the catalog price instead and this number
+ * only rides along on the response for the UI's confirmation copy.
+ *
+ * `annualPrice` is the YEARLY charge, not the per-month figure the marketing site displays.
+ */
+function planPriceCentsForInterval(plan: SubscriptionPlan, interval: CatalogInterval): number {
+    const raw =
+        interval === 'annual'
+            ? Number(plan.annualPrice)
+            : interval === 'lifetime'
+              ? Number(plan.lifetimePrice)
+              : Number(plan.monthlyPrice);
+    if (!Number.isFinite(raw) || raw <= 0) {
+        return 0;
+    }
+    return Math.round(raw * 100);
 }
 
 /** Map the provider id onto the entity's closed billing-provider set. */

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -2,6 +2,7 @@ import { BillingProviderError, BillingProviderNotConfiguredError } from './billi
 import {
     StripeBillingProvider,
     STRIPE_METADATA_KEYS,
+    STRIPE_PERPETUAL_LICENCE,
     STRIPE_PURCHASE_KINDS,
     STRIPE_SETUP_KIND,
 } from './stripe-billing.provider';
@@ -954,6 +955,193 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         expect(params.mode).toBe('subscription');
         expect(params.line_items[0].price_data.unit_amount).toBe(2900);
         expect(params.line_items[0].price_data.recurring).toEqual({ interval: 'month' });
+    });
+
+    it('buys a perpetual licence in payment mode, with no subscription_data', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, mode: 'payment', code: 'selfhosted_pro' },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('payment');
+        // Stripe rejects subscription_data outright in payment mode; the one-off equivalent is
+        // payment_intent_data, and the metadata has to be mirrored there because a one-off
+        // purchase creates no subscription for it to live on.
+        expect(params.subscription_data).toBeUndefined();
+        expect(params.payment_intent_data.metadata[STRIPE_METADATA_KEYS.planCode]).toBe(
+            'selfhosted_pro',
+        );
+    });
+
+    it('marks a licence sale so manual fulfilment can find it', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, mode: 'payment' },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        // Issuing the licence document is manual for now, so this marker is the only way to list
+        // who is owed one. It must be on BOTH objects.
+        expect(params.metadata[STRIPE_METADATA_KEYS.licence]).toBe(STRIPE_PERPETUAL_LICENCE);
+        expect(params.payment_intent_data.metadata[STRIPE_METADATA_KEYS.licence]).toBe(
+            STRIPE_PERPETUAL_LICENCE,
+        );
+    });
+
+    it('leaves the licence marker OFF a recurring purchase', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession(planRequest);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('subscription');
+        // A false positive here would put a recurring subscriber on the manual-fulfilment list.
+        expect(params.metadata[STRIPE_METADATA_KEYS.licence]).toBeUndefined();
+        expect(params.subscription_data.metadata[STRIPE_METADATA_KEYS.licence]).toBeUndefined();
+    });
+
+    it('keeps a licence purchase on the SAME webhook kind, so activation is one path', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, mode: 'payment' },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        // The act is identical — grant this user this plan — and `activate()` already accepts a
+        // null provider subscription id. A separate kind would need a second activation path for
+        // no reason, and the webhook gate keys on exactly this value.
+        expect(params.metadata[STRIPE_METADATA_KEYS.kind]).toBe(
+            STRIPE_PURCHASE_KINDS.planSubscription,
+        );
+    });
+
+    it('bills the shared-account CATALOG price when the lookup key resolves', async () => {
+        const { provider, client } = build();
+        client.prices = {
+            list: jest.fn().mockResolvedValue({ data: [{ id: 'price_cat_1' }] }),
+        };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        });
+
+        expect(client.prices.list).toHaveBeenCalledWith(
+            expect.objectContaining({
+                lookup_keys: ['ever_works_cloud_pro_monthly'],
+                active: true,
+            }),
+        );
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        // The catalog price object, NOT an ad-hoc amount — that is what makes the invoice line
+        // traceable back to a reviewed commit.
+        expect(params.line_items[0].price).toBe('price_cat_1');
+        expect(params.line_items[0].price_data).toBeUndefined();
+        expect(params.line_items).toHaveLength(1);
+    });
+
+    it('falls back to the inline price when the account has no such lookup key', async () => {
+        // This is what protects self-hosters, CI and local dev: a deployment that has never run
+        // the catalog sync must still be able to take a payment.
+        const { provider, client } = build();
+        client.prices = { list: jest.fn().mockResolvedValue({ data: [] }) };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.line_items[0].price).toBeUndefined();
+        expect(params.line_items[0].price_data.unit_amount).toBe(2900);
+    });
+
+    it('falls back to the inline price when the lookup itself throws', async () => {
+        // A Stripe outage on the price lookup must not take checkout down with it.
+        const { provider, client } = build();
+        client.prices = { list: jest.fn().mockRejectedValue(new Error('stripe down')) };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.line_items[0].price_data.unit_amount).toBe(2900);
+    });
+
+    it('adds a second line item for the seats beyond the allowance', async () => {
+        const { provider, client } = build();
+        client.prices = {
+            list: jest.fn().mockImplementation(async ({ lookup_keys }) => ({
+                data: [{ id: lookup_keys[0].includes('_seat_') ? 'price_seat_1' : 'price_cat_1' }],
+            })),
+        };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: {
+                ...planRequest.plan,
+                lookupKey: 'ever_works_cloud_pro_monthly',
+                seatLookupKey: 'ever_works_cloud_pro_seat_monthly',
+                extraSeats: 17,
+            },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.line_items).toHaveLength(2);
+        expect(params.line_items[0]).toEqual({ quantity: 1, price: 'price_cat_1' });
+        expect(params.line_items[1]).toEqual({ quantity: 17, price: 'price_seat_1' });
+    });
+
+    it('never emits a zero-quantity seat line — Stripe rejects one', async () => {
+        const { provider, client } = build();
+        client.prices = { list: jest.fn().mockResolvedValue({ data: [{ id: 'price_cat_1' }] }) };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: {
+                ...planRequest.plan,
+                lookupKey: 'ever_works_cloud_pro_monthly',
+                seatLookupKey: 'ever_works_cloud_pro_seat_monthly',
+                extraSeats: 0,
+            },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.line_items).toHaveLength(1);
+    });
+
+    it('sells the base plan rather than inventing a seat price it cannot resolve', async () => {
+        // The per-seat amount lives in the catalog, not the plan row, so there is no honest inline
+        // fallback for it. Billing a made-up number would be worse than under-billing.
+        const { provider, client } = build();
+        client.prices = {
+            list: jest.fn().mockImplementation(async ({ lookup_keys }) => ({
+                data: lookup_keys[0].includes('_seat_') ? [] : [{ id: 'price_cat_1' }],
+            })),
+        };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: {
+                ...planRequest.plan,
+                lookupKey: 'ever_works_cloud_pro_monthly',
+                seatLookupKey: 'ever_works_cloud_pro_seat_monthly',
+                extraSeats: 4,
+            },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.line_items).toHaveLength(1);
+        expect(params.line_items[0].price).toBe('price_cat_1');
     });
 
     it('mirrors the plan metadata onto the SUBSCRIPTION so renewals stay attributable', async () => {

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -49,7 +49,29 @@ export const STRIPE_METADATA_KEYS = {
      * without it a renewal could not be attributed to a tier.
      */
     planCode: 'ever_works_plan_code',
+    /**
+     * Set to `perpetual-commercial` on a one-off licence purchase, and absent on every recurring
+     * one. Fulfilment — issuing the licence document — is MANUAL for now, so this is the field that
+     * makes a sale findable after the fact:
+     *
+     *     GET /v1/payment_intents/search
+     *       ?query=metadata["ever_works_licence"]:"perpetual-commercial"
+     *
+     * 🛑 Two things that will waste your time otherwise, both confirmed against the live API:
+     * Stripe's search syntax requires DOUBLE quotes (single quotes 400 with a "properly quoted
+     * fields" error), and there is **no** `/v1/checkout/sessions/search` endpoint at all — it 400s
+     * with "Received unknown parameter: query". Search PAYMENT INTENTS, not sessions.
+     *
+     * That is exactly why this marker is mirrored onto `payment_intent_data.metadata` as well as
+     * the session: a one-off purchase creates no subscription for metadata to live on, and the
+     * session itself is not searchable. `/v1/charges/search` also works, but only once the payment
+     * has settled — an unpaid session has a payment intent and no charge yet.
+     */
+    licence: 'ever_works_licence',
 } as const;
+
+/** The only value {@link STRIPE_METADATA_KEYS.licence} ever takes. */
+export const STRIPE_PERPETUAL_LICENCE = 'perpetual-commercial' as const;
 
 /** `kind` metadata values — how a purchase at the provider originated. */
 export const STRIPE_PURCHASE_KINDS = {
@@ -236,41 +258,147 @@ export class StripeBillingProvider extends BillingProvider {
             existingCustomerId: request.customerId,
         });
 
+        // A perpetual commercial licence is bought outright, so it is `mode: payment` and there is
+        // no subscription for the metadata to live on. Everything downstream is deliberately the
+        // SAME kind — `plan-subscription` — because the act is identical: grant this user this
+        // plan. `activate()` already accepts a null provider subscription id, and a plan with no
+        // subscription id is one `cancelSubscription` correctly refuses to cancel, which is exactly
+        // right for a licence that never expires.
+        const isPerpetual = request.plan.mode === 'payment';
+
         const metadata = {
             [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
             [STRIPE_METADATA_KEYS.userId]: request.userId,
             [STRIPE_METADATA_KEYS.planCode]: request.plan.code,
             [STRIPE_METADATA_KEYS.referenceId]: request.referenceId,
+            // Only on a one-off licence — this is what makes the sale findable for the manual
+            // document fulfilment, which is not built for any Ever product yet.
+            ...(isPerpetual ? { [STRIPE_METADATA_KEYS.licence]: STRIPE_PERPETUAL_LICENCE } : {}),
         };
 
+        const lineItems = await this.buildPlanLineItems(request);
+
         const session = await stripe.checkout.sessions.create({
-            mode: 'subscription',
+            mode: isPerpetual ? 'payment' : 'subscription',
             customer: customerId,
             client_reference_id: request.referenceId,
             // The seam leaves the session-identifier token to the
             // implementation; this one is Stripe's.
             success_url: withSessionIdTemplate(request.successUrl),
             cancel_url: request.cancelUrl,
-            line_items: [
-                {
-                    quantity: 1,
-                    price_data: {
-                        // Price comes from the SERVER plan row.
-                        currency: request.plan.currency,
-                        unit_amount: request.plan.priceCents,
-                        recurring: { interval: request.plan.interval },
-                        product_data: { name: request.plan.label },
-                    },
-                },
-            ],
+            line_items: lineItems,
             metadata,
-            subscription_data: { metadata },
+            // `subscription_data` is rejected outright in payment mode; the one-off equivalent is
+            // `payment_intent_data`, which is also where the licence marker has to be mirrored so a
+            // refund or dispute on the charge can still be traced back to the sale.
+            ...(isPerpetual
+                ? { payment_intent_data: { metadata } }
+                : { subscription_data: { metadata } }),
         });
 
         if (!session.url) {
             throw new BillingProviderError('Checkout session did not return a redirect URL');
         }
         return { url: session.url, sessionId: session.id, customerId };
+    }
+
+    /**
+     * Resolve a catalog `lookup_key` to a Stripe Price id, or `null` if this account does not have
+     * it.
+     *
+     * 🛑 `null` is a normal answer, not an error: a self-hosted or CI deployment will not have had
+     * `scripts/stripe-sync-catalog.mjs` run against its account. Callers fall back to an inline
+     * price rather than failing the purchase.
+     *
+     * Results are memoised for the process lifetime. A price's id never changes; when an amount
+     * changes, the sync script moves the lookup_key onto a NEW price
+     * (`transfer_lookup_key`), so a long-lived process could hold a stale id — which is exactly the
+     * behaviour we want for in-flight checkouts, and is corrected on the next deploy.
+     */
+    private readonly priceIdByLookupKey = new Map<string, string | null>();
+
+    private async resolvePriceId(lookupKey: string | null | undefined): Promise<string | null> {
+        if (!nonEmpty(lookupKey)) return null;
+        const key = lookupKey as string;
+
+        const cached = this.priceIdByLookupKey.get(key);
+        if (cached !== undefined) return cached;
+
+        const stripe = this.requireClient();
+        let resolved: string | null = null;
+        try {
+            const found = await stripe.prices.list({ lookup_keys: [key], active: true, limit: 1 });
+            resolved = found.data[0]?.id ?? null;
+        } catch (error) {
+            // A lookup failure must not take a purchase down — fall back to the inline price.
+            this.logger.warn(
+                `Could not resolve Stripe price for lookup_key "${key}"; falling back to an inline price`,
+                error instanceof Error ? error.stack : undefined,
+            );
+            resolved = null;
+        }
+
+        if (resolved === null) {
+            this.logger.warn(
+                `No active Stripe price for lookup_key "${key}" in this account — billing the plan row's ` +
+                    `inline amount instead. Run scripts/stripe-sync-catalog.mjs to publish the catalog.`,
+            );
+        }
+
+        this.priceIdByLookupKey.set(key, resolved);
+        return resolved;
+    }
+
+    /**
+     * Line items for a plan checkout: the plan itself, plus a per-seat line when the buyer wants
+     * more seats than the plan includes.
+     *
+     * The plan line prefers the CATALOG price (shared Stripe account, stable `lookup_key`) and
+     * falls back to the historical inline `price_data` built from the server plan row. Both paths
+     * price from the SERVER — a client-supplied amount never reaches here; `PlanCheckoutController`
+     * rejects a body carrying one.
+     */
+    private async buildPlanLineItems(
+        request: PlanCheckoutRequest,
+    ): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> {
+        const planPriceId = await this.resolvePriceId(request.plan.lookupKey);
+
+        const planLine: Stripe.Checkout.SessionCreateParams.LineItem = planPriceId
+            ? { quantity: 1, price: planPriceId }
+            : {
+                  quantity: 1,
+                  price_data: {
+                      // Price comes from the SERVER plan row.
+                      currency: request.plan.currency,
+                      unit_amount: request.plan.priceCents,
+                      recurring: { interval: request.plan.interval },
+                      product_data: { name: request.plan.label },
+                  },
+              };
+
+        const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [planLine];
+
+        // Seats are additive and optional. A plan with unbounded seats, a plan whose buyer stays
+        // within the included allowance, and an account with no synced seat price all produce no
+        // second line — never a zero-quantity one, which Stripe rejects.
+        const extraSeats = Math.max(0, Math.floor(request.plan.extraSeats ?? 0));
+        if (extraSeats > 0) {
+            const seatPriceId = await this.resolvePriceId(request.plan.seatLookupKey);
+            if (seatPriceId) {
+                lineItems.push({ quantity: extraSeats, price: seatPriceId });
+            } else {
+                // There is deliberately no inline fallback for seats: the per-seat amount lives in
+                // the catalog, not in the plan row, so inventing one here would bill a number that
+                // no reviewed file contains. Log loudly and sell the base plan.
+                this.logger.error(
+                    `Plan checkout for user ${request.userId} asked for ${extraSeats} extra seat(s) but ` +
+                        `seat price "${request.plan.seatLookupKey}" is not available in this Stripe account. ` +
+                        `Selling the base plan only — the seats were NOT billed.`,
+                );
+            }
+        }
+
+        return lineItems;
     }
 
     /**

--- a/packages/agent/src/subscriptions/billing/stripe-catalog.data.json
+++ b/packages/agent/src/subscriptions/billing/stripe-catalog.data.json
@@ -1,0 +1,142 @@
+{
+    "$comment": [
+        "Ever Works' catalog in the SHARED Stripe account acct_1IDnd6DdBrwbGEir (\"Ever Tech\").",
+        "",
+        "Every Ever product sells through ONE Stripe account, so every price carries a prefixed",
+        "lookup_key. The account-wide plan convention, set by ever-co/ever-website's catalog.json, is:",
+        "  ever_<product>_<hosting>_<tier>_<interval>",
+        "Ever Works extends it with two shapes the shared schema cannot express:",
+        "  ever_works_<hosting>_<tier>_seat_<interval>   per-additional-seat add-on",
+        "  ever_works_credits_<n>                        one-time AI credit pack",
+        "",
+        "scripts/stripe-sync-catalog.mjs applies this file idempotently, keyed on lookup_key.",
+        "Stripe prices are immutable: changing an `amountCents` creates a NEW price, moves the",
+        "lookup_key onto it (transfer_lookup_key) and archives the old one. Existing subscribers stay",
+        "on the price they bought. Never create these by hand in the Dashboard.",
+        "",
+        "Amounts are integer minor units (cents) in `currency`. An annual amount is the figure the",
+        "marketing site displays per month x 12: cloud Pro shows \"$17/mo\" and bills 20400 once a year.",
+        "",
+        "`interval` values:",
+        "  monthly  - recurring, month",
+        "  annual   - recurring, year",
+        "  lifetime - ONE-TIME, bought in Stripe `mode: payment`. Grants a perpetual commercial licence",
+        "             exempting the buyer from AGPLv3. Fulfilment (sending the licence PDF) is a known",
+        "             follow-up across ALL Ever products and is NOT wired up yet.",
+        "",
+        "Prices are anchored to Ever Gauzy / Ever Teams (owner directive 2026-08-22) so the whole Ever",
+        "line reads consistently. The only numbers with no Gauzy counterpart are the credit allowances.",
+        "",
+        "`seatsIncluded: null` means unbounded - no seat price is emitted for that plan.",
+        "An empty `prices` array means the tier is a free download with NO Stripe object at all."
+    ],
+
+    "version": 1,
+    "product": "works",
+    "name": "Ever Works",
+    "site": "https://ever.works",
+    "currency": "usd",
+
+    "dailyFreeCredits": 50,
+
+    "plans": [
+        {
+            "hosting": "cloud",
+            "tier": "free",
+            "tierName": "Free",
+            "seatsIncluded": 1,
+            "seatCentsPerMonth": null,
+            "monthlyCredits": 0,
+            "note": "Free forever. 50 credits/day. Not purchasable through checkout - assigned by the self-service plan endpoint. The $0 prices exist only so a future move to the shared ever.co/checkout can keep 'does this email have a subscription?' a single uniform question.",
+            "prices": [
+                { "interval": "monthly", "amountCents": 0 },
+                { "interval": "annual", "amountCents": 0 }
+            ]
+        },
+        {
+            "hosting": "cloud",
+            "tier": "pro",
+            "tierName": "Pro",
+            "seatsIncluded": 10,
+            "seatCentsPerMonth": 500,
+            "monthlyCredits": 3000,
+            "note": "Matches Ever Gauzy / Ever Teams cloud Small Business ($25 / $204) and their $5 per additional employee.",
+            "prices": [
+                { "interval": "monthly", "amountCents": 2500 },
+                { "interval": "annual", "amountCents": 20400 }
+            ]
+        },
+        {
+            "hosting": "cloud",
+            "tier": "enterprise",
+            "tierName": "Enterprise",
+            "seatsIncluded": 10,
+            "seatCentsPerMonth": 1000,
+            "monthlyCredits": 25000,
+            "note": "Matches Ever Gauzy / Ever Teams Enterprise ($199 / $1,668) and their $10 per additional employee. Option 1 (one organization, unlimited seats) is the same SKU with seat metering switched off on the subscription; Option 2 (unlimited organizations, 10 seats each) is the metered default.",
+            "prices": [
+                { "interval": "monthly", "amountCents": 19900 },
+                { "interval": "annual", "amountCents": 166800 }
+            ]
+        },
+
+        {
+            "hosting": "selfhosted",
+            "tier": "free",
+            "tierName": "Community Edition",
+            "seatsIncluded": null,
+            "seatCentsPerMonth": null,
+            "monthlyCredits": null,
+            "note": "Free AGPLv3 download. Never bought, so it has NO Stripe object - exactly how Gauzy's and Teams' Community Editions are modelled. Unlimited seats. Credits still apply if the deployment uses Ever-hosted AI rather than its own model keys.",
+            "prices": []
+        },
+        {
+            "hosting": "selfhosted",
+            "tier": "pro",
+            "tierName": "Pro Edition",
+            "seatsIncluded": 10,
+            "seatCentsPerMonth": 500,
+            "monthlyCredits": 3000,
+            "note": "Commercial licence lifting AGPLv3 obligations. Mirrors Gauzy's self-hosted Small Business Edition: $49/mo, $408/yr (displays $34/mo), $99 one-time lifetime.",
+            "prices": [
+                { "interval": "monthly", "amountCents": 4900 },
+                { "interval": "annual", "amountCents": 40800 },
+                { "interval": "lifetime", "amountCents": 9900 }
+            ]
+        },
+        {
+            "hosting": "selfhosted",
+            "tier": "enterprise",
+            "tierName": "Enterprise Edition",
+            "seatsIncluded": 10,
+            "seatCentsPerMonth": 1000,
+            "monthlyCredits": 25000,
+            "note": "Commercial licence lifting AGPLv3 obligations. Mirrors Gauzy's self-hosted Enterprise Edition.",
+            "prices": [
+                { "interval": "monthly", "amountCents": 19900 },
+                { "interval": "annual", "amountCents": 166800 }
+            ]
+        }
+    ],
+
+    "creditPacks": [
+        {
+            "packId": "credits-1000",
+            "amountCents": 1000,
+            "credits": 1000,
+            "label": "1,000 credits"
+        },
+        {
+            "packId": "credits-5500",
+            "amountCents": 5000,
+            "credits": 5500,
+            "label": "5,500 credits"
+        },
+        {
+            "packId": "credits-25000",
+            "amountCents": 20000,
+            "credits": 25000,
+            "label": "25,000 credits"
+        }
+    ]
+}

--- a/packages/agent/src/subscriptions/billing/stripe-catalog.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-catalog.spec.ts
@@ -1,0 +1,278 @@
+import { CREDIT_PACKS } from './credit-packs';
+import {
+    allCatalogLookupKeys,
+    billableSeats,
+    catalog,
+    creditPackLookupKey,
+    findPlan,
+    planLookupKey,
+    planProductName,
+    resolveCatalogSku,
+    seatAmountCents,
+    seatLookupKey,
+    seatProductName,
+    type CatalogPlan,
+} from './stripe-catalog';
+
+/**
+ * The catalog is the only place a price can be changed, and it is read by two independent
+ * consumers — the checkout provider at runtime and `scripts/stripe-sync-catalog.mjs` at deploy
+ * time. These tests pin the things that would go wrong QUIETLY:
+ *
+ *  - a lookup_key drifting away from the account-wide convention, which would strand a price in
+ *    the shared Stripe account under a name nothing resolves;
+ *  - the mode/seat derivation getting it wrong for a one-time licence, which would try to sell a
+ *    perpetual licence as a subscription;
+ *  - the annual amount being stored as the per-month figure the marketing site displays, which is
+ *    the single easiest mistake to make here and would undercharge by 12x;
+ *  - the credit-pack prices drifting from `credit-packs.ts`, which grants the credits.
+ */
+describe('stripe-catalog', () => {
+    const plan = (
+        hosting: 'cloud' | 'selfhosted',
+        tier: 'free' | 'pro' | 'enterprise',
+    ): CatalogPlan => {
+        const found = findPlan(hosting, tier);
+        if (!found) throw new Error(`missing plan ${hosting}/${tier}`);
+        return found;
+    };
+
+    describe('shape', () => {
+        it('defines exactly three tiers on each of the two hostings', () => {
+            expect(catalog.plans).toHaveLength(6);
+            for (const hosting of ['cloud', 'selfhosted'] as const) {
+                const tiers = catalog.plans.filter((p) => p.hosting === hosting).map((p) => p.tier);
+                expect(tiers.sort()).toEqual(['enterprise', 'free', 'pro']);
+            }
+        });
+
+        it('prices everything in USD even though the shared account defaults to EUR', () => {
+            expect(catalog.currency).toBe('usd');
+        });
+
+        it('claims the "works" key in the shared account-wide namespace', () => {
+            expect(catalog.product).toBe('works');
+            for (const key of allCatalogLookupKeys()) {
+                expect(key.startsWith('ever_works_')).toBe(true);
+            }
+        });
+
+        it('emits no duplicate lookup keys', () => {
+            const keys = allCatalogLookupKeys();
+            expect(new Set(keys).size).toBe(keys.length);
+        });
+    });
+
+    describe('lookup keys', () => {
+        it('follows ever_<product>_<hosting>_<tier>_<interval> for plans', () => {
+            expect(planLookupKey('cloud', 'pro', 'monthly')).toBe('ever_works_cloud_pro_monthly');
+            expect(planLookupKey('selfhosted', 'pro', 'lifetime')).toBe(
+                'ever_works_selfhosted_pro_lifetime',
+            );
+            expect(planLookupKey('cloud', 'enterprise', 'annual')).toBe(
+                'ever_works_cloud_enterprise_annual',
+            );
+        });
+
+        it('infixes _seat_ for the per-additional-seat add-on', () => {
+            expect(seatLookupKey('cloud', 'pro', 'monthly')).toBe(
+                'ever_works_cloud_pro_seat_monthly',
+            );
+            expect(seatLookupKey('selfhosted', 'enterprise', 'annual')).toBe(
+                'ever_works_selfhosted_enterprise_seat_annual',
+            );
+        });
+
+        it('keeps credit packs free of hosting and tier — a pack is the same purchase for everyone', () => {
+            expect(creditPackLookupKey('credits-5500')).toBe('ever_works_credits_5500');
+            expect(creditPackLookupKey('credits-25000')).toBe('ever_works_credits_25000');
+        });
+    });
+
+    describe('prices agree with Ever Gauzy / Ever Teams', () => {
+        // Owner directive 2026-08-22. Amounts are CENTS; an annual amount is the yearly charge,
+        // NOT the per-month figure the marketing site displays.
+        it.each`
+            hosting         | tier            | interval      | cents     | displays
+            ${'cloud'}      | ${'free'}       | ${'monthly'}  | ${0}      | ${'$0'}
+            ${'cloud'}      | ${'free'}       | ${'annual'}   | ${0}      | ${'$0'}
+            ${'cloud'}      | ${'pro'}        | ${'monthly'}  | ${2500}   | ${'$25/mo'}
+            ${'cloud'}      | ${'pro'}        | ${'annual'}   | ${20400}  | ${'$17/mo'}
+            ${'cloud'}      | ${'enterprise'} | ${'monthly'}  | ${19900}  | ${'$199/mo'}
+            ${'cloud'}      | ${'enterprise'} | ${'annual'}   | ${166800} | ${'$139/mo'}
+            ${'selfhosted'} | ${'pro'}        | ${'monthly'}  | ${4900}   | ${'$49/mo'}
+            ${'selfhosted'} | ${'pro'}        | ${'annual'}   | ${40800}  | ${'$34/mo'}
+            ${'selfhosted'} | ${'pro'}        | ${'lifetime'} | ${9900}   | ${'$99 one-time'}
+            ${'selfhosted'} | ${'enterprise'} | ${'monthly'}  | ${19900}  | ${'$199/mo'}
+            ${'selfhosted'} | ${'enterprise'} | ${'annual'}   | ${166800} | ${'$139/mo'}
+        `(
+            '$hosting $tier $interval is $cents cents (displays $displays)',
+            ({ hosting, tier, interval, cents }) => {
+                const sku = resolveCatalogSku({ hosting, tier, interval });
+                expect(sku).not.toBeNull();
+                expect(sku!.price.amountCents).toBe(cents);
+            },
+        );
+
+        it('stores annual as the YEARLY charge, twelve times the displayed monthly figure', () => {
+            // The trap this guards: writing 1700 (the "$17/mo" the site shows) instead of 20400.
+            expect(
+                resolveCatalogSku({ hosting: 'cloud', tier: 'pro', interval: 'annual' })!.price
+                    .amountCents,
+            ).toBe(1700 * 12);
+            expect(
+                resolveCatalogSku({ hosting: 'cloud', tier: 'enterprise', interval: 'annual' })!
+                    .price.amountCents,
+            ).toBe(13900 * 12);
+        });
+    });
+
+    describe('mode derivation', () => {
+        it('sells a lifetime licence as a one-off payment, never a subscription', () => {
+            const sku = resolveCatalogSku({
+                hosting: 'selfhosted',
+                tier: 'pro',
+                interval: 'lifetime',
+            })!;
+            expect(sku.mode).toBe('payment');
+            // A one-off purchase cannot carry a recurring seat line.
+            expect(sku.seatLookupKey).toBeNull();
+        });
+
+        it('sells every other interval as a subscription', () => {
+            for (const interval of ['monthly', 'annual'] as const) {
+                expect(resolveCatalogSku({ hosting: 'cloud', tier: 'pro', interval })!.mode).toBe(
+                    'subscription',
+                );
+                expect(
+                    resolveCatalogSku({ hosting: 'selfhosted', tier: 'enterprise', interval })!
+                        .mode,
+                ).toBe('subscription');
+            }
+        });
+
+        it('matches the seat interval to the plan interval', () => {
+            expect(
+                resolveCatalogSku({ hosting: 'cloud', tier: 'pro', interval: 'monthly' })!
+                    .seatLookupKey,
+            ).toBe('ever_works_cloud_pro_seat_monthly');
+            expect(
+                resolveCatalogSku({ hosting: 'cloud', tier: 'pro', interval: 'annual' })!
+                    .seatLookupKey,
+            ).toBe('ever_works_cloud_pro_seat_annual');
+        });
+
+        it('returns null for a combination the catalog does not have, never a fallback', () => {
+            // The free download has no Stripe object at all.
+            expect(
+                resolveCatalogSku({ hosting: 'selfhosted', tier: 'free', interval: 'monthly' }),
+            ).toBeNull();
+            // Only self-hosted Pro sells a lifetime licence.
+            expect(
+                resolveCatalogSku({ hosting: 'cloud', tier: 'pro', interval: 'lifetime' }),
+            ).toBeNull();
+            expect(
+                resolveCatalogSku({
+                    hosting: 'selfhosted',
+                    tier: 'enterprise',
+                    interval: 'lifetime',
+                }),
+            ).toBeNull();
+        });
+    });
+
+    describe('seats', () => {
+        it('includes ten seats on every paid tier, matching Gauzy', () => {
+            expect(plan('cloud', 'pro').seatsIncluded).toBe(10);
+            expect(plan('cloud', 'enterprise').seatsIncluded).toBe(10);
+            expect(plan('selfhosted', 'pro').seatsIncluded).toBe(10);
+            expect(plan('selfhosted', 'enterprise').seatsIncluded).toBe(10);
+        });
+
+        it('charges Gauzy’s $5 on Pro and $10 on Enterprise', () => {
+            expect(plan('cloud', 'pro').seatCentsPerMonth).toBe(500);
+            expect(plan('selfhosted', 'pro').seatCentsPerMonth).toBe(500);
+            expect(plan('cloud', 'enterprise').seatCentsPerMonth).toBe(1000);
+            expect(plan('selfhosted', 'enterprise').seatCentsPerMonth).toBe(1000);
+        });
+
+        it('gives additional seats no annual discount — the yearly rate is exactly 12x', () => {
+            expect(seatAmountCents(plan('cloud', 'pro'), 'annual')).toBe(6000);
+            expect(seatAmountCents(plan('cloud', 'enterprise'), 'annual')).toBe(12000);
+        });
+
+        it('bills only the seats beyond the allowance, and never a negative quantity', () => {
+            const pro = plan('cloud', 'pro');
+            expect(billableSeats(pro, 0)).toBe(0);
+            expect(billableSeats(pro, 10)).toBe(0);
+            expect(billableSeats(pro, 11)).toBe(1);
+            expect(billableSeats(pro, 37)).toBe(27);
+            // Nonsense input must not produce a charge.
+            expect(billableSeats(pro, -5)).toBe(0);
+            expect(billableSeats(pro, Number.NaN)).toBe(0);
+            expect(billableSeats(pro, Number.POSITIVE_INFINITY)).toBe(0);
+            expect(billableSeats(pro, 10.9)).toBe(0);
+        });
+
+        it('never bills a seat on an unbounded plan — that is Enterprise Option 1', () => {
+            const community = plan('selfhosted', 'free');
+            expect(community.seatsIncluded).toBeNull();
+            expect(billableSeats(community, 5000)).toBe(0);
+            expect(seatAmountCents(community, 'monthly')).toBeNull();
+        });
+
+        it('emits no seat lookup keys for plans that cannot meter seats', () => {
+            const keys = allCatalogLookupKeys();
+            expect(keys).not.toContain('ever_works_cloud_free_seat_monthly');
+            expect(keys).not.toContain('ever_works_selfhosted_free_seat_monthly');
+        });
+    });
+
+    describe('credits', () => {
+        it('grants the published monthly allowances', () => {
+            expect(plan('cloud', 'free').monthlyCredits).toBe(0);
+            expect(plan('cloud', 'pro').monthlyCredits).toBe(3000);
+            expect(plan('cloud', 'enterprise').monthlyCredits).toBe(25000);
+        });
+
+        it('grants self-hosted paid editions the same allowance as their cloud twin', () => {
+            expect(plan('selfhosted', 'pro').monthlyCredits).toBe(
+                plan('cloud', 'pro').monthlyCredits,
+            );
+            expect(plan('selfhosted', 'enterprise').monthlyCredits).toBe(
+                plan('cloud', 'enterprise').monthlyCredits,
+            );
+        });
+
+        it('keeps the universal daily grant on the catalog, not on a plan', () => {
+            expect(catalog.dailyFreeCredits).toBe(50);
+        });
+
+        it('prices every pack exactly as credit-packs.ts does — that file grants the credits', () => {
+            // A drift here would charge one amount and grant a different pack's credits.
+            expect(catalog.creditPacks).toHaveLength(CREDIT_PACKS.length);
+            for (const pack of catalog.creditPacks) {
+                const source = CREDIT_PACKS.find((p) => p.id === pack.packId);
+                expect(source).toBeDefined();
+                expect(pack.amountCents).toBe(source!.priceCents);
+                expect(pack.credits).toBe(source!.credits);
+                expect(pack.label).toBe(source!.label);
+            }
+        });
+    });
+
+    describe('Stripe product names', () => {
+        it('names a plan so an invoice line identifies the product and the tier', () => {
+            expect(planProductName(plan('cloud', 'pro'))).toBe('Ever Works Cloud — Pro');
+            expect(planProductName(plan('selfhosted', 'enterprise'))).toBe(
+                'Ever Works Self-Hosted — Enterprise Edition',
+            );
+        });
+
+        it('distinguishes the seat add-on from the plan it belongs to', () => {
+            expect(seatProductName(plan('cloud', 'pro'))).toBe(
+                'Ever Works Cloud — Pro — Additional Seat',
+            );
+        });
+    });
+});

--- a/packages/agent/src/subscriptions/billing/stripe-catalog.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-catalog.ts
@@ -1,0 +1,297 @@
+import catalogJson from './stripe-catalog.data.json';
+
+/**
+ * Typed view over {@link ./stripe-catalog.data.json}, Ever Works' catalog in the SHARED Stripe account
+ * (`acct_1IDnd6DdBrwbGEir`, "Ever Tech").
+ *
+ * ## Why this file exists
+ *
+ * Every Ever product now sells through ONE Stripe account, so a price has to be identifiable from
+ * an invoice line and resolvable without knowing which product created it. The account-wide plan
+ * convention — set by `ever-co/ever-website` `packages/web/lib/billing/catalog.json` — is:
+ *
+ *     lookup_key = ever_<product>_<hosting>_<tier>_<interval>
+ *
+ * Ever Works keeps its OWN end-to-end checkout (`apps/api/src/billing/*`) rather than redirecting
+ * to `ever.co/checkout`; this table is what lets it do that against the shared account instead of
+ * minting ad-hoc `price_data` on every request. Pricing a checkout from a server-side catalog is
+ * also what makes a charge auditable after the fact: the invoice line carries a `lookup_key` that
+ * maps back to a reviewed commit, not to a number a request body happened to contain.
+ *
+ * Both this module and `scripts/stripe-sync-catalog.mjs` read the same JSON, so a SKU the checkout
+ * can reach is by construction a SKU the sync script created.
+ *
+ * ## The three things Ever Works sells
+ *
+ * 1. **A plan** — flat, recurring (or a one-time perpetual licence on self-hosted). Carries a seat
+ *    allowance and a monthly AI-credit allowance.
+ * 2. **Additional seats** — a per-unit recurring price, quantity `max(0, seats - seatsIncluded)`.
+ *    Mirrors Ever Gauzy / Ever Teams, which include 10 employees and bill $5 (Small Business) or
+ *    $10 (Enterprise) per additional employee per month. In Ever Works a seat is an employee OR an
+ *    agent — the two are interchangeable, which is the point of the product.
+ * 3. **Credit packs** — one-time top-ups for platform-billed AI usage. Credits are a SEPARATE axis
+ *    from seats and apply on every hosting mode: self-hosting the open-source platform is free, but
+ *    using Ever's own model access still spends credits. Runs on the customer's own model keys
+ *    spend nothing, on any plan. {@link ./credit-packs.ts} stays the authority on how many credits
+ *    a pack grants; this table only mirrors its PRICE into Stripe.
+ */
+
+export type CatalogHosting = 'cloud' | 'selfhosted';
+export type CatalogTier = 'free' | 'pro' | 'enterprise';
+export type CatalogInterval = 'monthly' | 'annual' | 'lifetime';
+export type SeatInterval = 'monthly' | 'annual';
+
+export interface CatalogPrice {
+    readonly interval: CatalogInterval;
+    /** Integer minor units (cents) in {@link Catalog.currency}. */
+    readonly amountCents: number;
+}
+
+export interface CatalogPlan {
+    readonly hosting: CatalogHosting;
+    readonly tier: CatalogTier;
+    /** Name as shown on ever.works and on the Stripe invoice line. */
+    readonly tierName: string;
+    /**
+     * Seats (employees OR agents) included before per-seat billing starts.
+     * `null` means unbounded — nothing to meter, so no seat price exists.
+     */
+    readonly seatsIncluded: number | null;
+    /**
+     * Per-additional-seat price in cents per seat per MONTH, or `null` where seats are unbounded.
+     * The annual seat price is exactly 12x this: additional seats carry no annual discount, which
+     * matches Gauzy's flat "$5 per month" wording.
+     */
+    readonly seatCentsPerMonth: number | null;
+    /**
+     * Platform-billed AI credits granted per month, or `null` on the free download (no plan row).
+     * The universal daily grant is {@link Catalog.dailyFreeCredits} and is not expressed per plan.
+     */
+    readonly monthlyCredits: number | null;
+    /** Empty when the tier is a free download with no Stripe object at all. */
+    readonly prices: readonly CatalogPrice[];
+    readonly note?: string;
+}
+
+export interface CatalogCreditPack {
+    /** Joins back to `CREDIT_PACKS` in {@link ./credit-packs.ts}. */
+    readonly packId: string;
+    readonly amountCents: number;
+    readonly credits: number;
+    readonly label: string;
+}
+
+export interface Catalog {
+    readonly version: number;
+    /** Ever Works' key inside the shared, account-wide lookup-key namespace. */
+    readonly product: string;
+    readonly name: string;
+    readonly site: string;
+    /** Every Ever price is USD, regardless of the account's EUR default. */
+    readonly currency: string;
+    readonly dailyFreeCredits: number;
+    readonly plans: readonly CatalogPlan[];
+    readonly creditPacks: readonly CatalogCreditPack[];
+}
+
+export const catalog = catalogJson as unknown as Catalog;
+
+export const CATALOG_PRODUCT_KEY = catalog.product;
+export const CATALOG_CURRENCY = catalog.currency;
+
+export const HOSTINGS: readonly CatalogHosting[] = ['cloud', 'selfhosted'];
+export const TIERS: readonly CatalogTier[] = ['free', 'pro', 'enterprise'];
+export const INTERVALS: readonly CatalogInterval[] = ['monthly', 'annual', 'lifetime'];
+
+/* -------------------------------------------------------------------------- */
+/*  Lookup keys                                                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `ever_works_<hosting>_<tier>_<interval>` — the account-wide plan convention, unchanged, so an
+ * Ever Works plan price resolves by exactly the same rule as a Gauzy or Teams one.
+ */
+export function planLookupKey(
+    hosting: CatalogHosting,
+    tier: CatalogTier,
+    interval: CatalogInterval,
+): string {
+    return `ever_${CATALOG_PRODUCT_KEY}_${hosting}_${tier}_${interval}`;
+}
+
+/**
+ * `ever_works_<hosting>_<tier>_seat_<interval>` — an Ever Works EXTENSION of the shared convention.
+ *
+ * The shared `catalog.json` schema has no seat concept: no other Ever product sells seats through
+ * Stripe yet (Gauzy quotes "$5 per additional employee" but bills it outside Stripe). The `_seat_`
+ * infix keeps these keys unambiguous while remaining inert to the shared 5-part reader, which
+ * simply will not match them. If seats are ever lifted into the shared catalog, standardise here.
+ */
+export function seatLookupKey(
+    hosting: CatalogHosting,
+    tier: CatalogTier,
+    interval: SeatInterval,
+): string {
+    return `ever_${CATALOG_PRODUCT_KEY}_${hosting}_${tier}_seat_${interval}`;
+}
+
+/**
+ * `ever_works_credits_<n>` — one-time credit packs. Deliberately carries no hosting or tier: a pack
+ * is the same purchase for a cloud Pro customer and for a self-hoster.
+ */
+export function creditPackLookupKey(packId: string): string {
+    return `ever_${CATALOG_PRODUCT_KEY}_${packId.replace(/-/g, '_')}`;
+}
+
+/** Stripe product name, e.g. "Ever Works Cloud — Pro". Shown on the invoice. */
+export function planProductName(plan: CatalogPlan): string {
+    const hosting = plan.hosting === 'cloud' ? 'Cloud' : 'Self-Hosted';
+    return `${catalog.name} ${hosting} — ${plan.tierName}`;
+}
+
+/** e.g. "Ever Works Cloud — Pro — Additional Seat". */
+export function seatProductName(plan: CatalogPlan): string {
+    return `${planProductName(plan)} — Additional Seat`;
+}
+
+/** e.g. "Ever Works — 5,500 credits". */
+export function creditPackProductName(pack: CatalogCreditPack): string {
+    return `${catalog.name} — ${pack.label}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Resolution                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export interface ResolvedCatalogSku {
+    readonly plan: CatalogPlan;
+    readonly price: CatalogPrice;
+    readonly lookupKey: string;
+    /** Stripe Checkout mode. A lifetime licence is a one-off purchase; everything else recurs. */
+    readonly mode: 'payment' | 'subscription';
+    /** Per-seat lookup key to add as a second line item, or `null` when there are no meterable seats. */
+    readonly seatLookupKey: string | null;
+}
+
+export function findPlan(hosting: CatalogHosting, tier: CatalogTier): CatalogPlan | undefined {
+    return catalog.plans.find((p) => p.hosting === hosting && p.tier === tier);
+}
+
+/**
+ * Resolve a plan purchase to a concrete SKU, or `null` when the combination does not exist.
+ *
+ * 🛑 Callers must treat `null` as "reject the request", never as "fall back to something". A
+ * fallback here would silently sell the wrong plan.
+ */
+export function resolveCatalogSku(params: {
+    hosting: CatalogHosting;
+    tier: CatalogTier;
+    interval: CatalogInterval;
+}): ResolvedCatalogSku | null {
+    const plan = findPlan(params.hosting, params.tier);
+    if (!plan) return null;
+
+    const price = plan.prices.find((p) => p.interval === params.interval);
+    if (!price) return null;
+
+    const isLifetime = price.interval === 'lifetime';
+    const hasMeterableSeats = plan.seatsIncluded !== null && plan.seatCentsPerMonth !== null;
+
+    return {
+        plan,
+        price,
+        lookupKey: planLookupKey(plan.hosting, plan.tier, price.interval),
+        mode: isLifetime ? 'payment' : 'subscription',
+        // A one-off licence cannot carry a recurring seat line, and an unbounded plan has nothing
+        // to meter. Both collapse to "no seat line item".
+        seatLookupKey:
+            !isLifetime && hasMeterableSeats
+                ? seatLookupKey(
+                      plan.hosting,
+                      plan.tier,
+                      price.interval === 'annual' ? 'annual' : 'monthly',
+                  )
+                : null,
+    };
+}
+
+/**
+ * Billable extra seats for a requested headcount. Never negative, never fractional.
+ *
+ * A plan with unbounded seats always bills zero extras — that is Enterprise "Option 1" (one
+ * organization, unlimited employees and agents).
+ */
+export function billableSeats(plan: CatalogPlan, requestedSeats: number): number {
+    if (plan.seatsIncluded === null) return 0;
+    if (!Number.isFinite(requestedSeats)) return 0;
+    return Math.max(0, Math.floor(requestedSeats) - plan.seatsIncluded);
+}
+
+/** The annual per-seat amount: 12x the monthly rate, with no annual discount. */
+export function seatAmountCents(plan: CatalogPlan, interval: SeatInterval): number | null {
+    if (plan.seatCentsPerMonth === null) return null;
+    return interval === 'annual' ? plan.seatCentsPerMonth * 12 : plan.seatCentsPerMonth;
+}
+
+/**
+ * `subscription_plans.code` → the catalog tier it sells.
+ *
+ * The two vocabularies are deliberately separate. A plan CODE is an identity that is stored on
+ * every `user_subscriptions` row and in Stripe metadata on every subscription ever created, so it
+ * can never be renamed. A catalog TIER is what the price is called in the shared account. `standard`
+ * has always been sold as "Pro" and `premium` as "Enterprise"; this map is where those two facts
+ * meet, instead of the string being parsed out of the code at each call site.
+ *
+ * Returns `null` for a code this catalog does not sell, which callers must treat as "bill from the
+ * plan row instead" — never as a reason to fail a purchase.
+ */
+const TIER_BY_PLAN_CODE: Readonly<Record<string, CatalogTier>> = {
+    free: 'free',
+    standard: 'pro',
+    premium: 'enterprise',
+    selfhosted_community: 'free',
+    selfhosted_pro: 'pro',
+    selfhosted_enterprise: 'enterprise',
+};
+
+export function catalogTierForPlanCode(code: string): CatalogTier | null {
+    return TIER_BY_PLAN_CODE[code] ?? null;
+}
+
+/**
+ * Resolve a stored plan row to its catalog SKU.
+ *
+ * This is the join between the database (which owns quotas, display names and the plan's identity)
+ * and the catalog (which owns what Stripe charges). A row whose code or hosting the catalog does
+ * not recognise returns `null`, and the provider then bills the row's own amount — the pre-catalog
+ * behaviour, preserved so an unsynced deployment keeps working.
+ */
+export function resolveSkuForPlanRow(params: {
+    code: string;
+    hosting: CatalogHosting | string | null | undefined;
+    interval: CatalogInterval;
+}): ResolvedCatalogSku | null {
+    const tier = catalogTierForPlanCode(params.code);
+    if (!tier) return null;
+
+    const hosting = params.hosting === 'selfhosted' ? 'selfhosted' : 'cloud';
+    return resolveCatalogSku({ hosting, tier, interval: params.interval });
+}
+
+/** Every plan/seat/credit lookup_key this catalog defines — used by the sync script and by tests. */
+export function allCatalogLookupKeys(): string[] {
+    const keys: string[] = [];
+    for (const plan of catalog.plans) {
+        for (const price of plan.prices) {
+            keys.push(planLookupKey(plan.hosting, plan.tier, price.interval));
+        }
+        if (plan.seatsIncluded !== null && plan.seatCentsPerMonth !== null) {
+            keys.push(seatLookupKey(plan.hosting, plan.tier, 'monthly'));
+            keys.push(seatLookupKey(plan.hosting, plan.tier, 'annual'));
+        }
+    }
+    for (const pack of catalog.creditPacks) {
+        keys.push(creditPackLookupKey(pack.packId));
+    }
+    return keys;
+}

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -124,16 +124,31 @@ describe('SubscriptionService', () => {
 
             await service.onModuleInit();
 
-            // Three rows: FREE, STANDARD, PREMIUM
-            expect(planRepository.upsert).toHaveBeenCalledTimes(3);
+            // Six rows: three cloud tiers and three self-hosted editions.
+            expect(planRepository.upsert).toHaveBeenCalledTimes(6);
             const codes = planRepository.upsert.mock.calls.map((call) => call[0].code).sort();
             expect(codes).toEqual(
                 [
                     SubscriptionPlanCode.FREE,
                     SubscriptionPlanCode.STANDARD,
                     SubscriptionPlanCode.PREMIUM,
+                    SubscriptionPlanCode.SELFHOSTED_COMMUNITY,
+                    SubscriptionPlanCode.SELFHOSTED_PRO,
+                    SubscriptionPlanCode.SELFHOSTED_ENTERPRISE,
                 ].sort(),
             );
+        });
+
+        it('tags every row with a hosting mode, three cloud and three self-hosted', async () => {
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const rows = planRepository.upsert.mock.calls.map((c) => c[0]);
+            expect(rows.filter((p: any) => p.hosting === 'cloud')).toHaveLength(3);
+            expect(rows.filter((p: any) => p.hosting === 'selfhosted')).toHaveLength(3);
+            // Nothing may seed without a hosting mode — the Stripe lookup_key is derived from it.
+            expect(
+                rows.every((p: any) => p.hosting === 'cloud' || p.hosting === 'selfhosted'),
+            ).toBe(true);
         });
 
         it('forwards the configured default currency on every upsert + sets active=true', async () => {
@@ -161,7 +176,7 @@ describe('SubscriptionService', () => {
             });
         });
 
-        it('STANDARD seed row pins maxWorks=5, monthlyPrice=29 + the 4 allowed cadences', async () => {
+        it('STANDARD seed row is the "Pro" tier: $25/mo, $204/yr, 10 seats at $5 + the 4 allowed cadences', async () => {
             const { service, planRepository } = makeService();
             await service.seedPlans();
             const std = planRepository.upsert.mock.calls
@@ -169,15 +184,25 @@ describe('SubscriptionService', () => {
                 .find((p: any) => p.code === SubscriptionPlanCode.STANDARD);
             expect(std).toMatchObject({
                 code: SubscriptionPlanCode.STANDARD,
-                displayName: 'Standard',
+                // The CODE stays 'standard' — it is stored on every existing subscription. Only the
+                // display name moved to the tier ever.works has always advertised.
+                displayName: 'Pro',
+                hosting: 'cloud',
                 maxWorks: 5,
-                monthlyPrice: '29',
+                // Ever Gauzy / Ever Teams cloud Small Business. annualPrice is the YEARLY charge,
+                // not the "$17/mo" the marketing site displays.
+                monthlyPrice: '25',
+                annualPrice: '204',
+                lifetimePrice: null,
+                seatsIncluded: 10,
+                seatMonthlyPrice: '5',
+                monthlyCredits: 3000,
                 overagePricePerRun: '8',
             });
             expect(std.allowedCadences).toEqual(STANDARD_ALLOWED_CADENCES);
         });
 
-        it('PREMIUM seed row pins maxWorks=15, monthlyPrice=99, overagePricePerRun=0 + ALL cadences', async () => {
+        it('PREMIUM seed row is the "Enterprise" tier: $199/mo, $1,668/yr, 10 seats at $10 + ALL cadences', async () => {
             const { service, planRepository } = makeService();
             await service.seedPlans();
             const premium = planRepository.upsert.mock.calls
@@ -185,9 +210,15 @@ describe('SubscriptionService', () => {
                 .find((p: any) => p.code === SubscriptionPlanCode.PREMIUM);
             expect(premium).toMatchObject({
                 code: SubscriptionPlanCode.PREMIUM,
-                displayName: 'Premium',
+                displayName: 'Enterprise',
+                hosting: 'cloud',
                 maxWorks: 15,
-                monthlyPrice: '99',
+                monthlyPrice: '199',
+                annualPrice: '1668',
+                lifetimePrice: null,
+                seatsIncluded: 10,
+                seatMonthlyPrice: '10',
+                monthlyCredits: 25000,
                 overagePricePerRun: '0',
             });
             // Premium has the same cadence set as the FREE "everything-allowed
@@ -195,6 +226,54 @@ describe('SubscriptionService', () => {
             // confirm it contains exactly the seven values without ordering.
             expect(new Set(premium.allowedCadences)).toEqual(new Set(ALL_CADENCES_IN_PUBLIC_ORDER));
             expect(premium.allowedCadences).toHaveLength(7);
+        });
+
+        it('SELFHOSTED_PRO seed row carries the one-time licence: $49/mo, $408/yr, $99 lifetime', async () => {
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const pro = planRepository.upsert.mock.calls
+                .map((c) => c[0])
+                .find((p: any) => p.code === SubscriptionPlanCode.SELFHOSTED_PRO);
+            expect(pro).toMatchObject({
+                displayName: 'Pro Edition',
+                hosting: 'selfhosted',
+                monthlyPrice: '49',
+                annualPrice: '408',
+                // The ONLY row sold as a perpetual commercial licence. Anything with a
+                // lifetimePrice is bought in Stripe `mode: payment`, never `subscription`.
+                lifetimePrice: '99',
+                seatsIncluded: 10,
+                seatMonthlyPrice: '5',
+                monthlyCredits: 3000,
+            });
+        });
+
+        it('SELFHOSTED_COMMUNITY is the free AGPLv3 download: unbounded seats, nothing to sell', async () => {
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const community = planRepository.upsert.mock.calls
+                .map((c) => c[0])
+                .find((p: any) => p.code === SubscriptionPlanCode.SELFHOSTED_COMMUNITY);
+            expect(community).toMatchObject({
+                displayName: 'Community Edition',
+                hosting: 'selfhosted',
+                monthlyPrice: '0',
+                annualPrice: '0',
+                lifetimePrice: null,
+                // null means UNBOUNDED — it must never be read as "zero seats included".
+                seatsIncluded: null,
+                seatMonthlyPrice: null,
+            });
+        });
+
+        it('only the self-hosted Pro Edition is sold as a one-time licence', async () => {
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const withLifetime = planRepository.upsert.mock.calls
+                .map((c) => c[0])
+                .filter((p: any) => p.lifetimePrice !== null && p.lifetimePrice !== undefined)
+                .map((p: any) => p.code);
+            expect(withLifetime).toEqual([SubscriptionPlanCode.SELFHOSTED_PRO]);
         });
 
         it('all seeds run in parallel via Promise.all (no per-row sequencing)', async () => {
@@ -205,11 +284,11 @@ describe('SubscriptionService', () => {
                     .fn()
                     .mockResolvedValueOnce(undefined)
                     .mockRejectedValueOnce(new Error('db down'))
-                    .mockResolvedValueOnce(undefined),
+                    .mockResolvedValue(undefined),
             });
 
             await expect(service.onModuleInit()).rejects.toThrow('db down');
-            expect(planRepository.upsert).toHaveBeenCalledTimes(3);
+            expect(planRepository.upsert).toHaveBeenCalledTimes(6);
         });
     });
 

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -14,6 +14,7 @@ import { WorkScheduleAllowedCadence } from '@src/dto';
 import { User } from '@src/entities/user.entity';
 import { UserRepository } from '@src/database/repositories/user.repository';
 import { WorkScheduleBillingMode, WorkScheduleCadence, SubscriptionPlanCode } from '@src/entities';
+import type { SubscriptionPlanHosting } from '@src/entities/types';
 
 const ALL_CADENCES: WorkScheduleCadence[] = [
     WorkScheduleCadence.MONTHLY,
@@ -25,50 +26,147 @@ const ALL_CADENCES: WorkScheduleCadence[] = [
     WorkScheduleCadence.HOURLY,
 ];
 
+const PAID_CADENCES: WorkScheduleCadence[] = [
+    WorkScheduleCadence.MONTHLY,
+    WorkScheduleCadence.WEEKLY,
+    WorkScheduleCadence.DAILY,
+    WorkScheduleCadence.EVERY_12_HOURS,
+];
+
+/**
+ * The plan catalog, upserted on `code` at boot by {@link SubscriptionService.seedPlans}.
+ *
+ * Prices were aligned with Ever Gauzy / Ever Teams on 2026-08-22 (owner directive) so the whole
+ * Ever line reads consistently, and the shared Stripe account
+ * (`acct_1IDnd6DdBrwbGEir`) now carries a matching price for every row — see
+ * {@link ./billing/stripe-catalog.json}. `monthlyPrice` / `annualPrice` / `lifetimePrice` here are
+ * MAJOR units (dollars) because the column is `decimal(10,2)`; the catalog holds the same numbers
+ * in cents. They must agree, and `stripe-catalog.spec.ts` asserts that they do.
+ *
+ * 🛑 `code` values are load-bearing and unchanged — they are stored in `user_subscriptions.planCode`
+ * and in Stripe metadata on every subscription ever created. What changed is `displayName`:
+ * `standard` is now shown as "Pro" and `premium` as "Enterprise", matching what ever.works has
+ * always advertised. The DB seed had drifted from the marketing site; this closes that gap.
+ *
+ * A "seat" is an employee OR an agent — interchangeable, which is the point of the product.
+ * `seatsIncluded: null` means UNBOUNDED and suppresses per-seat billing entirely.
+ *
+ * On the SELF-HOSTED rows, what is being sold is a commercial licence that lifts the buyer's
+ * AGPLv3 obligations. Quota fields there are advisory: a self-hoster owns the database and the
+ * platform cannot meaningfully enforce them. They are seeded so the plan switcher and the licence
+ * paperwork describe the same thing.
+ */
 const PLAN_SEED_DATA: Array<{
     code: SubscriptionPlanCode;
     displayName: string;
+    hosting: SubscriptionPlanHosting;
     maxWorks: number;
     allowedCadences: WorkScheduleCadence[];
     monthlyPrice: string;
+    annualPrice: string;
+    lifetimePrice: string | null;
+    seatsIncluded: number | null;
+    seatMonthlyPrice: string | null;
+    monthlyCredits: number;
     overagePricePerRun: string;
 }> = [
+    /* ------------------------------------------------------------------ cloud */
     {
         code: SubscriptionPlanCode.FREE,
         displayName: 'Free',
+        hosting: 'cloud',
         maxWorks: 1,
         // allowedCadences: [WorkScheduleCadence.MONTHLY],
         allowedCadences: ALL_CADENCES, // for now everything is free
         monthlyPrice: '0',
+        annualPrice: '0',
+        lifetimePrice: null,
+        // One seat, and no per-seat price: upgrading is how you get more, not a top-up.
+        seatsIncluded: 1,
+        seatMonthlyPrice: null,
+        // Free accounts live on the universal 50-credits-a-day grant, not a monthly allowance.
+        monthlyCredits: 0,
         overagePricePerRun: '10',
     },
     {
         code: SubscriptionPlanCode.STANDARD,
-        displayName: 'Standard',
+        displayName: 'Pro',
+        hosting: 'cloud',
         maxWorks: 5,
-        allowedCadences: [
-            WorkScheduleCadence.MONTHLY,
-            WorkScheduleCadence.WEEKLY,
-            WorkScheduleCadence.DAILY,
-            WorkScheduleCadence.EVERY_12_HOURS,
-        ],
-        monthlyPrice: '29',
+        allowedCadences: PAID_CADENCES,
+        // Ever Gauzy / Ever Teams cloud Small Business: $25/mo, $204/yr (displays "$17/mo").
+        monthlyPrice: '25',
+        annualPrice: '204',
+        lifetimePrice: null,
+        seatsIncluded: 10,
+        seatMonthlyPrice: '5',
+        monthlyCredits: 3000,
         overagePricePerRun: '8',
     },
     {
         code: SubscriptionPlanCode.PREMIUM,
-        displayName: 'Premium',
+        displayName: 'Enterprise',
+        hosting: 'cloud',
         maxWorks: 15,
-        allowedCadences: [
-            WorkScheduleCadence.MONTHLY,
-            WorkScheduleCadence.WEEKLY,
-            WorkScheduleCadence.DAILY,
-            WorkScheduleCadence.EVERY_12_HOURS,
-            WorkScheduleCadence.EVERY_8_HOURS,
-            WorkScheduleCadence.EVERY_3_HOURS,
-            WorkScheduleCadence.HOURLY,
-        ],
-        monthlyPrice: '99',
+        allowedCadences: ALL_CADENCES,
+        // Ever Gauzy / Ever Teams Enterprise: $199/mo, $1,668/yr (displays "$139/mo").
+        monthlyPrice: '199',
+        annualPrice: '1668',
+        lifetimePrice: null,
+        // Option 2 (unlimited organizations, 10 seats each) is the metered default. Option 1 (one
+        // organization, unlimited seats) is the same plan with seat metering switched off on the
+        // subscription rather than a separate row.
+        seatsIncluded: 10,
+        seatMonthlyPrice: '10',
+        monthlyCredits: 25000,
+        overagePricePerRun: '0',
+    },
+
+    /* ------------------------------------------------------------- self-hosted */
+    {
+        code: SubscriptionPlanCode.SELFHOSTED_COMMUNITY,
+        displayName: 'Community Edition',
+        hosting: 'selfhosted',
+        // Free AGPLv3 download with no limits, mirroring Gauzy's Community Edition. Never bought,
+        // so it has no Stripe object at all.
+        maxWorks: Number.MAX_SAFE_INTEGER,
+        allowedCadences: ALL_CADENCES,
+        monthlyPrice: '0',
+        annualPrice: '0',
+        lifetimePrice: null,
+        seatsIncluded: null, // unbounded
+        seatMonthlyPrice: null,
+        monthlyCredits: 0,
+        overagePricePerRun: '0',
+    },
+    {
+        code: SubscriptionPlanCode.SELFHOSTED_PRO,
+        displayName: 'Pro Edition',
+        hosting: 'selfhosted',
+        maxWorks: 5,
+        allowedCadences: PAID_CADENCES,
+        // Ever Gauzy self-hosted Small Business Edition: $49/mo, $408/yr (displays "$34/mo"),
+        // or a $99 one-time perpetual commercial licence.
+        monthlyPrice: '49',
+        annualPrice: '408',
+        lifetimePrice: '99',
+        seatsIncluded: 10,
+        seatMonthlyPrice: '5',
+        monthlyCredits: 3000,
+        overagePricePerRun: '8',
+    },
+    {
+        code: SubscriptionPlanCode.SELFHOSTED_ENTERPRISE,
+        displayName: 'Enterprise Edition',
+        hosting: 'selfhosted',
+        maxWorks: 15,
+        allowedCadences: ALL_CADENCES,
+        monthlyPrice: '199',
+        annualPrice: '1668',
+        lifetimePrice: null,
+        seatsIncluded: 10,
+        seatMonthlyPrice: '10',
+        monthlyCredits: 25000,
         overagePricePerRun: '0',
     },
 ];

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -180,6 +180,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'defaultAutoRechargePack',
                     'StripeBillingProvider',
                     'STRIPE_METADATA_KEYS',
+                    'STRIPE_PERPETUAL_LICENCE',
                     'STRIPE_PURCHASE_KINDS',
                     'STRIPE_CLIENT_FACTORY',
                     'BillingService',
@@ -339,6 +340,12 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                 // Audit B24 — mirrored onto subscription_data.metadata so
                 // renewals/cancels stay attributable to a tier.
                 planCode: 'ever_works_plan_code',
+                // Stamped ONLY on a one-off perpetual licence, on both the session and the payment
+                // intent. Issuing the licence document is manual for now, so this is what makes a
+                // sale findable: /v1/payment_intents/search with DOUBLE-quoted syntax. There is no
+                // /v1/checkout/sessions/search endpoint, which is why the session alone is not
+                // enough to carry it.
+                licence: 'ever_works_licence',
             });
         });
 

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -8,6 +8,12 @@
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
+        // Required by `subscriptions/billing/stripe-catalog.ts`, which imports the pricing catalog
+        // as data. The catalog is JSON rather than TypeScript so that
+        // `scripts/stripe-sync-catalog.mjs` — plain node, no build step — reads the exact same
+        // bytes the running app does; a second hand-maintained copy would drift, and the thing it
+        // would drift on is prices.
+        "resolveJsonModule": true,
         "target": "ES2021",
         "sourceMap": true,
         "outDir": "./dist",

--- a/scripts/stripe-sync-catalog.mjs
+++ b/scripts/stripe-sync-catalog.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+/**
+ * Apply packages/agent/src/subscriptions/billing/stripe-catalog.data.json to Stripe, idempotently.
+ *
+ *   node scripts/stripe-sync-catalog.mjs --dry-run     # show the plan, touch nothing
+ *   node scripts/stripe-sync-catalog.mjs               # apply
+ *   node scripts/stripe-sync-catalog.mjs --verify      # report drift only, exit 1 if any
+ *
+ * Reads STRIPE_SECRET_KEY from the environment. The key decides which mode is written: an
+ * `sk_test_…` key syncs test mode, an `sk_live_…` key syncs live. There is no --live flag on
+ * purpose — you cannot reach live by forgetting an argument.
+ *
+ * This is the Ever Works twin of ever-co/ever-website's scripts/stripe-sync-catalog.mjs, and it
+ * writes into the SAME shared Stripe account. It differs in three ways, all additive:
+ *   1. it syncs ONE product family (Ever Works) rather than a list of them;
+ *   2. it also emits per-additional-seat prices (`…_seat_monthly` / `…_seat_annual`);
+ *   3. it also emits one-time credit-pack prices (`ever_works_credits_<n>`).
+ *
+ * ## Idempotency
+ * Products are matched on metadata `ever_sku` (a stable per-SKU id); prices on `lookup_key`.
+ * Re-running with an unchanged catalog makes zero writes.
+ *
+ * ## Prices are immutable in Stripe
+ * If a catalog amount changes, the existing price cannot be edited. The script creates a new price,
+ * moves the lookup_key onto it (`transfer_lookup_key`), then archives the old one. Existing
+ * subscriptions stay on the price they were created with — that is Stripe's behaviour, and it is
+ * what you want: nobody's bill changes silently.
+ *
+ * 🛑 The script never deletes anything, and never archives a product. It also never touches an
+ * object belonging to another Ever product: every write is gated on the `ever_works_` lookup-key
+ * prefix and the `ever_product=works` metadata.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CATALOG_PATH = join(
+	HERE,
+	'..',
+	'packages',
+	'agent',
+	'src',
+	'subscriptions',
+	'billing',
+	'stripe-catalog.data.json'
+);
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const VERIFY = process.argv.includes('--verify');
+const API = 'https://api.stripe.com/v1';
+
+const KEY = process.env.STRIPE_SECRET_KEY;
+if (!KEY) {
+	console.error('STRIPE_SECRET_KEY is not set. Refusing to run.');
+	process.exit(1);
+}
+const MODE = KEY.startsWith('sk_live_') ? 'LIVE' : KEY.startsWith('sk_test_') ? 'TEST' : 'UNKNOWN';
+if (MODE === 'UNKNOWN') {
+	console.error('STRIPE_SECRET_KEY is neither sk_test_ nor sk_live_. Refusing to run.');
+	process.exit(1);
+}
+
+/* ------------------------------------------------------------------ Stripe */
+
+/** Stripe wants application/x-www-form-urlencoded with bracketed nesting. */
+function encodeForm(obj, prefix = '', out = []) {
+	for (const [k, v] of Object.entries(obj)) {
+		if (v === undefined || v === null) continue;
+		const key = prefix ? `${prefix}[${k}]` : k;
+		if (typeof v === 'object' && !Array.isArray(v)) encodeForm(v, key, out);
+		else out.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(v))}`);
+	}
+	return out;
+}
+
+async function stripe(method, path, body) {
+	const res = await fetch(`${API}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${KEY}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+			// Kept in step with the account-wide sync script so both see the same API shape.
+			'Stripe-Version': '2025-02-24.acacia'
+		},
+		body: body ? encodeForm(body).join('&') : undefined
+	});
+	const json = await res.json();
+	if (!res.ok) {
+		throw new Error(`Stripe ${method} ${path} -> ${res.status}: ${json?.error?.message ?? 'unknown error'}`);
+	}
+	return json;
+}
+
+/** Walk a list endpoint to completion. */
+async function listAll(path) {
+	const items = [];
+	let startingAfter;
+	for (;;) {
+		const qs = new URLSearchParams({ limit: '100' });
+		if (startingAfter) qs.set('starting_after', startingAfter);
+		const page = await stripe('GET', `${path}${path.includes('?') ? '&' : '?'}${qs}`);
+		items.push(...page.data);
+		if (!page.has_more || page.data.length === 0) return items;
+		startingAfter = page.data[page.data.length - 1].id;
+	}
+}
+
+/* ----------------------------------------------------------------- catalog */
+
+const catalog = JSON.parse(readFileSync(CATALOG_PATH, 'utf8'));
+const PRODUCT = catalog.product;
+const CURRENCY = catalog.currency;
+
+/** Guard: everything this script writes must start with this. */
+const KEY_PREFIX = `ever_${PRODUCT}_`;
+
+const planSkuId = (plan) => `ever_${PRODUCT}_${plan.hosting}_${plan.tier}`;
+const seatSkuId = (plan) => `ever_${PRODUCT}_${plan.hosting}_${plan.tier}_seat`;
+const creditSkuId = (pack) => `ever_${PRODUCT}_${pack.packId.replace(/-/g, '_')}`;
+
+const planLookupKey = (plan, interval) => `ever_${PRODUCT}_${plan.hosting}_${plan.tier}_${interval}`;
+const seatLookupKey = (plan, interval) => `ever_${PRODUCT}_${plan.hosting}_${plan.tier}_seat_${interval}`;
+const creditLookupKey = (pack) => `ever_${PRODUCT}_${pack.packId.replace(/-/g, '_')}`;
+
+const hostingLabel = (h) => (h === 'cloud' ? 'Cloud' : 'Self-Hosted');
+const planProductName = (plan) => `${catalog.name} ${hostingLabel(plan.hosting)} — ${plan.tierName}`;
+const seatProductName = (plan) => `${planProductName(plan)} — Additional Seat`;
+const creditProductName = (pack) => `${catalog.name} — ${pack.label}`;
+
+/** Catalog interval -> the Stripe recurrence it produces. `null` = one-off. */
+function recurringInterval(interval) {
+	if (interval === 'lifetime') return null;
+	return interval === 'annual' ? 'year' : 'month';
+}
+
+function priceShape(interval) {
+	const r = recurringInterval(interval);
+	return r ? { recurring: { interval: r } } : {};
+}
+
+/** True when an existing Stripe price still matches what the catalog wants. */
+function priceMatches(existing, amountCents, interval) {
+	if (existing.unit_amount !== amountCents) return false;
+	if (existing.currency !== CURRENCY) return false;
+	return (existing.recurring?.interval ?? null) === recurringInterval(interval);
+}
+
+/**
+ * Flatten the catalog into the full list of (product, price) intents.
+ * Doing this up front means the sync loop, the dry run and --verify all read the same list.
+ */
+function buildIntents() {
+	const intents = [];
+
+	for (const plan of catalog.plans) {
+		const baseMeta = {
+			ever_product: PRODUCT,
+			ever_hosting: plan.hosting,
+			ever_tier: plan.tier,
+			ever_site: catalog.site
+		};
+
+		// --- the plan itself. An empty `prices` array is a free download: no Stripe object at all.
+		if (plan.prices.length > 0) {
+			const sku = planSkuId(plan);
+			for (const price of plan.prices) {
+				intents.push({
+					kind: 'plan',
+					sku,
+					productName: planProductName(plan),
+					productMeta: { ...baseMeta, ever_sku: sku },
+					lookupKey: planLookupKey(plan, price.interval),
+					amountCents: price.amountCents,
+					interval: price.interval,
+					priceMeta: { ...baseMeta, ever_sku: sku, ever_interval: price.interval }
+				});
+			}
+		}
+
+		// --- the per-additional-seat add-on. Skipped where seats are unbounded.
+		if (plan.seatsIncluded !== null && plan.seatCentsPerMonth !== null) {
+			const sku = seatSkuId(plan);
+			for (const interval of ['monthly', 'annual']) {
+				// Additional seats carry NO annual discount: the annual rate is exactly 12x the monthly
+				// one, matching Gauzy's flat "$5 per month" wording.
+				const amountCents = interval === 'annual' ? plan.seatCentsPerMonth * 12 : plan.seatCentsPerMonth;
+				intents.push({
+					kind: 'seat',
+					sku,
+					productName: seatProductName(plan),
+					productMeta: { ...baseMeta, ever_sku: sku, ever_unit: 'seat' },
+					lookupKey: seatLookupKey(plan, interval),
+					amountCents,
+					interval,
+					priceMeta: {
+						...baseMeta,
+						ever_sku: sku,
+						ever_unit: 'seat',
+						ever_interval: interval,
+						ever_seats_included: String(plan.seatsIncluded)
+					}
+				});
+			}
+		}
+	}
+
+	// --- one-time credit packs. Hosting- and tier-agnostic by design.
+	for (const pack of catalog.creditPacks) {
+		const sku = creditSkuId(pack);
+		intents.push({
+			kind: 'credits',
+			sku,
+			productName: creditProductName(pack),
+			productMeta: {
+				ever_product: PRODUCT,
+				ever_sku: sku,
+				ever_site: catalog.site,
+				ever_unit: 'credits',
+				ever_pack_id: pack.packId,
+				ever_credits: String(pack.credits)
+			},
+			lookupKey: creditLookupKey(pack),
+			amountCents: pack.amountCents,
+			interval: 'lifetime', // one-off
+			priceMeta: {
+				ever_product: PRODUCT,
+				ever_sku: sku,
+				ever_unit: 'credits',
+				ever_pack_id: pack.packId,
+				ever_credits: String(pack.credits)
+			}
+		});
+	}
+
+	return intents;
+}
+
+/* -------------------------------------------------------------------- sync */
+
+const changes = [];
+const note = (verb, what, detail) => {
+	changes.push({ verb, what, detail });
+	console.log(`  ${DRY_RUN ? '[dry-run] ' : ''}${verb.padEnd(7)} ${what}${detail ? '  ' + detail : ''}`);
+};
+
+async function main() {
+	const intents = buildIntents();
+
+	console.log(`\nEver Works Stripe catalog sync — mode ${MODE}${DRY_RUN ? ' (dry run)' : VERIFY ? ' (verify)' : ''}`);
+	console.log(`Catalog v${catalog.version}, product "${PRODUCT}", currency ${CURRENCY}`);
+	console.log(`${intents.length} price intents across ${new Set(intents.map((i) => i.sku)).size} products\n`);
+
+	// Belt and braces: this script must never write outside the Ever Works namespace.
+	const stray = intents.filter((i) => !i.lookupKey.startsWith(KEY_PREFIX));
+	if (stray.length) {
+		throw new Error(`Refusing to run: ${stray.length} intent(s) outside the "${KEY_PREFIX}" namespace`);
+	}
+
+	if (MODE === 'LIVE' && !DRY_RUN && !VERIFY) {
+		console.log('🛑 Writing to LIVE mode.');
+		console.log('   Confirm first that the legacy Chargebee webhook subscribed to * is disabled,');
+		console.log('   or every price created here is delivered into Chargebee.');
+		console.log('   Ctrl-C within 10s to abort.\n');
+		await new Promise((r) => setTimeout(r, 10_000));
+	}
+
+	const existingProducts = await listAll('/products?active=true');
+	const existingPrices = await listAll('/prices?active=true');
+
+	const productBySku = new Map();
+	for (const p of existingProducts) {
+		if (p.metadata?.ever_sku) productBySku.set(p.metadata.ever_sku, p);
+	}
+	const priceByLookup = new Map();
+	for (const p of existingPrices) {
+		if (p.lookup_key) priceByLookup.set(p.lookup_key, p);
+	}
+
+	const drift = [];
+
+	for (const intent of intents) {
+		// ---------------------------------------------------------------- product
+		let product = productBySku.get(intent.sku);
+		if (!product) {
+			if (VERIFY) {
+				drift.push(`missing product ${intent.sku} (${intent.productName})`);
+			} else {
+				note('create', `product ${intent.productName}`);
+				if (DRY_RUN) {
+					// Record a placeholder so the next price intent for this same product does not report a
+					// second "create". Without it the dry run over-counts every multi-price product and the
+					// change total stops matching what a real run would do.
+					product = { id: `dry_run_${intent.sku}`, name: intent.productName, metadata: intent.productMeta };
+					productBySku.set(intent.sku, product);
+				} else {
+					product = await stripe('POST', '/products', {
+						name: intent.productName,
+						metadata: intent.productMeta
+					});
+					productBySku.set(intent.sku, product);
+				}
+			}
+		} else if (product.name !== intent.productName) {
+			if (VERIFY) {
+				drift.push(`product ${intent.sku} named "${product.name}", catalog says "${intent.productName}"`);
+			} else {
+				note('rename', `product ${product.name}`, `-> ${intent.productName}`);
+				if (!DRY_RUN) {
+					await stripe('POST', `/products/${product.id}`, {
+						name: intent.productName,
+						metadata: intent.productMeta
+					});
+				}
+			}
+		}
+
+		// ------------------------------------------------------------------ price
+		const existing = priceByLookup.get(intent.lookupKey);
+
+		if (existing && priceMatches(existing, intent.amountCents, intent.interval)) continue; // correct
+
+		if (VERIFY) {
+			drift.push(
+				existing
+					? `price ${intent.lookupKey} is ${existing.unit_amount} ${existing.currency}` +
+							`/${existing.recurring?.interval ?? 'one-time'}, catalog says ${intent.amountCents} ` +
+							`${CURRENCY}/${recurringInterval(intent.interval) ?? 'one-time'}`
+					: `missing price ${intent.lookupKey} (${intent.amountCents} ${CURRENCY} ${intent.interval})`
+			);
+			continue;
+		}
+
+		if (existing) {
+			// Immutable: supersede rather than edit.
+			note('replace', `price ${intent.lookupKey}`, `${existing.unit_amount} -> ${intent.amountCents}`);
+			if (!DRY_RUN) {
+				const created = await stripe('POST', '/prices', {
+					product: product.id,
+					currency: CURRENCY,
+					unit_amount: intent.amountCents,
+					lookup_key: intent.lookupKey,
+					transfer_lookup_key: 'true',
+					metadata: intent.priceMeta,
+					...priceShape(intent.interval)
+				});
+				await stripe('POST', `/prices/${existing.id}`, { active: 'false' });
+				priceByLookup.set(intent.lookupKey, created);
+			}
+			continue;
+		}
+
+		note(
+			'create',
+			`price ${intent.lookupKey}`,
+			`${intent.amountCents} ${CURRENCY} ${recurringInterval(intent.interval) ?? 'one-time'}`
+		);
+		if (!DRY_RUN) {
+			const created = await stripe('POST', '/prices', {
+				product: product.id,
+				currency: CURRENCY,
+				unit_amount: intent.amountCents,
+				lookup_key: intent.lookupKey,
+				metadata: intent.priceMeta,
+				...priceShape(intent.interval)
+			});
+			priceByLookup.set(intent.lookupKey, created);
+		}
+	}
+
+	if (VERIFY) {
+		if (drift.length === 0) {
+			console.log(`Stripe matches the catalog — ${intents.length} price(s) verified, 0 drift.\n`);
+			return;
+		}
+		console.error(`\n${drift.length} drift item(s):`);
+		for (const d of drift) console.error(`  - ${d}`);
+		console.error('');
+		process.exit(1);
+	}
+
+	console.log(
+		`\n${
+			changes.length === 0
+				? 'Already in sync — no changes.'
+				: `${changes.length} change(s)${DRY_RUN ? ' would be applied.' : ' applied.'}`
+		}\n`
+	);
+}
+
+main().catch((err) => {
+	console.error(`\n${err.message}\n`);
+	process.exit(1);
+});


### PR DESCRIPTION
Normal `develop → stage` cascade. The only content this carries is the billing work merged in #2160 — `develop`, `stage` and `main` were verified content-identical beforehand (identical tree hash `9c0a0877`), so nothing else rides along.

Cascaded on local evidence at the owner's direction: the self-hosted ARC fleet is jammed (26 `ever-works` runner pods Pending on `Insufficient memory`, no movement in ~2h), so PR CI never executed.

**Verification actually performed:**
- `@ever-works/agent`: 527/527 suites, 9,404 tests, 0 failed
- TSC 0 issues; `prettier --check` clean on every changed file (a control run on untouched files in the same package confirmed the baseline was clean)
- `apps/api`: billing 4/4 suites, 70 tests; `tsc --noEmit` 16 errors with the branch and 16 with it stashed — identical, none in a touched file
- Migration exercised against a throwaway **Postgres 16**: pre-existing row survived untouched and correctly defaulted; `down()` kept all 11 original columns and all 6 rows; re-run is a no-op. This matters because dev and stage `synchronize` from entities and never execute migration files — prod is the only environment that runs them (`migrationsRun = runMigrations() && !autoMigrate()`, and prod is the one with `AUTOMIGRATE=false`)
- End-to-end against real Stripe: seat and interval totals correct to the cent, licence sells in `payment` mode with no subscription, negative + positive controls both behaved

🤖 Generated with [Claude Code](https://claude.com/claude-code)