### PR TITLE
chore(release): cascade stage -> main (all eleven billing fixes)

### DIFF
--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -607,9 +607,9 @@ describe('applyWebhook — activation and revocation', () => {
      * A one-off perpetual licence (`mode: payment`) produces a
      * `checkout.session.completed` with **no subscription**, so the normalized event carries
      * `subscriptionId: null`. It is deliberately the SAME `subscription.activated` kind as a
-     * recurring purchase — the act is identical, grant this user this plan — and this is the path
-     * that runs for every $99 sale. It was reasoned to be safe because `activate()` accepts a
-     * nullable provider subscription id; these pin that rather than leaving it as reasoning.
+     * recurring purchase, so the webhook is ACKNOWLEDGED (Stripe must not retry) — but it writes
+     * nothing and grants nothing, because a licence applies to the buyer's own deployment. This is
+     * the path that runs for every $99 sale.
      */
     it('activates a perpetual licence even though it carries NO subscription id', async () => {
         const { service, subscriptionService, subscriptionRepository } = build({
@@ -630,15 +630,10 @@ describe('applyWebhook — activation and revocation', () => {
             ),
         ).resolves.toBe('subscription-activated');
 
-        // The purchase is RECORDED. It is deliberately NOT granted as the hosted tier — see the
-        // licence test below; `activate()` returns before the privileged grant for self-hosted.
+        // Nothing is written and nothing granted — the licence lives on the Stripe payment intent
+        // (stamped ever_works_licence), which is what manual fulfilment searches.
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
-        // The row must record that there is no provider subscription behind this plan — that null
-        // is what later makes `cancelSubscription` refuse, which is correct for a licence that
-        // never expires.
-        expect(subscriptionRepository.createOrUpdate.mock.calls[0][1]).toEqual(
-            expect.objectContaining({ providerSubscriptionId: null }),
-        );
+        expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
     });
 
     /**
@@ -649,7 +644,7 @@ describe('applyWebhook — activation and revocation', () => {
      * the buyer would not even be doing anything wrong. The purchase must still be RECORDED so we
      * know they hold a licence, for support and for the manual document fulfilment.
      */
-    it('records a self-hosted licence but does NOT grant it as the hosted tier', async () => {
+    it('writes NO subscription row and grants NO tier for a self-hosted licence', async () => {
         const { service, subscriptionService, subscriptionRepository } = build({
             profileRepository: makeProfileRepository({
                 findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
@@ -668,12 +663,14 @@ describe('applyWebhook — activation and revocation', () => {
             ),
         ).resolves.toBe('subscription-activated');
 
-        // Recorded: we must know the customer owns a licence.
-        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalledWith(
-            'u1',
-            expect.objectContaining({ planCode: 'selfhosted_pro' }),
-        );
-        // But NOT granted as the effective tier on this hosted deployment.
+        // 🛑 The row must NOT be written at all. An earlier version of this guard skipped only
+        // `assignPlanToUser` and still wrote here, which was ineffective twice over:
+        //   1. `resolvePlanForUser` reads the ACTIVE subscription BEFORE `user.defaultPlan`, so
+        //      the row alone made the licence the buyer's effective hosted tier.
+        //   2. `createOrUpdate` is one-active-row-per-user and UPDATEs in place, so a paying
+        //      cloud customer who bought a licence would have their real subscription OVERWRITTEN.
+        // Assert the OUTCOME (nothing written, nothing granted), not the guard.
+        expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
     });
 
@@ -709,11 +706,8 @@ describe('applyWebhook — activation and revocation', () => {
         await service.applyWebhook(licence);
         await service.applyWebhook(licence);
 
-        // The licence record is re-asserted identically, and the hosted tier is never granted.
-        expect(subscriptionRepository.createOrUpdate).toHaveBeenCalledTimes(2);
-        expect(subscriptionRepository.createOrUpdate.mock.calls[0][1]).toEqual(
-            subscriptionRepository.createOrUpdate.mock.calls[1][1],
-        );
+        // Replaying a licence delivery must stay inert: no row, no grant, however many times.
+        expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
     });
 

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -376,6 +376,32 @@ export class PlanSubscriptionService {
             return false;
         }
 
+        // 🛑 A SELF-HOSTED purchase is a LICENCE. It must not touch `user_subscriptions` AT ALL.
+        //
+        // An earlier version of this guard sat lower down and only skipped `assignPlanToUser`. That
+        // was ineffective, for two independent reasons found by re-reviewing the fix itself:
+        //
+        //  1. `assignPlanToUser` only sets `user.defaultPlan`, but `resolvePlanForUser` reads the
+        //     ACTIVE `user_subscriptions` row FIRST and only falls back to `defaultPlan`. So writing
+        //     the row below still made the licence the buyer's effective hosted tier — the exact
+        //     arbitrage the guard was supposed to stop ($99 once for what costs $25/mo).
+        //  2. `UserSubscriptionRepository.createOrUpdate` is a ONE-ACTIVE-ROW-PER-USER model: it
+        //     finds the caller's active subscription and UPDATEs it in place. So an existing paying
+        //     cloud customer who also bought a licence would have their real subscription row
+        //     OVERWRITTEN — losing the plan, the period end and the provider subscription id.
+        //
+        // The licence is still recorded where it actually matters: on the Stripe payment intent,
+        // stamped `ever_works_licence=perpetual-commercial`, which is what the manual fulfilment
+        // process searches. Nothing here needs a row to know the sale happened.
+        if (plan.hosting === 'selfhosted') {
+            this.logger.log(
+                `Recorded a self-hosted licence purchase for user ${input.userId} (plan ` +
+                    `'${plan.code}'). No hosted subscription row written and no tier granted — a ` +
+                    `licence applies to the buyer's OWN deployment, not to this one.`,
+            );
+            return true;
+        }
+
         await this.userSubscriptionRepository.createOrUpdate(input.userId, {
             planCode: plan.code,
             planId: plan.id,
@@ -385,25 +411,6 @@ export class PlanSubscriptionService {
             cancelAtPeriodEnd: input.cancelAtPeriodEnd,
             providerSubscriptionId: input.providerSubscriptionId ?? null,
         });
-
-        // 🛑 A SELF-HOSTED purchase is a LICENCE, not a tier on this deployment.
-        //
-        // The `user_subscriptions` row above is still written — we must know the customer holds a
-        // licence, both for support and for the manual document fulfilment. But it must NOT become
-        // their effective plan here: `assignPlanToUser` → `persistDefaultPlan` sets the tier that
-        // `work-schedule.service.ts` enforces (`maxWorks`, cadence allowances). Granting it would
-        // sell permanent CLOUD entitlements for a one-off $99 self-hosted licence, against $25/mo
-        // for cloud Pro — pure arbitrage, and the buyer would not even be doing anything wrong.
-        //
-        // Same principle as the self-service gate in `SubscriptionService.changePlanSelfService`:
-        // hosting decides where a plan applies, and price alone never does.
-        if (plan.hosting === 'selfhosted') {
-            this.logger.log(
-                `Recorded a self-hosted licence for user ${input.userId} (plan '${plan.code}') — ` +
-                    `the hosted tier is deliberately left unchanged.`,
-            );
-            return true;
-        }
 
         // THE privileged grant (`assignPlanToUser`) — documented as
         // "call only from a billing-verified path", which is exactly here.

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1149,9 +1149,18 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         expect(list).toHaveBeenCalledTimes(2);
     });
 
-    it('DOES cache a definitive absence — an unsynced account is not re-queried every checkout', async () => {
+    /**
+     * 🛑 A MISS must NOT be memoised either. The catalog is published by a script that runs
+     * independently of the pods, so a pod that starts before the sync would otherwise pin every key
+     * to null for its whole lifetime — and because the seat line has no inline fallback, that pod
+     * silently stops billing seats, with nothing in the logs after the first warning.
+     */
+    it('re-checks after a MISS, so a later catalog sync is picked up without a restart', async () => {
         const { provider, client } = build();
-        const list = jest.fn().mockResolvedValue({ data: [] });
+        const list = jest
+            .fn()
+            .mockResolvedValueOnce({ data: [] }) // catalog not synced yet
+            .mockResolvedValue({ data: [{ id: 'price_cat_1' }] }); // sync ran
         client.prices = { list };
 
         const req = {
@@ -1161,8 +1170,59 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         await provider.createPlanCheckoutSession(req);
         await provider.createPlanCheckoutSession(req);
 
-        // "This account does not have it" is a real answer and the steady state for a self-hoster,
-        // so it is memoised — one call, not one per checkout.
+        expect(list).toHaveBeenCalledTimes(2);
+        // The second checkout uses the now-published catalog price rather than a cached miss.
+        expect(client.checkout.sessions.create.mock.calls[1][0].line_items[0].price).toBe(
+            'price_cat_1',
+        );
+    });
+
+    /**
+     * 🛑 REGRESSION. The resolved-price cache belongs to the KEY, not the process. The same 22
+     * `ever_works_*` lookup keys exist in BOTH test and live mode of the shared account, so a
+     * process that resolved under `sk_test_…` and rotates to `sk_live_…` would otherwise hand
+     * TEST-mode price ids to a LIVE client.
+     */
+    it('drops the price cache when the secret key rotates', async () => {
+        const { provider, client } = build();
+        const list = jest
+            .fn()
+            .mockResolvedValueOnce({ data: [{ id: 'price_TEST_mode' }] })
+            .mockResolvedValue({ data: [{ id: 'price_LIVE_mode' }] });
+        client.prices = { list };
+
+        const req = {
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        };
+
+        await provider.createPlanCheckoutSession(req);
+        expect(client.checkout.sessions.create.mock.calls[0][0].line_items[0].price).toBe(
+            'price_TEST_mode',
+        );
+
+        // Rotate the key, exactly as a Secret update would.
+        process.env.STRIPE_SECRET_KEY = 'sk_live_rotated';
+        await provider.createPlanCheckoutSession(req);
+
+        const second = client.checkout.sessions.create.mock.calls[1][0];
+        expect(second.line_items[0].price).toBe('price_LIVE_mode');
+        // Proves the cache was dropped rather than the id reused.
+        expect(list).toHaveBeenCalledTimes(2);
+    });
+
+    it('memoises a HIT, so a healthy account is queried once and not per checkout', async () => {
+        const { provider, client } = build();
+        const list = jest.fn().mockResolvedValue({ data: [{ id: 'price_cat_1' }] });
+        client.prices = { list };
+
+        const req = {
+            ...planRequest,
+            plan: { ...planRequest.plan, lookupKey: 'ever_works_cloud_pro_monthly' },
+        };
+        await provider.createPlanCheckoutSession(req);
+        await provider.createPlanCheckoutSession(req);
+
         expect(list).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -349,10 +349,26 @@ export class StripeBillingProvider extends BillingProvider {
                 `No active Stripe price for lookup_key "${key}" in this account — billing the plan row's ` +
                     `inline amount instead. Run scripts/stripe-sync-catalog.mjs to publish the catalog.`,
             );
+            // 🛑 A MISS is not memoised either, only a hit.
+            //
+            // An earlier version cached the definitive "this account does not have it" on the
+            // grounds that it is the steady state for an unsynced deployment. That is a footgun:
+            // the catalog is published by a script that runs INDEPENDENTLY of the pods, so a pod
+            // that happens to start before the sync pins every one of its keys to null until it is
+            // restarted. The seat line has no inline fallback, so that pod then silently stops
+            // billing seats — for its whole lifetime, with nothing in the logs after the first
+            // warning. Undercharging that heals itself on the next checkout is strictly better
+            // than undercharging that persists until someone notices.
+            //
+            // The re-check costs one `prices.list` per checkout, and checkout is throttled to 10
+            // per minute per user (`plan-checkout.controller.ts`), so this cannot become a hot loop.
+            return null;
         }
 
-        // Only a SUCCESSFUL lookup is memoised — including a definitive "this account does not have
-        // it", which is the normal steady state for an unsynced deployment and is safe to cache.
+        // Only a HIT is memoised. A price id never changes for a given lookup_key while that price
+        // is active; when an amount changes the sync script moves the key onto a NEW price via
+        // `transfer_lookup_key`, so a long-lived process can hold a stale id — which is what you
+        // want for an in-flight checkout, and is corrected on the next deploy.
         this.priceIdByLookupKey.set(key, resolved);
         return resolved;
     }
@@ -808,6 +824,15 @@ export class StripeBillingProvider extends BillingProvider {
             const factory = this.clientFactory ?? defaultStripeClient;
             this.client = factory(secretKey as string);
             this.clientKey = secretKey as string;
+            // 🛑 The resolved-price cache belongs to the KEY, not to the process.
+            //
+            // `priceIdByLookupKey` is keyed on the bare lookup_key, and the SAME 22 `ever_works_*`
+            // keys exist in BOTH test and live mode of the shared account — deliberately, so the
+            // two stay in step. So a process that resolved prices under `sk_test_…` and is then
+            // rotated to `sk_live_…` would otherwise keep handing TEST-mode `price_…` ids to a LIVE
+            // client. Dropping the cache with the client is the only thing that makes the two
+            // consistent by construction.
+            this.priceIdByLookupKey.clear();
         }
         return this.client;
     }

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -411,6 +411,48 @@ describe('SubscriptionService', () => {
             expect(planRepository.findByCode).not.toHaveBeenCalled();
         });
 
+        /**
+         * 🛑 REGRESSION — the defect a first attempt at this fix missed entirely.
+         *
+         * `resolvePlanForUser` is the single place that answers "what plan is this user on", and it
+         * reads the ACTIVE subscription BEFORE `user.defaultPlan`. So guarding only the writer was
+         * not enough: an active row pointing at a self-hosted plan still made a $99 one-off licence
+         * the buyer's effective HOSTED tier — the very arbitrage the fix was for.
+         *
+         * Guarding here covers every route: the webhook, the return path, any future writer, and
+         * any row that already exists in the database.
+         */
+        it('IGNORES an active self-hosted subscription — a licence is not a hosted tier', async () => {
+            const selfHosted = {
+                id: 'sub-licence',
+                plan: { ...PREMIUM_PLAN, code: 'selfhosted_pro', hosting: 'selfhosted' },
+            };
+            const { service } = makeService(
+                {},
+                { findActiveByUser: jest.fn().mockResolvedValue(selfHosted) },
+            );
+
+            const plan = await service.resolvePlanForUser({
+                id: 'u1',
+                defaultPlan: FREE_PLAN,
+            } as any);
+
+            // Falls through to what they actually pay for on this deployment.
+            expect(plan).toBe(FREE_PLAN);
+            expect((plan as any).code).not.toBe('selfhosted_pro');
+        });
+
+        it('still returns an active CLOUD subscription — the guard must not break the paying path', async () => {
+            const cloud = { id: 'sub-1', plan: { ...PREMIUM_PLAN, hosting: 'cloud' } };
+            const { service } = makeService(
+                {},
+                { findActiveByUser: jest.fn().mockResolvedValue(cloud) },
+            );
+
+            const plan = await service.resolvePlanForUser({ id: 'u1' } as any);
+            expect((plan as any).code).toBe(PREMIUM_PLAN.code);
+        });
+
         it('falls back to user.defaultPlan when there is no active subscription', async () => {
             const { service, userSubscriptionRepository, planRepository } = makeService(
                 {},
@@ -451,6 +493,42 @@ describe('SubscriptionService', () => {
             const plan = await service.resolvePlanForUser({ id: 'u1' } as any);
             expect(plan).toBe(STANDARD_PLAN);
             expect(planRepository.findByCode).toHaveBeenCalledWith(SubscriptionPlanCode.STANDARD);
+        });
+
+        /**
+         * 🛑 REGRESSION. `SUBSCRIPTIONS_DEFAULT_PLAN` is an operator-set env var and
+         * `normalizePlanCode` accepts ANY member of the enum — which now includes
+         * `selfhosted_community`, a row that is free AND effectively unlimited. One typo in a Helm
+         * value would hand every user with no subscription an unlimited plan, fleet-wide, with no
+         * purchase involved. Same class as the self-service escalation, reached through
+         * CONFIGURATION rather than a request.
+         */
+        it('REFUSES a self-hosted default plan and falls back to FREE', async () => {
+            process.env.SUBSCRIPTIONS_DEFAULT_PLAN = 'selfhosted_community';
+            const community = {
+                ...FREE_PLAN,
+                code: 'selfhosted_community',
+                displayName: 'Community Edition',
+                hosting: 'selfhosted',
+                maxWorks: 2_147_483_647,
+            };
+            const findByCode = jest
+                .fn()
+                .mockImplementation(async (code: string) =>
+                    code === 'selfhosted_community' ? community : FREE_PLAN,
+                );
+            const { service } = makeService(
+                { findByCode },
+                { findActiveByUser: jest.fn().mockResolvedValue(null) },
+            );
+
+            const plan = await service.resolvePlanForUser({ id: 'u1' } as any);
+
+            // The unlimited row must NOT become everyone's default.
+            expect((plan as any).code).toBe(FREE_PLAN.code);
+            expect((plan as any).maxWorks).toBe(1);
+            // It fell back rather than silently accepting the misconfiguration.
+            expect(findByCode).toHaveBeenCalledWith(SubscriptionPlanCode.FREE);
         });
 
         it('short-circuits to resolveDefaultPlan when the kill-switch is OFF (no DB lookup of active sub)', async () => {

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -234,7 +234,17 @@ export class SubscriptionService implements OnModuleInit {
         }
 
         const subscription = await this.getActiveSubscription(user.id);
-        if (subscription?.plan) {
+        // 🛑 Defence in depth: a SELF-HOSTED plan never decides the tier on THIS deployment.
+        //
+        // This is the single choke point where "what plan is this user on" is answered, and it
+        // reads the active subscription BEFORE `user.defaultPlan` — so guarding only the writer
+        // (`activate()`) is not enough on its own. Any row that already exists, or any future
+        // writer, is covered here. A self-hosted licence applies to the buyer's own deployment;
+        // on the hosted service they fall through to whatever they actually pay for.
+        if (
+            subscription?.plan &&
+            (subscription.plan as SubscriptionPlan).hosting !== 'selfhosted'
+        ) {
             return subscription.plan as SubscriptionPlan;
         }
 
@@ -442,7 +452,23 @@ export class SubscriptionService implements OnModuleInit {
         const defaultCode = this.normalizePlanCode(config.subscriptions.getDefaultPlanCode());
         const plan = await this.planRepository.findByCode(defaultCode);
 
-        if (plan) {
+        // 🛑 A self-hosted edition can never be the DEFAULT plan on a hosted deployment.
+        //
+        // `SUBSCRIPTIONS_DEFAULT_PLAN` is an operator-set env var and `normalizePlanCode` accepts
+        // any member of the enum — which now includes `selfhosted_community`, a row that is free
+        // AND effectively unlimited. One typo in a Helm value would therefore hand every user with
+        // no subscription an unlimited plan, silently and fleet-wide, with no purchase involved.
+        //
+        // This is the same class as the self-service escalation, reached through configuration
+        // rather than through a request, so it needs the same answer: hosting decides where a plan
+        // applies, and nothing else does.
+        if (plan && plan.hosting === 'selfhosted') {
+            this.logger.error(
+                `SUBSCRIPTIONS_DEFAULT_PLAN is set to '${defaultCode}', a SELF-HOSTED edition — ` +
+                    `refusing to use it as the default on a hosted deployment. Falling back to FREE. ` +
+                    `Fix the environment variable.`,
+            );
+        } else if (plan) {
             return plan;
         }
 


### PR DESCRIPTION
Completes the promotion of all eleven billing fixes to production.

`main` currently carries six of them. This adds the five that came out of adversarially reviewing those six — including the discovery that **three of the first-pass fixes were mechanically wrong**.

## The two that matter most

**#7 — the licence guard was on the wrong write.** `activate()` wrote the ACTIVE `user_subscriptions` row *before* the guard, and `resolvePlanForUser` reads that row **before** `user.defaultPlan`. So a $99 one-off licence still became the buyer's cloud tier; the arbitrage was never actually closed. Now guarded at the resolution choke point as well as the writer, which covers the webhook, the return route, any future writer, and any row already in the database.

**#8 — a licence purchase clobbered an active subscription.** `createOrUpdate` is one-active-row-per-user and UPDATEs in place, so a paying $199/mo Enterprise customer buying a $99 licence would have had their real row overwritten — plan, period end, provider subscription id. Data corruption on a money path. Nobody flagged it; it surfaced while verifying #7. `activate()` now writes no row at all for a self-hosted purchase; the licence is recorded on the Stripe payment intent, which is what manual fulfilment searches.

Plus: a cache MISS no longer memoised for the process lifetime (#9), the price cache dies with the key so a rotation can't hand TEST ids to a LIVE client (#10), and `SUBSCRIPTIONS_DEFAULT_PLAN` refuses a self-hosted code (#11) — one Helm typo would otherwise have handed every user with no subscription an unlimited plan.

## Verification

**527/527 suites, 9,428 tests, 0 failed.** `tsc --noEmit` 0 errors. Prettier clean. Verified on `origin/develop` by content, with an **absence** control confirming a superseded guard is gone — not just that the wanted code is present.

Migration `1786940000000` was exercised against a throwaway Postgres 16 in the full production boot order (prod's real 11-column schema → migration → seed), producing `UPDATE 1`×3 and `INSERT 0 3` with every value matching the approved price table.

## Safety posture

`SUBSCRIPTIONS_ENABLED=false` and `STRIPE_SECRET_KEY` is empty in all three namespaces, so none of these paths is reachable yet — but every one of them had to be right *before* billing is switched on, which is the point of the work. Prod has zero subscriptions and zero billing profiles, so the plan reseed affects nobody.

Findings deliberately **not** fixed are in `_LOCAL/EVER_WORKS_BILLING_AUDIT_FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)