### PR TITLE
fix(pipeline): materialise lazy plugin stubs before routing/executing (generation broken on the Trigger worker)

### DIFF
--- a/packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts
+++ b/packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts
@@ -1,5 +1,6 @@
 import { PipelineOrchestratorService } from './pipeline-orchestrator.service';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { createLazyPluginProxy } from '../plugins/services/lazy-plugin-proxy';
 
 describe('PipelineOrchestratorService', () => {
     let stepExecutor: any;
@@ -150,6 +151,93 @@ describe('PipelineOrchestratorService', () => {
                 undefined,
             );
             expect(stepExecutor.execute).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('lazy plugin stubs (PLUGIN_LAZY_LOAD default)', () => {
+        const work = { id: 'w1', user: { id: 'u1' } } as any;
+        const existing = { items: [] } as any;
+
+        /** A real lazy proxy (what the registry holds before first use) around `real`. */
+        function makeLazyStub(id: string, real: any, loader = jest.fn(async () => real)) {
+            const manifest: any = {
+                id,
+                name: id,
+                version: '1.0.0',
+                category: 'pipeline',
+                capabilities: ['pipeline'],
+            };
+            return { stub: createLazyPluginProxy(manifest, loader), loader };
+        }
+
+        it('materialises the stub before routing so a self-managed pipeline is NOT misrouted to step mode', async () => {
+            // Before the fix the stub answered `executeStep`/`registerStepExecutor` with
+            // forwarding functions, `isStepOrchestratablePipeline()` said "step", and the
+            // step executor then died on `plugin.createContext()` (agent-pipeline: "has no
+            // method createContext"; standard-pipeline: createContext() returned a Promise so
+            // `context.work` was undefined). That was every generation run on the Trigger worker.
+            const real = makePlugin('agent-pipeline', { stepOrchestratable: false });
+            const { stub, loader } = makeLazyStub('agent-pipeline', real);
+            registry.get.mockImplementation((id: string) =>
+                id === 'agent-pipeline' ? makeRegistered(stub) : null,
+            );
+
+            await service.execute(
+                work,
+                { providers: { pipeline: 'agent-pipeline' } } as any,
+                existing,
+            );
+
+            expect(loader).toHaveBeenCalledTimes(1);
+            expect(fullExecutor.execute).toHaveBeenCalledWith(
+                real,
+                work,
+                expect.any(Object),
+                existing,
+                undefined,
+                undefined,
+            );
+            expect(stepExecutor.execute).not.toHaveBeenCalled();
+        });
+
+        it('hands the REAL step-orchestratable plugin (not the stub) to the step executor', async () => {
+            const real = makePlugin('standard', { stepOrchestratable: true });
+            const { stub } = makeLazyStub('standard', real);
+            registry.getByCapability.mockReturnValue([
+                makeRegistered(stub, { defaultForCapabilities: ['pipeline'] }),
+            ]);
+
+            await service.execute(work, { providers: { pipeline: undefined } } as any, existing);
+
+            expect(stepExecutor.execute).toHaveBeenCalledWith(
+                real,
+                work,
+                expect.any(Object),
+                existing,
+                undefined,
+                undefined,
+            );
+        });
+
+        it('getRecommendedMode / hasFullPipelinePlugin probe the materialised plugin surface', async () => {
+            const real = makePlugin('claude-code', { stepOrchestratable: false });
+            const { stub } = makeLazyStub('claude-code', real);
+            registry.getByCapability.mockReturnValue([makeRegistered(stub)]);
+
+            await expect(service.hasFullPipelinePlugin()).resolves.toBe(true);
+            await expect(service.getRecommendedMode()).resolves.toMatchObject({
+                mode: 'full',
+                plugin: 'claude-code',
+            });
+        });
+
+        it('passes real (already materialised / eager) plugins through untouched', async () => {
+            const plugin = makePlugin('standard', { stepOrchestratable: true });
+            registry.getByCapability.mockReturnValue([
+                makeRegistered(plugin, { defaultForCapabilities: ['pipeline'] }),
+            ]);
+            await service.execute(work, { providers: { pipeline: undefined } } as any, existing);
+            expect(stepExecutor.execute.mock.calls[0][0]).toBe(plugin);
         });
     });
 

--- a/packages/agent/src/pipeline/pipeline-orchestrator.service.ts
+++ b/packages/agent/src/pipeline/pipeline-orchestrator.service.ts
@@ -76,7 +76,7 @@ export class PipelineOrchestratorService {
 
         if (mode === 'full') {
             // Find a self-managed (non-step-orchestratable) pipeline plugin
-            const fullPlugin = this.getAvailablePipelinePlugins().find(
+            const fullPlugin = (await this.getMaterializedPipelinePlugins()).find(
                 (p) => !isStepOrchestratablePipeline(p),
             );
             if (fullPlugin) {
@@ -108,7 +108,7 @@ export class PipelineOrchestratorService {
         plugin?: string;
     }> {
         // Check if any self-managed (non-step-orchestratable) pipeline is available
-        const fullPlugin = this.getAvailablePipelinePlugins().find(
+        const fullPlugin = (await this.getMaterializedPipelinePlugins()).find(
             (p) => !isStepOrchestratablePipeline(p),
         );
         if (fullPlugin) {
@@ -126,7 +126,37 @@ export class PipelineOrchestratorService {
     }
 
     async hasFullPipelinePlugin(): Promise<boolean> {
-        return this.getAvailablePipelinePlugins().some((p) => !isStepOrchestratablePipeline(p));
+        return (await this.getMaterializedPipelinePlugins()).some(
+            (p) => !isStepOrchestratablePipeline(p),
+        );
+    }
+
+    /**
+     * Same as {@link getAvailablePipelinePlugins} but with every lazy stub
+     * materialised, so capability probes (`isStepOrchestratablePipeline`) see
+     * the real plugin surface.
+     */
+    private async getMaterializedPipelinePlugins(): Promise<IPipelinePlugin[]> {
+        return Promise.all(this.getAvailablePipelinePlugins().map((p) => this.materialize(p)));
+    }
+
+    /**
+     * Lazy-mode registries (`PLUGIN_LAZY_LOAD`, the default) hand out proxies
+     * that answer EVERY property with an async forwarding function until the
+     * real module has been imported. On such a stub capability probes like
+     * `isStepOrchestratablePipeline()` are meaningless (every method "exists")
+     * and the pipeline contract's synchronous calls — `createContext()`,
+     * `getStepDefinitions()`, `getState()` — come back as Promises. The
+     * orchestrator always *executes* the pipeline it resolves (never just
+     * inspects it), so materialising here costs nothing extra and restores the
+     * real plugin surface for routing + execution. No-op for eager/real plugins.
+     */
+    private async materialize(plugin: IPipelinePlugin): Promise<IPipelinePlugin> {
+        const stub = plugin as unknown as { __materialize?: () => Promise<unknown> };
+        if (typeof stub.__materialize === 'function') {
+            return (await stub.__materialize()) as IPipelinePlugin;
+        }
+        return plugin;
     }
 
     getAvailablePipelinePlugins(): IPipelinePlugin[] {
@@ -218,7 +248,7 @@ export class PipelineOrchestratorService {
                     userId,
                 );
                 if (isEnabled) {
-                    return registered.plugin;
+                    return this.materialize(registered.plugin);
                 }
             }
             this.logger.warn(
@@ -240,7 +270,7 @@ export class PipelineOrchestratorService {
                 workId,
                 userId,
             );
-            if (isEnabled) return registered.plugin;
+            if (isEnabled) return this.materialize(registered.plugin);
         }
 
         // Fallback: first loaded and enabled pipeline
@@ -252,7 +282,7 @@ export class PipelineOrchestratorService {
                 workId,
                 userId,
             );
-            if (isEnabled) return registered.plugin;
+            if (isEnabled) return this.materialize(registered.plugin);
         }
 
         throw new Error(

--- a/packages/agent/src/pipeline/step-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/step-pipeline-executor.service.ts
@@ -199,7 +199,11 @@ export class StepPipelineExecutorService {
                 `Pipeline plugin "${plugin.id}" must implement createContext() for engine-orchestrated execution.`,
             );
         }
-        const context = plugin.createContext(work, request, existing);
+        // `await` is deliberate: a lazy plugin stub (PLUGIN_LAZY_LOAD) answers
+        // every call with a Promise; the orchestrator materialises before
+        // routing, but a caller wiring the executor directly must not end up
+        // with `context.work === undefined` (TypeError at the first `work.id`).
+        const context = await plugin.createContext(work, request, existing);
 
         // Attach log interceptor to capture ALL plugin logger output
         const onLogEntry = options?.onLogEntry;


### PR DESCRIPTION
## Problem

With `PLUGIN_LAZY_LOAD` (the default) `PluginRegistryService` hands out **lazy proxies** that answer *every* property with an async forwarding function until the real module is imported (`lazy-plugin-proxy.ts`). Two pipeline code paths are not lazy-safe:

- `PipelineOrchestratorService` probes the stub with `isStepOrchestratablePipeline()` (`typeof plugin.executeStep === 'function' && …`) → always **true** → every pipeline, including self-managed ones like `agent-pipeline`, is routed to the step executor.
- `StepPipelineExecutorService.execute()` calls the synchronous `plugin.createContext()` → on a stub it returns a **Promise** → `context.work` is undefined → `TypeError … reading 'id'`.

On the self-hosted Trigger worker this broke **every** generation run the moment the worker finally shipped its plugins (#2166 / #2187):
- `agent-pipeline`: `TypeError: Plugin "agent-pipeline" has no method "createContext"` (run `run_cmt5gdp574nli2y0j6yttxkb6`)
- `standard-pipeline`: `TypeError: Cannot read properties of undefined (reading 'id') at StepPipelineExecutorService.executePipeline (step-pipeline-executor.service.ts:253)` (run `run_cmt5h1e534x182x0h8997k1zu`)

(The API never hit it only because generation is dispatched to the worker.) As an immediate mitigation the worker's prod env now has `PLUGIN_LAZY_LOAD=false` (eager mode kill switch).

## Fix

- `PipelineOrchestratorService.resolvePipelinePlugin()` materialises lazy stubs (`__materialize()`) before returning — the orchestrator always *executes* what it resolves, so this costs nothing; no-op for eager/real plugins. `executeWithMode` / `getRecommendedMode` / `hasFullPipelinePlugin` probe a materialised list too.
- `StepPipelineExecutorService.execute()` awaits `createContext()` defensively.
- Regression tests in `pipeline-orchestrator.service.spec.ts` use the real `createLazyPluginProxy` (62/62 pipeline orchestrator tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)