### PR TITLE
chore(release): promote develop to stage

### DIFF
--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -187,6 +187,9 @@ describe('startPlanCheckout — the server prices everything', () => {
             sessionId: 'cs_plan_1',
             planCode: 'standard',
             priceCents: 2500,
+            basePriceCents: 2500,
+            seatCents: 0,
+            extraSeats: 0,
             currency: 'usd',
         });
         const request = provider.createPlanCheckoutSession.mock.calls[0][0];
@@ -222,6 +225,56 @@ describe('startPlanCheckout — the server prices everything', () => {
         const request = provider.createPlanCheckoutSession.mock.calls[0][0];
         expect(request.plan.extraSeats).toBe(0);
         expect(request.plan.seatLookupKey).toBeNull();
+    });
+
+    // 🛑 The echoed total used to be the BASE plan amount while the seats were billed as a
+    // separate Stripe line item, so 27 seats on Pro was reported as 2500 and charged 11000.
+    // Stripe's hosted page always showed the truth, so nobody was mischarged — but any in-app
+    // confirmation built on this number understated the price. These assert the OUTCOME (the
+    // amount echoed equals the amount billed), not the mechanism that produces it.
+    it('echoes the TOTAL the buyer will pay, seats included', async () => {
+        const { service, provider } = build();
+
+        const started = await service.startPlanCheckout({ ...checkoutOptions, seats: 27 });
+
+        // 27 requested − 10 included = 17 billable, at $5.00/mo = 8500 on top of the 2500 base.
+        expect(started.basePriceCents).toBe(2500);
+        expect(started.extraSeats).toBe(17);
+        expect(started.seatCents).toBe(8500);
+        expect(started.priceCents).toBe(11000);
+
+        // The echoed total must equal what the provider was actually asked to bill.
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(started.priceCents).toBe(request.plan.priceCents + started.seatCents);
+        expect(request.plan.extraSeats).toBe(started.extraSeats);
+    });
+
+    it('uses the ANNUAL seat rate when the buyer is billed annually', async () => {
+        const { service } = build();
+
+        const started = await service.startPlanCheckout({
+            ...checkoutOptions,
+            interval: 'annual',
+            seats: 27,
+        });
+
+        // An annual seat is 12x the monthly rate with no discount: 17 x 6000 = 102000,
+        // on top of the 20400 annual base.
+        expect(started.basePriceCents).toBe(20400);
+        expect(started.seatCents).toBe(102000);
+        expect(started.priceCents).toBe(122400);
+    });
+
+    it('never adds a seat charge to a total that carries no seat line', async () => {
+        const { service, provider } = build();
+
+        // Inside the allowance: no seat line item, so no seat money either.
+        const started = await service.startPlanCheckout({ ...checkoutOptions, seats: 10 });
+
+        const request = provider.createPlanCheckoutSession.mock.calls[0][0];
+        expect(request.plan.seatLookupKey).toBeNull();
+        expect(started.seatCents).toBe(0);
+        expect(started.priceCents).toBe(started.basePriceCents);
     });
 
     it('bills only the seats beyond the allowance, on the matching seat price', async () => {

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -15,7 +15,12 @@ import {
     BillingProviderNotConfiguredError,
     type BillingWebhookEvent,
 } from './billing.provider';
-import { billableSeats, resolveSkuForPlanRow, type CatalogInterval } from './stripe-catalog';
+import {
+    billableSeats,
+    resolveSkuForPlanRow,
+    seatAmountCents,
+    type CatalogInterval,
+} from './stripe-catalog';
 
 /** A checkout was asked for with a plan code that is not sellable. */
 export class UnknownSubscriptionPlanError extends Error {
@@ -78,8 +83,24 @@ export interface PlanCheckoutStarted {
     url: string;
     sessionId: string;
     planCode: string;
-    /** Echoed for the UI's confirmation copy — from the SERVER plan row. */
+    /**
+     * What the buyer will ACTUALLY be charged for the first period: the plan price PLUS every
+     * additional seat. Echoed for the UI's confirmation copy.
+     *
+     * 🛑 This used to carry the base plan amount only, while the seats were added as a separate
+     * Stripe line item — so someone buying Pro with 17 seats was shown 2500 and charged 11000.
+     * Stripe's own hosted page always showed the true total, so nobody was ever mischarged, but
+     * any in-app confirmation built on this field understated the price. It is now the total, and
+     * it is derived from the SAME seat computation that builds the billed line item, so the two
+     * cannot drift apart.
+     */
     priceCents: number;
+    /** The plan price alone, without seats. */
+    basePriceCents: number;
+    /** The additional-seat portion of {@link priceCents}. Zero when no seats were added. */
+    seatCents: number;
+    /** Additional seats being billed, after the plan's own included allowance. */
+    extraSeats: number;
     currency: string;
 }
 
@@ -168,8 +189,18 @@ export class PlanSubscriptionService {
         // what the provider bills; the row is the fallback for an unsynced deployment. Reading the
         // row first would echo 0 for any period the row has no column value for — showing someone
         // "$0" on a confirmation screen for a charge that is about to be 204.00.
-        const priceCents =
+        const basePriceCents =
             catalogSku?.price.amountCents ?? planPriceCentsForInterval(plan, interval);
+
+        // Seats are a SEPARATE Stripe line item, so the base amount alone is not what the buyer
+        // pays. Compute them once here and reuse the same numbers for both the provider payload
+        // and the echoed total.
+        const { seatTotalCents, ...catalogKeys } = this.catalogKeysFor(
+            plan,
+            interval,
+            options.seats ?? null,
+        );
+        const priceCents = basePriceCents + seatTotalCents;
 
         const user = await this.userRepository.findById(options.userId);
         const existing = await this.billingProfileRepository.findByUserId(options.userId);
@@ -195,7 +226,11 @@ export class PlanSubscriptionService {
             plan: {
                 code: plan.code,
                 label: `${plan.displayName} plan`,
-                priceCents,
+                // 🛑 The BASE amount, never the seat-inclusive total. This becomes the
+                // `unit_amount` of the PLAN line item on deployments with no catalog price, and the
+                // seats are a SEPARATE line item — so sending the total here would bill every extra
+                // seat twice. Only the value this method RETURNS carries the total.
+                priceCents: basePriceCents,
                 currency: plan.currency || this.billingProvider.getDefaultCurrency(),
                 interval: interval === 'annual' ? 'year' : 'month',
                 // A `lifetime` SKU is bought outright. Decided from the catalog SKU, never from
@@ -205,7 +240,7 @@ export class PlanSubscriptionService {
                 // so the invoice line carries a lookup_key that maps back to a reviewed commit.
                 // `null` here is normal on a deployment whose catalog has not been synced — the
                 // provider falls back to billing `priceCents` exactly as it did before.
-                ...this.catalogKeysFor(plan, interval, options.seats ?? null),
+                ...catalogKeys,
             },
             successUrl: options.successUrl,
             cancelUrl: options.cancelUrl,
@@ -217,6 +252,9 @@ export class PlanSubscriptionService {
             sessionId: session.sessionId,
             planCode: plan.code,
             priceCents,
+            basePriceCents,
+            seatCents: seatTotalCents,
+            extraSeats: catalogKeys.extraSeats ?? 0,
             currency: plan.currency,
         };
     }
@@ -236,16 +274,31 @@ export class PlanSubscriptionService {
         plan: SubscriptionPlan,
         interval: CatalogInterval,
         requestedSeats: number | null,
-    ): { lookupKey?: string; seatLookupKey?: string | null; extraSeats?: number } {
+    ): {
+        lookupKey?: string;
+        seatLookupKey?: string | null;
+        extraSeats?: number;
+        /** The seat money, for the caller to add to the amount it echoes back. */
+        seatTotalCents: number;
+    } {
         const sku = resolveSkuForPlanRow({ code: plan.code, hosting: plan.hosting, interval });
-        if (!sku) return {};
+        if (!sku) return { seatTotalCents: 0 };
 
         const extraSeats = requestedSeats === null ? 0 : billableSeats(sku.plan, requestedSeats);
+        const billsSeats = extraSeats > 0 && sku.seatLookupKey !== null;
+
+        // Mirror resolveCatalogSku exactly: a lifetime licence and an unbounded plan both
+        // collapse to no seat line, and an annual seat is 12x the monthly rate.
+        const seatUnitCents = billsSeats
+            ? (seatAmountCents(sku.plan, sku.price.interval === 'annual' ? 'annual' : 'monthly') ??
+              0)
+            : 0;
 
         return {
             lookupKey: sku.lookupKey,
-            seatLookupKey: extraSeats > 0 ? sku.seatLookupKey : null,
+            seatLookupKey: billsSeats ? sku.seatLookupKey : null,
             extraSeats,
+            seatTotalCents: extraSeats * seatUnitCents,
         };
     }
 


### PR DESCRIPTION
Cascade. Carries the seat-inclusive checkout total (#2190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)