### PR TITLE
chore(release): promote develop to stage (agent dist JSON assets fix #2187)

### DIFF
--- a/packages/agent/nest-cli.json
+++ b/packages/agent/nest-cli.json
@@ -5,6 +5,12 @@
     "compilerOptions": {
         "builder": "swc",
         "deleteOutDir": false,
-        "typeCheck": true
+        "typeCheck": true,
+        "assets": [
+            {
+                "include": "**/*.data.json",
+                "watchAssets": true
+            }
+        ]
     }
 }


### PR DESCRIPTION
Carries [#2187](https://github.com/ever-works/ever-works/pull/2187) — ship `*.data.json` assets in `packages/agent/dist` so `stripe-catalog.data.json` (added by #2160) resolves from dist. Without it every dist consumer breaks: the self-hosted Trigger worker deploy fails at bundle time and the prod API image would `MODULE_NOT_FOUND` at bootstrap. Prod API currently still runs the pre-#2160 build; the main image builds for 63bc2ca3 were cancelled on purpose — this promotion rebuilds them with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)