### PR TITLE
chore(release): promote stage to main (per-Work runtime env + 503 provisioning, pipeline lazy-stub fix, worker secret decryption)

### DIFF
--- a/apps/api/src/migrations/1787423600000-AddWorkDeployRuntimeEnvVars.ts
+++ b/apps/api/src/migrations/1787423600000-AddWorkDeployRuntimeEnvVars.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds `works.deployRuntimeEnvEncrypted` — an AES-256-GCM-encrypted JSON map
+ * of the operator-managed, allow-listed per-Work runtime env (today: the
+ * Stripe payment keys the directory template reads, see
+ * `WORK_RUNTIME_ENV_ALLOWED_KEYS` in
+ * `packages/agent/src/services/work-runtime-env.constants.ts`).
+ *
+ * `DeployService` merges the map into the `${slug}-runtime-env` k8s Secret on
+ * server-side deploys and pushes each key as a GitHub Actions repo secret on
+ * workflow deploys. Encrypted at rest with `PLATFORM_ENCRYPTION_KEY`, exactly
+ * like the sibling `deployDatabaseUrlEncrypted` column.
+ *
+ * Nullable, no backfill (NULL = nothing configured). Forward-only and
+ * idempotent (`hasColumn` guard) — mirrors `AddWorkDeployRuntimeEnv` /
+ * `AddWorkDeployDatabaseMode`.
+ */
+export class AddWorkDeployRuntimeEnvVars1787423600000 implements MigrationInterface {
+    name = 'AddWorkDeployRuntimeEnvVars1787423600000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasColumn('works', 'deployRuntimeEnvEncrypted'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'deployRuntimeEnvEncrypted',
+                    type: 'text',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasColumn('works', 'deployRuntimeEnvEncrypted')) {
+            await queryRunner.dropColumn('works', 'deployRuntimeEnvEncrypted');
+        }
+    }
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -85,7 +85,20 @@ describe('DeployController', () => {
         setDatabaseUrl: jest.Mock;
         getDatabaseMode: jest.Mock;
         setDatabaseMode: jest.Mock;
+        getAllowedEnvKeys: jest.Mock;
+        describeRuntimeEnvVars: jest.Mock;
+        setRuntimeEnvVars: jest.Mock;
     };
+    // Mirrors WORK_RUNTIME_ENV_ALLOWED_KEYS shape (the real constant lives in
+    // @ever-works/agent/services, which this spec mocks wholesale).
+    const ALLOWED_ENV_KEYS = ['NEXT_PUBLIC_PAYMENT_PROVIDER', 'STRIPE_SECRET_KEY'];
+    const describeEnv = (set: Record<string, string> = {}) =>
+        ALLOWED_ENV_KEYS.map((key) => ({
+            key,
+            set: key in set,
+            masked: key in set ? set[key] : null,
+            secret: key === 'STRIPE_SECRET_KEY',
+        }));
     let managedSubdomainService: { getState: jest.Mock; update: jest.Mock };
     let dbProvisionService: {
         isReady: jest.Mock;
@@ -147,6 +160,9 @@ describe('DeployController', () => {
             setDatabaseUrl: jest.fn().mockResolvedValue(undefined),
             getDatabaseMode: jest.fn().mockResolvedValue(null),
             setDatabaseMode: jest.fn().mockResolvedValue(undefined),
+            getAllowedEnvKeys: jest.fn().mockReturnValue(ALLOWED_ENV_KEYS),
+            describeRuntimeEnvVars: jest.fn().mockResolvedValue(describeEnv()),
+            setRuntimeEnvVars: jest.fn().mockResolvedValue({}),
         };
 
         managedSubdomainService = {
@@ -276,6 +292,127 @@ describe('DeployController', () => {
             expect(res.status).toBe('success');
             expect(res.databaseUrl.configured).toBe(true);
             expect(res.databaseUrl.masked).not.toContain(':p@'); // password masked
+            // The DB-only body must not touch the per-Work env map.
+            expect(workRuntimeEnvService.setRuntimeEnvVars).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('runtime-env (allow-listed per-Work env vars)', () => {
+        beforeEach(() => {
+            ownershipService.ensureCanEdit.mockResolvedValue({
+                work: buildWork(),
+                isCreator: true,
+            });
+        });
+
+        it('getRuntimeEnv returns allowedEnvKeys plus one masked entry per key', async () => {
+            workRuntimeEnvService.describeRuntimeEnvVars.mockResolvedValue(
+                describeEnv({ STRIPE_SECRET_KEY: '***', NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe' }),
+            );
+
+            const res: any = await controller.getRuntimeEnv(
+                { userId: 'user-1' } as never,
+                'work-1',
+            );
+
+            expect(res.allowedEnvKeys).toEqual(ALLOWED_ENV_KEYS);
+            expect(res.env).toEqual([
+                {
+                    key: 'NEXT_PUBLIC_PAYMENT_PROVIDER',
+                    set: true,
+                    masked: 'stripe',
+                    secret: false,
+                },
+                { key: 'STRIPE_SECRET_KEY', set: true, masked: '***', secret: true },
+            ]);
+            // Never a plaintext secret in the read shape.
+            expect(JSON.stringify(res)).not.toContain('sk_live');
+        });
+
+        it('setRuntimeEnv with ONLY env applies the patch and leaves DB config untouched', async () => {
+            workRuntimeEnvService.describeRuntimeEnvVars.mockResolvedValue(
+                describeEnv({ STRIPE_SECRET_KEY: '***' }),
+            );
+
+            const res: any = await controller.setRuntimeEnv(
+                { userId: 'user-1' } as never,
+                'work-1',
+                { env: { STRIPE_SECRET_KEY: 'sk_live_abc' } },
+            );
+
+            expect(workRuntimeEnvService.setRuntimeEnvVars).toHaveBeenCalledWith('work-1', {
+                STRIPE_SECRET_KEY: 'sk_live_abc',
+            });
+            // DB section untouched.
+            expect(workRuntimeEnvService.setDatabaseUrl).not.toHaveBeenCalled();
+            expect(workRuntimeEnvService.setDatabaseMode).not.toHaveBeenCalled();
+            expect(dbProvisionService.ensureDatabaseForWork).not.toHaveBeenCalled();
+            expect(deployFacade.setWorkDbOverride).not.toHaveBeenCalled();
+
+            expect(res.status).toBe('success');
+            expect(res.env).toEqual(describeEnv({ STRIPE_SECRET_KEY: '***' }));
+            expect(res.allowedEnvKeys).toEqual(ALLOWED_ENV_KEYS);
+            expect(res.message).toMatch(/Environment variables updated/);
+            expect(JSON.stringify(res)).not.toContain('sk_live_abc');
+            // Activity log carries key NAMES only, never the value.
+            const summary = activityLogService.log.mock.calls[0][0].summary as string;
+            expect(summary).toContain('STRIPE_SECRET_KEY');
+            expect(summary).not.toContain('sk_live_abc');
+        });
+
+        it('setRuntimeEnv forwards null to remove a key', async () => {
+            await controller.setRuntimeEnv({ userId: 'user-1' } as never, 'work-1', {
+                env: { STRIPE_SECRET_KEY: null },
+            });
+            expect(workRuntimeEnvService.setRuntimeEnvVars).toHaveBeenCalledWith('work-1', {
+                STRIPE_SECRET_KEY: null,
+            });
+        });
+
+        it('setRuntimeEnv applies BOTH sections when databaseUrl and env are sent together', async () => {
+            workRuntimeEnvService.getDatabaseUrl.mockResolvedValue(
+                'postgresql://u:p@host.example.com/db',
+            );
+
+            const res: any = await controller.setRuntimeEnv(
+                { userId: 'user-1' } as never,
+                'work-1',
+                {
+                    databaseUrl: 'postgresql://u:p@host.example.com/db',
+                    env: { NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe' },
+                },
+            );
+
+            expect(workRuntimeEnvService.setDatabaseUrl).toHaveBeenCalledWith(
+                'work-1',
+                'postgresql://u:p@host.example.com/db',
+            );
+            expect(workRuntimeEnvService.setDatabaseMode).toHaveBeenCalledWith('work-1', 'custom');
+            expect(workRuntimeEnvService.setRuntimeEnvVars).toHaveBeenCalledWith('work-1', {
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            });
+            expect(res.message).toMatch(/Runtime env updated/);
+        });
+
+        it('setRuntimeEnv propagates the service 400 for a non-allow-listed key', async () => {
+            workRuntimeEnvService.setRuntimeEnvVars.mockRejectedValue(
+                new BadRequestException('Unsupported runtime env key(s): DATABASE_URL'),
+            );
+
+            await expect(
+                controller.setRuntimeEnv({ userId: 'user-1' } as never, 'work-1', {
+                    env: { DATABASE_URL: 'postgres://evil' },
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(activityLogService.log).not.toHaveBeenCalled();
+        });
+
+        it('setRuntimeEnv rejects an empty body (neither section addressed)', async () => {
+            await expect(
+                controller.setRuntimeEnv({ userId: 'user-1' } as never, 'work-1', {}),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(workRuntimeEnvService.setRuntimeEnvVars).not.toHaveBeenCalled();
+            expect(workRuntimeEnvService.setDatabaseUrl).not.toHaveBeenCalled();
         });
     });
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -38,7 +38,7 @@ jest.mock('../../auth', () => ({
     CurrentUser: () => () => undefined,
 }));
 
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ServiceUnavailableException } from '@nestjs/common';
 import { DeployController } from './deploy.controller';
 import type { DeployFacadeService } from '@ever-works/agent/facades';
 import type { WorkOwnershipService } from '@ever-works/agent/services';
@@ -404,6 +404,40 @@ describe('DeployController', () => {
                     env: { DATABASE_URL: 'postgres://evil' },
                 }),
             ).rejects.toBeInstanceOf(BadRequestException);
+            expect(activityLogService.log).not.toHaveBeenCalled();
+        });
+
+        it('setRuntimeEnv mode:shared surfaces a provisioning failure as 503 with a sanitized reason', async () => {
+            ownershipService.ensureCanEdit.mockResolvedValue({
+                work: buildWork(),
+                isCreator: true,
+            });
+            dbProvisionService.isReady.mockReturnValue(true);
+            // pg / net errors carry the admin host in their message — that must
+            // never reach the caller, only the errno / SQLSTATE class.
+            dbProvisionService.ensureDatabaseForWork.mockRejectedValue(
+                Object.assign(
+                    new Error('connect ECONNREFUSED 10.0.0.12:5432 (pg-admin.internal)'),
+                    {
+                        code: 'ECONNREFUSED',
+                    },
+                ),
+            );
+
+            const promise = controller.setRuntimeEnv({ userId: 'user-1' } as never, 'work-1', {
+                mode: 'shared',
+            });
+            await expect(promise).rejects.toBeInstanceOf(ServiceUnavailableException);
+            const error = (await promise.catch((e: unknown) => e)) as ServiceUnavailableException;
+            const body = error.getResponse() as Record<string, unknown>;
+            expect(body.code).toBe('SHARED_DB_PROVISION_FAILED');
+            expect(body.reason).toBe('connection refused [ECONNREFUSED]');
+            expect(JSON.stringify(body)).not.toContain('pg-admin.internal');
+            expect(JSON.stringify(body)).not.toContain('10.0.0.12');
+            // The mode switch itself is kept (provisioning is retried on deploy)…
+            expect(workRuntimeEnvService.setDatabaseMode).toHaveBeenCalledWith('work-1', 'shared');
+            // …but nothing else ran and no "updated" activity was logged.
+            expect(workRuntimeEnvService.setRuntimeEnvVars).not.toHaveBeenCalled();
             expect(activityLogService.log).not.toHaveBeenCalled();
         });
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -4,10 +4,12 @@ import {
     Controller,
     Delete,
     Get,
+    Logger,
     Param,
     ParseUUIDPipe,
     Post,
     Put,
+    ServiceUnavailableException,
     UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
@@ -36,7 +38,10 @@ import { AddDomainDto } from './dto/domain.dto';
 import { SetRuntimeEnvDto, TestDbConnectionDto, type DatabaseMode } from './dto/runtime-env.dto';
 import { SubdomainResponseDto, UpdateSubdomainDto } from './dto/subdomain.dto';
 import { ManagedSubdomainService } from './managed-subdomain.service';
-import { EverWorksDbProvisionService } from '@ever-works/agent/ever-works-providers';
+import {
+    EverWorksDbProvisionService,
+    summarizeDbProvisionError,
+} from '@ever-works/agent/ever-works-providers';
 
 /**
  * Mask a Postgres connection string for display — keep scheme/host/db, hide the
@@ -74,6 +79,8 @@ function resolveDeployProviderId(providerId: string): string {
 @Controller('api/deploy')
 @UseGuards(AuthSessionGuard)
 export class DeployController {
+    private readonly logger = new Logger(DeployController.name);
+
     constructor(
         private readonly deployService: DeployService,
         private readonly deployFacade: DeployFacadeService,
@@ -372,6 +379,11 @@ export class DeployController {
             'Runtime env updated: { mode, sharedAvailable, databaseUrl: { configured, masked }, allowedEnvKeys: string[], env: Array<{ key, set, masked, secret }>, message }',
     })
     @ApiResponse({ status: 400, description: 'Invalid body or non-allow-listed env key' })
+    @ApiResponse({
+        status: 503,
+        description:
+            'mode=shared but the Ever Works DB could not be provisioned (admin connection / DDL failure). Body: { code: "SHARED_DB_PROVISION_FAILED", reason, message } — reason is a sanitized SQLSTATE/errno class, never the connection string.',
+    })
     async setRuntimeEnv(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', new ParseUUIDPipe()) id: string,
@@ -401,7 +413,30 @@ export class DeployController {
                 await this.workRuntimeEnvService.setDatabaseMode(id, 'shared');
                 // Provision (or re-point) the shared DB now so it is set + visible
                 // immediately; also re-runs idempotently on the next deploy.
-                await this.dbProvisionService.ensureDatabaseForWork(id, { force: true });
+                try {
+                    await this.dbProvisionService.ensureDatabaseForWork(id, { force: true });
+                } catch (error) {
+                    // Surface the failure instead of a bare 500 so the caller (and the
+                    // operator reading the response) learns WHY provisioning failed —
+                    // SQLSTATE / errno class only, never the admin connection string.
+                    const reason = summarizeDbProvisionError(error);
+                    this.logger.error(
+                        `Shared DB provisioning failed for work ${id} (${reason}): ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                    throw new ServiceUnavailableException({
+                        statusCode: 503,
+                        error: 'Service Unavailable',
+                        code: 'SHARED_DB_PROVISION_FAILED',
+                        reason,
+                        message:
+                            `The Ever Works DB could not be provisioned for this Work: ${reason}. ` +
+                            'The Work stays on the Ever Works DB mode and provisioning is retried on the next deploy; ' +
+                            "an operator should check the platform's shared-cluster admin connection " +
+                            '(DB_EVER_WORKS_SHARED_ADMIN_URL: reachability, credentials, CREATEDB/CREATEROLE privileges).',
+                    });
+                }
                 // Keep the PostgreSQL DB plugin authoritative: clear any per-Work
                 // override so the Work inherits the account-level setting. Best-
                 // effort — never fail the deploy config if the plugin isn't loaded.

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -303,17 +303,24 @@ export class DeployController {
     }
 
     /**
-     * Get the per-Work deploy runtime env state. Only `DATABASE_URL` is
-     * user-managed (and returned masked); `AUTH_SECRET`/`COOKIE_SECRET` are
-     * auto-minted by the deploy feature and intentionally not exposed.
+     * Get the per-Work deploy runtime env state: the `DATABASE_URL` section
+     * (masked) plus the operator-managed, allow-listed env map (Stripe keys &
+     * co.), one masked entry per allow-listed key so the dashboard can render
+     * the whole form. `AUTH_SECRET`/`COOKIE_SECRET` are auto-minted by the
+     * deploy feature and intentionally not exposed.
      */
     @Get('/works/:id/runtime-env')
     @ApiOperation({
         summary: 'Get Work runtime env',
-        description: 'Per-Work DATABASE_URL state (masked) for the k8s-deployed site.',
+        description:
+            'Per-Work DATABASE_URL state (masked) plus the allow-listed per-Work env vars (masked, one entry per allowed key) for the deployed site.',
     })
     @ApiParam({ name: 'id', description: 'Work ID' })
-    @ApiResponse({ status: 200, description: 'Runtime env state' })
+    @ApiResponse({
+        status: 200,
+        description:
+            'Runtime env state: { mode, sharedAvailable, databaseUrl: { configured, masked }, managed: string[], allowedEnvKeys: string[], env: Array<{ key, set, masked, secret }> }',
+    })
     async getRuntimeEnv(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', new ParseUUIDPipe()) id: string,
@@ -322,6 +329,7 @@ export class DeployController {
         const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(id);
         const explicitMode = await this.workRuntimeEnvService.getDatabaseMode(id);
         const configured = Boolean(databaseUrl);
+        const env = await this.workRuntimeEnvService.describeRuntimeEnvVars(id);
         return {
             status: 'success',
             // 'shared' (platform-managed Ever Works DB) vs 'custom' (BYO URL).
@@ -335,50 +343,97 @@ export class DeployController {
             // Auto-managed by the deploy feature (minted server-side), so they
             // are not editable here.
             managed: ['AUTH_SECRET', 'COOKIE_SECRET', 'COOKIE_SECURE'],
+            // Operator-managed per-Work env — the keys the UI may offer, and
+            // the masked current state of each (never plaintext).
+            allowedEnvKeys: [...this.workRuntimeEnvService.getAllowedEnvKeys()],
+            env,
         };
     }
 
     /**
-     * Set the per-Work `DATABASE_URL`. Persisted AES-256-GCM-encrypted on the
-     * Work and pushed into the `${slug}-runtime-env` k8s Secret on the next
-     * deploy (so the change applies after a redeploy).
+     * Set the per-Work runtime env. Two independent sections:
+     *  - database (`mode` / `databaseUrl`) — the pre-existing behaviour;
+     *  - `env` — merge-patch over the allow-listed per-Work env map.
+     * Either may be sent alone; `env`-only bodies leave the DB config alone.
+     * Everything is persisted AES-256-GCM-encrypted on the Work and pushed into
+     * the `${slug}-runtime-env` k8s Secret / GitHub Actions repo secrets on the
+     * next deploy (so the change applies after a redeploy).
      */
     @Put('/works/:id/runtime-env')
     @ApiOperation({
         summary: 'Set Work runtime env',
-        description: 'Sets the per-Work DATABASE_URL used by the k8s-deployed site.',
+        description:
+            'Sets the per-Work DATABASE_URL and/or merge-patches the allow-listed per-Work env vars (Stripe keys & co.) used by the deployed site. Keys outside the allow-list are rejected with 400.',
     })
     @ApiParam({ name: 'id', description: 'Work ID' })
-    @ApiResponse({ status: 200, description: 'Runtime env updated' })
+    @ApiResponse({
+        status: 200,
+        description:
+            'Runtime env updated: { mode, sharedAvailable, databaseUrl: { configured, masked }, allowedEnvKeys: string[], env: Array<{ key, set, masked, secret }>, message }',
+    })
+    @ApiResponse({ status: 400, description: 'Invalid body or non-allow-listed env key' })
     async setRuntimeEnv(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', new ParseUUIDPipe()) id: string,
         @Body() dto: SetRuntimeEnvDto,
     ) {
         const { work } = await this.ownershipService.ensureCanEdit(id, auth.userId);
-        const mode: DatabaseMode = dto.mode ?? 'custom';
-        if (mode === 'shared') {
-            if (!this.dbProvisionService.isReady()) {
-                throw new BadRequestException(
-                    'The Ever Works DB (shared) option is not available. Ask an operator to enable it, or use a custom database.',
-                );
+        // The database section applies when the caller addressed it (any
+        // `mode`, or a `databaseUrl` — the legacy bare body). A body that only
+        // carries `env` must NOT touch the DB mode/URL.
+        const appliesDatabase = dto.mode !== undefined || dto.databaseUrl !== undefined;
+        const appliesEnv = dto.env !== undefined;
+        if (!appliesDatabase && !appliesEnv) {
+            throw new BadRequestException(
+                'Provide a database section (mode / databaseUrl) and/or an env patch.',
+            );
+        }
+
+        let mode: DatabaseMode | null = null;
+        if (appliesDatabase) {
+            mode = dto.mode ?? 'custom';
+            if (mode === 'shared') {
+                if (!this.dbProvisionService.isReady()) {
+                    throw new BadRequestException(
+                        'The Ever Works DB (shared) option is not available. Ask an operator to enable it, or use a custom database.',
+                    );
+                }
+                await this.workRuntimeEnvService.setDatabaseMode(id, 'shared');
+                // Provision (or re-point) the shared DB now so it is set + visible
+                // immediately; also re-runs idempotently on the next deploy.
+                await this.dbProvisionService.ensureDatabaseForWork(id, { force: true });
+                // Keep the PostgreSQL DB plugin authoritative: clear any per-Work
+                // override so the Work inherits the account-level setting. Best-
+                // effort — never fail the deploy config if the plugin isn't loaded.
+                await this.deployFacade.setWorkDbOverride(id, '').catch(() => {});
+            } else {
+                await this.workRuntimeEnvService.setDatabaseUrl(id, dto.databaseUrl as string);
+                await this.workRuntimeEnvService.setDatabaseMode(id, 'custom');
+                // Mirror the per-Work override into the PostgreSQL DB plugin's
+                // work-scoped setting (source of truth). Best-effort as above.
+                await this.deployFacade
+                    .setWorkDbOverride(id, dto.databaseUrl as string)
+                    .catch(() => {});
             }
-            await this.workRuntimeEnvService.setDatabaseMode(id, 'shared');
-            // Provision (or re-point) the shared DB now so it is set + visible
-            // immediately; also re-runs idempotently on the next deploy.
-            await this.dbProvisionService.ensureDatabaseForWork(id, { force: true });
-            // Keep the PostgreSQL DB plugin authoritative: clear any per-Work
-            // override so the Work inherits the account-level setting. Best-
-            // effort — never fail the deploy config if the plugin isn't loaded.
-            await this.deployFacade.setWorkDbOverride(id, '').catch(() => {});
-        } else {
-            await this.workRuntimeEnvService.setDatabaseUrl(id, dto.databaseUrl as string);
-            await this.workRuntimeEnvService.setDatabaseMode(id, 'custom');
-            // Mirror the per-Work override into the PostgreSQL DB plugin's
-            // work-scoped setting (source of truth). Best-effort as above.
-            await this.deployFacade
-                .setWorkDbOverride(id, dto.databaseUrl as string)
-                .catch(() => {});
+        }
+
+        let changedEnvKeys: string[] = [];
+        if (appliesEnv) {
+            // Service validates against the allow-list (400 on unknown keys),
+            // trims, caps length, and persists encrypted. Key NAMES only in
+            // logs / activity — never values.
+            changedEnvKeys = Object.keys(dto.env ?? {});
+            await this.workRuntimeEnvService.setRuntimeEnvVars(id, dto.env ?? {});
+        }
+
+        const summaryParts: string[] = [];
+        if (mode) summaryParts.push(`DATABASE_URL (${mode})`);
+        if (appliesEnv) {
+            summaryParts.push(
+                changedEnvKeys.length > 0
+                    ? `env vars ${changedEnvKeys.join(', ')}`
+                    : 'env vars (no-op)',
+            );
         }
         this.activityLogService
             .log({
@@ -387,11 +442,13 @@ export class DeployController {
                 actionType: ActivityActionType.DEPLOYMENT,
                 action: 'work.runtime-env.updated',
                 status: ActivityStatus.COMPLETED,
-                summary: `Updated DATABASE_URL for ${work.name} (${mode})`,
+                summary: `Updated ${summaryParts.join(' and ')} for ${work.name}`,
             })
             .catch(() => {});
+
         const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(id);
         const explicitMode = await this.workRuntimeEnvService.getDatabaseMode(id);
+        const env = await this.workRuntimeEnvService.describeRuntimeEnvVars(id);
         return {
             status: 'success',
             mode: this.resolveDbMode(explicitMode, Boolean(databaseUrl)),
@@ -400,10 +457,14 @@ export class DeployController {
                 configured: Boolean(databaseUrl),
                 masked: databaseUrl ? maskDatabaseUrl(databaseUrl) : null,
             },
+            allowedEnvKeys: [...this.workRuntimeEnvService.getAllowedEnvKeys()],
+            env,
             message:
                 mode === 'shared'
                     ? 'Switched to the Ever Works DB. Redeploy to apply it to the live site.'
-                    : 'Runtime env updated. Redeploy to apply it to the live site.',
+                    : appliesDatabase
+                      ? 'Runtime env updated. Redeploy to apply it to the live site.'
+                      : 'Environment variables updated. Redeploy to apply them to the live site.',
         };
     }
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.server-side.spec.ts
@@ -174,6 +174,8 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
             getOrGenerateAuthSecret: jest.fn().mockResolvedValue('auth-secret-base64'),
             getOrGenerateCookieSecret: jest.fn().mockResolvedValue('cookie-secret-base64'),
             getDatabaseUrl: jest.fn().mockResolvedValue(null),
+            // Allow-listed per-Work env (Stripe keys & co.). Default = none.
+            getRuntimeEnvVars: jest.fn().mockResolvedValue({}),
         };
 
         // EW-617 G5: DNS automation no-ops in tests (no env vars). The
@@ -243,6 +245,7 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
             funnel,
             subdomainAllocator,
             customDomainRepository,
+            workRuntimeEnvService,
         };
     };
 
@@ -314,6 +317,56 @@ describe('DeployService — server-side deploy for managed cluster tiers', () =>
         expect(pushedNames).not.toContain('DEPLOY_TOKEN');
         // Everything non-credential still pushes (CI builds keep working).
         expect(pushedNames).toContain('WORK_ID');
+    });
+
+    it('managed tier → allow-listed per-Work env is merged into the runtime env; managed keys win', async () => {
+        const plugin = managedPlugin();
+        const { service, githubPlugin, workRuntimeEnvService } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+        workRuntimeEnvService.getRuntimeEnvVars.mockResolvedValue({
+            STRIPE_SECRET_KEY: 'sk_live_abc',
+            NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            // Defensive: even if a managed key ever slipped into the stored
+            // map, the platform-managed value must win.
+            TENANT_ID: 'spoofed-tenant',
+        });
+
+        await service.deploy('work-1', 'user-1');
+
+        expect(workRuntimeEnvService.getRuntimeEnvVars).toHaveBeenCalledWith('work-1');
+        const [config] = plugin.deploy.mock.calls[0];
+        const runtimeEnv = config.options.runtimeEnv as Record<string, string>;
+        expect(runtimeEnv.STRIPE_SECRET_KEY).toBe('sk_live_abc');
+        expect(runtimeEnv.NEXT_PUBLIC_PAYMENT_PROVIDER).toBe('stripe');
+        expect(runtimeEnv.TENANT_ID).toBe('work-1');
+        expect(runtimeEnv.AUTH_SECRET).toBe('auth-secret-base64');
+        // The workflow-path push also ran (server-side deploys still push
+        // non-credential repo secrets so CI builds keep working).
+        const pushedNames = githubPlugin.setActionSecret.mock.calls.map(
+            (c: unknown[]) => (c[0] as { key: string }).key,
+        );
+        expect(pushedNames).toContain('STRIPE_SECRET_KEY');
+    });
+
+    it('managed tier → a failing per-Work env lookup does not block the deploy', async () => {
+        const plugin = managedPlugin();
+        const { service, workRuntimeEnvService } = buildService({
+            plugin,
+            settings: { clusterSource: 'k8s-works-shared' },
+        });
+        workRuntimeEnvService.getRuntimeEnvVars.mockRejectedValue(
+            new Error('deploy runtime-env map is malformed.'),
+        );
+
+        const result = await service.deploy('work-1', 'user-1');
+
+        expect(result.dispatched).toBe(true);
+        const [config] = plugin.deploy.mock.calls[0];
+        const runtimeEnv = config.options.runtimeEnv as Record<string, string>;
+        expect(runtimeEnv.TENANT_ID).toBe('work-1');
+        expect(runtimeEnv.STRIPE_SECRET_KEY).toBeUndefined();
     });
 
     it('managed tier → branch alias image tag (main → prod)', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -157,6 +157,8 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             getOrGenerateAuthSecret: jest.fn().mockResolvedValue('auth-secret-base64'),
             getOrGenerateCookieSecret: jest.fn().mockResolvedValue('cookie-secret-base64'),
             getDatabaseUrl: jest.fn().mockResolvedValue(null),
+            // Allow-listed per-Work env (Stripe keys & co.). Default = none.
+            getRuntimeEnvVars: jest.fn().mockResolvedValue({}),
         };
 
         // EW-617 G5: DNS automation no-ops in tests (no env vars). The
@@ -226,6 +228,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             funnel,
             subdomainAllocator,
             customDomainRepository,
+            workRuntimeEnvService,
         };
     };
 
@@ -233,6 +236,105 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         secrets: gh.setActionSecret.mock.calls.map((c: any[]) => c[0]),
         variables: gh.setActionVariable.mock.calls.map((c: any[]) => c[0]),
         dispatches: gh.dispatchWorkflow.mock.calls.map((c: any[]) => c[0]),
+    });
+
+    describe('per-Work allow-listed runtime env (Stripe keys & co.) — workflow path', () => {
+        it('pushes each configured per-Work env var as a repo secret, for any provider (Vercel here)', async () => {
+            const { service, githubPlugin, workRuntimeEnvService } = buildService({
+                plugin: { id: 'vercel' },
+                deployProvider: 'vercel',
+                token: 'vercel-token',
+            });
+            workRuntimeEnvService.getRuntimeEnvVars.mockResolvedValue({
+                STRIPE_SECRET_KEY: 'sk_live_abc',
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(workRuntimeEnvService.getRuntimeEnvVars).toHaveBeenCalledWith('work-1');
+            const byKey = Object.fromEntries(
+                captureCalls(githubPlugin).secrets.map((s: any) => [s.key, s.value]),
+            );
+            expect(byKey.STRIPE_SECRET_KEY).toBe('sk_live_abc');
+            expect(byKey.NEXT_PUBLIC_PAYMENT_PROVIDER).toBe('stripe');
+            // The managed secrets still land alongside.
+            expect(byKey.WORK_ID).toBe('work-1');
+        });
+
+        it('pushes each configured per-Work env var on the k8s workflow path too', async () => {
+            const { service, githubPlugin, workRuntimeEnvService } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                deployProvider: 'k8s',
+            });
+            workRuntimeEnvService.getRuntimeEnvVars.mockResolvedValue({
+                STRIPE_WEBHOOK_SECRET: 'whsec_123',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+            expect(keys).toContain('STRIPE_WEBHOOK_SECRET');
+            // Managed runtime env pushed by ensureRuntimeEnv is untouched.
+            expect(keys).toContain('AUTH_SECRET');
+            expect(keys).toContain('COOKIE_SECRET');
+        });
+
+        it('pushes nothing extra when no per-Work env is configured', async () => {
+            const { service, githubPlugin } = buildService({
+                plugin: { id: 'vercel' },
+                deployProvider: 'vercel',
+                token: 'vercel-token',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+            expect(keys.some((k: string) => k.startsWith('STRIPE_'))).toBe(false);
+        });
+
+        it('does NOT block the deploy when the per-Work env lookup throws', async () => {
+            const { service, githubPlugin, workRuntimeEnvService } = buildService({
+                plugin: { id: 'vercel' },
+                deployProvider: 'vercel',
+                token: 'vercel-token',
+            });
+            workRuntimeEnvService.getRuntimeEnvVars.mockRejectedValueOnce(
+                new Error('PLATFORM_ENCRYPTION_KEY is not set'),
+            );
+
+            await expect(service.deploy('work-1', 'user-1', {})).resolves.toMatchObject({
+                dispatched: true,
+            });
+            const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+            expect(keys).toContain('WORK_ID');
+        });
+
+        it('does NOT block the deploy when pushing one per-Work env secret fails', async () => {
+            const { service, githubPlugin, workRuntimeEnvService } = buildService({
+                plugin: { id: 'vercel' },
+                deployProvider: 'vercel',
+                token: 'vercel-token',
+            });
+            workRuntimeEnvService.getRuntimeEnvVars.mockResolvedValue({
+                STRIPE_SECRET_KEY: 'sk_live_abc',
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            });
+            githubPlugin.setActionSecret.mockImplementation(async (args: { key: string }) => {
+                if (args.key === 'STRIPE_SECRET_KEY') throw new Error('GitHub 502');
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).resolves.toMatchObject({
+                dispatched: true,
+            });
+            const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+            // The other var was still attempted; the failure is contained.
+            expect(keys).toContain('NEXT_PUBLIC_PAYMENT_PROVIDER');
+        });
     });
 
     it('writes the Vercel team scope secret name consumed by template workflows', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -293,6 +293,7 @@ export class DeployService {
         await this.ensureCronSecret(ctx);
         await this.ensureWebhookSecret(ctx, work);
         await this.ensureRuntimeEnv(ctx, work, plugin);
+        await this.pushWorkRuntimeEnvSecrets(ctx, work);
 
         const template = await this.websiteTemplateResolver.resolveForWork(work);
         const targetBranch = env.branch ?? template.branch;
@@ -1476,6 +1477,32 @@ export class DeployService {
                 );
             }
         }
+        // Operator-managed, allow-listed per-Work env (Stripe keys & co.) —
+        // merged LAST so every platform-managed key above wins on a collision
+        // (the allow-list already excludes them; this is belt-and-braces).
+        // Best-effort like the other lookups: a decrypt failure logs and
+        // omits the vars rather than failing the deploy. Key NAMES only in
+        // logs — never values.
+        try {
+            const perWorkEnv = await this.workRuntimeEnvService.getRuntimeEnvVars(work.id);
+            const applied: string[] = [];
+            for (const [key, value] of Object.entries(perWorkEnv)) {
+                if (key in env) continue;
+                env[key] = value;
+                applied.push(key);
+            }
+            if (applied.length > 0) {
+                this.logger.debug(
+                    `Applied ${applied.length} per-Work runtime env var(s) for work ${work.id}: ${applied.join(', ')}`,
+                );
+            }
+        } catch (error: unknown) {
+            this.logger.error(
+                `Runtime-env per-Work env lookup failed for work ${work.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
         return env;
     }
 
@@ -1765,6 +1792,60 @@ export class DeployService {
                 `Failed to push runtime env for ${ctx.owner}/${ctx.repo}: ${
                     error instanceof Error ? error.message : String(error)
                 }`,
+            );
+        }
+    }
+
+    /**
+     * Push the operator-managed, allow-listed per-Work env (Stripe keys & co.,
+     * see `WORK_RUNTIME_ENV_ALLOWED_KEYS`) as GitHub Actions repo secrets so
+     * the workflow deploy paths can forward them: `deploy_k8s.yaml` copies
+     * every non-CI repo secret into the `${slug}-runtime-env` k8s Secret, and
+     * the Vercel workflows can read them the same way. Provider-agnostic on
+     * purpose (unlike `ensureRuntimeEnv`, which is k8s-only): the values are
+     * the Work owner's own payment config for their own site repo.
+     *
+     * Best-effort — a missing encryption key / decrypt failure / GitHub error
+     * logs and continues; the deploy itself must not fail because a Stripe
+     * key could not be pushed. Logs key NAMES only, never values.
+     */
+    private async pushWorkRuntimeEnvSecrets(ctx: RepoContext, work: Work) {
+        let vars: Record<string, string>;
+        try {
+            vars = await this.workRuntimeEnvService.getRuntimeEnvVars(work.id);
+        } catch (error: unknown) {
+            this.logger.warn(
+                `Per-Work runtime env lookup failed for work ${work.id}; skipping env secret push: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return;
+        }
+        const entries = Object.entries(vars);
+        if (entries.length === 0) {
+            return;
+        }
+        const results = await Promise.allSettled(
+            entries.map(([key, value]) => this.setSecret(ctx, key, value)),
+        );
+        const pushed: string[] = [];
+        results.forEach((result, index) => {
+            const key = entries[index][0];
+            if (result.status === 'fulfilled') {
+                pushed.push(key);
+            } else {
+                this.logger.error(
+                    `Failed to push per-Work runtime env secret ${key} for work ${work.id} on ${ctx.owner}/${ctx.repo}: ${
+                        result.reason instanceof Error
+                            ? result.reason.message
+                            : String(result.reason)
+                    }`,
+                );
+            }
+        });
+        if (pushed.length > 0) {
+            this.logger.debug(
+                `Pushed ${pushed.length} per-Work runtime env secret(s) for work ${work.id} to ${ctx.owner}/${ctx.repo}: ${pushed.join(', ')}`,
             );
         }
     }

--- a/apps/api/src/plugins-capabilities/deploy/dto/runtime-env.dto.ts
+++ b/apps/api/src/plugins-capabilities/deploy/dto/runtime-env.dto.ts
@@ -1,5 +1,13 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsIn, IsNotEmpty, IsOptional, IsString, Matches, ValidateIf } from 'class-validator';
+import {
+    IsIn,
+    IsNotEmpty,
+    IsObject,
+    IsOptional,
+    IsString,
+    Matches,
+    ValidateIf,
+} from 'class-validator';
 
 export const DATABASE_MODES = ['shared', 'custom'] as const;
 export type DatabaseMode = (typeof DATABASE_MODES)[number];
@@ -7,7 +15,9 @@ export type DatabaseMode = (typeof DATABASE_MODES)[number];
 /**
  * Body for `PUT /api/deploy/works/:id/runtime-env`.
  *
- * `mode` selects where the Work's site DATABASE_URL comes from:
+ * Two independent concerns share this endpoint; either (or both) may be sent:
+ *
+ * **Database** — `mode` selects where the Work's site DATABASE_URL comes from:
  *  - `'shared'` — the platform-managed **Ever Works DB**. No `databaseUrl` is
  *    required; the platform auto-provisions a per-Work database and injects it
  *    on the next deploy.
@@ -15,8 +25,15 @@ export type DatabaseMode = (typeof DATABASE_MODES)[number];
  *    `databaseUrl`. This is the pre-existing behaviour.
  *
  * `mode` is optional for backward-compatibility: a body with only `databaseUrl`
- * is treated as `'custom'` (the old contract). When `mode !== 'shared'` the
- * connection string is required and must be a `postgres(ql)://` URL.
+ * is treated as `'custom'` (the old contract). When the database section is
+ * being applied and `mode !== 'shared'` the connection string is required and
+ * must be a `postgres(ql)://` URL.
+ *
+ * **Per-Work env** — `env` is a merge-patch over the allow-listed runtime env
+ * map (Stripe keys & co., see `WORK_RUNTIME_ENV_ALLOWED_KEYS`): provided keys
+ * overwrite, `null` / empty string removes, omitted keys are untouched. Keys
+ * outside the allow-list are rejected with 400 by the service. A body with
+ * ONLY `env` leaves the database mode/URL untouched.
  */
 export class SetRuntimeEnvDto {
     @ApiPropertyOptional({
@@ -33,13 +50,32 @@ export class SetRuntimeEnvDto {
             'Postgres connection string used as the Work site DATABASE_URL. Required for custom mode; ignored for shared mode.',
         example: 'postgresql://user:password@your-db-host:5432/dbname?sslmode=require',
     })
-    @ValidateIf((o) => o.mode !== 'shared')
+    // Required whenever the database section is being applied: an explicit
+    // `mode: 'custom'`, a `databaseUrl` of any shape, or the legacy bare body
+    // (neither `mode` nor `env` present). A body carrying only `env` skips it.
+    @ValidateIf(
+        (o) =>
+            o.mode === 'custom' ||
+            o.databaseUrl !== undefined ||
+            (o.mode === undefined && o.env === undefined),
+    )
     @IsString()
     @IsNotEmpty()
     @Matches(/^postgres(ql)?:\/\/.+/i, {
         message: 'databaseUrl must be a postgres:// or postgresql:// connection string',
     })
     databaseUrl?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Merge-patch over the allow-listed per-Work runtime env (e.g. STRIPE_SECRET_KEY). Provided keys overwrite; null or empty string removes; omitted keys are untouched. Keys outside the allow-list are rejected (400).',
+        type: 'object',
+        additionalProperties: { type: 'string', nullable: true },
+        example: { STRIPE_SECRET_KEY: 'sk_live_…', NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe' },
+    })
+    @IsOptional()
+    @IsObject({ message: 'env must be an object of KEY: value pairs' })
+    env?: Record<string, string | null>;
 }
 
 /**

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5711,6 +5711,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {

--- a/apps/web/src/app/actions/dashboard/deploy.ts
+++ b/apps/web/src/app/actions/dashboard/deploy.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { workAPI, websiteAPI, deployAPI } from '@/lib/api';
+import type { RuntimeEnvVarState } from '@/lib/api/plugins-capabilities/deploy';
 import { getAuthFromCookie } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { ROUTES } from '@/lib/constants';
@@ -199,6 +200,8 @@ export async function getWorkRuntimeEnv(workId: string) {
             sharedAvailable: response.sharedAvailable ?? false,
             databaseUrl: response.databaseUrl ?? { configured: false, masked: null },
             managed: response.managed ?? [],
+            allowedEnvKeys: response.allowedEnvKeys ?? [],
+            env: response.env ?? [],
         };
     } catch (error) {
         console.error('Get runtime env error:', error);
@@ -208,7 +211,48 @@ export async function getWorkRuntimeEnv(workId: string) {
             sharedAvailable: false,
             databaseUrl: { configured: false, masked: null as string | null },
             managed: [] as string[],
+            allowedEnvKeys: [] as string[],
+            env: [] as RuntimeEnvVarState[],
             error: error instanceof Error ? error.message : 'Failed to get runtime env',
+        };
+    }
+}
+
+/**
+ * Merge-patch the allow-listed per-Work env vars (Stripe keys & co.) via
+ * `PUT /api/deploy/works/:id/runtime-env { env }`. Provided keys overwrite,
+ * `null` removes, omitted keys persist. Leaves the DB mode/URL untouched.
+ * Returns the masked state of every allow-listed key (never plaintext).
+ */
+export async function setWorkRuntimeEnvVars(workId: string, env: Record<string, string | null>) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const keys = Object.keys(env);
+    if (keys.length === 0) {
+        return {
+            success: false,
+            env: [] as RuntimeEnvVarState[],
+            error: 'No environment variable provided',
+        };
+    }
+
+    try {
+        const response = await deployAPI.setRuntimeEnv(workId, { env });
+        revalidatePath(ROUTES.DASHBOARD_WORK_DEPLOY(workId));
+        return {
+            success: response.status === 'success',
+            allowedEnvKeys: response.allowedEnvKeys ?? [],
+            env: response.env ?? [],
+        };
+    } catch (error) {
+        console.error('Set runtime env vars error:', error);
+        return {
+            success: false,
+            env: [] as RuntimeEnvVarState[],
+            error: error instanceof Error ? error.message : 'Failed to set environment variables',
         };
     }
 }

--- a/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
+++ b/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
@@ -1,15 +1,28 @@
 'use client';
 
 import { useEffect, useState, useTransition, type ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
 import type { Work } from '@/lib/api';
+import type { RuntimeEnvVarState } from '@/lib/api/plugins-capabilities/deploy';
 import { toast } from 'sonner';
 import { useRouter } from '@/i18n/navigation';
 import {
     getWorkRuntimeEnv,
     setWorkRuntimeEnv,
+    setWorkRuntimeEnvVars,
     testWorkDbConnection,
 } from '@/app/actions/dashboard/deploy';
-import { CheckCircle2, Database, Loader2, Lock, Save, Server, XCircle } from 'lucide-react';
+import {
+    CheckCircle2,
+    Database,
+    KeyRound,
+    Loader2,
+    Lock,
+    Save,
+    Server,
+    Trash2,
+    XCircle,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
@@ -41,6 +54,7 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
         masked: string | null;
     } | null>(null);
     const [managed, setManaged] = useState<string[]>([]);
+    const [envVars, setEnvVars] = useState<RuntimeEnvVarState[]>([]);
     const [mode, setMode] = useState<DbMode>('custom');
     const [sharedAvailable, setSharedAvailable] = useState(false);
     const [value, setValue] = useState('');
@@ -59,6 +73,7 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
                 if (result.success) {
                     setDatabaseUrl(result.databaseUrl);
                     setManaged(result.managed);
+                    setEnvVars(result.env ?? []);
                     setLoadError(null);
                 } else {
                     // Server-reported failure: don't claim "Not configured"
@@ -256,6 +271,15 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
                         </div>
                     )}
 
+                    {envVars.length > 0 && (
+                        <EnvVarsSection
+                            workId={work.id}
+                            vars={envVars}
+                            disabled={hasLoadError}
+                            onChange={setEnvVars}
+                        />
+                    )}
+
                     {managed.length > 0 && (
                         <div>
                             <div className="mb-1 flex items-center gap-1 text-xs font-medium text-muted-foreground">
@@ -278,6 +302,134 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
                     )}
                 </div>
             )}
+        </div>
+    );
+}
+
+/**
+ * Operator-managed, allow-listed per-Work env vars (Stripe keys & co.).
+ *
+ * The API returns one masked entry per allow-listed key (`allowedEnvKeys` /
+ * `env` on `GET /runtime-env`), so this section renders the whole form from
+ * the server's list — no client-side key list to drift. Each row saves via
+ * `PUT /runtime-env { env: { KEY: value } }` (merge-patch) and removes via
+ * `{ env: { KEY: null } }`. Values are never echoed back: secrets show as
+ * `***`, non-secrets as a short prefix.
+ */
+function EnvVarsSection({
+    workId,
+    vars,
+    disabled,
+    onChange,
+}: {
+    workId: string;
+    vars: RuntimeEnvVarState[];
+    disabled: boolean;
+    onChange: (next: RuntimeEnvVarState[]) => void;
+}) {
+    const t = useTranslations('dashboard.workDetail.deploy.runtimeEnvVars');
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    const [drafts, setDrafts] = useState<Record<string, string>>({});
+    const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+    const submit = (key: string, value: string | null) => {
+        setPendingKey(key);
+        startTransition(async () => {
+            const result = await setWorkRuntimeEnvVars(workId, { [key]: value });
+            setPendingKey(null);
+            if (result.success) {
+                onChange(result.env);
+                setDrafts((prev) => {
+                    const next = { ...prev };
+                    delete next[key];
+                    return next;
+                });
+                toast.success(value === null ? t('removeSuccess') : t('saveSuccess'));
+                router.refresh();
+            } else {
+                toast.error(result.error ?? (value === null ? t('removeFailed') : t('saveFailed')));
+            }
+        });
+    };
+
+    return (
+        <div>
+            <div className="mb-1 flex items-center gap-1 text-xs font-medium text-muted-foreground">
+                <KeyRound className="h-3 w-3" /> {t('title')}
+            </div>
+            <p className="text-xs text-muted-foreground">{t('description')}</p>
+            <div className="mt-2 space-y-2">
+                {vars.map((entry) => {
+                    const draft = drafts[entry.key] ?? '';
+                    const busy = isPending && pendingKey === entry.key;
+                    return (
+                        <div key={entry.key}>
+                            <label
+                                htmlFor={`runtime-env-${entry.key}`}
+                                className="mb-1 block font-mono text-[11px] font-medium text-muted-foreground"
+                            >
+                                {entry.key}
+                            </label>
+                            <div className="flex gap-2">
+                                <Input
+                                    id={`runtime-env-${entry.key}`}
+                                    type={entry.secret ? 'password' : 'text'}
+                                    autoComplete="off"
+                                    spellCheck={false}
+                                    placeholder={
+                                        entry.set
+                                            ? (entry.masked ?? t('placeholderSet'))
+                                            : t('placeholderUnset')
+                                    }
+                                    value={draft}
+                                    onChange={(e) =>
+                                        setDrafts((prev) => ({
+                                            ...prev,
+                                            [entry.key]: e.target.value,
+                                        }))
+                                    }
+                                    disabled={disabled || isPending}
+                                    className="font-mono text-xs"
+                                />
+                                <Button
+                                    onClick={() => submit(entry.key, draft)}
+                                    disabled={disabled || isPending || !draft.trim()}
+                                    size="sm"
+                                    aria-label={t('saveAria', { key: entry.key })}
+                                >
+                                    {busy ? (
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Save className="h-4 w-4" />
+                                    )}
+                                    <span className="ml-1">{t('saveButton')}</span>
+                                </Button>
+                                {entry.set && (
+                                    <Button
+                                        variant="secondary"
+                                        onClick={() => submit(entry.key, null)}
+                                        disabled={disabled || isPending}
+                                        size="sm"
+                                        aria-label={t('removeAria', { key: entry.key })}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                        <span className="ml-1">{t('removeButton')}</span>
+                                    </Button>
+                                )}
+                            </div>
+                            <p className="mt-0.5 text-[11px] text-muted-foreground">
+                                {entry.set
+                                    ? entry.secret
+                                        ? t('currentSecret')
+                                        : t('currentValue', { masked: entry.masked ?? '' })
+                                    : t('notSet')}
+                            </p>
+                        </div>
+                    );
+                })}
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">{t('hint')}</p>
         </div>
     );
 }

--- a/apps/web/src/lib/api/plugins-capabilities/deploy.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/deploy.ts
@@ -98,6 +98,20 @@ export type VerifyDomainResponseDto = APIResponse<{
     domain: DeploymentDomain;
 }>;
 
+/**
+ * One allow-listed per-Work env var (Stripe keys & co.) as returned by
+ * `GET/PUT /api/deploy/works/:id/runtime-env` — masked, never plaintext.
+ */
+export interface RuntimeEnvVarState {
+    key: string;
+    /** Whether a value is currently stored for this key. */
+    set: boolean;
+    /** `***` for secrets, a short prefix otherwise; null when unset. */
+    masked: string | null;
+    /** True for credential keys that are always fully masked. */
+    secret: boolean;
+}
+
 export interface RuntimeEnvState {
     /** Where the site DATABASE_URL comes from: managed shared DB vs BYO URL. */
     mode?: 'shared' | 'custom';
@@ -106,9 +120,24 @@ export interface RuntimeEnvState {
     databaseUrl: { configured: boolean; masked: string | null };
     /** Secrets auto-managed by the deploy feature (not user-editable). */
     managed: string[];
+    /** The per-Work env keys the user may set (allow-list, display order). */
+    allowedEnvKeys?: string[];
+    /** Masked state of every allow-listed per-Work env key. */
+    env?: RuntimeEnvVarState[];
 }
 
 export type RuntimeEnvResponseDto = APIResponse<RuntimeEnvState>;
+
+/**
+ * Body for `PUT /api/deploy/works/:id/runtime-env`. `mode`/`databaseUrl` and
+ * `env` are independent sections — send either or both. `env` is a
+ * merge-patch: provided keys overwrite, `null` removes, omitted keys persist.
+ */
+export interface SetRuntimeEnvBody {
+    mode?: 'shared' | 'custom';
+    databaseUrl?: string;
+    env?: Record<string, string | null>;
+}
 
 /**
  * EW-740 — per-Work managed subdomain ("Site URL / Subdomain") state surfaced
@@ -269,11 +298,13 @@ export const deployAPI = {
     },
 
     /**
-     * Set the per-Work database config (applied on next deploy). `mode: 'shared'`
-     * selects the managed Ever Works DB (no `databaseUrl` needed); `mode: 'custom'`
-     * (the default) sets a BYO connection string.
+     * Set the per-Work runtime env (applied on next deploy). Database section:
+     * `mode: 'shared'` selects the managed Ever Works DB (no `databaseUrl`
+     * needed); `mode: 'custom'` (the default) sets a BYO connection string.
+     * `env` merge-patches the allow-listed per-Work env vars (Stripe keys &
+     * co.) and may be sent on its own without touching the DB config.
      */
-    setRuntimeEnv(workId: string, body: { mode?: 'shared' | 'custom'; databaseUrl?: string }) {
+    setRuntimeEnv(workId: string, body: SetRuntimeEnvBody) {
         return serverMutation<RuntimeEnvResponseDto>({
             // Security: encode workId to prevent path-segment injection
             endpoint: `/deploy/works/${encodeURIComponent(workId)}/runtime-env`,

--- a/docs/runbooks/WORK_RUNTIME_ENV.md
+++ b/docs/runbooks/WORK_RUNTIME_ENV.md
@@ -171,6 +171,19 @@ back.
 - **`PLATFORM_ENCRYPTION_KEY` missing** on the API: writes fail with a clear
   error; deploys log `Runtime-env per-Work env lookup failed …` and proceed
   without the vars.
+- **`PUT … {"mode":"shared"}` answers 503 `SHARED_DB_PROVISION_FAILED`**: the
+  API switched the Work to the Ever Works DB mode but `ensureDatabaseForWork`
+  (direct DDL over `DB_EVER_WORKS_SHARED_ADMIN_URL`: `CREATE ROLE` /
+  `CREATE DATABASE`) threw. The body's `reason` is the sanitized errno /
+  SQLSTATE class — `connection refused [ECONNREFUSED]`,
+  `host not found [ENOTFOUND]`, `password authentication failed [28P01]`,
+  `insufficient privilege … [42501]`, … — never the connection string (the
+  full error is in the API log: `Shared DB provisioning failed for work …`).
+  Fix the admin connection (reachability from the API pods, credentials,
+  `CREATEDB` / `CREATEROLE` on the admin role) and re-send the same request;
+  deploys also retry provisioning idempotently (warn-level
+  `Shared DB provision failed for work …` when it keeps failing — the site then
+  runs without `DATABASE_URL`). Before this the endpoint answered a bare 500.
 - **Audit**: every write logs an Activity Feed entry
   (`work.runtime-env.updated`) with the changed key **names**; values are
   never logged anywhere.

--- a/docs/runbooks/WORK_RUNTIME_ENV.md
+++ b/docs/runbooks/WORK_RUNTIME_ENV.md
@@ -1,0 +1,176 @@
+# Per-Work runtime env — allow-listed env vars for deployed directories
+
+> Companion to [`docs/features/k8s-deployment.md`](../features/k8s-deployment.md)
+> (how a Work reaches the cluster) and
+> [`docs/specs/features/work-db-storage-and-subdomains/design.md`](../specs/features/work-db-storage-and-subdomains/design.md)
+> (the `DATABASE_URL` / shared-DB half of the same endpoint).
+> Code: `packages/agent/src/services/work-runtime-env.service.ts`,
+> `packages/agent/src/services/work-runtime-env.constants.ts`,
+> `apps/api/src/plugins-capabilities/deploy/deploy.controller.ts`,
+> `apps/api/src/plugins-capabilities/deploy/deploy.service.ts`.
+
+## What this is
+
+A deployed directory site (`directory-web-template`) reads a handful of
+**per-site** settings from `process.env` that the platform cannot derive on its
+own — today the Stripe payment configuration. This runbook covers the small,
+**allow-listed** set of per-Work runtime env vars an operator (the Work owner
+or a member with edit rights) can set from the dashboard or the API, how they
+are stored, and how they reach the running site.
+
+It does **not** cover the platform-managed keys (`AUTH_SECRET`,
+`COOKIE_SECRET`, `DATABASE_URL`, `GH_TOKEN`, `DATA_REPOSITORY`, `TENANT_ID`,
+`SITE_URL`, `PLATFORM_*`, …). Those are minted by `DeployService` /
+`WorkRuntimeEnvService` on every deploy and are deliberately **not** settable
+through this surface — the allow-list is the guard.
+
+## The allow-list
+
+Source of truth: `WORK_RUNTIME_ENV_ALLOWED_KEYS` in
+`packages/agent/src/services/work-runtime-env.constants.ts`.
+
+| Key                                  | Secret (masked `***`) | Purpose in the template                                 |
+| ------------------------------------ | --------------------- | ------------------------------------------------------- |
+| `NEXT_PUBLIC_PAYMENT_PROVIDER`       | no                    | Selects the payment provider (`stripe`).                |
+| `STRIPE_SECRET_KEY`                  | **yes**               | Server-side Stripe API key (`sk_live_…` / `sk_test_…`). |
+| `STRIPE_PUBLISHABLE_KEY`             | no                    | Publishable key (server-side alias).                    |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | no                    | Publishable key exposed to the browser bundle.          |
+| `STRIPE_WEBHOOK_SECRET`              | **yes**               | Signing secret for `/api/webhooks/stripe` (`whsec_…`).  |
+| `NEXT_PUBLIC_STRIPE_DYNAMIC_PRICING` | no                    | Feature toggle (`true` / `false`).                      |
+| `STRIPE_SPONSOR_WEEKLY_PRICE_ID`     | no                    | Stripe Price id for the weekly sponsor slot.            |
+| `STRIPE_SPONSOR_MONTHLY_PRICE_ID`    | no                    | Stripe Price id for the monthly sponsor slot.           |
+
+Rules enforced by `WorkRuntimeEnvService.setRuntimeEnvVars`:
+
+- Any key outside the list → **400** (`Unsupported runtime env key(s): …`);
+  the whole call is rejected, nothing is written.
+- Values are trimmed; empty / whitespace-only / `null` **removes** the key.
+- Max 4096 characters per value; control characters are rejected.
+- Merge-patch semantics: keys you do not mention are left untouched.
+
+To add a key: extend `WORK_RUNTIME_ENV_ALLOWED_KEYS` (and
+`WORK_RUNTIME_ENV_SECRET_KEYS` if it is a credential), run the agent spec
+`work-runtime-env.service.spec.ts`, and update the table above. The dashboard
+renders the form from the API's `allowedEnvKeys`, so no UI change is needed.
+
+## Storage
+
+All configured keys for a Work are stored as **one JSON map**, AES-256-GCM
+encrypted with `PLATFORM_ENCRYPTION_KEY`, in `works.deployRuntimeEnvEncrypted`
+(migration `1787423600000-AddWorkDeployRuntimeEnvVars`). Same envelope and
+helper as the sibling `deployDatabaseUrlEncrypted` column. `NULL` means
+nothing is configured.
+
+Reads are defensive: keys no longer allow-listed (or non-string values) are
+dropped when the map is decoded, so the allow-list remains authoritative even
+over old rows.
+
+## How the values reach the site
+
+Nothing is applied live — **a redeploy is required** after any change.
+
+1. **Server-side managed k8s deploys** (`k8s-works` / `k8s-works-shared`):
+   `DeployService.collectServerSideRuntimeEnv` merges the map into the env the
+   k8s plugin writes to the `${slug}-runtime-env` Secret (mounted via
+   `envFrom`). The merge runs **after** every platform-managed key, so a
+   managed key always wins on a collision. Applied key names (never values)
+   are logged at `debug`.
+2. **Workflow deploys** (GitHub Actions — custom kubeconfig and Vercel):
+   `DeployService.pushWorkRuntimeEnvSecrets` pushes each configured key as a
+   **GitHub Actions repo secret** on the Work's website repo, right after the
+   managed runtime env. `deploy_k8s.yaml` forwards every non-CI repo secret
+   into the cluster Secret; the Vercel workflows can read
+   `secrets.STRIPE_SECRET_KEY` etc. the same way. Provider-agnostic and
+   best-effort (a push failure logs and the deploy continues).
+
+## API
+
+Both endpoints require edit rights on the Work (`WorkOwnershipService.ensureCanEdit`).
+
+### Read (masked)
+
+```http
+GET /api/deploy/works/{workId}/runtime-env
+```
+
+```json
+{
+	"status": "success",
+	"mode": "shared",
+	"sharedAvailable": true,
+	"databaseUrl": { "configured": true, "masked": "postgresql://app:***@db.example.com/work_123" },
+	"managed": ["AUTH_SECRET", "COOKIE_SECRET", "COOKIE_SECURE"],
+	"allowedEnvKeys": [
+		"NEXT_PUBLIC_PAYMENT_PROVIDER",
+		"STRIPE_SECRET_KEY",
+		"STRIPE_PUBLISHABLE_KEY",
+		"NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+		"STRIPE_WEBHOOK_SECRET",
+		"NEXT_PUBLIC_STRIPE_DYNAMIC_PRICING",
+		"STRIPE_SPONSOR_WEEKLY_PRICE_ID",
+		"STRIPE_SPONSOR_MONTHLY_PRICE_ID"
+	],
+	"env": [
+		{ "key": "NEXT_PUBLIC_PAYMENT_PROVIDER", "set": true, "masked": "stripe", "secret": false },
+		{ "key": "STRIPE_SECRET_KEY", "set": true, "masked": "***", "secret": true },
+		{ "key": "STRIPE_PUBLISHABLE_KEY", "set": false, "masked": null, "secret": false },
+		{ "key": "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "set": true, "masked": "pk_live…", "secret": false },
+		{ "key": "STRIPE_WEBHOOK_SECRET", "set": false, "masked": null, "secret": true },
+		{ "key": "NEXT_PUBLIC_STRIPE_DYNAMIC_PRICING", "set": false, "masked": null, "secret": false },
+		{ "key": "STRIPE_SPONSOR_WEEKLY_PRICE_ID", "set": false, "masked": null, "secret": false },
+		{ "key": "STRIPE_SPONSOR_MONTHLY_PRICE_ID", "set": false, "masked": null, "secret": false }
+	]
+}
+```
+
+`env` always lists **every** allow-listed key so a client can render the full
+form; `masked` is `***` for secrets and a 7-character prefix + `…` otherwise
+(short toggle/enum values such as `stripe` or `true` are shown verbatim).
+Plaintext is never returned.
+
+### Write (merge-patch)
+
+```http
+PUT /api/deploy/works/{workId}/runtime-env
+Content-Type: application/json
+
+{
+    "env": {
+        "NEXT_PUBLIC_PAYMENT_PROVIDER": "stripe",
+        "STRIPE_SECRET_KEY": "sk_live_…",
+        "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_live_…",
+        "STRIPE_WEBHOOK_SECRET": null
+    }
+}
+```
+
+- A body with **only `env`** leaves the database mode/URL untouched.
+- `mode` / `databaseUrl` keep their pre-existing behaviour and may be sent
+  together with `env` in one call.
+- Response: same shape as `GET` plus `message` (for example
+  `"Environment variables updated. Redeploy to apply them to the live site."`).
+- `400` for a non-allow-listed key, an over-long value, or a malformed body.
+
+### Dashboard
+
+**Work → Deploy → Database & environment → Environment variables**: one row
+per allow-listed key with the masked current value, an input, **Save**, and
+**Remove** (sends `null`). Secrets use a password field and are never echoed
+back.
+
+## Operational notes
+
+- **Rotation**: save the new value, then redeploy. Server-side deploys
+  re-apply the Secret on every deploy (server-side apply is idempotent); the
+  workflow path overwrites the repo secret.
+- **Removing a key** from the Work does not delete an already-pushed GitHub
+  repo secret (GitHub has no "unset on next deploy" semantics for a value we
+  no longer know about); delete it in the repo's _Settings → Secrets_ if the
+  leftover matters. The server-side k8s path rebuilds the Secret from scratch
+  each deploy, so removals take effect there on the next deploy.
+- **`PLATFORM_ENCRYPTION_KEY` missing** on the API: writes fail with a clear
+  error; deploys log `Runtime-env per-Work env lookup failed …` and proceed
+  without the vars.
+- **Audit**: every write logs an Activity Feed entry
+  (`work.runtime-env.updated`) with the changed key **names**; values are
+  never logged anywhere.

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -655,6 +655,16 @@ export class Work {
     @Column({ type: 'text', nullable: true })
     deployDatabaseMode?: 'shared' | 'custom' | null;
 
+    // AES-256-GCM-encrypted JSON map of the operator-managed, allow-listed
+    // per-Work runtime env (today: the Stripe payment keys the directory
+    // template reads — see `WORK_RUNTIME_ENV_ALLOWED_KEYS`). Managed by
+    // `WorkRuntimeEnvService.{get,set}RuntimeEnvVars`; merged into the
+    // `${slug}-runtime-env` k8s Secret on server-side deploys and pushed as
+    // GitHub Actions repo secrets on workflow deploys. NULL when no key is set.
+    // Same `text` + `nullable: true` shape as `deployDatabaseUrlEncrypted`.
+    @Column({ type: 'text', nullable: true })
+    deployRuntimeEnvEncrypted?: string | null;
+
     /**
      * EW-734 / EW-736 — globally-unique persisted managed subdomain claim.
      *

--- a/packages/agent/src/ever-works-providers/ever-works-db-provision.service.spec.ts
+++ b/packages/agent/src/ever-works-providers/ever-works-db-provision.service.spec.ts
@@ -1,0 +1,46 @@
+import { summarizeDbProvisionError } from './ever-works-db-provision.service';
+
+describe('summarizeDbProvisionError', () => {
+    it('maps Node network errno codes to a label + code and drops the host', () => {
+        const err = Object.assign(new Error('connect ECONNREFUSED 10.0.0.12:5432'), {
+            code: 'ECONNREFUSED',
+        });
+        const out = summarizeDbProvisionError(err);
+        expect(out).toBe('connection refused [ECONNREFUSED]');
+        expect(out).not.toContain('10.0.0.12');
+    });
+
+    it('maps Postgres SQLSTATEs (auth / privilege) without echoing the message', () => {
+        expect(
+            summarizeDbProvisionError(
+                Object.assign(new Error('password authentication failed for user "ewadmin"'), {
+                    code: '28P01',
+                }),
+            ),
+        ).toBe('password authentication failed [28P01]');
+        expect(
+            summarizeDbProvisionError(
+                Object.assign(new Error('permission denied to create database'), { code: '42501' }),
+            ),
+        ).toContain('[42501]');
+    });
+
+    it('falls back to the bare code, then to message classes, then to unknown', () => {
+        expect(summarizeDbProvisionError(Object.assign(new Error('x'), { code: 'XX000' }))).toBe(
+            'error code XX000',
+        );
+        expect(
+            summarizeDbProvisionError(new Error('Connection terminated due to connection timeout')),
+        ).toBe('connection timed out');
+        expect(
+            summarizeDbProvisionError(new Error('self signed certificate in certificate chain')),
+        ).toBe('TLS certificate rejected');
+        expect(
+            summarizeDbProvisionError(new Error('The server does not support SSL connections')),
+        ).toBe('TLS negotiation failed');
+        expect(summarizeDbProvisionError(new Error('something odd at db.internal'))).toBe(
+            'unknown error',
+        );
+        expect(summarizeDbProvisionError(null)).toBe('unknown error');
+    });
+});

--- a/packages/agent/src/ever-works-providers/ever-works-db-provision.service.ts
+++ b/packages/agent/src/ever-works-providers/ever-works-db-provision.service.ts
@@ -28,6 +28,42 @@ import { WorkRuntimeEnvService } from '../services/work-runtime-env.service';
  * role owns the database it can create the `drizzle`/`public` schema objects
  * that migrate-on-boot needs.
  */
+
+/**
+ * Turn a shared-DB provisioning failure into a short, operator-actionable token
+ * that is SAFE to return to an API caller: only the Postgres SQLSTATE / Node
+ * errno class plus a generic label — never the raw error message, which can
+ * embed the admin connection's host, user or database name.
+ */
+export function summarizeDbProvisionError(error: unknown): string {
+    const rawCode = (error as { code?: unknown } | null | undefined)?.code;
+    const code = typeof rawCode === 'string' ? rawCode : '';
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    const labels: Record<string, string> = {
+        ECONNREFUSED: 'connection refused',
+        ECONNRESET: 'connection reset',
+        ETIMEDOUT: 'connection timed out',
+        ENOTFOUND: 'host not found',
+        EAI_AGAIN: 'DNS lookup failed',
+        EHOSTUNREACH: 'host unreachable',
+        ENETUNREACH: 'network unreachable',
+        '28P01': 'password authentication failed',
+        '28000': 'authentication failed',
+        '42501': 'insufficient privilege (admin role cannot CREATE ROLE / CREATE DATABASE)',
+        '3D000': 'admin database does not exist',
+        '53300': 'too many connections',
+        '57P03': 'server not accepting connections',
+        '08001': 'could not connect',
+        '08006': 'connection failure',
+    };
+    if (code && labels[code]) return `${labels[code]} [${code}]`;
+    if (code) return `error code ${code}`;
+    if (/timeout/i.test(message)) return 'connection timed out';
+    if (/self[- ]signed|certificate/i.test(message)) return 'TLS certificate rejected';
+    if (/\bssl\b|\btls\b/i.test(message)) return 'TLS negotiation failed';
+    return 'unknown error';
+}
+
 @Injectable()
 export class EverWorksDbProvisionService {
     private readonly logger = new Logger(EverWorksDbProvisionService.name);

--- a/packages/agent/src/ever-works-providers/index.ts
+++ b/packages/agent/src/ever-works-providers/index.ts
@@ -22,4 +22,7 @@ export {
     type DnsRecordSnapshot,
 } from './cloudflare-dns.provider';
 export { SubdomainAllocator, type SubdomainAllocationResult } from './subdomain-allocator.service';
-export { EverWorksDbProvisionService } from './ever-works-db-provision.service';
+export {
+    EverWorksDbProvisionService,
+    summarizeDbProvisionError,
+} from './ever-works-db-provision.service';

--- a/packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts
+++ b/packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts
@@ -1,5 +1,6 @@
 import { PipelineOrchestratorService } from './pipeline-orchestrator.service';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { createLazyPluginProxy } from '../plugins/services/lazy-plugin-proxy';
 
 describe('PipelineOrchestratorService', () => {
     let stepExecutor: any;
@@ -150,6 +151,93 @@ describe('PipelineOrchestratorService', () => {
                 undefined,
             );
             expect(stepExecutor.execute).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('lazy plugin stubs (PLUGIN_LAZY_LOAD default)', () => {
+        const work = { id: 'w1', user: { id: 'u1' } } as any;
+        const existing = { items: [] } as any;
+
+        /** A real lazy proxy (what the registry holds before first use) around `real`. */
+        function makeLazyStub(id: string, real: any, loader = jest.fn(async () => real)) {
+            const manifest: any = {
+                id,
+                name: id,
+                version: '1.0.0',
+                category: 'pipeline',
+                capabilities: ['pipeline'],
+            };
+            return { stub: createLazyPluginProxy(manifest, loader), loader };
+        }
+
+        it('materialises the stub before routing so a self-managed pipeline is NOT misrouted to step mode', async () => {
+            // Before the fix the stub answered `executeStep`/`registerStepExecutor` with
+            // forwarding functions, `isStepOrchestratablePipeline()` said "step", and the
+            // step executor then died on `plugin.createContext()` (agent-pipeline: "has no
+            // method createContext"; standard-pipeline: createContext() returned a Promise so
+            // `context.work` was undefined). That was every generation run on the Trigger worker.
+            const real = makePlugin('agent-pipeline', { stepOrchestratable: false });
+            const { stub, loader } = makeLazyStub('agent-pipeline', real);
+            registry.get.mockImplementation((id: string) =>
+                id === 'agent-pipeline' ? makeRegistered(stub) : null,
+            );
+
+            await service.execute(
+                work,
+                { providers: { pipeline: 'agent-pipeline' } } as any,
+                existing,
+            );
+
+            expect(loader).toHaveBeenCalledTimes(1);
+            expect(fullExecutor.execute).toHaveBeenCalledWith(
+                real,
+                work,
+                expect.any(Object),
+                existing,
+                undefined,
+                undefined,
+            );
+            expect(stepExecutor.execute).not.toHaveBeenCalled();
+        });
+
+        it('hands the REAL step-orchestratable plugin (not the stub) to the step executor', async () => {
+            const real = makePlugin('standard', { stepOrchestratable: true });
+            const { stub } = makeLazyStub('standard', real);
+            registry.getByCapability.mockReturnValue([
+                makeRegistered(stub, { defaultForCapabilities: ['pipeline'] }),
+            ]);
+
+            await service.execute(work, { providers: { pipeline: undefined } } as any, existing);
+
+            expect(stepExecutor.execute).toHaveBeenCalledWith(
+                real,
+                work,
+                expect.any(Object),
+                existing,
+                undefined,
+                undefined,
+            );
+        });
+
+        it('getRecommendedMode / hasFullPipelinePlugin probe the materialised plugin surface', async () => {
+            const real = makePlugin('claude-code', { stepOrchestratable: false });
+            const { stub } = makeLazyStub('claude-code', real);
+            registry.getByCapability.mockReturnValue([makeRegistered(stub)]);
+
+            await expect(service.hasFullPipelinePlugin()).resolves.toBe(true);
+            await expect(service.getRecommendedMode()).resolves.toMatchObject({
+                mode: 'full',
+                plugin: 'claude-code',
+            });
+        });
+
+        it('passes real (already materialised / eager) plugins through untouched', async () => {
+            const plugin = makePlugin('standard', { stepOrchestratable: true });
+            registry.getByCapability.mockReturnValue([
+                makeRegistered(plugin, { defaultForCapabilities: ['pipeline'] }),
+            ]);
+            await service.execute(work, { providers: { pipeline: undefined } } as any, existing);
+            expect(stepExecutor.execute.mock.calls[0][0]).toBe(plugin);
         });
     });
 

--- a/packages/agent/src/pipeline/pipeline-orchestrator.service.ts
+++ b/packages/agent/src/pipeline/pipeline-orchestrator.service.ts
@@ -76,7 +76,7 @@ export class PipelineOrchestratorService {
 
         if (mode === 'full') {
             // Find a self-managed (non-step-orchestratable) pipeline plugin
-            const fullPlugin = this.getAvailablePipelinePlugins().find(
+            const fullPlugin = (await this.getMaterializedPipelinePlugins()).find(
                 (p) => !isStepOrchestratablePipeline(p),
             );
             if (fullPlugin) {
@@ -108,7 +108,7 @@ export class PipelineOrchestratorService {
         plugin?: string;
     }> {
         // Check if any self-managed (non-step-orchestratable) pipeline is available
-        const fullPlugin = this.getAvailablePipelinePlugins().find(
+        const fullPlugin = (await this.getMaterializedPipelinePlugins()).find(
             (p) => !isStepOrchestratablePipeline(p),
         );
         if (fullPlugin) {
@@ -126,7 +126,37 @@ export class PipelineOrchestratorService {
     }
 
     async hasFullPipelinePlugin(): Promise<boolean> {
-        return this.getAvailablePipelinePlugins().some((p) => !isStepOrchestratablePipeline(p));
+        return (await this.getMaterializedPipelinePlugins()).some(
+            (p) => !isStepOrchestratablePipeline(p),
+        );
+    }
+
+    /**
+     * Same as {@link getAvailablePipelinePlugins} but with every lazy stub
+     * materialised, so capability probes (`isStepOrchestratablePipeline`) see
+     * the real plugin surface.
+     */
+    private async getMaterializedPipelinePlugins(): Promise<IPipelinePlugin[]> {
+        return Promise.all(this.getAvailablePipelinePlugins().map((p) => this.materialize(p)));
+    }
+
+    /**
+     * Lazy-mode registries (`PLUGIN_LAZY_LOAD`, the default) hand out proxies
+     * that answer EVERY property with an async forwarding function until the
+     * real module has been imported. On such a stub capability probes like
+     * `isStepOrchestratablePipeline()` are meaningless (every method "exists")
+     * and the pipeline contract's synchronous calls — `createContext()`,
+     * `getStepDefinitions()`, `getState()` — come back as Promises. The
+     * orchestrator always *executes* the pipeline it resolves (never just
+     * inspects it), so materialising here costs nothing extra and restores the
+     * real plugin surface for routing + execution. No-op for eager/real plugins.
+     */
+    private async materialize(plugin: IPipelinePlugin): Promise<IPipelinePlugin> {
+        const stub = plugin as unknown as { __materialize?: () => Promise<unknown> };
+        if (typeof stub.__materialize === 'function') {
+            return (await stub.__materialize()) as IPipelinePlugin;
+        }
+        return plugin;
     }
 
     getAvailablePipelinePlugins(): IPipelinePlugin[] {
@@ -218,7 +248,7 @@ export class PipelineOrchestratorService {
                     userId,
                 );
                 if (isEnabled) {
-                    return registered.plugin;
+                    return this.materialize(registered.plugin);
                 }
             }
             this.logger.warn(
@@ -240,7 +270,7 @@ export class PipelineOrchestratorService {
                 workId,
                 userId,
             );
-            if (isEnabled) return registered.plugin;
+            if (isEnabled) return this.materialize(registered.plugin);
         }
 
         // Fallback: first loaded and enabled pipeline
@@ -252,7 +282,7 @@ export class PipelineOrchestratorService {
                 workId,
                 userId,
             );
-            if (isEnabled) return registered.plugin;
+            if (isEnabled) return this.materialize(registered.plugin);
         }
 
         throw new Error(

--- a/packages/agent/src/pipeline/step-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/step-pipeline-executor.service.ts
@@ -199,7 +199,11 @@ export class StepPipelineExecutorService {
                 `Pipeline plugin "${plugin.id}" must implement createContext() for engine-orchestrated execution.`,
             );
         }
-        const context = plugin.createContext(work, request, existing);
+        // `await` is deliberate: a lazy plugin stub (PLUGIN_LAZY_LOAD) answers
+        // every call with a Promise; the orchestrator materialises before
+        // routing, but a caller wiring the executor directly must not end up
+        // with `context.work === undefined` (TypeError at the first `work.id`).
+        const context = await plugin.createContext(work, request, existing);
 
         // Attach log interceptor to capture ALL plugin logger output
         const onLogEntry = options?.onLogEntry;

--- a/packages/agent/src/plugins/services/index.ts
+++ b/packages/agent/src/plugins/services/index.ts
@@ -5,6 +5,7 @@ export * from './plugin-manifest-validator.service';
 export * from './plugin-version-checker.service';
 export * from './plugin-class-validator.service';
 export * from './plugin-lifecycle-manager.service';
+export * from './plugin-secret-enc.service';
 export * from './plugin-settings.service';
 export * from './plugin-context-factory.service';
 export * from './custom-capability-registry.service';

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -25,6 +25,7 @@ export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
 export * from './webhook-secret.service';
 export * from './work-runtime-env.service';
+export * from './work-runtime-env.constants';
 export * from './webhook-subscription-secret.service';
 export * from './zero-friction-funnel.service';
 export * from './deploy-ready-poller.service';

--- a/packages/agent/src/services/work-runtime-env.constants.ts
+++ b/packages/agent/src/services/work-runtime-env.constants.ts
@@ -1,0 +1,84 @@
+/**
+ * Allow-list for the operator-managed, per-Work **application runtime env**
+ * that a deployed directory site reads at runtime — today the Stripe payment
+ * configuration the `directory-web-template` consumes via `process.env`.
+ *
+ * These keys are the ONLY ones `WorkRuntimeEnvService.setRuntimeEnvVars`
+ * accepts; anything else is rejected with a 400. The platform-managed keys
+ * (`AUTH_SECRET`, `COOKIE_SECRET`, `DATABASE_URL`, `GH_TOKEN`,
+ * `DATA_REPOSITORY`, `TENANT_ID`, `SITE_URL`, `PLATFORM_*`, …) are minted by
+ * their own code paths in `DeployService` / `WorkRuntimeEnvService` and are
+ * deliberately NOT listed here so a dashboard user can never override them.
+ *
+ * Values are persisted AES-256-GCM-encrypted on `works.deployRuntimeEnvEncrypted`
+ * (a single JSON map) and delivered on every deploy:
+ *  - server-side managed k8s deploys: merged into the `${slug}-runtime-env`
+ *    Secret the platform applies (`DeployService.collectServerSideRuntimeEnv`);
+ *  - workflow deploys: pushed as GitHub Actions repo secrets so
+ *    `deploy_k8s.yaml` / the Vercel workflows can forward them.
+ *
+ * Keep this list small and intentional — every entry is something the
+ * deployed site actually reads. See `docs/runbooks/WORK_RUNTIME_ENV.md`.
+ */
+export const WORK_RUNTIME_ENV_ALLOWED_KEYS = [
+    'NEXT_PUBLIC_PAYMENT_PROVIDER',
+    'STRIPE_SECRET_KEY',
+    'STRIPE_PUBLISHABLE_KEY',
+    'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+    'STRIPE_WEBHOOK_SECRET',
+    'NEXT_PUBLIC_STRIPE_DYNAMIC_PRICING',
+    'STRIPE_SPONSOR_WEEKLY_PRICE_ID',
+    'STRIPE_SPONSOR_MONTHLY_PRICE_ID',
+] as const;
+
+export type WorkRuntimeEnvKey = (typeof WORK_RUNTIME_ENV_ALLOWED_KEYS)[number];
+
+/**
+ * Subset of the allow-list whose values are credentials. They are never
+ * echoed back by the API — `describeRuntimeEnvVars` masks them to `***`
+ * (non-secret keys are shown as a short prefix so an operator can tell
+ * which key is configured without leaking it).
+ */
+export const WORK_RUNTIME_ENV_SECRET_KEYS: ReadonlySet<WorkRuntimeEnvKey> =
+    new Set<WorkRuntimeEnvKey>(['STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET']);
+
+/** Upper bound on a single stored value (trimmed). */
+export const WORK_RUNTIME_ENV_MAX_VALUE_LENGTH = 4096;
+
+/** Visible prefix length for a non-secret value in the masked API view. */
+export const WORK_RUNTIME_ENV_MASK_PREFIX_LENGTH = 7;
+
+/** What the API returns per allow-listed key (values are never plaintext). */
+export interface WorkRuntimeEnvVarState {
+    key: WorkRuntimeEnvKey;
+    /** Whether a value is currently stored for this key. */
+    set: boolean;
+    /** Masked preview (`***` for secrets, short prefix otherwise); null when unset. */
+    masked: string | null;
+    /** True for credential keys that are always fully masked. */
+    secret: boolean;
+}
+
+export function isWorkRuntimeEnvKey(key: string): key is WorkRuntimeEnvKey {
+    return (WORK_RUNTIME_ENV_ALLOWED_KEYS as readonly string[]).includes(key);
+}
+
+export function isWorkRuntimeEnvSecretKey(key: string): boolean {
+    return isWorkRuntimeEnvKey(key) && WORK_RUNTIME_ENV_SECRET_KEYS.has(key);
+}
+
+/**
+ * Mask a stored value for display. Secrets collapse to `***`; non-secret
+ * values keep a short prefix (`pk_live…`, `price_1…`) so an operator can
+ * recognise what is configured. Short non-secret values (`stripe`, `true`)
+ * are returned verbatim — there is nothing to hide in a feature toggle.
+ */
+export function maskWorkRuntimeEnvValue(key: string, value: string): string {
+    if (isWorkRuntimeEnvSecretKey(key)) {
+        return '***';
+    }
+    if (value.length <= WORK_RUNTIME_ENV_MASK_PREFIX_LENGTH) {
+        return value;
+    }
+    return `${value.slice(0, WORK_RUNTIME_ENV_MASK_PREFIX_LENGTH)}…`;
+}

--- a/packages/agent/src/services/work-runtime-env.service.spec.ts
+++ b/packages/agent/src/services/work-runtime-env.service.spec.ts
@@ -1,0 +1,343 @@
+import { BadRequestException } from '@nestjs/common';
+import { WorkRuntimeEnvService } from './work-runtime-env.service';
+import {
+    WORK_RUNTIME_ENV_ALLOWED_KEYS,
+    WORK_RUNTIME_ENV_MAX_VALUE_LENGTH,
+    WORK_RUNTIME_ENV_SECRET_KEYS,
+    maskWorkRuntimeEnvValue,
+} from './work-runtime-env.constants';
+
+/**
+ * Allow-listed per-Work runtime env (Stripe keys & co.) — the operator-managed
+ * map stored encrypted on `works.deployRuntimeEnvEncrypted`.
+ *
+ * Covers: allow-list rejection (nothing written), merge / overwrite / remove
+ * semantics, trimming + length cap, AES-256-GCM round-trip through the real
+ * encrypt/decrypt helpers, and the masked API view.
+ */
+describe('WorkRuntimeEnvService — allow-listed per-Work env vars', () => {
+    const ORIGINAL_KEY = process.env.PLATFORM_ENCRYPTION_KEY;
+    // 32 bytes, hex-encoded — what the service expects for AES-256-GCM.
+    const TEST_KEY_HEX = 'ab'.repeat(32);
+
+    type StoredWork = {
+        id: string;
+        deployRuntimeEnvEncrypted: string | null;
+        deployAuthSecretEncrypted?: string | null;
+        deployCookieSecretEncrypted?: string | null;
+        deployDatabaseUrlEncrypted?: string | null;
+        deployDatabaseMode?: 'shared' | 'custom' | null;
+    };
+
+    let work: StoredWork;
+    let workRepository: {
+        findById: jest.Mock;
+        update: jest.Mock;
+    };
+    let service: WorkRuntimeEnvService;
+
+    beforeEach(() => {
+        process.env.PLATFORM_ENCRYPTION_KEY = TEST_KEY_HEX;
+        work = { id: 'work-1', deployRuntimeEnvEncrypted: null };
+        workRepository = {
+            findById: jest.fn(async (id: string) => (id === work.id ? { ...work } : null)),
+            update: jest.fn(async (_id: string, patch: Partial<StoredWork>) => {
+                Object.assign(work, patch);
+                return { ...work };
+            }),
+        };
+        service = new WorkRuntimeEnvService(workRepository as never);
+    });
+
+    afterEach(() => {
+        if (ORIGINAL_KEY === undefined) {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+        } else {
+            process.env.PLATFORM_ENCRYPTION_KEY = ORIGINAL_KEY;
+        }
+        jest.restoreAllMocks();
+    });
+
+    describe('allow-list', () => {
+        it('exposes the allow-list in display order', () => {
+            expect(service.getAllowedEnvKeys()).toEqual(WORK_RUNTIME_ENV_ALLOWED_KEYS);
+            expect(WORK_RUNTIME_ENV_ALLOWED_KEYS).toEqual(
+                expect.arrayContaining([
+                    'STRIPE_SECRET_KEY',
+                    'STRIPE_PUBLISHABLE_KEY',
+                    'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+                    'STRIPE_WEBHOOK_SECRET',
+                    'NEXT_PUBLIC_STRIPE_DYNAMIC_PRICING',
+                    'STRIPE_SPONSOR_WEEKLY_PRICE_ID',
+                    'STRIPE_SPONSOR_MONTHLY_PRICE_ID',
+                    'NEXT_PUBLIC_PAYMENT_PROVIDER',
+                ]),
+            );
+        });
+
+        it('never allow-lists the platform-managed keys', () => {
+            for (const managed of [
+                'AUTH_SECRET',
+                'COOKIE_SECRET',
+                'DATABASE_URL',
+                'GH_TOKEN',
+                'DATA_REPOSITORY',
+                'TENANT_ID',
+                'WORK_ID',
+                'SITE_URL',
+                'PLATFORM_API_SECRET_TOKEN',
+            ]) {
+                expect(WORK_RUNTIME_ENV_ALLOWED_KEYS as readonly string[]).not.toContain(managed);
+            }
+        });
+
+        it('rejects keys outside the allow-list with a 400 and writes nothing', async () => {
+            await expect(
+                service.setRuntimeEnvVars('work-1', {
+                    STRIPE_SECRET_KEY: 'sk_live_abc',
+                    DATABASE_URL: 'postgres://evil',
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(service.setRuntimeEnvVars('work-1', { AUTH_SECRET: 'x' })).rejects.toThrow(
+                /Unsupported runtime env key\(s\): AUTH_SECRET/,
+            );
+            // The whole call is rejected atomically — the valid key was NOT written.
+            expect(workRepository.update).not.toHaveBeenCalled();
+            expect(work.deployRuntimeEnvEncrypted).toBeNull();
+        });
+
+        it('rejects non-string values', async () => {
+            await expect(
+                service.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: 42 as never }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(workRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('throws when the Work does not exist', async () => {
+            await expect(
+                service.setRuntimeEnvVars('missing', { STRIPE_SECRET_KEY: 'sk' }),
+            ).rejects.toThrow(/Work not found/);
+        });
+    });
+
+    describe('merge / remove semantics', () => {
+        it('returns an empty map when nothing is configured', async () => {
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({});
+            await expect(service.getRuntimeEnvVars('missing')).resolves.toEqual({});
+        });
+
+        it('provided keys overwrite, untouched keys persist, and null/empty removes', async () => {
+            await service.setRuntimeEnvVars('work-1', {
+                STRIPE_SECRET_KEY: 'sk_live_one',
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            });
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+                STRIPE_SECRET_KEY: 'sk_live_one',
+            });
+
+            // Overwrite one key; the other survives.
+            const afterOverwrite = await service.setRuntimeEnvVars('work-1', {
+                STRIPE_SECRET_KEY: 'sk_live_two',
+            });
+            expect(afterOverwrite).toEqual({
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+                STRIPE_SECRET_KEY: 'sk_live_two',
+            });
+
+            // null removes; '' / whitespace-only remove too.
+            await service.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: null });
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            });
+            await service.setRuntimeEnvVars('work-1', { NEXT_PUBLIC_PAYMENT_PROVIDER: '   ' });
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({});
+            // Removing the last key clears the column entirely (NULL, not an
+            // encrypted "{}").
+            expect(work.deployRuntimeEnvEncrypted).toBeNull();
+        });
+
+        it('removing a key that was never set is a no-op', async () => {
+            const result = await service.setRuntimeEnvVars('work-1', {
+                STRIPE_WEBHOOK_SECRET: null,
+            });
+            expect(result).toEqual({});
+            expect(work.deployRuntimeEnvEncrypted).toBeNull();
+        });
+
+        it('trims values and enforces the maximum length', async () => {
+            await service.setRuntimeEnvVars('work-1', {
+                STRIPE_PUBLISHABLE_KEY: '  pk_live_trimmed  ',
+            });
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({
+                STRIPE_PUBLISHABLE_KEY: 'pk_live_trimmed',
+            });
+
+            const tooLong = 'x'.repeat(WORK_RUNTIME_ENV_MAX_VALUE_LENGTH + 1);
+            await expect(
+                service.setRuntimeEnvVars('work-1', { STRIPE_PUBLISHABLE_KEY: tooLong }),
+            ).rejects.toThrow(/exceeds the maximum length/);
+            // Exactly the cap is fine.
+            const atCap = 'y'.repeat(WORK_RUNTIME_ENV_MAX_VALUE_LENGTH);
+            await service.setRuntimeEnvVars('work-1', { STRIPE_PUBLISHABLE_KEY: atCap });
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({
+                STRIPE_PUBLISHABLE_KEY: atCap,
+            });
+        });
+
+        it('rejects values containing control characters (e.g. a stray newline)', async () => {
+            const withNewline = 'sk_live_abc' + String.fromCharCode(10) + 'def';
+            await expect(
+                service.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: withNewline }),
+            ).rejects.toThrow(/control characters/);
+            expect(workRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('persists keys in allow-list order regardless of input order', async () => {
+            await service.setRuntimeEnvVars('work-1', {
+                STRIPE_SPONSOR_MONTHLY_PRICE_ID: 'price_m',
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+                STRIPE_SECRET_KEY: 'sk',
+            });
+            const keys = Object.keys(await service.getRuntimeEnvVars('work-1'));
+            expect(keys).toEqual([
+                'NEXT_PUBLIC_PAYMENT_PROVIDER',
+                'STRIPE_SECRET_KEY',
+                'STRIPE_SPONSOR_MONTHLY_PRICE_ID',
+            ]);
+        });
+    });
+
+    describe('encryption round-trip', () => {
+        it('stores ciphertext (not plaintext) and decrypts back to the same map', async () => {
+            await service.setRuntimeEnvVars('work-1', {
+                STRIPE_SECRET_KEY: 'sk_live_supersecret',
+                STRIPE_WEBHOOK_SECRET: 'whsec_123',
+            });
+            const stored = work.deployRuntimeEnvEncrypted as string;
+            expect(stored).toBeTruthy();
+            expect(stored).not.toContain('sk_live_supersecret');
+            expect(stored).not.toContain('whsec_123');
+            expect(stored).not.toContain('STRIPE_SECRET_KEY');
+            // base64 envelope: iv(12) + tag(16) + ciphertext
+            expect(Buffer.from(stored, 'base64').length).toBeGreaterThan(12 + 16);
+
+            // A fresh service instance (cold key cache) decrypts it.
+            const fresh = new WorkRuntimeEnvService(workRepository as never);
+            await expect(fresh.getRuntimeEnvVars('work-1')).resolves.toEqual({
+                STRIPE_SECRET_KEY: 'sk_live_supersecret',
+                STRIPE_WEBHOOK_SECRET: 'whsec_123',
+            });
+        });
+
+        it('uses a random IV — re-encrypting the same map yields a different envelope', async () => {
+            await service.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: 'sk' });
+            const first = work.deployRuntimeEnvEncrypted;
+            await service.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: 'sk' });
+            const second = work.deployRuntimeEnvEncrypted;
+            expect(first).toBeTruthy();
+            expect(second).toBeTruthy();
+            expect(first).not.toBe(second);
+        });
+
+        it('drops keys that are no longer allow-listed when reading a stored map', async () => {
+            // Simulate a legacy envelope that carries an extra key: encrypt
+            // through the service's own helper so the envelope is valid.
+            const encrypt = (service as unknown as { encrypt: (s: string) => string }).encrypt.bind(
+                service,
+            );
+            work.deployRuntimeEnvEncrypted = encrypt(
+                JSON.stringify({
+                    STRIPE_SECRET_KEY: 'sk',
+                    DATABASE_URL: 'postgres://should-not-leak',
+                    NOT_A_KEY: 1,
+                }),
+            );
+            await expect(service.getRuntimeEnvVars('work-1')).resolves.toEqual({
+                STRIPE_SECRET_KEY: 'sk',
+            });
+        });
+
+        it('fails loudly (not silently) on a tampered envelope', async () => {
+            await service.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: 'sk' });
+            const buf = Buffer.from(work.deployRuntimeEnvEncrypted as string, 'base64');
+            buf[buf.length - 1] ^= 0xff; // flip a ciphertext byte
+            work.deployRuntimeEnvEncrypted = buf.toString('base64');
+            jest.spyOn(
+                (service as unknown as { logger: { error: (...a: unknown[]) => void } }).logger,
+                'error',
+            ).mockImplementation(() => {});
+            await expect(service.getRuntimeEnvVars('work-1')).rejects.toThrow(/malformed/);
+        });
+
+        it('refuses to encrypt without PLATFORM_ENCRYPTION_KEY', async () => {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+            const noKey = new WorkRuntimeEnvService(workRepository as never);
+            await expect(
+                noKey.setRuntimeEnvVars('work-1', { STRIPE_SECRET_KEY: 'sk' }),
+            ).rejects.toThrow(/PLATFORM_ENCRYPTION_KEY is not set/);
+            expect(work.deployRuntimeEnvEncrypted).toBeNull();
+        });
+    });
+
+    describe('masked API view', () => {
+        it('lists every allow-listed key, unset ones as { set:false, masked:null }', async () => {
+            const view = await service.describeRuntimeEnvVars('work-1');
+            expect(view.map((v) => v.key)).toEqual([...WORK_RUNTIME_ENV_ALLOWED_KEYS]);
+            for (const entry of view) {
+                expect(entry.set).toBe(false);
+                expect(entry.masked).toBeNull();
+                expect(entry.secret).toBe(WORK_RUNTIME_ENV_SECRET_KEYS.has(entry.key));
+            }
+        });
+
+        it('masks secrets to *** and non-secrets to a short prefix', async () => {
+            await service.setRuntimeEnvVars('work-1', {
+                STRIPE_SECRET_KEY: 'sk_live_1234567890',
+                STRIPE_WEBHOOK_SECRET: 'whsec_abcdefghij',
+                NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_live_1234567890',
+                NEXT_PUBLIC_PAYMENT_PROVIDER: 'stripe',
+            });
+            const view = await service.describeRuntimeEnvVars('work-1');
+            const byKey = Object.fromEntries(view.map((v) => [v.key, v]));
+
+            expect(byKey.STRIPE_SECRET_KEY).toEqual({
+                key: 'STRIPE_SECRET_KEY',
+                set: true,
+                masked: '***',
+                secret: true,
+            });
+            expect(byKey.STRIPE_WEBHOOK_SECRET.masked).toBe('***');
+            expect(byKey.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY).toEqual({
+                key: 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+                set: true,
+                masked: 'pk_live…',
+                secret: false,
+            });
+            // Short non-secret toggles/enum values are shown verbatim.
+            expect(byKey.NEXT_PUBLIC_PAYMENT_PROVIDER.masked).toBe('stripe');
+            expect(byKey.STRIPE_PUBLISHABLE_KEY).toEqual({
+                key: 'STRIPE_PUBLISHABLE_KEY',
+                set: false,
+                masked: null,
+                secret: false,
+            });
+
+            // Never the plaintext.
+            const serialized = JSON.stringify(view);
+            expect(serialized).not.toContain('sk_live_1234567890');
+            expect(serialized).not.toContain('whsec_abcdefghij');
+            expect(serialized).not.toContain('pk_live_1234567890');
+        });
+
+        it('maskWorkRuntimeEnvValue helper matches the service view', () => {
+            expect(maskWorkRuntimeEnvValue('STRIPE_SECRET_KEY', 'sk_live_x')).toBe('***');
+            expect(maskWorkRuntimeEnvValue('STRIPE_SPONSOR_WEEKLY_PRICE_ID', 'price_1Hxyz')).toBe(
+                'price_1…',
+            );
+            expect(maskWorkRuntimeEnvValue('NEXT_PUBLIC_STRIPE_DYNAMIC_PRICING', 'true')).toBe(
+                'true',
+            );
+        });
+    });
+});

--- a/packages/agent/src/services/work-runtime-env.service.ts
+++ b/packages/agent/src/services/work-runtime-env.service.ts
@@ -1,8 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { config } from '../config';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { Work } from '../entities/work.entity';
+import {
+    WORK_RUNTIME_ENV_ALLOWED_KEYS,
+    WORK_RUNTIME_ENV_MAX_VALUE_LENGTH,
+    isWorkRuntimeEnvKey,
+    isWorkRuntimeEnvSecretKey,
+    maskWorkRuntimeEnvValue,
+    type WorkRuntimeEnvKey,
+    type WorkRuntimeEnvVarState,
+} from './work-runtime-env.constants';
 
 const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH_BYTES = 32;
@@ -107,6 +116,138 @@ export class WorkRuntimeEnvService {
     /** Set the Work's DB mode. */
     async setDatabaseMode(workId: string, mode: 'shared' | 'custom'): Promise<void> {
         await this.workRepository.setDeployDatabaseMode(workId, mode);
+    }
+
+    // ------------------------------------------------------------------
+    // Operator-managed, allow-listed per-Work env (Stripe keys & co.)
+    // ------------------------------------------------------------------
+
+    /** The keys a dashboard user may set via `setRuntimeEnvVars`, in display order. */
+    getAllowedEnvKeys(): readonly WorkRuntimeEnvKey[] {
+        return WORK_RUNTIME_ENV_ALLOWED_KEYS;
+    }
+
+    /**
+     * The decrypted per-Work env map (allow-listed keys only). Empty when the
+     * Work has none configured. Used by `DeployService` to merge the values
+     * into the k8s runtime-env Secret / push them as GitHub Actions secrets.
+     *
+     * Defensive on read: keys that are no longer allow-listed (e.g. after the
+     * list shrinks) or whose stored value is not a string are dropped rather
+     * than delivered, so the allow-list stays the single source of truth.
+     */
+    async getRuntimeEnvVars(workId: string): Promise<Record<string, string>> {
+        const work = await this.workRepository.findById(workId);
+        return this.decodeRuntimeEnvVars(work?.deployRuntimeEnvEncrypted);
+    }
+
+    /**
+     * Merge-update the per-Work env map and persist it encrypted.
+     *
+     * Semantics: every provided key overwrites the stored value; `null`,
+     * `undefined` or an empty/whitespace-only string REMOVES the key; keys not
+     * mentioned are left untouched. Values are trimmed and capped at
+     * `WORK_RUNTIME_ENV_MAX_VALUE_LENGTH`. Any key outside
+     * `WORK_RUNTIME_ENV_ALLOWED_KEYS` rejects the whole call with a 400 —
+     * nothing is written in that case, so a typo cannot half-apply.
+     *
+     * Returns the resulting (plaintext) map. Read-modify-write without a row
+     * lock: concurrent PUTs for the same Work are last-writer-wins, which is
+     * acceptable for an operator-driven settings form.
+     */
+    async setRuntimeEnvVars(
+        workId: string,
+        vars: Record<string, string | null | undefined>,
+    ): Promise<Record<string, string>> {
+        const existing = await this.workRepository.findById(workId);
+        if (!existing) {
+            throw new Error(`Work not found: ${workId}`);
+        }
+        const entries = Object.entries(vars ?? {});
+        const unknown = entries.map(([key]) => key).filter((key) => !isWorkRuntimeEnvKey(key));
+        if (unknown.length > 0) {
+            throw new BadRequestException(
+                `Unsupported runtime env key(s): ${unknown.join(', ')}. Allowed keys: ${WORK_RUNTIME_ENV_ALLOWED_KEYS.join(', ')}.`,
+            );
+        }
+
+        const next = this.decodeRuntimeEnvVars(existing.deployRuntimeEnvEncrypted);
+        for (const [key, raw] of entries) {
+            if (raw === null || raw === undefined) {
+                delete next[key];
+                continue;
+            }
+            if (typeof raw !== 'string') {
+                throw new BadRequestException(`${key} must be a string (or null to remove it).`);
+            }
+            const value = raw.trim();
+            if (!value) {
+                delete next[key];
+                continue;
+            }
+            if (value.length > WORK_RUNTIME_ENV_MAX_VALUE_LENGTH) {
+                throw new BadRequestException(
+                    `${key} exceeds the maximum length of ${WORK_RUNTIME_ENV_MAX_VALUE_LENGTH} characters.`,
+                );
+            }
+            // eslint-disable-next-line no-control-regex
+            if (/[\u0000-\u001f\u007f]/.test(value)) {
+                throw new BadRequestException(`${key} must not contain control characters.`);
+            }
+            next[key] = value;
+        }
+
+        // Persist in allow-list order so the stored JSON is deterministic.
+        const ordered: Record<string, string> = {};
+        for (const key of WORK_RUNTIME_ENV_ALLOWED_KEYS) {
+            if (next[key] !== undefined) ordered[key] = next[key];
+        }
+        await this.workRepository.update(workId, {
+            deployRuntimeEnvEncrypted:
+                Object.keys(ordered).length > 0 ? this.encrypt(JSON.stringify(ordered)) : null,
+        });
+        return ordered;
+    }
+
+    /**
+     * Masked, API-safe view of the per-Work env: one entry per allow-listed
+     * key (so the dashboard can render the whole form), never a plaintext
+     * value. Secrets collapse to `***`; non-secret values keep a short prefix.
+     */
+    async describeRuntimeEnvVars(workId: string): Promise<WorkRuntimeEnvVarState[]> {
+        const vars = await this.getRuntimeEnvVars(workId);
+        return WORK_RUNTIME_ENV_ALLOWED_KEYS.map((key) => {
+            const value = vars[key];
+            return {
+                key,
+                set: value !== undefined,
+                masked: value !== undefined ? maskWorkRuntimeEnvValue(key, value) : null,
+                secret: isWorkRuntimeEnvSecretKey(key),
+            };
+        });
+    }
+
+    /** Decrypt + parse the stored JSON map, keeping only allow-listed string values. */
+    private decodeRuntimeEnvVars(envelope: string | null | undefined): Record<string, string> {
+        if (!envelope) {
+            return {};
+        }
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(this.decrypt(envelope));
+        } catch (err) {
+            this.logger.error('Failed to decode per-Work runtime env map', err);
+            throw new Error('deploy runtime-env map is malformed.');
+        }
+        const out: Record<string, string> = {};
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+                if (isWorkRuntimeEnvKey(key) && typeof value === 'string' && value.length > 0) {
+                    out[key] = value;
+                }
+            }
+        }
+        return out;
     }
 
     /**

--- a/packages/tasks/src/trigger/worker/modules/trigger-plugins.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-plugins.module.ts
@@ -13,6 +13,7 @@ import {
     PluginVersionCheckerService,
     PluginClassValidatorService,
     PluginLifecycleManagerService,
+    PluginSecretEncService,
     PluginSettingsService,
     PluginContextFactoryService,
     CustomCapabilityRegistryService,
@@ -79,6 +80,15 @@ export class TriggerPluginsModule {
                 PluginRegistryService,
                 PluginLoaderService,
                 PluginLifecycleManagerService,
+                // C-08: plugin secrets (API keys & co.) are stored AES-GCM-encrypted
+                // (`enc::v1::…`). PluginSettingsService takes this service as an OPTIONAL
+                // dependency and passes envelopes through untouched when it is missing —
+                // which is exactly what happened here: the worker sent
+                // `Authorization: Bearer enc::v1::…` to OpenRouter ("Missing Authentication
+                // header") and every generation failed. Must be registered BEFORE
+                // PluginSettingsService; needs PLUGIN_SECRET_ENCRYPTION_KEY in the worker env
+                // (same key as the API).
+                PluginSecretEncService,
                 PluginSettingsService,
                 PluginContextFactoryService,
                 CustomCapabilityRegistryService,
@@ -92,6 +102,7 @@ export class TriggerPluginsModule {
                 PluginRegistryService,
                 PluginLoaderService,
                 PluginLifecycleManagerService,
+                PluginSecretEncService,
                 PluginSettingsService,
                 PluginContextFactoryService,
                 CustomCapabilityRegistryService,


### PR DESCRIPTION
Promotes tonight's platform fixes merged to `develop`:
- [#2164](https://github.com/ever-works/ever-works/pull/2164) per-Work allow-listed runtime env (Stripe keys) API/UI + shared-DB provisioning failures as 503 with a sanitized reason (was a bare 500)
- [#2194](https://github.com/ever-works/ever-works/pull/2194) pipeline orchestrator materialises lazy plugin stubs (generation misrouted/crashed under PLUGIN_LAZY_LOAD)
- [#2195](https://github.com/ever-works/ever-works/pull/2195) Trigger worker registers PluginSecretEncService (plugin secrets were sent as enc::v1 ciphertext)

Merged with admin override while the Actions queue is stalled; details/evidence on each PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)