### PR TITLE
fix(trigger-worker): register PluginSecretEncService so plugin secrets decrypt on the worker (generation sent enc::v1:: envelopes as API keys)

### DIFF
--- a/packages/agent/src/plugins/services/index.ts
+++ b/packages/agent/src/plugins/services/index.ts
@@ -5,6 +5,7 @@ export * from './plugin-manifest-validator.service';
 export * from './plugin-version-checker.service';
 export * from './plugin-class-validator.service';
 export * from './plugin-lifecycle-manager.service';
+export * from './plugin-secret-enc.service';
 export * from './plugin-settings.service';
 export * from './plugin-context-factory.service';
 export * from './custom-capability-registry.service';

--- a/packages/tasks/src/trigger/worker/modules/trigger-plugins.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-plugins.module.ts
@@ -13,6 +13,7 @@ import {
     PluginVersionCheckerService,
     PluginClassValidatorService,
     PluginLifecycleManagerService,
+    PluginSecretEncService,
     PluginSettingsService,
     PluginContextFactoryService,
     CustomCapabilityRegistryService,
@@ -79,6 +80,15 @@ export class TriggerPluginsModule {
                 PluginRegistryService,
                 PluginLoaderService,
                 PluginLifecycleManagerService,
+                // C-08: plugin secrets (API keys & co.) are stored AES-GCM-encrypted
+                // (`enc::v1::…`). PluginSettingsService takes this service as an OPTIONAL
+                // dependency and passes envelopes through untouched when it is missing —
+                // which is exactly what happened here: the worker sent
+                // `Authorization: Bearer enc::v1::…` to OpenRouter ("Missing Authentication
+                // header") and every generation failed. Must be registered BEFORE
+                // PluginSettingsService; needs PLUGIN_SECRET_ENCRYPTION_KEY in the worker env
+                // (same key as the API).
+                PluginSecretEncService,
                 PluginSettingsService,
                 PluginContextFactoryService,
                 CustomCapabilityRegistryService,
@@ -92,6 +102,7 @@ export class TriggerPluginsModule {
                 PluginRegistryService,
                 PluginLoaderService,
                 PluginLifecycleManagerService,
+                PluginSecretEncService,
                 PluginSettingsService,
                 PluginContextFactoryService,
                 CustomCapabilityRegistryService,


### PR DESCRIPTION
## Problem

`TriggerPluginsModule` (packages/tasks) provides `PluginSettingsService` but **not** `PluginSecretEncService` — it was not even exported from `@ever-works/agent/plugins`. `PluginSettingsService` takes the enc service as an *optional* dependency and, when it is absent, passes DB secret envelopes (`enc::v1::…`) through untouched (`decryptSecrets()`). So on the worker every provider secret (OpenRouter key, Tavily key, …) resolved to the **ciphertext envelope**.

OpenRouter answers a malformed bearer token with `{"error":{"message":"Missing Authentication header","code":401}}` (verified: `Authorization: Bearer enc::v1::…` → that message; a plain wrong key → `User not found`). That is exactly what every generation run on trigger.ever.co died with once the worker could load plugins at all (after #2166 / #2187 and with `PLUGIN_LAZY_LOAD=false` / #2194): runs `run_cmt5h5nv64x252x0hscv495rr`, `run_cmt5hi5yv6de52x1owq8f4761`, `run_cmt5hnms06dfs2x1oo6iasuhf` — `AI_APICallError: Missing Authentication header` from `ai.streamText`, with both the org user's key and a freshly stored work-scope key.

## Fix

- export `PluginSecretEncService` from the agent plugins barrel
- register it in `TriggerPluginsModule` **before** `PluginSettingsService` and export it

The worker env already carries `PLUGIN_SECRET_ENCRYPTION_KEY` (must equal the API's key; a mismatch now fails loudly with `auth tag mismatch` instead of silently sending ciphertext).

🤖 Generated with [Claude Code](https://claude.com/claude-code)