### PR TITLE
chore(cascade): stage -> main

### DIFF
--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -58,10 +58,26 @@ export interface FacadeCloneOptions {
     readonly autoSwitchToMainBranch?: boolean;
 }
 
+/**
+ * Clone ONE branch into a directory of its own — see
+ * `GitFacadeService.cloneBranch`. `branch` is required (that is the whole
+ * point) and there is no `autoSwitchToMainBranch`: the requested branch is
+ * what stays checked out.
+ */
+export interface FacadeCloneBranchOptions {
+    readonly owner: string;
+    readonly repo: string;
+    readonly branch: string;
+}
+
 export interface FacadePushOptions {
     readonly dir: string;
     readonly force?: boolean;
     readonly maxRetries?: number;
+    /** Local ref to push. Omitted → whatever branch HEAD points at. */
+    readonly ref?: string;
+    /** Receiving branch on the remote. Omitted → derived from `ref`. */
+    readonly remoteRef?: string;
 }
 
 export class GitFacadeError extends FacadeError {
@@ -1046,6 +1062,31 @@ export class GitFacadeService implements IGitFacade {
         this.cloneOrPullRequests.set(key, request);
 
         return request;
+    }
+
+    /**
+     * Clone ONE branch into an isolated working directory.
+     *
+     * Deliberately NOT coalesced the way `cloneOrPull` is: the value of
+     * this call is that every caller gets a directory nobody else touches,
+     * and sharing one in-flight promise would hand two callers the same
+     * path again. Callers own the returned directory and must remove it.
+     *
+     * OPTIONAL on the contract, so the absence path is an explicit
+     * `GitOperationNotSupportedError` (→ 409) and the method is
+     * materialised off the resolved plugin first — the lazy-plugin proxy
+     * over-reports optional methods (see the class doc above).
+     */
+    async cloneBranch(
+        cloneOptions: FacadeCloneBranchOptions,
+        options: GitFacadeOptions,
+    ): Promise<string> {
+        const { plugin, token } = await this.resolvePluginAndToken(options);
+        const impl = plugin.cloneBranch;
+        if (typeof impl !== 'function') {
+            throw new GitOperationNotSupportedError('cloneBranch', plugin.id);
+        }
+        return impl.call(plugin, { ...cloneOptions, token });
     }
 
     async pull(

--- a/packages/agent/src/generators/website-generator/branch-sync.service.spec.ts
+++ b/packages/agent/src/generators/website-generator/branch-sync.service.spec.ts
@@ -7,6 +7,9 @@ jest.mock('node:fs/promises', () => ({
 
 const fsMock = jest.requireMock('node:fs/promises') as { rm: jest.Mock };
 
+/** Sha every branch of every repo reports in the default happy-path stub. */
+const IN_SYNC_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 describe('BranchSyncService', () => {
     let gitFacade: any;
     let websiteTemplateResolver: any;
@@ -22,13 +25,28 @@ describe('BranchSyncService', () => {
         betaBranch: null,
     };
 
+    /**
+     * Default readback: every branch on every repo is already at
+     * IN_SYNC_SHA, so the post-push verification guard passes. Tests that
+     * care about the guard override this per repo.
+     */
+    function stubBranchesInSync() {
+        gitFacade.listBranches.mockImplementation(async () =>
+            ['main', 'stage', 'develop', 'next'].map((name) => ({
+                name,
+                commit: IN_SYNC_SHA,
+                isDefault: name === 'main',
+            })),
+        );
+    }
+
     beforeEach(() => {
         jest.useFakeTimers();
         fsMock.rm.mockClear();
         fsMock.rm.mockResolvedValue(undefined);
 
         gitFacade = {
-            cloneOrPull: jest.fn(),
+            cloneBranch: jest.fn(),
             renameBranch: jest.fn(),
             getCloneUrl: jest.fn(),
             replaceRemote: jest.fn(),
@@ -39,6 +57,7 @@ describe('BranchSyncService', () => {
         websiteTemplateResolver = {
             resolveForWork: jest.fn(),
         };
+        stubBranchesInSync();
 
         service = new BranchSyncService(gitFacade, websiteTemplateResolver);
     });
@@ -63,8 +82,8 @@ describe('BranchSyncService', () => {
     }
 
     describe('syncBranch', () => {
-        it('clones the template, pushes to target, and cleans up the temp dir', async () => {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/work-dir');
+        it('clones the template branch, pushes to target, and cleans up the temp dir', async () => {
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/work-dir');
             gitFacade.getCloneUrl.mockReturnValue(
                 'https://github.com/target-owner/target-repo.git',
             );
@@ -82,12 +101,11 @@ describe('BranchSyncService', () => {
                 workId: 'work-1',
             });
 
-            expect(gitFacade.cloneOrPull).toHaveBeenCalledWith(
+            expect(gitFacade.cloneBranch).toHaveBeenCalledWith(
                 {
                     owner: 'ever-works',
                     repo: 'directory-web-template',
                     branch: 'main',
-                    committer: { name: 'ever', email: 'ever@x.test' },
                 },
                 { userId: 'user-1', providerId: 'github', workId: 'work-1' },
             );
@@ -104,7 +122,7 @@ describe('BranchSyncService', () => {
                 'https://github.com/target-owner/target-repo.git',
             );
             expect(gitFacade.push).toHaveBeenCalledWith(
-                { dir: '/tmp/work-dir', force: true },
+                { dir: '/tmp/work-dir', force: true, ref: 'main', remoteRef: 'main' },
                 { userId: 'user-1', providerId: 'github', workId: 'work-1' },
             );
             expect(fsMock.rm).toHaveBeenCalledWith('/tmp/work-dir', {
@@ -119,7 +137,7 @@ describe('BranchSyncService', () => {
         });
 
         it('renames branch when targetBranch differs from branchName', async () => {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/work-dir');
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/work-dir');
             gitFacade.getCloneUrl.mockReturnValue('https://example.test/owner/repo.git');
 
             const result = await service.syncBranch({
@@ -143,8 +161,28 @@ describe('BranchSyncService', () => {
             expect(result.message).toBe("Successfully synced branch 'stage' (mapped to 'main')");
         });
 
+        it('pushes a mapped branch to the MAPPED remote ref, not the source ref', async () => {
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/work-dir');
+            gitFacade.getCloneUrl.mockReturnValue('url');
+
+            await service.syncBranch({
+                branchName: 'stage',
+                targetBranch: 'main',
+                targetOwner: 'owner',
+                targetRepo: 'repo',
+                template: baseTemplate,
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+            });
+
+            expect(gitFacade.push).toHaveBeenCalledWith(
+                expect.objectContaining({ ref: 'main', remoteRef: 'main' }),
+                expect.any(Object),
+            );
+        });
+
         it('honours forcePush=false', async () => {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/d');
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
             gitFacade.getCloneUrl.mockReturnValue('url');
 
             await service.syncBranch({
@@ -158,13 +196,13 @@ describe('BranchSyncService', () => {
             });
 
             expect(gitFacade.push).toHaveBeenCalledWith(
-                { dir: '/tmp/d', force: false },
+                { dir: '/tmp/d', force: false, ref: 'main', remoteRef: 'main' },
                 expect.any(Object),
             );
         });
 
         it('forwards undefined providerId/workId verbatim', async () => {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/d');
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
             gitFacade.getCloneUrl.mockReturnValue('url');
 
             await service.syncBranch({
@@ -176,7 +214,7 @@ describe('BranchSyncService', () => {
                 committer: { name: 'n', email: 'e' },
             });
 
-            expect(gitFacade.cloneOrPull).toHaveBeenCalledWith(expect.any(Object), {
+            expect(gitFacade.cloneBranch).toHaveBeenCalledWith(expect.any(Object), {
                 userId: 'u',
                 providerId: undefined,
                 workId: undefined,
@@ -190,7 +228,7 @@ describe('BranchSyncService', () => {
         });
 
         it('returns error result and still cleans up tempDir on failure after clone', async () => {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/d');
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
             gitFacade.getCloneUrl.mockReturnValue('url');
             gitFacade.replaceRemote.mockRejectedValue(new Error('replace failed'));
 
@@ -212,7 +250,7 @@ describe('BranchSyncService', () => {
         });
 
         it('does not call fs.rm when clone fails before tempDir is set', async () => {
-            gitFacade.cloneOrPull.mockRejectedValue(new Error('clone failed'));
+            gitFacade.cloneBranch.mockRejectedValue(new Error('clone failed'));
 
             const result = await service.syncBranch({
                 branchName: 'main',
@@ -234,7 +272,7 @@ describe('BranchSyncService', () => {
         });
 
         it('swallows fs.rm cleanup failure silently', async () => {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/d');
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
             gitFacade.getCloneUrl.mockReturnValue('url');
             fsMock.rm.mockRejectedValueOnce(new Error('fs unavailable'));
 
@@ -251,9 +289,141 @@ describe('BranchSyncService', () => {
         });
     });
 
+    // ── Verification guard ────────────────────────────────────────────
+    //
+    // The regression these cover: a push that resolves without throwing
+    // was treated as proof the remote branch moved. It is not — it is
+    // proof the transport did not error. Every test here reports
+    // status:'synced' against a service that does not read the ref back.
+    describe('syncBranch verification guard', () => {
+        function stubRepoBranches(shas: {
+            template: Record<string, string>;
+            target: Record<string, string>;
+        }) {
+            gitFacade.listBranches.mockImplementation(async (owner: string) => {
+                const table = owner === 'ever-works' ? shas.template : shas.target;
+                return Object.entries(table).map(([name, commit]) => ({ name, commit }));
+            });
+        }
+
+        it('reports error when the target ref did NOT move to the pushed sha', async () => {
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
+            gitFacade.getCloneUrl.mockReturnValue('url');
+            gitFacade.push.mockResolvedValue(undefined);
+            stubRepoBranches({
+                template: { develop: 'dddddddddddddddddddddddddddddddddddddddd' },
+                // Frozen exactly the way the 11 stale sites were: the push
+                // "succeeded" and develop stayed where it was.
+                target: { develop: '1eb0424f1eb0424f1eb0424f1eb0424f1eb0424f' },
+            });
+
+            const result = await service.syncBranch({
+                branchName: 'develop',
+                targetOwner: 'o',
+                targetRepo: 'r',
+                template: baseTemplate,
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+            });
+
+            expect(gitFacade.push).toHaveBeenCalled();
+            expect(result.status).toBe('error');
+            expect(result.message).toContain('1eb0424f1eb0424f1eb0424f1eb0424f1eb0424f');
+            expect(result.message).toContain('dddddddddddddddddddddddddddddddddddddddd');
+        });
+
+        it('reports error when the target branch does not exist after the push', async () => {
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
+            gitFacade.getCloneUrl.mockReturnValue('url');
+            stubRepoBranches({
+                template: { stage: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+                target: { main: 'cccccccccccccccccccccccccccccccccccccccc' },
+            });
+
+            const result = await service.syncBranch({
+                branchName: 'stage',
+                targetOwner: 'o',
+                targetRepo: 'r',
+                template: baseTemplate,
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+            });
+
+            expect(result.status).toBe('error');
+            expect(result.message).toContain('(branch missing)');
+        });
+
+        it('does NOT pass when both sides are missing the branch', async () => {
+            // Guards the vacuous case: `undefined === undefined` must not
+            // read as "in sync". The template lookup fails first, so the
+            // clone is never attempted.
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
+            stubRepoBranches({ template: { main: 'x' }, target: { main: 'x' } });
+
+            const result = await service.syncBranch({
+                branchName: 'develop',
+                targetOwner: 'o',
+                targetRepo: 'r',
+                template: baseTemplate,
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+            });
+
+            expect(result.status).toBe('error');
+            expect(result.message).toContain("Template branch 'develop' not found");
+            expect(gitFacade.cloneBranch).not.toHaveBeenCalled();
+            expect(gitFacade.push).not.toHaveBeenCalled();
+        });
+
+        it('reports error when the readback itself cannot be performed', async () => {
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
+            gitFacade.getCloneUrl.mockReturnValue('url');
+            gitFacade.listBranches
+                .mockResolvedValueOnce([{ name: 'main', commit: IN_SYNC_SHA }])
+                .mockRejectedValueOnce(new Error('rate limited'));
+
+            const result = await service.syncBranch({
+                branchName: 'main',
+                targetOwner: 'o',
+                targetRepo: 'r',
+                template: baseTemplate,
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+            });
+
+            expect(result).toEqual({
+                branch: 'main',
+                status: 'error',
+                message: 'rate limited',
+            });
+        });
+
+        it('accepts a sha that differs only in case', async () => {
+            gitFacade.cloneBranch.mockResolvedValue('/tmp/d');
+            gitFacade.getCloneUrl.mockReturnValue('url');
+            stubRepoBranches({
+                template: { main: 'ABCDEF0123456789abcdef0123456789ABCDEF01' },
+                target: { main: 'abcdef0123456789abcdef0123456789abcdef01' },
+            });
+
+            const result = await service.syncBranch({
+                branchName: 'main',
+                targetOwner: 'o',
+                targetRepo: 'r',
+                template: baseTemplate,
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+            });
+
+            expect(result.status).toBe('synced');
+        });
+    });
+
     describe('syncAllBranches', () => {
         function stubSyncSuccess() {
-            gitFacade.cloneOrPull.mockResolvedValue('/tmp/d');
+            // A distinct directory per call — the whole point of cloneBranch.
+            let n = 0;
+            gitFacade.cloneBranch.mockImplementation(async () => `/tmp/d-${++n}`);
             gitFacade.getCloneUrl.mockReturnValue('url');
             gitFacade.replaceRemote.mockResolvedValue(undefined);
             gitFacade.push.mockResolvedValue(undefined);
@@ -274,8 +444,8 @@ describe('BranchSyncService', () => {
             await jest.runAllTimersAsync();
             const summary = await promise;
 
-            expect(gitFacade.cloneOrPull).toHaveBeenCalledTimes(3);
-            const cloneBranches = gitFacade.cloneOrPull.mock.calls.map((c: any[]) => c[0].branch);
+            expect(gitFacade.cloneBranch).toHaveBeenCalledTimes(3);
+            const cloneBranches = gitFacade.cloneBranch.mock.calls.map((c: any[]) => c[0].branch);
             expect(cloneBranches).toEqual(['main', 'stage', 'develop']);
             expect(summary).toEqual({
                 totalBranches: 3,
@@ -288,6 +458,87 @@ describe('BranchSyncService', () => {
                     expect.objectContaining({ branch: 'develop', status: 'synced' }),
                 ],
             });
+        });
+
+        it('pushes ONE remote ref per branch instead of main three times', async () => {
+            // The original defect, asserted as an effect rather than as the
+            // arguments handed to a mocked clone: syncing main/stage/develop
+            // used to push the same checked-out `main` three times and still
+            // report "3 synced, 0 errors".
+            stubSyncSuccess();
+
+            const promise = service.syncAllBranches({
+                targetOwner: 'o',
+                targetRepo: 'r',
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+                template: baseTemplate,
+            });
+
+            await jest.runAllTimersAsync();
+            await promise;
+
+            const pushedRefs = gitFacade.push.mock.calls.map((c: any[]) => c[0].ref);
+            expect(pushedRefs).toEqual(['main', 'stage', 'develop']);
+            expect(new Set(pushedRefs).size).toBe(3);
+
+            const pushedRemoteRefs = gitFacade.push.mock.calls.map((c: any[]) => c[0].remoteRef);
+            expect(pushedRemoteRefs).toEqual(['main', 'stage', 'develop']);
+        });
+
+        it('gives each branch its own working directory and removes it', async () => {
+            stubSyncSuccess();
+
+            const promise = service.syncAllBranches({
+                targetOwner: 'o',
+                targetRepo: 'r',
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+                template: baseTemplate,
+            });
+
+            await jest.runAllTimersAsync();
+            await promise;
+
+            const pushedDirs = gitFacade.push.mock.calls.map((c: any[]) => c[0].dir);
+            expect(new Set(pushedDirs).size).toBe(3);
+            for (const dir of pushedDirs) {
+                expect(fsMock.rm).toHaveBeenCalledWith(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('counts a branch whose push did not land as an error, not a success', async () => {
+            stubSyncSuccess();
+            gitFacade.listBranches.mockImplementation(async (owner: string, _repo: string) => {
+                if (owner === 'ever-works') {
+                    return [
+                        { name: 'main', commit: IN_SYNC_SHA },
+                        { name: 'stage', commit: IN_SYNC_SHA },
+                        { name: 'develop', commit: IN_SYNC_SHA },
+                    ];
+                }
+                // Target: main tracked the template, stage/develop froze.
+                return [
+                    { name: 'main', commit: IN_SYNC_SHA },
+                    { name: 'stage', commit: '7e237a8c7e237a8c7e237a8c7e237a8c7e237a8c' },
+                    { name: 'develop', commit: '1eb0424f1eb0424f1eb0424f1eb0424f1eb0424f' },
+                ];
+            });
+
+            const promise = service.syncAllBranches({
+                targetOwner: 'o',
+                targetRepo: 'r',
+                userId: 'u',
+                committer: { name: 'n', email: 'e' },
+                template: baseTemplate,
+            });
+
+            await jest.runAllTimersAsync();
+            const summary = await promise;
+
+            expect(summary.synced).toBe(1);
+            expect(summary.errors).toBe(2);
+            expect(summary.results.map((r) => r.status)).toEqual(['synced', 'error', 'error']);
         });
 
         it('expands branchMapping into an additional sync target without skipping the original', async () => {
@@ -305,16 +556,21 @@ describe('BranchSyncService', () => {
             await jest.runAllTimersAsync();
             const summary = await promise;
 
-            expect(gitFacade.cloneOrPull).toHaveBeenCalledTimes(2);
+            expect(gitFacade.cloneBranch).toHaveBeenCalledTimes(2);
             expect(summary.totalBranches).toBe(1);
             expect(summary.synced).toBe(2);
             expect(gitFacade.renameBranch).toHaveBeenCalledTimes(1);
             expect(gitFacade.renameBranch).toHaveBeenCalledWith(
                 undefined,
-                '/tmp/d',
+                '/tmp/d-2',
                 'stage',
                 'main',
             );
+            // stage→stage then stage→main: two ops, two different remote refs.
+            expect(gitFacade.push.mock.calls.map((c: any[]) => c[0].remoteRef)).toEqual([
+                'stage',
+                'main',
+            ]);
         });
 
         it('skips a branch that is the mapped target of another branch', async () => {
@@ -336,8 +592,8 @@ describe('BranchSyncService', () => {
 
             // Two ops: stage→stage and stage→main. The standalone 'main'
             // entry is skipped because it's a mapped target.
-            expect(gitFacade.cloneOrPull).toHaveBeenCalledTimes(2);
-            const branchesCloned = gitFacade.cloneOrPull.mock.calls.map((c: any[]) => c[0].branch);
+            expect(gitFacade.cloneBranch).toHaveBeenCalledTimes(2);
+            const branchesCloned = gitFacade.cloneBranch.mock.calls.map((c: any[]) => c[0].branch);
             expect(branchesCloned).toEqual(['stage', 'stage']);
             expect(summary.totalBranches).toBe(2);
         });
@@ -360,7 +616,7 @@ describe('BranchSyncService', () => {
             const summary = await promise;
 
             // One op: main→main (the additional 'main !== main' branch is suppressed).
-            expect(gitFacade.cloneOrPull).toHaveBeenCalledTimes(1);
+            expect(gitFacade.cloneBranch).toHaveBeenCalledTimes(1);
             expect(summary.synced).toBe(1);
             expect(gitFacade.renameBranch).not.toHaveBeenCalled();
         });
@@ -644,8 +900,15 @@ describe('BranchSyncService', () => {
     });
 
     describe('contracts', () => {
-        it('exposes MAX_CONCURRENT_SYNCS=1 (sequential to avoid cloneOrPull dir collisions)', () => {
+        it('exposes MAX_CONCURRENT_SYNCS=1 (kept sequential for API/CPU pacing)', () => {
             expect((service as any).MAX_CONCURRENT_SYNCS).toBe(1);
+        });
+
+        it('never falls back to the branch-blind cloneOrPull', () => {
+            // cloneOrPull resolves a directory keyed on owner+repo and
+            // switches the checkout back to main. If it reappears in this
+            // service, the per-branch guarantee is gone again.
+            expect(gitFacade.cloneOrPull).toBeUndefined();
         });
 
         it('logger context is the service name', () => {

--- a/packages/agent/src/generators/website-generator/branch-sync.service.ts
+++ b/packages/agent/src/generators/website-generator/branch-sync.service.ts
@@ -50,27 +50,32 @@ function isSafeGitBranchName(name: unknown): name is string {
  * code (and any beta branch overrides, when `Work.websiteTemplateUseBeta`
  * is set).
  *
- * **Single-flight on purpose — do not parallelise.** The shared
- * `gitFacade.cloneOrPull` uses a deterministic working directory keyed on
- * owner+repo (not on branch), so two concurrent calls into the same
- * work's repo would race against the same `.git` checkout and corrupt
- * each other (mid-pull index, half-written packfiles, branch HEAD
- * pointing into the wrong tree). `MAX_CONCURRENT_SYNCS = 1` enforces a
- * sequential pipeline at the service level. Callers that fan out across
- * MANY works are responsible for serialising per-work; this class only
- * serialises within a single `syncFromTemplate()` invocation.
+ * **Every branch is cloned into a directory of its own** via
+ * `gitFacade.cloneBranch`. `cloneOrPull` cannot be used here: its working
+ * directory is keyed on owner+repo (not on branch) AND it switches the
+ * checkout back to the default branch, so syncing `['main','stage',
+ * 'develop']` from one template resolved to the same `main` checkout three
+ * times and pushed `main` three times — while reporting three successes.
+ * See the verification guard in `syncBranch` for why that stayed invisible.
+ *
+ * `MAX_CONCURRENT_SYNCS = 1` is retained: per-branch directories mean it is
+ * no longer required for correctness, but sequential syncing keeps the
+ * provider API call rate and the pure-JS git CPU cost predictable. Raising
+ * it is a separate, measured change.
  *
  * Return shape: `BranchSyncSummary` (or `null` when there's no template
  * resolved for the work). Each branch's outcome is one of `synced` /
  * `skipped` / `error`; the summary's `errors` count drives the calling
- * service's "did the deploy refresh succeed" gate.
+ * service's "did the deploy refresh succeed" gate — so a branch whose push
+ * cannot be VERIFIED to have landed is reported as `error`, never `synced`.
  */
 @Injectable()
 export class BranchSyncService {
     private readonly logger = new Logger(BranchSyncService.name);
 
-    // Syncs must run sequentially: cloneOrPull uses a deterministic dir
-    // based on owner+repo (not branch), so parallel syncs corrupt each other.
+    // Kept at 1 deliberately. `cloneBranch` gives each branch its own dir,
+    // so this is no longer load-bearing for correctness — it now just keeps
+    // provider API calls and pure-JS git work sequential.
     private readonly MAX_CONCURRENT_SYNCS = 1;
 
     constructor(
@@ -338,6 +343,11 @@ export class BranchSyncService {
         targetRepo: string;
         template: WebsiteTemplateConfig;
         userId: string;
+        /**
+         * Kept on the signature so existing callers are unaffected. It is no
+         * longer read here: the sync is a fresh single-branch clone followed
+         * by a push, which never authors a merge commit.
+         */
         committer: GitCommitter;
         forcePush?: boolean;
         providerId?: string;
@@ -350,7 +360,6 @@ export class BranchSyncService {
             targetRepo,
             template,
             userId,
-            committer,
             forcePush = true,
             providerId,
             workId,
@@ -364,13 +373,33 @@ export class BranchSyncService {
         let tempDir: string | null = null;
 
         try {
-            // Clone template branch
-            tempDir = await this.gitFacade.cloneOrPull(
+            // The sha the target branch has to end up at. Read BEFORE the
+            // clone: if the template moves mid-run the guard below fires
+            // (loud, one branch) instead of comparing the new head against
+            // itself and rubber-stamping whatever happened.
+            const expectedSha = await this.resolveRemoteBranchSha(
+                template.owner,
+                template.repo,
+                branchName,
+                { userId, providerId },
+            );
+            if (!expectedSha) {
+                return {
+                    branch: branchName,
+                    status: 'error',
+                    message: `Template branch '${branchName}' not found on ${template.owner}/${template.repo}; nothing to sync`,
+                };
+            }
+
+            // Clone the template branch into a directory of its own.
+            // NOT cloneOrPull: that keys its dir on owner+repo only and
+            // switches the checkout back to the default branch, so every
+            // branch of one template collapsed onto the same main checkout.
+            tempDir = await this.gitFacade.cloneBranch(
                 {
                     owner: template.owner,
                     repo: template.repo,
                     branch: branchName,
-                    committer,
                 },
                 { userId, providerId, workId },
             );
@@ -384,11 +413,39 @@ export class BranchSyncService {
             const targetRepoUrl = this.gitFacade.getCloneUrl(providerId, targetOwner, targetRepo);
             await this.gitFacade.replaceRemote(providerId, tempDir, 'origin', targetRepoUrl);
 
-            // Push to target
+            // Push to target. `ref`/`remoteRef` are explicit on purpose:
+            // without them the push follows HEAD and whatever
+            // `branch.<name>.merge` the clone left in the config, which is
+            // exactly how a 'develop' sync used to land on 'main'.
             await this.gitFacade.push(
-                { dir: tempDir, force: forcePush },
+                {
+                    dir: tempDir,
+                    force: forcePush,
+                    ref: targetBranch,
+                    remoteRef: targetBranch,
+                },
                 { userId, providerId, workId },
             );
+
+            // Verification guard. A push that resolves without throwing is
+            // NOT proof the remote branch moved — it is proof the transport
+            // did not error. Read the ref back and compare; a mismatch (or
+            // a branch that still doesn't exist) is an `error`, so the
+            // caller's `errors` gate can see it. Without this, the next
+            // regression in the git layer is silent all over again.
+            const actualSha = await this.resolveRemoteBranchSha(
+                targetOwner,
+                targetRepo,
+                targetBranch,
+                { userId, providerId },
+            );
+            if (actualSha !== expectedSha) {
+                const message =
+                    `Push reported success but ${targetOwner}/${targetRepo}@${targetBranch} is at ` +
+                    `${actualSha ?? '(branch missing)'}, expected ${expectedSha}`;
+                this.logger.error(message);
+                return { branch: branchName, status: 'error', message };
+            }
 
             return {
                 branch: branchName,
@@ -408,5 +465,30 @@ export class BranchSyncService {
                 await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
             }
         }
+    }
+
+    /**
+     * Head sha of `branch` on `owner/repo`, straight from the provider API,
+     * or `null` when the repo has no such branch.
+     *
+     * Uses `listBranches` on purpose. It is a REQUIRED capability, whereas
+     * `getLatestCommit` is optional and the facade answers `null` for a
+     * provider that lacks it — a verification guard built on that would
+     * quietly degrade into a no-op, which is the failure mode this whole
+     * change exists to remove. Errors are deliberately NOT swallowed: an
+     * unverifiable sync must surface as `error`, not as success.
+     */
+    private async resolveRemoteBranchSha(
+        owner: string,
+        repo: string,
+        branch: string,
+        options: { userId: string; providerId?: string },
+    ): Promise<string | null> {
+        const branches = await this.gitFacade.listBranches(owner, repo, {
+            userId: options.userId,
+            providerId: options.providerId,
+        });
+        const match = branches.find((b) => b.name === branch);
+        return match?.commit ? match.commit.toLowerCase() : null;
     }
 }

--- a/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
@@ -58,11 +58,40 @@ export interface GitCloneOptions {
 	readonly autoSwitchToMainBranch?: boolean;
 }
 
+/**
+ * Clone a SINGLE branch into a directory of its own.
+ *
+ * Distinct from {@link GitCloneOptions}: `branch` is required, and the
+ * implementation is expected to give every call an isolated working
+ * directory rather than a deterministic owner+repo one.
+ */
+export interface GitCloneBranchOptions {
+	readonly owner: string;
+	readonly repo: string;
+	readonly branch: string;
+	readonly token: string;
+}
+
 export interface GitPushOptions {
 	readonly dir: string;
 	readonly token: string;
 	readonly force?: boolean;
 	readonly maxRetries?: number;
+	/**
+	 * Local ref to push. When omitted the underlying git implementation
+	 * pushes whatever branch HEAD happens to point at — correct only when
+	 * the caller owns the checkout. Pass it explicitly whenever *which*
+	 * branch gets pushed is part of the caller's intent.
+	 */
+	readonly ref?: string;
+	/**
+	 * Receiving branch on the remote. When omitted it is derived from the
+	 * remote-tracking config of `ref`, falling back to `ref` itself. Pass
+	 * it to push a local branch onto a differently-named remote branch, or
+	 * to stop a `branch.<name>.merge` entry left over from the clone from
+	 * silently choosing the destination.
+	 */
+	readonly remoteRef?: string;
 }
 
 export interface CreateRepoOptions {
@@ -298,6 +327,20 @@ export interface GitDiffResult {
  */
 export interface IGitOperations {
 	cloneOrPull(options: GitCloneOptions): Promise<string>;
+	/**
+	 * Clone one branch into a working directory of its own.
+	 *
+	 * `cloneOrPull` keys its directory on owner+repo only and switches the
+	 * checkout back to the default branch, so it cannot express "give me
+	 * THIS branch" for two branches of the same repo in one run. This does:
+	 * every call gets its own directory with `branch` checked out, and the
+	 * caller removes it when finished.
+	 *
+	 * Optional so existing providers keep compiling. Callers MUST verify
+	 * the method is present before calling it — the lazy-plugin proxy
+	 * over-reports optional methods (see `GitFacadeService`).
+	 */
+	cloneBranch?(options: GitCloneBranchOptions): Promise<string>;
 	pull(dir: string, token: string, committer?: GitCommitter): Promise<void>;
 	add(dir: string, paths: string | string[]): Promise<void>;
 	addAll(dir: string): Promise<void>;

--- a/packages/plugin/src/git/git-operations.ts
+++ b/packages/plugin/src/git/git-operations.ts
@@ -8,6 +8,7 @@ import type {
 	GitAuth,
 	GitCommitter,
 	GitCloneOptions,
+	GitCloneBranchOptions,
 	GitPushOptions,
 	GitFileChange,
 	GitFileStatus
@@ -146,7 +147,7 @@ export class GitOperations implements IGitOperations {
 	}
 
 	async push(options: GitPushOptions): Promise<void> {
-		const { dir, token, force = false, maxRetries = 3 } = options;
+		const { dir, token, force = false, maxRetries = 3, ref, remoteRef } = options;
 
 		if (!token) {
 			throw new Error('Git token is required for push operation');
@@ -157,11 +158,17 @@ export class GitOperations implements IGitOperations {
 
 		for (let attempt = 1; attempt <= maxRetries; attempt++) {
 			try {
+				// `ref`/`remoteRef` are forwarded as-is: leaving them undefined
+				// keeps isomorphic-git's existing defaults (current branch →
+				// its tracking branch), so callers that don't pass them are
+				// unaffected.
 				await git.push({
 					onAuth: () => auth,
 					fs,
 					http,
 					dir,
+					ref,
+					remoteRef,
 					force
 				});
 				return;
@@ -266,7 +273,7 @@ export class GitOperations implements IGitOperations {
 		await this.removeDirSafe(this.getLocalDir(owner, repo));
 	}
 
-	async cloneBranch(params: { owner: string; repo: string; branch: string; token: string }): Promise<string> {
+	async cloneBranch(params: GitCloneBranchOptions): Promise<string> {
 		const { owner, repo, branch, token } = params;
 		const url = this.getCloneUrl(owner, repo);
 		const auth = this.getAuth(token);

--- a/packages/plugin/src/git/index.ts
+++ b/packages/plugin/src/git/index.ts
@@ -11,6 +11,7 @@ export type {
 	GitFileStatus,
 	GitFileChange,
 	GitCloneOptions,
+	GitCloneBranchOptions,
 	GitPushOptions,
 	CreateRepoOptions,
 	UpdateRepoOptions,

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -25,6 +25,7 @@ import type {
 	ListRepositoriesOptions,
 	ListPullRequestsOptions,
 	GitCloneOptions,
+	GitCloneBranchOptions,
 	GitPushOptions,
 	GitCommitter,
 	GitFileChange,
@@ -386,6 +387,11 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 	async cloneOrPull(options: GitCloneOptions): Promise<string> {
 		this.ensureGitOps();
 		return this.gitOps!.cloneOrPull(options);
+	}
+
+	async cloneBranch(options: GitCloneBranchOptions): Promise<string> {
+		this.ensureGitOps();
+		return this.gitOps!.cloneBranch(options);
 	}
 
 	async pull(dir: string, token: string, committer?: GitCommitter): Promise<void> {


### PR DESCRIPTION
Whole-branch cascade `stage` -> `main` (no cherry-picking, golden rule #14). Owner instruction 2026-08-23.