### PR TITLE
chore(release): promote stage to main (shared-DB pg SSL fix)

### DIFF
--- a/packages/agent/src/ever-works-providers/ever-works-db-provision.service.spec.ts
+++ b/packages/agent/src/ever-works-providers/ever-works-db-provision.service.spec.ts
@@ -1,4 +1,4 @@
-import { summarizeDbProvisionError } from './ever-works-db-provision.service';
+import { pgClientOptions, summarizeDbProvisionError } from './ever-works-db-provision.service';
 
 describe('summarizeDbProvisionError', () => {
     it('maps Node network errno codes to a label + code and drops the host', () => {
@@ -42,5 +42,44 @@ describe('summarizeDbProvisionError', () => {
             'unknown error',
         );
         expect(summarizeDbProvisionError(null)).toBe('unknown error');
+    });
+});
+
+describe('pgClientOptions', () => {
+    it('strips sslmode=require from the URL and disables CA verification (libpq semantics)', () => {
+        const out = pgClientOptions(
+            'postgresql://u:p@pg-rw.databases.svc.cluster.local:5432/postgres?sslmode=require',
+        );
+        expect(out.connectionString).toBe(
+            'postgresql://u:p@pg-rw.databases.svc.cluster.local:5432/postgres',
+        );
+        expect(out.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it('keeps other query params and handles sslmode in the middle of the query', () => {
+        const out = pgClientOptions(
+            'postgresql://u:p@h:5432/db?application_name=x&sslmode=prefer&connect_timeout=5',
+        );
+        expect(out.connectionString).toBe(
+            'postgresql://u:p@h:5432/db?application_name=x&connect_timeout=5',
+        );
+        expect(out.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it('keeps full verification for verify-ca / verify-full', () => {
+        expect(pgClientOptions('postgresql://u:p@h/db?sslmode=verify-full').ssl).toEqual({
+            rejectUnauthorized: true,
+        });
+        expect(pgClientOptions('postgresql://u:p@h/db?sslmode=verify-ca').ssl).toEqual({
+            rejectUnauthorized: true,
+        });
+    });
+
+    it('leaves URLs without sslmode (or disable) untouched and unencrypted', () => {
+        expect(pgClientOptions('postgresql://u:p@h/db')).toEqual({
+            connectionString: 'postgresql://u:p@h/db',
+            ssl: undefined,
+        });
+        expect(pgClientOptions('postgresql://u:p@h/db?sslmode=disable').ssl).toBeUndefined();
     });
 });

--- a/packages/agent/src/ever-works-providers/ever-works-db-provision.service.ts
+++ b/packages/agent/src/ever-works-providers/ever-works-db-provision.service.ts
@@ -64,6 +64,39 @@ export function summarizeDbProvisionError(error: unknown): string {
     return 'unknown error';
 }
 
+/**
+ * Connection options for the `pg` Client given a libpq-style connection string.
+ *
+ * `sslmode=require` / `prefer` mean "encrypt, but do NOT verify the CA" (libpq
+ * semantics; the managed shared cluster uses a self-signed CA). Newer `pg` /
+ * `pg-connection-string` releases parse `sslmode=require` from the URL into a
+ * VERIFYING TLS config, which overrides the explicit `ssl` option and makes every
+ * connection fail with `self-signed certificate in certificate chain` — that is
+ * what broke shared-DB provisioning (`CREATE ROLE` / `CREATE DATABASE` never ran,
+ * `PUT …/runtime-env {mode:"shared"}` answered 500/503) even though the host was
+ * reachable. So: strip `sslmode` from the URL we hand to `pg` and express the
+ * intent through `ssl` ourselves. `verify-ca` / `verify-full` keep full verification.
+ */
+export function pgClientOptions(url: string): {
+    connectionString: string;
+    ssl: { rejectUnauthorized: boolean } | undefined;
+} {
+    const m = /[?&]sslmode=([^&#]*)/i.exec(url);
+    const mode = m ? decodeURIComponent(m[1]).toLowerCase() : '';
+    if (!mode || mode === 'disable' || mode === 'allow') {
+        return { connectionString: url, ssl: undefined };
+    }
+    const stripped = url
+        .replace(/([?&])sslmode=[^&#]*&?/i, '$1')
+        .replace(/[?&]$/, '')
+        .replace(/\?&/, '?');
+    if (mode === 'verify-ca' || mode === 'verify-full') {
+        return { connectionString: stripped, ssl: { rejectUnauthorized: true } };
+    }
+    // require / prefer (and anything unknown): encrypt without CA verification.
+    return { connectionString: stripped, ssl: { rejectUnauthorized: false } };
+}
+
 @Injectable()
 export class EverWorksDbProvisionService {
     private readonly logger = new Logger(EverWorksDbProvisionService.name);
@@ -174,8 +207,7 @@ export class EverWorksDbProvisionService {
         const hex = workId.replace(/-/g, '').toLowerCase();
         const dbName = `${config.everWorks.sharedDb.getNamePrefix()}_${hex}`;
         const client = new Client({
-            connectionString: serverUrl,
-            ssl: this.sslFor(serverUrl),
+            ...pgClientOptions(serverUrl),
             connectionTimeoutMillis: 10000,
         });
         try {
@@ -216,8 +248,7 @@ export class EverWorksDbProvisionService {
             };
         }
         const client = new Client({
-            connectionString: databaseUrl,
-            ssl: this.sslFor(databaseUrl),
+            ...pgClientOptions(databaseUrl),
             connectionTimeoutMillis: 8000,
             statement_timeout: 8000,
         });
@@ -244,8 +275,7 @@ export class EverWorksDbProvisionService {
         password: string,
     ): Promise<void> {
         const client = new Client({
-            connectionString: adminUrl,
-            ssl: this.sslFor(adminUrl),
+            ...pgClientOptions(adminUrl),
             connectionTimeoutMillis: 10000,
         });
         await client.connect();
@@ -277,14 +307,6 @@ export class EverWorksDbProvisionService {
         const sslmode = shared.getSslMode();
         const auth = `${encodeURIComponent(role)}:${encodeURIComponent(password)}`;
         return `postgresql://${auth}@${host}:${port}/${dbName}?sslmode=${sslmode}`;
-    }
-
-    private sslFor(url: string): { rejectUnauthorized: boolean } | undefined {
-        // Managed cluster uses a self-signed CA; `sslmode=require` means encrypt
-        // without CA verification (matches libpq's `require`).
-        return /sslmode=(require|prefer|verify)/i.test(url)
-            ? { rejectUnauthorized: false }
-            : undefined;
     }
 
     private randomPassword(): string {


### PR DESCRIPTION
Promotes [#2205](https://github.com/ever-works/ever-works/pull/2205) — shared-DB provisioning: stop pg from verifying the self-signed CA on sslmode=require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)