### PR TITLE
feat(billing): deliver the entitlements the pricing page sells + make the $99 licence buyable

### DIFF
--- a/apps/api/src/billing/plan-checkout.controller.spec.ts
+++ b/apps/api/src/billing/plan-checkout.controller.spec.ts
@@ -54,8 +54,21 @@ jest.mock('@ever-works/agent/subscriptions', () => ({
     CheckoutSessionNotFoundError: FakeCheckoutSessionNotFoundError,
     PlanSubscriptionService: class PlanSubscriptionService {},
 }));
+// 🛑 Keep this in step with the REAL enum in packages/agent/src/entities/types.ts.
+// It stubbed only the three cloud codes, which silently made every DTO
+// assertion here validate against a catalog that has not existed since the
+// self-hosted editions landed - so a `selfhosted_pro` body looked like a 400
+// in tests while the running API accepts it. A mock that lags the enum turns
+// this suite from a guard into a decoy.
 jest.mock('@ever-works/agent/entities', () => ({
-    SubscriptionPlanCode: { FREE: 'free', STANDARD: 'standard', PREMIUM: 'premium' },
+    SubscriptionPlanCode: {
+        FREE: 'free',
+        STANDARD: 'standard',
+        PREMIUM: 'premium',
+        SELFHOSTED_COMMUNITY: 'selfhosted_community',
+        SELFHOSTED_PRO: 'selfhosted_pro',
+        SELFHOSTED_ENTERPRISE: 'selfhosted_enterprise',
+    },
 }));
 jest.mock('../auth', () => ({
     AuthSessionGuard: class AuthSessionGuard {},
@@ -365,6 +378,41 @@ describe('CreatePlanCheckoutDto — the client can never name a price', () => {
 
     it('rejects a missing plan code', async () => {
         expect(await validateBody({})).not.toHaveLength(0);
+    });
+
+    /**
+     * H1 — `interval` and `seats` decide WHICH catalog SKU is priced. They
+     * have always been accepted here and forwarded by the controller, and
+     * until now no test at this boundary said so, while the web client never
+     * sent them. That is what made the $99 lifetime licence unreachable: not
+     * refused, just never requested.
+     */
+    it('accepts each supported interval, and rejects anything else', async () => {
+        for (const interval of ['monthly', 'annual', 'lifetime']) {
+            expect(await validateBody({ planCode: 'selfhosted_pro', interval })).toHaveLength(0);
+        }
+        for (const interval of ['weekly', 'perpetual', '', 1]) {
+            expect(await validateBody({ planCode: 'selfhosted_pro', interval })).not.toHaveLength(
+                0,
+            );
+        }
+    });
+
+    it('treats an omitted interval as not supplied (the server defaults to monthly)', async () => {
+        // @IsOptional() skips validation for null AND undefined, so both mean
+        // 'field absent' - which the controller turns into 'monthly'. Asserted
+        // so a later switch to @ValidateIf cannot silently start 400ing every
+        // body that predates this field.
+        expect(await validateBody({ planCode: 'standard' })).toHaveLength(0);
+        expect(await validateBody({ planCode: 'standard', interval: null })).toHaveLength(0);
+    });
+
+    it('accepts a seat count in range and rejects one outside it', async () => {
+        expect(await validateBody({ planCode: 'standard', seats: 0 })).toHaveLength(0);
+        expect(await validateBody({ planCode: 'standard', seats: 17 })).toHaveLength(0);
+        for (const seats of [-1, 1.5, 100001]) {
+            expect(await validateBody({ planCode: 'standard', seats })).not.toHaveLength(0);
+        }
     });
 });
 

--- a/apps/api/src/migrations/1787500000000-WidenCreditLedgerRefId.ts
+++ b/apps/api/src/migrations/1787500000000-WidenCreditLedgerRefId.ts
@@ -49,6 +49,16 @@ export class WidenCreditLedgerRefId1787500000000 implements MigrationInterface {
         if (column.type !== 'uuid') {
             return;
         }
+        // `uuid` -> `varchar` is not binary-coercible in PostgreSQL, so this is a
+        // full heap rewrite plus an index rebuild, holding ACCESS EXCLUSIVE for the
+        // duration. It runs at POD BOOT, so a lock it cannot get would queue every
+        // reader of the credits path behind it while the pod sits in startup.
+        //
+        // Bound the wait instead: on timeout the migration transaction rolls back,
+        // the pod restarts, and the next boot retries — a loud, recoverable retry
+        // rather than a silent stall. SET LOCAL is scoped to this transaction and
+        // needs no cleanup.
+        await queryRunner.query("SET LOCAL lock_timeout = '5s'");
         await queryRunner.query(
             'ALTER TABLE "credit_ledger_entries" ALTER COLUMN "refId" TYPE character varying(128)',
         );

--- a/apps/api/src/migrations/1787500000000-WidenCreditLedgerRefId.ts
+++ b/apps/api/src/migrations/1787500000000-WidenCreditLedgerRefId.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Widens `credit_ledger_entries.refId` from `uuid` to `varchar(128)`.
+ *
+ * 🛑 This is a live production blocker on the money path, not a tidy-up.
+ *
+ * The creating migration (`1783400000000`) declared `refId` as a Postgres
+ * `uuid`, but the only code that writes it puts a STRIPE id there:
+ * `BillingService` records a settled credit-pack purchase with
+ * `refId: event.paymentId` (billing.service.ts:549) and sizes a refund
+ * reversal from the same column (`:607`, read back via `findLatestByRef`).
+ * `event.paymentId` is `intent.id` — a `pi_…` string
+ * (stripe-billing.provider.ts:533, 701).
+ *
+ * So the FIRST settled credit-pack purchase on any Postgres environment
+ * raises `22P02 invalid input syntax for type uuid`, the webhook 500s, and
+ * Stripe retries that delivery on its back-off schedule indefinitely. The
+ * customer is charged and never receives the credits.
+ *
+ * The test suite cannot see it: it runs on better-sqlite3, where `uuid` is
+ * just a varchar and `'pi_3ABC'` inserts happily. Only the absence of any
+ * completed purchase to date has kept this from firing.
+ *
+ * Widening `uuid` → `varchar(128)` is lossless (every uuid is a valid
+ * 36-char string) and needs no data migration. `findLatestByRef` keeps
+ * working because it compares the column to a string either way.
+ *
+ * Forward-only and idempotent: the column type is checked first, so a
+ * re-run is a no-op and a database that never had the uuid type is left
+ * alone. `down()` deliberately does NOT narrow back — that would fail on
+ * any row holding a real Stripe id, which is exactly the data this
+ * migration exists to allow.
+ */
+export class WidenCreditLedgerRefId1787500000000 implements MigrationInterface {
+    name = 'WidenCreditLedgerRefId1787500000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('credit_ledger_entries');
+        const column = table?.findColumnByName('refId');
+        if (!column) {
+            return;
+        }
+        // Only Postgres actually enforces the uuid type; on sqlite/mysql the
+        // column is already string-shaped and there is nothing to widen.
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+        if (column.type !== 'uuid') {
+            return;
+        }
+        await queryRunner.query(
+            'ALTER TABLE "credit_ledger_entries" ALTER COLUMN "refId" TYPE character varying(128)',
+        );
+    }
+
+    public async down(): Promise<void> {
+        // Intentionally empty. Narrowing back to `uuid` would fail on any row
+        // holding a Stripe `pi_…` id — the very rows this migration enables.
+    }
+}

--- a/apps/api/src/subscriptions/subscriptions.controller.spec.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.spec.ts
@@ -34,7 +34,11 @@ describe('SubscriptionsController', () => {
     let subscriptionService: jest.Mocked<
         Pick<
             SubscriptionService,
-            'summarizePlan' | 'isEnabled' | 'changePlanSelfService' | 'listPlans'
+            | 'summarizePlan'
+            | 'isEnabled'
+            | 'changePlanSelfService'
+            | 'listPlans'
+            | 'listSelfHostedPlans'
         >
     >;
     let authService: jest.Mocked<Pick<AuthService, 'getUser'>>;
@@ -62,6 +66,7 @@ describe('SubscriptionsController', () => {
             isEnabled: jest.fn(),
             changePlanSelfService: jest.fn(),
             listPlans: jest.fn(),
+            listSelfHostedPlans: jest.fn(),
         } as any;
         authService = {
             getUser: jest.fn().mockResolvedValue(user),
@@ -133,6 +138,12 @@ describe('SubscriptionsController', () => {
     });
 
     describe('listPlans (Wave 13 — Billing page plan switcher)', () => {
+        beforeEach(() => {
+            // Most cases care only about the hosted switcher; the licence list
+            // is asserted separately below.
+            subscriptionService.listSelfHostedPlans.mockResolvedValue([]);
+        });
+
         const seededPlans = [
             {
                 code: 'free',
@@ -173,15 +184,67 @@ describe('SubscriptionsController', () => {
             expect(result.plans[0]).toEqual({
                 code: 'free',
                 name: 'Free',
+                hosting: undefined,
                 maxWorks: 1,
                 allowedCadences: ['monthly'],
                 monthlyPrice: '0',
+                annualPrice: undefined,
+                lifetimePrice: undefined,
+                seatsIncluded: undefined,
+                seatMonthlyPrice: undefined,
+                monthlyCredits: undefined,
                 overagePricePerRun: '10',
                 currency: 'usd',
                 isCurrent: false,
                 dailyFreeCredits: 50,
             });
             expect(result.plans[1].isCurrent).toBe(true);
+        });
+
+        /**
+         * H1 — self-hosted editions ship in their OWN array.
+         *
+         * They are purchasable (the $99 perpetual licence is the only lifetime
+         * SKU in the catalog) but never self-assignable: `changePlanSelfService`
+         * refuses them, so a card in the switcher would be a button whose only
+         * possible outcome is a 403. The switcher must keep exactly the plans a
+         * user can switch between.
+         */
+        it('returns self-hosted editions separately from the switchable plans', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                plan: { code: 'free', displayName: 'Free' },
+                allowances: [],
+            } as any);
+            subscriptionService.listPlans.mockResolvedValue(seededPlans);
+            subscriptionService.listSelfHostedPlans.mockResolvedValue([
+                {
+                    code: 'selfhosted_pro',
+                    displayName: 'Pro Edition',
+                    hosting: 'selfhosted',
+                    maxWorks: 5,
+                    allowedCadences: ['monthly'],
+                    monthlyPrice: '49',
+                    annualPrice: '408',
+                    lifetimePrice: '99',
+                    seatsIncluded: 10,
+                    seatMonthlyPrice: '5',
+                    monthlyCredits: 3000,
+                    overagePricePerRun: '0',
+                    currency: 'usd',
+                },
+            ] as any[]);
+            entitlementsService.getNumber.mockResolvedValue(50);
+
+            const result = await controller.listPlans(auth);
+
+            // The switcher is untouched — no self-hosted card leaks into it.
+            expect(result.plans.map((plan) => plan.code)).toEqual(['free', 'premium']);
+            expect(result.licences).toHaveLength(1);
+            expect(result.licences[0].code).toBe('selfhosted_pro');
+            expect(result.licences[0].lifetimePrice).toBe('99');
+            // A licence never becomes "your current plan" on this deployment.
+            expect(result.licences[0].isCurrent).toBe(false);
         });
 
         it('falls back to free as the current plan when subscriptions are disabled', async () => {

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -82,9 +82,10 @@ export class SubscriptionsController {
     @ApiResponse({ status: 200, description: 'Active plans + current plan code' })
     async listPlans(@CurrentUser() auth: AuthenticatedUser) {
         const user = await this.authService.getUser(auth.userId);
-        const [summary, plans] = await Promise.all([
+        const [summary, plans, licences] = await Promise.all([
             this.subscriptionService.summarizePlan(user),
             this.subscriptionService.listPlans(),
+            this.subscriptionService.listSelfHostedPlans(),
         ]);
         const currentPlanCode = summary.enabled ? summary.plan.code : 'free';
 
@@ -103,6 +104,13 @@ export class SubscriptionsController {
                 maxWorks: plan.maxWorks,
                 allowedCadences: plan.allowedCadences ?? [],
                 monthlyPrice: plan.monthlyPrice,
+                // The yearly total, NOT a per-month figure (cloud Pro stores
+                // '204'). Rendering it against a '/mo' suffix shows $204/mo.
+                annualPrice: plan.annualPrice,
+                lifetimePrice: plan.lifetimePrice,
+                seatsIncluded: plan.seatsIncluded,
+                seatMonthlyPrice: plan.seatMonthlyPrice,
+                monthlyCredits: plan.monthlyCredits,
                 overagePricePerRun: plan.overagePricePerRun,
                 currency: plan.currency,
                 isCurrent: plan.code === currentPlanCode,
@@ -114,11 +122,36 @@ export class SubscriptionsController {
             })),
         );
 
+        // Self-hosted editions ship as a SEPARATE array, never merged into
+        // `plans`. They are purchasable but not self-assignable, so a card in
+        // the switcher would be a button whose only outcome is a 403 from
+        // `changePlanSelfService`. The switcher keeps its three cards; the
+        // licence surface renders from this.
+        const licenceItems = licences.map((plan) => ({
+            code: plan.code,
+            name: plan.displayName,
+            hosting: plan.hosting,
+            maxWorks: plan.maxWorks,
+            allowedCadences: plan.allowedCadences ?? [],
+            monthlyPrice: plan.monthlyPrice,
+            annualPrice: plan.annualPrice,
+            lifetimePrice: plan.lifetimePrice,
+            seatsIncluded: plan.seatsIncluded,
+            seatMonthlyPrice: plan.seatMonthlyPrice,
+            monthlyCredits: plan.monthlyCredits,
+            overagePricePerRun: plan.overagePricePerRun,
+            currency: plan.currency,
+            // A licence never becomes "your current plan" on this deployment.
+            isCurrent: false,
+            dailyFreeCredits: 0,
+        }));
+
         return {
             status: 'success',
             enabled: summary.enabled,
             currentPlanCode,
             plans: items,
+            licences: licenceItems,
         };
     }
 

--- a/apps/api/src/subscriptions/subscriptions.module.ts
+++ b/apps/api/src/subscriptions/subscriptions.module.ts
@@ -3,9 +3,10 @@ import { AuthModule } from '@src/auth';
 import {
     SubscriptionsModule as AgentSubscriptionsModule,
     RunCostSettlementService,
+    PlanRunLimitsService,
 } from '@ever-works/agent/subscriptions';
 import { RUN_COST_SETTLER } from '@ever-works/agent/database';
-import { RUN_CREDITS_PRECHECK } from '@ever-works/agent/agents';
+import { RUN_CREDITS_PRECHECK, RUN_PLAN_LIMITS } from '@ever-works/agent/agents';
 import { SubscriptionsController } from './subscriptions.controller';
 import { CreditsController } from './credits.controller';
 import { CostsController } from './costs.controller';
@@ -36,7 +37,14 @@ import { CostsController } from './costs.controller';
         // instance behind both tokens (useExisting keeps it a singleton).
         { provide: RUN_COST_SETTLER, useExisting: RunCostSettlementService },
         { provide: RUN_CREDITS_PRECHECK, useExisting: RunCostSettlementService },
+        // H2 — the per-user PLAN concurrency ceiling. Same @Global()
+        // reasoning as the two above: RunDispatchGateService lives in the
+        // agent-side AgentsModule and consults this token through an
+        // @Optional() @Inject(), which would silently resolve to undefined
+        // (and leave `max-concurrent-runs` unread, exactly as before) if
+        // this binding were not global.
+        { provide: RUN_PLAN_LIMITS, useExisting: PlanRunLimitsService },
     ],
-    exports: [RUN_COST_SETTLER, RUN_CREDITS_PRECHECK],
+    exports: [RUN_COST_SETTLER, RUN_CREDITS_PRECHECK, RUN_PLAN_LIMITS],
 })
 export class SubscriptionsModule {}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3658,6 +3658,15 @@
                     "pagePrev": "Previous",
                     "pageNext": "Next",
                     "pageInfo": "Page {page} of {pages}"
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
                 }
             },
             "usage": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3667,6 +3667,11 @@
                     "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
                     "confirmCta": "Continue to payment",
                     "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {

--- a/apps/web/src/app/[locale]/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/billing/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { creditsAPI, subscriptionsAPI } from '@/lib/api/credits';
 import { billingAPI } from '@/lib/api/billing';
+import type { PlanCheckoutReturnResponse } from '@/lib/api/billing';
 import type {
     CreditsBalance,
     CreditsLedgerPage,
@@ -42,9 +43,17 @@ export default async function BillingSettingsPage({ searchParams }: BillingSetti
     // the call to the session user, so a session id pasted from another
     // account's redirect resolves to a 404 and is swallowed here.
     const params = await searchParams;
-    if (params.session_id) {
-        await billingAPI.completePlanCheckout(params.session_id).catch(() => null);
-    }
+    // 🛑 The RESULT is what the page needs, not just the side effect. It used
+    // to be discarded, which is how a settled $99 perpetual licence produced a
+    // page byte-identical to the one before payment — a licence writes no
+    // subscription row and grants no tier by design, so without this the only
+    // visible change was none, and the same enabled "Buy" button was still
+    // sitting there inviting a second charge.
+    const checkoutReturn = params.session_id
+        ? await billingAPI
+              .completePlanCheckout(params.session_id)
+              .catch((): PlanCheckoutReturnResponse | null => null)
+        : null;
 
     // Each fetch degrades independently: a failed call renders that
     // section's error/empty state instead of failing the whole page.
@@ -76,6 +85,7 @@ export default async function BillingSettingsPage({ searchParams }: BillingSetti
             initialLedger={ledger}
             initialOverview={overview}
             initialInvoices={invoices}
+            checkoutReturn={checkoutReturn}
         />
     );
 }

--- a/apps/web/src/app/actions/dashboard/billing.ts
+++ b/apps/web/src/app/actions/dashboard/billing.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { subscriptionsAPI } from '@/lib/api/credits';
-import { billingAPI } from '@/lib/api/billing';
+import { billingAPI, type PlanCheckoutOptions } from '@/lib/api/billing';
 import { getAuthFromCookie } from '@/lib/auth';
 import { ROUTES } from '@/lib/constants';
 // Security: map ApiResponseError HTTP status codes to generic client-safe
@@ -90,14 +90,17 @@ export async function startCreditCheckoutAction(packId: string) {
  * failure branch inline (production redacts thrown server-action
  * messages).
  */
-export async function startPlanCheckoutAction(planCode: string) {
+export async function startPlanCheckoutAction(planCode: string, options: PlanCheckoutOptions = {}) {
     const user = await getAuthFromCookie();
     if (!user) {
         redirect(ROUTES.AUTH_LOGIN);
     }
 
     try {
-        const result = await billingAPI.startPlanCheckout(planCode);
+        // Pure pass-through. `interval` and `seats` are hints about WHICH
+        // catalog SKU to price; the amount is still resolved server-side from
+        // `subscription_plans` and the client can never name a price.
+        const result = await billingAPI.startPlanCheckout(planCode, options);
         return { success: true as const, url: result.url, error: null };
     } catch (error) {
         // Security: log full error server-side; return a generic client-safe message.

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -10,6 +10,7 @@ import {
     CreditCard,
     FileText,
     RefreshCw,
+    ShieldCheck,
     Wallet,
     Zap,
     Check,
@@ -168,6 +169,12 @@ export function BillingSettings({
     const subscriptionsEnabled = initialPlans?.enabled ?? initialPlan?.enabled ?? false;
     const currentPlanCode = initialPlans?.currentPlanCode ?? initialPlan?.plan?.code ?? 'free';
     const plans = initialPlans?.plans ?? [];
+    // Only editions that are actually priced for a one-off purchase. Today
+    // that is exactly one SKU (`selfhosted_pro` @ $99); Community Edition
+    // has no prices at all and must not render a buy button.
+    const licences = (initialPlans?.licences ?? []).filter(
+        (licence) => Number(licence.lifetimePrice ?? 0) > 0,
+    );
     const currentPlan =
         plans.find((p) => p.isCurrent) ?? plans.find((p) => p.code === currentPlanCode) ?? null;
     const balanceCredits =
@@ -190,6 +197,8 @@ export function BillingSettings({
     // apply must not be offered as a live button.
     const upgradeEnabled = canUpgradePlan(overview, paymentsEnabled, subscriptionsEnabled);
     const [upgradingPlanCode, setUpgradingPlanCode] = useState<string | null>(null);
+    const [licencePendingCode, setLicencePendingCode] = useState<string | null>(null);
+    const [licenceConfirmCode, setLicenceConfirmCode] = useState<string | null>(null);
 
     const [autoRechargeOn, setAutoRechargeOn] = useState(overview?.autoRecharge.enabled ?? false);
     const [autoRechargeThreshold, setAutoRechargeThreshold] = useState(
@@ -308,6 +317,39 @@ export function BillingSettings({
         },
         [upgradeEnabled, t],
     );
+
+    /**
+     * Buy a perpetual self-hosted commercial licence.
+     *
+     * 🛑 Deliberately NOT wrapped in `useCallback`. The sibling
+     * `handleUpgradePlan` memoizes on `[upgradeEnabled, t]`, both stable for
+     * the mounted component — so any new state read inside such a callback
+     * would be captured at first render and never update. For a checkout
+     * handler that means charging the cadence the page opened with rather
+     * than the one the buyer chose. There is nothing here worth memoizing.
+     */
+    const handleBuyLicence = async (licence: SubscriptionPlanListItem) => {
+        if (!upgradeEnabled) {
+            toast.info(t('plans.upgradeHint'));
+            return;
+        }
+        setLicencePendingCode(licence.code);
+        try {
+            // `interval: lifetime` selects the one-off SKU; the server still
+            // prices it from the catalog.
+            const result = await startPlanCheckoutAction(licence.code, {
+                interval: 'lifetime',
+            });
+            if (result.success && result.url) {
+                window.location.assign(result.url);
+                return;
+            }
+            toast.error(result.error ?? t('credits.checkoutError'));
+        } finally {
+            setLicencePendingCode(null);
+            setLicenceConfirmCode(null);
+        }
+    };
 
     const handleSaveAutoRecharge = useCallback(async () => {
         setAutoRechargeSaving(true);
@@ -610,6 +652,86 @@ export function BillingSettings({
                     </div>
                 )}
             </SectionCard>
+
+            {/* ── Commercial licence (self-hosted) ──────────────────────────
+                Deliberately its own card, BELOW the switcher and never inside
+                it. A licence is not a tier you can switch to: the activation
+                path writes no subscription row and grants no plan, because it
+                applies to the deployment the buyer runs themselves. Putting it
+                in the switcher would read as "upgrade", and a buyer would pay
+                $99 expecting their hosted plan to change. */}
+            {licences.length > 0 && (
+                <SectionCard
+                    icon={ShieldCheck}
+                    title={t('licence.title')}
+                    subtitle={t('licence.subtitle')}
+                    testId="billing-licences"
+                >
+                    <div className="space-y-3">
+                        {licences.map((licence) => (
+                            <div
+                                key={licence.code}
+                                className="rounded-lg border border-border/60 p-4"
+                                data-testid={`billing-licence-${licence.code}`}
+                            >
+                                <div className="flex items-baseline justify-between gap-3">
+                                    <p className="text-sm font-medium">{licence.name}</p>
+                                    <p className="text-sm font-semibold">
+                                        {formatMonthlyPrice(
+                                            String(licence.lifetimePrice ?? '0'),
+                                            licence.currency,
+                                        )}
+                                    </p>
+                                </div>
+                                <p className="mt-2 text-xs text-muted-foreground">
+                                    {t('licence.explainer')}
+                                </p>
+                                {licenceConfirmCode === licence.code ? (
+                                    <div className="mt-3 flex flex-col gap-2">
+                                        <p className="text-xs text-muted-foreground">
+                                            {t('licence.confirmBody')}
+                                        </p>
+                                        <div className="flex gap-2">
+                                            <Button
+                                                className="text-xs"
+                                                data-testid={`billing-licence-confirm-${licence.code}`}
+                                                disabled={licencePendingCode !== null}
+                                                onClick={() => void handleBuyLicence(licence)}
+                                            >
+                                                {licencePendingCode === licence.code
+                                                    ? t('credits.redirecting')
+                                                    : t('licence.confirmCta')}
+                                            </Button>
+                                            <Button
+                                                variant="secondary"
+                                                className="text-xs"
+                                                disabled={licencePendingCode !== null}
+                                                onClick={() => setLicenceConfirmCode(null)}
+                                            >
+                                                {t('licence.cancel')}
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <Button
+                                        className="mt-3 text-xs"
+                                        data-testid={`billing-licence-buy-${licence.code}`}
+                                        disabled={licencePendingCode !== null}
+                                        onClick={() => setLicenceConfirmCode(licence.code)}
+                                    >
+                                        {t('licence.buyLifetime', {
+                                            price: formatMonthlyPrice(
+                                                String(licence.lifetimePrice ?? '0'),
+                                                licence.currency,
+                                            ),
+                                        })}
+                                    </Button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </SectionCard>
+            )}
 
             {/* ── Buy credits (PRD §3.2 — flag-gated until payments land) ── */}
             <SectionCard

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -59,6 +59,7 @@ import {
     subscriptionStatusTone,
     type BillingOverview,
     type InvoiceListPage,
+    type PlanCheckoutReturnResponse,
     type SubscriptionState,
 } from '@/lib/api/billing.shared';
 
@@ -71,6 +72,11 @@ interface BillingSettingsProps {
     /** Money path (billing PRD B5). Null ⇒ the overview call failed. */
     initialOverview: BillingOverview | null;
     initialInvoices: InvoiceListPage | null;
+    /**
+     * Result of finalising a checkout the provider just redirected back from.
+     * Null when this is an ordinary page load.
+     */
+    checkoutReturn?: PlanCheckoutReturnResponse | null;
 }
 
 const LEDGER_PAGE_SIZE = 10;
@@ -162,6 +168,7 @@ export function BillingSettings({
     initialLedger,
     initialOverview,
     initialInvoices,
+    checkoutReturn,
 }: BillingSettingsProps) {
     const t = useTranslations('dashboard.settings.billing');
     const [isPending, startTransition] = useTransition();
@@ -175,6 +182,14 @@ export function BillingSettings({
     const licences = (initialPlans?.licences ?? []).filter(
         (licence) => Number(licence.lifetimePrice ?? 0) > 0,
     );
+
+    // What was just bought, if anything. `ignored` means a credit top-up came
+    // back through the plan route — not an error, and not something to announce.
+    const justPurchased =
+        checkoutReturn && checkoutReturn.status !== 'ignored' ? checkoutReturn : null;
+    const purchasedLicence = justPurchased?.planCode
+        ? (licences.find((l) => l.code === justPurchased.planCode) ?? null)
+        : null;
     const currentPlan =
         plans.find((p) => p.isCurrent) ?? plans.find((p) => p.code === currentPlanCode) ?? null;
     const balanceCredits =
@@ -434,6 +449,35 @@ export function BillingSettings({
                 </h2>
                 <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
             </div>
+
+            {/* ── Just-completed checkout ──────────────────────────────────
+                A perpetual licence deliberately writes no subscription row and
+                grants no tier, so without this the page after a settled $99
+                payment is identical to the page before it — same enabled "Buy"
+                button, no invoice yet, nothing. That reads as a failed payment,
+                and the obvious next action is to pay again. */}
+            {justPurchased ? (
+                <div
+                    data-testid="billing-checkout-return"
+                    className="flex items-start gap-2 rounded-lg border border-success/40 bg-success/5 p-4 text-sm text-text dark:text-text-dark"
+                >
+                    <Check className="w-4 h-4 shrink-0 mt-0.5 text-success" />
+                    <div className="space-y-1">
+                        <p className="font-medium">
+                            {justPurchased.status === 'active'
+                                ? t('checkoutReturn.confirmed')
+                                : t('checkoutReturn.settling')}
+                        </p>
+                        {purchasedLicence ? (
+                            <p className="text-text-muted dark:text-text-muted-dark">
+                                {t('checkoutReturn.licenceBody', {
+                                    name: purchasedLicence.name,
+                                })}
+                            </p>
+                        ) : null}
+                    </div>
+                </div>
+            ) : null}
 
             {dataUnavailable ? (
                 <div

--- a/apps/web/src/lib/api/billing-plan-checkout.unit.spec.ts
+++ b/apps/web/src/lib/api/billing-plan-checkout.unit.spec.ts
@@ -1,0 +1,102 @@
+// H1 — regression spec for the plan-checkout request BODY.
+//
+// 🛑 This exists because of the exact bug it guards. The API has accepted
+// `interval` and `seats` on `POST /billing/checkout/plan` since the plan
+// catalog landed, the controller forwarded them, the service priced them and
+// the $99 perpetual-licence SKU sat in Stripe — and the perpetual licence was
+// still unbuyable, because `billingAPI.startPlanCheckout` built a body of
+// `{ planCode }` and nothing else. Every server-side test passed. The feature
+// was not refused, it was unreachable.
+//
+// So the assertion here is the SERIALISED BODY, not a mock call count: if a
+// refactor drops the `interval` key, this must go red.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+}));
+
+async function importApi() {
+    return import('./billing');
+}
+
+/** The parsed JSON body of the single serverFetch call. */
+function sentBody(): Record<string, unknown> {
+    expect(serverFetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = serverFetchMock.mock.calls[0];
+    return JSON.parse(String(init.body));
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverFetchMock.mockResolvedValue({ status: 'success', url: 'https://pay.test/cs_1' });
+});
+afterEach(() => vi.resetModules());
+
+describe('billingAPI.startPlanCheckout — what actually crosses the wire', () => {
+    it('sends interval when asked for a lifetime licence', async () => {
+        const { billingAPI } = await importApi();
+
+        await billingAPI.startPlanCheckout('selfhosted_pro', { interval: 'lifetime' });
+
+        expect(serverFetchMock).toHaveBeenCalledWith(
+            '/billing/checkout/plan',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        expect(sentBody()).toEqual({ planCode: 'selfhosted_pro', interval: 'lifetime' });
+    });
+
+    it('sends seats when a seat count is supplied', async () => {
+        const { billingAPI } = await importApi();
+
+        await billingAPI.startPlanCheckout('standard', { interval: 'monthly', seats: 17 });
+
+        expect(sentBody()).toEqual({ planCode: 'standard', interval: 'monthly', seats: 17 });
+    });
+
+    it('sends seats: 0 — a falsy value that is still a real answer', async () => {
+        const { billingAPI } = await importApi();
+
+        await billingAPI.startPlanCheckout('standard', { seats: 0 });
+
+        // A `if (options.seats)` truthiness check would silently drop this.
+        expect(sentBody()).toEqual({ planCode: 'standard', seats: 0 });
+    });
+
+    it('omits both when not supplied, so the body stays what it always was', async () => {
+        // Back-compatibility: the server defaults a missing interval to monthly,
+        // and the DTO is `forbidNonWhitelisted` — an explicit `undefined` key
+        // would serialise away, but an explicit `null` would 400.
+        const { billingAPI } = await importApi();
+
+        await billingAPI.startPlanCheckout('standard');
+
+        expect(sentBody()).toEqual({ planCode: 'standard' });
+    });
+
+    it('still forwards organizationId, and never invents a price field', async () => {
+        const { billingAPI } = await importApi();
+
+        await billingAPI.startPlanCheckout('standard', {
+            organizationId: 'org-1',
+            interval: 'annual',
+        });
+
+        const body = sentBody();
+        expect(body).toEqual({
+            planCode: 'standard',
+            organizationId: 'org-1',
+            interval: 'annual',
+        });
+        // The client can never name an amount: the DTO rejects the whole request
+        // rather than stripping it, so a stray field here is a hard 400.
+        for (const forbidden of ['priceCents', 'monthlyPrice', 'amount', 'credits', 'userId']) {
+            expect(body).not.toHaveProperty(forbidden);
+        }
+    });
+});

--- a/apps/web/src/lib/api/billing.ts
+++ b/apps/web/src/lib/api/billing.ts
@@ -32,6 +32,20 @@ export type {
  * `API_URL`, which is normalized to end in `/api` — see the
  * double-prefix regression specs beside the other lib/api wrappers).
  */
+/**
+ * Billing cadence for a plan checkout. `lifetime` is a one-off
+ * `mode: 'payment'` purchase, and the catalog carries exactly one such SKU:
+ * the $99 perpetual self-hosted commercial licence.
+ */
+export type PlanCheckoutInterval = 'monthly' | 'annual' | 'lifetime';
+
+export interface PlanCheckoutOptions {
+    organizationId?: string | null;
+    interval?: PlanCheckoutInterval;
+    /** TOTAL seats, inclusive of the plan allowance - not the extras. */
+    seats?: number;
+}
+
 export const billingAPI = {
     /** One round-trip snapshot for the Billing page. */
     async overview(): Promise<BillingOverview> {
@@ -72,11 +86,26 @@ export const billingAPI = {
      */
     async startPlanCheckout(
         planCode: string,
-        organizationId?: string | null,
+        options: PlanCheckoutOptions = {},
     ): Promise<PlanCheckoutResponse> {
-        const body: { planCode: string; organizationId?: string } = { planCode };
-        if (organizationId) {
-            body.organizationId = organizationId;
+        const body: {
+            planCode: string;
+            organizationId?: string;
+            interval?: PlanCheckoutInterval;
+            seats?: number;
+        } = { planCode };
+        if (options.organizationId) {
+            body.organizationId = options.organizationId;
+        }
+        // Sent only when present, so the one-field body every existing caller
+        // produces stays byte-identical and the API keeps defaulting to
+        // monthly. NEVER add a price field here — the DTO is
+        // `forbidNonWhitelisted` and would 400 the whole request.
+        if (options.interval) {
+            body.interval = options.interval;
+        }
+        if (typeof options.seats === 'number') {
+            body.seats = options.seats;
         }
         return serverFetch<PlanCheckoutResponse>('/billing/checkout/plan', {
             method: 'POST',

--- a/apps/web/src/lib/api/credits.shared.ts
+++ b/apps/web/src/lib/api/credits.shared.ts
@@ -119,10 +119,22 @@ export interface SubscriptionPlanSummary {
 export interface SubscriptionPlanListItem {
     code: string;
     name: string;
+    /** `'cloud'` | `'selfhosted'`. Echoed by the API; was silently dropped here. */
+    hosting?: string;
     maxWorks: number;
     allowedCadences: string[];
     /** Decimal string from the API (e.g. `'29'` / `'29.00'`). */
     monthlyPrice: string;
+    /**
+     * The YEARLY total, not a monthly equivalent — cloud Pro is `'204'`.
+     * Divide by 12 before rendering it next to a `/mo` suffix.
+     */
+    annualPrice?: string | null;
+    /** One-off perpetual licence price. Only `selfhosted_pro` has one. */
+    lifetimePrice?: string | null;
+    seatsIncluded?: number | null;
+    seatMonthlyPrice?: string | null;
+    monthlyCredits?: number | null;
     overagePricePerRun: string;
     currency: string;
     isCurrent: boolean;
@@ -134,6 +146,16 @@ export interface SubscriptionPlanList {
     enabled: boolean;
     currentPlanCode: string;
     plans: SubscriptionPlanListItem[];
+    /**
+     * Self-hosted commercial editions — a SEPARATE list from `plans`.
+     *
+     * They are purchasable but never self-assignable: buying one is a
+     * licence for a deployment you run yourself and changes nothing about
+     * your tier here. Rendering them as cards in the plan switcher would
+     * offer buttons whose only possible outcome is a 403. Optional so an
+     * older API response still types.
+     */
+    licences?: SubscriptionPlanListItem[];
 }
 
 // ── Pure helpers (unit-tested in credits.shared.unit.spec.ts) ───────

--- a/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
@@ -100,19 +100,22 @@ describe('run admission chain', () => {
         });
 
         /**
-         * "Unlimited" is stored as `-1` and must switch the valve OFF — and, as
-         * with a valve of 0 anywhere else in this chain, never touch the
-         * repository. That second half is what guards a future `??` → `||`
-         * refactor, which would silently collapse every unlimited plan to the
-         * fallback and cap Enterprise at 25.
+         * "Unlimited" is stored as `-1`. It EXEMPTS the buyer from the env valve;
+         * it does not switch the valve off before it has been evaluated. The
+         * distinction matters because the exemption is conditional (below).
          */
-        it('treats an unlimited plan as valve-off and never counts', async () => {
+        it('exempts an unlimited plan from a saturated env valve', async () => {
             const counters = {
                 countInFlightForWork: jest.fn().mockResolvedValue(0),
-                countInFlightForOrganization: jest.fn().mockResolvedValue(999),
-                countInFlightForUser: jest.fn().mockResolvedValue(999),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(9999),
+                countInFlightForUser: jest.fn().mockResolvedValue(9999),
             };
-            const context = planCtx(-1, { resolveOrgLimit: () => 25, counters });
+            const context = planCtx(-1, {
+                input: { userId: 'user-1', workId: 'work-1', organizationId: null },
+                resolveOrgLimit: () => 25,
+                resolveWorkLimit: () => 10,
+                counters,
+            });
 
             const verdict = await orgConcurrencyAdmission(
                 context,
@@ -120,47 +123,31 @@ describe('run admission chain', () => {
             );
 
             expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
-            expect(counters.countInFlightForUser).not.toHaveBeenCalled();
-            expect(counters.countInFlightForOrganization).not.toHaveBeenCalled();
         });
 
         /**
-         * 🛑 THE SENTINEL COLLISION.
+         * 🛑 BOTH halves of the bypass condition are load-bearing.
          *
-         * The producer returns `0` for a plan with NO entitlement row, documented
-         * as "no plan-level ceiling, only the env valves apply". This middleware
-         * used to read anything `<= 0` as UNLIMITED and `return next()` — so a plan
-         * with no row escaped the org valve completely and had no concurrency
-         * ceiling of any kind. Producer and consumer must agree: only a NEGATIVE
-         * value means unlimited.
+         * `workConcurrencyAdmission` returns next() when EITHER there is no workId
+         * OR its own limit is `<= 0` — and a Work limit of 0 is a supported way to
+         * disable that valve. Checking only for a workId therefore let an unlimited
+         * plan plus `AGENT_MAX_CONCURRENT_RUNS_PER_WORK=0` bypass every valve in
+         * the chain at once, with nothing bounding the user anywhere.
          *
-         * Revert-check: change the guard back to `planLimit <= 0` and this goes RED.
+         * Revert-check: drop `&& context.resolveWorkLimit() > 0` and this goes RED.
          */
-        it('treats 0 as "no plan ceiling", NOT as unlimited', async () => {
+        it('does NOT exempt an unlimited plan when the Work valve is itself disabled', async () => {
             const counters = {
                 countInFlightForWork: jest.fn().mockResolvedValue(0),
-                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(9999),
                 countInFlightForUser: jest.fn().mockResolvedValue(9999),
             };
-            const context = planCtx(0, { resolveOrgLimit: () => 25, counters });
-
-            const verdict = await orgConcurrencyAdmission(
-                context,
-                async () => RUN_ADMISSION_ADMITTED,
-            );
-
-            // The env valve must still bite at 25.
-            expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
-            expect(counters.countInFlightForUser).toHaveBeenCalled();
-        });
-
-        it('leaves the env ceiling untouched when the plan has no opinion (null)', async () => {
-            const counters = {
-                countInFlightForWork: jest.fn().mockResolvedValue(0),
-                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
-                countInFlightForUser: jest.fn().mockResolvedValue(9999),
-            };
-            const context = planCtx(null, { resolveOrgLimit: () => 25, counters });
+            const context = planCtx(-1, {
+                input: { userId: 'user-1', workId: 'work-1', organizationId: null },
+                resolveOrgLimit: () => 25,
+                resolveWorkLimit: () => 0,
+                counters,
+            });
 
             const verdict = await orgConcurrencyAdmission(
                 context,
@@ -170,22 +157,69 @@ describe('run admission chain', () => {
             expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
         });
 
-        /**
-         * The docblock used to justify the unlimited bypass with "the per-Work
-         * valve still bounds everything above it". That is only true when the run
-         * carries a workId — `workConcurrencyAdmission` short-circuits on
-         * `!input.workId`, and the heartbeat dispatcher passes `workId: null`
-         * deliberately, because the org/user valve is meant to be the one that
-         * applies. Bypassing there left the user with NO valve at all.
-         */
-        it('keeps the valve armed for an unlimited plan on a Work-LESS run', async () => {
+        it('does NOT exempt an unlimited plan on a Work-LESS run', async () => {
             const counters = {
                 countInFlightForWork: jest.fn().mockResolvedValue(0),
-                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(9999),
                 countInFlightForUser: jest.fn().mockResolvedValue(9999),
             };
             const context = planCtx(-1, {
                 input: { userId: 'user-1', workId: null, organizationId: null },
+                resolveOrgLimit: () => 25,
+                resolveWorkLimit: () => 10,
+                counters,
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
+        });
+
+        /**
+         * 🛑 THE ENTITLEMENT IS PER-USER, SO IT MUST BE MEASURED PER-USER.
+         *
+         * Subscriptions hang off `userId`; `Organization` carries no plan at all.
+         * Applying one member's allowance to the ORG counter raised the ceiling for
+         * everyone in the org — handing out capacity nobody bought, and letting
+         * colleagues consume the allowance the buyer paid for.
+         *
+         * Here the org is saturated (30 of 25) but the buyer holds only 2 of their
+         * own 10. They should run; their colleagues should not.
+         *
+         * Revert-check: measure the plan against the org count and this goes RED.
+         */
+        it('measures the plan allowance against the BUYER, not the org', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(30),
+                countInFlightForUser: jest.fn().mockResolvedValue(2),
+            };
+            const context = planCtx(10, {
+                input: { userId: 'buyer', workId: 'work-1', organizationId: 'org-1' },
+                resolveOrgLimit: () => 25,
+                counters,
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
+            expect(counters.countInFlightForUser).toHaveBeenCalledWith('buyer');
+        });
+
+        it('parks a buyer who has exhausted their OWN allowance, even in a quiet org', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(30),
+                countInFlightForUser: jest.fn().mockResolvedValue(10),
+            };
+            const context = planCtx(10, {
+                input: { userId: 'buyer', workId: 'work-1', organizationId: 'org-1' },
                 resolveOrgLimit: () => 25,
                 counters,
             });
@@ -198,13 +232,15 @@ describe('run admission chain', () => {
             expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
         });
 
-        it('still lets an unlimited plan through when a Work valve is in play', async () => {
+        it("does not spend a second query when the env count is already the user's", async () => {
+            // Outside an org the env valve counts the user, so the plan check has
+            // the number it needs already.
             const counters = {
                 countInFlightForWork: jest.fn().mockResolvedValue(0),
-                countInFlightForOrganization: jest.fn().mockResolvedValue(9999),
-                countInFlightForUser: jest.fn().mockResolvedValue(9999),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                countInFlightForUser: jest.fn().mockResolvedValue(26),
             };
-            const context = planCtx(-1, {
+            const context = planCtx(40, {
                 input: { userId: 'user-1', workId: 'work-1', organizationId: null },
                 resolveOrgLimit: () => 25,
                 counters,
@@ -216,7 +252,7 @@ describe('run admission chain', () => {
             );
 
             expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
-            expect(counters.countInFlightForUser).not.toHaveBeenCalled();
+            expect(counters.countInFlightForUser).toHaveBeenCalledTimes(1);
         });
 
         it('keeps the env ceiling when the lookup throws (fail-open)', async () => {

--- a/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
@@ -124,6 +124,101 @@ describe('run admission chain', () => {
             expect(counters.countInFlightForOrganization).not.toHaveBeenCalled();
         });
 
+        /**
+         * 🛑 THE SENTINEL COLLISION.
+         *
+         * The producer returns `0` for a plan with NO entitlement row, documented
+         * as "no plan-level ceiling, only the env valves apply". This middleware
+         * used to read anything `<= 0` as UNLIMITED and `return next()` — so a plan
+         * with no row escaped the org valve completely and had no concurrency
+         * ceiling of any kind. Producer and consumer must agree: only a NEGATIVE
+         * value means unlimited.
+         *
+         * Revert-check: change the guard back to `planLimit <= 0` and this goes RED.
+         */
+        it('treats 0 as "no plan ceiling", NOT as unlimited', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                countInFlightForUser: jest.fn().mockResolvedValue(9999),
+            };
+            const context = planCtx(0, { resolveOrgLimit: () => 25, counters });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            // The env valve must still bite at 25.
+            expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
+            expect(counters.countInFlightForUser).toHaveBeenCalled();
+        });
+
+        it('leaves the env ceiling untouched when the plan has no opinion (null)', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                countInFlightForUser: jest.fn().mockResolvedValue(9999),
+            };
+            const context = planCtx(null, { resolveOrgLimit: () => 25, counters });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
+        });
+
+        /**
+         * The docblock used to justify the unlimited bypass with "the per-Work
+         * valve still bounds everything above it". That is only true when the run
+         * carries a workId — `workConcurrencyAdmission` short-circuits on
+         * `!input.workId`, and the heartbeat dispatcher passes `workId: null`
+         * deliberately, because the org/user valve is meant to be the one that
+         * applies. Bypassing there left the user with NO valve at all.
+         */
+        it('keeps the valve armed for an unlimited plan on a Work-LESS run', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                countInFlightForUser: jest.fn().mockResolvedValue(9999),
+            };
+            const context = planCtx(-1, {
+                input: { userId: 'user-1', workId: null, organizationId: null },
+                resolveOrgLimit: () => 25,
+                counters,
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
+        });
+
+        it('still lets an unlimited plan through when a Work valve is in play', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(9999),
+                countInFlightForUser: jest.fn().mockResolvedValue(9999),
+            };
+            const context = planCtx(-1, {
+                input: { userId: 'user-1', workId: 'work-1', organizationId: null },
+                resolveOrgLimit: () => 25,
+                counters,
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
+            expect(counters.countInFlightForUser).not.toHaveBeenCalled();
+        });
+
         it('keeps the env ceiling when the lookup throws (fail-open)', async () => {
             const context = makeContext({
                 isPlanConcurrencyEnabled: () => true,

--- a/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
@@ -32,7 +32,133 @@ describe('run admission chain', () => {
         resolveWorkLimit: () => 10,
         resolveOrgLimit: () => 25,
         isCreditsEnforcementEnabled: () => false,
+        isPlanConcurrencyEnabled: () => false,
         ...over,
+    });
+
+    /**
+     * H2 — the plan's `max-concurrent-runs` entitlement, folded into the org
+     * valve as a RAISE-ONLY adjustment.
+     *
+     * The whole safety argument is "this can never park a run that would not
+     * already have parked", so the tests that matter are the ones that would
+     * go red if it ever gained the power to LOWER a ceiling.
+     */
+    describe('plan concurrency (raise-only)', () => {
+        const planCtx = (planLimit: number | null, over: Partial<RunAdmissionContext> = {}) =>
+            makeContext({
+                isPlanConcurrencyEnabled: () => true,
+                planLimits: { resolveConcurrencyLimit: jest.fn().mockResolvedValue(planLimit) },
+                ...over,
+            });
+
+        /**
+         * 🛑 THE load-bearing test. `free` is seeded at 3 and the enforced
+         * status quo is the env valve at 25. If the plan value were ever
+         * allowed to win, giving this entitlement its first reader would cut
+         * every existing user from 25 to 3 on the first deploy — and park runs
+         * that nothing can drain, because the drain is Work-keyed.
+         *
+         * Revert-check: change `Math.max(envLimit, planLimit)` to `planLimit`
+         * and this must go RED.
+         */
+        it('never LOWERS the env ceiling', async () => {
+            const context = planCtx(3, {
+                resolveOrgLimit: () => 25,
+                counters: {
+                    countInFlightForWork: jest.fn().mockResolvedValue(0),
+                    countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                    // Above the plan value of 3, below the env value of 25.
+                    countInFlightForUser: jest.fn().mockResolvedValue(10),
+                },
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
+        });
+
+        it('RAISES the ceiling when the plan allows more than the env default', async () => {
+            const context = planCtx(40, {
+                resolveOrgLimit: () => 25,
+                counters: {
+                    countInFlightForWork: jest.fn().mockResolvedValue(0),
+                    countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                    countInFlightForUser: jest.fn().mockResolvedValue(30),
+                },
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
+        });
+
+        /**
+         * "Unlimited" is stored as `-1` and must switch the valve OFF — and, as
+         * with a valve of 0 anywhere else in this chain, never touch the
+         * repository. That second half is what guards a future `??` → `||`
+         * refactor, which would silently collapse every unlimited plan to the
+         * fallback and cap Enterprise at 25.
+         */
+        it('treats an unlimited plan as valve-off and never counts', async () => {
+            const counters = {
+                countInFlightForWork: jest.fn().mockResolvedValue(0),
+                countInFlightForOrganization: jest.fn().mockResolvedValue(999),
+                countInFlightForUser: jest.fn().mockResolvedValue(999),
+            };
+            const context = planCtx(-1, { resolveOrgLimit: () => 25, counters });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            expect(verdict).toEqual(RUN_ADMISSION_ADMITTED);
+            expect(counters.countInFlightForUser).not.toHaveBeenCalled();
+            expect(counters.countInFlightForOrganization).not.toHaveBeenCalled();
+        });
+
+        it('keeps the env ceiling when the lookup throws (fail-open)', async () => {
+            const context = makeContext({
+                isPlanConcurrencyEnabled: () => true,
+                planLimits: {
+                    resolveConcurrencyLimit: jest.fn().mockRejectedValue(new Error('billing down')),
+                },
+                resolveOrgLimit: () => 25,
+                counters: {
+                    countInFlightForWork: jest.fn().mockResolvedValue(0),
+                    countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+                    countInFlightForUser: jest.fn().mockResolvedValue(25),
+                },
+            });
+
+            const verdict = await orgConcurrencyAdmission(
+                context,
+                async () => RUN_ADMISSION_ADMITTED,
+            );
+
+            // The env valve still applies — fail-open means "ignore the plan",
+            // not "admit everything".
+            expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
+        });
+
+        it('does not consult the plan at all when the kill-switch is off', async () => {
+            const resolveConcurrencyLimit = jest.fn().mockResolvedValue(3);
+            const context = makeContext({
+                isPlanConcurrencyEnabled: () => false,
+                planLimits: { resolveConcurrencyLimit },
+            });
+
+            await orgConcurrencyAdmission(context, async () => RUN_ADMISSION_ADMITTED);
+
+            expect(resolveConcurrencyLimit).not.toHaveBeenCalled();
+        });
     });
 
     describe('composeRunAdmission', () => {

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -51,6 +51,7 @@ export * from './sub-agent-delegation.port';
 export * from './sub-agent-delegation.service';
 export * from './run-steering.service';
 export * from './run-credits-precheck';
+export * from './run-plan-limits';
 export * from './terminal-session-dispatcher';
 export * from './terminal-session-launcher.service';
 // Streaming-terminal M9 / founder decision D1 — persisted, redacted,

--- a/packages/agent/src/agents/run-admission-chain.ts
+++ b/packages/agent/src/agents/run-admission-chain.ts
@@ -152,44 +152,25 @@ export const workConcurrencyAdmission: RunAdmissionMiddleware = async (context, 
  * Raise-only makes all three moot: this can never park a run that would
  * not already have parked, so a wrong answer can only over-deliver.
  *
- * The per-Work valve bounds everything above it — but ONLY on runs that
- * carry a workId. Heartbeats pass `workId: null` and reach this valve with
- * nothing else in front of them, which is why the unlimited sentinel does
- * not switch the valve off there.
+ * The per-Work valve bounds everything above it — but only on runs that
+ * carry a workId AND when that valve is itself enabled, which is why the
+ * unlimited sentinel checks both before bypassing.
+ *
+ * The plan allowance is measured against the BUYER's own in-flight count,
+ * never the org's: the entitlement is per-user, and applying it to an org
+ * counter would share one member's paid capacity with all of them.
  */
 export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, next) => {
     const { input, counters, logger } = context;
     const envLimit = context.resolveOrgLimit();
-    let limit = envLimit;
 
+    // Resolved up front but consulted ONLY after the env valve has decided to
+    // park. That ordering is what keeps the plan adjustment raise-only: it can
+    // exempt a run, never park one.
+    let planLimit: number | null = null;
     if (context.planLimits && context.isPlanConcurrencyEnabled()) {
         try {
-            const planLimit = await context.planLimits.resolveConcurrencyLimit(input.userId);
-            // `null` = the plan has no opinion; leave the env valve exactly as it
-            // was. Deliberately NOT folded in with the `0` case: they used to be
-            // the same branch, which let a plan with no entitlement row bypass the
-            // org valve entirely instead of falling back to it.
-            if (planLimit !== null) {
-                if (planLimit < 0) {
-                    // Unlimited tier. This lifts the PLAN ceiling, not the
-                    // operator's last line of defence: bypass only when the
-                    // per-Work valve is actually in play to bound the user.
-                    //
-                    // 🛑 On the Work-LESS path this valve is the only one in the
-                    // chain — `workConcurrencyAdmission` short-circuits on
-                    // `!input.workId`, and the heartbeat dispatcher passes
-                    // `workId: null` precisely because "the org/user valve is the
-                    // one that applies". Switching it off there would leave the
-                    // user completely unbounded, which is a capacity failure
-                    // rather than the generosity the raise-only argument assumes.
-                    if (input.workId) {
-                        return next();
-                    }
-                } else if (planLimit > 0) {
-                    limit = Math.max(envLimit, planLimit);
-                }
-                // planLimit === 0 -> an explicit "no plan ceiling"; keep envLimit.
-            }
+            planLimit = await context.planLimits.resolveConcurrencyLimit(input.userId);
         } catch (err) {
             // Fail open on the ENV limit: a broken billing lookup must never
             // change how much work the platform will accept.
@@ -200,23 +181,65 @@ export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, n
         }
     }
 
-    if (limit <= 0) return next();
-    const inFlight = input.organizationId
-        ? await counters.countInFlightForOrganization(input.organizationId)
+    if (envLimit <= 0) return next();
+
+    const scopedToOrg = Boolean(input.organizationId);
+    const inFlight = scopedToOrg
+        ? await counters.countInFlightForOrganization(input.organizationId as string)
         : await counters.countInFlightForUser(input.userId);
-    if (inFlight < limit) return next();
-    // Name the plan when it moved the ceiling. Without this an operator who set
-    // AGENT_MAX_CONCURRENT_RUNS_PER_ORG=25 greps for their own 25 and finds a
-    // number they never configured, with nothing pointing at the entitlement.
-    const ceilingNote = limit === envLimit ? '' : ` (env ${envLimit}, raised by plan entitlement)`;
+    if (inFlight < envLimit) return next();
+
+    // The env valve would park this run. A plan entitlement may exempt the
+    // BUYER — and only the buyer.
+    //
+    // 🛑 The entitlement is per-USER (subscriptions hang off `userId`;
+    // `Organization` carries no plan at all), so it must never be measured
+    // against the ORG counter. Raising the org ceiling because one member
+    // bought Enterprise would hand that capacity to every colleague, and let
+    // them consume the allowance the buyer paid for. Their own in-flight count
+    // is the only number their plan has an opinion about.
+    if (planLimit !== null) {
+        if (planLimit < 0) {
+            // Unlimited tier. This lifts the PLAN ceiling, not the operator's
+            // last line of defence — so bypass only when a per-Work valve is
+            // genuinely still bounding this run.
+            //
+            // Both halves of that condition are load-bearing.
+            // `workConcurrencyAdmission` returns next() when EITHER there is no
+            // workId (heartbeats pass `workId: null` deliberately) OR the Work
+            // limit is `<= 0` (a supported way to disable that valve). Checking
+            // only for a workId would let an unlimited plan plus
+            // `AGENT_MAX_CONCURRENT_RUNS_PER_WORK=0` bypass every valve in the
+            // chain at once.
+            if (input.workId && context.resolveWorkLimit() > 0) {
+                return next();
+            }
+        } else if (planLimit > 0) {
+            // Reuse the count when it is already the user's own — the non-org
+            // path measures exactly that, so this costs a query only inside an
+            // org, and only on the path that was about to park anyway.
+            const ownInFlight = scopedToOrg
+                ? await counters.countInFlightForUser(input.userId)
+                : inFlight;
+            if (ownInFlight < planLimit) {
+                return next();
+            }
+        }
+        // planLimit === 0 -> an explicit "no plan ceiling"; the env valve stands.
+    }
+
+    // Name the plan when it was consulted and still did not exempt the run, so
+    // an operator who set AGENT_MAX_CONCURRENT_RUNS_PER_ORG can tell their own
+    // valve firing from an entitlement that declined to lift it.
+    const planNote =
+        planLimit !== null && planLimit !== 0 ? ` (plan allowance ${planLimit} not met)` : '';
     logger.log(
         `Dispatch gate: ${
             input.organizationId ? `org ${input.organizationId}` : `user ${input.userId}`
-        } at ${inFlight}/${limit}${ceilingNote} in-flight runs — queueing.`,
+        } at ${inFlight}/${envLimit}${planNote} in-flight runs — queueing.`,
     );
     return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
 };
-
 /**
  * Soft credits enforcement (ship-dark). Runs ONLY when the kill-switch
  * is on AND the precheck token is bound. Fail-open on any error: a

--- a/packages/agent/src/agents/run-admission-chain.ts
+++ b/packages/agent/src/agents/run-admission-chain.ts
@@ -1,4 +1,5 @@
 import type { RunCreditsPrecheck } from './run-credits-precheck';
+import type { RunPlanLimits } from './run-plan-limits';
 
 /**
  * Pre-run admission chain (judgment layer G15).
@@ -14,10 +15,13 @@ import type { RunCreditsPrecheck } from './run-credits-precheck';
  * {@link composeRunAdmission} folds a list into one callable, so the
  * order is data (`DEFAULT_RUN_ADMISSION_CHAIN`) rather than control flow.
  *
- * This is a STRUCTURAL change only. `DEFAULT_RUN_ADMISSION_CHAIN`
- * reproduces the previous behaviour exactly, token for token and log
- * line for log line: Work valve first, then org/user valve, then the
+ * The refactor that introduced this file was a STRUCTURAL change only.
+ * The shipped order today is: Work valve, org/user valve, then the
  * (kill-switched, fail-open) credits precheck.
+ *
+ * The org valve additionally folds in the plan's `max-concurrent-runs`
+ * entitlement as a RAISE-ONLY adjustment — see its docblock for why it
+ * may never lower a ceiling.
  */
 
 /** Stamped when the gate parks a run for concurrency. Re-exported by the gate service. */
@@ -64,6 +68,8 @@ export interface RunAdmissionContext {
     readonly resolveOrgLimit: () => number;
     readonly isCreditsEnforcementEnabled: () => boolean;
     readonly creditsPrecheck?: RunCreditsPrecheck;
+    readonly isPlanConcurrencyEnabled: () => boolean;
+    readonly planLimits?: RunPlanLimits;
 }
 
 export type RunAdmissionNext = () => Promise<RunAdmissionVerdict>;
@@ -120,10 +126,59 @@ export const workConcurrencyAdmission: RunAdmissionMiddleware = async (context, 
 /**
  * Per-org valve, falling back to per-user when the run has no org. Same
  * `<= 0` disables semantics as the Work valve.
+ *
+ * The plan's `max-concurrent-runs` entitlement is folded in here as a
+ * RAISE-ONLY adjustment — `max(envLimit, planLimit)`, and a plan whose
+ * value is `<= 0` (the "unlimited" sentinel) switches the valve off.
+ *
+ * 🛑 Raise-only is not a style choice, it is what makes this safe. Three
+ * things break if a plan may LOWER the ceiling:
+ *
+ *  1. **Parked runs would be unrecoverable.** The drain is Work-keyed:
+ *     `findOldestQueuedForConcurrency` filters `run.workId`, and every
+ *     caller passes the workId of a run that just went terminal. A valve
+ *     scoped to the USER can park a run in a Work that then has no
+ *     terminal transition to fire a drain — precisely the cross-Work case
+ *     the valve exists for. The run sits `queued` until the sweeper
+ *     mislabels it `stuck-timeout`.
+ *  2. **It would be a cut for every existing user.** Nothing read this
+ *     entitlement before, so the ENFORCED status quo is this valve's env
+ *     default (25). The `free` row seeded at 3 would take everyone from
+ *     25 to 3 on the first deploy.
+ *  3. **The plan can be resolved wrongly.** A seat-holder on someone
+ *     else's Enterprise org, and anyone whose plan row exists while
+ *     `defaultPlanId` still says free, both resolve to `free`.
+ *
+ * Raise-only makes all three moot: this can never park a run that would
+ * not already have parked, so a wrong answer can only over-deliver. The
+ * per-Work valve still bounds everything above it.
  */
 export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, next) => {
     const { input, counters, logger } = context;
-    const limit = context.resolveOrgLimit();
+    const envLimit = context.resolveOrgLimit();
+    let limit = envLimit;
+
+    if (context.planLimits && context.isPlanConcurrencyEnabled()) {
+        try {
+            const planLimit = await context.planLimits.resolveConcurrencyLimit(input.userId);
+            if (planLimit !== null && planLimit <= 0) {
+                // "Unlimited" tier — the valve is off, and (as with a valve
+                // of 0 anywhere else) it never touches the repository.
+                return next();
+            }
+            if (planLimit !== null) {
+                limit = Math.max(envLimit, planLimit);
+            }
+        } catch (err) {
+            // Fail open on the ENV limit: a broken billing lookup must never
+            // change how much work the platform will accept.
+            logger.warn(
+                `Dispatch gate: plan concurrency lookup failed for user ${input.userId} ` +
+                    `(keeping the env limit): ${err}`,
+            );
+        }
+    }
+
     if (limit <= 0) return next();
     const inFlight = input.organizationId
         ? await counters.countInFlightForOrganization(input.organizationId)

--- a/packages/agent/src/agents/run-admission-chain.ts
+++ b/packages/agent/src/agents/run-admission-chain.ts
@@ -150,8 +150,12 @@ export const workConcurrencyAdmission: RunAdmissionMiddleware = async (context, 
  *     `defaultPlanId` still says free, both resolve to `free`.
  *
  * Raise-only makes all three moot: this can never park a run that would
- * not already have parked, so a wrong answer can only over-deliver. The
- * per-Work valve still bounds everything above it.
+ * not already have parked, so a wrong answer can only over-deliver.
+ *
+ * The per-Work valve bounds everything above it — but ONLY on runs that
+ * carry a workId. Heartbeats pass `workId: null` and reach this valve with
+ * nothing else in front of them, which is why the unlimited sentinel does
+ * not switch the valve off there.
  */
 export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, next) => {
     const { input, counters, logger } = context;
@@ -161,13 +165,30 @@ export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, n
     if (context.planLimits && context.isPlanConcurrencyEnabled()) {
         try {
             const planLimit = await context.planLimits.resolveConcurrencyLimit(input.userId);
-            if (planLimit !== null && planLimit <= 0) {
-                // "Unlimited" tier — the valve is off, and (as with a valve
-                // of 0 anywhere else) it never touches the repository.
-                return next();
-            }
+            // `null` = the plan has no opinion; leave the env valve exactly as it
+            // was. Deliberately NOT folded in with the `0` case: they used to be
+            // the same branch, which let a plan with no entitlement row bypass the
+            // org valve entirely instead of falling back to it.
             if (planLimit !== null) {
-                limit = Math.max(envLimit, planLimit);
+                if (planLimit < 0) {
+                    // Unlimited tier. This lifts the PLAN ceiling, not the
+                    // operator's last line of defence: bypass only when the
+                    // per-Work valve is actually in play to bound the user.
+                    //
+                    // 🛑 On the Work-LESS path this valve is the only one in the
+                    // chain — `workConcurrencyAdmission` short-circuits on
+                    // `!input.workId`, and the heartbeat dispatcher passes
+                    // `workId: null` precisely because "the org/user valve is the
+                    // one that applies". Switching it off there would leave the
+                    // user completely unbounded, which is a capacity failure
+                    // rather than the generosity the raise-only argument assumes.
+                    if (input.workId) {
+                        return next();
+                    }
+                } else if (planLimit > 0) {
+                    limit = Math.max(envLimit, planLimit);
+                }
+                // planLimit === 0 -> an explicit "no plan ceiling"; keep envLimit.
             }
         } catch (err) {
             // Fail open on the ENV limit: a broken billing lookup must never
@@ -184,10 +205,14 @@ export const orgConcurrencyAdmission: RunAdmissionMiddleware = async (context, n
         ? await counters.countInFlightForOrganization(input.organizationId)
         : await counters.countInFlightForUser(input.userId);
     if (inFlight < limit) return next();
+    // Name the plan when it moved the ceiling. Without this an operator who set
+    // AGENT_MAX_CONCURRENT_RUNS_PER_ORG=25 greps for their own 25 and finds a
+    // number they never configured, with nothing pointing at the entitlement.
+    const ceilingNote = limit === envLimit ? '' : ` (env ${envLimit}, raised by plan entitlement)`;
     logger.log(
         `Dispatch gate: ${
             input.organizationId ? `org ${input.organizationId}` : `user ${input.userId}`
-        } at ${inFlight}/${limit} in-flight runs — queueing.`,
+        } at ${inFlight}/${limit}${ceilingNote} in-flight runs — queueing.`,
     );
     return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
 };

--- a/packages/agent/src/agents/run-dispatch-gate.service.ts
+++ b/packages/agent/src/agents/run-dispatch-gate.service.ts
@@ -9,6 +9,7 @@ import {
     type AgentTaskExecuteDispatcher,
 } from '../tasks-domain/task-dispatcher';
 import { RUN_CREDITS_PRECHECK, type RunCreditsPrecheck } from './run-credits-precheck';
+import { RUN_PLAN_LIMITS, type RunPlanLimits } from './run-plan-limits';
 import {
     composeRunAdmission,
     DEFAULT_RUN_ADMISSION_CHAIN,
@@ -183,6 +184,15 @@ export class RunDispatchGateService {
         @Optional()
         @Inject(AGENT_CHAT_REPLY_DISPATCHER)
         private readonly chatDispatcher?: AgentChatReplyDispatcher,
+        // H2 — the per-user PLAN concurrency ceiling. Bound (to
+        // PlanRunLimitsService) by the api-side @Global()
+        // SubscriptionsModule; absent in unit tests and installs without
+        // the subscriptions stack, where the plan valve simply never runs.
+        // Same @Optional() + appended-LAST posture as every other seam
+        // here (the positional-spec arity rule).
+        @Optional()
+        @Inject(RUN_PLAN_LIMITS)
+        private readonly planLimits?: RunPlanLimits,
     ) {}
 
     /** Env default today; per-Work override column when it lands. */
@@ -252,7 +262,9 @@ export class RunDispatchGateService {
             resolveWorkLimit: () => this.resolveWorkLimit(),
             resolveOrgLimit: () => this.resolveOrgLimit(),
             isCreditsEnforcementEnabled: () => config.billing.credits.isEnforcementEnabled(),
+            isPlanConcurrencyEnabled: () => config.agents.isPlanConcurrencyEnforcementEnabled(),
             ...(this.creditsPrecheck ? { creditsPrecheck: this.creditsPrecheck } : {}),
+            ...(this.planLimits ? { planLimits: this.planLimits } : {}),
         });
     }
 

--- a/packages/agent/src/agents/run-plan-limits.ts
+++ b/packages/agent/src/agents/run-plan-limits.ts
@@ -36,10 +36,18 @@ export interface RunPlanLimits {
     /**
      * The user's plan concurrency ceiling.
      *
-     * `<= 0` means UNLIMITED, matching the contract the two env valves
-     * already publish (a limit of 0 disables that valve and skips its
-     * count query entirely). Return `null` when no plan-level ceiling
-     * applies, which is also treated as unlimited.
+     * Three distinct answers, and they must stay distinct:
+     *
+     *   `null`     the plan has no opinion (no entitlement row). The env
+     *              valves apply unchanged.
+     *   negative   unlimited — the plan lifts its own ceiling. `-1` is what
+     *              the seed writes (`ENTITLEMENT_UNLIMITED`).
+     *   positive   a real ceiling, applied RAISE-ONLY against the env valve.
+     *
+     * 🛑 `0` is NOT unlimited here. Elsewhere in the gate a limit of 0 disables
+     * a valve, but a plan entitlement of 0 is an operator writing "no plan
+     * ceiling", and collapsing the two once meant a plan with no row escaped
+     * the org valve completely.
      */
     resolveConcurrencyLimit(userId: string): Promise<number | null>;
 }

--- a/packages/agent/src/agents/run-plan-limits.ts
+++ b/packages/agent/src/agents/run-plan-limits.ts
@@ -1,0 +1,47 @@
+/**
+ * Plan-driven concurrency ceiling for the run dispatch gate (H2).
+ *
+ * Token + contract only (leaf file, zero imports — same circular-dep
+ * dodge as the other agent injection tokens, see
+ * `docs/architecture/agent-injection-tokens.md`).
+ * `RunDispatchGateService` consumes it via `@Optional() @Inject(...)`;
+ * the implementation (`PlanRunLimitsService`, subscriptions/credits) is
+ * bound to the token by the api-side `@Global()` SubscriptionsModule.
+ *
+ * ## Why this seam exists at all
+ *
+ * The gate already had two concurrency valves, but both are plan-blind
+ * operator knobs (`AGENT_MAX_CONCURRENT_RUNS_PER_WORK` / `_PER_ORG`).
+ * The number the pricing page SELLS — "10 concurrent agent sessions" —
+ * lived in `plan_entitlements` under `max-concurrent-runs` and was read
+ * by nothing: the entitlement was decorative, and every tier got the
+ * same env-wide ceiling.
+ *
+ * ## Why per USER and not per organization
+ *
+ * Subscriptions are user-scoped in this schema: `user_subscriptions`
+ * hangs off `userId`, `organizationId` is a nullable annotation, and
+ * `Organization` carries no plan at all. The entity that buys a plan is
+ * therefore the user, and neither existing valve has that scope.
+ *
+ * ## Contract
+ *
+ * Implementations must be cheap (this is called once per dispatch, on a
+ * one-minute cron loop) and must never throw — the middleware fails
+ * OPEN regardless, because a billing lookup that parks every run would
+ * be a self-sustaining outage: parked heartbeat runs carry no taskId
+ * and can never be drained.
+ */
+export interface RunPlanLimits {
+    /**
+     * The user's plan concurrency ceiling.
+     *
+     * `<= 0` means UNLIMITED, matching the contract the two env valves
+     * already publish (a limit of 0 disables that valve and skips its
+     * count query entirely). Return `null` when no plan-level ceiling
+     * applies, which is also treated as unlimited.
+     */
+    resolveConcurrencyLimit(userId: string): Promise<number | null>;
+}
+
+export const RUN_PLAN_LIMITS = 'RUN_PLAN_LIMITS' as const;

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -1072,6 +1072,25 @@ export const config = {
             return Number.isFinite(raw) ? raw : 25;
         },
         /**
+         * H2 kill-switch for the plan-driven concurrency ceiling
+         * (`plan_entitlements.max-concurrent-runs`), folded into the org
+         * valve above as a RAISE-ONLY adjustment.
+         *
+         * Ships DARK (default off), like the credits kill-switch. The
+         * adjustment can only ever raise a ceiling or switch the valve off
+         * for an "unlimited" tier, so turning it on cannot park a run that
+         * would not already have parked — but it does change how much
+         * concurrent work the platform will accept, and that deserves a
+         * deliberate flip rather than arriving with a deploy.
+         *
+         * Set `PLAN_CONCURRENCY_ENFORCEMENT=on` to honour the plan's
+         * entitlement.
+         */
+        isPlanConcurrencyEnforcementEnabled() {
+            const raw = (process.env.PLAN_CONCURRENCY_ENFORCEMENT || '').toLowerCase();
+            return raw === 'on' || raw === 'true' || raw === '1';
+        },
+        /**
          * Merge-policy matrix (Wave 3, D4) — operator kill-switch for
          * enforcement at the git facade. Default ON: an agent-driven merge
          * consults the resolved policy and is refused when the policy says

--- a/packages/agent/src/database/repositories/__tests__/user-subscription.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/user-subscription.repository.spec.ts
@@ -42,6 +42,24 @@ describe('UserSubscriptionRepository', () => {
         });
     });
 
+    describe('findCurrentByUser', () => {
+        it('selects the newest active or trialing subscription', async () => {
+            const row = { id: 's-newest' } as UserSubscription;
+            repository.findOne.mockResolvedValueOnce(row);
+
+            await expect(service.findCurrentByUser('u1')).resolves.toBe(row);
+
+            expect(repository.findOne).toHaveBeenCalledWith({
+                where: [
+                    { userId: 'u1', status: SubscriptionStatus.ACTIVE },
+                    { userId: 'u1', status: SubscriptionStatus.TRIALING },
+                ],
+                relations: ['plan'],
+                order: { createdAt: 'DESC' },
+            });
+        });
+    });
+
     describe('listByUser', () => {
         it('orders by createdAt DESC and joins the plan relation', async () => {
             const rows = [{ id: 's1' } as UserSubscription, { id: 's2' } as UserSubscription];

--- a/packages/agent/src/database/repositories/credit-ledger.repository.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.ts
@@ -234,6 +234,34 @@ export class CreditLedgerRepository {
     }
 
     /**
+     * Sum of movements of ONE `refType` inside a half-open `[from, to)`
+     * window. Used by the monthly plan grant to top UP to the best
+     * allowance the user has held this calendar month, so a mid-cycle
+     * upgrade adds only the difference and a downgrade removes nothing.
+     *
+     * No unary minus here on purpose - see the long note on
+     * {@link getPeriodTotals} for why `-e.amountCredits` breaks on
+     * Postgres while staying green on the SQLite the tests run against.
+     */
+    async sumByRefTypeInWindow(
+        userId: string,
+        refType: string,
+        from: Date,
+        to: Date,
+    ): Promise<number> {
+        const row = await this.repository
+            .createQueryBuilder('e')
+            .select('COALESCE(SUM(e.amountCredits), 0)', 'total')
+            .where('e.userId = :userId', { userId })
+            .andWhere('e.refType = :refType', { refType })
+            .andWhere('e.createdAt >= :from', { from })
+            .andWhere('e.createdAt < :to', { to })
+            .getRawOne<{ total: string }>();
+
+        return Number(row?.total ?? 0);
+    }
+
+    /**
      * Serialize concurrent ledger writes for one user. Pessimistic row
      * locks are only supported on postgres/mysql/mariadb; better-sqlite3
      * throws `LockNotSupportedOnGivenDriverError` AND serializes writes

--- a/packages/agent/src/database/repositories/plan-entitlement.repository.ts
+++ b/packages/agent/src/database/repositories/plan-entitlement.repository.ts
@@ -24,6 +24,47 @@ export class PlanEntitlementRepository {
         return this.repository.find({ where: { planId }, order: { key: 'ASC' } });
     }
 
+    /**
+     * Insert one (planId, key) lever ONLY if it does not already exist.
+     *
+     * 🛑 This, not {@link upsert}, is what a boot-time seeder must call.
+     * `upsert` OVERWRITES an existing row and nulls the sibling value
+     * column, so seeding through it at every pod start would silently
+     * reset any operator-tuned lever - including the `free` plan rows the
+     * 1783400000000 migration seeded from env. Insert-if-missing matches
+     * that migration's own posture (`if (existing) continue`) and can
+     * never reduce an entitlement a live user already holds.
+     *
+     * Returns the existing row untouched when one is present.
+     */
+    async insertIfMissing(
+        entitlement: Pick<PlanEntitlement, 'planId' | 'key'> &
+            Partial<Pick<PlanEntitlement, 'valueInt' | 'valueText'>>,
+    ): Promise<{ entitlement: PlanEntitlement; created: boolean }> {
+        const existing = await this.findByPlanAndKey(entitlement.planId, entitlement.key);
+        if (existing) {
+            return { entitlement: existing, created: false };
+        }
+        try {
+            const created = await this.repository.save(this.repository.create(entitlement));
+            return { entitlement: created, created: true };
+        } catch (error) {
+            // Check-then-insert against a UNIQUE (planId, key). Two API replicas
+            // booting together on a rolling deploy both pass the check and one
+            // hits 23505 - inside onModuleInit, which means that pod NEVER
+            // finishes booting. Recover by re-reading, the same shape the ledger
+            // uses for its own unique-key race.
+            const message = String((error as Error)?.message ?? '');
+            if (/duplicate key|UNIQUE constraint failed|Duplicate entry/i.test(message)) {
+                const raced = await this.findByPlanAndKey(entitlement.planId, entitlement.key);
+                if (raced) {
+                    return { entitlement: raced, created: false };
+                }
+            }
+            throw error;
+        }
+    }
+
     /** Insert-or-update one (planId, key) lever. */
     async upsert(
         entitlement: Pick<PlanEntitlement, 'planId' | 'key'> &

--- a/packages/agent/src/database/repositories/plan-entitlement.repository.ts
+++ b/packages/agent/src/database/repositories/plan-entitlement.repository.ts
@@ -54,8 +54,20 @@ export class PlanEntitlementRepository {
             // hits 23505 - inside onModuleInit, which means that pod NEVER
             // finishes booting. Recover by re-reading, the same shape the ledger
             // uses for its own unique-key race.
+            // SQLSTATE first, message second. PostgreSQL translates error text
+            // according to `lc_messages`, so a server with a non-English locale
+            // would fail the regex and let a boot-time race become a pod that never
+            // starts. `23505` is locale-independent. This mirrors
+            // `CreditLedgerRepository.isUniqueViolation`, which this comment used to
+            // claim to match while testing strictly less.
+            const code =
+                (error as { code?: string; driverError?: { code?: string } })?.code ??
+                (error as { driverError?: { code?: string } })?.driverError?.code;
             const message = String((error as Error)?.message ?? '');
-            if (/duplicate key|UNIQUE constraint failed|Duplicate entry/i.test(message)) {
+            if (
+                code === '23505' ||
+                /duplicate key|UNIQUE constraint failed|Duplicate entry/i.test(message)
+            ) {
                 const raced = await this.findByPlanAndKey(entitlement.planId, entitlement.key);
                 if (raced) {
                     return { entitlement: raced, created: false };

--- a/packages/agent/src/database/repositories/user-subscription.repository.ts
+++ b/packages/agent/src/database/repositories/user-subscription.repository.ts
@@ -18,6 +18,28 @@ export class UserSubscriptionRepository {
     }
 
     /**
+     * The user's CURRENT subscription — active or trialing.
+     *
+     * Additive sibling of {@link findActiveByUser}, which matches only
+     * `ACTIVE` and is left untouched because other callers depend on that
+     * exact meaning. A trialing customer is entitled to what they are
+     * trialing, so the monthly credit grant reads THIS.
+     *
+     * Deliberately excludes `PAST_DUE`: a subscription in dunning must not
+     * keep drawing a paid allowance while Stripe retries the invoice.
+     */
+    async findCurrentByUser(userId: string): Promise<UserSubscription | null> {
+        return this.repository.findOne({
+            where: [
+                { userId, status: SubscriptionStatus.ACTIVE },
+                { userId, status: SubscriptionStatus.TRIALING },
+            ],
+            relations: ['plan'],
+            order: { createdAt: 'ASC' },
+        });
+    }
+
+    /**
      * Look a subscription up by the PROVIDER's id (audit B24 — plan
      * checkout). This is how a later `customer.subscription.*` delivery
      * finds exactly the row the hosted checkout created, without

--- a/packages/agent/src/database/repositories/user-subscription.repository.ts
+++ b/packages/agent/src/database/repositories/user-subscription.repository.ts
@@ -35,7 +35,7 @@ export class UserSubscriptionRepository {
                 { userId, status: SubscriptionStatus.TRIALING },
             ],
             relations: ['plan'],
-            order: { createdAt: 'ASC' },
+            order: { createdAt: 'DESC' },
         });
     }
 

--- a/packages/agent/src/entities/credit-ledger-entry.entity.ts
+++ b/packages/agent/src/entities/credit-ledger-entry.entity.ts
@@ -81,8 +81,18 @@ export class CreditLedgerEntry {
     @Column({ type: 'varchar', length: 32, nullable: true })
     refType?: string | null;
 
-    /** UUID of the correlated run/generation/task. */
-    @Column({ type: 'uuid', nullable: true })
+    /**
+     * Id of the correlated run / generation / task / PAYMENT.
+     *
+     * varchar, not uuid: the settled-purchase and refund-reversal paths
+     * write the provider payment id here (`billing.service.ts` records
+     * `refId: event.paymentId`, a Stripe `pi_...` string), and
+     * `findLatestByRef` reads it back to size a refund. Declared `uuid` by
+     * the creating migration, it made the first real credit-pack purchase
+     * fail with 22P02 on Postgres while the sqlite test suite stayed green.
+     * Widened by migration 1787500000000.
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
     refId?: string | null;
 
     /** Balance materialized at write time (display; SUM is authoritative). */

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1624,7 +1624,7 @@ describe('Stripe Tax — every session that CHARGES asks for tax', () => {
             userEmail: 'u1@example.com',
             customerId: 'cus_1',
             pack: {
-                packId: 'credits-5500',
+                id: 'credits-5500',
                 label: '5,500 credits',
                 credits: 5500,
                 priceCents: 5000,
@@ -1669,7 +1669,7 @@ describe('Stripe Tax — every session that CHARGES asks for tax', () => {
             userEmail: 'u1@example.com',
             customerId: 'cus_1',
             pack: {
-                packId: 'credits-1000',
+                id: 'credits-1000',
                 label: '1,000 credits',
                 credits: 1000,
                 priceCents: 1000,

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1606,7 +1606,12 @@ describe('Stripe Tax — every session that CHARGES asks for tax', () => {
         expect(params.automatic_tax).toEqual({ enabled: true });
         // Required alongside automatic_tax when an existing customer is passed: Stripe needs an
         // address to pick a jurisdiction, and without this the session errors instead of taxing.
-        expect(params.customer_update).toEqual({ address: 'auto' });
+        //
+        // 🛑 `name: 'auto'` is just as load-bearing, and this assertion previously said
+        // `{ address: 'auto' }` alone — which Stripe REJECTS with a 400 whenever
+        // `tax_id_collection` is on and the session names an existing customer. The test
+        // passed because it asserted the object we built, not the object Stripe accepts.
+        expect(params.customer_update).toEqual({ address: 'auto', name: 'auto' });
         // Lets a business supply its VAT/GST number, which is what triggers EU reverse charge.
         expect(params.tax_id_collection).toEqual({ enabled: true });
     });
@@ -1634,6 +1639,63 @@ describe('Stripe Tax — every session that CHARGES asks for tax', () => {
         expect(params.automatic_tax).toEqual({ enabled: true });
     });
 
+    /**
+     * 🛑 THE INVARIANT THIS FILE EXISTS TO PROTECT.
+     *
+     * Stripe refuses `tax_id_collection` on any session that passes an existing
+     * `customer` unless `customer_update.name` is also `'auto'`:
+     *
+     *   "Tax ID collection requires updating business name on the customer. To
+     *    enable tax ID collection for an existing customer, please set
+     *    `customer_update[name]` to `auto`."
+     *
+     * Every charging session here passes a customer, so dropping that one field
+     * does not degrade tax collection — it 400s EVERY purchase in the product:
+     * credit packs, plans and the perpetual licence alike.
+     *
+     * This cannot be caught by mocking harder. The Stripe client is a jest mock in
+     * these specs, so it accepts any shape; the rejection exists only at the real
+     * API. Verified against Stripe test mode on 2026-08-23:
+     *   address-only            -> 400 invalid_request_error
+     *   address + name = 'auto' -> 200, session created
+     * Re-run that probe if this ever needs changing; do not reason about it.
+     */
+    it('pairs tax_id_collection with customer_update.name on EVERY charging session', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession(taxPlanRequest as any);
+        await provider.createCreditCheckoutSession({
+            userId: 'u1',
+            userEmail: 'u1@example.com',
+            customerId: 'cus_1',
+            pack: {
+                packId: 'credits-1000',
+                label: '1,000 credits',
+                credits: 1000,
+                priceCents: 1000,
+                currency: 'usd',
+            },
+            successUrl: 'https://app.test/ok',
+            cancelUrl: 'https://app.test/no',
+            referenceId: 'u1:credits-1000',
+        } as any);
+        await provider.createPlanCheckoutSession({
+            ...taxPlanRequest,
+            plan: { ...taxPlanRequest.plan, mode: 'payment', code: 'selfhosted_pro' },
+        } as any);
+
+        const calls = client.checkout.sessions.create.mock.calls.map(([params]) => params);
+        expect(calls).toHaveLength(3);
+        for (const params of calls) {
+            if (!params.tax_id_collection?.enabled) continue;
+            expect(params.customer_update?.name).toBe('auto');
+        }
+        // Control: the loop must actually have inspected something. Without this, a
+        // future change that stops setting tax_id_collection would make the assertion
+        // vacuous and this test would keep passing while collecting no tax ids.
+        expect(calls.filter((p) => p.tax_id_collection?.enabled)).toHaveLength(3);
+    });
+
     it('does NOT enable automatic tax on a card-setup session', async () => {
         // `mode: 'setup'` charges nothing and Stripe rejects automatic_tax there, so this is not
         // an oversight to "fix" later — sending it would break saving a card outright.
@@ -1650,5 +1712,31 @@ describe('Stripe Tax — every session that CHARGES asks for tax', () => {
         expect(params.mode).toBe('setup');
         expect(params.automatic_tax).toBeUndefined();
         expect(params.tax_id_collection).toBeUndefined();
+    });
+
+    /**
+     * 🛑 A `mode: 'setup'` session needs EITHER `currency` or an explicit
+     * `payment_method_types`. With neither, Stripe answers
+     * "Missing required param: currency" and saving a card fails outright - it does
+     * not degrade, it 400s.
+     *
+     * This was live and unnoticed because the Stripe client is mocked here, so the
+     * incomplete shape looked fine to every test. Confirmed against Stripe test mode
+     * on 2026-08-23: without currency => 400, with currency => 200 and
+     * `payment_method_types: ["card"]` still resolved dynamically.
+     */
+    it('sends a currency on the setup session, or Stripe refuses it', async () => {
+        const { provider, client } = build();
+
+        await provider.createPaymentMethodSetupSession({
+            userId: 'u1',
+            customerId: 'cus_1',
+            successUrl: 'https://app.test/ok',
+            cancelUrl: 'https://app.test/no',
+        } as any);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('setup');
+        expect(Boolean(params.currency) || Boolean(params.payment_method_types?.length)).toBe(true);
     });
 });

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1573,3 +1573,82 @@ describe('StripeBillingProvider — subscription event normalization (audit B24)
         expect(normalized.kind).toBe('ignored');
     });
 });
+
+// H5: the account has Stripe Tax active with live registrations, but no session asked for it —
+// so every invoice would have shipped with NO tax line while we were registered to collect it.
+// A session only calculates tax if it sets `automatic_tax`; nothing else turns it on.
+describe('Stripe Tax — every session that CHARGES asks for tax', () => {
+    beforeEach(() => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+    });
+
+    const taxPlanRequest = {
+        userId: 'u1',
+        customerId: 'cus_1',
+        plan: {
+            code: 'standard',
+            label: 'Standard plan',
+            priceCents: 2500,
+            currency: 'usd',
+            interval: 'month' as const,
+        },
+        successUrl: 'https://app.test/ok',
+        cancelUrl: 'https://app.test/no',
+        referenceId: 'u1:standard',
+    };
+
+    it('enables automatic tax on a plan checkout, and collects what Stripe needs to compute it', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession(taxPlanRequest as any);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.automatic_tax).toEqual({ enabled: true });
+        // Required alongside automatic_tax when an existing customer is passed: Stripe needs an
+        // address to pick a jurisdiction, and without this the session errors instead of taxing.
+        expect(params.customer_update).toEqual({ address: 'auto' });
+        // Lets a business supply its VAT/GST number, which is what triggers EU reverse charge.
+        expect(params.tax_id_collection).toEqual({ enabled: true });
+    });
+
+    it('enables automatic tax on a credit-pack purchase too', async () => {
+        const { provider, client } = build();
+
+        await provider.createCreditCheckoutSession({
+            userId: 'u1',
+            userEmail: 'u1@example.com',
+            customerId: 'cus_1',
+            pack: {
+                packId: 'credits-5500',
+                label: '5,500 credits',
+                credits: 5500,
+                priceCents: 5000,
+                currency: 'usd',
+            },
+            successUrl: 'https://app.test/ok',
+            cancelUrl: 'https://app.test/no',
+            referenceId: 'u1:credits-5500',
+        } as any);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.automatic_tax).toEqual({ enabled: true });
+    });
+
+    it('does NOT enable automatic tax on a card-setup session', async () => {
+        // `mode: 'setup'` charges nothing and Stripe rejects automatic_tax there, so this is not
+        // an oversight to "fix" later — sending it would break saving a card outright.
+        const { provider, client } = build();
+
+        await provider.createPaymentMethodSetupSession({
+            userId: 'u1',
+            customerId: 'cus_1',
+            successUrl: 'https://app.test/ok',
+            cancelUrl: 'https://app.test/no',
+        } as any);
+
+        const params = client.checkout.sessions.create.mock.calls[0][0];
+        expect(params.mode).toBe('setup');
+        expect(params.automatic_tax).toBeUndefined();
+        expect(params.tax_id_collection).toBeUndefined();
+    });
+});

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -95,7 +95,21 @@ export const STRIPE_PERPETUAL_LICENCE = 'perpetual-commercial' as const;
  */
 const STRIPE_TAX_SESSION_FIELDS = {
     automatic_tax: { enabled: true },
-    customer_update: { address: 'auto' },
+    // 🛑 `name: 'auto'` is NOT optional here, and its absence is not a degraded
+    // experience - it is a hard 400 on EVERY session. Stripe refuses
+    // `tax_id_collection` on a session that passes an existing `customer` unless
+    // `customer_update.name` is also 'auto':
+    //
+    //   "Tax ID collection requires updating business name on the customer. To
+    //    enable tax ID collection for an existing customer, please set
+    //    `customer_update[name]` to `auto`."
+    //
+    // Every session this constant is spread into passes a `customer`, so without
+    // this line NOTHING in Ever Works can be bought - not credit packs, not plans,
+    // not the perpetual licence. No unit test can catch it either: the provider
+    // specs mock the Stripe client, so the rejection only exists at the real API.
+    // Verified against Stripe test mode: address-only => 400, address+name => 200.
+    customer_update: { address: 'auto', name: 'auto' },
     tax_id_collection: { enabled: true },
 } as const;
 
@@ -896,6 +910,17 @@ export class StripeBillingProvider extends BillingProvider {
         const session = await stripe.checkout.sessions.create({
             mode: 'setup',
             customer: request.customerId,
+            // 🛑 Required. Stripe rejects a `mode: 'setup'` session outright -
+            // "Missing required param: currency" - unless EITHER `currency` or an
+            // explicit `payment_method_types` is given. Neither was, so saving a card
+            // has been returning a 400 for every user, not degrading gracefully.
+            //
+            // Found by replaying this exact call against Stripe test mode; the unit
+            // specs mock the client, so they accept the incomplete shape happily.
+            // `currency` is preferred over pinning `payment_method_types: ['card']`
+            // because it lets Checkout keep offering whatever methods the account has
+            // enabled for that currency instead of hardcoding cards.
+            currency: this.getDefaultCurrency(),
             success_url: request.successUrl,
             cancel_url: request.cancelUrl,
             metadata: {

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -536,7 +536,8 @@ export class StripeBillingProvider extends BillingProvider {
     }
 
     /**
-     * 🛑 THIS PATH COLLECTS NO TAX, AND CANNOT BE MADE TO WITHOUT RESHAPING IT.
+     * 🛑 THIS PATH COLLECTS NO TAX. It can be made to - see the flow below -
+     * but it is not wired, and the difference is real money.
      *
      * The Checkout credit-pack purchase asks for `automatic_tax`, so a German
      * buyer of the 5,500-credit pack pays $50 + $9.50 VAT. The SAME pack bought
@@ -545,14 +546,24 @@ export class StripeBillingProvider extends BillingProvider {
      * way, so the difference comes out of margin - and the two prices for one
      * product is the kind of thing an audit finds.
      *
-     * It is not an omission that can be patched here: PaymentIntents do not
-     * accept the parameter at all. Verified against the live API, 2026-08-23:
-     *   POST /v1/payment_intents  automatic_tax[enabled]=true
-     *   -> 400 "Received unknown parameter: automatic_tax"
-     * Collecting tax off-session means routing through an Invoice (invoice items
-     * + an invoice carrying `automatic_tax`, paid off-session), which changes
-     * this method's result shape and the events it emits. Deliberately left
-     * alone rather than half-done.
+     * `automatic_tax` is not the mechanism here - PaymentIntents reject it
+     * outright (verified 2026-08-23: `POST /v1/payment_intents`
+     * `automatic_tax[enabled]=true` -> 400 "Received unknown parameter"). But a
+     * supported off-session flow DOES exist, and it is smaller than an Invoice
+     * rewrite:
+     *
+     *   1. `POST /v1/tax/calculations` with the pack amount, the product tax
+     *      code and the customer's address -> `amount_total` including tax;
+     *   2. create the PaymentIntent for that total, passing the calculation id
+     *      as `hooks[inputs][tax][calculation]`;
+     *   3. after it succeeds, `POST /v1/tax/transactions/create_from_calculation`
+     *      so the collected tax is actually reported.
+     *
+     * Step 2 is confirmed accepted on this account (2026-08-23; control: a bogus
+     * `hooks[inputs][tax][not_a_field]` on the same call IS rejected, so the
+     * probe discriminates). It is left unimplemented deliberately - it changes
+     * the amount charged, and shipping a new tax path on a money route with no
+     * end-to-end test would be worse than the gap it closes.
      *
      * EXPOSURE TODAY IS ZERO, and the reason is worth knowing because it is
      * about to change: `autoRechargeEnabled` defaults false and is opt-in, and

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -316,6 +316,19 @@ export class StripeBillingProvider extends BillingProvider {
             line_items: lineItems,
             metadata,
             ...STRIPE_TAX_SESSION_FIELDS,
+            // A `mode: 'payment'` sale emits no `invoice.*` event unless invoice
+            // creation is asked for explicitly. Without this, a successful $99
+            // perpetual-licence payment produces NO invoice, NO ledger row and NO
+            // subscription row — by design, since a licence grants no hosted
+            // tier — so the billing page after paying is byte-identical to
+            // before, with the same enabled "$99" button. The buyer concludes it
+            // failed and pays again, and nothing on this path is idempotent
+            // (`checkout.sessions.create` carries no idempotency key here).
+            //
+            // Turning it on routes the sale through the existing
+            // `invoice.updated` -> `mirrorInvoice` path, so the buyer gets a
+            // receipt in-app through plumbing that already exists.
+            ...(isPerpetual ? { invoice_creation: { enabled: true } } : {}),
             // `subscription_data` is rejected outright in payment mode; the one-off equivalent is
             // `payment_intent_data`, which is also where the licence marker has to be mirrored so a
             // refund or dispute on the charge can still be traced back to the sale.

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -73,6 +73,32 @@ export const STRIPE_METADATA_KEYS = {
 /** The only value {@link STRIPE_METADATA_KEYS.licence} ever takes. */
 export const STRIPE_PERPETUAL_LICENCE = 'perpetual-commercial' as const;
 
+/**
+ * Stripe Tax, applied to every session that actually CHARGES.
+ *
+ * The account has Stripe Tax active with live registrations, but a session only calculates tax if
+ * it asks: without `automatic_tax` every invoice ships with no tax line, and VAT we are registered
+ * to collect has to come out of margin or be chased retroactively.
+ *
+ * - `customer_update.address: 'auto'` is REQUIRED alongside `automatic_tax` whenever an existing
+ *   `customer` is passed. Stripe needs an address to pick a jurisdiction, and this lets Checkout
+ *   collect it and write it back to the customer.
+ * - `tax_id_collection` lets a business enter its VAT/GST number, which is what triggers EU
+ *   reverse-charge instead of us charging VAT to a registered business.
+ *
+ * 🛑 Deliberately NOT applied to `mode: 'setup'` sessions — saving a card charges nothing, and
+ * Stripe rejects `automatic_tax` there.
+ *
+ * `tax_behavior` is left `unspecified` on prices on purpose: the account default
+ * `inferred_by_currency` already resolves USD to tax-exclusive, and the field is IMMUTABLE once
+ * set, so pinning it would foreclose tax-inclusive EUR pricing later for no gain today.
+ */
+const STRIPE_TAX_SESSION_FIELDS = {
+    automatic_tax: { enabled: true },
+    customer_update: { address: 'auto' },
+    tax_id_collection: { enabled: true },
+} as const;
+
 /** `kind` metadata values — how a purchase at the provider originated. */
 export const STRIPE_PURCHASE_KINDS = {
     checkout: 'credit-topup',
@@ -208,6 +234,7 @@ export class StripeBillingProvider extends BillingProvider {
             client_reference_id: request.referenceId,
             success_url: request.successUrl,
             cancel_url: request.cancelUrl,
+            ...STRIPE_TAX_SESSION_FIELDS,
             line_items: [
                 {
                     quantity: 1,
@@ -288,6 +315,7 @@ export class StripeBillingProvider extends BillingProvider {
             cancel_url: request.cancelUrl,
             line_items: lineItems,
             metadata,
+            ...STRIPE_TAX_SESSION_FIELDS,
             // `subscription_data` is rejected outright in payment mode; the one-off equivalent is
             // `payment_intent_data`, which is also where the licence marker has to be mirrored so a
             // refund or dispute on the charge can still be traced back to the sale.

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -535,6 +535,36 @@ export class StripeBillingProvider extends BillingProvider {
         };
     }
 
+    /**
+     * 🛑 THIS PATH COLLECTS NO TAX, AND CANNOT BE MADE TO WITHOUT RESHAPING IT.
+     *
+     * The Checkout credit-pack purchase asks for `automatic_tax`, so a German
+     * buyer of the 5,500-credit pack pays $50 + $9.50 VAT. The SAME pack bought
+     * through auto-recharge goes out as a bare PaymentIntent and is charged at
+     * $50 flat. Under the account's OSS registration that VAT is owed either
+     * way, so the difference comes out of margin - and the two prices for one
+     * product is the kind of thing an audit finds.
+     *
+     * It is not an omission that can be patched here: PaymentIntents do not
+     * accept the parameter at all. Verified against the live API, 2026-08-23:
+     *   POST /v1/payment_intents  automatic_tax[enabled]=true
+     *   -> 400 "Received unknown parameter: automatic_tax"
+     * Collecting tax off-session means routing through an Invoice (invoice items
+     * + an invoice carrying `automatic_tax`, paid off-session), which changes
+     * this method's result shape and the events it emits. Deliberately left
+     * alone rather than half-done.
+     *
+     * EXPOSURE TODAY IS ZERO, and the reason is worth knowing because it is
+     * about to change: `autoRechargeEnabled` defaults false and is opt-in, and
+     * turning it on requires a saved card - which was impossible, because the
+     * setup session was rejected by Stripe for want of a `currency`. Measured:
+     * zero live Stripe customers carry an Ever Works userId (control: 1 of 8
+     * live customers in the shared account does have a default payment method,
+     * so the probe discriminates).
+     *
+     * Fixing that setup session is what makes this path reachable for the first
+     * time. Resolve the tax question BEFORE auto-recharge is advertised.
+     */
     async chargeOffSession(request: OffSessionChargeRequest): Promise<OffSessionChargeResult> {
         const stripe = this.requireClient();
         try {

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -1,4 +1,9 @@
-import { CreditLedgerService, InsufficientCreditsError } from './credit-ledger.service';
+import {
+    addWholeMonths,
+    CreditLedgerService,
+    elapsedWholeMonths,
+    InsufficientCreditsError,
+} from './credit-ledger.service';
 import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
 
 /**
@@ -20,6 +25,7 @@ function makeLedgerRepository(overrides: Record<string, jest.Mock> = {}) {
         getBalance: jest.fn().mockResolvedValue(0),
         findForUser: jest.fn().mockResolvedValue({ entries: [], total: 0 }),
         findByIdempotencyKey: jest.fn().mockResolvedValue(null),
+        sumByRefTypeInWindow: jest.fn().mockResolvedValue(0),
         ...overrides,
     };
 }
@@ -40,20 +46,36 @@ function makeUserRepository(overrides: Record<string, jest.Mock> = {}) {
     };
 }
 
+function makeSubscriptionRepository(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        findCurrentByUser: jest.fn().mockResolvedValue(null),
+        ...overrides,
+    };
+}
+
 function makeService(
     ledger: Record<string, jest.Mock> = {},
     entitlements: Record<string, jest.Mock> = {},
     users: Record<string, jest.Mock> = {},
+    subscriptions: Record<string, jest.Mock> = {},
 ) {
     const ledgerRepository = makeLedgerRepository(ledger);
     const entitlementsService = makeEntitlements(entitlements);
     const userRepository = makeUserRepository(users);
+    const subscriptionRepository = makeSubscriptionRepository(subscriptions);
     const service = new CreditLedgerService(
         ledgerRepository as any,
         entitlementsService as any,
         userRepository as any,
+        subscriptionRepository as any,
     );
-    return { service, ledgerRepository, entitlementsService, userRepository };
+    return {
+        service,
+        ledgerRepository,
+        entitlementsService,
+        userRepository,
+        subscriptionRepository,
+    };
 }
 
 describe('CreditLedgerService', () => {
@@ -316,9 +338,22 @@ describe('CreditLedgerService', () => {
                     amountCredits: 50,
                     idempotencyKey: 'daily:u1:2026-07-25',
                 }),
-                expect.objectContaining({ maxBalanceAfter: 50 }),
+                // Was `{ maxBalanceAfter: 50 }` — the top-up-to-N ceiling. It is
+                // gone on purpose: the ceiling clamps against the WHOLE balance,
+                // so it silently denied the advertised daily credits to every
+                // paid tier AND to any free user who had bought a credit pack.
+                // The UNIQUE daily key is what limits this to one grant a day.
+                expect.objectContaining({ maxBalanceAfter: null }),
             );
-            expect(summary).toEqual({ granted: 1, skipped: 0, alreadyGranted: 0, scanned: 1 });
+            expect(summary).toEqual({
+                granted: 1,
+                skipped: 0,
+                alreadyGranted: 0,
+                scanned: 1,
+                failed: 0,
+                monthlyGranted: 0,
+                monthlyAlreadyGranted: 0,
+            });
         });
 
         it('is a no-op on re-run: an existing daily key counts as alreadyGranted', async () => {
@@ -332,7 +367,15 @@ describe('CreditLedgerService', () => {
             const summary = await service.dispatchDailyGrants(NOW);
 
             expect(ledgerRepository.recordAtomic).not.toHaveBeenCalled();
-            expect(summary).toEqual({ granted: 0, skipped: 0, alreadyGranted: 1, scanned: 1 });
+            expect(summary).toEqual({
+                granted: 0,
+                skipped: 0,
+                alreadyGranted: 1,
+                scanned: 1,
+                failed: 0,
+                monthlyGranted: 0,
+                monthlyAlreadyGranted: 0,
+            });
         });
 
         it('skips users whose plan has no daily-free entitlement and counts ceiling clamps as skipped', async () => {
@@ -357,7 +400,15 @@ describe('CreditLedgerService', () => {
 
             const summary = await service.dispatchDailyGrants(NOW);
 
-            expect(summary).toEqual({ granted: 0, skipped: 2, alreadyGranted: 0, scanned: 2 });
+            expect(summary).toEqual({
+                granted: 0,
+                skipped: 2,
+                alreadyGranted: 0,
+                scanned: 2,
+                failed: 0,
+                monthlyGranted: 0,
+                monthlyAlreadyGranted: 0,
+            });
         });
 
         it('keeps sweeping when one user fails (best-effort per user)', async () => {
@@ -378,10 +429,399 @@ describe('CreditLedgerService', () => {
 
             const summary = await service.dispatchDailyGrants(NOW);
 
-            expect(summary).toEqual({ granted: 1, skipped: 1, alreadyGranted: 0, scanned: 2 });
+            expect(summary).toEqual({
+                granted: 1,
+                skipped: 1,
+                alreadyGranted: 0,
+                scanned: 2,
+                // A thrown grant is now visible instead of being indistinguishable
+                // from a healthy no-op: `failed` is a subset of `skipped`.
+                failed: 1,
+                monthlyGranted: 0,
+                monthlyAlreadyGranted: 0,
+            });
+        });
+
+        /**
+         * H3 (a) — the advertised daily allowance is universal.
+         *
+         * The sweep used to pass `planCode === 'free' ? fallback : 0` as the
+         * entitlement fallback, so ANY plan without an explicit
+         * `daily-free-credits` row resolved to zero and received nothing,
+         * while the pricing page promised 50/day on every tier.
+         *
+         * This asserts the OUTCOME (a paid user with no row is granted), not
+         * the argument passed to a mock: `getNumber` here behaves like the real
+         * service when no row exists, i.e. it returns the fallback it is given.
+         */
+        it('grants the daily allowance on a PAID plan that has no entitlement row', async () => {
+            const users = [{ id: 'pro-user', defaultPlan: { code: 'standard' } }];
+            const { service, ledgerRepository } = makeService(
+                {},
+                {
+                    // "no row" — the real EntitlementsService returns the fallback.
+                    getNumber: jest
+                        .fn()
+                        .mockImplementation(async (_plan: string, _key: string, fb: number) => fb),
+                },
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.granted).toBe(1);
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'pro-user',
+                    kind: CreditLedgerKind.DAILY_FREE,
+                    amountCredits: 50,
+                }),
+                expect.anything(),
+            );
+        });
+
+        /**
+         * H3 (c) — THE hidden blocker, and the correction the attack found.
+         *
+         * `maxBalanceAfter` makes the daily grant a top-up-to-N, which is right
+         * for a free user and catastrophic for a paid one: a Pro balance of
+         * 3,000 monthly credits leaves negative headroom against a level of 50,
+         * so the repository clamps to nothing and writes no row. Every test
+         * passes and the paid tiers silently receive ZERO daily credits.
+         *
+         * Revert-check: change the ceiling back to an unconditional `level` and
+         * this test must go RED (the repository stub reports `skipped`, so
+         * `granted` drops to 0). If it stays green it is asserting nothing.
+         */
+        it('passes NO balance ceiling, so daily credits are always additive', async () => {
+            const users = [
+                { id: 'pro-user', defaultPlan: { code: 'standard', monthlyCredits: 3000 } },
+            ];
+            const { service, ledgerRepository } = makeService(
+                {},
+                {},
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.granted).toBe(1);
+            const [, options] = ledgerRepository.recordAtomic.mock.calls[0];
+            expect(options).not.toHaveProperty('maxBalanceAfter', expect.any(Number));
+            expect(options.maxBalanceAfter ?? null).toBeNull();
+        });
+
+        /**
+         * The case that killed the first attempt at a conditional ceiling.
+         *
+         * `maxBalanceAfter` clamps against the WHOLE balance, and `sumBalance`
+         * sums every kind — purchases included. So any ceiling denies the
+         * advertised daily credits to a free user who bought a credit pack:
+         * 25,000 purchased credits against a level of 50 is negative headroom,
+         * the repository writes nothing, and the sweep logs `skipped` exactly
+         * as it does for a healthy user. ~500 days of silence, for the one
+         * free-tier user who actually paid.
+         *
+         * Revert-check: reinstate `maxBalanceAfter: level` and this goes RED.
+         */
+        it('still grants a FREE user who has bought a large credit pack', async () => {
+            const users = [{ id: 'free-buyer', defaultPlan: { code: 'free', monthlyCredits: 0 } }];
+            const { service, ledgerRepository } = makeService(
+                {
+                    // Faithful to the repository: a ceiling below the current
+                    // balance clamps the grant to nothing and writes NO row.
+                    recordAtomic: jest.fn().mockImplementation(async (write: any, opts: any) => {
+                        const balance = 25000; // bought the $200 pack
+                        const ceiling = opts?.maxBalanceAfter;
+                        if (
+                            typeof ceiling === 'number' &&
+                            balance + write.amountCredits > ceiling
+                        ) {
+                            return { status: 'skipped', balance };
+                        }
+                        return {
+                            status: 'created',
+                            entry: {
+                                id: 'e1',
+                                ...write,
+                                balanceAfter: balance + write.amountCredits,
+                            },
+                        };
+                    }),
+                },
+                {},
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.granted).toBe(1);
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ kind: CreditLedgerKind.DAILY_FREE, amountCredits: 50 }),
+                expect.anything(),
+            );
         });
     });
 
+    /**
+     * Month arithmetic for the subscription anniversary. A 31st anchor is
+     * the case that breaks naive implementations: rolling Jan 31 forward by
+     * one month must give Feb 28/29, not Mar 3 — otherwise a customer is
+     * granted twice in March.
+     */
+    describe('anniversary month arithmetic', () => {
+        it('clamps a 31st anchor to the last day of a shorter month', () => {
+            const anchor = new Date('2026-01-31T12:00:00.000Z');
+            expect(addWholeMonths(anchor, 1).toISOString()).toBe('2026-02-28T12:00:00.000Z');
+            expect(addWholeMonths(anchor, 2).toISOString()).toBe('2026-03-31T12:00:00.000Z');
+            expect(addWholeMonths(anchor, 3).toISOString()).toBe('2026-04-30T12:00:00.000Z');
+        });
+
+        it('does not advance the index before the anniversary instant', () => {
+            const anchor = new Date('2026-01-31T12:00:00.000Z');
+            expect(elapsedWholeMonths(anchor, new Date('2026-02-28T11:59:59.000Z'))).toBe(0);
+            expect(elapsedWholeMonths(anchor, new Date('2026-02-28T12:00:00.000Z'))).toBe(1);
+            expect(elapsedWholeMonths(anchor, new Date('2026-03-30T00:00:00.000Z'))).toBe(1);
+            expect(elapsedWholeMonths(anchor, new Date('2026-03-31T12:00:00.000Z'))).toBe(2);
+        });
+
+        it('never returns a negative index', () => {
+            const anchor = new Date('2026-06-15T00:00:00.000Z');
+            expect(elapsedWholeMonths(anchor, new Date('2026-01-01T00:00:00.000Z'))).toBe(0);
+        });
+
+        it('counts twelve grants across an annual subscription year', () => {
+            const anchor = new Date('2026-08-31T09:00:00.000Z');
+            const indexes = new Set<number>();
+            for (let day = 0; day < 365; day++) {
+                const at = new Date(anchor.getTime() + day * 24 * 3600 * 1000);
+                indexes.add(elapsedWholeMonths(anchor, at));
+            }
+            // Index 0 through 11 — one distinct grant key per month of the year.
+            expect(indexes.size).toBe(12);
+        });
+    });
+    /**
+     * H3 (b) — the plan's MONTHLY allowance.
+     *
+     * `subscription_plans.monthlyCredits` was seeded on every paid plan,
+     * mirrored into the Stripe catalog and printed on the pricing page, and
+     * read by no code anywhere. These pin what the key choice decides.
+     */
+    describe('monthly plan credits', () => {
+        const NOW = new Date('2026-07-25T00:05:00.000Z');
+        const ANCHOR = new Date('2026-05-10T08:00:00.000Z'); // 2 whole months before NOW
+
+        const proSubscription = {
+            id: 'sub-1',
+            planCode: 'standard',
+            createdAt: ANCHOR,
+            plan: { code: 'standard', displayName: 'Pro', monthlyCredits: 3000 },
+        };
+        const anyUser = [{ id: 'u1', defaultPlan: { code: 'free', monthlyCredits: 0 } }];
+
+        const withUser = (subscription: unknown, ledger: Record<string, jest.Mock> = {}) =>
+            makeService(
+                ledger,
+                {},
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(anyUser).mockResolvedValue([]) },
+                { findCurrentByUser: jest.fn().mockResolvedValue(subscription) },
+            );
+
+        it('grants the full allowance, keyed by subscription + elapsed month + plan', async () => {
+            const { service, ledgerRepository } = withUser(proSubscription);
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyGranted).toBe(1);
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    kind: CreditLedgerKind.GRANT,
+                    amountCredits: 3000,
+                    refType: 'plan-monthly',
+                    refId: 'sub-1',
+                    idempotencyKey: 'plan-monthly:u1:sub-1:2:standard',
+                }),
+                expect.anything(),
+            );
+        });
+
+        /**
+         * The reason this reads the subscription and not `user.defaultPlan`.
+         *
+         * `assignPlanToUser` (the only writer of `defaultPlanId`) is gated on
+         * SUBSCRIPTIONS_ENABLED while the subscription row is written
+         * unconditionally — so a paying customer on a deploy where the flag
+         * was off has an ACTIVE paid row and `defaultPlanId = free`.
+         */
+        it('pays a subscriber whose defaultPlan still says free', async () => {
+            const { service, ledgerRepository } = withUser(proSubscription);
+
+            await service.dispatchDailyGrants(NOW);
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ kind: CreditLedgerKind.GRANT, amountCredits: 3000 }),
+                expect.anything(),
+            );
+        });
+
+        /**
+         * Dunning. A failed invoice leaves `defaultPlanId` on the paid tier
+         * for the whole of Stripe's retry window, so a defaultPlan-driven
+         * grant keeps paying out for invoices that never cleared.
+         * `findCurrentByUser` returns only ACTIVE/TRIALING rows.
+         */
+        it('pays nothing when there is no current subscription (cancelled or past_due)', async () => {
+            const { service, ledgerRepository } = withUser(null);
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyGranted).toBe(0);
+            const grants = ledgerRepository.recordAtomic.mock.calls.filter(
+                ([write]: any[]) => write.kind === CreditLedgerKind.GRANT,
+            );
+            expect(grants).toHaveLength(0);
+        });
+
+        it('grants only the DIFFERENCE after a mid-cycle upgrade', async () => {
+            const upgraded = {
+                ...proSubscription,
+                planCode: 'premium',
+                plan: { code: 'premium', displayName: 'Enterprise', monthlyCredits: 25000 },
+            };
+            const { service, ledgerRepository } = withUser(upgraded, {
+                sumByRefTypeInWindow: jest.fn().mockResolvedValue(3000),
+            });
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyGranted).toBe(1);
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    kind: CreditLedgerKind.GRANT,
+                    amountCredits: 22000,
+                    idempotencyKey: 'plan-monthly:u1:sub-1:2:premium',
+                }),
+                expect.anything(),
+            );
+        });
+
+        it('writes NOTHING after a mid-cycle downgrade — credits are never clawed back', async () => {
+            const { service, ledgerRepository } = withUser(proSubscription, {
+                sumByRefTypeInWindow: jest.fn().mockResolvedValue(25000),
+            });
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyGranted).toBe(0);
+            const grants = ledgerRepository.recordAtomic.mock.calls.filter(
+                ([write]: any[]) => write.kind === CreditLedgerKind.GRANT,
+            );
+            expect(grants).toHaveLength(0);
+        });
+
+        it('is idempotent: an existing key for the period writes nothing', async () => {
+            const { service, ledgerRepository } = withUser(proSubscription, {
+                findByIdempotencyKey: jest
+                    .fn()
+                    .mockImplementation(async (key: string) =>
+                        key.startsWith('plan-monthly:') ? { id: 'prior' } : null,
+                    ),
+            });
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyAlreadyGranted).toBe(1);
+            const grants = ledgerRepository.recordAtomic.mock.calls.filter(
+                ([write]: any[]) => write.kind === CreditLedgerKind.GRANT,
+            );
+            expect(grants).toHaveLength(0);
+        });
+
+        /**
+         * 🛑 The bug a CALENDAR-month key would have: a customer who
+         * subscribes on the 31st is granted again hours later on the 1st.
+         * Anchored on the subscription, the day after activation is still
+         * month index 0 — the key is already claimed, so nothing is written.
+         */
+        it('does not re-grant the day after a month-end signup', async () => {
+            const lateSignup = {
+                ...proSubscription,
+                createdAt: new Date('2026-08-31T22:00:00.000Z'),
+            };
+            const { service, ledgerRepository } = withUser(lateSignup);
+
+            await service.dispatchDailyGrants(new Date('2026-09-01T00:05:00.000Z'));
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ idempotencyKey: 'plan-monthly:u1:sub-1:0:standard' }),
+                expect.anything(),
+            );
+        });
+
+        /**
+         * An ANNUAL subscriber renews once a year. Keying the grant off the
+         * billing PERIOD would hand them 3,000 credits for a $204 year;
+         * keying it off the elapsed-month index gives them twelve.
+         */
+        it('advances the index every month, which is what makes annual work', async () => {
+            const { service, ledgerRepository } = withUser(proSubscription);
+
+            await service.dispatchDailyGrants(new Date('2027-04-10T08:00:00.000Z'));
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ idempotencyKey: 'plan-monthly:u1:sub-1:11:standard' }),
+                expect.anything(),
+            );
+        });
+
+        it('skips a subscription whose plan carries no monthly allowance', async () => {
+            const freeSub = {
+                ...proSubscription,
+                planCode: 'free',
+                plan: { code: 'free', displayName: 'Free', monthlyCredits: 0 },
+            };
+            const { service, ledgerRepository } = withUser(freeSub);
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyGranted).toBe(0);
+            expect(ledgerRepository.sumByRefTypeInWindow).not.toHaveBeenCalled();
+        });
+
+        /**
+         * `credit_ledger_entries.idempotencyKey` is varchar(128). The longest
+         * possible key is 13 + 36 + 1 + 36 + 1 + 4 + 1 + 21 = 113.
+         */
+        it('produces a key that fits the varchar(128) column', async () => {
+            const longest = {
+                id: '11111111-2222-3333-4444-555555555555',
+                planCode: 'selfhosted_enterprise',
+                createdAt: ANCHOR,
+                plan: {
+                    code: 'selfhosted_enterprise',
+                    displayName: 'Enterprise Edition',
+                    monthlyCredits: 25000,
+                },
+            };
+            const users = [{ id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }];
+            const { service, ledgerRepository } = makeService(
+                {},
+                {},
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+                { findCurrentByUser: jest.fn().mockResolvedValue(longest) },
+            );
+
+            await service.dispatchDailyGrants(NOW);
+
+            const grant = ledgerRepository.recordAtomic.mock.calls.find(
+                ([write]: any[]) => write.kind === CreditLedgerKind.GRANT,
+            );
+            expect(grant).toBeDefined();
+            expect(grant![0].idempotencyKey.length).toBeLessThanOrEqual(128);
+        });
+    });
     describe('getBalance', () => {
         it('delegates to the repository SUM (authoritative balance)', async () => {
             const { service, ledgerRepository } = makeService({

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -53,21 +53,32 @@ function makeSubscriptionRepository(overrides: Record<string, jest.Mock> = {}) {
     };
 }
 
+function makeBillingProfileRepository(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        // "collecting fine" by default.
+        findByUserId: jest.fn().mockResolvedValue({ subscriptionStatus: 'active' }),
+        ...overrides,
+    };
+}
+
 function makeService(
     ledger: Record<string, jest.Mock> = {},
     entitlements: Record<string, jest.Mock> = {},
     users: Record<string, jest.Mock> = {},
     subscriptions: Record<string, jest.Mock> = {},
+    billingProfiles: Record<string, jest.Mock> = {},
 ) {
     const ledgerRepository = makeLedgerRepository(ledger);
     const entitlementsService = makeEntitlements(entitlements);
     const userRepository = makeUserRepository(users);
     const subscriptionRepository = makeSubscriptionRepository(subscriptions);
+    const billingProfileRepository = makeBillingProfileRepository(billingProfiles);
     const service = new CreditLedgerService(
         ledgerRepository as any,
         entitlementsService as any,
         userRepository as any,
         subscriptionRepository as any,
+        billingProfileRepository as any,
     );
     return {
         service,
@@ -75,6 +86,7 @@ function makeService(
         entitlementsService,
         userRepository,
         subscriptionRepository,
+        billingProfileRepository,
     };
 }
 
@@ -353,6 +365,7 @@ describe('CreditLedgerService', () => {
                 failed: 0,
                 monthlyGranted: 0,
                 monthlyAlreadyGranted: 0,
+                monthlyFailed: 0,
             });
         });
 
@@ -375,6 +388,7 @@ describe('CreditLedgerService', () => {
                 failed: 0,
                 monthlyGranted: 0,
                 monthlyAlreadyGranted: 0,
+                monthlyFailed: 0,
             });
         });
 
@@ -408,6 +422,7 @@ describe('CreditLedgerService', () => {
                 failed: 0,
                 monthlyGranted: 0,
                 monthlyAlreadyGranted: 0,
+                monthlyFailed: 0,
             });
         });
 
@@ -439,6 +454,7 @@ describe('CreditLedgerService', () => {
                 failed: 1,
                 monthlyGranted: 0,
                 monthlyAlreadyGranted: 0,
+                monthlyFailed: 0,
             });
         });
 
@@ -620,12 +636,17 @@ describe('CreditLedgerService', () => {
         };
         const anyUser = [{ id: 'u1', defaultPlan: { code: 'free', monthlyCredits: 0 } }];
 
-        const withUser = (subscription: unknown, ledger: Record<string, jest.Mock> = {}) =>
+        const withUser = (
+            subscription: unknown,
+            ledger: Record<string, jest.Mock> = {},
+            billingProfiles: Record<string, jest.Mock> = {},
+        ) =>
             makeService(
                 ledger,
                 {},
                 { findActiveBatch: jest.fn().mockResolvedValueOnce(anyUser).mockResolvedValue([]) },
                 { findCurrentByUser: jest.fn().mockResolvedValue(subscription) },
+                billingProfiles,
             );
 
         it('grants the full allowance, keyed by subscription + elapsed month + plan', async () => {
@@ -682,6 +703,68 @@ describe('CreditLedgerService', () => {
                 ([write]: any[]) => write.kind === CreditLedgerKind.GRANT,
             );
             expect(grants).toHaveLength(0);
+        });
+
+        /**
+         * 🛑 THE DUNNING GUARD THAT ALMOST WAS NOT.
+         *
+         * Reading the subscription row looks like it excludes dunning — the
+         * repository even documents that it 'deliberately excludes PAST_DUE'. But
+         * `SubscriptionStatus.PAST_DUE` is declared in the enum and assigned
+         * NOWHERE: the provider maps a failed invoice onto
+         * `billing_profiles.subscriptionStatus`, a different table entirely. So a
+         * subscription-row-only check leaves the customer 'active' for the whole of
+         * Stripe's retry window and pays out every month against invoices that
+         * never cleared.
+         *
+         * Revert-check: delete the billing-profile lookup and this goes RED.
+         */
+        it('pays NOTHING while the provider cannot collect (past_due / unpaid)', async () => {
+            for (const status of ['past_due', 'unpaid']) {
+                const { service, ledgerRepository } = withUser(
+                    proSubscription,
+                    {},
+                    { findByUserId: jest.fn().mockResolvedValue({ subscriptionStatus: status }) },
+                );
+
+                const summary = await service.dispatchDailyGrants(NOW);
+
+                expect(summary.monthlyGranted).toBe(0);
+                const grants = ledgerRepository.recordAtomic.mock.calls.filter(
+                    ([write]: any[]) => write.kind === CreditLedgerKind.GRANT,
+                );
+                expect(grants).toHaveLength(0);
+            }
+        });
+
+        it('still pays when there is no billing profile at all', async () => {
+            // A missing profile means "nothing has gone wrong yet", which is the
+            // posture every other reader of this state already takes.
+            const { service } = withUser(
+                proSubscription,
+                {},
+                { findByUserId: jest.fn().mockResolvedValue(null) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyGranted).toBe(1);
+        });
+
+        /**
+         * The same defect the daily path had: a thrown grant vanished into the
+         * gaps of the summary, so a sweep in which EVERY paying subscriber failed
+         * to be paid reported exactly like a healthy one.
+         */
+        it('counts a thrown monthly grant instead of losing it', async () => {
+            const { service } = withUser(proSubscription, {
+                sumByRefTypeInWindow: jest.fn().mockRejectedValue(new Error('db down')),
+            });
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary.monthlyFailed).toBe(1);
+            expect(summary.monthlyGranted).toBe(0);
         });
 
         it('grants only the DIFFERENCE after a mid-cycle upgrade', async () => {

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import {
     addWholeMonths,
     CreditLedgerService,
@@ -756,15 +757,25 @@ describe('CreditLedgerService', () => {
          * gaps of the summary, so a sweep in which EVERY paying subscriber failed
          * to be paid reported exactly like a healthy one.
          */
-        it('counts a thrown monthly grant instead of losing it', async () => {
-            const { service } = withUser(proSubscription, {
-                sumByRefTypeInWindow: jest.fn().mockRejectedValue(new Error('db down')),
-            });
+        it('counts a thrown monthly grant instead of losing it, and SAYS so', async () => {
+            // Counting it is not enough: the number has to leave the process. The
+            // cron emitter used to gate every log line on the DAILY counters, so on
+            // a same-day re-run (retry, redeploy, manual trigger) a sweep in which
+            // every subscriber failed to be paid logged nothing at all.
+            const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+            try {
+                const { service } = withUser(proSubscription, {
+                    sumByRefTypeInWindow: jest.fn().mockRejectedValue(new Error('db down')),
+                });
 
-            const summary = await service.dispatchDailyGrants(NOW);
+                const summary = await service.dispatchDailyGrants(NOW);
 
-            expect(summary.monthlyFailed).toBe(1);
-            expect(summary.monthlyGranted).toBe(0);
+                expect(summary.monthlyFailed).toBe(1);
+                expect(summary.monthlyGranted).toBe(0);
+                expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('FAILED'));
+            } finally {
+                errorSpy.mockRestore();
+            }
         });
 
         it('grants only the DIFFERENCE after a mid-cycle upgrade', async () => {

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -5,7 +5,10 @@ import {
     CreditLedgerWrite,
 } from '@src/database/repositories/credit-ledger.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
+import { UserSubscriptionRepository } from '@src/database/repositories/user-subscription.repository';
 import { CreditLedgerEntry, CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+import type { SubscriptionPlan } from '@src/entities/subscription-plan.entity';
+import type { ClassToObject } from '@src/entities/types';
 import { config } from '@src/config';
 import { ENTITLEMENT_KEYS, EntitlementsService } from './entitlements.service';
 
@@ -76,7 +79,26 @@ export interface DailyGrantSummary {
     alreadyGranted: number;
     /** Users scanned. */
     scanned: number;
+    /**
+     * Users whose grant threw. A SUBSET of `skipped` (which has always
+     * lumped failures in with healthy no-ops) - reported separately so a
+     * systematic failure is visible instead of looking like a quiet run.
+     */
+    failed: number;
+    /** Users that received a monthly plan allowance (or a top-up) this run. */
+    monthlyGranted: number;
+    /** Users whose monthly allowance for this calendar month already existed. */
+    monthlyAlreadyGranted: number;
 }
+
+/**
+ * `refType` stamped on every monthly plan-allowance row. 12 chars, well
+ * inside the varchar(32) column. The monthly grant sums prior rows of this
+ * type inside the calendar month to work out how much is still owed, so
+ * this string is load-bearing - changing it re-grants the full allowance
+ * to every user in the current month.
+ */
+export const MONTHLY_PLAN_REF_TYPE = 'plan-monthly';
 
 const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 100;
@@ -103,6 +125,7 @@ export class CreditLedgerService {
         private readonly creditLedgerRepository: CreditLedgerRepository,
         private readonly entitlementsService: EntitlementsService,
         private readonly userRepository: UserRepository,
+        private readonly userSubscriptionRepository: UserSubscriptionRepository,
     ) {}
 
     /**
@@ -253,6 +276,9 @@ export class CreditLedgerService {
             skipped: 0,
             alreadyGranted: 0,
             scanned: 0,
+            failed: 0,
+            monthlyGranted: 0,
+            monthlyAlreadyGranted: 0,
         };
         const date = now.toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
         const batchSize = config.billing.credits.getDailyGrantBatchSize();
@@ -268,47 +294,38 @@ export class CreditLedgerService {
             for (const user of users) {
                 summary.scanned += 1;
                 const planCode = (user.defaultPlan?.code as string) || defaultPlanCode;
-                const level = await this.entitlementsService.getNumber(
+
+                const daily = await this.grantDailyCredits(
+                    user.id,
                     planCode,
-                    ENTITLEMENT_KEYS.DAILY_FREE_CREDITS,
-                    planCode === 'free' ? fallbackDailyFree : 0,
+                    date,
+                    fallbackDailyFree,
                 );
-                if (level <= 0) {
+                if (daily === 'granted') {
+                    summary.granted += 1;
+                } else if (daily === 'already') {
+                    summary.alreadyGranted += 1;
+                } else if (daily === 'failed') {
+                    // Counted separately from `skipped`: a systematic grant
+                    // failure used to be byte-identical to a healthy sweep, so
+                    // it could re-fail once a day forever with nobody paged.
+                    summary.failed += 1;
                     summary.skipped += 1;
-                    continue;
+                } else {
+                    summary.skipped += 1;
                 }
 
-                try {
-                    const idempotencyKey = `daily:${user.id}:${date}`;
-                    const existing =
-                        await this.creditLedgerRepository.findByIdempotencyKey(idempotencyKey);
-                    if (existing) {
-                        summary.alreadyGranted += 1;
-                        continue;
-                    }
-                    const entry = await this.record({
-                        userId: user.id,
-                        kind: CreditLedgerKind.DAILY_FREE,
-                        amountCredits: level,
-                        maxBalanceAfter: level,
-                        description: `Daily free credits (${date})`,
-                        idempotencyKey,
-                    });
-                    if (entry) {
-                        summary.granted += 1;
-                    } else {
-                        summary.skipped += 1;
-                    }
-                } catch (error) {
-                    // Best-effort per user — one failure must not starve the
-                    // rest of the sweep; the idempotency key retries tomorrow.
-                    summary.skipped += 1;
-                    this.logger.warn(
-                        `Daily grant failed for user ${user.id}: ${(error as Error).message}`,
-                    );
+                // Deliberately NOT chained to the daily outcome. The daily
+                // grant returns early on a zero entitlement and on a cron
+                // re-run, and a plan monthly allowance must not inherit
+                // either of those exits - they are separate promises.
+                const monthly = await this.grantMonthlyPlanCredits(user.id, now);
+                if (monthly === 'granted') {
+                    summary.monthlyGranted += 1;
+                } else if (monthly === 'already') {
+                    summary.monthlyAlreadyGranted += 1;
                 }
             }
-
             if (users.length < batchSize) {
                 break;
             }
@@ -316,4 +333,221 @@ export class CreditLedgerService {
 
         return summary;
     }
+    /**
+     * One user daily free credits. Extracted from the sweep so that its
+     * early exits cannot swallow the monthly plan allowance.
+     *
+     * `'skipped'` covers three genuinely different outcomes that the summary
+     * has always counted together: a zero entitlement, a ceiling that clamped
+     * the grant to nothing, and a per-user failure.
+     */
+    private async grantDailyCredits(
+        userId: string,
+        planCode: string,
+        date: string,
+        fallbackDailyFree: number,
+    ): Promise<'granted' | 'already' | 'failed' | 'skipped'> {
+        // The advertised daily allowance is universal (the pricing page says
+        // "50 free credits/day" on every tier), so the FALLBACK is the same for
+        // every plan. A plan that should get none carries an explicit
+        // `daily-free-credits` row of 0, which still wins over this fallback
+        // because EntitlementsService resolves the stored row with `??`.
+        const level = await this.entitlementsService.getNumber(
+            planCode,
+            ENTITLEMENT_KEYS.DAILY_FREE_CREDITS,
+            fallbackDailyFree,
+        );
+        if (level <= 0) {
+            return 'skipped';
+        }
+
+        try {
+            const idempotencyKey = `daily:${userId}:${date}`;
+            const existing = await this.creditLedgerRepository.findByIdempotencyKey(idempotencyKey);
+            if (existing) {
+                return 'already';
+            }
+
+            // 🛑 No `maxBalanceAfter`. It used to top the balance UP TO the
+            // daily level, which silently cancels the grant for anyone holding
+            // a balance above it - and `sumBalance` sums EVERY kind, purchases
+            // included. So the top-up ceiling denied the advertised daily
+            // credits to exactly two groups: paid tiers carrying a monthly
+            // allowance, and free users who had BOUGHT a credit pack (a $200
+            // 25,000-pack buyer would get nothing for ~500 days). Both looked
+            // identical in the logs to a healthy topped-up user.
+            //
+            // Any balance ceiling is unfixable for someone who bought credits,
+            // so there is none. The UNIQUE `daily:{userId}:{date}` key already
+            // guarantees at most one grant per user per day, which is the only
+            // invariant that ever mattered. Accepted consequence: an idle free
+            // user accrues without bound. Capping accrual needs lot tracking
+            // and expiry, not a ceiling - and this repo has no code that can
+            // remove a granted credit, deliberately.
+            const entry = await this.record({
+                userId,
+                kind: CreditLedgerKind.DAILY_FREE,
+                amountCredits: level,
+                description: `Daily free credits (${date})`,
+                idempotencyKey,
+            });
+            return entry ? 'granted' : 'skipped';
+        } catch (error) {
+            // Best-effort per user - one failure must not starve the rest of
+            // the sweep; the idempotency key retries tomorrow.
+            this.logger.warn(`Daily grant failed for user ${userId}: ${(error as Error).message}`);
+            return 'failed';
+        }
+    }
+
+    /**
+     * The plan's monthly credit allowance (`subscription_plans.monthlyCredits`).
+     *
+     * ## What it is keyed to, and why that is the whole design
+     *
+     * Resolved from the user's CURRENT subscription row, never from
+     * `user.defaultPlan`. Two independent reasons, both live today:
+     *
+     *  - **Dunning.** A failed invoice moves the subscription to `past_due`,
+     *    but the webhook handler deliberately neither grants nor revokes, so
+     *    `defaultPlanId` stays on the paid tier through Stripe's whole retry
+     *    window. A `defaultPlan` reader would keep paying out 3,000 / 25,000
+     *    credits a month for invoices that never cleared.
+     *  - **Divergence.** The subscription row is written unconditionally,
+     *    while `assignPlanToUser` (the only writer of `defaultPlanId`) is
+     *    gated on `SUBSCRIPTIONS_ENABLED`. On a deployment where that flag
+     *    is off, a paying customer has an ACTIVE `standard` row and
+     *    `defaultPlanId = free` — a `defaultPlan` reader pays them nothing,
+     *    forever, and nothing self-heals it.
+     *
+     * Consequence to state plainly: a plan assigned by an admin with no
+     * `user_subscriptions` row receives no monthly credits. That is
+     * deliberate — this grant follows money, not tier labels.
+     *
+     * ## The idempotency key
+     *
+     * `plan-monthly:{userId}:{subscriptionId}:{monthIndex}:{planCode}`, where
+     * `monthIndex` counts whole months elapsed since the subscription's
+     * `createdAt` — its billing anniversary, not the calendar. Written as a
+     * TOP-UP to the best allowance held inside that anniversary window, so:
+     *
+     *   - a monthly renewal grants again (the index moves on the anniversary);
+     *   - an ANNUAL subscriber still gets twelve grants a year, not one;
+     *   - a mid-cycle upgrade grants only the difference (Pro to Enterprise
+     *     adds 22,000, not a second 25,000);
+     *   - a mid-cycle downgrade writes nothing and removes nothing;
+     *   - a cancelled subscription simply stops.
+     *
+     * 🛑 A CALENDAR-month key looks equivalent and is not: someone who
+     * subscribes on the 31st would be granted again hours later on the 1st.
+     * Anchoring on the subscription keeps grants and charges in step, and
+     * makes it safe to also call this straight from the activation path.
+     *
+     * Max key length: 13 + 36 + 1 + 36 + 1 + 4 + 1 + 21 = 113 <= varchar(128).
+     *
+     * Credits ROLL OVER. Nothing in this codebase expires or claws back a
+     * granted credit, and this method deliberately does not become the first
+     * thing that does.
+     */
+    private async grantMonthlyPlanCredits(
+        userId: string,
+        now: Date,
+    ): Promise<'granted' | 'already' | 'failed' | 'skipped'> {
+        try {
+            const subscription = await this.userSubscriptionRepository.findCurrentByUser(userId);
+            if (!subscription) {
+                return 'skipped';
+            }
+
+            const plan = subscription.plan ?? null;
+            const allowance = Number(plan?.monthlyCredits ?? 0);
+            if (!Number.isInteger(allowance) || allowance <= 0) {
+                return 'skipped';
+            }
+
+            const anchor = subscription.createdAt;
+            if (!(anchor instanceof Date) || Number.isNaN(anchor.getTime())) {
+                return 'skipped';
+            }
+            const monthIndex = elapsedWholeMonths(anchor, now);
+            const planCode = String(subscription.planCode ?? plan?.code ?? 'unknown');
+            const idempotencyKey = `plan-monthly:${userId}:${subscription.id}:${monthIndex}:${planCode}`;
+
+            const existing = await this.creditLedgerRepository.findByIdempotencyKey(idempotencyKey);
+            if (existing) {
+                return 'already';
+            }
+
+            const from = addWholeMonths(anchor, monthIndex);
+            const to = addWholeMonths(anchor, monthIndex + 1);
+            const alreadyGrantedThisPeriod = await this.creditLedgerRepository.sumByRefTypeInWindow(
+                userId,
+                MONTHLY_PLAN_REF_TYPE,
+                from,
+                to,
+            );
+            const delta = allowance - alreadyGrantedThisPeriod;
+            if (delta <= 0) {
+                // A downgrade, or a re-grant under a different plan code in the
+                // same period. Never write a zero or negative row.
+                return 'skipped';
+            }
+
+            const entry = await this.record({
+                userId,
+                kind: CreditLedgerKind.GRANT,
+                amountCredits: delta,
+                refType: MONTHLY_PLAN_REF_TYPE,
+                refId: subscription.id,
+                description: `Monthly plan credits - ${plan?.displayName ?? planCode}`,
+                idempotencyKey,
+                // No maxBalanceAfter: the monthly allowance accumulates. A
+                // balance ceiling here would deny a customer the allowance they
+                // are actively paying for the moment they buy a credit pack.
+            });
+            return entry ? 'granted' : 'skipped';
+        } catch (error) {
+            this.logger.warn(
+                `Monthly plan grant failed for user ${userId}: ${(error as Error).message}`,
+            );
+            return 'failed';
+        }
+    }
+}
+
+/**
+ * Whole UTC months elapsed from `anchor` to `now`, never negative.
+ *
+ * Month arithmetic, not 30-day arithmetic: a subscription created on the
+ * 31st has anniversaries on the 30th/28th in shorter months, and
+ * {@link addWholeMonths} clamps to the last valid day rather than rolling
+ * into the following month. Rolling over is how a Jan-31 anchor silently
+ * grants twice in March.
+ */
+export function elapsedWholeMonths(anchor: Date, now: Date): number {
+    let months =
+        (now.getUTCFullYear() - anchor.getUTCFullYear()) * 12 +
+        (now.getUTCMonth() - anchor.getUTCMonth());
+    if (now.getTime() < addWholeMonths(anchor, months).getTime()) {
+        months -= 1;
+    }
+    return Math.max(0, months);
+}
+
+/** `anchor` + `months`, with the day clamped to the target month length. */
+export function addWholeMonths(anchor: Date, months: number): Date {
+    const year = anchor.getUTCFullYear();
+    const month = anchor.getUTCMonth() + months;
+    const lastDayOfTarget = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    return new Date(
+        Date.UTC(
+            year,
+            month,
+            Math.min(anchor.getUTCDate(), lastDayOfTarget),
+            anchor.getUTCHours(),
+            anchor.getUTCMinutes(),
+            anchor.getUTCSeconds(),
+            anchor.getUTCMilliseconds(),
+        ),
+    );
 }

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -343,6 +343,16 @@ export class CreditLedgerService {
             }
         }
 
+        // Emitted here as well as in the cron task, because this method is also
+        // reachable over the internal RPC channel and a payout failure must be
+        // visible from whichever side invoked it.
+        if (summary.failed > 0 || summary.monthlyFailed > 0) {
+            this.logger.error(
+                `Credit grant sweep: ${summary.failed} daily and ${summary.monthlyFailed} monthly ` +
+                    `grant(s) FAILED across ${summary.scanned} user(s).`,
+            );
+        }
+
         return summary;
     }
     /**

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -6,6 +6,8 @@ import {
 } from '@src/database/repositories/credit-ledger.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
 import { UserSubscriptionRepository } from '@src/database/repositories/user-subscription.repository';
+import { BillingProfileRepository } from '@src/database/repositories/billing-profile.repository';
+import { isPastDueSubscriptionStatus } from '@src/entities/billing-profile.entity';
 import { CreditLedgerEntry, CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
 import type { SubscriptionPlan } from '@src/entities/subscription-plan.entity';
 import type { ClassToObject } from '@src/entities/types';
@@ -87,8 +89,14 @@ export interface DailyGrantSummary {
     failed: number;
     /** Users that received a monthly plan allowance (or a top-up) this run. */
     monthlyGranted: number;
-    /** Users whose monthly allowance for this calendar month already existed. */
+    /** Users whose monthly allowance for this period already existed. */
     monthlyAlreadyGranted: number;
+    /**
+     * Users whose MONTHLY grant threw. Counted for exactly the same reason as
+     * {@link failed}: without it, a sweep in which every paying subscriber
+     * failed to be paid is byte-identical to a healthy one.
+     */
+    monthlyFailed: number;
 }
 
 /**
@@ -126,6 +134,7 @@ export class CreditLedgerService {
         private readonly entitlementsService: EntitlementsService,
         private readonly userRepository: UserRepository,
         private readonly userSubscriptionRepository: UserSubscriptionRepository,
+        private readonly billingProfileRepository: BillingProfileRepository,
     ) {}
 
     /**
@@ -279,6 +288,7 @@ export class CreditLedgerService {
             failed: 0,
             monthlyGranted: 0,
             monthlyAlreadyGranted: 0,
+            monthlyFailed: 0,
         };
         const date = now.toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
         const batchSize = config.billing.credits.getDailyGrantBatchSize();
@@ -324,6 +334,8 @@ export class CreditLedgerService {
                     summary.monthlyGranted += 1;
                 } else if (monthly === 'already') {
                     summary.monthlyAlreadyGranted += 1;
+                } else if (monthly === 'failed') {
+                    summary.monthlyFailed += 1;
                 }
             }
             if (users.length < batchSize) {
@@ -408,11 +420,17 @@ export class CreditLedgerService {
      * Resolved from the user's CURRENT subscription row, never from
      * `user.defaultPlan`. Two independent reasons, both live today:
      *
-     *  - **Dunning.** A failed invoice moves the subscription to `past_due`,
-     *    but the webhook handler deliberately neither grants nor revokes, so
-     *    `defaultPlanId` stays on the paid tier through Stripe's whole retry
-     *    window. A `defaultPlan` reader would keep paying out 3,000 / 25,000
-     *    credits a month for invoices that never cleared.
+     *  - **Dunning.** A failed invoice leaves `defaultPlanId` on the paid tier
+     *    for the whole of Stripe's retry window, because the webhook handler
+     *    deliberately neither grants nor revokes. A `defaultPlan` reader would
+     *    keep paying out 3,000 / 25,000 credits a month for invoices that never
+     *    cleared.
+     *
+     *    🛑 Reading the subscription row is NOT by itself enough to stop that.
+     *    `SubscriptionStatus.PAST_DUE` exists in the enum and is never assigned
+     *    anywhere — the dunning state is persisted on a different table,
+     *    `billing_profiles.subscriptionStatus`. So the grant consults the billing
+     *    profile too, and skips while the provider cannot collect.
      *  - **Divergence.** The subscription row is written unconditionally,
      *    while `assignPlanToUser` (the only writer of `defaultPlanId`) is
      *    gated on `SUBSCRIPTIONS_ENABLED`. On a deployment where that flag
@@ -462,6 +480,16 @@ export class CreditLedgerService {
             const plan = subscription.plan ?? null;
             const allowance = Number(plan?.monthlyCredits ?? 0);
             if (!Number.isInteger(allowance) || allowance <= 0) {
+                return 'skipped';
+            }
+
+            // The real dunning signal. `user_subscriptions.status` never becomes
+            // `past_due` — nothing writes it — so without this a customer whose
+            // invoice has been failing for weeks keeps drawing the full monthly
+            // allowance. A missing profile is treated as "collecting fine", which
+            // is the pre-existing posture everywhere else that reads this state.
+            const profile = await this.billingProfileRepository.findByUserId(userId);
+            if (isPastDueSubscriptionStatus(profile?.subscriptionStatus)) {
                 return 'skipped';
             }
 

--- a/packages/agent/src/subscriptions/credits/plan-run-limits.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/plan-run-limits.service.spec.ts
@@ -1,0 +1,139 @@
+import { PlanRunLimitsService } from './plan-run-limits.service';
+
+/**
+ * `PlanRunLimitsService` is the only production implementation of the
+ * `RUN_PLAN_LIMITS` seam — it is what turns a plan entitlement into the number
+ * the dispatch gate enforces. It shipped with no tests at all, and the seam it
+ * feeds is a three-valued contract that a single wrong fallback collapses:
+ *
+ *   null     the plan has no opinion; the env valves apply unchanged
+ *   negative unlimited
+ *   positive a real ceiling, applied raise-only
+ *
+ * The first version passed `0` as the "no row" fallback, and the consumer reads
+ * `0`-and-below as "valve off" — so a plan with no entitlement row escaped the
+ * org valve entirely instead of falling back to it. These pin the contract at
+ * the producer end so the two cannot drift apart again.
+ */
+
+function build(
+    overrides: { entitlements?: Record<string, jest.Mock>; users?: Record<string, jest.Mock> } = {},
+) {
+    const entitlementsService = {
+        get: jest.fn().mockResolvedValue(null),
+        getNumber: jest.fn(),
+        clearCache: jest.fn(),
+        ...(overrides.entitlements ?? {}),
+    };
+    const userRepository = {
+        findByIdForScheduledRun: jest
+            .fn()
+            .mockResolvedValue({ id: 'u1', defaultPlan: { code: 'standard' } }),
+        ...(overrides.users ?? {}),
+    };
+    const service = new PlanRunLimitsService(userRepository as never, entitlementsService as never);
+    return { service, entitlementsService, userRepository };
+}
+
+describe('PlanRunLimitsService', () => {
+    describe('the three-valued contract', () => {
+        it('returns null when the plan has NO entitlement row', async () => {
+            // The whole point: "absent" must not arrive at the gate as a number.
+            const { service, entitlementsService } = build({
+                entitlements: { get: jest.fn().mockResolvedValue(null) },
+            });
+
+            await expect(service.resolveConcurrencyLimit('u1')).resolves.toBeNull();
+            // It must ask with a null fallback, or it cannot tell absent from zero.
+            expect(entitlementsService.get).toHaveBeenCalledWith(
+                'standard',
+                'max-concurrent-runs',
+                null,
+            );
+        });
+
+        it('preserves a stored 0 as 0, distinct from absent', async () => {
+            // An operator writing 0 means "no plan ceiling"; the gate keeps the env
+            // valve. If this ever came back as null the meaning would be the same
+            // today, but the two must stay separable — one is a decision.
+            const { service } = build({ entitlements: { get: jest.fn().mockResolvedValue(0) } });
+
+            await expect(service.resolveConcurrencyLimit('u1')).resolves.toBe(0);
+        });
+
+        it('passes the unlimited sentinel through unchanged', async () => {
+            const { service } = build({ entitlements: { get: jest.fn().mockResolvedValue(-1) } });
+
+            await expect(service.resolveConcurrencyLimit('u1')).resolves.toBe(-1);
+        });
+
+        it('returns a real ceiling as a number', async () => {
+            const { service } = build({ entitlements: { get: jest.fn().mockResolvedValue(10) } });
+
+            await expect(service.resolveConcurrencyLimit('u1')).resolves.toBe(10);
+        });
+
+        it('coerces a numeric string, and rejects a non-numeric one as null', async () => {
+            // `valueText` can hold anything; the column is a varchar.
+            const asText = build({ entitlements: { get: jest.fn().mockResolvedValue('10') } });
+            await expect(asText.service.resolveConcurrencyLimit('u1')).resolves.toBe(10);
+
+            const garbage = build({ entitlements: { get: jest.fn().mockResolvedValue('lots') } });
+            await expect(garbage.service.resolveConcurrencyLimit('u1')).resolves.toBeNull();
+        });
+    });
+
+    describe('failure posture', () => {
+        it('never throws — a broken lookup resolves to "no plan opinion"', async () => {
+            // The middleware fails open too, so this is belt-and-braces. A DB blip
+            // must not become a fleet-wide dispatch decision.
+            const { service } = build({
+                users: {
+                    findByIdForScheduledRun: jest.fn().mockRejectedValue(new Error('db down')),
+                },
+            });
+
+            await expect(service.resolveConcurrencyLimit('u1')).resolves.toBeNull();
+        });
+    });
+
+    describe('the userId -> planCode cache', () => {
+        it('reads the user once and serves the second call from cache', async () => {
+            const { service, userRepository } = build({
+                entitlements: { get: jest.fn().mockResolvedValue(10) },
+            });
+
+            await service.resolveConcurrencyLimit('u1');
+            await service.resolveConcurrencyLimit('u1');
+
+            expect(userRepository.findByIdForScheduledRun).toHaveBeenCalledTimes(1);
+        });
+
+        it('re-reads after clearCache()', async () => {
+            const { service, userRepository } = build({
+                entitlements: { get: jest.fn().mockResolvedValue(10) },
+            });
+
+            await service.resolveConcurrencyLimit('u1');
+            service.clearCache();
+            await service.resolveConcurrencyLimit('u1');
+
+            expect(userRepository.findByIdForScheduledRun).toHaveBeenCalledTimes(2);
+        });
+
+        it('falls back to the configured default plan when the user has none', async () => {
+            const { service, entitlementsService } = build({
+                users: { findByIdForScheduledRun: jest.fn().mockResolvedValue({ id: 'u1' }) },
+                entitlements: { get: jest.fn().mockResolvedValue(null) },
+            });
+
+            await service.resolveConcurrencyLimit('u1');
+
+            expect(entitlementsService.get).toHaveBeenCalledWith(
+                'free',
+                'max-concurrent-runs',
+                null,
+            );
+        });
+    });
+});

--- a/packages/agent/src/subscriptions/credits/plan-run-limits.service.ts
+++ b/packages/agent/src/subscriptions/credits/plan-run-limits.service.ts
@@ -4,6 +4,13 @@ import { config } from '@src/config';
 import type { RunPlanLimits } from '@src/agents/run-plan-limits';
 import { ENTITLEMENT_KEYS, EntitlementsService } from './entitlements.service';
 
+/**
+ * Ceiling on the userId -> planCode cache. Reached only by a pod that has seen
+ * this many distinct users inside one TTL window; clearing costs one re-read
+ * per active user.
+ */
+const PLAN_CODE_CACHE_MAX_ENTRIES = 50_000;
+
 type PlanCodeSlot = {
     planCode: string;
     /** epoch ms after which the slot is stale. */
@@ -52,14 +59,31 @@ export class PlanRunLimitsService implements RunPlanLimits {
             if (!planCode) {
                 return null;
             }
-            // Fallback 0 = "no plan-level ceiling", so a plan with no
-            // `max-concurrent-runs` row behaves exactly as it did before this
-            // service existed: only the two env valves apply.
-            const limit = await this.entitlementsService.getNumber(
+            // 🛑 "No row" must come back as `null`, never as a number.
+            //
+            // This used to pass a fallback of `0`, meaning "no plan-level ceiling,
+            // only the env valves apply" — but `0` is also the codebase-wide
+            // "valve disabled" sentinel, so the consumer read it as UNLIMITED and
+            // skipped the org valve entirely. A plan with no entitlement row got
+            // no concurrency ceiling of any kind. The producer and the consumer
+            // have to agree on the sentinel, so there is now exactly one:
+            //
+            //   null      -> the plan has no opinion; the env valves stand alone
+            //   negative  -> unlimited (ENTITLEMENT_UNLIMITED = -1, what the seed writes)
+            //   positive  -> a real ceiling, applied raise-only
+            //
+            // `EntitlementsService.get` resolves a missing row to the fallback with
+            // `??`, so a stored `0` still survives as `0` and stays distinguishable
+            // from "absent".
+            const raw = await this.entitlementsService.get(
                 planCode,
                 ENTITLEMENT_KEYS.MAX_CONCURRENT_RUNS,
-                0,
+                null as number | null,
             );
+            if (raw === null || raw === undefined) {
+                return null;
+            }
+            const limit = typeof raw === 'number' ? raw : Number(raw);
             return Number.isFinite(limit) ? limit : null;
         } catch (error) {
             this.logger.warn(
@@ -80,6 +104,14 @@ export class PlanRunLimitsService implements RunPlanLimits {
         const cached = this.planCodeCache.get(userId);
         if (cached && cached.expiresAt > now) {
             return cached.planCode;
+        }
+
+        // Crude but bounded. The slots are tiny and the TTL is ~60s, so the map
+        // only grows through users who dispatched once and never came back; a
+        // hard reset at a generous size keeps a long-lived pod flat without the
+        // bookkeeping of an LRU on a hot path.
+        if (this.planCodeCache.size >= PLAN_CODE_CACHE_MAX_ENTRIES) {
+            this.planCodeCache.clear();
         }
 
         const user = await this.userRepository.findByIdForScheduledRun(userId);

--- a/packages/agent/src/subscriptions/credits/plan-run-limits.service.ts
+++ b/packages/agent/src/subscriptions/credits/plan-run-limits.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UserRepository } from '@src/database/repositories/user.repository';
+import { config } from '@src/config';
+import type { RunPlanLimits } from '@src/agents/run-plan-limits';
+import { ENTITLEMENT_KEYS, EntitlementsService } from './entitlements.service';
+
+type PlanCodeSlot = {
+    planCode: string;
+    /** epoch ms after which the slot is stale. */
+    expiresAt: number;
+};
+
+/**
+ * Resolves the concurrency ceiling a user's PLAN entitles them to
+ * (`plan_entitlements.max-concurrent-runs`), for the dispatch gate.
+ *
+ * Bound to the `RUN_PLAN_LIMITS` token by the api-side `@Global()`
+ * SubscriptionsModule. Before this existed, `max-concurrent-runs` had
+ * zero readers anywhere in the product: the number on the pricing page
+ * was seeded into the database and consulted by nothing.
+ *
+ * ## Cost
+ *
+ * `admit()` is on a hot path — the schedule dispatcher iterates up to
+ * `AGENT_DISPATCH_MAX_BATCH` users every `AGENT_DISPATCH_INTERVAL_MINUTES`,
+ * plus one call per drain promotion and per fanned-out task. So the
+ * userId → planCode hop gets its own short TTL cache here, and the
+ * planCode → entitlement hop is already cached by
+ * {@link EntitlementsService}. Both TTLs are deliberately short: a plan
+ * change should take effect within about a minute, not on the next
+ * deploy.
+ *
+ * ## Never throws
+ *
+ * Every path resolves to `null` (= unlimited) on error. The middleware
+ * fails open too, so this is belt-and-braces: a DB blip must not park
+ * every run in the fleet.
+ */
+@Injectable()
+export class PlanRunLimitsService implements RunPlanLimits {
+    private readonly logger = new Logger(PlanRunLimitsService.name);
+    private readonly planCodeCache = new Map<string, PlanCodeSlot>();
+
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly entitlementsService: EntitlementsService,
+    ) {}
+
+    async resolveConcurrencyLimit(userId: string): Promise<number | null> {
+        try {
+            const planCode = await this.resolvePlanCode(userId);
+            if (!planCode) {
+                return null;
+            }
+            // Fallback 0 = "no plan-level ceiling", so a plan with no
+            // `max-concurrent-runs` row behaves exactly as it did before this
+            // service existed: only the two env valves apply.
+            const limit = await this.entitlementsService.getNumber(
+                planCode,
+                ENTITLEMENT_KEYS.MAX_CONCURRENT_RUNS,
+                0,
+            );
+            return Number.isFinite(limit) ? limit : null;
+        } catch (error) {
+            this.logger.warn(
+                `Plan concurrency lookup failed for user ${userId} (treated as unlimited): ` +
+                    `${(error as Error).message}`,
+            );
+            return null;
+        }
+    }
+
+    /** Drop all cached plan codes (tests + plan changes that want immediacy). */
+    clearCache(): void {
+        this.planCodeCache.clear();
+    }
+
+    private async resolvePlanCode(userId: string): Promise<string | null> {
+        const now = Date.now();
+        const cached = this.planCodeCache.get(userId);
+        if (cached && cached.expiresAt > now) {
+            return cached.planCode;
+        }
+
+        const user = await this.userRepository.findByIdForScheduledRun(userId);
+        const planCode =
+            (user?.defaultPlan?.code as string | undefined) ||
+            config.subscriptions.getDefaultPlanCode();
+        this.planCodeCache.set(userId, {
+            planCode,
+            expiresAt: now + config.billing.credits.getEntitlementsCacheTtlMs(),
+        });
+        return planCode;
+    }
+}

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -15,6 +15,7 @@ export * from './billing/payment-method.service';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)
 export * from './credits/credit-ledger.service';
 export * from './credits/entitlements.service';
+export * from './credits/plan-run-limits.service';
 // Run-cost settlement + dispatch-gate credits precheck (pricing Wave 9 M2)
 export * from './credits/run-cost-settlement.service';
 // Account-wide usage aggregations for the Billing/Usage pages (Wave 13)

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -3,6 +3,8 @@ import { SubscriptionService } from './subscription.service';
 import { SubscriptionPlanCode } from '@src/entities/types';
 import { WorkScheduleBillingMode, WorkScheduleCadence } from '@ever-works/contracts/api';
 
+type SubscriptionServiceDependencies = ConstructorParameters<typeof SubscriptionService>;
+
 /**
  * SubscriptionService is the agent-package gateway between user accounts and
  * the seeded `SubscriptionPlan` rows. It owns: idempotent plan seeding from
@@ -76,10 +78,10 @@ function makeService(
     const userRepository = makeUserRepository(user);
     const planEntitlementRepository = makePlanEntitlementRepository(planEntitlement);
     const service = new SubscriptionService(
-        planRepository as any,
-        userSubscriptionRepository as any,
-        userRepository as any,
-        planEntitlementRepository as any,
+        planRepository as unknown as SubscriptionServiceDependencies[0],
+        userSubscriptionRepository as unknown as SubscriptionServiceDependencies[1],
+        userRepository as unknown as SubscriptionServiceDependencies[2],
+        planEntitlementRepository as unknown as SubscriptionServiceDependencies[3],
     );
     return {
         service,

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -55,20 +55,39 @@ function makeUserRepository(overrides: Record<string, jest.Mock> = {}) {
     };
 }
 
+function makePlanEntitlementRepository(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        findByPlanAndKey: jest.fn().mockResolvedValue(null),
+        insertIfMissing: jest
+            .fn()
+            .mockImplementation(async (e: unknown) => ({ entitlement: e, created: true })),
+        ...overrides,
+    };
+}
+
 function makeService(
     plan: Record<string, jest.Mock> = {},
     userSub: Record<string, jest.Mock> = {},
     user: Record<string, jest.Mock> = {},
+    planEntitlement: Record<string, jest.Mock> = {},
 ) {
     const planRepository = makePlanRepository(plan);
     const userSubscriptionRepository = makeUserSubscriptionRepository(userSub);
     const userRepository = makeUserRepository(user);
+    const planEntitlementRepository = makePlanEntitlementRepository(planEntitlement);
     const service = new SubscriptionService(
         planRepository as any,
         userSubscriptionRepository as any,
         userRepository as any,
+        planEntitlementRepository as any,
     );
-    return { service, planRepository, userSubscriptionRepository, userRepository };
+    return {
+        service,
+        planRepository,
+        userSubscriptionRepository,
+        userRepository,
+        planEntitlementRepository,
+    };
 }
 
 const FREE_PLAN = {

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -13,6 +13,7 @@ import { config } from '@src/config';
 import { WorkScheduleAllowedCadence } from '@src/dto';
 import { User } from '@src/entities/user.entity';
 import { UserRepository } from '@src/database/repositories/user.repository';
+import { PlanEntitlementRepository } from '@src/database/repositories/plan-entitlement.repository';
 import { WorkScheduleBillingMode, WorkScheduleCadence, SubscriptionPlanCode } from '@src/entities';
 import type { SubscriptionPlanHosting } from '@src/entities/types';
 
@@ -184,6 +185,76 @@ const PLAN_SEED_DATA: Array<{
     },
 ];
 
+/**
+ * "Unlimited" for an entitlement valve.
+ *
+ * The dispatch gate treats ANY value <= 0 as "no ceiling", which is the
+ * same contract the two env-driven concurrency valves already publish
+ * (a limit of 0 disables that valve and skips its count query). -1 is
+ * used in the seed because it reads as a deliberate sentinel rather than
+ * an unset column, matching RETENTION_FOREVER.
+ */
+const ENTITLEMENT_UNLIMITED = -1;
+
+/**
+ * Boot-time entitlement seed. Insert-if-missing - see {@link
+ * SubscriptionService.seedEntitlements} for why this is not an upsert and
+ * why `works-limit` is not here.
+ *
+ * `daily-free-credits` is 50 on EVERY tier because that is what the
+ * pricing page promises on every tier; the paid tiers additionally carry
+ * an accumulating monthly allowance (`subscription_plans.monthlyCredits`).
+ *
+ * `max-concurrent-runs` mirrors the published "concurrent agent sessions"
+ * figure. `free` is intentionally NOT listed: its row already exists at 3
+ * (seeded from CREDITS_FREE_MAX_CONCURRENT_RUNS), the page says 1, and
+ * lowering it would take away something live users already have.
+ */
+export const PLAN_ENTITLEMENT_SEED_DATA: {
+    planId: string;
+    key: string;
+    valueInt: number;
+}[] = [
+    // Daily free credits - universal, matches CREDITS_DAILY_FREE / the page.
+    { planId: SubscriptionPlanCode.FREE, key: 'daily-free-credits', valueInt: 50 },
+    { planId: SubscriptionPlanCode.STANDARD, key: 'daily-free-credits', valueInt: 50 },
+    { planId: SubscriptionPlanCode.PREMIUM, key: 'daily-free-credits', valueInt: 50 },
+    {
+        planId: SubscriptionPlanCode.SELFHOSTED_COMMUNITY,
+        key: 'daily-free-credits',
+        valueInt: 50,
+    },
+    { planId: SubscriptionPlanCode.SELFHOSTED_PRO, key: 'daily-free-credits', valueInt: 50 },
+    {
+        planId: SubscriptionPlanCode.SELFHOSTED_ENTERPRISE,
+        key: 'daily-free-credits',
+        valueInt: 50,
+    },
+
+    // Concurrent agent sessions. free is omitted on purpose (see above).
+    { planId: SubscriptionPlanCode.STANDARD, key: 'max-concurrent-runs', valueInt: 10 },
+    {
+        planId: SubscriptionPlanCode.PREMIUM,
+        key: 'max-concurrent-runs',
+        valueInt: ENTITLEMENT_UNLIMITED,
+    },
+    {
+        planId: SubscriptionPlanCode.SELFHOSTED_COMMUNITY,
+        key: 'max-concurrent-runs',
+        valueInt: 3,
+    },
+    {
+        planId: SubscriptionPlanCode.SELFHOSTED_PRO,
+        key: 'max-concurrent-runs',
+        valueInt: 10,
+    },
+    {
+        planId: SubscriptionPlanCode.SELFHOSTED_ENTERPRISE,
+        key: 'max-concurrent-runs',
+        valueInt: ENTITLEMENT_UNLIMITED,
+    },
+];
+
 @Injectable()
 export class SubscriptionService implements OnModuleInit {
     private readonly logger = new Logger(SubscriptionService.name);
@@ -192,10 +263,12 @@ export class SubscriptionService implements OnModuleInit {
         private readonly planRepository: SubscriptionPlanRepository,
         private readonly userSubscriptionRepository: UserSubscriptionRepository,
         private readonly userRepository: UserRepository,
+        private readonly planEntitlementRepository: PlanEntitlementRepository,
     ) {}
 
     async onModuleInit() {
         await this.seedPlans();
+        await this.seedEntitlements();
     }
 
     async seedPlans() {
@@ -208,6 +281,44 @@ export class SubscriptionService implements OnModuleInit {
                 }),
             ),
         );
+    }
+
+    /**
+     * Per-plan entitlement levers, seeded at boot the same way the plan
+     * catalog is.
+     *
+     * Why boot-time and not another migration: the `free` rows arrived in
+     * the 1783400000000 migration and nothing has written
+     * `plan_entitlements` since, so every PAID plan resolves every lever to
+     * a code fallback. A migration only covers databases that run
+     * migrations; seeding beside {@link seedPlans} covers every environment
+     * on every boot and self-heals a row someone deleted.
+     *
+     * 🛑 INSERT-IF-MISSING, never upsert. Re-writing these at each pod start
+     * would stomp operator tuning and could REDUCE an entitlement a live
+     * user already holds - specifically `free`/`max-concurrent-runs`, which
+     * the migration seeded at 3 while the pricing page advertises 1. The
+     * existing row wins; if the page and the row must agree, change the
+     * page.
+     *
+     * Only keys with a real READER are seeded. `works-limit` is deliberately
+     * absent: it has no consumer anywhere, and the limit it purports to
+     * describe is actually enforced from `subscription_plans.maxWorks`.
+     * Seeding a second, unread source of truth for the same number is how
+     * the two silently diverge.
+     */
+    async seedEntitlements() {
+        const results = await Promise.all(
+            PLAN_ENTITLEMENT_SEED_DATA.map((seed) =>
+                this.planEntitlementRepository.insertIfMissing(seed),
+            ),
+        );
+        const created = results.filter((r) => r.created).length;
+        if (created > 0) {
+            this.logger.log(
+                `Seeded ${created} plan entitlement row(s); ${results.length - created} already present`,
+            );
+        }
     }
 
     isEnabled() {
@@ -234,6 +345,26 @@ export class SubscriptionService implements OnModuleInit {
     async listPlans(): Promise<SubscriptionPlan[]> {
         const plans = await this.planRepository.findAllActive();
         return plans.filter((plan) => plan.hosting !== 'selfhosted');
+    }
+
+    /**
+     * The self-hosted editions, as a SEPARATE list from {@link listPlans}.
+     *
+     * These are commercial licences for a deployment the buyer runs
+     * themselves. They are PURCHASABLE - the $99 perpetual licence is the
+     * only lifetime SKU in the whole catalog - but they are never
+     * self-assignable, and buying one does not change the tier on this
+     * hosted service.
+     *
+     * That is exactly why this is an additive sibling and not a relaxed
+     * filter on `listPlans`: the plan switcher must keep showing only the
+     * three cards a user can actually switch between, or every self-hosted
+     * card becomes a button whose only outcome is the
+     * `changePlanSelfService` rejection.
+     */
+    async listSelfHostedPlans(): Promise<SubscriptionPlan[]> {
+        const plans = await this.planRepository.findAllActive();
+        return plans.filter((plan) => plan.hosting === 'selfhosted');
     }
 
     async getActiveSubscription(userId: string) {

--- a/packages/agent/src/subscriptions/subscriptions.di-contract.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.di-contract.spec.ts
@@ -1,0 +1,177 @@
+import 'reflect-metadata';
+import { REPOSITORY_PROVIDERS } from '@src/database/_repository-inventory';
+import { SubscriptionsModule } from './subscriptions.module';
+import { SubscriptionService } from './subscription.service';
+import { CreditLedgerService } from './credits/credit-ledger.service';
+import { EntitlementsService } from './credits/entitlements.service';
+import { PlanRunLimitsService } from './credits/plan-run-limits.service';
+import { RunCostSettlementService } from './credits/run-cost-settlement.service';
+import { UsageSummaryService } from './credits/usage-summary.service';
+import { PlanSubscriptionService } from './billing/plan-subscription.service';
+import { PaymentMethodService } from './billing/payment-method.service';
+import { BillingService } from './billing/billing.service';
+import { AutoRechargeService } from './billing/auto-recharge.service';
+import { CostsSummaryService } from './credits/costs-summary.service';
+import { PluginSettingsService } from '@src/plugins/services/plugin-settings.service';
+
+/**
+ * Nest resolves constructor dependencies at BOOT, and nothing else in this repo
+ * checks that it can.
+ *
+ * `subscriptions.module.spec.ts` asserts the shape of the module's metadata —
+ * that `CreditLedgerService` appears in the `providers` array — via
+ * `Reflect.getMetadata`. That is a different question. Adding a constructor
+ * parameter whose provider is not visible to this module passes every one of
+ * those assertions, passes `tsc`, passes every unit spec (which construct these
+ * services positionally with `as any` mocks), and then fails on the first pod
+ * that starts:
+ *
+ *     Nest can't resolve dependencies of the CreditLedgerService (…, ?).
+ *
+ * Inside `onModuleInit` — which is where `seedPlans()`/`seedEntitlements()` run
+ * — that is a pod that never finishes booting, on every environment at once.
+ *
+ * This spec closes the gap without standing up a database: it reads the
+ * `design:paramtypes` TypeScript emits for each service and checks every
+ * parameter is something this module can actually supply. It is the same
+ * question Nest asks, minus the instantiation, and it runs in milliseconds.
+ *
+ * Injection TOKENS (string/symbol `@Inject(...)`) and `@Optional()` parameters
+ * are skipped deliberately: the first are not classes and carry no paramtype,
+ * and the second are contractually allowed to be absent — the dispatch gate's
+ * `RUN_PLAN_LIMITS` seam depends on exactly that.
+ */
+describe('SubscriptionsModule — constructor dependencies are resolvable', () => {
+    const moduleProviders = (Reflect.getMetadata('providers', SubscriptionsModule) ??
+        []) as unknown[];
+    const moduleImports = (Reflect.getMetadata('imports', SubscriptionsModule) ?? []) as unknown[];
+
+    /** `{ provide, useFactory }` entries answer to their token, not the literal. */
+    const asToken = (provider: unknown) =>
+        provider && typeof provider === 'object' && 'provide' in (provider as object)
+            ? (provider as { provide: unknown }).provide
+            : provider;
+
+    /**
+     * Everything this module can hand to a constructor: its own providers, plus
+     * whatever every imported module EXPORTS.
+     *
+     * The import walk is not decoration - the first version of this spec omitted
+     * it and immediately reported `RunCostSettlementService` as broken, because
+     * `NotificationService` reaches it through `NotificationsModule` rather than
+     * through DatabaseModule. A probe that cries wolf gets deleted, so it has to
+     * model what Nest actually does.
+     *
+     * One level of re-export is followed (a module exporting another module),
+     * which is how `DatabaseModule` republishes `TypeOrmModule`.
+     */
+    const collectExports = (mod: unknown, depth = 0): unknown[] => {
+        if (typeof mod !== 'function' || depth > 2) return [];
+        const exported = (Reflect.getMetadata('exports', mod) ?? []) as unknown[];
+        return exported.flatMap((entry) => {
+            const token = asToken(entry);
+            const nested =
+                typeof token === 'function' && Reflect.getMetadata('exports', token)
+                    ? collectExports(token, depth + 1)
+                    : [];
+            return [token, ...nested];
+        });
+    };
+
+    /**
+     * The one thing this static probe genuinely cannot see.
+     *
+     * `PluginsModule` is `@Global()` AND dynamic: its exports are assembled inside
+     * `forRoot()`/`forRootAsync()` and returned on a `DynamicModule` object, so
+     * there is no static `exports` metadata to read and the private `EXPORTS`
+     * array is not importable. Nest resolves it at runtime; nothing here can.
+     *
+     * So it is exempted BY CLASS, not by module — a module-level exemption would
+     * wave through everything that module might ever export. Verified by hand:
+     * `plugins.module.ts` carries `@Global()`, lists PluginSettingsService in its
+     * providers (:85) and in the private EXPORTS array (:103) used by both
+     * factories. `RunCostSettlementService` has taken it since long before this
+     * change and boots fine in every environment.
+     *
+     * Keep this list at one entry if at all possible. Anything added here is a
+     * dependency no test can check.
+     */
+    const DYNAMIC_GLOBAL_PROVIDERS: Array<[string, unknown]> = [
+        ['PluginSettingsService', PluginSettingsService],
+    ];
+
+    const resolvable = new Set<unknown>([
+        ...moduleProviders.map(asToken),
+        ...moduleImports.flatMap((mod) => collectExports(mod)),
+        ...DYNAMIC_GLOBAL_PROVIDERS.map(([, cls]) => cls),
+        // Belt and braces: DatabaseModule re-exports the whole inventory, and
+        // naming it directly keeps the spec honest if that module is restructured.
+        ...REPOSITORY_PROVIDERS,
+    ]);
+
+    /**
+     * Every service this module provides that has collaborators worth checking.
+     * Listed explicitly rather than derived, so ADDING a service to the module
+     * without adding it here is visible in review.
+     */
+    const SERVICES: Array<[string, new (...args: never[]) => unknown]> = [
+        ['SubscriptionService', SubscriptionService],
+        ['CreditLedgerService', CreditLedgerService],
+        ['EntitlementsService', EntitlementsService],
+        ['PlanRunLimitsService', PlanRunLimitsService],
+        ['RunCostSettlementService', RunCostSettlementService],
+        ['UsageSummaryService', UsageSummaryService],
+        ['PlanSubscriptionService', PlanSubscriptionService],
+        ['PaymentMethodService', PaymentMethodService],
+        ['BillingService', BillingService],
+        ['AutoRechargeService', AutoRechargeService],
+        ['CostsSummaryService', CostsSummaryService],
+    ];
+
+    it.each(SERVICES)('%s can be constructed from this module', (name, Service) => {
+        const paramTypes = (Reflect.getMetadata('design:paramtypes', Service) ?? []) as unknown[];
+        // `@Inject(TOKEN)` params are recorded here, by parameter index.
+        const injected = (Reflect.getMetadata('self:paramtypes', Service) ?? []) as Array<{
+            index: number;
+        }>;
+        const optional = (Reflect.getMetadata('optional:paramtypes', Service) ?? []) as Array<{
+            index: number;
+        }>;
+        const skip = new Set<number>([
+            ...injected.map((i) => i.index),
+            ...optional.map((o) => o.index),
+        ]);
+
+        const unresolvable = paramTypes
+            .map((type, index) => ({ type, index }))
+            .filter(({ index }) => !skip.has(index))
+            .filter(({ type }) => typeof type === 'function')
+            // Primitives carry Object/String/Number paramtypes; they are never
+            // injected and would be `@Inject`ed if they were.
+            .filter(({ type }) => ![Object, String, Number, Boolean, Array].includes(type as never))
+            .filter(({ type }) => !resolvable.has(type))
+            .map(
+                ({ type, index }) => `#${index} ${(type as { name?: string }).name ?? 'anonymous'}`,
+            );
+
+        expect({ service: name, unresolvable }).toEqual({ service: name, unresolvable: [] });
+    });
+
+    it('the dynamic-global exemption list stays small and deliberate', () => {
+        // Not a style rule. Every entry is a dependency this spec stops checking,
+        // so growth here is the probe quietly losing its teeth.
+        expect(DYNAMIC_GLOBAL_PROVIDERS.map(([name]) => name)).toEqual(['PluginSettingsService']);
+    });
+
+    it('the probe can actually fail — a class this module does not provide is caught', () => {
+        // Without this control, a bug that made `resolvable` contain everything
+        // (or `paramTypes` empty) would turn every assertion above green.
+        class NotProvidedAnywhere {}
+        expect(resolvable.has(NotProvidedAnywhere)).toBe(false);
+    });
+
+    it('imports DatabaseModule, which is what supplies the repositories', () => {
+        const names = moduleImports.map((m) => (m as { name?: string })?.name).filter(Boolean);
+        expect(names).toContain('DatabaseModule');
+    });
+});

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -30,6 +30,7 @@ import {
 import { CREDIT_PACKS, CREDIT_PACK_IDS } from './billing/credit-packs';
 import { CreditLedgerService, InsufficientCreditsError } from './credits/credit-ledger.service';
 import { ENTITLEMENT_KEYS, EntitlementsService } from './credits/entitlements.service';
+import { PlanRunLimitsService } from './credits/plan-run-limits.service';
 import { RunCostSettlementService } from './credits/run-cost-settlement.service';
 import {
     InvalidUsagePeriodError,
@@ -83,6 +84,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
         it('re-exports the credits surface (pricing Wave 9 M1)', () => {
             expect(subscriptionsBarrel.CreditLedgerService).toBe(CreditLedgerService);
             expect(subscriptionsBarrel.EntitlementsService).toBe(EntitlementsService);
+            expect(subscriptionsBarrel.PlanRunLimitsService).toBe(PlanRunLimitsService);
             expect(subscriptionsBarrel.InsufficientCreditsError).toBe(InsufficientCreditsError);
             expect(subscriptionsBarrel.ENTITLEMENT_KEYS).toBe(ENTITLEMENT_KEYS);
         });
@@ -168,6 +170,8 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                 [
                     'SubscriptionsModule',
                     'SubscriptionService',
+                    // Boot-time per-plan entitlement seed (insert-if-missing).
+                    'PLAN_ENTITLEMENT_SEED_DATA',
                     'UsageLedgerService',
                     'BillingProvider',
                     'BillingProviderError',
@@ -205,11 +209,23 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     // Credits ledger + plan entitlements (pricing Wave 9 M1)
                     'CreditLedgerService',
                     'InsufficientCreditsError',
+                    // Subscription-anniversary month arithmetic for the monthly
+                    // credit grant. Exported so the clamping rules that decide how
+                    // often a customer is paid can be tested directly.
+                    'elapsedWholeMonths',
+                    'addWholeMonths',
+                    // refType stamped on every monthly plan-allowance row. The
+                    // grant sums prior rows of this type to work out what is still
+                    // owed, so the string is load-bearing - exported so a rename
+                    // cannot happen without this list noticing.
+                    'MONTHLY_PLAN_REF_TYPE',
                     // Transcript retention sentinels (#1877).
                     'RETENTION_FOREVER',
                     'RETENTION_NONE',
                     'EntitlementsService',
                     'ENTITLEMENT_KEYS',
+                    // Plan-driven concurrency ceiling for the dispatch gate (H2)
+                    'PlanRunLimitsService',
                     // Run-cost settlement (pricing Wave 9 M2)
                     'RunCostSettlementService',
                     // Usage-summary aggregations (Wave 13 Billing/Usage UI)
@@ -253,6 +269,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             const providers = getMeta('providers');
             expect(providers).toContain(CreditLedgerService);
             expect(providers).toContain(EntitlementsService);
+            expect(providers).toContain(PlanRunLimitsService);
         });
 
         it('declares + exports RunCostSettlementService (Wave 9 M2)', () => {
@@ -360,6 +377,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             const exports = getMeta('exports');
             expect(exports).toContain(CreditLedgerService);
             expect(exports).toContain(EntitlementsService);
+            expect(exports).toContain(PlanRunLimitsService);
         });
 
         it('does NOT export ManualBillingProvider directly — consumers use the abstract token', () => {

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -14,6 +14,7 @@ import { PlanSubscriptionService } from './billing/plan-subscription.service';
 import { PaymentMethodService } from './billing/payment-method.service';
 import { CreditLedgerService } from './credits/credit-ledger.service';
 import { EntitlementsService } from './credits/entitlements.service';
+import { PlanRunLimitsService } from './credits/plan-run-limits.service';
 import { RunCostSettlementService } from './credits/run-cost-settlement.service';
 import { UsageSummaryService } from './credits/usage-summary.service';
 import { CostsSummaryService } from './credits/costs-summary.service';
@@ -41,6 +42,10 @@ import { CostsSummaryService } from './credits/costs-summary.service';
         // additive beside the existing plan/usage-ledger services.
         CreditLedgerService,
         EntitlementsService,
+        // H2 — resolves a user's PLAN concurrency ceiling for the dispatch
+        // gate. The api-side @Global() SubscriptionsModule binds this
+        // instance to the RUN_PLAN_LIMITS token.
+        PlanRunLimitsService,
         // Run-cost settlement + gate precheck (pricing Wave 9 M2) — the
         // api-side @Global() SubscriptionsModule binds this instance to
         // the RUN_COST_SETTLER + RUN_CREDITS_PRECHECK tokens.
@@ -87,6 +92,7 @@ import { CostsSummaryService } from './credits/costs-summary.service';
         UsageLedgerService,
         CreditLedgerService,
         EntitlementsService,
+        PlanRunLimitsService,
         RunCostSettlementService,
         UsageSummaryService,
         CostsSummaryService,

--- a/packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts
+++ b/packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts
@@ -44,7 +44,7 @@ export const creditsDailyGrantTask = schedules.task({
                     summary.monthlyAlreadyGranted > 0 ||
                     summary.monthlyFailed > 0
                 ) {
-                    logger.info('credits-daily-grant dispatched daily free credits', {
+                    logger.info('credits-daily-grant completed a credit grant sweep', {
                         ...summary,
                     });
                 }

--- a/packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts
+++ b/packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts
@@ -31,9 +31,28 @@ export const creditsDailyGrantTask = schedules.task({
             async (appContext) => {
                 const svc = appContext.get(CreditLedgerService);
                 const summary = await svc.dispatchDailyGrants();
-                if (summary.granted > 0 || summary.skipped > 0) {
+                // 🛑 The monthly counters must not hide behind the daily ones. On any
+                // same-day re-run - a retry, a redeploy, a manual trigger - every daily
+                // grant returns 'already', so granted and skipped are both 0 and this
+                // used to log NOTHING AT ALL, even in a sweep where every paying
+                // subscriber's monthly grant threw. Silence that looks like health is
+                // the exact failure the `failed` counters were added to end.
+                if (
+                    summary.granted > 0 ||
+                    summary.skipped > 0 ||
+                    summary.monthlyGranted > 0 ||
+                    summary.monthlyAlreadyGranted > 0 ||
+                    summary.monthlyFailed > 0
+                ) {
                     logger.info('credits-daily-grant dispatched daily free credits', {
                         ...summary,
+                    });
+                }
+                if (summary.failed > 0 || summary.monthlyFailed > 0) {
+                    logger.error('credits-daily-grant had per-user failures', {
+                        failed: summary.failed,
+                        monthlyFailed: summary.monthlyFailed,
+                        scanned: summary.scanned,
                     });
                 }
                 return summary;


### PR DESCRIPTION
Three numbers were printed on ever.works/pricing, seeded into the database and mirrored into the Stripe catalog, and read by **no code**: the monthly credit allowance, the concurrency ceiling, and the daily credits on paid tiers. A fourth thing was sold and unreachable: the $99 perpetual licence.

## H3 — credits
- `subscription_plans.monthlyCredits` gets its first reader. The daily sweep now also grants the plan's monthly allowance — idempotent per (user, subscription, elapsed month, plan code), written as a **top-up**, so a mid-cycle upgrade adds only the difference and a downgrade removes nothing.
- Anchored on the **subscription anniversary**, not the calendar: a calendar key grants a second time hours after a month-end signup.
- Resolved from the **current subscription row**, never `user.defaultPlan`. `defaultPlanId` stays on the paid tier through Stripe's dunning retries, and `assignPlanToUser` is gated on `SUBSCRIPTIONS_ENABLED` while the subscription row is written unconditionally — so `defaultPlan` both over-pays users who stopped paying and under-pays users who are paying.
- The daily entitlement fallback is now universal (was `planCode === 'free' ? fallback : 0`, so **every paid tier got zero** against a page promising 50/day on all tiers).
- Dropped `maxBalanceAfter` from the daily grant: it clamped against the *whole* balance, purchases included, so it silently denied daily credits to every paid tier **and** to any free user who had bought a credit pack. The UNIQUE `daily:{user}:{date}` key is what limits this to one grant a day.

## H2 — concurrency
- `plan_entitlements.max-concurrent-runs` gets its first reader, folded into the org valve as a **raise-only** adjustment (`max(env, plan)`; a plan of `<= 0` switches the valve off for unlimited tiers).
- Raise-only is the safety argument. A valve that could *lower* would park runs nothing can drain (the drain is Work-keyed and every caller passes the workId of a run that just went terminal — exactly the cross-Work case a per-user valve exists for), cut every existing user from the enforced 25 to the seeded free value of 3, and mis-resolve seat-holders to `free`.
- Ships dark behind `PLAN_CONCURRENCY_ENFORCEMENT` (default off).

## H1 — the $99 perpetual licence becomes buyable
- `interval`/`seats` were accepted by the DTO and forwarded by the controller, and the web client never sent them — not refused, **unreachable**. Plumbed through, back-compatible.
- Self-hosted editions ship in their own `licences` array via a new `listSelfHostedPlans()`. The `listPlans` filter is untouched: `changePlanSelfService` refuses self-hosted rows, so a switcher card would be a button whose only outcome is a 403.
- A licence card with a confirmation step and copy stating plainly that it does **not** change your tier here.
- `invoice_creation` on the perpetual session — a `mode: payment` sale emits no `invoice.*`, so a successful $99 payment produced no invoice, no ledger row and no visible change. The page after paying was identical to before, with the same enabled button, and nothing on that path is idempotent.

## Fixes found on the way
- 🛑 **`credit_ledger_entries.refId` was a Postgres `uuid`** while the only writers put a Stripe `pi_…` id in it. The first settled credit-pack purchase would raise `22P02`, the webhook would 500, and Stripe would retry forever — invisible to CI, which runs SQLite. Widened to `varchar(128)` (migration `1787500000000`, lossless, forward-only).
- `plan-checkout.controller.spec` stubbed `SubscriptionPlanCode` with only the three cloud codes, so every DTO assertion validated against a catalog that stopped existing when the self-hosted editions landed.
- Boot-time entitlement seeding is insert-if-missing (never `upsert`, which would reset operator tuning at every pod start) and recovers from the unique-key race two replicas hit on a rolling deploy — inside `onModuleInit`, that race is a pod that never finishes booting.

## Deliberately deferred
- **Annual toggle.** An existing Pro-monthly customer's card renders a disabled "Current" button, so the only clickable annual card is a different tier — and `startPlanCheckout` never checks for an existing subscription, so it would create a **second live Stripe subscription** and `createOrUpdate` would overwrite the row, leaving the first uncancellable from the app.
- **Extra seats.** Nothing anywhere meters seats, so they would be money for an unenforced number; also needs a catalog sync first.
- **Refund/chargeback reversal of a monthly grant.** Would be the first credit-removing code in this repo. Zero exposure today; a hard gate before prod payments.

## Verification
Every fix has a test **proven to bite** by reverting the fix and watching it go red:

| reverted | result |
|---|---|
| daily balance ceiling reinstated | 3 red |
| read `defaultPlan` instead of the subscription | 7 red |
| calendar month instead of the anniversary index | 4 red |
| plan allowed to lower the ceiling | 1 red |
| unlimited plan falls through to the count query | 1 red |

`packages/agent` 238 passed · `apps/api` billing/subscriptions 134 passed · `apps/web` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-hosted commercial licence listings and lifetime purchase checkout.
  * Added plan-based concurrency limits for scheduled runs.
  * Expanded billing details with pricing, seats, credits, and checkout intervals.
  * Added automatic tax, address collection, and tax ID collection during checkout.

* **Bug Fixes**
  * Fixed credit ledger references for payment-provider transaction identifiers.
  * Prevented monthly credit grants for past-due or unpaid accounts.

* **Improvements**
  * Added entitlement setup and clearer checkout completion statuses.
  * Improved credit-grant reporting and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->