### PR TITLE
fix(agent): emit .json assets into dist so runtime imports resolve

### DIFF
--- a/packages/agent/nest-cli.json
+++ b/packages/agent/nest-cli.json
@@ -5,6 +5,12 @@
     "compilerOptions": {
         "builder": "swc",
         "deleteOutDir": false,
-        "typeCheck": true
+        "typeCheck": true,
+        "assets": [
+            {
+                "include": "**/*.json",
+                "outDir": "dist"
+            }
+        ]
     }
 }


### PR DESCRIPTION
## develop is currently red for every branch

`lint-and-test` fails in `apps/internal-cli`:

```
FAIL src/commands/serve/__tests__/serve.command.spec.ts
Error: Cannot find module './stripe-catalog.data.json'
```

It is currently failing #2165 and #2169, and will fail any PR cut from develop.

## Cause

`packages/agent/src/subscriptions/billing/stripe-catalog.ts` does `import catalogJson from './stripe-catalog.data.json'`. The agent package builds with `nest build -b swc` and **no `assets` configuration**, so swc emits `.js` / `.d.ts` and silently drops every `.json`. The compiled `dist/subscriptions/billing/stripe-catalog.js` then requires a file that isn't there.

`find packages/agent/dist -name '*.json'` returned **nothing at all**.

`works-config/schema/works.v2.schema.json` had the same latent gap — it simply had no runtime `import` yet, so nothing had failed on it. Both emit now.

## Why this is confusing to diagnose

The source tree looks perfectly healthy. The JSON **is** committed, **is** in git history, and **is** on disk — only `dist/` is missing it. Any check that greps the source concludes the file is fine.

I initially got this wrong myself and blamed the file for being uncommitted; it wasn't. If you're chasing this class of error, look in `dist/`, not `src/`.

## Verified by control, not assertion

- with the asset emitted → `serve.command.spec.ts` passes **8/8**
- remove **only** that emitted file from `dist` → the same suite fails with the **exact CI error**
- restore it → passes again

## Scope

One file, `packages/agent/nest-cli.json`. No billing source touched — `packages/agent/src/subscriptions/**` is another agent's active area and this deliberately stays out of it. Purely the package build config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)