### PR TITLE
fix(agent): ship *.data.json assets in dist (stripe-catalog.data.json unresolvable from dist)

### DIFF
--- a/packages/agent/nest-cli.json
+++ b/packages/agent/nest-cli.json
@@ -5,6 +5,12 @@
     "compilerOptions": {
         "builder": "swc",
         "deleteOutDir": false,
-        "typeCheck": true
+        "typeCheck": true,
+        "assets": [
+            {
+                "include": "**/*.data.json",
+                "watchAssets": true
+            }
+        ]
     }
 }


### PR DESCRIPTION
## Problem

[#2160](https://github.com/ever-works/ever-works/pull/2160) added `packages/agent/src/subscriptions/billing/stripe-catalog.ts` with `import catalogJson from './stripe-catalog.data.json'` (`resolveJsonModule`). The swc build emits `stripe-catalog.js` with a relative `require('./stripe-catalog.data.json')`, but the Nest CLI only copies files listed under `compilerOptions.assets` — `packages/agent/dist` never contained the JSON.

Consequence for every consumer of the agent **from dist**:
- The self-hosted Trigger.dev worker deploy fails at bundle time — [run 32594603972](https://github.com/ever-works/ever-works/actions/runs/32594603972) (first worker deploy after #2160): `../agent/dist/subscriptions/billing/stripe-catalog.js:70:78: ERROR: Could not resolve "./stripe-catalog.data.json"`. No worker deployment after `v20260822.1` exists on trigger.ever.co, so generation (`POST /api/works/:id/generate`) keeps failing.
- Any runtime `require` from dist would `MODULE_NOT_FOUND` at bootstrap: `stripe-catalog` is reached from `entities/subscription-plan.entity.ts`, `subscriptions/subscription.service.ts` and `plan-subscription.service.ts`.

## Fix

Declare `**/*.data.json` as Nest build assets in `packages/agent/nest-cli.json` (the swc builder honours `assets`; `watchAssets` keeps `build:dev` in sync). Verified locally on the swc build: a probe `src/subscriptions/billing/*.data.json` lands in `dist/subscriptions/billing/`.

## Follow-up (after merge)

Re-dispatch `release-trigger-selfhosted.yml --ref develop -f environment=prod` so the worker (with the #2166 plugin build) finally ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)