### PR TITLE
fix(ci): self-hosted Trigger worker ships no pipeline plugins — build packages/plugins/* before prepare:plugins

### DIFF
--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -129,6 +129,21 @@ jobs:
         # runner for 48min+). The CLI compiles the tasks package itself from source.
         run: pnpm turbo run build --filter=@ever-works/trigger-tasks^... --concurrency=1
 
+      - name: Build the plugins shipped inside the worker bundle
+        if: steps.env.outputs.skip != 'true'
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        # `prepare:plugins` copies every packages/plugins/* that already has a
+        # dist/. The dependency-closure build above only produces a dist/ for the
+        # two plugins the tasks package imports directly (job-runtime-trigger,
+        # pty-local), so the deployed worker discovered exactly 2 plugins and
+        # every Trigger-dispatched generation failed with "No pipeline plugin
+        # available. Ensure at least one pipeline plugin is loaded." (prod,
+        # 2026-08-22 — run_cmt4q02v84rtf2x0hxrfbicnn). The legacy cloud workflow
+        # built `./packages/**`; build the plugins explicitly here, serialized
+        # for the same ARC-runner reasons as the step above.
+        run: pnpm turbo run build --filter='./packages/plugins/*' --concurrency=1
+
       - name: Prepare plugins for Trigger.dev
         if: steps.env.outputs.skip != 'true'
         working-directory: packages/tasks


### PR DESCRIPTION
## Why

Every generation dispatched to the self-hosted Trigger.dev worker currently fails within ~20 s with

> No pipeline plugin available. Ensure at least one pipeline plugin is loaded.

(prod, e.g. `run_cmt4q02v84rtf2x0hxrfbicnn`, 2026-08-22 18:37 UTC, worker version `20260822.1`). The run trace shows why:

```
[TriggerPluginHydratorService] Bootstrapping plugins from filesystem...
[PluginLoaderService] Discovered 2 plugins
[PluginRegistryService] Registered plugin: job-runtime-trigger v1.0.0
[PluginRegistryService] Registered plugin: pty-local v1.0.0
```

`release-trigger-selfhosted.yml` builds only `@ever-works/trigger-tasks^...` (the tasks' dependency closure) and then runs `prepare:plugins`, which copies every `packages/plugins/*` that has a `dist/` — only the two plugins the tasks package imports directly have one, so the worker bundle ships 2 plugins and no pipeline/search/AI plugins at all. The legacy cloud workflow (`release-trigger-prod.yml`) built `./packages/**`.

## What

One extra step before `Prepare plugins for Trigger.dev`:

```yaml
run: pnpm turbo run build --filter='./packages/plugins/*' --concurrency=1
```

with the same `NODE_OPTIONS` heap setting, serialized for the same ARC-runner reasons as the closure build. Nothing else changes.

## Rollout

`workflow_run` deploys read this workflow from the default branch, so once this lands on `develop` the next CI success on `main`/`stage` redeploys the worker with all plugins; it can also be dispatched manually (`gh workflow run release-trigger-selfhosted.yml --ref develop -f environment=prod`) to unblock generation immediately — the currently deployed prod worker (`20260822.1`) was already built from develop-lineage commit `892fed76`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)