### PR TITLE
fix(subscriptions): stop offering self-hosted editions in the hosted plan switcher

### DIFF
--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -94,6 +94,12 @@ export class SubscriptionsController {
             plans.map(async (plan) => ({
                 code: plan.code,
                 name: plan.displayName,
+                // Echoed so the response is self-describing: the switcher can tell a hosted tier
+                // from a self-hosted licence instead of inferring it from the plan name. Today
+                // `listPlans` only returns cloud plans, so this is always 'cloud' — it exists so a
+                // future self-hosted build does not have to guess, and so the omission that caused
+                // six undifferentiated cards cannot silently recur.
+                hosting: plan.hosting,
                 maxWorks: plan.maxWorks,
                 allowedCadences: plan.allowedCadences ?? [],
                 monthlyPrice: plan.monthlyPrice,

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -1051,3 +1051,74 @@ describe('SubscriptionService', () => {
         });
     });
 });
+
+// H7: #2160 added three SELF-HOSTED editions to the seed. `listPlans()` returned
+// `findAllActive()` unfiltered, so the hosted Billing page's plan switcher rendered six
+// cards instead of three — including a "Community Edition" whose only possible outcome
+// was an error, because `changePlanSelfService` (correctly) refuses self-hosted here.
+// Found by an adversarial audit of the SHIPPED system, not by this suite.
+describe('listPlans — the switcher only offers what this deployment can actually grant', () => {
+    const cloudPlan = (code: string, name: string) =>
+        ({ code, displayName: name, hosting: 'cloud' }) as any;
+    const selfHostedPlan = (code: string, name: string) =>
+        ({ code, displayName: name, hosting: 'selfhosted' }) as any;
+
+    const ALL_SIX = [
+        cloudPlan('free', 'Free'),
+        cloudPlan('standard', 'Pro'),
+        cloudPlan('premium', 'Enterprise'),
+        selfHostedPlan('selfhosted_community', 'Community Edition'),
+        selfHostedPlan('selfhosted_pro', 'Pro Edition'),
+        selfHostedPlan('selfhosted_enterprise', 'Enterprise Edition'),
+    ];
+
+    it('excludes every self-hosted edition', async () => {
+        const { service } = makeService({
+            findAllActive: jest.fn().mockResolvedValue(ALL_SIX),
+        });
+
+        const plans = await service.listPlans();
+
+        // Guard against a vacuous pass: the repository really did offer all six.
+        expect(ALL_SIX).toHaveLength(6);
+        expect(plans.map((p) => p.code)).toEqual(['free', 'standard', 'premium']);
+        expect(plans.every((p) => p.hosting !== 'selfhosted')).toBe(true);
+    });
+
+    it('agrees with the self-hosted guard about what is selectable here', async () => {
+        // The invariant is about HOSTING specifically: the switcher must not advertise a
+        // plan the guard rejects for being self-hosted. (Self-service separately allows
+        // only FREE — EW-711 #23 — which is why this asserts the hosting rule, not that
+        // every offered plan is freely assignable.)
+        const { service } = makeService({
+            findAllActive: jest.fn().mockResolvedValue(ALL_SIX),
+            findByCode: jest.fn(async (code: string) => ALL_SIX.find((p) => p.code === code)),
+        });
+
+        const offered = await service.listPlans();
+        expect(offered.length).toBeGreaterThan(0);
+        expect(offered.every((p) => p.hosting === 'cloud')).toBe(true);
+
+        // ...and the guard really does refuse the ones now withheld — so the two agree
+        // rather than merely happening not to collide.
+        for (const code of ['selfhosted_community', 'selfhosted_pro', 'selfhosted_enterprise']) {
+            expect(offered.some((p) => p.code === code)).toBe(false);
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as any, code as any),
+            ).rejects.toThrow();
+        }
+    });
+
+    it('passes through when the catalog has no self-hosted rows at all', async () => {
+        const cloudOnly = ALL_SIX.filter((p) => p.hosting === 'cloud');
+        const { service } = makeService({
+            findAllActive: jest.fn().mockResolvedValue(cloudOnly),
+        });
+
+        expect((await service.listPlans()).map((p) => p.code)).toEqual([
+            'free',
+            'standard',
+            'premium',
+        ]);
+    });
+});

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -215,13 +215,25 @@ export class SubscriptionService implements OnModuleInit {
     }
 
     /**
-     * Wave 13 (Billing page) — all active seeded plans for the plan/tier
-     * switcher. Read-only; plans are seeded at boot by {@link seedPlans}
-     * regardless of the `SUBSCRIPTIONS_ENABLED` flag, so the switcher can
+     * Wave 13 (Billing page) — the active seeded plans a user on THIS deployment can actually
+     * choose, for the plan/tier switcher. Read-only; plans are seeded at boot by
+     * {@link seedPlans} regardless of the `SUBSCRIPTIONS_ENABLED` flag, so the switcher can
      * render (degraded) even on deploys where billing is off.
+     *
+     * 🛑 SELF-HOSTED editions are excluded. They are licences for the buyer's OWN deployment, and
+     * {@link changePlanSelfService} refuses them here — so listing them offered a "Community
+     * Edition" card whose only possible outcome was an error, alongside two paid editions that
+     * cannot be bought on the hosted service either. Six cards where three belong.
+     *
+     * This mirrors the guard rather than duplicating a rule: anything `changePlanSelfService`
+     * would reject must not be advertised by the switcher in the first place. If this code is ever
+     * run as part of a genuinely self-hosted distribution, BOTH places need a deployment-mode
+     * config — filtering here alone would then show no plans at all, which is why the two are
+     * deliberately written against the same condition.
      */
     async listPlans(): Promise<SubscriptionPlan[]> {
-        return this.planRepository.findAllActive();
+        const plans = await this.planRepository.findAllActive();
+        return plans.filter((plan) => plan.hosting !== 'selfhosted');
     }
 
     async getActiveSubscription(userId: string) {


### PR DESCRIPTION
#2160 added three **self-hosted editions** to the plan seed. `listPlans()` returned `findAllActive()` **unfiltered**, so the hosted Billing page's plan switcher rendered **six cards instead of three** — including a *"Community Edition"* whose only possible outcome is an error, because `changePlanSelfService` (correctly) refuses self-hosted on a hosted deployment. The response did not even carry `hosting`, so the UI had no way to tell a licence from a subscription.

The switcher now offers only what this deployment can actually grant. It **mirrors the guard rather than duplicating a rule**: anything `changePlanSelfService` rejects for being self-hosted must not be advertised in the first place.

Also echoes `hosting` in the plan-list response — always `'cloud'` today, but it means a future self-hosted build doesn't have to guess, and the omission that produced six undifferentiated cards can't silently recur.

🛑 **If this ever runs as a genuinely self-hosted distribution**, both this filter and the guard need a deployment-mode config — filtering here alone would show *no* plans. They're deliberately written against the same condition so they move together.

**Verification**
- Three tests added, **proven load-bearing**: removing the filter turns 2 of them red.
- The second test asserts the *hosting* invariant specifically, not "every offered plan is assignable" — self-service separately permits only FREE (EW-711 #23). My first draft asserted the latter and failed, which is how I found out.
- `src/subscriptions`: **16 suites, 456 tests, all passing.**

Context: finding **H7** in `_LOCAL/EVER_WORKS_BILLING_AUDIT_FINDINGS.md`, from an adversarial audit of the shipped system. Worth noting those 456 tests passed the whole time the leak was live — nothing compared the switcher's output against the guard.

Nothing is purchasable today (`SUBSCRIPTIONS_ENABLED=false` in all three namespaces), so this is a UX correction rather than an escalation fix. The guard itself was never bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)