### PR TITLE
chore(cascade): stage → main — claude-code HOME isolation + fleet passthrough schema parity

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
@@ -179,6 +179,50 @@ describe('fleet agent-task dispatch (AUDIT A46/A24 producer wiring)', () => {
         expect(enqueued.payload.workspacePath).toBe('/srv/ever-works');
     });
 
+    it('grants the well-known CLI credential names to the agent-task step by default', async () => {
+        // A node builds its subprocess env from scratch and drops secret-SHAPED
+        // names unless the step grants them. Without this the credential never
+        // arrives and the agent runs unauthenticated — failing in a way that
+        // reads as a model problem rather than a config one.
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        process.env.FLEET_NODE_AGENT_TASK_COMMAND = 'ever-works agent run --task {taskId}';
+
+        await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
+
+        const step = fleetJobs.enqueue.mock.calls[0][0].payload.steps[0];
+        expect(step.envPassthrough).toEqual([
+            'CLAUDE_CODE_OAUTH_TOKEN',
+            'ANTHROPIC_API_KEY',
+            'CODEX_ACCESS_TOKEN',
+            'OPENAI_API_KEY',
+        ]);
+    });
+
+    it('honours an operator override of the granted credential names', async () => {
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        process.env.FLEET_NODE_AGENT_TASK_COMMAND = 'ever-works agent run --task {taskId}';
+        process.env.FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH = ' MY_WRAPPER_TOKEN , OTHER_KEY ';
+
+        await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
+
+        const step = fleetJobs.enqueue.mock.calls[0][0].payload.steps[0];
+        expect(step.envPassthrough).toEqual(['MY_WRAPPER_TOKEN', 'OTHER_KEY']);
+    });
+
+    it('omits envPassthrough entirely when the operator grants nothing', async () => {
+        // Opting out must leave the field ABSENT rather than an empty array, so a
+        // node sees "no grant" instead of "granted nothing", and the step shape
+        // stays identical to what shipped before this setting existed.
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        process.env.FLEET_NODE_AGENT_TASK_COMMAND = 'ever-works agent run --task {taskId}';
+        process.env.FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH = '';
+
+        await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
+
+        const step = fleetJobs.enqueue.mock.calls[0][0].payload.steps[0];
+        expect(step.envPassthrough).toBeUndefined();
+    });
+
     it('keeps the platform dispatcher when no fleet runtime is selected', async () => {
         const result = await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
 

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -94,6 +94,12 @@ export class SubscriptionsController {
             plans.map(async (plan) => ({
                 code: plan.code,
                 name: plan.displayName,
+                // Echoed so the response is self-describing: the switcher can tell a hosted tier
+                // from a self-hosted licence instead of inferring it from the plan name. Today
+                // `listPlans` only returns cloud plans, so this is always 'cloud' — it exists so a
+                // future self-hosted build does not have to guess, and so the omission that caused
+                // six undifferentiated cards cannot silently recur.
+                hosting: plan.hosting,
                 maxWorks: plan.maxWorks,
                 allowedCadences: plan.allowedCadences ?? [],
                 monthlyPrice: plan.monthlyPrice,

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -1051,3 +1051,74 @@ describe('SubscriptionService', () => {
         });
     });
 });
+
+// H7: #2160 added three SELF-HOSTED editions to the seed. `listPlans()` returned
+// `findAllActive()` unfiltered, so the hosted Billing page's plan switcher rendered six
+// cards instead of three — including a "Community Edition" whose only possible outcome
+// was an error, because `changePlanSelfService` (correctly) refuses self-hosted here.
+// Found by an adversarial audit of the SHIPPED system, not by this suite.
+describe('listPlans — the switcher only offers what this deployment can actually grant', () => {
+    const cloudPlan = (code: string, name: string) =>
+        ({ code, displayName: name, hosting: 'cloud' }) as any;
+    const selfHostedPlan = (code: string, name: string) =>
+        ({ code, displayName: name, hosting: 'selfhosted' }) as any;
+
+    const ALL_SIX = [
+        cloudPlan('free', 'Free'),
+        cloudPlan('standard', 'Pro'),
+        cloudPlan('premium', 'Enterprise'),
+        selfHostedPlan('selfhosted_community', 'Community Edition'),
+        selfHostedPlan('selfhosted_pro', 'Pro Edition'),
+        selfHostedPlan('selfhosted_enterprise', 'Enterprise Edition'),
+    ];
+
+    it('excludes every self-hosted edition', async () => {
+        const { service } = makeService({
+            findAllActive: jest.fn().mockResolvedValue(ALL_SIX),
+        });
+
+        const plans = await service.listPlans();
+
+        // Guard against a vacuous pass: the repository really did offer all six.
+        expect(ALL_SIX).toHaveLength(6);
+        expect(plans.map((p) => p.code)).toEqual(['free', 'standard', 'premium']);
+        expect(plans.every((p) => p.hosting !== 'selfhosted')).toBe(true);
+    });
+
+    it('agrees with the self-hosted guard about what is selectable here', async () => {
+        // The invariant is about HOSTING specifically: the switcher must not advertise a
+        // plan the guard rejects for being self-hosted. (Self-service separately allows
+        // only FREE — EW-711 #23 — which is why this asserts the hosting rule, not that
+        // every offered plan is freely assignable.)
+        const { service } = makeService({
+            findAllActive: jest.fn().mockResolvedValue(ALL_SIX),
+            findByCode: jest.fn(async (code: string) => ALL_SIX.find((p) => p.code === code)),
+        });
+
+        const offered = await service.listPlans();
+        expect(offered.length).toBeGreaterThan(0);
+        expect(offered.every((p) => p.hosting === 'cloud')).toBe(true);
+
+        // ...and the guard really does refuse the ones now withheld — so the two agree
+        // rather than merely happening not to collide.
+        for (const code of ['selfhosted_community', 'selfhosted_pro', 'selfhosted_enterprise']) {
+            expect(offered.some((p) => p.code === code)).toBe(false);
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as any, code as any),
+            ).rejects.toThrow();
+        }
+    });
+
+    it('passes through when the catalog has no self-hosted rows at all', async () => {
+        const cloudOnly = ALL_SIX.filter((p) => p.hosting === 'cloud');
+        const { service } = makeService({
+            findAllActive: jest.fn().mockResolvedValue(cloudOnly),
+        });
+
+        expect((await service.listPlans()).map((p) => p.code)).toEqual([
+            'free',
+            'standard',
+            'premium',
+        ]);
+    });
+});

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -215,13 +215,25 @@ export class SubscriptionService implements OnModuleInit {
     }
 
     /**
-     * Wave 13 (Billing page) — all active seeded plans for the plan/tier
-     * switcher. Read-only; plans are seeded at boot by {@link seedPlans}
-     * regardless of the `SUBSCRIPTIONS_ENABLED` flag, so the switcher can
+     * Wave 13 (Billing page) — the active seeded plans a user on THIS deployment can actually
+     * choose, for the plan/tier switcher. Read-only; plans are seeded at boot by
+     * {@link seedPlans} regardless of the `SUBSCRIPTIONS_ENABLED` flag, so the switcher can
      * render (degraded) even on deploys where billing is off.
+     *
+     * 🛑 SELF-HOSTED editions are excluded. They are licences for the buyer's OWN deployment, and
+     * {@link changePlanSelfService} refuses them here — so listing them offered a "Community
+     * Edition" card whose only possible outcome was an error, alongside two paid editions that
+     * cannot be bought on the hosted service either. Six cards where three belong.
+     *
+     * This mirrors the guard rather than duplicating a rule: anything `changePlanSelfService`
+     * would reject must not be advertised by the switcher in the first place. If this code is ever
+     * run as part of a genuinely self-hosted distribution, BOTH places need a deployment-mode
+     * config — filtering here alone would then show no plans at all, which is why the two are
+     * deliberately written against the same condition.
      */
     async listPlans(): Promise<SubscriptionPlan[]> {
-        return this.planRepository.findAllActive();
+        const plans = await this.planRepository.findAllActive();
+        return plans.filter((plan) => plan.hosting !== 'selfhosted');
     }
 
     async getActiveSubscription(userId: string) {

--- a/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
+++ b/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
@@ -105,6 +105,40 @@ describe('buildSubprocessEnv (C-10)', () => {
 		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('subscription-token');
 	});
 
+	it('isolates HOME and USERPROFILE when a config dir is pinned', () => {
+		// The CLI runs with --dangerously-skip-permissions over scraped web content,
+		// so a hostile prompt must not be able to walk `~` into ~/.aws or ~/.ssh.
+		process.env.HOME = '/home/appuser';
+		process.env.USERPROFILE = 'C:\\Users\\appuser';
+		process.env.TMPDIR = '/tmp/isolated';
+
+		const env = buildSubprocessEnv({ CLAUDE_CONFIG_DIR: '/tmp/cc-run-1' });
+
+		expect(env.HOME).toBe('/tmp/isolated');
+		expect(env.USERPROFILE).toBe('/tmp/isolated');
+		expect(env.HOME).not.toBe('/home/appuser');
+	});
+
+	it('keeps the real HOME when no config dir is pinned, so auth probes still resolve ~/.claude', () => {
+		process.env.HOME = '/home/appuser';
+		process.env.USERPROFILE = 'C:\\Users\\appuser';
+		process.env.TMPDIR = '/tmp/isolated';
+
+		const env = buildSubprocessEnv();
+
+		expect(env.HOME).toBe('/home/appuser');
+		expect(env.USERPROFILE).toBe('C:\\Users\\appuser');
+	});
+
+	it('treats an empty CLAUDE_CONFIG_DIR as not pinned rather than isolating on a blank path', () => {
+		process.env.HOME = '/home/appuser';
+		process.env.TMPDIR = '/tmp/isolated';
+
+		const env = buildSubprocessEnv({ CLAUDE_CONFIG_DIR: '' });
+
+		expect(env.HOME).toBe('/home/appuser');
+	});
+
 	it('drops arbitrary ANTHROPIC_*/CLAUDE_CODE_*-prefixed vars not on the allow-list', () => {
 		// Regression guard: the env was previously built by matching any key that
 		// merely STARTED WITH `ANTHROPIC_` or `CLAUDE_CODE_`, which silently

--- a/packages/plugins/claude-code/src/utils/subprocess-env.ts
+++ b/packages/plugins/claude-code/src/utils/subprocess-env.ts
@@ -100,18 +100,46 @@ export function buildSubprocessEnv(
 	overrides: Record<string, string> = {},
 	options: BuildSubprocessEnvOptions = {}
 ): Record<string, string> {
+	const tmpdir = process.env.TMPDIR ?? os.tmpdir();
+
+	// Security: when the caller pins an explicit `CLAUDE_CONFIG_DIR` — which every
+	// prompt-injectable run does — point the home directory at the isolated tmpdir
+	// instead of the server user's real home. Claude Code resolves its settings,
+	// session state and credentials from `CLAUDE_CONFIG_DIR`, and this runner
+	// supplies the credential through the environment besides, so a legitimate run
+	// loses nothing. What it does lose is the ability of a hostile work prompt to
+	// walk `~` and exfiltrate `~/.aws`, `~/.ssh`, `~/.npmrc`, `~/.kube` — the CLI
+	// runs with `--dangerously-skip-permissions` on scraped web content and
+	// community-PR text, so that is not a hypothetical.
+	//
+	// Mirrors the codex plugin's `CODEX_HOME` handling, with one addition: on
+	// Windows `~` resolves from `USERPROFILE`, not `HOME`, so repointing only
+	// `HOME` would leave the hardening a no-op there.
+	//
+	// Runs without a pinned config dir (e.g. an auth probe) keep the real home so
+	// the CLI's `~/.claude` fallback still resolves and auth detection is unchanged.
+	const isolateHome = typeof overrides.CLAUDE_CONFIG_DIR === 'string' && overrides.CLAUDE_CONFIG_DIR !== '';
+	const home = isolateHome ? tmpdir : (process.env.HOME ?? os.homedir());
+
 	const env: Record<string, string> = {
 		PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
-		HOME: process.env.HOME ?? os.homedir(),
-		TMPDIR: process.env.TMPDIR ?? os.tmpdir()
+		HOME: home,
+		TMPDIR: tmpdir
 	};
 
 	// `USERPROFILE` is the Windows equivalent of `HOME`; some Anthropic SDK
 	// versions look it up. Forward when present so the runner works on
 	// Windows dev boxes without leaking other host vars.
-	if (process.env.USERPROFILE) {
+	if (isolateHome) {
+		env.USERPROFILE = tmpdir;
+	} else if (process.env.USERPROFILE) {
 		env.USERPROFILE = process.env.USERPROFILE;
 	}
+	// `APPDATA` / `LOCALAPPDATA` stay pointed at the real profile even when the
+	// home is isolated: Node and the package managers the agent shells out to read
+	// their own machine config from there, and breaking that would fail runs rather
+	// than harden them. They are a known residual on Windows — `%APPDATA%\npm` can
+	// hold an npm token — but the deployed runner is Linux, where these are unset.
 	if (process.env.APPDATA) {
 		env.APPDATA = process.env.APPDATA;
 	}

--- a/packages/plugins/job-runtime-node/src/node-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-node/src/node-job-runtime.plugin.ts
@@ -139,6 +139,13 @@ export class NodeJobRuntimePlugin implements IJobRuntimeProvider {
 				description:
 					'Absolute directory ON THE NODE that `agent-task` steps run in. Blank lets the node use its own working directory.',
 				'x-envVar': 'FLEET_NODE_AGENT_TASK_WORKSPACE'
+			},
+			agentTaskEnvPassthrough: {
+				type: 'string',
+				title: 'Agent task credential env names',
+				description:
+					'Comma-separated environment variable NAMES an `agent-task` step may read from the node’s own environment. A node drops secret-shaped names unless granted, so without this a machine whose Claude or Codex credential lives in an environment variable authenticates with nothing. Only the NAME travels — the value is read on the node and never leaves it, which is why one list works for a fleet of differently-credentialled machines: granting a name a machine does not set is a no-op. Blank inherits the default (the four well-known Claude/Codex names); set it to a single space to grant none.',
+				'x-envVar': 'FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH'
 			}
 		}
 	};


### PR DESCRIPTION
Cascade `stage` → `main` (production). Three commits.

**Mine:**
- **#2165** `fix(claude-code)`: isolate `HOME` and `USERPROFILE` whenever `CLAUDE_CONFIG_DIR` is pinned, so a prompt-injected agent running with `--dangerously-skip-permissions` over scraped web content and community-PR text cannot walk `~` into `~/.aws`, `~/.ssh`, `~/.npmrc`, `~/.kube`. Same class as audit C-10, which stopped secrets arriving *in the environment* but left the ones *on disk under `~`* reachable.
- **#2169** `feat(fleet)`: expose `FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH` on the `job-runtime-node` plugin schema, plus the dispatch tests that were missing.

**Riding along (not mine, already on stage):**
- `8f971367e` `fix(subscriptions): stop offering self-hosted editions in the hosted plan switcher` — cascaded whole rather than cherry-picked, per the no-cherry-pick rule.

## Verification

Both of my PRs previously settled at **14 green / 1 failed** and **12 green / 1 failed**, where the single failure in each was the repo-wide `lint-and-test` break since fixed on develop by `16582cad7`. Both passed the full matrix on their own merits. Local: claude-code 78 tests, fleet dispatch 18 tests, `tsc` + `prettier` clean.

The HOME change does not affect auth: Claude Code reads config and credentials from `CLAUDE_CONFIG_DIR`, and the runner supplies the credential via the environment. The one call site *without* a pinned config dir is the auth probe — fixed prompt `'Reply with OK.'`, `maxTurns: 1`, throwaway cwd, not prompt-injectable — which deliberately keeps the real home so `~/.claude` still resolves.

## E2E gate override — justification

Applying `override-e2e-gate` deliberately, with the reasoning on record rather than bypassing silently.

**The stage E2E suite cannot produce a verdict right now.** In the last 24 hours there were **zero** non-cancelled completed runs (five runs: four `cancelled`, one stuck `queued`). Each push to `stage` cancels the previous run via the workflow concurrency group, and the 33 shards need hours to get runner slots — so under active cascade traffic no run survives to completion. This is a suite that cannot finish, not a suite that is failing.

Owner explicitly directed merging and cascading without waiting for green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)