### PR TITLE
ci: route the Vercel docs deploy CLI install through Verdaccio (+ .vercelignore guard)

### DIFF
--- a/.github/workflows/deploy-vercel-docs-prod.yml
+++ b/.github/workflows/deploy-vercel-docs-prod.yml
@@ -50,6 +50,27 @@ jobs:
         with:
           node-version: 22.x
 
+      # Resolve `npm install -g vercel@latest` through the internal Verdaccio cache when this
+      # job runs on the in-network ARC pool (`vars.RUNNER_LINUX_X64_4`, currently
+      # ever-works-linux-x64-4). Falls back to npmjs automatically when the VIP does not answer,
+      # so the GitHub-hosted `ubuntu-latest` fallback in `runs-on` still works.
+      #
+      # `setup-node` above declares no `cache:`, so there is no lockfile-keyed cache whose save
+      # key could bifurcate against a restore key here — nothing to pin.
+      #
+      # 🛑 The action writes `.npmrc` at the repo root, and `vercel deploy` UPLOADS the project
+      # directory. Vercel CLI has no `.gitignore` fallback and `.npmrc` is not in its default
+      # ignore list, so without the `.vercelignore` added alongside this step the LAN registry
+      # (and, if VERDACCIO_FORCE_PUBLIC is ever turned on, the packages.ever.co auth token) would
+      # be shipped to Vercel and used by the remote builder. See `.vercelignore` at the repo root.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,19 @@
+# Files that must never reach a Vercel deployment.
+#
+# `vercel deploy` (see .github/workflows/deploy-vercel-docs-prod.yml) uploads the project
+# directory from the runner. Unlike a Git-integration deploy, the CLI upload has NO `.gitignore`
+# fallback -- Vercel's own default-ignore list is fixed and does not contain `.npmrc`
+# (https://vercel.com/docs/builds/build-features#ignored-files-and-folders), and Vercel treats a
+# project-root `.npmrc` as build configuration for the remote install.
+#
+# CI writes `.npmrc` / `.yarnrc` at the repo root (the `Configure Registry` action) to point the
+# install at the internal Verdaccio VIP. Those are gitignored, but gitignored is not the same as
+# not-uploaded here. Shipping them to Vercel would:
+#   * point Vercel's builder at http://192.168.1.183:4873/, which it can never reach, and
+#   * expose the packages.ever.co auth token in the deployment source view (/_src) if the
+#     VERDACCIO_FORCE_PUBLIC opt-in is ever enabled.
+#
+# Vercel's default exclusions still apply on top of this file, so listing these two adds
+# exclusions rather than replacing any.
+.npmrc
+.yarnrc


### PR DESCRIPTION
## What

Closes the Verdaccio-coverage gap in **`deploy-vercel-docs-prod.yml`**, and explains why the other
reported gap (**`desktop-build.yml`**) is deliberately left alone.

Both hunks are purely additive — **40 insertions, 0 deletions**. Nothing is removed or replaced.

## `deploy-vercel-docs-prod.yml` — changed ✅

`runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}`, and `RUNNER_LINUX_X64_4` **is** set at
the org level (`ever-works-linux-x64-4`), so this job lands on the in-network ARC pool and can reach
the Verdaccio VIP. It qualifies.

Added the repo-local `./.github/actions/configure-registry` step — same input shape as the other 16
call sites in this repo, with `expect-vip` derived from the runner variable this job actually uses:

```yaml
- name: Configure Registry
  uses: ./.github/actions/configure-registry
  with:
    verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
    verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
    force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
    expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
```

Placed after `Setup Node.js` and before `Install Vercel CLI`. `setup-node` here declares no `cache:`,
so there is **no lockfile-keyed cache** whose save key could bifurcate against a restore key —
nothing to pin.

The install it covers is `npm install -g vercel@latest`. npm loads the project `.npmrc` from the
working directory even for `-g` installs, so the CLI and its dependency tree resolve through the
internal cache instead of npmjs.

## The `.vercelignore` is load-bearing, not decoration 🛑

This is the part worth reviewing. `vercel deploy` **uploads the project directory** from the runner,
and:

- Vercel CLI has **no `.gitignore` fallback** — `.gitignore` is itself on Vercel's ignore list, and
  the docs state that aside from the fixed default exclusions, *all* files in the project are
  uploaded unless a `.vercelignore` excludes them.
- **`.npmrc` is not in that default-ignore list**
  ([ignored files and folders](https://vercel.com/docs/builds/build-features#ignored-files-and-folders)).
- Vercel explicitly treats a project-root `.npmrc` as **build configuration** for the remote install.

So adding `Configure Registry` without a guard would have shipped the generated `.npmrc` to Vercel
and pointed the remote builder at `http://192.168.1.183:4873/`, which it can never reach — breaking
the very deploy the step was meant to speed up. And if the `VERDACCIO_FORCE_PUBLIC` opt-in were ever
turned on, the file also carries `//packages.ever.co/:_authToken=…`, which would then be visible in
the deployment's `/_src` source view.

Being gitignored is not the same as not-uploaded here. The new root `.vercelignore` excludes exactly
`.npmrc` and `.yarnrc`. Vercel's default exclusions still apply on top of this file, so it adds
exclusions rather than replacing any, and it is the only `.vercelignore` in the repo.

## `desktop-build.yml` — NOT changed, on purpose ⛔

All three matrix cells are **hard-coded GitHub-hosted runners**:

| cell | `runner` | hosted? |
|---|---|---|
| linux | `ubuntu-latest` | GitHub-hosted |
| windows | `windows-latest` | GitHub-hosted |
| macos | `macos-latest` | GitHub-hosted |

There is no `vars.RUNNER_*` fallback and no self-hosted label anywhere in the file. A GitHub-hosted
runner cannot reach the private VIP `192.168.1.183`, so adding the step there would add a probe
timeout to every cell for zero benefit. Its `pnpm install --frozen-lockfile` stays on npmjs, which is
correct for where it runs.

## Notes

- This job is currently gated off (`if: ${{ vars.VERCEL_ENABLED == 'true' }}`, and `VERCEL_ENABLED`
  is set at neither repo nor org level — Vercel is decommissioned; docs.ever.works is served from
  ever-k8s). The change is therefore inert today and takes effect only if the owner re-enables the
  legacy Vercel path. The gate itself is untouched.
- Kept on the **local** copy of the action (`./.github/actions/configure-registry`), not the shared
  Gauzy one — this is a pnpm workspace that tracks neither `.npmrc` nor `yarn.lock` at root, and the
  shared action's unconditional `git checkout -- .npmrc yarn.lock` would hard-fail here. That
  reasoning is already documented at the top of the local action.
- The workflow file has a pre-existing UTF-8 BOM; it was left untouched. The file parses cleanly as
  YAML with the BOM stripped, and step order verified: `Checkout → Setup Node.js → Configure
  Registry → Install Vercel CLI → vercel pull → vercel deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
