### PR TITLE
feat(fleet): expose the credential-passthrough setting on the runtime plugin + cover it in tests

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
@@ -179,6 +179,50 @@ describe('fleet agent-task dispatch (AUDIT A46/A24 producer wiring)', () => {
         expect(enqueued.payload.workspacePath).toBe('/srv/ever-works');
     });
 
+    it('grants the well-known CLI credential names to the agent-task step by default', async () => {
+        // A node builds its subprocess env from scratch and drops secret-SHAPED
+        // names unless the step grants them. Without this the credential never
+        // arrives and the agent runs unauthenticated — failing in a way that
+        // reads as a model problem rather than a config one.
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        process.env.FLEET_NODE_AGENT_TASK_COMMAND = 'ever-works agent run --task {taskId}';
+
+        await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
+
+        const step = fleetJobs.enqueue.mock.calls[0][0].payload.steps[0];
+        expect(step.envPassthrough).toEqual([
+            'CLAUDE_CODE_OAUTH_TOKEN',
+            'ANTHROPIC_API_KEY',
+            'CODEX_ACCESS_TOKEN',
+            'OPENAI_API_KEY',
+        ]);
+    });
+
+    it('honours an operator override of the granted credential names', async () => {
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        process.env.FLEET_NODE_AGENT_TASK_COMMAND = 'ever-works agent run --task {taskId}';
+        process.env.FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH = ' MY_WRAPPER_TOKEN , OTHER_KEY ';
+
+        await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
+
+        const step = fleetJobs.enqueue.mock.calls[0][0].payload.steps[0];
+        expect(step.envPassthrough).toEqual(['MY_WRAPPER_TOKEN', 'OTHER_KEY']);
+    });
+
+    it('omits envPassthrough entirely when the operator grants nothing', async () => {
+        // Opting out must leave the field ABSENT rather than an empty array, so a
+        // node sees "no grant" instead of "granted nothing", and the step shape
+        // stays identical to what shipped before this setting existed.
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        process.env.FLEET_NODE_AGENT_TASK_COMMAND = 'ever-works agent run --task {taskId}';
+        process.env.FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH = '';
+
+        await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
+
+        const step = fleetJobs.enqueue.mock.calls[0][0].payload.steps[0];
+        expect(step.envPassthrough).toBeUndefined();
+    });
+
     it('keeps the platform dispatcher when no fleet runtime is selected', async () => {
         const result = await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
 

--- a/packages/plugins/job-runtime-node/src/node-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-node/src/node-job-runtime.plugin.ts
@@ -139,6 +139,13 @@ export class NodeJobRuntimePlugin implements IJobRuntimeProvider {
 				description:
 					'Absolute directory ON THE NODE that `agent-task` steps run in. Blank lets the node use its own working directory.',
 				'x-envVar': 'FLEET_NODE_AGENT_TASK_WORKSPACE'
+			},
+			agentTaskEnvPassthrough: {
+				type: 'string',
+				title: 'Agent task credential env names',
+				description:
+					'Comma-separated environment variable NAMES an `agent-task` step may read from the node’s own environment. A node drops secret-shaped names unless granted, so without this a machine whose Claude or Codex credential lives in an environment variable authenticates with nothing. Only the NAME travels — the value is read on the node and never leaves it, which is why one list works for a fleet of differently-credentialled machines: granting a name a machine does not set is a no-op. Blank inherits the default (the four well-known Claude/Codex names); set it to a single space to grant none.',
+				'x-envVar': 'FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH'
 			}
 		}
 	};


### PR DESCRIPTION
Two gaps in what #2150 shipped, found while auditing my own change.

## 1. The setting wasn't on the runtime plugin schema

`FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH` reached the desktop runtime form but not the `job-runtime-node` plugin settings schema — where its siblings `agentTaskCommand` / `agentTaskWorkspace` already live. An operator configuring the runtime through the plugin had no way to set it.

## 2. The feature was shipped untested at the layer that produces it

Nothing asserted the run router actually puts `envPassthrough` **on** the dispatched step. The existing dispatch spec asserts the step with `toMatchObject`, which tolerates extra properties — so it passed identically with and without my change.

Three cases added:
- the **default** grant of the four well-known Claude/Codex names
- an **operator override**
- **opting out**, which must leave the field *absent* rather than an empty array, so a node reads "no grant" instead of "granted nothing" and the step shape matches what shipped before this setting existed

Writing them immediately earned their keep: the first draft asserted against an undefined `steps`, because a step only exists when `FLEET_NODE_AGENT_TASK_COMMAND` is set. **The test was wrong, not the feature** — but nothing would have told me that without the test.

## Deliberately not done

Not added to the **web tenant-overlay form**. That form carries sizing and targeting knobs; which credential names a node step may read is an operator decision, not a per-tenant one. (`agentTaskCommand` / `agentTaskWorkspace` are absent from it for the same reason.)

## Verification

```
apps/api  fleet-agent-task-dispatch.spec.ts   18 passed (15 + 3 new)
packages/plugins/job-runtime-node             tsc clean
prettier                                      clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)