### PR TITLE
ci(e2e): queue superseded stage E2E runs instead of cancelling them

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,8 +38,19 @@ name: E2E Tests
 # manually on the branch (`gh workflow run e2e.yml --ref <branch>`); that
 # one-off run is the pre-merge signal, replacing the old auto-on-push runs.
 #
-# The `concurrency` block below cancels a superseded run when a newer
-# commit reaches develop, so only the latest commit is ever validated.
+# The `concurrency` block below QUEUES a run that arrives while an older one
+# for the same ref is still going, instead of cancelling the older one.
+#
+# It used to be `cancel-in-progress: true` ("only the latest commit is ever
+# validated"). In practice NO commit was: the suite takes ~2 h (32 shards on
+# a 12-runner pool) and stage was being pushed to about hourly, so on
+# 2026-08-22/23 six consecutive stage runs were cancelled in a row and the
+# Promotion Gate (stage -> main) had no E2E verdict for a day. GitHub keeps at
+# most ONE pending run per concurrency group and cancels older *pending* ones,
+# so with `cancel-in-progress: false` the running suite finishes, the newest
+# push waits behind it, and every push still converges on the latest commit -
+# the runner load is the same either way (one run at a time), but the gate
+# now produces verdicts. Same policy as k8s-e2e.yml in this repo.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
 
@@ -54,7 +65,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,10 +47,11 @@ name: E2E Tests
 # 2026-08-22/23 six consecutive stage runs were cancelled in a row and the
 # Promotion Gate (stage -> main) had no E2E verdict for a day. GitHub keeps at
 # most ONE pending run per concurrency group and cancels older *pending* ones,
-# so with `cancel-in-progress: false` the running suite finishes, the newest
-# push waits behind it, and every push still converges on the latest commit -
-# the runner load is the same either way (one run at a time), but the gate
-# now produces verdicts. Same policy as k8s-e2e.yml in this repo.
+# so with `cancel-in-progress: false` the running suite finishes and the newest
+# push waits behind it. During a burst, GitHub may replace an older pending run;
+# the runner load stays at one run at a time while the gate validates the active
+# commit and then converges on the newest queued commit. Same policy as
+# k8s-e2e.yml in this repo.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
 
@@ -637,4 +638,3 @@ jobs:
             apps/web/e2e/test-results
           retention-days: 14
           if-no-files-found: ignore
-


### PR DESCRIPTION
## What

`.github/workflows/e2e.yml`: `concurrency.cancel-in-progress: true` → `false` (+ the header comment now says why). One file, one flag.

## Why

The stage E2E gate validated **nothing** for ~a day. The suite takes ~2 h (32 shards on a 12-runner `x64-8` pool) and `stage` was pushed to roughly hourly on 2026-08-22/23, so `cancel-in-progress: true` killed **six consecutive stage runs in a row** — and the Promotion Gate (stage → main) then had no E2E verdict to read, which is exactly the state it exists to prevent. The old comment claimed "only the latest commit is ever validated"; in practice *no* commit was.

GitHub keeps at most **one pending** run per concurrency group and cancels older *pending* ones, so with `cancel-in-progress: false`:

- the running suite finishes and produces a verdict,
- the newest push waits behind it (older pending pushes are still dropped — every push still converges on the latest commit),
- runner load is the same as today: one run at a time either way. The difference is that runs now *finish*.

`k8s-e2e.yml` in this repo already uses `cancel-in-progress: false` for the same reason.

## Verification plan

This change only takes effect for the ref the workflow file lives on, so the proof is on `stage` after the cascade: the push to stage starts an E2E run that is **not** cancelled by the next push and reaches a terminal verdict. I will cascade develop → stage → main and watch that run to completion before promoting stage → main (the Promotion Gate will then have a real verdict, no override label).

Ref: `E:\Coding\_LOCAL\docs\handoffs\HANDOVER-2026-08-23-ci-velero-cache.md` §"Known-broken" #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow handling so new runs wait in a queue while the active run completes.
  * Improved workflow documentation to clarify the revised run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->