### PR TITLE
fix(deploy): use Work-scoped context for deployment lookup

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
@@ -12,6 +12,7 @@ import {
     resolveKubeconfigForClusterSource,
     validateClusterSourceForOwner,
 } from './cluster-source-matrix';
+import { resolveEffectiveDeploymentContext } from '@ever-works/agent/deployment-context';
 
 describe('cluster-source-matrix — deploy matrix (renamed: k8s-works internal, k8s-works-shared shared)', () => {
     describe('isEverWorksSharedOrg', () => {
@@ -290,6 +291,130 @@ describe('cluster-source-matrix — deploy matrix (renamed: k8s-works internal, 
 
         it('normalises the legacy k8s-gauzy alias (→ internal, not shared)', () => {
             expect(isSharedClusterSource('k8s-gauzy' as ClusterSource)).toBe(false);
+        });
+    });
+
+    describe('effective namespace provenance', () => {
+        it('derives the internal namespace when ever-works comes only from the schema default', () => {
+            const result = resolveEffectiveDeploymentContext({
+                deployProvider: 'k8s',
+                pluginId: 'k8s',
+                resolvedToken: '__ever-works-platform-managed-kubeconfig__',
+                settings: { clusterSource: 'k8s-works', namespace: 'ever-works' },
+                settingSources: { clusterSource: 'work', namespace: 'default' },
+                websiteOwner: 'ever-works',
+                workId: 'work-1',
+                workSlug: 'awesome-time-tracking',
+                ownerUserId: 'user-1',
+                isPlatformAdmin: true,
+                env: { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-kubeconfig' },
+            } as any);
+
+            expect(result.namespace).toBe('ever-works-awesome-time-tracking-prod');
+            expect(result.settings.namespace).toBe('ever-works-awesome-time-tracking-prod');
+        });
+
+        it('keeps the documented ever-works default for a legacy custom cluster', () => {
+            const result = resolveEffectiveDeploymentContext({
+                deployProvider: 'k8s',
+                pluginId: 'k8s',
+                resolvedToken: 'customer-kubeconfig',
+                settings: { clusterSource: 'custom-kubeconfig', namespace: 'ever-works' },
+                settingSources: { clusterSource: 'default', namespace: 'default' },
+                websiteOwner: 'customer-org',
+                workId: 'work-1',
+                workSlug: 'customer-site',
+                ownerUserId: 'user-1',
+                isPlatformAdmin: false,
+                env: {},
+            } as any);
+
+            expect(result.namespace).toBe('ever-works');
+            expect(result.settings.namespace).toBe('ever-works');
+        });
+
+        it('still rejects an explicitly saved reserved namespace', () => {
+            expect(() =>
+                resolveEffectiveDeploymentContext({
+                    deployProvider: 'k8s',
+                    pluginId: 'k8s',
+                    resolvedToken: 'customer-kubeconfig',
+                    settings: { clusterSource: 'custom-kubeconfig', namespace: 'ever-works' },
+                    settingSources: { clusterSource: 'work', namespace: 'work' },
+                    websiteOwner: 'customer-org',
+                    workId: 'work-1',
+                    workSlug: 'customer-site',
+                    ownerUserId: 'user-1',
+                    isPlatformAdmin: false,
+                    env: {},
+                } as any),
+            ).toThrow(/reserved/i);
+        });
+    });
+
+    describe('effective managed kubeconfig context', () => {
+        const baseInput = {
+            pluginId: 'k8s',
+            websiteOwner: 'ever-works',
+            workId: 'work-1',
+            workSlug: 'awesome-time-tracking',
+            ownerUserId: 'user-1',
+            isPlatformAdmin: true,
+        } as const;
+
+        it.each([
+            ['k8s-works', 'EVER_WORKS_K8S_WORKS_KUBECONFIG'],
+            ['k8s-works-shared', 'EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG'],
+        ] as const)(
+            'drops a stale tenant kubeContext when %s selects an operator kubeconfig',
+            (clusterSource, envKey) => {
+                const result = resolveEffectiveDeploymentContext({
+                    ...baseInput,
+                    deployProvider: 'k8s',
+                    resolvedToken: '__ever-works-platform-managed-kubeconfig__',
+                    settings: { clusterSource, kubeContext: 'tenant-stale-context' },
+                    env: { [envKey]: 'operator-kubeconfig' },
+                });
+
+                expect(result.token).toBe('operator-kubeconfig');
+                expect(result.settings).not.toHaveProperty('kubeContext');
+                expect(result.lookupContext?.settingsOverride).not.toHaveProperty('kubeContext');
+                expect(result.lookupContext?.kubeContextOverride).toBeNull();
+            },
+        );
+
+        it('drops a stale tenant kubeContext for the managed provider alias', () => {
+            const result = resolveEffectiveDeploymentContext({
+                ...baseInput,
+                deployProvider: 'ever-works',
+                resolvedToken: 'dedicated-managed-kubeconfig',
+                settings: {
+                    clusterSource: 'custom-kubeconfig',
+                    kubeContext: 'tenant-stale-context',
+                },
+            });
+
+            expect(result.token).toBe('dedicated-managed-kubeconfig');
+            expect(result.settings).not.toHaveProperty('kubeContext');
+            expect(result.lookupContext?.kubeContextOverride).toBeNull();
+        });
+
+        it('preserves kubeContext only with the tenant custom kubeconfig', () => {
+            const result = resolveEffectiveDeploymentContext({
+                ...baseInput,
+                deployProvider: 'k8s',
+                websiteOwner: 'customer-org',
+                isPlatformAdmin: false,
+                resolvedToken: 'tenant-kubeconfig',
+                settings: {
+                    clusterSource: 'custom-kubeconfig',
+                    kubeContext: 'tenant-current-context',
+                },
+            });
+
+            expect(result.token).toBe('tenant-kubeconfig');
+            expect(result.settings.kubeContext).toBe('tenant-current-context');
+            expect(result.lookupContext?.kubeContextOverride).toBe('tenant-current-context');
         });
     });
 });

--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
@@ -1,310 +1,61 @@
 /**
- * Deploy-target resolution matrix for the per-Work Kubernetes deploy path.
+ * Deploy-target matrix presentation helpers.
  *
- * Three inputs decide where a Work may be published:
- *
- *  - **isPlatformAdmin** — whether the deploying user is a platform admin
- *    (`User.isPlatformAdmin`).
- *  - **Website repo owner** (and therefore the GHCR namespace the image
- *    lives in): `ever-works`, `ever-works-cloud`, or customer-owned.
- *  - **Cluster source**: `k8s-works`, `k8s-works-shared`, `custom-kubeconfig`.
- *
- * Renamed from EW-616 (old `k8s-gauzy` → `k8s-works` internal, old
- * `k8s-works` → `k8s-works-shared` shared). See `normalizeClusterSource`
- * for the back-compat alias and the one-shot data migration
- * `*-RenameK8sClusterSource.ts` for the stored-value rewrite.
- *
- * Rules that combine to produce the supported set:
- *
- *  1. `k8s-works` (the Ever Works INTERNAL cluster) is admin-only. It
- *     requires BOTH `isPlatformAdmin` AND a website repo in the `ever-works`
- *     GitHub org. Real customers must never be able to deploy onto it, and a
- *     non-admin must never be able to select it (even via the API/CLI).
- *
- *  2. `custom-kubeconfig` cannot be combined with an Ever Works-shared GHCR
- *     namespace (`ever-works` or `ever-works-cloud`). The cluster would
- *     receive an org-scoped classic PAT as an `imagePullSecret`, and
- *     `kubectl get secret -o yaml` on the customer's cluster could recover it
- *     and read every GHCR image in that shared org. To use your own cluster
- *     you must also bring your own GitHub org.
- *
- *  3. `k8s-works-shared` (the Ever Works SHARED customer cluster) is the
- *     default and is allowed for every owner. Its cluster may not be
- *     provisioned yet — `resolveKubeconfigForClusterSource` fails with a
- *     clear "not yet available" error rather than crashing.
- *
- * The resulting supported combinations (admin gate applies only to `k8s-works`):
- *
- * | Website owner      | k8s-works                | k8s-works-shared | custom-kubeconfig |
- * | ------------------ | ------------------------ | ---------------- | ----------------- |
- * | `ever-works`       | OK (admin only)          | OK               | rejected (rule 2) |
- * | `ever-works-cloud` | rejected (rule 1)        | OK (default)     | rejected (rule 2) |
- * | customer-owned     | rejected (rule 1)        | OK (default)     | OK                |
- *
- * The full background is in the EW-615/EW-616 tickets and the
- * `EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md` runbook.
+ * The security-sensitive cluster, token, and namespace rules live with the
+ * authoritative deployment-context resolver in `@ever-works/agent/deployment-context`.
+ * This API module re-exports those primitives so existing controllers and
+ * tests keep their public import path while deploy and lookup cannot drift.
  */
+import {
+    isAdminOnlyOrg,
+    isEverWorksSharedOrg,
+    type ClusterSource,
+} from '@ever-works/agent/deployment-context';
 
-export type ClusterSource = 'k8s-works' | 'k8s-works-shared' | 'custom-kubeconfig';
+export {
+    RESERVED_DEPLOY_NAMESPACES,
+    isAdminOnlyOrg,
+    isEverWorksSharedOrg,
+    isReservedDeployNamespace,
+    isSharedClusterSource,
+    normalizeClusterSource,
+    resolveKubeconfigForClusterSource,
+    validateClusterSourceForOwner,
+} from '@ever-works/agent/deployment-context';
+export type {
+    ClusterSource,
+    ClusterSourceValidationFailure,
+    LegacyClusterSource,
+} from '@ever-works/agent/deployment-context';
 
 /**
- * Pre-rename value that may still appear in un-migrated rows or in-flight
- * requests during a rolling deploy. `k8s-gauzy` was the internal cluster and
- * maps to the renamed `k8s-works`.
- *
- * NOTE: the OTHER pre-rename value, the string `k8s-works`, is deliberately
- * NOT remapped here — after the rename it unambiguously means the internal
- * cluster. Genuine old-shared `k8s-works` rows are rewritten to
- * `k8s-works-shared` once, atomically, by the data migration; treating a
- * runtime `k8s-works` as "old shared" would silently break every admin
- * selection.
- */
-export type LegacyClusterSource = 'k8s-gauzy';
-
-const LEGACY_CLUSTER_SOURCE_ALIASES: Readonly<Record<LegacyClusterSource, ClusterSource>> = {
-    'k8s-gauzy': 'k8s-works',
-};
-
-const EVER_WORKS_SHARED_ORGS = new Set(['ever-works', 'ever-works-cloud']);
-
-export function isEverWorksSharedOrg(websiteOwner: string): boolean {
-    return EVER_WORKS_SHARED_ORGS.has(websiteOwner.trim().toLowerCase());
-}
-
-export function isAdminOnlyOrg(websiteOwner: string): boolean {
-    return websiteOwner.trim().toLowerCase() === 'ever-works';
-}
-
-/**
- * Normalise a stored/incoming cluster-source string to a canonical
- * `ClusterSource`, remapping the unambiguous legacy `k8s-gauzy` alias.
- * Returns `undefined` for anything unrecognised so callers can fall back to
- * their own default (`custom-kubeconfig` for the deploy path).
- */
-export function normalizeClusterSource(value: string): ClusterSource | undefined {
-    if (value === 'k8s-works' || value === 'k8s-works-shared' || value === 'custom-kubeconfig') {
-        return value;
-    }
-    if (value === 'k8s-gauzy') {
-        return LEGACY_CLUSTER_SOURCE_ALIASES['k8s-gauzy'];
-    }
-    return undefined;
-}
-
-/**
- * Allowed cluster sources for the caller, in the order they should appear in
- * the UI dropdown (first entry = recommended default). Drives the
- * `k8s-cluster-source` widget via `GET /api/deploy/cluster-sources`.
- *
- * `websiteOwner` is optional: the user-global plugin-settings page has no Work
- * context, so it filters on `isPlatformAdmin` alone. When a Work owner IS
- * known (a Work-scoped call), the same org rules the deploy gate enforces are
- * applied so the dropdown never offers a combination the deploy would reject.
+ * Allowed cluster sources for the caller, in UI order (first = recommended).
+ * The deploy resolver remains the authoritative admission gate.
  */
 export function allowedClusterSourcesFor(
     isPlatformAdmin: boolean,
     websiteOwner?: string,
 ): readonly ClusterSource[] {
     const out: ClusterSource[] = [];
-    // Internal cluster: platform admins only. When a specific Work owner is
-    // known, additionally require the `ever-works` org (mirrors rule 1).
     if (isPlatformAdmin && (websiteOwner === undefined || isAdminOnlyOrg(websiteOwner))) {
         out.push('k8s-works');
     }
-    // Shared customer cluster: the default, always offered.
     out.push('k8s-works-shared');
-    // Custom kubeconfig: hidden for Ever Works-shared orgs (rule 2). Offered
-    // when the owner is unknown (user-global settings page) or customer-owned.
     if (websiteOwner === undefined || !isEverWorksSharedOrg(websiteOwner)) {
         out.push('custom-kubeconfig');
     }
     return out;
 }
 
-/**
- * Human labels for the cluster-source dropdown. The raw enum values are opaque
- * (`k8s-works-shared`, …); the `k8s-cluster-source` widget renders these
- * instead. Kept next to the enum so a new value can't be added without a label.
- */
 export const CLUSTER_SOURCE_LABELS: Readonly<Record<ClusterSource, string>> = {
     'k8s-works-shared': 'Ever Works shared customer cluster',
     'k8s-works': 'Ever Works internal cluster (admin only)',
     'custom-kubeconfig': 'Custom — paste your own kubeconfig',
 };
 
-/**
- * Per-option help text. Mirrors the owner-provided settings-page copy; the
- * `k8s-works` line is only ever sent to platform admins (a non-admin's allowed
- * list never includes `k8s-works`, so its description never reaches them).
- */
 export const CLUSTER_SOURCE_DESCRIPTIONS: Readonly<Record<ClusterSource, string>> = {
     'k8s-works-shared': 'Ever Works shared customer cluster.',
     'k8s-works':
         "Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org).",
     'custom-kubeconfig': 'Paste your own kubeconfig below.',
 };
-
-export interface ClusterSourceValidationFailure {
-    readonly code:
-        | 'K8S_WORKS_NOT_ALLOWED'
-        | 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG'
-        | 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG';
-    readonly message: string;
-}
-
-/**
- * Validate a (websiteOwner, clusterSource) pair against the deploy matrix.
- * Returns a failure record when the pair is rejected, `null` otherwise. The
- * caller decides how to surface the failure (HTTP exception in the controller,
- * logger.error in batch flows, etc).
- *
- * Fails closed: `isPlatformAdmin` defaults to `false` and `hasKubeconfig`
- * defaults to `true` when the options are omitted. Pure / side-effect-free so
- * it can be unit-tested without DI.
- */
-export function validateClusterSourceForOwner(
-    websiteOwner: string,
-    clusterSource: ClusterSource,
-    options: { hasKubeconfig?: boolean; isPlatformAdmin?: boolean } = {},
-): ClusterSourceValidationFailure | null {
-    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
-    const isPlatformAdmin = options.isPlatformAdmin ?? false;
-    const hasKubeconfig = options.hasKubeconfig ?? true;
-
-    // Rule 1: `k8s-works` (internal cluster). BOTH gates required — platform
-    // admin AND `ever-works` org. Fails closed.
-    if (source === 'k8s-works' && (!isPlatformAdmin || !isAdminOnlyOrg(websiteOwner))) {
-        const message = !isPlatformAdmin
-            ? `'k8s-works' is the Ever Works internal cluster and is restricted to platform admins. ` +
-              `Pick 'k8s-works-shared' (the shared customer cluster) instead.`
-            : `'k8s-works' is the Ever Works internal cluster and requires the website repo to live in ` +
-              `the 'ever-works' GitHub org. The website repo for this Work is in '${websiteOwner}'. ` +
-              `Pick 'k8s-works-shared' instead, or move the Work to the 'ever-works' org.`;
-        return { code: 'K8S_WORKS_NOT_ALLOWED', message };
-    }
-
-    // Rule 2: `custom-kubeconfig` vs Ever Works-shared org (cross-tenant PAT).
-    if (source === 'custom-kubeconfig' && isEverWorksSharedOrg(websiteOwner)) {
-        return {
-            code: 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG',
-            message:
-                `Cannot deploy a Work in the '${websiteOwner}' organisation to a customer-provided cluster. ` +
-                `The cluster's imagePullSecret would contain an org-scoped PAT that grants read access ` +
-                `to every GHCR image in '${websiteOwner}' (cross-tenant exposure). ` +
-                `To use your own cluster, move this Work to your own GitHub org first, ` +
-                `or pick 'k8s-works-shared' as the target cluster.`,
-        };
-    }
-
-    if (source === 'custom-kubeconfig' && !hasKubeconfig) {
-        return {
-            code: 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG',
-            message:
-                `Target cluster is 'custom-kubeconfig' but no kubeconfig is saved on the Kubernetes plugin. ` +
-                `Paste a kubeconfig in plugin settings, or pick a platform-managed cluster.`,
-        };
-    }
-
-    return null;
-}
-
-/**
- * Resolve the kubeconfig YAML to push as the workflow's `K8S_TOKEN` secret.
- * For platform-managed cluster sources this reads the right env var; for
- * `custom-kubeconfig` it returns the user-pasted token. Legacy `k8s-gauzy` is
- * normalised to `k8s-works` first.
- *
- *  - `k8s-works`         → `EVER_WORKS_K8S_WORKS_KUBECONFIG` (internal cluster)
- *  - `k8s-works-shared`  → `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` (shared
- *                          customer cluster — may not be provisioned yet)
- *
- * Throws when a platform-managed source is requested but the platform has not
- * provisioned the corresponding env var. The env-var lookup is injected so
- * unit tests can avoid touching `process.env` directly.
- */
-export function resolveKubeconfigForClusterSource(
-    clusterSource: ClusterSource,
-    userKubeconfig: string,
-    env: NodeJS.ProcessEnv = process.env,
-): string {
-    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
-
-    if (source === 'k8s-works') {
-        const value = env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
-        if (!value || !value.trim()) {
-            throw new Error(
-                "Cluster source is 'k8s-works' but EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured on the platform.",
-            );
-        }
-        return value;
-    }
-    if (source === 'k8s-works-shared') {
-        const value = env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
-        if (!value || !value.trim()) {
-            // The shared customer cluster may not be provisioned yet. Surface a
-            // clear, user-actionable message instead of a raw env-var error.
-            throw new Error(
-                "The Ever Works shared customer cluster ('k8s-works-shared') is not available yet: " +
-                    'EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG is not configured on the platform. ' +
-                    'Choose another target cluster, or try again once the shared cluster is provisioned.',
-            );
-        }
-        return value;
-    }
-    return userKubeconfig;
-}
-
-/**
- * Namespaces a tenant deploy may NEVER target on a platform-managed cluster.
- *
- * EW — server-side namespace enforcement (Task 7 / owner item #3b). The k8s
- * `namespace` field is free-text and, before this guard, had no server-side
- * check — a shared-cluster deploy could target the platform's own
- * `ever-works` namespace, a Kubernetes system namespace, or another tenant's
- * space. This is the authoritative blocklist consulted by
- * `DeployService.resolveDeployNamespace`.
- *
- * Any `kube-*` namespace is additionally rejected (see `isReservedDeployNamespace`)
- * so the whole reserved `kube-system` / `kube-public` / `kube-node-lease`
- * family is covered even if a new one is introduced upstream.
- */
-export const RESERVED_DEPLOY_NAMESPACES: ReadonlySet<string> = new Set([
-    'ever-works',
-    'kube-system',
-    'kube-public',
-    'kube-node-lease',
-    'default',
-    'argocd',
-    'cert-manager',
-    'ingress-nginx',
-    'monitoring',
-]);
-
-/**
- * True when `namespace` is a platform-reserved namespace that no tenant deploy
- * may target. Matches the explicit `RESERVED_DEPLOY_NAMESPACES` set plus any
- * `kube-*` namespace. Case- and whitespace-insensitive. An empty/blank input
- * is NOT reserved (the caller decides how to treat "no namespace supplied").
- */
-export function isReservedDeployNamespace(namespace: string): boolean {
-    const ns = namespace.trim().toLowerCase();
-    if (!ns) return false;
-    if (RESERVED_DEPLOY_NAMESPACES.has(ns)) return true;
-    // Cover the entire Kubernetes system-namespace family (`kube-system`,
-    // `kube-public`, `kube-node-lease`, and any future `kube-*`).
-    return ns.startsWith('kube-');
-}
-
-/**
- * True for cluster sources that are a platform-owned SHARED cluster, where a
- * user-supplied namespace must be ignored in favour of a deterministic
- * per-tenant namespace (cross-tenant isolation). Today that is exactly
- * `k8s-works-shared`; the `includes('shared')` guard keeps a future shared
- * source (e.g. a regional `k8s-works-shared-eu`) covered without a code change.
- * The internal admin cluster (`k8s-works`) and the user's own cluster
- * (`custom-kubeconfig`) are NOT shared.
- */
-export function isSharedClusterSource(clusterSource: ClusterSource): boolean {
-    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
-    return source === 'k8s-works-shared' || source.includes('shared');
-}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
@@ -69,6 +69,7 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
         plugin: Record<string, unknown>;
         token?: string;
         settings?: Record<string, unknown>;
+        settingSources?: Record<string, string>;
         deployProvider?: string;
         /** Owner returned by `work.getRepoOwner('website')`. Defaults to
          *  the customer-owned org `'acme'` so most tests run on the
@@ -110,6 +111,7 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
                 token: overrides.token ?? 'kubeconfig:::yaml',
                 work,
                 settings: overrides.settings ?? {},
+                settingSources: overrides.settingSources,
             }),
             getOtherPluginSettings: jest
                 .fn()
@@ -247,6 +249,7 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
     };
 
     const SHARED_KC = 'shared-cluster-kubeconfig-yaml';
+    const INTERNAL_KC = 'internal-cluster-kubeconfig-yaml';
     const managedPlugin = () => ({
         id: 'k8s',
         deploy: jest.fn().mockResolvedValue({ status: 'deploying', id: 'd', createdAt: 't' }),
@@ -256,16 +259,21 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
 
     beforeEach(() => {
         process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = SHARED_KC;
+        process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = INTERNAL_KC;
     });
     afterEach(() => {
         delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+        delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
     });
 
     it('managed tier → plugin.deploy applies server-side with the platform kubeconfig', async () => {
         const plugin = managedPlugin();
         const { service, githubPlugin } = buildService({
             plugin,
-            settings: { clusterSource: 'k8s-works-shared' },
+            settings: {
+                clusterSource: 'k8s-works-shared',
+                kubeContext: 'tenant-stale-context',
+            },
         });
 
         const result = await service.deploy('work-1', 'user-1');
@@ -288,8 +296,31 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
         // a pull secret, and throws GITHUB_NOT_CONNECTED on an empty token
         // BEFORE applying anything.
         expect(config.options.githubReadPackagesToken).toBeTruthy();
+        expect(config.options.settingsOverride).not.toHaveProperty('kubeContext');
+        expect(config.options.kubeContextOverride).toBeNull();
         // No workflow dispatch on the managed path.
         expect(githubPlugin.dispatchWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('internal managed tier derives its namespace when ever-works is only the schema default', async () => {
+        const plugin = managedPlugin();
+        const { service } = buildService({
+            plugin,
+            token: '__ever-works-platform-managed-kubeconfig__',
+            settings: { clusterSource: 'k8s-works', namespace: 'ever-works' },
+            settingSources: { clusterSource: 'work', namespace: 'default' },
+            websiteOwner: 'ever-works',
+            isPlatformAdmin: true,
+        });
+
+        await expect(service.deploy('work-1', 'user-1')).resolves.toMatchObject({
+            dispatched: true,
+        });
+
+        const [config, kubeconfig] = plugin.deploy.mock.calls[0];
+        expect(kubeconfig).toBe(INTERNAL_KC);
+        expect(config.options.namespaceOverride).toBe('ever-works-my-site-prod');
+        expect(config.options.settingsOverride.namespace).toBe('ever-works-my-site-prod');
     });
 
     it('managed tier → the platform kubeconfig is NEVER written to the repo', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -43,7 +43,12 @@ import {
     WebsiteTemplateResolverService,
 } from '@ever-works/agent/generators';
 import { DeploymentDispatchedEvent } from '@ever-works/agent/events';
-import type { DeploymentConfig, DeploymentResult, IDeploymentPlugin } from '@ever-works/plugin';
+import type {
+    DeploymentConfig,
+    DeploymentResult,
+    IDeploymentPlugin,
+    SettingSource,
+} from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
 
 const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
@@ -173,7 +178,7 @@ export class DeployService {
         options: DeployOptions = {},
     ): Promise<DeployResult> {
         const env = DeployService.buildEnvironmentOptions(options);
-        const { plugin, token, work, settings } =
+        const { plugin, token, work, settings, settingSources } =
             await this.deployFacade.getPluginAndTokenAndSettings({
                 userId,
                 workId,
@@ -207,6 +212,7 @@ export class DeployService {
             settings ?? {},
             token,
             user,
+            settingSources,
         );
         const effectiveDeployToken = effectiveContext.token;
 
@@ -307,6 +313,7 @@ export class DeployService {
                   gitToken,
                   revision: env.commitSha,
                   deploySettings: deploySettings ?? {},
+                  kubeContextOverride: effectiveContext.lookupContext?.kubeContextOverride ?? null,
                   deploymentId: deployment.id,
                   targetBranch,
               })
@@ -459,6 +466,7 @@ export class DeployService {
         settings: Record<string, unknown>,
         resolvedToken: string,
         user: User,
+        settingSources?: Readonly<Record<string, SettingSource | undefined>>,
     ): EffectiveDeploymentContext {
         try {
             return resolveEffectiveDeploymentContext({
@@ -466,7 +474,9 @@ export class DeployService {
                 pluginId,
                 resolvedToken,
                 settings,
+                settingSources,
                 websiteOwner,
+                websiteProjectName: work.getWebsiteRepo(),
                 workId: work.id,
                 workSlug: work.slug,
                 ownerUserId: user.id,
@@ -1098,6 +1108,7 @@ export class DeployService {
         kubeconfig: string;
         gitToken: string;
         deploySettings: Record<string, unknown>;
+        kubeContextOverride: string | null;
         deploymentId: string;
         targetBranch: string;
         revision?: string;
@@ -1109,6 +1120,7 @@ export class DeployService {
             kubeconfig,
             gitToken,
             deploySettings,
+            kubeContextOverride,
             deploymentId,
             targetBranch,
             revision,
@@ -1177,6 +1189,7 @@ export class DeployService {
                         githubOwner: work.getRepoOwner('website'),
                         imageName: work.getWebsiteRepo(),
                         namespaceOverride: namespace,
+                        kubeContextOverride,
                         hosts,
                         runtimeEnv,
                         // BLOCK-1: without a read:packages token the plugin

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -6,11 +6,13 @@ import {
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomBytes } from 'crypto';
+import { DeployFacadeService, GitFacadeService } from '@ever-works/agent/facades';
 import {
-    DeployFacadeService,
-    GitFacadeService,
-    PLATFORM_MANAGED_KUBECONFIG_SENTINEL,
-} from '@ever-works/agent/facades';
+    DeploymentContextResolutionError,
+    coerceDeploymentClusterSource,
+    resolveEffectiveDeploymentContext,
+    type EffectiveDeploymentContext,
+} from '@ever-works/agent/deployment-context';
 import {
     WorkRepository,
     WorkDeploymentRepository,
@@ -33,7 +35,6 @@ import {
     EverWorksDnsService,
     SubdomainAllocator,
     EverWorksDbProvisionService,
-    buildEverWorksTenantNamespace,
 } from '@ever-works/agent/ever-works-providers';
 import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import {
@@ -44,34 +45,9 @@ import {
 import { DeploymentDispatchedEvent } from '@ever-works/agent/events';
 import type { DeploymentConfig, DeploymentResult, IDeploymentPlugin } from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
-import {
-    ClusterSource,
-    isReservedDeployNamespace,
-    isSharedClusterSource,
-    normalizeClusterSource,
-    resolveKubeconfigForClusterSource,
-    validateClusterSourceForOwner,
-} from './cluster-source-matrix';
 
 const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
 const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
-
-function coerceClusterSource(value: unknown): ClusterSource {
-    if (typeof value === 'string') {
-        // `normalizeClusterSource` accepts the current values and remaps the
-        // unambiguous legacy `k8s-gauzy` alias → `k8s-works`. It deliberately
-        // does NOT remap `k8s-works` → `k8s-works-shared` (that stored-value
-        // rewrite is done once, atomically, by the RenameK8sClusterSource
-        // migration); doing it here would silently break admin selections.
-        const normalized = normalizeClusterSource(value);
-        if (normalized) return normalized;
-    }
-    // Back-compat: Works that pre-date the cluster-source dropdown have no
-    // `clusterSource` set in their plugin settings. Treat them as
-    // `custom-kubeconfig` so they keep working as long as their
-    // website repo is not in an Ever Works-shared org.
-    return 'custom-kubeconfig';
-}
 
 /**
  * Default workflow filenames to dispatch when a deployment plugin does not
@@ -224,14 +200,15 @@ export class DeployService {
         //   to avoid cross-tenant credential exposure.
         // The resolved kubeconfig replaces the user-pasted one for
         // platform-managed sources.
-        const effectiveDeployToken = this.resolveDeployToken(
-            work.deployProvider,
+        const effectiveContext = this.resolveDeploymentContext(
+            work,
             plugin.id,
             websiteOwner,
             settings ?? {},
             token,
-            Boolean(user.isPlatformAdmin),
+            user,
         );
+        const effectiveDeployToken = effectiveContext.token;
 
         const ctx = await this.createRepoContext(websiteOwner, websiteRepo, gitToken);
 
@@ -248,23 +225,7 @@ export class DeployService {
         // the user's directory is reachable at that subdomain without any
         // manual DNS. If env vars are missing the DNS service no-ops; the
         // k8s plugin's default LB hostname remains the fallback.
-        let deploySettings = await this.applyManagedSubdomain(work, settings);
-
-        // EW (owner item #3b) — authoritative, server-side namespace policy.
-        // The k8s `namespace` field is free-text with no client-side guarantee;
-        // enforce the per-tenant override (shared clusters) + reserved-namespace
-        // blocklist HERE, before the plugin's `getDeploymentSecrets` turns it
-        // into the pushed `K8S_NAMESPACE`. A user-supplied `ever-works` /
-        // `kube-system` / other-tenant namespace can never reach the cluster.
-        const enforcedNamespace = this.resolveDeployNamespace(
-            work.deployProvider,
-            plugin?.id,
-            work,
-            settings ?? {},
-        );
-        if (enforcedNamespace !== undefined) {
-            deploySettings = { ...(deploySettings ?? {}), namespace: enforcedNamespace };
-        }
+        const deploySettings = await this.applyManagedSubdomain(work, effectiveContext.settings);
 
         // EW — server-side deploy for platform-managed cluster tiers.
         //
@@ -281,7 +242,7 @@ export class DeployService {
         const serverSide = this.isServerSideManagedDeploy(
             work.deployProvider,
             plugin,
-            settings ?? {},
+            effectiveContext.settings,
             effectiveDeployToken,
         );
 
@@ -491,150 +452,39 @@ export class DeployService {
         }
     }
 
-    /**
-     * EW-616: Apply the deploy-matrix validation for the k8s provider and
-     * substitute the platform's kubeconfig env var when the user picked a
-     * platform-managed cluster source. For non-k8s providers (Vercel, etc.)
-     * this is a pass-through and the validation is skipped.
-     */
-    private resolveDeployToken(
-        deployProvider: string | undefined,
+    private resolveDeploymentContext(
+        work: Work,
         pluginId: string | undefined,
         websiteOwner: string,
         settings: Record<string, unknown>,
-        userToken: string,
-        isPlatformAdmin: boolean,
-    ): string {
-        if (!this.isKubernetesDeploy(deployProvider, pluginId)) {
-            return userToken;
-        }
-
-        // Task 10 — the managed `ever-works` provider deploys to a
-        // platform-OWNED cluster using a platform-HELD kubeconfig that the
-        // deploy facade already resolved from `EVER_WORKS_DEPLOY_*` (dedicated,
-        // Path A) or `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` (shared, Path B).
-        // The user-cluster deploy matrix (`validateClusterSourceForOwner`)
-        // exists to stop a USER's own cluster from receiving a shared-org PAT —
-        // it does not apply here, and applying it would wrongly reject managed
-        // deploys whose website repo lives in the `ever-works-cloud` storage
-        // org (rule 2). Pass the platform kubeconfig straight through; strip
-        // the sentinel so it can never leak into `K8S_TOKEN`.
-        if (deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID) {
-            return userToken === PLATFORM_MANAGED_KUBECONFIG_SENTINEL ? '' : userToken;
-        }
-
-        // EW-616: the deploy facade returns a sentinel string when the
-        // user picked a platform-managed cluster without pasting a
-        // kubeconfig. Treat it as "no kubeconfig" for the validator and
-        // discard it before resolution so it can never leak into the
-        // pushed `K8S_TOKEN` secret on the website repo.
-        const realUserToken = userToken === PLATFORM_MANAGED_KUBECONFIG_SENTINEL ? '' : userToken;
-
-        const clusterSource = coerceClusterSource(settings.clusterSource);
-        const failure = validateClusterSourceForOwner(websiteOwner, clusterSource, {
-            hasKubeconfig: Boolean(realUserToken && realUserToken.trim()),
-            isPlatformAdmin,
-        });
-        if (failure) {
-            this.logger.warn(`Deploy-matrix violation [${failure.code}]: ${failure.message}`);
-            throw new BadRequestException(failure.message);
-        }
-
+        resolvedToken: string,
+        user: User,
+    ): EffectiveDeploymentContext {
         try {
-            return resolveKubeconfigForClusterSource(clusterSource, realUserToken);
-        } catch (error: any) {
-            // The only failure path here is a missing platform-managed
-            // env var (`EVER_WORKS_K8S_WORKS_KUBECONFIG` /
-            // `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`). The user picked a
-            // valid option — this is a platform-provisioning gap, so
-            // surface it as 5xx, not 4xx, so on-call can distinguish it
-            // from genuine user-input errors.
-            const message = error instanceof Error ? error.message : String(error);
-            this.logger.error(`Cluster-source resolution failed for ${websiteOwner}: ${message}`);
-            throw new InternalServerErrorException(message);
-        }
-    }
-
-    /**
-     * EW (owner item #3b) — authoritative per-tenant namespace resolution for
-     * the k8s deploy path. Mirrors `resolveDeployToken`: a no-op pass-through
-     * (returns `undefined`) for non-k8s providers, so Vercel and friends are
-     * untouched.
-     *
-     * Policy (see `cluster-source-matrix`):
-     *  - **Shared, platform-owned clusters** (`k8s-works-shared`, any shared
-     *    source) AND the managed `ever-works` provider: OVERRIDE whatever the
-     *    user typed with a deterministic per-tenant namespace
-     *    (`{base}-{ownerUserId}`). The namespace field is never user-editable
-     *    to a foreign/system namespace on a cluster shared with other tenants.
-     *  - **All other k8s sources** (`custom-kubeconfig` = user's own cluster,
-     *    `k8s-works` = admin internal): the user's namespace passes through,
-     *    but a platform-reserved namespace (`ever-works`, `kube-system`, …,
-     *    any `kube-*`) is rejected with a clear 400. An empty namespace returns
-     *    `undefined` so the k8s plugin keeps its existing default.
-     *
-     * Returns the namespace to force onto `deploySettings.namespace`, or
-     * `undefined` to leave the plugin's own resolution in place.
-     */
-    private resolveDeployNamespace(
-        deployProvider: string | undefined,
-        pluginId: string | undefined,
-        work: Work,
-        settings: Record<string, unknown>,
-    ): string | undefined {
-        if (!this.isKubernetesDeploy(deployProvider, pluginId)) {
-            return undefined;
-        }
-
-        const clusterSource = coerceClusterSource(settings.clusterSource);
-        const isManagedShared =
-            deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID ||
-            isSharedClusterSource(clusterSource);
-
-        if (isManagedShared) {
-            // Cross-tenant isolation: ignore user input entirely and derive a
-            // deterministic per-tenant namespace from the Work owner.
-            const owner = work.user as User | undefined;
-            const tenantId = owner?.id || work.id;
-            const base = process.env.EVER_WORKS_DEPLOY_NAMESPACE?.trim() || 'ever-works-tenants';
-            return buildEverWorksTenantNamespace(tenantId, base);
-        }
-
-        // custom-kubeconfig (user's own cluster) / k8s-works (admin internal):
-        // honour the user's namespace, but never a platform-reserved one.
-        const requested = typeof settings.namespace === 'string' ? settings.namespace.trim() : '';
-        if (!requested) {
-            // `k8s-works` is OUR cluster, and leaving this undefined means the
-            // plugin falls back to its own DEFAULT_NAMESPACE ('ever-works') —
-            // which is platform-reserved. The blocklist below never catches it
-            // because it only inspects a namespace the user actually typed, so
-            // every Work created on k8s-works without an explicit namespace
-            // silently targets the reserved shared namespace. Derive one.
-            //
-            // custom-kubeconfig is deliberately left alone: that is the user's
-            // own cluster and their default namespace is their business.
-            if (clusterSource === 'k8s-works') {
-                const slug = (work.slug || work.id)
-                    .toLowerCase()
-                    .replace(/[^a-z0-9-]+/g, '-')
-                    .replace(/^-+|-+$/g, '')
-                    .slice(0, 40);
-                const derived = slug ? `ever-works-${slug}-prod` : '';
-                if (derived && !isReservedDeployNamespace(derived)) {
-                    return derived;
-                }
+            return resolveEffectiveDeploymentContext({
+                deployProvider: work.deployProvider,
+                pluginId,
+                resolvedToken,
+                settings,
+                websiteOwner,
+                workId: work.id,
+                workSlug: work.slug,
+                ownerUserId: user.id,
+                isPlatformAdmin: Boolean(user.isPlatformAdmin),
+            });
+        } catch (error) {
+            if (!(error instanceof DeploymentContextResolutionError)) throw error;
+            if (error.code === 'DEPLOY_MATRIX_VIOLATION' || error.code === 'RESERVED_NAMESPACE') {
+                this.logger.warn(
+                    `Deploy context rejected${error.reason ? ` [${error.reason}]` : ''}: ${error.message}`,
+                );
+                throw new BadRequestException(error.message);
             }
-            return undefined;
+            this.logger.error(
+                `Cluster-source resolution failed for ${websiteOwner}: ${error.message}`,
+            );
+            throw new InternalServerErrorException(error.message);
         }
-        if (isReservedDeployNamespace(requested)) {
-            const message =
-                `Namespace '${requested}' is reserved and cannot be used as a deploy target. ` +
-                `Choose a different namespace (reserved: ever-works, default, kube-*, argocd, ` +
-                `cert-manager, ingress-nginx, monitoring).`;
-            this.logger.warn(`Deploy namespace rejected for work ${work.id}: ${message}`);
-            throw new BadRequestException(message);
-        }
-        return requested;
     }
 
     private async createRepoContext(
@@ -1224,7 +1074,7 @@ export class DeployService {
             return false;
         if (!resolvedKubeconfig || !resolvedKubeconfig.trim()) return false;
         if (deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID) return true;
-        return coerceClusterSource(settings.clusterSource) !== 'custom-kubeconfig';
+        return coerceDeploymentClusterSource(settings.clusterSource) !== 'custom-kubeconfig';
     }
 
     /**

--- a/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.spec.ts
@@ -666,12 +666,12 @@ describe('DeploymentVerifierService', () => {
             expect(result).toEqual({ found: false });
         });
 
-        it('facade rejects → swallows error + logs + returns {found:false}', async () => {
+        it('facade rejects → logs and preserves the deterministic failure', async () => {
             deployFacade.lookupExistingDeployment.mockRejectedValueOnce(new Error('oops'));
 
-            const result = await service.lookupExistingDeployment(buildWork() as any, 'user-1');
-
-            expect(result).toEqual({ found: false });
+            await expect(
+                service.lookupExistingDeployment(buildWork() as any, 'user-1'),
+            ).rejects.toThrow('oops');
             expect(errorSpy).toHaveBeenCalledWith(
                 expect.stringContaining('Failed to lookup existing deployment for work work-1'),
                 expect.any(Error),

--- a/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.ts
@@ -302,7 +302,7 @@ export class DeploymentVerifierService {
             return result;
         } catch (error) {
             this.logger.error(`Failed to lookup existing deployment for work ${work.id}:`, error);
-            return { found: false };
+            throw error;
         }
     }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -97,6 +97,10 @@
             "types": "./dist/facades/index.d.ts",
             "default": "./dist/facades/index.js"
         },
+        "./deployment-context": {
+            "types": "./dist/deployment-context/index.d.ts",
+            "default": "./dist/deployment-context/index.js"
+        },
         "./plugins": {
             "types": "./dist/plugins/index.d.ts",
             "default": "./dist/plugins/index.js"

--- a/packages/agent/src/deployment-context/index.ts
+++ b/packages/agent/src/deployment-context/index.ts
@@ -1,0 +1,1 @@
+export * from '../facades/deployment-context.resolver';

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -7,6 +7,10 @@ describe('DeployFacadeService', () => {
         scopedSettings?: Record<string, unknown>;
         pluginId?: string;
         pluginName?: string;
+        pluginOverrides?: Record<string, unknown>;
+        work?: Record<string, unknown>;
+        domainRepository?: Record<string, unknown>;
+        everWorksDeployProvider?: Record<string, unknown>;
     }) => {
         const pluginId = args.pluginId ?? args.deployProvider ?? 'k8s';
         const plugin = {
@@ -15,6 +19,7 @@ describe('DeployFacadeService', () => {
             providerName: 'kubernetes',
             capabilities: ['deployment'],
             lookupExistingDeployment: jest.fn().mockResolvedValue({ found: false }),
+            ...args.pluginOverrides,
         };
         const registered = {
             plugin,
@@ -39,12 +44,20 @@ describe('DeployFacadeService', () => {
         const workRepository = {
             findById: jest.fn().mockResolvedValue({
                 id: 'work-1',
+                slug: 'awesome-time-tracking',
+                user: { id: 'user-1', isPlatformAdmin: true },
                 deployProvider: args.deployProvider ?? pluginId,
+                getWebsiteRepo: () => 'awesome-time-tracking-website',
+                getRepoOwner: () => 'ever-works',
+                ...args.work,
             }),
             update: jest.fn(),
         };
         const domainRepository = {
             findByWork: jest.fn().mockResolvedValue([]),
+            findOne: jest.fn().mockResolvedValue(null),
+            removeDomain: jest.fn().mockResolvedValue(false),
+            ...args.domainRepository,
         };
 
         const service = new DeployFacadeService(
@@ -53,9 +66,11 @@ describe('DeployFacadeService', () => {
             workRepository as any,
             {} as any,
             domainRepository as any,
+            undefined,
+            args.everWorksDeployProvider as any,
         );
 
-        return { service, plugin, registry, settingsService, workRepository };
+        return { service, plugin, registry, settingsService, workRepository, domainRepository };
     };
 
     describe('work-scoped deployment lookup context', () => {
@@ -75,16 +90,15 @@ describe('DeployFacadeService', () => {
             }
         });
 
-        it('uses the Work cluster and enforced namespace instead of the inherited shared context', async () => {
+        it('uses the Work cluster and generated internal namespace instead of singleton defaults', async () => {
             process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
             process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'wrong-shared-cluster';
             const scopedSettings = {
                 clusterSource: 'k8s-works',
-                namespace: 'ever-works-timetrack-prod',
                 kubeContext: 'work-context',
             };
             const { service, plugin } = createService({
-                deployProvider: 'ever-works',
+                deployProvider: 'k8s',
                 pluginId: 'k8s',
                 settings: { clusterSource: { value: 'k8s-works' } },
                 scopedSettings,
@@ -100,8 +114,180 @@ describe('DeployFacadeService', () => {
                 'internal-work-cluster',
                 undefined,
                 {
-                    settingsOverride: scopedSettings,
-                    namespaceOverride: 'ever-works-timetrack-prod',
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                },
+            );
+        });
+
+        it('keeps the dedicated managed-provider kubeconfig even when Work settings name the internal cluster', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'wrong-internal-cluster';
+            const scopedSettings = {
+                clusterSource: 'k8s-works',
+                namespace: 'foreign-tenant',
+            };
+            const { service, plugin } = createService({
+                deployProvider: 'ever-works',
+                pluginId: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings,
+                everWorksDeployProvider: {
+                    isEnabled: () => true,
+                    resolveKubeconfig: jest.fn().mockResolvedValue('dedicated-managed-cluster'),
+                },
+            });
+
+            await service.lookupExistingDeployment('awesome-time-tracking-website', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking-website',
+                'dedicated-managed-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-tenants-user-1',
+                    },
+                    namespaceOverride: 'ever-works-tenants-user-1',
+                },
+            );
+        });
+
+        it('keeps the managed-provider shared fallback instead of re-resolving clusterSource', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'wrong-internal-cluster';
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'managed-shared-fallback';
+            const scopedSettings = { clusterSource: 'k8s-works' };
+            const { service, plugin } = createService({
+                deployProvider: 'ever-works',
+                pluginId: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings,
+                everWorksDeployProvider: { isEnabled: () => false },
+            });
+
+            await service.lookupExistingDeployment('awesome-time-tracking-website', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking-website',
+                'managed-shared-fallback',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-tenants-user-1',
+                    },
+                    namespaceOverride: 'ever-works-tenants-user-1',
+                },
+            );
+        });
+
+        it('replaces a user-supplied shared-cluster namespace with the tenant namespace', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-cluster';
+            const scopedSettings = {
+                clusterSource: 'k8s-works-shared',
+                namespace: 'foreign-tenant',
+            };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                pluginId: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works-shared' } },
+                scopedSettings,
+            });
+
+            await service.lookupExistingDeployment('awesome-time-tracking-website', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking-website',
+                'shared-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-tenants-user-1',
+                    },
+                    namespaceOverride: 'ever-works-tenants-user-1',
+                },
+            );
+        });
+
+        it('propagates the effective context through the post-domain-removal relookup', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            const scopedSettings = { clusterSource: 'k8s-works' };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings,
+                work: {
+                    website: 'https://old.example.com',
+                    deployProjectId: 'project-1',
+                },
+                pluginOverrides: {
+                    removeDomain: jest.fn().mockResolvedValue(undefined),
+                },
+                domainRepository: {
+                    findOne: jest.fn().mockResolvedValue({ provider: 'k8s' }),
+                    removeDomain: jest.fn().mockResolvedValue(true),
+                },
+            });
+
+            await service.removeDomain('old.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                },
+            );
+        });
+
+        it('propagates the effective context through project-id resolution', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            const scopedSettings = { clusterSource: 'k8s-works' };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings,
+                pluginOverrides: {
+                    lookupExistingDeployment: jest
+                        .fn()
+                        .mockResolvedValue({ found: true, projectId: 'project-1' }),
+                    getDomains: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.getDomains({ userId: 'user-1', workId: 'work-1' });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking-website',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
                 },
             );
         });

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -5,6 +5,7 @@ describe('DeployFacadeService', () => {
         deployProvider?: string;
         settings?: Record<string, { value?: unknown }>;
         scopedSettings?: Record<string, unknown>;
+        scopedResolvedSettings?: Record<string, unknown>;
         pluginId?: string;
         pluginName?: string;
         pluginOverrides?: Record<string, unknown>;
@@ -38,7 +39,12 @@ describe('DeployFacadeService', () => {
             getByCapability: jest.fn(() => [registered]),
         };
         const settingsService = {
-            getResolvedSettings: jest.fn().mockResolvedValue(args.settings ?? {}),
+            getResolvedSettings: jest.fn().mockImplementation((_pluginId, options) => {
+                if (options?.includeSecrets === false && args.scopedResolvedSettings) {
+                    return Promise.resolve(args.scopedResolvedSettings);
+                }
+                return Promise.resolve(args.settings ?? {});
+            }),
             getSettings: jest.fn().mockResolvedValue(args.scopedSettings ?? {}),
         };
         const workRepository = {
@@ -115,10 +121,70 @@ describe('DeployFacadeService', () => {
                 undefined,
                 {
                     settingsOverride: {
+                        clusterSource: scopedSettings.clusterSource,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
+                },
+            );
+        });
+
+        it('derives the internal namespace when the reserved value is only a schema default', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            const scopedSettings = {
+                clusterSource: 'k8s-works',
+                namespace: 'ever-works',
+            };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                pluginId: 'k8s',
+                settings: {
+                    clusterSource: {
+                        key: 'clusterSource',
+                        value: 'k8s-works',
+                        source: 'work',
+                        isFallback: false,
+                    },
+                } as any,
+                scopedSettings,
+                scopedResolvedSettings: {
+                    clusterSource: {
+                        key: 'clusterSource',
+                        value: 'k8s-works',
+                        source: 'work',
+                        isFallback: false,
+                    },
+                    namespace: {
+                        key: 'namespace',
+                        value: 'ever-works',
+                        source: 'default',
+                        isFallback: true,
+                    },
+                },
+                pluginOverrides: {
+                    lookupExistingDeployment: jest
+                        .fn()
+                        .mockResolvedValue({ found: true, projectId: 'project-1' }),
+                    getDomains: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.getDomains({ userId: 'user-1', workId: 'work-1' });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking-website',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
                         ...scopedSettings,
                         namespace: 'ever-works-awesome-time-tracking-prod',
                     },
                     namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -155,6 +221,8 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-tenants-user-1',
                     },
                     namespaceOverride: 'ever-works-tenants-user-1',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -186,6 +254,8 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-tenants-user-1',
                     },
                     namespaceOverride: 'ever-works-tenants-user-1',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -218,6 +288,8 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-tenants-user-1',
                     },
                     namespaceOverride: 'ever-works-tenants-user-1',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -258,6 +330,8 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-awesome-time-tracking-prod',
                     },
                     namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
             expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
@@ -270,6 +344,8 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-awesome-time-tracking-prod',
                     },
                     namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -301,6 +377,8 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-awesome-time-tracking-prod',
                     },
                     namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
             expect((plugin as any).getDomains).toHaveBeenCalledWith(
@@ -313,6 +391,40 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-awesome-time-tracking-prod',
                     },
                     namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
+                },
+            );
+        });
+
+        it('overrides a stale cached Kubernetes project ID with the current namespace and website repo', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            const scopedSettings = { clusterSource: 'k8s-works' };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings,
+                work: {
+                    deployProjectId: 'stale-namespace/stale-repo',
+                    getWebsiteRepo: () => 'renamed-website-repo',
+                },
+                pluginOverrides: { getDomains: jest.fn().mockResolvedValue([]) },
+            });
+
+            await service.getDomains({ userId: 'user-1', workId: 'work-1' });
+
+            expect((plugin as any).getDomains).toHaveBeenCalledWith(
+                'stale-namespace/stale-repo',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                    projectNameOverride: 'renamed-website-repo',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -353,10 +465,13 @@ describe('DeployFacadeService', () => {
                 'tenant-team',
                 {
                     settingsOverride: {
-                        ...scopedSettings,
+                        clusterSource: scopedSettings.clusterSource,
+                        defaultTeamScope: scopedSettings.defaultTeamScope,
                         namespace: 'ever-works-tenants-user-1',
                     },
                     namespaceOverride: 'ever-works-tenants-user-1',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
         });
@@ -393,12 +508,35 @@ describe('DeployFacadeService', () => {
                 undefined,
                 {
                     settingsOverride: {
-                        ...scopedSettings,
+                        clusterSource: scopedSettings.clusterSource,
                         namespace: 'ever-works-tenants-user-1',
                     },
                     namespaceOverride: 'ever-works-tenants-user-1',
+                    projectNameOverride: 'awesome-time-tracking-website',
+                    kubeContextOverride: null,
                 },
             );
+        });
+
+        it('propagates deterministic provider lookup failures instead of reporting not-found', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            const { service } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings: { clusterSource: 'k8s-works' },
+                pluginOverrides: {
+                    lookupExistingDeployment: jest
+                        .fn()
+                        .mockRejectedValue(new Error('cluster authentication failed')),
+                },
+            });
+
+            await expect(
+                service.lookupExistingDeployment('awesome-time-tracking-website', {
+                    userId: 'user-1',
+                    workId: 'work-1',
+                }),
+            ).rejects.toThrow('cluster authentication failed');
         });
     });
 

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -96,6 +96,45 @@ describe('DeployFacadeService', () => {
             }
         });
 
+        it('uses the authoritative Work context when the caller supplies a stale deployment ID', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            const getDeploymentStatus = jest.fn().mockImplementation(
+                async (
+                    _deploymentId: string,
+                    token: string,
+                    context?: {
+                        namespaceOverride?: string;
+                        projectNameOverride?: string;
+                        kubeContextOverride?: string | null;
+                    },
+                ) => ({
+                    id: `${context?.namespaceOverride}/${context?.projectNameOverride}`,
+                    status:
+                        token === 'internal-work-cluster' &&
+                        context?.namespaceOverride === 'ever-works-awesome-time-tracking-prod' &&
+                        context?.projectNameOverride === 'awesome-time-tracking-website' &&
+                        context?.kubeContextOverride === null
+                            ? 'ready'
+                            : 'error',
+                    createdAt: '2026-08-22T00:00:00.000Z',
+                }),
+            );
+            const { service } = createService({
+                deployProvider: 'k8s',
+                pluginId: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings: { clusterSource: 'k8s-works' },
+                pluginOverrides: { getDeploymentStatus },
+            });
+
+            const result = await service.getDeploymentStatus('tenant-b/repo-b', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(result.status).toBe('ready');
+        });
+
         it('uses the Work cluster and generated internal namespace instead of singleton defaults', async () => {
             process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
             process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'wrong-shared-cluster';

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -247,8 +247,21 @@ describe('DeployFacadeService', () => {
                 workId: 'work-1',
             });
 
+            expect((plugin as any).removeDomain).toHaveBeenCalledWith(
+                'project-1',
+                'old.example.com',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                },
+            );
             expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
-                'awesome-time-tracking',
+                'awesome-time-tracking-website',
                 'internal-work-cluster',
                 undefined,
                 {
@@ -288,6 +301,102 @@ describe('DeployFacadeService', () => {
                         namespace: 'ever-works-awesome-time-tracking-prod',
                     },
                     namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                },
+            );
+            expect((plugin as any).getDomains).toHaveBeenCalledWith(
+                'project-1',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-awesome-time-tracking-prod',
+                    },
+                    namespaceOverride: 'ever-works-awesome-time-tracking-prod',
+                },
+            );
+        });
+
+        it('uses the shared Work cluster and scoped context for add-domain operations', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-work-cluster';
+            const scopedSettings = {
+                clusterSource: 'k8s-works-shared',
+                kubeContext: 'shared-work-context',
+                defaultTeamScope: 'tenant-team',
+            };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works-shared' } },
+                scopedSettings,
+                work: { deployProjectId: 'project-1' },
+                pluginOverrides: {
+                    addDomain: jest.fn().mockResolvedValue({
+                        domain: { name: 'tools.example.com', verified: false },
+                        verified: false,
+                    }),
+                },
+                domainRepository: {
+                    addDomain: jest.fn(),
+                    updateVerified: jest.fn(),
+                },
+            });
+
+            await service.addDomain('tools.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect((plugin as any).addDomain).toHaveBeenCalledWith(
+                'project-1',
+                'tools.example.com',
+                'shared-work-cluster',
+                'tenant-team',
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-tenants-user-1',
+                    },
+                    namespaceOverride: 'ever-works-tenants-user-1',
+                },
+            );
+        });
+
+        it('uses the shared Work cluster and scoped context for verify-domain operations', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-work-cluster';
+            const scopedSettings = {
+                clusterSource: 'k8s-works-shared',
+                kubeContext: 'shared-work-context',
+            };
+            const { service, plugin } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works-shared' } },
+                scopedSettings,
+                work: { deployProjectId: 'project-1' },
+                pluginOverrides: {
+                    verifyDomain: jest.fn().mockResolvedValue({
+                        name: 'tools.example.com',
+                        verified: false,
+                    }),
+                },
+                domainRepository: { updateVerified: jest.fn() },
+            });
+
+            await service.verifyDomain('tools.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect((plugin as any).verifyDomain).toHaveBeenCalledWith(
+                'project-1',
+                'tools.example.com',
+                'shared-work-cluster',
+                undefined,
+                {
+                    settingsOverride: {
+                        ...scopedSettings,
+                        namespace: 'ever-works-tenants-user-1',
+                    },
+                    namespaceOverride: 'ever-works-tenants-user-1',
                 },
             );
         });
@@ -623,6 +732,8 @@ describe('DeployFacadeService', () => {
                 deployProvider: 'k8s',
                 user: { id: 'user-1' },
                 website: 'https://site.ever.works',
+                getWebsiteRepo: () => 'site-website',
+                getRepoOwner: () => 'customer-org',
                 // Short-circuit `resolveProjectId` — the BYO custom-domain
                 // path doesn't care what projectId resolves to; we just need
                 // the addDomain pipeline to reach the DB persist + DNS hook.

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -4,6 +4,7 @@ describe('DeployFacadeService', () => {
     const createService = (args: {
         deployProvider?: string;
         settings?: Record<string, { value?: unknown }>;
+        scopedSettings?: Record<string, unknown>;
         pluginId?: string;
         pluginName?: string;
     }) => {
@@ -13,6 +14,7 @@ describe('DeployFacadeService', () => {
             name: args.pluginName ?? 'Kubernetes',
             providerName: 'kubernetes',
             capabilities: ['deployment'],
+            lookupExistingDeployment: jest.fn().mockResolvedValue({ found: false }),
         };
         const registered = {
             plugin,
@@ -32,7 +34,7 @@ describe('DeployFacadeService', () => {
         };
         const settingsService = {
             getResolvedSettings: jest.fn().mockResolvedValue(args.settings ?? {}),
-            getSettings: jest.fn().mockResolvedValue({}),
+            getSettings: jest.fn().mockResolvedValue(args.scopedSettings ?? {}),
         };
         const workRepository = {
             findById: jest.fn().mockResolvedValue({
@@ -53,8 +55,57 @@ describe('DeployFacadeService', () => {
             domainRepository as any,
         );
 
-        return { service, registry, settingsService, workRepository };
+        return { service, plugin, registry, settingsService, workRepository };
     };
+
+    describe('work-scoped deployment lookup context', () => {
+        const originalInternal = process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+        const originalShared = process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+
+        afterEach(() => {
+            if (originalInternal === undefined) {
+                delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+            } else {
+                process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = originalInternal;
+            }
+            if (originalShared === undefined) {
+                delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+            } else {
+                process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = originalShared;
+            }
+        });
+
+        it('uses the Work cluster and enforced namespace instead of the inherited shared context', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-work-cluster';
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'wrong-shared-cluster';
+            const scopedSettings = {
+                clusterSource: 'k8s-works',
+                namespace: 'ever-works-timetrack-prod',
+                kubeContext: 'work-context',
+            };
+            const { service, plugin } = createService({
+                deployProvider: 'ever-works',
+                pluginId: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+                scopedSettings,
+            });
+
+            await service.lookupExistingDeployment('awesome-time-tracking-website', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(plugin.lookupExistingDeployment).toHaveBeenCalledWith(
+                'awesome-time-tracking-website',
+                'internal-work-cluster',
+                undefined,
+                {
+                    settingsOverride: scopedSettings,
+                    namespaceOverride: 'ever-works-timetrack-prod',
+                },
+            );
+        });
+    });
 
     it('treats Kubernetes kubeconfig as the deployment credential', async () => {
         const { service } = createService({

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -6,6 +6,7 @@ import type {
     DeployFacadeTeam,
     DeployProviderInfo,
     DeploymentLookupResult,
+    DeploymentLookupContext,
     DeploymentDomain,
     AddDomainResult,
 } from '@ever-works/plugin';
@@ -307,7 +308,24 @@ export class DeployFacadeService implements IDeployFacade {
             const teamScope = settings.defaultTeamScope as string | undefined;
 
             if (plugin.lookupExistingDeployment) {
-                const result = await plugin.lookupExistingDeployment(projectName, token, teamScope);
+                const lookupToken = this.resolveLookupToken(plugin.id, token, settings);
+                const lookupContext: DeploymentLookupContext | undefined =
+                    plugin.id === KUBERNETES_DEPLOY_PROVIDER_ID
+                        ? {
+                              settingsOverride: settings,
+                              namespaceOverride:
+                                  typeof settings.namespace === 'string' &&
+                                  settings.namespace.trim()
+                                      ? settings.namespace.trim()
+                                      : undefined,
+                          }
+                        : undefined;
+                const result = await plugin.lookupExistingDeployment(
+                    projectName,
+                    lookupToken,
+                    teamScope,
+                    lookupContext,
+                );
 
                 // Update work with deployment info if found
                 if (result.found && (result.website || result.deploymentState)) {
@@ -966,6 +984,48 @@ export class DeployFacadeService implements IDeployFacade {
         }
 
         return null;
+    }
+
+    /**
+     * Resolve the same platform-managed cluster selected by the Work settings
+     * for read-back. `resolvePluginAndTokenWithWork` can inherit the managed
+     * `ever-works` provider's shared/dedicated token before the Work's k8s
+     * `clusterSource` is considered; using that token here made verification
+     * query a different cluster than deploy.
+     */
+    private resolveLookupToken(
+        pluginId: string,
+        resolvedToken: string,
+        settings: Record<string, unknown>,
+    ): string {
+        if (pluginId !== KUBERNETES_DEPLOY_PROVIDER_ID) {
+            return resolvedToken;
+        }
+
+        const clusterSource = settings.clusterSource;
+        if (clusterSource === 'k8s-works' || clusterSource === 'k8s-gauzy') {
+            const kubeconfig = process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG?.trim();
+            if (!kubeconfig) {
+                throw new DeployFacadeError(
+                    'The k8s-works cluster kubeconfig is not configured on the platform.',
+                    'lookupExistingDeployment',
+                    pluginId,
+                );
+            }
+            return kubeconfig;
+        }
+        if (clusterSource === 'k8s-works-shared') {
+            const kubeconfig = process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG?.trim();
+            if (!kubeconfig) {
+                throw new DeployFacadeError(
+                    'The k8s-works-shared cluster kubeconfig is not configured on the platform.',
+                    'lookupExistingDeployment',
+                    pluginId,
+                );
+            }
+            return kubeconfig;
+        }
+        return resolvedToken;
     }
 
     /**

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -9,6 +9,7 @@ import type {
     DeploymentLookupContext,
     DeploymentDomain,
     AddDomainResult,
+    SettingSource,
 } from '@ever-works/plugin';
 import { PLUGIN_CAPABILITIES, isDnsProvider } from '@ever-works/plugin';
 import type { IDnsProvider } from '@ever-works/plugin';
@@ -306,38 +307,29 @@ export class DeployFacadeService implements IDeployFacade {
         projectName: string,
         options: DeployFacadeOptions,
     ): Promise<DeploymentLookupResult> {
-        try {
-            const { plugin, token, work } = await this.resolvePluginAndTokenWithWork(options);
+        const { plugin, token, work } = await this.resolvePluginAndTokenWithWork(options);
 
-            if (plugin.lookupExistingDeployment) {
-                const lookup = await this.resolveDeploymentLookupContext(
-                    plugin,
-                    token,
-                    work,
-                    options,
-                );
-                const result = await plugin.lookupExistingDeployment(
-                    projectName,
-                    lookup.token,
-                    lookup.teamScope,
-                    lookup.context,
-                );
+        if (plugin.lookupExistingDeployment) {
+            const lookup = await this.resolveDeploymentLookupContext(plugin, token, work, options);
+            const result = await plugin.lookupExistingDeployment(
+                projectName,
+                lookup.token,
+                lookup.teamScope,
+                lookup.context,
+            );
 
-                // Update work with deployment info if found
-                if (result.found && (result.website || result.deploymentState)) {
-                    await this.workRepository.update(work.id, {
-                        website: result.website ?? undefined,
-                        deploymentState: result.deploymentState ?? work.deploymentState,
-                    });
-                }
-
-                return result;
+            // Update work with deployment info if found
+            if (result.found && (result.website || result.deploymentState)) {
+                await this.workRepository.update(work.id, {
+                    website: result.website ?? undefined,
+                    deploymentState: result.deploymentState ?? work.deploymentState,
+                });
             }
 
-            return { found: false };
-        } catch {
-            return { found: false };
+            return result;
         }
+
+        return { found: false };
     }
 
     /**
@@ -400,14 +392,15 @@ export class DeployFacadeService implements IDeployFacade {
         token: string;
         work: Work;
         settings: Record<string, unknown>;
+        settingSources: Record<string, SettingSource | undefined>;
     }> {
         const result = await this.resolvePluginAndTokenWithWork(options);
-        const settings = await this.settingsService.getSettings(result.plugin.id, {
-            userId: options.userId,
-            workId: options.workId,
-            includeSecrets: true,
-        });
-        return { ...result, settings };
+        const { settings, settingSources } = await this.getDeploymentSettingsSnapshot(
+            result.plugin.id,
+            options,
+            true,
+        );
+        return { ...result, settings, settingSources };
     }
 
     /**
@@ -1064,18 +1057,20 @@ export class DeployFacadeService implements IDeployFacade {
         work: Work,
         options: DeployFacadeOptions,
     ): Promise<EffectiveDeploymentOperationContext> {
-        const settings = await this.settingsService.getSettings(plugin.id, {
-            userId: options.userId,
-            workId: options.workId,
-            includeSecrets: false,
-        });
+        const { settings, settingSources } = await this.getDeploymentSettingsSnapshot(
+            plugin.id,
+            options,
+            false,
+        );
         const owner = work.user as User | undefined;
         const effective = resolveEffectiveDeploymentContext({
             deployProvider: work.deployProvider,
             pluginId: plugin.id,
             resolvedToken,
             settings,
+            settingSources,
             websiteOwner: work.getRepoOwner('website'),
+            websiteProjectName: work.getWebsiteRepo(),
             workId: work.id,
             workSlug: work.slug,
             ownerUserId: owner?.id,
@@ -1086,6 +1081,30 @@ export class DeployFacadeService implements IDeployFacade {
             teamScope: effective.settings.defaultTeamScope as string | undefined,
             context: effective.lookupContext,
         };
+    }
+
+    private async getDeploymentSettingsSnapshot(
+        pluginId: string,
+        options: DeployFacadeOptions,
+        includeSecrets: boolean,
+    ): Promise<{
+        settings: Record<string, unknown>;
+        settingSources: Record<string, SettingSource | undefined>;
+    }> {
+        const resolutionOptions = {
+            userId: options.userId,
+            workId: options.workId,
+            includeSecrets,
+        };
+        const [settings, resolved] = await Promise.all([
+            this.settingsService.getSettings(pluginId, resolutionOptions),
+            this.settingsService.getResolvedSettings(pluginId, resolutionOptions),
+        ]);
+        const settingSources: Record<string, SettingSource | undefined> = {};
+        for (const [key, value] of Object.entries(resolved)) {
+            settingSources[key] = value.source;
+        }
+        return { settings, settingSources };
     }
 
     /**

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -291,8 +291,18 @@ export class DeployFacadeService implements IDeployFacade {
         deploymentId: string,
         options: DeployFacadeOptions,
     ): Promise<{ status: string; url?: string; error?: string }> {
-        const { plugin, token } = await this.resolvePluginAndToken(options);
-        const result = await plugin.getDeploymentStatus(deploymentId, token);
+        const { plugin, token, work } = await this.resolvePluginAndTokenWithWork(options);
+        const deploymentContext = await this.resolveDeploymentLookupContext(
+            plugin,
+            token,
+            work,
+            options,
+        );
+        const result = await plugin.getDeploymentStatus(
+            deploymentId,
+            deploymentContext.token,
+            deploymentContext.context,
+        );
         return {
             status: result.status,
             url: result.url,

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -6,7 +6,6 @@ import type {
     DeployFacadeTeam,
     DeployProviderInfo,
     DeploymentLookupResult,
-    DeploymentLookupContext,
     DeploymentDomain,
     AddDomainResult,
 } from '@ever-works/plugin';
@@ -22,6 +21,10 @@ import { EverWorksK8sDeployProvider } from '../ever-works-providers';
 import { FacadeError, NoProviderError, ProviderNotFoundError } from './base.facade';
 import type { Work } from '../entities/work.entity';
 import type { User } from '../entities/user.entity';
+import {
+    PLATFORM_MANAGED_KUBECONFIG_SENTINEL,
+    resolveEffectiveDeploymentContext,
+} from './deployment-context.resolver';
 
 const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
 const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
@@ -299,32 +302,18 @@ export class DeployFacadeService implements IDeployFacade {
         try {
             const { plugin, token, work } = await this.resolvePluginAndTokenWithWork(options);
 
-            // Get team scope from settings
-            const settings = await this.settingsService.getSettings(plugin.id, {
-                userId: options.userId,
-                workId: options.workId,
-                includeSecrets: false,
-            });
-            const teamScope = settings.defaultTeamScope as string | undefined;
-
             if (plugin.lookupExistingDeployment) {
-                const lookupToken = this.resolveLookupToken(plugin.id, token, settings);
-                const lookupContext: DeploymentLookupContext | undefined =
-                    plugin.id === KUBERNETES_DEPLOY_PROVIDER_ID
-                        ? {
-                              settingsOverride: settings,
-                              namespaceOverride:
-                                  typeof settings.namespace === 'string' &&
-                                  settings.namespace.trim()
-                                      ? settings.namespace.trim()
-                                      : undefined,
-                          }
-                        : undefined;
+                const lookup = await this.resolveDeploymentLookupContext(
+                    plugin,
+                    token,
+                    work,
+                    options,
+                );
                 const result = await plugin.lookupExistingDeployment(
                     projectName,
-                    lookupToken,
-                    teamScope,
-                    lookupContext,
+                    lookup.token,
+                    lookup.teamScope,
+                    lookup.context,
                 );
 
                 // Update work with deployment info if found
@@ -825,12 +814,18 @@ export class DeployFacadeService implements IDeployFacade {
         // If the removed domain was the current website URL, re-lookup to update
         if (removed && work.website === `https://${domain}`) {
             try {
-                const teamScope = await this.getTeamScope(plugin.id, options);
                 if (plugin.lookupExistingDeployment) {
+                    const lookupContext = await this.resolveDeploymentLookupContext(
+                        plugin,
+                        token,
+                        work,
+                        options,
+                    );
                     const lookup = await plugin.lookupExistingDeployment(
                         work.slug,
-                        token,
-                        teamScope,
+                        lookupContext.token,
+                        lookupContext.teamScope,
+                        lookupContext.context,
                     );
                     await this.workRepository.update(work.id, {
                         website: lookup.website ?? undefined,
@@ -986,46 +981,34 @@ export class DeployFacadeService implements IDeployFacade {
         return null;
     }
 
-    /**
-     * Resolve the same platform-managed cluster selected by the Work settings
-     * for read-back. `resolvePluginAndTokenWithWork` can inherit the managed
-     * `ever-works` provider's shared/dedicated token before the Work's k8s
-     * `clusterSource` is considered; using that token here made verification
-     * query a different cluster than deploy.
-     */
-    private resolveLookupToken(
-        pluginId: string,
+    private async resolveDeploymentLookupContext(
+        plugin: IDeploymentPlugin,
         resolvedToken: string,
-        settings: Record<string, unknown>,
-    ): string {
-        if (pluginId !== KUBERNETES_DEPLOY_PROVIDER_ID) {
-            return resolvedToken;
-        }
-
-        const clusterSource = settings.clusterSource;
-        if (clusterSource === 'k8s-works' || clusterSource === 'k8s-gauzy') {
-            const kubeconfig = process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG?.trim();
-            if (!kubeconfig) {
-                throw new DeployFacadeError(
-                    'The k8s-works cluster kubeconfig is not configured on the platform.',
-                    'lookupExistingDeployment',
-                    pluginId,
-                );
-            }
-            return kubeconfig;
-        }
-        if (clusterSource === 'k8s-works-shared') {
-            const kubeconfig = process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG?.trim();
-            if (!kubeconfig) {
-                throw new DeployFacadeError(
-                    'The k8s-works-shared cluster kubeconfig is not configured on the platform.',
-                    'lookupExistingDeployment',
-                    pluginId,
-                );
-            }
-            return kubeconfig;
-        }
-        return resolvedToken;
+        work: Work,
+        options: DeployFacadeOptions,
+    ) {
+        const settings = await this.settingsService.getSettings(plugin.id, {
+            userId: options.userId,
+            workId: options.workId,
+            includeSecrets: false,
+        });
+        const owner = work.user as User | undefined;
+        const effective = resolveEffectiveDeploymentContext({
+            deployProvider: work.deployProvider,
+            pluginId: plugin.id,
+            resolvedToken,
+            settings,
+            websiteOwner: work.getRepoOwner('website'),
+            workId: work.id,
+            workSlug: work.slug,
+            ownerUserId: owner?.id,
+            isPlatformAdmin: Boolean(owner?.isPlatformAdmin),
+        });
+        return {
+            token: effective.token,
+            teamScope: effective.settings.defaultTeamScope as string | undefined,
+            context: effective.lookupContext,
+        };
     }
 
     /**
@@ -1043,12 +1026,18 @@ export class DeployFacadeService implements IDeployFacade {
             return work.deployProjectId;
         }
 
-        const teamScope = await this.getTeamScope(plugin.id, options);
         if (plugin.lookupExistingDeployment) {
+            const lookupContext = await this.resolveDeploymentLookupContext(
+                plugin,
+                token,
+                work,
+                options,
+            );
             const result = await plugin.lookupExistingDeployment(
                 work.getWebsiteRepo(),
-                token,
-                teamScope,
+                lookupContext.token,
+                lookupContext.teamScope,
+                lookupContext.context,
             );
             if (result.found && result.projectId) {
                 // Cache the projectId for future calls
@@ -1135,15 +1124,4 @@ export class DeployFacadeService implements IDeployFacade {
     }
 }
 
-/**
- * Sentinel value returned by `getTokenFromSettings` for k8s deploys
- * targeting a platform-managed cluster (`k8s-works` / `k8s-works-shared`).
- * The deploy facade only checks that a token is non-empty before
- * deciding the work is "configured", so any unique string works.
- * `DeployService.resolveDeployToken()` discards this sentinel and
- * substitutes the real platform kubeconfig from
- * `EVER_WORKS_K8S_*_KUBECONFIG` env vars at deploy time.
- *
- * Exported so callers (or tests) can pattern-match on it if needed.
- */
-export const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';
+export { PLATFORM_MANAGED_KUBECONFIG_SENTINEL } from './deployment-context.resolver';

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -6,6 +6,7 @@ import type {
     DeployFacadeTeam,
     DeployProviderInfo,
     DeploymentLookupResult,
+    DeploymentLookupContext,
     DeploymentDomain,
     AddDomainResult,
 } from '@ever-works/plugin';
@@ -82,6 +83,12 @@ export class NoDeployCredentialsError extends DeployFacadeError {
 export interface DeployFacadeFullOptions extends DeployFacadeOptions {
     /** Override the provider (instead of using work.deployProvider) */
     providerOverride?: string;
+}
+
+interface EffectiveDeploymentOperationContext {
+    readonly token: string;
+    readonly teamScope: string | undefined;
+    readonly context: DeploymentLookupContext;
 }
 
 /**
@@ -479,9 +486,25 @@ export class DeployFacadeService implements IDeployFacade {
             const { plugin, token, work } = await this.resolvePluginAndTokenWithWork(options);
             providerId = plugin.id;
             if (plugin.getDomains) {
-                const projectId = await this.resolveProjectId(plugin, token, work, options);
-                const teamScope = await this.getTeamScope(plugin.id, options);
-                providerDomains = await plugin.getDomains(projectId, token, teamScope);
+                const deploymentContext = await this.resolveDeploymentLookupContext(
+                    plugin,
+                    token,
+                    work,
+                    options,
+                );
+                const projectId = await this.resolveProjectId(
+                    plugin,
+                    token,
+                    work,
+                    options,
+                    deploymentContext,
+                );
+                providerDomains = await plugin.getDomains(
+                    projectId,
+                    deploymentContext.token,
+                    deploymentContext.teamScope,
+                    deploymentContext.context,
+                );
                 if (shouldAutoImportProviderDomains) {
                     await this.reconcileProviderDomains(options.workId, plugin.id, providerDomains);
                 }
@@ -572,16 +595,26 @@ export class DeployFacadeService implements IDeployFacade {
             );
         }
 
-        const projectId = await this.resolveProjectId(plugin, token, work, options);
-        const teamScope = await this.getTeamScope(plugin.id, options);
+        const deploymentContext = await this.resolveDeploymentLookupContext(
+            plugin,
+            token,
+            work,
+            options,
+        );
+        const projectId = await this.resolveProjectId(
+            plugin,
+            token,
+            work,
+            options,
+            deploymentContext,
+        );
         const existing = await this.domainRepository.findOne(options.workId, domain);
 
         if (plugin.getDomains) {
             const providerDomain = await this.findProviderDomain(
                 plugin,
                 projectId,
-                token,
-                teamScope,
+                deploymentContext,
                 domain,
             );
 
@@ -608,7 +641,13 @@ export class DeployFacadeService implements IDeployFacade {
         // Push to provider
         let result: AddDomainResult;
         try {
-            result = await plugin.addDomain(projectId, domain, token, teamScope);
+            result = await plugin.addDomain(
+                projectId,
+                domain,
+                deploymentContext.token,
+                deploymentContext.teamScope,
+                deploymentContext.context,
+            );
         } catch (error) {
             throw error;
         }
@@ -711,14 +750,18 @@ export class DeployFacadeService implements IDeployFacade {
     private async findProviderDomain(
         plugin: IDeploymentPlugin,
         projectId: string,
-        token: string,
-        teamScope: string | undefined,
+        deploymentContext: EffectiveDeploymentOperationContext,
         domain: string,
     ): Promise<DeploymentDomain | undefined> {
         if (!plugin.getDomains) return undefined;
 
         try {
-            const providerDomains = await plugin.getDomains(projectId, token, teamScope);
+            const providerDomains = await plugin.getDomains(
+                projectId,
+                deploymentContext.token,
+                deploymentContext.teamScope,
+                deploymentContext.context,
+            );
             return providerDomains.find((item) => item.name === domain);
         } catch (error) {
             this.logger.warn(
@@ -793,14 +836,36 @@ export class DeployFacadeService implements IDeployFacade {
      */
     async removeDomain(domain: string, options: DeployFacadeOptions): Promise<boolean> {
         const { plugin, token, work } = await this.resolvePluginAndTokenWithWork(options);
+        let deploymentContext: EffectiveDeploymentOperationContext | undefined;
+        const getDeploymentContext = async (): Promise<EffectiveDeploymentOperationContext> => {
+            deploymentContext ??= await this.resolveDeploymentLookupContext(
+                plugin,
+                token,
+                work,
+                options,
+            );
+            return deploymentContext;
+        };
 
         // If provider supports removal and domain is synced, remove from provider
         const dbRecord = await this.domainRepository.findOne(options.workId, domain);
         if (dbRecord?.provider && plugin.removeDomain) {
             try {
-                const projectId = await this.resolveProjectId(plugin, token, work, options);
-                const teamScope = await this.getTeamScope(plugin.id, options);
-                await plugin.removeDomain(projectId, domain, token, teamScope);
+                const effective = await getDeploymentContext();
+                const projectId = await this.resolveProjectId(
+                    plugin,
+                    token,
+                    work,
+                    options,
+                    effective,
+                );
+                await plugin.removeDomain(
+                    projectId,
+                    domain,
+                    effective.token,
+                    effective.teamScope,
+                    effective.context,
+                );
             } catch (error) {
                 this.logger.warn(
                     `Failed to remove domain from provider, removing from DB anyway: ${error}`,
@@ -815,14 +880,9 @@ export class DeployFacadeService implements IDeployFacade {
         if (removed && work.website === `https://${domain}`) {
             try {
                 if (plugin.lookupExistingDeployment) {
-                    const lookupContext = await this.resolveDeploymentLookupContext(
-                        plugin,
-                        token,
-                        work,
-                        options,
-                    );
+                    const lookupContext = await getDeploymentContext();
                     const lookup = await plugin.lookupExistingDeployment(
-                        work.slug,
+                        work.getWebsiteRepo(),
                         lookupContext.token,
                         lookupContext.teamScope,
                         lookupContext.context,
@@ -852,9 +912,26 @@ export class DeployFacadeService implements IDeployFacade {
                 plugin.id,
             );
         }
-        const projectId = await this.resolveProjectId(plugin, token, work, options);
-        const teamScope = await this.getTeamScope(plugin.id, options);
-        const result = await plugin.verifyDomain(projectId, domain, token, teamScope);
+        const deploymentContext = await this.resolveDeploymentLookupContext(
+            plugin,
+            token,
+            work,
+            options,
+        );
+        const projectId = await this.resolveProjectId(
+            plugin,
+            token,
+            work,
+            options,
+            deploymentContext,
+        );
+        const result = await plugin.verifyDomain(
+            projectId,
+            domain,
+            deploymentContext.token,
+            deploymentContext.teamScope,
+            deploymentContext.context,
+        );
 
         // Update DB with verification result
         await this.domainRepository.updateVerified(options.workId, domain, result.verified);
@@ -986,7 +1063,7 @@ export class DeployFacadeService implements IDeployFacade {
         resolvedToken: string,
         work: Work,
         options: DeployFacadeOptions,
-    ) {
+    ): Promise<EffectiveDeploymentOperationContext> {
         const settings = await this.settingsService.getSettings(plugin.id, {
             userId: options.userId,
             workId: options.workId,
@@ -1020,6 +1097,7 @@ export class DeployFacadeService implements IDeployFacade {
         token: string,
         work: Work,
         options: DeployFacadeOptions,
+        effectiveContext?: EffectiveDeploymentOperationContext,
     ): Promise<string> {
         // Use cached value if available
         if (work.deployProjectId) {
@@ -1027,12 +1105,9 @@ export class DeployFacadeService implements IDeployFacade {
         }
 
         if (plugin.lookupExistingDeployment) {
-            const lookupContext = await this.resolveDeploymentLookupContext(
-                plugin,
-                token,
-                work,
-                options,
-            );
+            const lookupContext =
+                effectiveContext ??
+                (await this.resolveDeploymentLookupContext(plugin, token, work, options));
             const result = await plugin.lookupExistingDeployment(
                 work.getWebsiteRepo(),
                 lookupContext.token,
@@ -1052,21 +1127,6 @@ export class DeployFacadeService implements IDeployFacade {
             'resolveProjectId',
             plugin.id,
         );
-    }
-
-    /**
-     * Get team scope from plugin settings
-     */
-    private async getTeamScope(
-        pluginId: string,
-        options: DeployFacadeOptions,
-    ): Promise<string | undefined> {
-        const settings = await this.settingsService.getSettings(pluginId, {
-            userId: options.userId,
-            workId: options.workId,
-            includeSecrets: false,
-        });
-        return settings.defaultTeamScope as string | undefined;
     }
 
     /**

--- a/packages/agent/src/facades/deployment-context.resolver.ts
+++ b/packages/agent/src/facades/deployment-context.resolver.ts
@@ -1,4 +1,4 @@
-import type { DeploymentLookupContext } from '@ever-works/plugin';
+import type { DeploymentLookupContext, SettingSource } from '@ever-works/plugin';
 import { buildEverWorksTenantNamespace } from '../ever-works-providers/ever-works-k8s-deploy.provider';
 
 export const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';
@@ -35,7 +35,9 @@ export interface EffectiveDeploymentContextInput {
     readonly pluginId?: string;
     readonly resolvedToken: string;
     readonly settings: Record<string, unknown>;
+    readonly settingSources?: Readonly<Record<string, SettingSource | undefined>>;
     readonly websiteOwner: string;
+    readonly websiteProjectName?: string;
     readonly workId: string;
     readonly workSlug?: string | null;
     readonly ownerUserId?: string | null;
@@ -220,8 +222,23 @@ export function resolveEffectiveDeploymentContext(
     }
 
     const settings = { ...input.settings };
+    const usesManagedKubeconfig = managedAlias || clusterSource !== 'custom-kubeconfig';
+    const requestedKubeContext =
+        typeof input.settings.kubeContext === 'string' && input.settings.kubeContext.trim()
+            ? input.settings.kubeContext
+            : null;
+    if (usesManagedKubeconfig) {
+        // Cluster credentials and their selected context are one trust unit.
+        // A tenant-saved context is meaningful only inside that tenant's
+        // custom kubeconfig; managed kubeconfigs must use their operator-owned
+        // current context instead of inheriting a stale/foreign tenant value.
+        delete settings.kubeContext;
+    }
     const requestedNamespace =
         typeof input.settings.namespace === 'string' ? input.settings.namespace.trim() : '';
+    const namespaceSource = input.settingSources?.namespace;
+    const namespaceIsExplicit =
+        namespaceSource === undefined ? Boolean(requestedNamespace) : namespaceSource !== 'default';
     let namespace: string | undefined;
 
     if (managedAlias || isSharedClusterSource(clusterSource)) {
@@ -229,7 +246,7 @@ export function resolveEffectiveDeploymentContext(
         const base =
             (input.env ?? process.env).EVER_WORKS_DEPLOY_NAMESPACE?.trim() || 'ever-works-tenants';
         namespace = buildEverWorksTenantNamespace(tenantId, base);
-    } else if (requestedNamespace) {
+    } else if (requestedNamespace && namespaceIsExplicit) {
         if (isReservedDeployNamespace(requestedNamespace)) {
             throw new DeploymentContextResolutionError(
                 `Namespace '${requestedNamespace}' is reserved and cannot be used as a deploy target. ` +
@@ -249,6 +266,11 @@ export function resolveEffectiveDeploymentContext(
         if (derived && !isReservedDeployNamespace(derived)) {
             namespace = derived;
         }
+    } else if (requestedNamespace) {
+        // The Kubernetes plugin's documented custom-cluster default is the
+        // legacy `ever-works` namespace. A schema default is not a user request
+        // for a reserved platform namespace, so preserve it for BYOC Works.
+        namespace = requestedNamespace;
     }
 
     if (namespace !== undefined) {
@@ -263,6 +285,8 @@ export function resolveEffectiveDeploymentContext(
         lookupContext: {
             settingsOverride: settings,
             namespaceOverride: namespace,
+            projectNameOverride: input.websiteProjectName,
+            kubeContextOverride: usesManagedKubeconfig ? null : requestedKubeContext,
         },
     };
 }

--- a/packages/agent/src/facades/deployment-context.resolver.ts
+++ b/packages/agent/src/facades/deployment-context.resolver.ts
@@ -1,0 +1,268 @@
+import type { DeploymentLookupContext } from '@ever-works/plugin';
+import { buildEverWorksTenantNamespace } from '../ever-works-providers/ever-works-k8s-deploy.provider';
+
+export const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';
+
+export type ClusterSource = 'k8s-works' | 'k8s-works-shared' | 'custom-kubeconfig';
+export type LegacyClusterSource = 'k8s-gauzy';
+
+export interface ClusterSourceValidationFailure {
+    readonly code:
+        | 'K8S_WORKS_NOT_ALLOWED'
+        | 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG'
+        | 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG';
+    readonly message: string;
+}
+
+export type DeploymentContextResolutionErrorCode =
+    | 'DEPLOY_MATRIX_VIOLATION'
+    | 'PLATFORM_KUBECONFIG_MISSING'
+    | 'RESERVED_NAMESPACE';
+
+export class DeploymentContextResolutionError extends Error {
+    constructor(
+        message: string,
+        readonly code: DeploymentContextResolutionErrorCode,
+        readonly reason?: string,
+    ) {
+        super(message);
+        this.name = 'DeploymentContextResolutionError';
+    }
+}
+
+export interface EffectiveDeploymentContextInput {
+    readonly deployProvider?: string;
+    readonly pluginId?: string;
+    readonly resolvedToken: string;
+    readonly settings: Record<string, unknown>;
+    readonly websiteOwner: string;
+    readonly workId: string;
+    readonly workSlug?: string | null;
+    readonly ownerUserId?: string | null;
+    readonly isPlatformAdmin?: boolean;
+    readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface EffectiveDeploymentContext {
+    readonly token: string;
+    readonly settings: Record<string, unknown>;
+    readonly namespace?: string;
+    readonly clusterSource?: ClusterSource;
+    readonly lookupContext?: DeploymentLookupContext;
+}
+
+const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
+const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
+const EVER_WORKS_SHARED_ORGS = new Set(['ever-works', 'ever-works-cloud']);
+
+export function normalizeClusterSource(value: string): ClusterSource | undefined {
+    if (value === 'k8s-works' || value === 'k8s-works-shared' || value === 'custom-kubeconfig') {
+        return value;
+    }
+    return value === 'k8s-gauzy' ? 'k8s-works' : undefined;
+}
+
+export function coerceDeploymentClusterSource(value: unknown): ClusterSource {
+    if (typeof value === 'string') {
+        const normalized = normalizeClusterSource(value);
+        if (normalized) return normalized;
+    }
+    return 'custom-kubeconfig';
+}
+
+export function isEverWorksSharedOrg(websiteOwner: string): boolean {
+    return EVER_WORKS_SHARED_ORGS.has(websiteOwner.trim().toLowerCase());
+}
+
+export function isAdminOnlyOrg(websiteOwner: string): boolean {
+    return websiteOwner.trim().toLowerCase() === 'ever-works';
+}
+
+export function validateClusterSourceForOwner(
+    websiteOwner: string,
+    clusterSource: ClusterSource,
+    options: { hasKubeconfig?: boolean; isPlatformAdmin?: boolean } = {},
+): ClusterSourceValidationFailure | null {
+    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
+    const isPlatformAdmin = options.isPlatformAdmin ?? false;
+    const hasKubeconfig = options.hasKubeconfig ?? true;
+
+    if (source === 'k8s-works' && (!isPlatformAdmin || !isAdminOnlyOrg(websiteOwner))) {
+        const message = !isPlatformAdmin
+            ? `'k8s-works' is the Ever Works internal cluster and is restricted to platform admins. ` +
+              `Pick 'k8s-works-shared' (the shared customer cluster) instead.`
+            : `'k8s-works' is the Ever Works internal cluster and requires the website repo to live in ` +
+              `the 'ever-works' GitHub org. The website repo for this Work is in '${websiteOwner}'. ` +
+              `Pick 'k8s-works-shared' instead, or move the Work to the 'ever-works' org.`;
+        return { code: 'K8S_WORKS_NOT_ALLOWED', message };
+    }
+
+    if (source === 'custom-kubeconfig' && isEverWorksSharedOrg(websiteOwner)) {
+        return {
+            code: 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG',
+            message:
+                `Cannot deploy a Work in the '${websiteOwner}' organisation to a customer-provided cluster. ` +
+                `The cluster's imagePullSecret would contain an org-scoped PAT that grants read access ` +
+                `to every GHCR image in '${websiteOwner}' (cross-tenant exposure). ` +
+                `To use your own cluster, move this Work to your own GitHub org first, ` +
+                `or pick 'k8s-works-shared' as the target cluster.`,
+        };
+    }
+
+    if (source === 'custom-kubeconfig' && !hasKubeconfig) {
+        return {
+            code: 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG',
+            message:
+                `Target cluster is 'custom-kubeconfig' but no kubeconfig is saved on the Kubernetes plugin. ` +
+                `Paste a kubeconfig in plugin settings, or pick a platform-managed cluster.`,
+        };
+    }
+
+    return null;
+}
+
+export function resolveKubeconfigForClusterSource(
+    clusterSource: ClusterSource,
+    userKubeconfig: string,
+    env: NodeJS.ProcessEnv = process.env,
+): string {
+    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
+
+    if (source === 'k8s-works') {
+        const value = env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+        if (!value || !value.trim()) {
+            throw new Error(
+                "Cluster source is 'k8s-works' but EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured on the platform.",
+            );
+        }
+        return value;
+    }
+    if (source === 'k8s-works-shared') {
+        const value = env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+        if (!value || !value.trim()) {
+            throw new Error(
+                "The Ever Works shared customer cluster ('k8s-works-shared') is not available yet: " +
+                    'EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG is not configured on the platform. ' +
+                    'Choose another target cluster, or try again once the shared cluster is provisioned.',
+            );
+        }
+        return value;
+    }
+    return userKubeconfig;
+}
+
+export const RESERVED_DEPLOY_NAMESPACES: ReadonlySet<string> = new Set([
+    'ever-works',
+    'kube-system',
+    'kube-public',
+    'kube-node-lease',
+    'default',
+    'argocd',
+    'cert-manager',
+    'ingress-nginx',
+    'monitoring',
+]);
+
+export function isReservedDeployNamespace(namespace: string): boolean {
+    const normalized = namespace.trim().toLowerCase();
+    return Boolean(
+        normalized &&
+        (RESERVED_DEPLOY_NAMESPACES.has(normalized) || normalized.startsWith('kube-')),
+    );
+}
+
+export function isSharedClusterSource(clusterSource: ClusterSource): boolean {
+    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
+    return source === 'k8s-works-shared' || source.includes('shared');
+}
+
+export function resolveEffectiveDeploymentContext(
+    input: EffectiveDeploymentContextInput,
+): EffectiveDeploymentContext {
+    const isKubernetes =
+        input.deployProvider === KUBERNETES_DEPLOY_PROVIDER_ID ||
+        input.deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID ||
+        input.pluginId === KUBERNETES_DEPLOY_PROVIDER_ID;
+    if (!isKubernetes) {
+        return { token: input.resolvedToken, settings: input.settings };
+    }
+
+    const managedAlias = input.deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID;
+    const clusterSource = coerceDeploymentClusterSource(input.settings.clusterSource);
+    const realUserToken =
+        input.resolvedToken === PLATFORM_MANAGED_KUBECONFIG_SENTINEL ? '' : input.resolvedToken;
+
+    let token = realUserToken;
+    if (!managedAlias) {
+        const failure = validateClusterSourceForOwner(input.websiteOwner, clusterSource, {
+            hasKubeconfig: Boolean(realUserToken.trim()),
+            isPlatformAdmin: input.isPlatformAdmin,
+        });
+        if (failure) {
+            throw new DeploymentContextResolutionError(
+                failure.message,
+                'DEPLOY_MATRIX_VIOLATION',
+                failure.code,
+            );
+        }
+        try {
+            token = resolveKubeconfigForClusterSource(
+                clusterSource,
+                realUserToken,
+                input.env ?? process.env,
+            );
+        } catch (error) {
+            throw new DeploymentContextResolutionError(
+                error instanceof Error ? error.message : String(error),
+                'PLATFORM_KUBECONFIG_MISSING',
+            );
+        }
+    }
+
+    const settings = { ...input.settings };
+    const requestedNamespace =
+        typeof input.settings.namespace === 'string' ? input.settings.namespace.trim() : '';
+    let namespace: string | undefined;
+
+    if (managedAlias || isSharedClusterSource(clusterSource)) {
+        const tenantId = input.ownerUserId?.trim() || input.workId;
+        const base =
+            (input.env ?? process.env).EVER_WORKS_DEPLOY_NAMESPACE?.trim() || 'ever-works-tenants';
+        namespace = buildEverWorksTenantNamespace(tenantId, base);
+    } else if (requestedNamespace) {
+        if (isReservedDeployNamespace(requestedNamespace)) {
+            throw new DeploymentContextResolutionError(
+                `Namespace '${requestedNamespace}' is reserved and cannot be used as a deploy target. ` +
+                    `Choose a different namespace (reserved: ever-works, default, kube-*, argocd, ` +
+                    `cert-manager, ingress-nginx, monitoring).`,
+                'RESERVED_NAMESPACE',
+            );
+        }
+        namespace = requestedNamespace;
+    } else if (clusterSource === 'k8s-works') {
+        const slug = (input.workSlug || input.workId)
+            .toLowerCase()
+            .replace(/[^a-z0-9-]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 40);
+        const derived = slug ? `ever-works-${slug}-prod` : '';
+        if (derived && !isReservedDeployNamespace(derived)) {
+            namespace = derived;
+        }
+    }
+
+    if (namespace !== undefined) {
+        settings.namespace = namespace;
+    }
+
+    return {
+        token,
+        settings,
+        namespace,
+        clusterSource,
+        lookupContext: {
+            settingsOverride: settings,
+            namespaceOverride: namespace,
+        },
+    };
+}

--- a/packages/plugin/src/contracts/capabilities/deployment.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/deployment.interface.ts
@@ -139,7 +139,11 @@ export interface IDeploymentPlugin extends IPlugin {
 	/**
 	 * Get deployment status
 	 */
-	getDeploymentStatus(deploymentId: string, token: string): Promise<DeploymentResult>;
+	getDeploymentStatus(
+		deploymentId: string,
+		token: string,
+		context?: DeploymentLookupContext
+	): Promise<DeploymentResult>;
 
 	/**
 	 * Validate API token

--- a/packages/plugin/src/contracts/capabilities/deployment.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/deployment.interface.ts
@@ -114,6 +114,13 @@ export interface DeploymentLookupContext {
 	readonly settingsOverride?: Record<string, unknown>;
 	/** Namespace previously validated/enforced by the deploy orchestrator. */
 	readonly namespaceOverride?: string;
+	/** Current website repository/project name enforced by the orchestrator. */
+	readonly projectNameOverride?: string;
+	/**
+	 * Context selected together with the effective kubeconfig. `null` means
+	 * use that kubeconfig's operator-controlled current context.
+	 */
+	readonly kubeContextOverride?: string | null;
 }
 
 /**

--- a/packages/plugin/src/contracts/capabilities/deployment.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/deployment.interface.ts
@@ -102,7 +102,7 @@ export interface AddDomainResult {
 }
 
 /**
- * Effective context for looking up a deployment.
+ * Effective context for deployment operations that must use Work-scoped settings.
  *
  * Deployment plugins are singletons, so their PluginContext does not carry the
  * user/Work settings used by the deploy orchestrator. Facades may provide the
@@ -177,22 +177,45 @@ export interface IDeploymentPlugin extends IPlugin {
 	/**
 	 * Get domains for a project
 	 */
-	getDomains?(projectId: string, token: string, teamScope?: string): Promise<DeploymentDomain[]>;
+	getDomains?(
+		projectId: string,
+		token: string,
+		teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<DeploymentDomain[]>;
 
 	/**
 	 * Add a domain to a project
 	 */
-	addDomain?(projectId: string, domain: string, token: string, teamScope?: string): Promise<AddDomainResult>;
+	addDomain?(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<AddDomainResult>;
 
 	/**
 	 * Remove a domain from a project
 	 */
-	removeDomain?(projectId: string, domain: string, token: string, teamScope?: string): Promise<boolean>;
+	removeDomain?(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<boolean>;
 
 	/**
 	 * Verify a domain on a project
 	 */
-	verifyDomain?(projectId: string, domain: string, token: string, teamScope?: string): Promise<DeploymentDomain>;
+	verifyDomain?(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<DeploymentDomain>;
 
 	/**
 	 * Workflow filenames to dispatch when deploying, in priority order.

--- a/packages/plugin/src/contracts/capabilities/deployment.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/deployment.interface.ts
@@ -102,6 +102,21 @@ export interface AddDomainResult {
 }
 
 /**
+ * Effective context for looking up a deployment.
+ *
+ * Deployment plugins are singletons, so their PluginContext does not carry the
+ * user/Work settings used by the deploy orchestrator. Facades may provide the
+ * already-resolved Work settings and the namespace that deploy enforced.
+ * Providers that do not need this context can ignore it.
+ */
+export interface DeploymentLookupContext {
+	/** Work-scoped plugin settings, layered over singleton defaults. */
+	readonly settingsOverride?: Record<string, unknown>;
+	/** Namespace previously validated/enforced by the deploy orchestrator. */
+	readonly namespaceOverride?: string;
+}
+
+/**
  * Deployment plugin interface
  * Capability: 'deployment'
  */
@@ -135,7 +150,8 @@ export interface IDeploymentPlugin extends IPlugin {
 	lookupExistingDeployment?(
 		projectName: string,
 		token: string,
-		teamScope?: string
+		teamScope?: string,
+		context?: DeploymentLookupContext
 	): Promise<{
 		found: boolean;
 		website?: string;

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -490,6 +490,33 @@ describe('KubernetesPlugin.deploy (mocked api)', () => {
 });
 
 describe('KubernetesPlugin.getDeploymentStatus', () => {
+	it('uses the authoritative Work target and managed kubeconfig context instead of a stale deployment ID', async () => {
+		const api = makeMockApi({
+			getDeployment: vi.fn(async (_kubeconfig, namespace, name) => ({
+				metadata: { name, namespace },
+				status: {
+					conditions:
+						name === 'repo-a'
+							? [{ type: 'Available', status: 'True' }]
+							: [{ type: 'Progressing', status: 'False', reason: 'SiblingDeployment' }]
+				}
+			}))
+		});
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		const result = await (plugin as any).getDeploymentStatus('tenant-b/repo-b', VALID, {
+			settingsOverride: { clusterSource: 'k8s-works' },
+			namespaceOverride: 'tenant-a',
+			projectNameOverride: 'repo-a',
+			kubeContextOverride: null
+		});
+
+		expect(api.getDeployment).toHaveBeenCalledWith(VALID, 'tenant-a', 'repo-a', undefined);
+		expect(result.id).toBe('tenant-a/repo-a');
+		expect(result.status).toBe('ready');
+	});
+
 	it('maps Available=True to ready', async () => {
 		const api = makeMockApi();
 		const plugin = new KubernetesPlugin({ api });

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -545,6 +545,65 @@ describe('KubernetesPlugin.lookupExistingDeployment', () => {
 	});
 });
 
+describe('KubernetesPlugin Work-scoped domain context', () => {
+	const scopedContext = {
+		settingsOverride: {
+			kubeContext: 'work-context',
+			ingressClass: 'nginx'
+		}
+	};
+
+	it('uses the Work kubeContext when listing domains', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		await (plugin as any).getDomains('tenant-ns/my-site', VALID, undefined, scopedContext);
+
+		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+	});
+
+	it('uses the Work kubeContext when adding a domain', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		await (plugin as any).addDomain('tenant-ns/my-site', 'tools.example.com', VALID, undefined, scopedContext);
+
+		expect(api.listIngressClasses).toHaveBeenCalledWith(VALID, expect.any(Function), 'work-context');
+		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+		expect(api.applyIngress).toHaveBeenCalledWith(VALID, expect.any(Object), 'work-context');
+	});
+
+	it('uses the Work kubeContext when removing a domain', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		await (plugin as any).removeDomain('tenant-ns/my-site', 'tools.example.com', VALID, undefined, scopedContext);
+
+		expect(api.listIngressClasses).toHaveBeenCalledWith(VALID, expect.any(Function), 'work-context');
+		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+		expect(api.applyIngress).toHaveBeenCalledWith(VALID, expect.any(Object), 'work-context');
+	});
+
+	it('uses the Work kubeContext when verifying a domain', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({
+			api,
+			dnsResolver: {
+				resolveCname: vi.fn(async () => ['lb.cluster.example.com']),
+				resolve4: vi.fn(async () => [])
+			}
+		});
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		await (plugin as any).verifyDomain('tenant-ns/my-site', 'tools.example.com', VALID, undefined, scopedContext);
+
+		expect(api.getIngressLoadBalancerHost).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+	});
+});
+
 describe('KubernetesPlugin.getTeams', () => {
 	it('returns an empty list (k8s has no team concept)', async () => {
 		expect(await new KubernetesPlugin().getTeams('whatever')).toEqual([]);

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -506,6 +506,40 @@ describe('KubernetesPlugin.getDeploymentStatus', () => {
 });
 
 describe('KubernetesPlugin.lookupExistingDeployment', () => {
+	it('uses the authoritative Work repository when the positional project name is stale', async () => {
+		const api = makeMockApi({
+			getDeployment: vi.fn(async (_kubeconfig, namespace, name) => ({
+				metadata: { name, namespace },
+				status: {
+					conditions:
+						name === 'current-website-repo'
+							? [{ type: 'Progressing', status: 'True' }]
+							: [{ type: 'Available', status: 'True' }],
+					replicas: 1
+				}
+			})),
+			readIngress: vi.fn(async (_kubeconfig, _namespace, name) => ({
+				metadata: { name },
+				spec: { rules: [{ host: `${name}.example.com` }] }
+			}))
+		});
+		const plugin = new KubernetesPlugin({ api });
+
+		const result = await plugin.lookupExistingDeployment('stale-sibling-repo', VALID, undefined, {
+			namespaceOverride: 'current-tenant-ns',
+			projectNameOverride: 'current-website-repo'
+		});
+
+		expect(api.getDeployment).toHaveBeenCalledWith(VALID, 'current-tenant-ns', 'current-website-repo', undefined);
+		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'current-tenant-ns', 'current-website-repo', undefined);
+		expect(result).toEqual({
+			found: true,
+			projectId: 'current-tenant-ns/current-website-repo',
+			website: 'https://current-website-repo.example.com',
+			deploymentState: 'BUILDING'
+		});
+	});
+
 	it('uses the managed kubeconfig current context instead of a stale singleton context', async () => {
 		const api = makeMockApi();
 		const plugin = new KubernetesPlugin({ api });

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -478,6 +478,26 @@ describe('KubernetesPlugin.getDeploymentStatus', () => {
 });
 
 describe('KubernetesPlugin.lookupExistingDeployment', () => {
+	it('uses the Work-scoped namespace and context instead of singleton defaults', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(
+			createMockContext({ namespace: 'ever-works-shared-default', kubeContext: 'shared-context' })
+		);
+
+		const result = await plugin.lookupExistingDeployment('my-site', VALID, undefined, {
+			settingsOverride: {
+				namespace: 'ever-works-timetrack-prod',
+				kubeContext: 'work-context'
+			},
+			namespaceOverride: 'ever-works-timetrack-prod'
+		});
+
+		expect(api.getDeployment).toHaveBeenCalledWith(VALID, 'ever-works-timetrack-prod', 'my-site', 'work-context');
+		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'ever-works-timetrack-prod', 'my-site', 'work-context');
+		expect(result.projectId).toBe('ever-works-timetrack-prod/my-site');
+	});
+
 	it('returns verifier-compatible terminal state and ingress website URL', async () => {
 		const api = makeMockApi({
 			readIngress: vi.fn(async () => ({

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import type { PluginContext } from '@ever-works/plugin';
 import { KubernetesPlugin } from '../k8s.plugin';
 import { KubernetesApiService } from '../k8s-api.service';
+import { K8sPluginError } from '../errors';
 import type { IngressClassDescriptor, KubernetesClusterInfo } from '../types';
 
 const VALID = readFileSync(resolve(__dirname, 'fixtures/kubeconfig-valid.yml'), 'utf-8');
@@ -412,6 +413,33 @@ describe('KubernetesPlugin.deploy (mocked api)', () => {
 		expect(api.applyService).toHaveBeenCalledTimes(1);
 	});
 
+	it('uses the managed kubeconfig current context instead of a stale singleton context', async () => {
+		await plugin.onLoad(
+			createMockContext({
+				kubeContext: 'obsolete-singleton-context',
+				registry: { kind: 'github', visibility: 'auto' }
+			})
+		);
+
+		const result = await plugin.deploy(
+			{
+				projectName: 'work-1',
+				sourceDir: '.',
+				options: {
+					githubOwner: 'acme',
+					websiteRepoIsPrivate: false,
+					settingsOverride: { clusterSource: 'k8s-works' },
+					kubeContextOverride: null
+				}
+			},
+			VALID
+		);
+
+		expect(result.status).toBe('deploying');
+		expect(api.ensureNamespace).toHaveBeenCalledWith(VALID, 'ever-works', undefined);
+		expect(api.applyDeployment).toHaveBeenCalledWith(VALID, expect.any(Object), undefined);
+	});
+
 	it('private website repo + GHCR → applies a pull secret', async () => {
 		const result = await plugin.deploy(
 			{
@@ -478,6 +506,28 @@ describe('KubernetesPlugin.getDeploymentStatus', () => {
 });
 
 describe('KubernetesPlugin.lookupExistingDeployment', () => {
+	it('uses the managed kubeconfig current context instead of a stale singleton context', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		await plugin.lookupExistingDeployment('my-site', VALID, undefined, {
+			settingsOverride: { clusterSource: 'k8s-works' },
+			namespaceOverride: 'ever-works-my-site-prod',
+			kubeContextOverride: null
+		} as any);
+
+		expect(api.getDeployment).toHaveBeenCalledWith(VALID, 'ever-works-my-site-prod', 'my-site', undefined);
+	});
+
+	it('propagates typed cluster/auth failures instead of reporting not-found', async () => {
+		const failure = new K8sPluginError('UNAUTHORIZED', 'Kubernetes credentials were rejected.');
+		const api = makeMockApi({ getDeployment: vi.fn(async () => Promise.reject(failure)) });
+		const plugin = new KubernetesPlugin({ api });
+
+		await expect(plugin.lookupExistingDeployment('my-site', VALID)).rejects.toBe(failure);
+	});
+
 	it('uses the Work-scoped namespace and context instead of singleton defaults', async () => {
 		const api = makeMockApi();
 		const plugin = new KubernetesPlugin({ api });
@@ -543,6 +593,14 @@ describe('KubernetesPlugin.lookupExistingDeployment', () => {
 		expect(result.website).toBeUndefined();
 		expect(result.deploymentState).toBe('READY');
 	});
+
+	it('propagates typed ingress connectivity failures after finding the deployment', async () => {
+		const failure = new K8sPluginError('CLUSTER_UNREACHABLE', 'Ingress API is unreachable.');
+		const api = makeMockApi({ readIngress: vi.fn(async () => Promise.reject(failure)) });
+		const plugin = new KubernetesPlugin({ api });
+
+		await expect(plugin.lookupExistingDeployment('my-site', VALID)).rejects.toBe(failure);
+	});
 });
 
 describe('KubernetesPlugin Work-scoped domain context', () => {
@@ -550,17 +608,39 @@ describe('KubernetesPlugin Work-scoped domain context', () => {
 		settingsOverride: {
 			kubeContext: 'work-context',
 			ingressClass: 'nginx'
-		}
+		},
+		namespaceOverride: 'current-tenant-ns',
+		projectNameOverride: 'current-website-repo'
 	};
+
+	it('uses the managed kubeconfig current context for domain operations', async () => {
+		const api = makeMockApi();
+		const plugin = new KubernetesPlugin({ api });
+		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
+
+		await (plugin as any).getDomains('stale-ns/stale-site', VALID, undefined, {
+			settingsOverride: { clusterSource: 'k8s-works-shared' },
+			namespaceOverride: 'current-tenant-ns',
+			projectNameOverride: 'current-website-repo',
+			kubeContextOverride: null
+		});
+
+		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'current-tenant-ns', 'current-website-repo', undefined);
+	});
 
 	it('uses the Work kubeContext when listing domains', async () => {
 		const api = makeMockApi();
 		const plugin = new KubernetesPlugin({ api });
 		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
 
-		await (plugin as any).getDomains('tenant-ns/my-site', VALID, undefined, scopedContext);
+		await (plugin as any).getDomains('stale-tenant-ns/stale-site', VALID, undefined, scopedContext);
 
-		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+		expect(api.readIngress).toHaveBeenCalledWith(
+			VALID,
+			'current-tenant-ns',
+			'current-website-repo',
+			'work-context'
+		);
 	});
 
 	it('uses the Work kubeContext when adding a domain', async () => {
@@ -568,11 +648,29 @@ describe('KubernetesPlugin Work-scoped domain context', () => {
 		const plugin = new KubernetesPlugin({ api });
 		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
 
-		await (plugin as any).addDomain('tenant-ns/my-site', 'tools.example.com', VALID, undefined, scopedContext);
+		await (plugin as any).addDomain(
+			'stale-tenant-ns/stale-site',
+			'tools.example.com',
+			VALID,
+			undefined,
+			scopedContext
+		);
 
 		expect(api.listIngressClasses).toHaveBeenCalledWith(VALID, expect.any(Function), 'work-context');
-		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+		expect(api.readIngress).toHaveBeenCalledWith(
+			VALID,
+			'current-tenant-ns',
+			'current-website-repo',
+			'work-context'
+		);
 		expect(api.applyIngress).toHaveBeenCalledWith(VALID, expect.any(Object), 'work-context');
+		expect(api.applyIngress).toHaveBeenCalledWith(
+			VALID,
+			expect.objectContaining({
+				metadata: { name: 'current-website-repo', namespace: 'current-tenant-ns' }
+			}),
+			'work-context'
+		);
 	});
 
 	it('uses the Work kubeContext when removing a domain', async () => {
@@ -580,11 +678,29 @@ describe('KubernetesPlugin Work-scoped domain context', () => {
 		const plugin = new KubernetesPlugin({ api });
 		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
 
-		await (plugin as any).removeDomain('tenant-ns/my-site', 'tools.example.com', VALID, undefined, scopedContext);
+		await (plugin as any).removeDomain(
+			'stale-tenant-ns/stale-site',
+			'tools.example.com',
+			VALID,
+			undefined,
+			scopedContext
+		);
 
 		expect(api.listIngressClasses).toHaveBeenCalledWith(VALID, expect.any(Function), 'work-context');
-		expect(api.readIngress).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+		expect(api.readIngress).toHaveBeenCalledWith(
+			VALID,
+			'current-tenant-ns',
+			'current-website-repo',
+			'work-context'
+		);
 		expect(api.applyIngress).toHaveBeenCalledWith(VALID, expect.any(Object), 'work-context');
+		expect(api.applyIngress).toHaveBeenCalledWith(
+			VALID,
+			expect.objectContaining({
+				metadata: { name: 'current-website-repo', namespace: 'current-tenant-ns' }
+			}),
+			'work-context'
+		);
 	});
 
 	it('uses the Work kubeContext when verifying a domain', async () => {
@@ -598,9 +714,20 @@ describe('KubernetesPlugin Work-scoped domain context', () => {
 		});
 		await plugin.onLoad(createMockContext({ kubeContext: 'obsolete-singleton-context' }));
 
-		await (plugin as any).verifyDomain('tenant-ns/my-site', 'tools.example.com', VALID, undefined, scopedContext);
+		await (plugin as any).verifyDomain(
+			'stale-tenant-ns/stale-site',
+			'tools.example.com',
+			VALID,
+			undefined,
+			scopedContext
+		);
 
-		expect(api.getIngressLoadBalancerHost).toHaveBeenCalledWith(VALID, 'tenant-ns', 'my-site', 'work-context');
+		expect(api.getIngressLoadBalancerHost).toHaveBeenCalledWith(
+			VALID,
+			'current-tenant-ns',
+			'current-website-repo',
+			'work-context'
+		);
 	});
 });
 

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -3,6 +3,7 @@ import type {
 	ConnectionValidationResult,
 	DeploymentConfig,
 	DeploymentDomain,
+	DeploymentLookupContext,
 	DeploymentProject,
 	DeploymentResult,
 	IDeploymentPlugin,
@@ -691,11 +692,20 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 
 	async lookupExistingDeployment(
 		projectName: string,
-		kubeconfig: string
+		kubeconfig: string,
+		_teamScope?: string,
+		context?: DeploymentLookupContext
 	): Promise<{ found: boolean; website?: string; deploymentState?: string; projectId?: string }> {
-		const settings = await this.loadSettings();
+		const settings = {
+			...(await this.loadSettings()),
+			...this.coerceSettings(context?.settingsOverride ?? {})
+		};
 		const slug = sanitiseSlug(projectName);
-		const namespace = settings.namespace?.trim() || DEFAULT_NAMESPACE;
+		const requestedNamespace = context?.namespaceOverride?.trim();
+		const namespace =
+			(requestedNamespace && isValidK8sNamespace(requestedNamespace) ? requestedNamespace : undefined) ??
+			settings.namespace?.trim() ??
+			DEFAULT_NAMESPACE;
 		try {
 			const deployment = await this.api.getDeployment(kubeconfig, namespace, slug, settings.kubeContext);
 			if (!deployment) return { found: false };

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -696,10 +696,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		_teamScope?: string,
 		context?: DeploymentLookupContext
 	): Promise<{ found: boolean; website?: string; deploymentState?: string; projectId?: string }> {
-		const settings = {
-			...(await this.loadSettings()),
-			...this.coerceSettings(context?.settingsOverride ?? {})
-		};
+		const settings = await this.loadEffectiveDeploymentSettings(context);
 		const slug = sanitiseSlug(projectName);
 		const requestedNamespace = context?.namespaceOverride?.trim();
 		const namespace =
@@ -721,8 +718,13 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		}
 	}
 
-	async getDomains(projectId: string, kubeconfig: string): Promise<DeploymentDomain[]> {
-		const settings = await this.loadSettings();
+	async getDomains(
+		projectId: string,
+		kubeconfig: string,
+		_teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<DeploymentDomain[]> {
+		const settings = await this.loadEffectiveDeploymentSettings(context);
 		const { namespace, name } = parseDeploymentId(projectId);
 		const ingress = await this.api.readIngress(kubeconfig, namespace, name, settings.kubeContext);
 		if (!ingress?.spec) return [];
@@ -746,8 +748,14 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			}));
 	}
 
-	async addDomain(projectId: string, domain: string, kubeconfig: string): Promise<AddDomainResult> {
-		const settings = await this.loadSettings();
+	async addDomain(
+		projectId: string,
+		domain: string,
+		kubeconfig: string,
+		_teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<AddDomainResult> {
+		const settings = await this.loadEffectiveDeploymentSettings(context);
 		// Security: the domain is written verbatim as the Ingress `host:` rule.
 		// Reject anything that is not a strict RFC-1123 hostname so a value like
 		// `*` (catch-all rule that hijacks unmatched cluster traffic) or an empty
@@ -789,8 +797,14 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		};
 	}
 
-	async removeDomain(projectId: string, domain: string, kubeconfig: string): Promise<boolean> {
-		const settings = await this.loadSettings();
+	async removeDomain(
+		projectId: string,
+		domain: string,
+		kubeconfig: string,
+		_teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<boolean> {
+		const settings = await this.loadEffectiveDeploymentSettings(context);
 		const { namespace, name } = parseDeploymentId(projectId);
 		const controller = await this.controllerForClassName(kubeconfig, settings.kubeContext, settings.ingressClass);
 		const strategy = this.ingressStrategies.selectStrategy(controller);
@@ -811,8 +825,14 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		return true;
 	}
 
-	async verifyDomain(projectId: string, domain: string, kubeconfig: string): Promise<DeploymentDomain> {
-		const settings = await this.loadSettings();
+	async verifyDomain(
+		projectId: string,
+		domain: string,
+		kubeconfig: string,
+		_teamScope?: string,
+		context?: DeploymentLookupContext
+	): Promise<DeploymentDomain> {
+		const settings = await this.loadEffectiveDeploymentSettings(context);
 		const { namespace, name } = parseDeploymentId(projectId);
 		// Resolve the cluster's actual ingress LB host/IP. Without this, any
 		// domain with any DNS record was returned `verified: true` —
@@ -904,6 +924,13 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		if (!this.context) return {};
 		const raw = (await this.context.getSettings()) ?? {};
 		return this.coerceSettings(raw);
+	}
+
+	private async loadEffectiveDeploymentSettings(context?: DeploymentLookupContext): Promise<KubernetesSettings> {
+		return {
+			...(await this.loadSettings()),
+			...this.coerceSettings(context?.settingsOverride ?? {})
+		};
 	}
 
 	private coerceSettings(raw: Record<string, unknown>): KubernetesSettings {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -100,6 +100,8 @@ interface DeployOptions {
 	 * workflow's toJSON(secrets) copy step; values never touch the repo.
 	 */
 	namespaceOverride?: string;
+	/** `null` selects the effective kubeconfig's current context. */
+	kubeContextOverride?: string | null;
 	imageName?: string;
 	runtimeEnv?: Record<string, string>;
 	/**
@@ -501,6 +503,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			...(await this.loadSettings()),
 			...((opts.settingsOverride ?? {}) as Partial<KubernetesSettings>)
 		} as KubernetesSettings;
+		applyKubeContextOverride(settings, opts.kubeContextOverride);
 		// `namespaceOverride` is the namespace the PLATFORM enforced server-side
 		// (per-tenant override + reserved-namespace blocklist). It must win over
 		// the plugin's own persisted `namespace`, which is free-text the user
@@ -703,19 +706,15 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			(requestedNamespace && isValidK8sNamespace(requestedNamespace) ? requestedNamespace : undefined) ??
 			settings.namespace?.trim() ??
 			DEFAULT_NAMESPACE;
-		try {
-			const deployment = await this.api.getDeployment(kubeconfig, namespace, slug, settings.kubeContext);
-			if (!deployment) return { found: false };
-			const projectId = makeDeploymentId(namespace, slug);
-			return {
-				found: true,
-				projectId,
-				website: await this.resolveWebsiteUrl(kubeconfig, namespace, slug, settings),
-				deploymentState: toVerifierDeploymentState(mapDeploymentToStatus(deployment))
-			};
-		} catch {
-			return { found: false };
-		}
+		const deployment = await this.api.getDeployment(kubeconfig, namespace, slug, settings.kubeContext);
+		if (!deployment) return { found: false };
+		const projectId = makeDeploymentId(namespace, slug);
+		return {
+			found: true,
+			projectId,
+			website: await this.resolveWebsiteUrl(kubeconfig, namespace, slug, settings),
+			deploymentState: toVerifierDeploymentState(mapDeploymentToStatus(deployment))
+		};
 	}
 
 	async getDomains(
@@ -725,7 +724,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		context?: DeploymentLookupContext
 	): Promise<DeploymentDomain[]> {
 		const settings = await this.loadEffectiveDeploymentSettings(context);
-		const { namespace, name } = parseDeploymentId(projectId);
+		const { namespace, name } = resolveDeploymentTarget(projectId, context);
 		const ingress = await this.api.readIngress(kubeconfig, namespace, name, settings.kubeContext);
 		if (!ingress?.spec) return [];
 		const spec = ingress.spec as { rules?: Array<{ host?: string }> };
@@ -764,7 +763,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		if (!host) {
 			throw new K8sPluginError('UNKNOWN', 'Invalid domain: provide a valid hostname.');
 		}
-		const { namespace, name } = parseDeploymentId(projectId);
+		const { namespace, name } = resolveDeploymentTarget(projectId, context);
 		const controller = await this.controllerForClassName(kubeconfig, settings.kubeContext, settings.ingressClass);
 		const strategy = this.ingressStrategies.selectStrategy(controller);
 
@@ -805,7 +804,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		context?: DeploymentLookupContext
 	): Promise<boolean> {
 		const settings = await this.loadEffectiveDeploymentSettings(context);
-		const { namespace, name } = parseDeploymentId(projectId);
+		const { namespace, name } = resolveDeploymentTarget(projectId, context);
 		const controller = await this.controllerForClassName(kubeconfig, settings.kubeContext, settings.ingressClass);
 		const strategy = this.ingressStrategies.selectStrategy(controller);
 		const existing = await this.api.readIngress(kubeconfig, namespace, name, settings.kubeContext);
@@ -833,7 +832,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		context?: DeploymentLookupContext
 	): Promise<DeploymentDomain> {
 		const settings = await this.loadEffectiveDeploymentSettings(context);
-		const { namespace, name } = parseDeploymentId(projectId);
+		const { namespace, name } = resolveDeploymentTarget(projectId, context);
 		// Resolve the cluster's actual ingress LB host/IP. Without this, any
 		// domain with any DNS record was returned `verified: true` —
 		// including domains pointing at a completely unrelated server.
@@ -927,10 +926,12 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 	}
 
 	private async loadEffectiveDeploymentSettings(context?: DeploymentLookupContext): Promise<KubernetesSettings> {
-		return {
+		const settings = {
 			...(await this.loadSettings()),
 			...this.coerceSettings(context?.settingsOverride ?? {})
 		};
+		applyKubeContextOverride(settings, context?.kubeContextOverride);
+		return settings;
 	}
 
 	private coerceSettings(raw: Record<string, unknown>): KubernetesSettings {
@@ -981,14 +982,10 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		name: string,
 		settings: KubernetesSettings
 	): Promise<string | undefined> {
-		try {
-			const ingress = await this.api.readIngress(kubeconfig, namespace, name, settings.kubeContext);
-			const rules = (ingress?.spec as { rules?: Array<{ host?: string }> } | undefined)?.rules ?? [];
-			const host = rules.find((rule) => typeof rule.host === 'string' && rule.host.trim().length > 0)?.host;
-			return host ? `https://${host}` : undefined;
-		} catch {
-			return undefined;
-		}
+		const ingress = await this.api.readIngress(kubeconfig, namespace, name, settings.kubeContext);
+		const rules = (ingress?.spec as { rules?: Array<{ host?: string }> } | undefined)?.rules ?? [];
+		const host = rules.find((rule) => typeof rule.host === 'string' && rule.host.trim().length > 0)?.host;
+		return host ? `https://${host}` : undefined;
 	}
 
 	private async controllerForClassName(
@@ -1052,6 +1049,34 @@ function parseDeploymentId(id: string): { namespace: string; name: string } {
 		return { namespace: DEFAULT_NAMESPACE, name: id };
 	}
 	return { namespace: id.slice(0, slash), name: id.slice(slash + 1) };
+}
+
+function resolveDeploymentTarget(
+	projectId: string,
+	context?: DeploymentLookupContext
+): { namespace: string; name: string } {
+	const parsed = parseDeploymentId(projectId);
+	const namespaceOverride = context?.namespaceOverride?.trim();
+	if (namespaceOverride && !isValidK8sNamespace(namespaceOverride)) {
+		throw new K8sPluginError('NOT_CONFIGURED', 'The effective Kubernetes namespace is invalid.');
+	}
+	const projectNameOverride = context?.projectNameOverride?.trim();
+	const name = projectNameOverride ? sanitiseSlug(projectNameOverride) : parsed.name;
+	if (!name) {
+		throw new K8sPluginError('NOT_CONFIGURED', 'The effective Kubernetes project name is invalid.');
+	}
+	return {
+		namespace: namespaceOverride || parsed.namespace,
+		name
+	};
+}
+
+function applyKubeContextOverride(settings: KubernetesSettings, override?: string | null): void {
+	if (override === null) {
+		delete settings.kubeContext;
+	} else if (typeof override === 'string') {
+		settings.kubeContext = override;
+	}
 }
 
 function sanitiseSlug(input: string): string {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -650,19 +650,24 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		}
 	}
 
-	async getDeploymentStatus(deploymentId: string, kubeconfig: string): Promise<DeploymentResult> {
-		const settings = await this.loadSettings();
-		const { namespace, name } = parseDeploymentId(deploymentId);
+	async getDeploymentStatus(
+		deploymentId: string,
+		kubeconfig: string,
+		context?: DeploymentLookupContext
+	): Promise<DeploymentResult> {
+		const settings = await this.loadEffectiveDeploymentSettings(context);
+		const { namespace, name } = resolveDeploymentTarget(deploymentId, context);
+		const effectiveDeploymentId = makeDeploymentId(namespace, name);
 		const createdAt = new Date().toISOString();
 
 		try {
 			const deployment = await this.api.getDeployment(kubeconfig, namespace, name, settings.kubeContext);
 			if (!deployment) {
-				return { id: deploymentId, status: 'pending', createdAt };
+				return { id: effectiveDeploymentId, status: 'pending', createdAt };
 			}
 			const status = mapDeploymentToStatus(deployment);
 			return {
-				id: deploymentId,
+				id: effectiveDeploymentId,
 				status,
 				createdAt,
 				completedAt: status === 'ready' || status === 'error' ? new Date().toISOString() : undefined
@@ -670,7 +675,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		} catch (err) {
 			const scrubbed = scrubError(err, this.runtimeScrubPatterns({ kubeconfig }));
 			return {
-				id: deploymentId,
+				id: effectiveDeploymentId,
 				status: 'error',
 				error: scrubbed.message,
 				createdAt,

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -700,7 +700,8 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		context?: DeploymentLookupContext
 	): Promise<{ found: boolean; website?: string; deploymentState?: string; projectId?: string }> {
 		const settings = await this.loadEffectiveDeploymentSettings(context);
-		const slug = sanitiseSlug(projectName);
+		const projectNameOverride = context?.projectNameOverride?.trim();
+		const slug = sanitiseSlug(projectNameOverride || projectName);
 		const requestedNamespace = context?.namespaceOverride?.trim();
 		const namespace =
 			(requestedNamespace && isValidK8sNamespace(requestedNamespace) ? requestedNamespace : undefined) ??


### PR DESCRIPTION
## Summary
- pass a typed, backward-compatible Work-scoped lookup context through the deployment capability
- select the Kubernetes kubeconfig from the Work's `clusterSource` instead of an inherited managed/shared token
- layer the Work settings and stored/enforced namespace over the Kubernetes plugin singleton defaults

## Root cause
The deploy path already passed Work-scoped settings and the enforced namespace to the Kubernetes plugin. Verification reloaded the plugin singleton context and only forwarded `defaultTeamScope`, so a Work targeting `k8s-works` could be read back from `k8s-works-shared` and the default namespace. The healthy deployment was therefore reported as `TIMEOUT`.

## TDD evidence
The new facade regression first failed with:
- expected token: `internal-work-cluster`
- received token: `wrong-shared-cluster`
- expected namespace/context: `ever-works-timetrack-prod` / `work-context`
- received Kubernetes singleton defaults

After the fix:
- `@ever-works/agent` facade suite: 23/23 passed
- `@ever-works/k8s-plugin` suite: 42/42 passed
- type-checks passed for plugin contracts, agent, Kubernetes plugin, and Vercel compatibility
- Prettier and `git diff --check` passed

## Scope and safety
Code/tests only. No deployment replay, Work/plugin row change, Kubernetes change, immutable history rewrite, merge, cascade, or production rollout. Deliberately file-disjoint from #2149 current-health/history work.