### PR TITLE
docs(billing): works-limit has no reader — stop presenting it as effective; state the real posture of max-concurrent-runs

### DIFF
--- a/docs/features/credits-and-billing.md
+++ b/docs/features/credits-and-billing.md
@@ -101,12 +101,12 @@ Rows that cannot be attributed to a model, agent or Work are grouped under **Una
 
 Plans carry additive entitlement keys. A missing row always means "use the platform default", never an error:
 
-| Key                   | Effect                                                  |
-| --------------------- | ------------------------------------------------------- |
-| `daily-free-credits`  | Size of the daily free grant (every plan; default 50).  |
-| `max-concurrent-runs` | Concurrency ceiling consulted by the run dispatch gate. |
-| `works-limit`         | How many Works the plan allows.                         |
-| `credit-limited`      | Whether the plan's runs are billed against the balance. |
+| Key                   | Effect                                                                                                                                                                                                                                                                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `daily-free-credits`  | Size of the daily free grant (every plan; default 50).                                                                                                                                                                                                                                                                                               |
+| `max-concurrent-runs` | Concurrency ceiling folded into run admission (raise-only vs the org ceiling), dark behind `PLAN_CONCURRENCY_ENFORCEMENT` (default off).                                                                                                                                                                                                             |
+| `works-limit`         | ⚠️ Declared but **not read by anything** — the live Works ceiling is `subscription_plans.maxWorks` (`UNLIMITED_WORKS = 2_147_483_647` sentinel, comparisons `activeScheduleCount >= plan.maxWorks`). Do **not** seed it, and never with `-1`: a future reader wired against `-1` would refuse every schedule on exactly the tiers sold as unlimited. |
+| `credit-limited`      | Whether the plan's runs are billed against the balance.                                                                                                                                                                                                                                                                                              |
 
 Credit enforcement is deliberately conservative: only a `credit-limited` plan with a balance at or below zero parks new runs, and only when `CREDITS_ENFORCEMENT=on`. Today no plan seeds that row, so enforcement stays dark and a zero balance never blocks work unexpectedly.
 


### PR DESCRIPTION
Closes the doc half of **H4** from the 2026-08-23 billing audit (`_LOCAL/EVER_WORKS_BILLING_AUDIT_FINDINGS.md` §H4, handover §9.2): `docs/features/credits-and-billing.md` presented `works-limit` as an effective entitlement while **nothing reads it** — the live ceiling is `subscription_plans.maxWorks` (`UNLIMITED_WORKS = 2_147_483_647`, comparisons `activeScheduleCount >= plan.maxWorks`). The row now says exactly that and warns against seeding it (`-1` would refuse every schedule on the unlimited tiers if a reader ever appears). Also updates the `max-concurrent-runs` row: since #2203 it HAS a reader — raise-only in run admission, dark behind `PLAN_CONCURRENCY_ENFORCEMENT` (default off).

Docs-only — CI's scope gate skips build/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how concurrent run limits are enforced for each plan.
  - Documented that Works limits are managed through subscription plan settings.
  - Clarified the representation and handling of unlimited Works allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->