### PR TITLE
fix(claude-code): isolate HOME so a prompt-injected agent cannot read ~/.aws or ~/.ssh

### DIFF
--- a/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
+++ b/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
@@ -105,6 +105,40 @@ describe('buildSubprocessEnv (C-10)', () => {
 		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('subscription-token');
 	});
 
+	it('isolates HOME and USERPROFILE when a config dir is pinned', () => {
+		// The CLI runs with --dangerously-skip-permissions over scraped web content,
+		// so a hostile prompt must not be able to walk `~` into ~/.aws or ~/.ssh.
+		process.env.HOME = '/home/appuser';
+		process.env.USERPROFILE = 'C:\\Users\\appuser';
+		process.env.TMPDIR = '/tmp/isolated';
+
+		const env = buildSubprocessEnv({ CLAUDE_CONFIG_DIR: '/tmp/cc-run-1' });
+
+		expect(env.HOME).toBe('/tmp/isolated');
+		expect(env.USERPROFILE).toBe('/tmp/isolated');
+		expect(env.HOME).not.toBe('/home/appuser');
+	});
+
+	it('keeps the real HOME when no config dir is pinned, so auth probes still resolve ~/.claude', () => {
+		process.env.HOME = '/home/appuser';
+		process.env.USERPROFILE = 'C:\\Users\\appuser';
+		process.env.TMPDIR = '/tmp/isolated';
+
+		const env = buildSubprocessEnv();
+
+		expect(env.HOME).toBe('/home/appuser');
+		expect(env.USERPROFILE).toBe('C:\\Users\\appuser');
+	});
+
+	it('treats an empty CLAUDE_CONFIG_DIR as not pinned rather than isolating on a blank path', () => {
+		process.env.HOME = '/home/appuser';
+		process.env.TMPDIR = '/tmp/isolated';
+
+		const env = buildSubprocessEnv({ CLAUDE_CONFIG_DIR: '' });
+
+		expect(env.HOME).toBe('/home/appuser');
+	});
+
 	it('drops arbitrary ANTHROPIC_*/CLAUDE_CODE_*-prefixed vars not on the allow-list', () => {
 		// Regression guard: the env was previously built by matching any key that
 		// merely STARTED WITH `ANTHROPIC_` or `CLAUDE_CODE_`, which silently

--- a/packages/plugins/claude-code/src/utils/subprocess-env.ts
+++ b/packages/plugins/claude-code/src/utils/subprocess-env.ts
@@ -100,18 +100,46 @@ export function buildSubprocessEnv(
 	overrides: Record<string, string> = {},
 	options: BuildSubprocessEnvOptions = {}
 ): Record<string, string> {
+	const tmpdir = process.env.TMPDIR ?? os.tmpdir();
+
+	// Security: when the caller pins an explicit `CLAUDE_CONFIG_DIR` — which every
+	// prompt-injectable run does — point the home directory at the isolated tmpdir
+	// instead of the server user's real home. Claude Code resolves its settings,
+	// session state and credentials from `CLAUDE_CONFIG_DIR`, and this runner
+	// supplies the credential through the environment besides, so a legitimate run
+	// loses nothing. What it does lose is the ability of a hostile work prompt to
+	// walk `~` and exfiltrate `~/.aws`, `~/.ssh`, `~/.npmrc`, `~/.kube` — the CLI
+	// runs with `--dangerously-skip-permissions` on scraped web content and
+	// community-PR text, so that is not a hypothetical.
+	//
+	// Mirrors the codex plugin's `CODEX_HOME` handling, with one addition: on
+	// Windows `~` resolves from `USERPROFILE`, not `HOME`, so repointing only
+	// `HOME` would leave the hardening a no-op there.
+	//
+	// Runs without a pinned config dir (e.g. an auth probe) keep the real home so
+	// the CLI's `~/.claude` fallback still resolves and auth detection is unchanged.
+	const isolateHome = typeof overrides.CLAUDE_CONFIG_DIR === 'string' && overrides.CLAUDE_CONFIG_DIR !== '';
+	const home = isolateHome ? tmpdir : (process.env.HOME ?? os.homedir());
+
 	const env: Record<string, string> = {
 		PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
-		HOME: process.env.HOME ?? os.homedir(),
-		TMPDIR: process.env.TMPDIR ?? os.tmpdir()
+		HOME: home,
+		TMPDIR: tmpdir
 	};
 
 	// `USERPROFILE` is the Windows equivalent of `HOME`; some Anthropic SDK
 	// versions look it up. Forward when present so the runner works on
 	// Windows dev boxes without leaking other host vars.
-	if (process.env.USERPROFILE) {
+	if (isolateHome) {
+		env.USERPROFILE = tmpdir;
+	} else if (process.env.USERPROFILE) {
 		env.USERPROFILE = process.env.USERPROFILE;
 	}
+	// `APPDATA` / `LOCALAPPDATA` stay pointed at the real profile even when the
+	// home is isolated: Node and the package managers the agent shells out to read
+	// their own machine config from there, and breaking that would fail runs rather
+	// than harden them. They are a known residual on Windows — `%APPDATA%\npm` can
+	// hold an npm token — but the deployed runner is Linux, where these are unset.
 	if (process.env.APPDATA) {
 		env.APPDATA = process.env.APPDATA;
 	}


### PR DESCRIPTION
## The gap

The **codex** plugin repoints `HOME` at an isolated tmpdir whenever `CODEX_HOME` is pinned, with an in-code rationale about a hostile work prompt exfiltrating the server user's home. The same argument applies to **claude-code**, and it wasn't doing it.

claude-code runs the CLI with `--dangerously-skip-permissions` over user prompts, scraped web content and community-PR text — with `HOME` still pointed at the real home. A prompt-injected run could walk `~` into `~/.aws`, `~/.ssh`, `~/.npmrc`, `~/.kube`.

This is the same class of finding as **audit C-10**, which this file already exists to fix. C-10 stopped the secrets arriving *in the environment*; it left the ones sitting *on disk under `~`* reachable.

I found this while shipping #2146 and deliberately did **not** bundle it there — changing `HOME` is a behaviour change and had no place inside a credential-billing fix.

## The change

Isolates `HOME` **and `USERPROFILE`** whenever the caller pins `CLAUDE_CONFIG_DIR`.

Repointing only `HOME` — the literal codex pattern — would be a **no-op on Windows**, where `~` resolves from `USERPROFILE`. That's the one place this deliberately improves on the pattern it mirrors.

## Why auth is unaffected

Claude Code reads its settings, session state and credentials from `CLAUDE_CONFIG_DIR`, and this runner supplies the credential through the environment besides. Both real run paths (generation and code-edit) pin a config dir — which #2146 made actually true, since the previous `CLAUDE_CODE_CONFIG_DIR` was not a real variable — so every prompt-injectable run is covered.

A run *without* a pinned config dir (an auth probe) keeps the real home, so the CLI's `~/.claude` fallback still resolves and auth detection is unchanged.

## Deliberate residual

`APPDATA` / `LOCALAPPDATA` keep pointing at the real profile: Node and the package managers the agent shells out to read their machine config from there, and breaking that would fail runs rather than harden them. Documented in-code as a Windows-only residual (`%APPDATA%\npm` can hold a token). The deployed runner is Linux, where both are unset.

## Verification

```
packages/plugins/claude-code   78 tests pass (75 + 3 new), tsc clean, prettier clean
```

New tests: isolation applied when a config dir is pinned; real `HOME` preserved when it isn't (so auth probes still work); and an empty `CLAUDE_CONFIG_DIR` treated as not-pinned rather than isolating onto a blank path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)