### PR TITLE
chore(release): cascade develop -> stage (billing fixes: boot crashloop, escalation, licence arbitrage)

### DIFF
--- a/.github/workflows/ops-diagnose.yml
+++ b/.github/workflows/ops-diagnose.yml
@@ -1,0 +1,91 @@
+name: ops-diagnose (read-only k8s inspection)
+
+# Read-only kubectl inspection of the Ever Works clusters from CI, for operators
+# who have no local kubeconfig. Never prints Secret values (only key names).
+# Dispatch: gh workflow run ops-diagnose.yml --ref <branch> -f cluster=gauzy -f action=logs -f target=deploy/ever-works-api -f grep='pipeline' -f since=3h
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: 'Cluster'
+        required: true
+        type: choice
+        options: [gauzy, works]
+        default: gauzy
+      namespace:
+        description: 'Namespace (default: "default" for gauzy, "ever-works" for works)'
+        required: false
+        type: string
+        default: ''
+      action:
+        description: 'What to inspect'
+        required: true
+        type: choice
+        options: [pods, deployments, ingress, events, top, describe, logs, secret-keys, nodes]
+        default: pods
+      target:
+        description: 'Target for describe/logs/secret-keys, e.g. deploy/ever-works-api or pod/<name> or <secret-name>'
+        required: false
+        type: string
+        default: ''
+      grep:
+        description: 'Optional case-insensitive regex to filter output lines (logs/events)'
+        required: false
+        type: string
+        default: ''
+      since:
+        description: 'Logs lookback (kubectl --since), e.g. 3h'
+        required: false
+        type: string
+        default: '2h'
+      tail:
+        description: 'Max log lines (kubectl --tail)'
+        required: false
+        type: string
+        default: '2000'
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Write kubeconfig (from repo secret, never echoed)
+        env:
+          KC_GAUZY_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+          KC_WORKS_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          CLUSTER: ${{ inputs.cluster }}
+        run: |
+          set -euo pipefail
+          if [ "$CLUSTER" = "gauzy" ]; then printf '%s' "$KC_GAUZY_B64" | base64 -d > "$RUNNER_TEMP/kubeconfig"; else printf '%s' "$KC_WORKS_B64" | base64 -d > "$RUNNER_TEMP/kubeconfig"; fi
+          chmod 600 "$RUNNER_TEMP/kubeconfig"
+          echo "KUBECONFIG=$RUNNER_TEMP/kubeconfig" >> "$GITHUB_ENV"
+          kubectl version --client=true
+      - name: Inspect
+        env:
+          CLUSTER: ${{ inputs.cluster }}
+          NS_IN: ${{ inputs.namespace }}
+          ACTION: ${{ inputs.action }}
+          TARGET: ${{ inputs.target }}
+          GREP: ${{ inputs.grep }}
+          SINCE: ${{ inputs.since }}
+          TAIL: ${{ inputs.tail }}
+        run: |
+          set -euo pipefail
+          NS="$NS_IN"; if [ -z "$NS" ]; then if [ "$CLUSTER" = "gauzy" ]; then NS=default; else NS=ever-works; fi; fi
+          filter() { if [ -n "$GREP" ]; then grep -i -E "$GREP" || true; else cat; fi; }
+          echo "### cluster=$CLUSTER ns=$NS action=$ACTION target=$TARGET"
+          case "$ACTION" in
+            nodes)       kubectl get nodes -o wide; kubectl top nodes || true; kubectl describe nodes | grep -E "Name:|Allocated resources|cpu |memory |MemoryPressure|DiskPressure|PIDPressure" || true ;;
+            pods)        kubectl -n "$NS" get pods -o wide; echo; kubectl top pods -n "$NS" || true ;;
+            deployments) kubectl -n "$NS" get deploy,rs -o wide ;;
+            ingress)     kubectl -n "$NS" get ingress -o wide; kubectl -n "$NS" get ingress -o jsonpath='{range .items[*]}{.metadata.name}{" hosts="}{.spec.rules[*].host}{"\n"}{end}' ;;
+            events)      kubectl -n "$NS" get events --sort-by=.lastTimestamp | filter | tail -n 300 ;;
+            top)         kubectl top pods -n "$NS" --sort-by=memory || true; kubectl top nodes || true ;;
+            describe)    kubectl -n "$NS" describe "$TARGET" | grep -v -i -E "token|password|secret:" ;;
+            logs)        kubectl -n "$NS" logs "$TARGET" --all-containers=true --since="$SINCE" --tail="$TAIL" --timestamps 2>&1 | filter | tail -n 800 ;;
+            secret-keys) kubectl -n "$NS" get secret "$TARGET" -o jsonpath='{range $k,$v := .data}{$k}{"\n"}{end}' 2>/dev/null || kubectl -n "$NS" get secret "$TARGET" -o json | jq -r '.data | keys[]' ;;
+          esac

--- a/.github/workflows/ops-diagnose.yml
+++ b/.github/workflows/ops-diagnose.yml
@@ -8,11 +8,10 @@ on:
   workflow_dispatch:
     inputs:
       cluster:
-        description: 'Cluster'
+        description: 'DigitalOcean cluster name (doctl), e.g. k8s-works or k8s-gauzy; legacy aliases gauzy/works map to those'
         required: true
-        type: choice
-        options: [gauzy, works]
-        default: gauzy
+        type: string
+        default: 'k8s-works'
       namespace:
         description: 'Namespace (default: "default" for gauzy, "ever-works" for works)'
         required: false
@@ -22,7 +21,7 @@ on:
         description: 'What to inspect'
         required: true
         type: choice
-        options: [pods, deployments, ingress, events, top, describe, logs, secret-keys, nodes]
+        options: [clusters, pods, deployments, ingress, events, top, describe, logs, secret-keys, nodes]
         default: pods
       target:
         description: 'Target for describe/logs/secret-keys, e.g. deploy/ever-works-api or pod/<name> or <secret-name>'
@@ -53,18 +52,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Write kubeconfig (from repo secret, never echoed)
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Resolve cluster + write a short-lived kubeconfig (never echoed)
         env:
-          KC_GAUZY_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
-          KC_WORKS_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
-          CLUSTER: ${{ inputs.cluster }}
+          CLUSTER_IN: ${{ inputs.cluster }}
+          ACTION: ${{ inputs.action }}
         run: |
           set -euo pipefail
-          if [ "$CLUSTER" = "gauzy" ]; then printf '%s' "$KC_GAUZY_B64" | base64 -d > "$RUNNER_TEMP/kubeconfig"; else printf '%s' "$KC_WORKS_B64" | base64 -d > "$RUNNER_TEMP/kubeconfig"; fi
+          echo "### DigitalOcean Kubernetes clusters visible to this token"
+          doctl kubernetes cluster list --format ID,Name,Region,Version,Status,NodePools
+          if [ "$ACTION" = "clusters" ]; then echo "CLUSTERS_ONLY=true" >> "$GITHUB_ENV"; exit 0; fi
+          CLUSTER="$CLUSTER_IN"
+          case "$CLUSTER" in gauzy) CLUSTER=k8s-gauzy ;; works) CLUSTER=k8s-works ;; esac
+          # The EVER_WORKS_K8S_*_KUBECONFIG_B64 repo secrets point at a deleted
+          # cluster id (DNS `no such host`, 2026-08-22); doctl always returns the
+          # live endpoint for the named cluster.
+          export KUBECONFIG="$RUNNER_TEMP/kubeconfig"
+          doctl kubernetes cluster kubeconfig save --expiry-seconds 900 "$CLUSTER"
           chmod 600 "$RUNNER_TEMP/kubeconfig"
           echo "KUBECONFIG=$RUNNER_TEMP/kubeconfig" >> "$GITHUB_ENV"
           kubectl version --client=true
+          kubectl get nodes -o wide
       - name: Inspect
+        if: env.CLUSTERS_ONLY != 'true'
         env:
           CLUSTER: ${{ inputs.cluster }}
           NS_IN: ${{ inputs.namespace }}
@@ -75,7 +88,7 @@ jobs:
           TAIL: ${{ inputs.tail }}
         run: |
           set -euo pipefail
-          NS="$NS_IN"; if [ -z "$NS" ]; then if [ "$CLUSTER" = "gauzy" ]; then NS=default; else NS=ever-works; fi; fi
+          NS="$NS_IN"; if [ -z "$NS" ]; then case "$CLUSTER" in gauzy|k8s-gauzy) NS=default ;; *) NS=ever-works ;; esac; fi
           filter() { if [ -n "$GREP" ]; then grep -i -E "$GREP" || true; else cat; fi; }
           echo "### cluster=$CLUSTER ns=$NS action=$ACTION target=$TARGET"
           case "$ACTION" in

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -129,6 +129,21 @@ jobs:
         # runner for 48min+). The CLI compiles the tasks package itself from source.
         run: pnpm turbo run build --filter=@ever-works/trigger-tasks^... --concurrency=1
 
+      - name: Build the plugins shipped inside the worker bundle
+        if: steps.env.outputs.skip != 'true'
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        # `prepare:plugins` copies every packages/plugins/* that already has a
+        # dist/. The dependency-closure build above only produces a dist/ for the
+        # two plugins the tasks package imports directly (job-runtime-trigger,
+        # pty-local), so the deployed worker discovered exactly 2 plugins and
+        # every Trigger-dispatched generation failed with "No pipeline plugin
+        # available. Ensure at least one pipeline plugin is loaded." (prod,
+        # 2026-08-22 — run_cmt4q02v84rtf2x0hxrfbicnn). The legacy cloud workflow
+        # built `./packages/**`; build the plugins explicitly here, serialized
+        # for the same ARC-runner reasons as the step above.
+        run: pnpm turbo run build --filter='./packages/plugins/*' --concurrency=1
+
       - name: Prepare plugins for Trigger.dev
         if: steps.env.outputs.skip != 'true'
         working-directory: packages/tasks

--- a/packages/agent/src/entities/subscription-plan.entity.ts
+++ b/packages/agent/src/entities/subscription-plan.entity.ts
@@ -56,7 +56,11 @@ export class SubscriptionPlan {
      * `lookup_key` in the shared account — see
      * `packages/agent/src/subscriptions/billing/stripe-catalog.ts`.
      */
-    @Column({ type: 'varchar', default: 'cloud' })
+    // 🛑 `length` must match the migration's `varchar(32)`. Without it TypeORM `synchronize`
+    // renders an unbounded `character varying` on dev and stage, while prod — the only environment
+    // that executes migration files — gets `varchar(32)`. The two would then run different schemas,
+    // which is precisely what makes "it worked on stage" worthless for anything schema-shaped.
+    @Column({ type: 'varchar', length: 32, default: 'cloud' })
     hosting: SubscriptionPlanHosting;
 
     /**

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -87,6 +87,12 @@ function makePlanRepository(overrides: Record<string, unknown> = {}) {
         findByCode: jest.fn().mockImplementation(async (code: string) => {
             if (code === 'standard') return STANDARD_PLAN;
             if (code === 'free') return FREE_PLAN;
+            // Seeded by `SubscriptionService.seedPlans()` in every real deployment. Without it here
+            // a licence webhook resolves no plan and activation is skipped — which is also the
+            // production failure mode if a plan code is ever added to the seed but NOT to the
+            // `SubscriptionPlanCode` enum, since `findPlanByCode` rejects unknown codes before it
+            // ever reaches the repository.
+            if (code === 'selfhosted_pro') return SELFHOSTED_PRO_PLAN;
             return null;
         }),
         ...overrides,
@@ -595,6 +601,120 @@ describe('applyWebhook — activation and revocation', () => {
             expect.objectContaining({ id: 'u1' }),
             'standard',
         );
+    });
+
+    /**
+     * A one-off perpetual licence (`mode: payment`) produces a
+     * `checkout.session.completed` with **no subscription**, so the normalized event carries
+     * `subscriptionId: null`. It is deliberately the SAME `subscription.activated` kind as a
+     * recurring purchase — the act is identical, grant this user this plan — and this is the path
+     * that runs for every $99 sale. It was reasoned to be safe because `activate()` accepts a
+     * nullable provider subscription id; these pin that rather than leaving it as reasoning.
+     */
+    it('activates a perpetual licence even though it carries NO subscription id', async () => {
+        const { service, subscriptionService, subscriptionRepository } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(
+            service.applyWebhook(
+                event({
+                    planCode: 'selfhosted_pro',
+                    referenceId: 'u1:selfhosted_pro',
+                    subscriptionId: null,
+                    amountCents: 9900,
+                    currentPeriodEnd: null,
+                }),
+            ),
+        ).resolves.toBe('subscription-activated');
+
+        // The purchase is RECORDED. It is deliberately NOT granted as the hosted tier — see the
+        // licence test below; `activate()` returns before the privileged grant for self-hosted.
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+        // The row must record that there is no provider subscription behind this plan — that null
+        // is what later makes `cancelSubscription` refuse, which is correct for a licence that
+        // never expires.
+        expect(subscriptionRepository.createOrUpdate.mock.calls[0][1]).toEqual(
+            expect.objectContaining({ providerSubscriptionId: null }),
+        );
+    });
+
+    /**
+     * 🛑 REGRESSION. A self-hosted purchase is a LICENCE, not a tier on THIS deployment.
+     * `activate()` used to grant by plan code alone, so a one-off $99 self-hosted lifetime licence
+     * permanently set the buyer's CLOUD tier to `selfhosted_pro` — 5 works and paid cadences,
+     * enforced by `work-schedule.service.ts` — against $25/mo for cloud Pro. Pure arbitrage, and
+     * the buyer would not even be doing anything wrong. The purchase must still be RECORDED so we
+     * know they hold a licence, for support and for the manual document fulfilment.
+     */
+    it('records a self-hosted licence but does NOT grant it as the hosted tier', async () => {
+        const { service, subscriptionService, subscriptionRepository } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await expect(
+            service.applyWebhook(
+                event({
+                    planCode: 'selfhosted_pro',
+                    referenceId: 'u1:selfhosted_pro',
+                    subscriptionId: null,
+                    amountCents: 9900,
+                    currentPeriodEnd: null,
+                }),
+            ),
+        ).resolves.toBe('subscription-activated');
+
+        // Recorded: we must know the customer owns a licence.
+        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ planCode: 'selfhosted_pro' }),
+        );
+        // But NOT granted as the effective tier on this hosted deployment.
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('still grants a CLOUD purchase as the tier — the guard must not break the paying path', async () => {
+        const { service, subscriptionService } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        await service.applyWebhook(event());
+
+        expect(subscriptionService.assignPlanToUser).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'u1' }),
+            'standard',
+        );
+    });
+
+    it('is idempotent for a licence too — a replayed delivery records it once, not twice', async () => {
+        const { service, subscriptionService, subscriptionRepository } = build({
+            profileRepository: makeProfileRepository({
+                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+            }),
+        });
+
+        const licence = event({
+            planCode: 'selfhosted_pro',
+            referenceId: 'u1:selfhosted_pro',
+            subscriptionId: null,
+            amountCents: 9900,
+            currentPeriodEnd: null,
+        });
+        await service.applyWebhook(licence);
+        await service.applyWebhook(licence);
+
+        // The licence record is re-asserted identically, and the hosted tier is never granted.
+        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalledTimes(2);
+        expect(subscriptionRepository.createOrUpdate.mock.calls[0][1]).toEqual(
+            subscriptionRepository.createOrUpdate.mock.calls[1][1],
+        );
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
     });
 
     it('is idempotent — a replayed delivery re-asserts the same tier', async () => {

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -386,6 +386,25 @@ export class PlanSubscriptionService {
             providerSubscriptionId: input.providerSubscriptionId ?? null,
         });
 
+        // 🛑 A SELF-HOSTED purchase is a LICENCE, not a tier on this deployment.
+        //
+        // The `user_subscriptions` row above is still written — we must know the customer holds a
+        // licence, both for support and for the manual document fulfilment. But it must NOT become
+        // their effective plan here: `assignPlanToUser` → `persistDefaultPlan` sets the tier that
+        // `work-schedule.service.ts` enforces (`maxWorks`, cadence allowances). Granting it would
+        // sell permanent CLOUD entitlements for a one-off $99 self-hosted licence, against $25/mo
+        // for cloud Pro — pure arbitrage, and the buyer would not even be doing anything wrong.
+        //
+        // Same principle as the self-service gate in `SubscriptionService.changePlanSelfService`:
+        // hosting decides where a plan applies, and price alone never does.
+        if (plan.hosting === 'selfhosted') {
+            this.logger.log(
+                `Recorded a self-hosted licence for user ${input.userId} (plan '${plan.code}') — ` +
+                    `the hosted tier is deliberately left unchanged.`,
+            );
+            return true;
+        }
+
         // THE privileged grant (`assignPlanToUser`) — documented as
         // "call only from a billing-verified path", which is exactly here.
         // The `user_subscriptions` row above is written regardless so the

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1022,6 +1022,43 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         );
     });
 
+    /**
+     * 🛑 REGRESSION. Stripe rejects a line item carrying `recurring` in a `mode: payment` session.
+     * The inline fallback attached it unconditionally, so on any deployment whose catalog is NOT
+     * synced — exactly the deployments the fallback exists to serve — the $99 perpetual licence
+     * checkout threw instead of selling.
+     */
+    it('omits recurring from the inline fallback for a one-off licence', async () => {
+        const { provider, client } = build();
+        client.prices = { list: jest.fn().mockResolvedValue({ data: [] }) };
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: {
+                ...planRequest.plan,
+                mode: 'payment',
+                lookupKey: 'ever_works_selfhosted_pro_lifetime',
+            },
+        });
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('payment');
+        expect(params.line_items[0].price_data).toBeDefined();
+        expect(params.line_items[0].price_data.recurring).toBeUndefined();
+    });
+
+    it('KEEPS recurring on the inline fallback for a subscription', async () => {
+        // Control: the fix must not strip it from the recurring path.
+        const { provider, client } = build();
+        client.prices = { list: jest.fn().mockResolvedValue({ data: [] }) };
+
+        await provider.createPlanCheckoutSession(planRequest);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('subscription');
+        expect(params.line_items[0].price_data.recurring).toEqual({ interval: 'month' });
+    });
+
     it('bills the shared-account CATALOG price when the lookup key resolves', async () => {
         const { provider, client } = build();
         client.prices = {
@@ -1075,6 +1112,58 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
 
         const params = client.checkout.sessions.create.mock.calls[0][0];
         expect(params.line_items[0].price_data.unit_amount).toBe(2900);
+    });
+
+    /**
+     * 🛑 REGRESSION. A THROWN lookup must not be memoised. It is a transient condition — timeout,
+     * 5xx, rate limit — not an answer about this account. Caching it made one blip permanent for
+     * the process lifetime, and because the seat line has no inline fallback (the per-seat amount
+     * lives only in the catalog) every later checkout on that pod would silently stop billing
+     * seats. Undercharging, and invisible after the first warning.
+     */
+    it('does NOT cache a thrown lookup — the next attempt retries and bills correctly', async () => {
+        const { provider, client } = build();
+        const list = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('stripe timeout'))
+            .mockResolvedValue({ data: [{ id: 'price_cat_1' }] });
+        client.prices = { list };
+
+        const req = {
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        };
+
+        // First attempt: the lookup throws, so it falls back to the inline price.
+        await provider.createPlanCheckoutSession(req);
+        expect(
+            client.checkout.sessions.create.mock.calls[0][0].line_items[0].price_data,
+        ).toBeDefined();
+
+        // Second attempt: Stripe is healthy again and the catalog price MUST be used.
+        await provider.createPlanCheckoutSession(req);
+        const second = client.checkout.sessions.create.mock.calls[1][0];
+        expect(second.line_items[0].price).toBe('price_cat_1');
+        expect(second.line_items[0].price_data).toBeUndefined();
+        // Proves the retry actually happened rather than a cached null being reused.
+        expect(list).toHaveBeenCalledTimes(2);
+    });
+
+    it('DOES cache a definitive absence — an unsynced account is not re-queried every checkout', async () => {
+        const { provider, client } = build();
+        const list = jest.fn().mockResolvedValue({ data: [] });
+        client.prices = { list };
+
+        const req = {
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        };
+        await provider.createPlanCheckoutSession(req);
+        await provider.createPlanCheckoutSession(req);
+
+        // "This account does not have it" is a real answer and the steady state for a self-hoster,
+        // so it is memoised — one call, not one per checkout.
+        expect(list).toHaveBeenCalledTimes(1);
     });
 
     it('adds a second line item for the seats beyond the allowance', async () => {

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -335,7 +335,13 @@ export class StripeBillingProvider extends BillingProvider {
                 `Could not resolve Stripe price for lookup_key "${key}"; falling back to an inline price`,
                 error instanceof Error ? error.stack : undefined,
             );
-            resolved = null;
+            // 🛑 Return WITHOUT caching. A thrown lookup is a transient condition — a timeout, a
+            // 5xx, a rate limit — not an answer about this account. Memoising it would make one
+            // blip permanent for the lifetime of the process, and the seat line has no inline
+            // fallback (the per-seat amount lives only in the catalog), so every later checkout on
+            // this pod would silently stop billing seats. That is undercharging, and it would look
+            // like nothing at all in the logs after the first warning.
+            return null;
         }
 
         if (resolved === null) {
@@ -345,6 +351,8 @@ export class StripeBillingProvider extends BillingProvider {
             );
         }
 
+        // Only a SUCCESSFUL lookup is memoised — including a definitive "this account does not have
+        // it", which is the normal steady state for an unsynced deployment and is safe to cache.
         this.priceIdByLookupKey.set(key, resolved);
         return resolved;
     }
@@ -363,6 +371,12 @@ export class StripeBillingProvider extends BillingProvider {
     ): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> {
         const planPriceId = await this.resolvePriceId(request.plan.lookupKey);
 
+        // 🛑 The inline fallback must respect the MODE. Stripe rejects a line item carrying
+        // `recurring` in a `mode: payment` session, so attaching it unconditionally made the $99
+        // perpetual licence unbuyable on any deployment whose catalog is not synced — the exact
+        // deployments the fallback exists to serve. A one-off line item simply omits `recurring`.
+        const isPerpetualLine = request.plan.mode === 'payment';
+
         const planLine: Stripe.Checkout.SessionCreateParams.LineItem = planPriceId
             ? { quantity: 1, price: planPriceId }
             : {
@@ -371,7 +385,9 @@ export class StripeBillingProvider extends BillingProvider {
                       // Price comes from the SERVER plan row.
                       currency: request.plan.currency,
                       unit_amount: request.plan.priceCents,
-                      recurring: { interval: request.plan.interval },
+                      ...(isPerpetualLine
+                          ? {}
+                          : { recurring: { interval: request.plan.interval } }),
                       product_data: { name: request.plan.label },
                   },
               };

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -139,6 +139,79 @@ describe('SubscriptionService', () => {
             );
         });
 
+        /**
+         * 🛑 Every seeded code MUST be a member of `SubscriptionPlanCode`.
+         *
+         * `PlanSubscriptionService.findPlanByCode` rejects any code that is not in the enum
+         * BEFORE it reaches the repository, and `activate()` treats "no plan" as
+         * "activation skipped" — a warning log and a `false`. So a plan seeded with a code the
+         * enum does not carry is fully purchasable and then silently grants nothing: the money
+         * moves, the webhook returns `ignored`, and the buyer gets no tier. Nothing else in the
+         * suite would catch it, because seeding and activation are tested apart.
+         */
+        it('seeds no plan code that SubscriptionPlanCode does not carry', async () => {
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const seeded = planRepository.upsert.mock.calls.map((c) => c[0].code);
+            const known = new Set<string>(Object.values(SubscriptionPlanCode));
+
+            expect(seeded.length).toBeGreaterThan(0); // never pass vacuously
+            expect(seeded.filter((c: string) => !known.has(c))).toEqual([]);
+        });
+
+        /**
+         * 🛑 REGRESSION. `maxWorks` is a Postgres `integer` (ceiling 2147483647). Seeding
+         * `Number.MAX_SAFE_INTEGER` (9007199254740991) as "unlimited" made Postgres reject the
+         * INSERT with `integer out of range` — and because `seedPlans()` runs inside
+         * `onModuleInit`, that does not degrade gracefully: module init aborts and the API never
+         * finishes booting, on dev, stage AND production alike.
+         *
+         * Nothing else in this suite can catch it, because `planRepository` is a mock here and a
+         * mock accepts any number. This test encodes the column's real ceiling so the value is
+         * checked without a database.
+         */
+        const PG_INT4_MAX = 2_147_483_647;
+
+        it('seeds no integer quota that Postgres int4 would reject', async () => {
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const rows = planRepository.upsert.mock.calls.map((c) => c[0]);
+
+            expect(rows.length).toBeGreaterThan(0); // never pass vacuously
+            for (const row of rows) {
+                expect({ code: row.code, maxWorks: row.maxWorks }).toEqual({
+                    code: row.code,
+                    maxWorks: expect.any(Number),
+                });
+                expect(row.maxWorks).toBeLessThanOrEqual(PG_INT4_MAX);
+                expect(row.maxWorks).toBeGreaterThanOrEqual(0);
+                expect(Number.isInteger(row.maxWorks)).toBe(true);
+            }
+        });
+
+        it('seeds prices that fit decimal(10,2) and parse back to the same number', async () => {
+            // The price columns are decimal(10,2) — max 99,999,999.99 — and TypeORM hands them back
+            // as STRINGS. A value that does not round-trip would bill a different amount than the
+            // one reviewed here.
+            const { service, planRepository } = makeService();
+            await service.seedPlans();
+            const rows = planRepository.upsert.mock.calls.map((c) => c[0]);
+
+            for (const row of rows) {
+                for (const field of ['monthlyPrice', 'annualPrice', 'lifetimePrice'] as const) {
+                    const raw = row[field];
+                    if (raw === null || raw === undefined) continue;
+                    expect(typeof raw).toBe('string');
+                    const n = Number(raw);
+                    expect(Number.isFinite(n)).toBe(true);
+                    expect(n).toBeLessThan(100_000_000);
+                    expect(n).toBeGreaterThanOrEqual(0);
+                    // Two decimal places at most, or the column silently rounds the charge.
+                    expect(Math.round(n * 100)).toBe(n * 100);
+                }
+            }
+        });
+
         it('tags every row with a hosting mode, three cloud and three self-hosted', async () => {
             const { service, planRepository } = makeService();
             await service.seedPlans();
@@ -716,6 +789,59 @@ describe('SubscriptionService', () => {
             await expect(
                 service.changePlanSelfService({ id: 'u1' } as any, SubscriptionPlanCode.FREE),
             ).rejects.toThrow(NotFoundException);
+        });
+
+        /**
+         * 🛑 REGRESSION (EW-711 #23, reopened and re-closed 2026-08-22).
+         *
+         * Adding the self-hosted editions introduced a row that is genuinely FREE
+         * (`monthlyPrice: '0'`) and genuinely UNLIMITED (`maxWorks` at the int4 ceiling, every
+         * cadence) — correct for someone self-hosting the AGPLv3 platform, where quotas are
+         * advisory because they own the database. But `isPaidPlan()` gates purely on price, so on
+         * the HOSTED service that row looked self-serviceable: any authenticated user could POST
+         * `{planCode:'selfhosted_community'}` and receive unlimited scheduled works plus hourly
+         * cadence for free. Those entitlements ARE enforced — `work-schedule.service.ts` reads
+         * `plan.maxWorks` and `getCadenceAllowances` — so this was a live free→paid escalation,
+         * exactly what #23 exists to prevent. The price check alone is not sufficient once a
+         * hosting axis exists.
+         */
+        it.each([
+            SubscriptionPlanCode.SELFHOSTED_COMMUNITY,
+            SubscriptionPlanCode.SELFHOSTED_PRO,
+            SubscriptionPlanCode.SELFHOSTED_ENTERPRISE,
+        ])('refuses to self-assign %s even when it is free-priced', async (code) => {
+            const { service, userRepository } = makeService({
+                findByCode: jest.fn().mockResolvedValue({
+                    id: 'plan-sh',
+                    code,
+                    displayName: 'Community Edition',
+                    hosting: 'selfhosted',
+                    // Deliberately free AND unlimited — the exact shape that slipped past the
+                    // price-only gate.
+                    monthlyPrice: '0',
+                    maxWorks: 2_147_483_647,
+                    allowedCadences: ALL_CADENCES_IN_PUBLIC_ORDER,
+                    overagePricePerRun: '0',
+                }),
+            });
+
+            await expect(service.changePlanSelfService({ id: 'u1' } as any, code)).rejects.toThrow(
+                ForbiddenException,
+            );
+            // The escalation is only truly closed if NOTHING was written.
+            expect(userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('still allows a FREE CLOUD plan — the guard must not break the legitimate path', async () => {
+            const user = { id: 'u1' } as any;
+            const { service, userRepository } = makeService({
+                findByCode: jest.fn().mockResolvedValue({ ...FREE_PLAN, hosting: 'cloud' }),
+            });
+
+            await expect(
+                service.changePlanSelfService(user, SubscriptionPlanCode.FREE),
+            ).resolves.toBeDefined();
+            expect(userRepository.update).toHaveBeenCalled();
         });
 
         it('assigns a FREE plan (monthlyPrice 0) and persists it', async () => {

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -26,6 +26,18 @@ const ALL_CADENCES: WorkScheduleCadence[] = [
     WorkScheduleCadence.HOURLY,
 ];
 
+/**
+ * "Unlimited" for a quota stored in an `int` column.
+ *
+ * 🛑 NOT `Number.MAX_SAFE_INTEGER`. `subscription_plans.maxWorks` is a Postgres `integer`, whose
+ * ceiling is 2147483647; MAX_SAFE_INTEGER is 9007199254740991 and Postgres rejects the INSERT with
+ * `integer out of range`. Because `seedPlans()` runs inside `onModuleInit`, that rejection does not
+ * degrade — it aborts module init and the API never finishes booting, on every environment with a
+ * real database. Unit tests cannot catch it: the plan repository is a mock there, so the value is
+ * never handed to Postgres.
+ */
+const UNLIMITED_WORKS = 2_147_483_647;
+
 const PAID_CADENCES: WorkScheduleCadence[] = [
     WorkScheduleCadence.MONTHLY,
     WorkScheduleCadence.WEEKLY,
@@ -128,8 +140,9 @@ const PLAN_SEED_DATA: Array<{
         displayName: 'Community Edition',
         hosting: 'selfhosted',
         // Free AGPLv3 download with no limits, mirroring Gauzy's Community Edition. Never bought,
-        // so it has no Stripe object at all.
-        maxWorks: Number.MAX_SAFE_INTEGER,
+        // so it has no Stripe object at all. Quotas are advisory here anyway — a self-hoster owns
+        // the database — but the value still has to fit the column. See {@link UNLIMITED_WORKS}.
+        maxWorks: UNLIMITED_WORKS,
         allowedCadences: ALL_CADENCES,
         monthlyPrice: '0',
         annualPrice: '0',
@@ -387,6 +400,26 @@ export class SubscriptionService implements OnModuleInit {
         if (this.isPaidPlan(plan) && !config.subscriptions.allowSelfServePaidPlans()) {
             throw new ForbiddenException(
                 'Paid plans must be activated through billing and cannot be self-assigned.',
+            );
+        }
+        // EW-711 #23, second gate (added with the self-hosted editions, 2026-08-22).
+        //
+        // 🛑 The price check alone is NOT sufficient once a self-hosted tier exists. The Community
+        // Edition is genuinely free (`monthlyPrice: '0'`) and genuinely unlimited — that is correct
+        // for someone running the AGPLv3 platform on their own hardware, where quotas are advisory
+        // because they own the database. But it makes the row look self-serviceable to
+        // `isPaidPlan()`, so on the HOSTED service any authenticated user could assign it to
+        // themselves and receive `maxWorks: 2_147_483_647` plus every cadence — entitlements that
+        // ARE enforced here (`work-schedule.service.ts` checks `plan.maxWorks` and
+        // `getCadenceAllowances`). That is precisely the free→paid escalation #23 closed.
+        //
+        // Self-hosted rows exist so the plan switcher and the licence paperwork describe the same
+        // thing. They are never something a user picks: the paid editions are commercial licences
+        // granted through billing, and the Community Edition applies to a deployment this instance
+        // is not.
+        if (plan.hosting === 'selfhosted') {
+            throw new ForbiddenException(
+                'Self-hosted editions cannot be self-assigned on a hosted deployment.',
             );
         }
         return this.persistDefaultPlan(user, plan);


### PR DESCRIPTION
Cascades the six billing fixes from #2171, plus the develop commits that landed alongside them (#2150 fleet credentials, #2163/#2167 ops-diagnose, #2166 trigger plugin build).

**Why this one matters:** `main` currently carries a boot-breaking defect. `seedPlans()` writes `maxWorks: Number.MAX_SAFE_INTEGER` into a Postgres `integer`, which is rejected `integer out of range` — and because it runs inside `onModuleInit`, the API never finishes booting. I cancelled the queued prod image build so it was never published; this is the fix that makes `main` deployable again.

| Fix | Would have caused |
|---|---|
| `maxWorks` fits int4 | API crashloop on boot — dev, stage **and prod** |
| Self-hosted rows not self-assignable | Any user gets unlimited works + hourly cadence free (reopened EW-711 #23) |
| Licence ≠ hosted tier | $99 once buys what costs $25/mo |
| No caching of a thrown price lookup | One Stripe blip permanently stops that pod billing seats |
| No `recurring` on a one-off line | Stripe rejects it — the $99 licence was unbuyable without a synced catalog |
| `hosting` pinned to `varchar(32)` | prod and dev/stage would run different schemas for that column |

All six were introduced by the billing change itself and found by an adversarial pre-production audit (28 agents, four lenses, every candidate put to a verifier told to refute it — 23 confirmed, 1 refuted). None was caught by the 9,400-test suite, because `planRepository` is a `jest.fn()` and a mock accepts any value.

**Verification:** 527/527 suites, 9,423 tests, 0 failed on the merged tree; `tsc --noEmit` 0 errors (after rebuilding `packages/contracts`, which #2150 changed); Prettier clean. Every fix carries a regression test **proved load-bearing** by reverting the fix and watching it go red. The crashloop and the corrected seed were both exercised against a throwaway Postgres 16 — the bad INSERT fails while a control succeeds, and all six seed rows insert cleanly afterwards.

Conflicts with develop were resolved by taking this branch on all five conflicted files, after confirming with a control that no develop commit since the billing squash had touched any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)