### PR TITLE
fix(subscriptions): upgrade-reason copy names the catalog tiers (Pro/Enterprise); e2e specs expect them

### DIFF
--- a/apps/web/e2e/flow-subscription-billing-grace.spec.ts
+++ b/apps/web/e2e/flow-subscription-billing-grace.spec.ts
@@ -353,7 +353,7 @@ test.describe('Flow: subscription billing grace / past-due / dunning / reactivat
         )) {
             expect(c.allowed, `${c.cadence} gated on standard`).toBe(false);
             expect(c.payPerUse, `${c.cadence} pay-per-use on standard`).toBe(true);
-            expect(c.reason, `${c.cadence} carries an upgrade reason`).toContain('Premium');
+            expect(c.reason, `${c.cadence} carries an upgrade reason`).toContain('Enterprise');
         }
 
         // HARD-STOP: enabling a gated cadence under SUBSCRIPTION billing is rejected

--- a/apps/web/e2e/flow-subscription-plan-tiers.spec.ts
+++ b/apps/web/e2e/flow-subscription-plan-tiers.spec.ts
@@ -189,7 +189,7 @@ test.describe('Flow: subscription tier ↔ work-schedule entitlement integration
             if (!c.allowed) {
                 gated += 1;
                 expect(c.payPerUse, `gated ${name} should be pay-per-use`).toBe(true);
-                expect(c.reason, `gated ${name} carries an upgrade reason`).toContain('Premium');
+                expect(c.reason, `gated ${name} carries an upgrade reason`).toContain('Enterprise');
             }
         }
         expect(

--- a/apps/web/e2e/flow-subscriptions-billing-multistep.spec.ts
+++ b/apps/web/e2e/flow-subscriptions-billing-multistep.spec.ts
@@ -35,7 +35,7 @@ import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from '.
  *       -> 200 { status:'success', enabled:true, plan:{ code:'free', name:'Free',
  *                allowedCadences:[{cadence,allowed,payPerUse,reason?} x7] } }  (fresh user → free)
  *     POST /api/subscriptions/plan { planCode:'free'|'standard'|'premium' }
- *       -> 200 { status:'success', enabled:true, plan:{ code, name:'Free'|'Standard'|'Premium',
+ *       -> 200 { status:'success', enabled:true, plan:{ code, name:'Free'|'Pro'|'Enterprise',
  *                allowedCadences:[...] } }
  *          SELF-SERVE PAID IS ON in e2e: standard/premium POST → 200 (not the 403 the
  *          production gate would give). On STANDARD the sub-hourly cadences flip to
@@ -186,7 +186,7 @@ test.describe('Flow: self-serve plan tier → per-work budget provisioning', () 
         expect(std.status(), 'self-serve paid (standard) accepted').toBe(200);
         const stdBody = await std.json();
         expect(stdBody.plan.code).toBe('standard');
-        expect(stdBody.plan.name).toBe('Standard');
+        expect(stdBody.plan.name).toBe('Pro');
         const stdCadences: Array<{ cadence: string; allowed: boolean; payPerUse: boolean }> =
             stdBody.plan.allowedCadences ?? [];
         const hourly = stdCadences.find((c) => c.cadence === 'hourly');
@@ -203,7 +203,7 @@ test.describe('Flow: self-serve plan tier → per-work budget provisioning', () 
         expect(prem.status()).toBe(200);
         const premBody = await prem.json();
         expect(premBody.plan.code).toBe('premium');
-        expect(premBody.plan.name).toBe('Premium');
+        expect(premBody.plan.name).toBe('Enterprise');
         for (const c of premBody.plan.allowedCadences ?? []) {
             expect(c.allowed, `premium ${c.cadence} re-allowed`).toBe(true);
             expect(c.payPerUse).toBe(false);

--- a/apps/web/e2e/flow-subscriptions-validation-matrix.spec.ts
+++ b/apps/web/e2e/flow-subscriptions-validation-matrix.spec.ts
@@ -274,7 +274,7 @@ test.describe('Subscriptions plan — POST happy path, self-serve gate, transiti
         const body = await res.json();
         if (res.status() === 200) {
             expect(body.plan.code).toBe('standard');
-            expect(body.plan.name).toBe('Standard');
+            expect(body.plan.name).toBe('Pro');
             // STANDARD gates the sub-12h cadences to pay-per-use.
             const gated = body.plan.allowedCadences.filter((c: { allowed: boolean }) => !c.allowed);
             for (const c of gated) {
@@ -296,7 +296,7 @@ test.describe('Subscriptions plan — POST happy path, self-serve gate, transiti
         const body = await res.json();
         if (res.status() === 200) {
             expect(body.plan.code).toBe('premium');
-            expect(body.plan.name).toBe('Premium');
+            expect(body.plan.name).toBe('Enterprise');
             for (const c of body.plan.allowedCadences) {
                 expect(c.allowed).toBe(true);
                 expect(c.payPerUse).toBe(false);

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -653,7 +653,7 @@ describe('SubscriptionService', () => {
                 expect(byCadence[cadence].reason).toBeUndefined();
             }
 
-            // The three NOT-allowed cadences should recommend Premium
+            // The three NOT-allowed cadences should recommend Enterprise (the catalog name of `premium`)
             for (const cadence of [
                 WorkScheduleCadence.EVERY_8_HOURS,
                 WorkScheduleCadence.EVERY_3_HOURS,
@@ -661,7 +661,7 @@ describe('SubscriptionService', () => {
             ]) {
                 expect(byCadence[cadence].allowed).toBe(false);
                 expect(byCadence[cadence].payPerUse).toBe(true);
-                expect(byCadence[cadence].reason).toBe('Upgrade to Premium for this cadence');
+                expect(byCadence[cadence].reason).toBe('Upgrade to Enterprise for this cadence');
             }
         });
 
@@ -688,12 +688,12 @@ describe('SubscriptionService', () => {
         // Validated by emitting a pure-payPerUse plan (allowedCadences: []) so
         // EVERY cadence triggers the reason field.
         it.each([
-            [WorkScheduleCadence.HOURLY, 'Premium'],
-            [WorkScheduleCadence.EVERY_3_HOURS, 'Premium'],
-            [WorkScheduleCadence.EVERY_8_HOURS, 'Premium'],
-            [WorkScheduleCadence.EVERY_12_HOURS, 'Standard'],
-            [WorkScheduleCadence.DAILY, 'Standard'],
-            [WorkScheduleCadence.WEEKLY, 'Standard'],
+            [WorkScheduleCadence.HOURLY, 'Enterprise'],
+            [WorkScheduleCadence.EVERY_3_HOURS, 'Enterprise'],
+            [WorkScheduleCadence.EVERY_8_HOURS, 'Enterprise'],
+            [WorkScheduleCadence.EVERY_12_HOURS, 'Pro'],
+            [WorkScheduleCadence.DAILY, 'Pro'],
+            [WorkScheduleCadence.WEEKLY, 'Pro'],
             [WorkScheduleCadence.MONTHLY, 'Free'],
         ] as const)('%s cadence → recommend %s', async (cadence, recommended) => {
             const emptyPlan = { ...FREE_PLAN, allowedCadences: [] };

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -184,6 +184,11 @@ const PLAN_SEED_DATA: Array<{
     },
 ];
 
+/** Display name of a seeded plan by code; the code itself if the seed has no such row. */
+function planDisplayName(code: SubscriptionPlanCode): string {
+    return PLAN_SEED_DATA.find((plan) => plan.code === code)?.displayName ?? code;
+}
+
 @Injectable()
 export class SubscriptionService implements OnModuleInit {
     private readonly logger = new Logger(SubscriptionService.name);
@@ -315,18 +320,26 @@ export class SubscriptionService implements OnModuleInit {
         return billingMode !== WorkScheduleBillingMode.USAGE;
     }
 
+    /**
+     * The plan a user should be told to upgrade to for a cadence their plan
+     * does not allow. Returns the catalog DISPLAY name, resolved from the
+     * seed by plan code, so the copy cannot drift from the plan switcher
+     * again: the tiers were renamed Standard/Premium -> Pro/Enterprise in
+     * the catalog while this string kept recommending plans that no longer
+     * exist under those names (and three e2e specs asserted the stale copy).
+     */
     private recommendationForCadence(cadence: WorkScheduleCadence): string {
         switch (cadence) {
             case WorkScheduleCadence.HOURLY:
             case WorkScheduleCadence.EVERY_3_HOURS:
             case WorkScheduleCadence.EVERY_8_HOURS:
-                return 'Premium';
+                return planDisplayName(SubscriptionPlanCode.PREMIUM);
             case WorkScheduleCadence.EVERY_12_HOURS:
             case WorkScheduleCadence.DAILY:
             case WorkScheduleCadence.WEEKLY:
-                return 'Standard';
+                return planDisplayName(SubscriptionPlanCode.STANDARD);
             default:
-                return 'Free';
+                return planDisplayName(SubscriptionPlanCode.FREE);
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the billing lane (#2203), deliberately kept OUT of that PR so as not to restart its CI queue.

- `SubscriptionService.recommendationForCadence` still returned the pre-rename tier names (`Premium` / `Standard`) in the user-facing "Upgrade to … for this cadence" reason, although the catalog has shown them as **Enterprise** / **Pro** since `345a6a79`. It now resolves the display name from `PLAN_SEED_DATA` by plan code, so the copy cannot drift from the plan switcher again.
- The same rename left **four stage E2E specs** asserting the stale names — these are **3 of the 4 "new" stage E2E failures** measured on the isolated run `32613921527` (see `_LOCAL/docs/handoffs/HANDOVER-2026-08-23-ever-works-billing-entitlements.md` §5.1b):
  - `flow-subscriptions-billing-multistep.spec.ts:189/206` (`Standard`/`Premium` → `Pro`/`Enterprise`)
  - `flow-subscriptions-validation-matrix.spec.ts:277/299` (same)
  - the 4th, `flow-subscriptions-budgets.spec.ts:261` (`catalogue offers unknown plan code 'selfhosted_community'`), is **already fixed on `develop`** by #2198 (`listPlans()` filters out self-hosted editions) and kept by #2203.
- `flow-subscription-billing-grace.spec.ts:356` and `flow-subscription-plan-tiers.spec.ts:192` asserted the stale upgrade reason; updated with the copy.

## Test plan

- [x] `packages/agent` `subscription.service.spec.ts`: 77/77 green with the change.
- [x] **Proven to bite**: with only the service change reverted, 7 cases go red (`hourly/every_3_hours/every_8_hours cadence → recommend Enterprise`, `every_12_hours/daily/weekly → recommend Pro`, plus the cadence-allowance reason case).
- [ ] Stage E2E (after cascade): the four specs above should leave the "new failures" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
