### PR TITLE
fix(scope): let edge rows follow their validated endpoints + unbreak the repo-wide format gate

### DIFF
--- a/apps/node/src/core/executors/acceptance-checks.ts
+++ b/apps/node/src/core/executors/acceptance-checks.ts
@@ -379,10 +379,7 @@ async function resolveStepCwd(rootCwd: string, declared: string | undefined): Pr
 	} catch {
 		throw new AcceptanceChecksPayloadError('Step cwd is missing, linked, or not a directory');
 	}
-	const canonicalDeclaredCandidate = resolve(
-		canonicalRoot,
-		relative(lexicalRoot, lexicalCandidate)
-	);
+	const canonicalDeclaredCandidate = resolve(canonicalRoot, relative(lexicalRoot, lexicalCandidate));
 	if (
 		!sameFilesystemPath(canonicalCandidate, canonicalDeclaredCandidate) ||
 		!isStrictDescendantPath(canonicalRoot, canonicalCandidate)

--- a/apps/node/src/core/model-execution/model-process.spec.ts
+++ b/apps/node/src/core/model-execution/model-process.spec.ts
@@ -1553,7 +1553,11 @@ if (process.argv.includes('--version')) {
 					(result) => ({ kind: 'resolved' as const, result }),
 					(error: unknown) => ({ kind: 'rejected' as const, error })
 				),
-				new Promise<{ kind: 'hung' }>((resolve) => setTimeout(() => resolve({ kind: 'hung' }), 1_500))
+				// The cleanup itself is bounded to 3 x 250 ms, but this race
+				// covers the complete real-process execution as well. Keep enough
+				// headroom for process startup on loaded/Windows CI runners while
+				// still proving that a never-settling cleanup cannot hang forever.
+				new Promise<{ kind: 'hung' }>((resolve) => setTimeout(() => resolve({ kind: 'hung' }), 4_000))
 			]);
 
 			expect(outcome.kind).toBe('resolved');
@@ -1563,7 +1567,7 @@ if (process.argv.includes('--version')) {
 		} finally {
 			if (cleanupPath) await rm(cleanupPath, { recursive: true, force: true });
 		}
-	}, 5_000);
+	}, 8_000);
 });
 
 describe('executeModelProcess — request refusal', () => {

--- a/docs/specs/features/billing/plan.md
+++ b/docs/specs/features/billing/plan.md
@@ -10,16 +10,16 @@
 
 ## 0. Current state this plan builds on (verified 2026-08-23 on `develop` @ `2512abd10`)
 
-| Layer | Exists today | File(s) |
-| --- | --- | --- |
-| Ledger | append-only `credit_ledger_entries`, SUM = balance, idempotent `recordAtomic` under a per-user row lock, floor/ceiling guards | `packages/agent/src/database/repositories/credit-ledger.repository.ts`, `entities/credit-ledger-entry.entity.ts` |
-| Debit | `RunCostSettlementService.settleRun` → `CreditLedgerService.consumeForRun` (ceil(costCents × cpd/100 × (1+margin))), partial debit to 0 + notification on exhaustion, BYOK exemption | `subscriptions/credits/run-cost-settlement.service.ts`, `credit-ledger.service.ts` |
-| Grants | daily free (Trigger cron `credits-daily-grant`, 00:05 UTC, free plan only) | `packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts` |
-| Money | `BillingProvider` seam + `StripeBillingProvider` (Checkout payment/subscription/setup, off-session PI, portal, webhooks: `checkout.session.completed`, `payment_intent.succeeded`, `charge.refunded`, `charge.dispute.created`, `invoice.*`, `customer.subscription.*`, `payment_method.*`) | `subscriptions/billing/*.ts` |
-| Catalog | `stripe-catalog.data.json` + `stripe-catalog.ts` + `scripts/stripe-sync-catalog.mjs` (22 flat prices on the shared account, lookup-key convention `ever_works_*`) | same dir + `scripts/` |
-| API | `apps/api/src/billing/*` (overview, checkout, plan checkout, payment methods, subscription cancel/resume/portal, webhook) and `apps/api/src/subscriptions/*` (credits balance/ledger/usage, costs, plans) | |
-| Web | `settings/billing` (BillingSettings.tsx + server actions in `app/actions/dashboard/billing.ts`), `settings/usage` | `apps/web/src/...` |
-| Gate | `run-admission-chain.ts` credits step → `RunCostSettlementService.shouldQueueForCredits` (`CREDITS_ENFORCEMENT` + `credit-limited` entitlement + balance ≤ 0) | `packages/agent/src/agents/run-admission-chain.ts` |
+| Layer   | Exists today                                                                                                                                                                                                                                                                                | File(s)                                                                                                          |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Ledger  | append-only `credit_ledger_entries`, SUM = balance, idempotent `recordAtomic` under a per-user row lock, floor/ceiling guards                                                                                                                                                               | `packages/agent/src/database/repositories/credit-ledger.repository.ts`, `entities/credit-ledger-entry.entity.ts` |
+| Debit   | `RunCostSettlementService.settleRun` → `CreditLedgerService.consumeForRun` (ceil(costCents × cpd/100 × (1+margin))), partial debit to 0 + notification on exhaustion, BYOK exemption                                                                                                        | `subscriptions/credits/run-cost-settlement.service.ts`, `credit-ledger.service.ts`                               |
+| Grants  | daily free (Trigger cron `credits-daily-grant`, 00:05 UTC, free plan only)                                                                                                                                                                                                                  | `packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts`                                                   |
+| Money   | `BillingProvider` seam + `StripeBillingProvider` (Checkout payment/subscription/setup, off-session PI, portal, webhooks: `checkout.session.completed`, `payment_intent.succeeded`, `charge.refunded`, `charge.dispute.created`, `invoice.*`, `customer.subscription.*`, `payment_method.*`) | `subscriptions/billing/*.ts`                                                                                     |
+| Catalog | `stripe-catalog.data.json` + `stripe-catalog.ts` + `scripts/stripe-sync-catalog.mjs` (22 flat prices on the shared account, lookup-key convention `ever_works_*`)                                                                                                                           | same dir + `scripts/`                                                                                            |
+| API     | `apps/api/src/billing/*` (overview, checkout, plan checkout, payment methods, subscription cancel/resume/portal, webhook) and `apps/api/src/subscriptions/*` (credits balance/ledger/usage, costs, plans)                                                                                   |                                                                                                                  |
+| Web     | `settings/billing` (BillingSettings.tsx + server actions in `app/actions/dashboard/billing.ts`), `settings/usage`                                                                                                                                                                           | `apps/web/src/...`                                                                                               |
+| Gate    | `run-admission-chain.ts` credits step → `RunCostSettlementService.shouldQueueForCredits` (`CREDITS_ENFORCEMENT` + `credit-limited` entitlement + balance ≤ 0)                                                                                                                               | `packages/agent/src/agents/run-admission-chain.ts`                                                               |
 
 Nothing metered, no `GRANT`/`EXPIRY` writers, no seats persistence, margin 0.
 
@@ -27,52 +27,52 @@ Nothing metered, no `GRANT`/`EXPIRY` writers, no seats persistence, margin 0.
 
 ### 1.1 `credit_ledger_entries` (PR-A)
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `expiresAt` | timestamp NULL | set on `grant` (allowance month end); NULL on purchase/daily-free/adjustment |
-| `remainingCredits` | int NULL | for positive rows: unconsumed part of this bucket; NULL on negative rows |
+| Column             | Type           | Notes                                                                        |
+| ------------------ | -------------- | ---------------------------------------------------------------------------- |
+| `expiresAt`        | timestamp NULL | set on `grant` (allowance month end); NULL on purchase/daily-free/adjustment |
+| `remainingCredits` | int NULL       | for positive rows: unconsumed part of this bucket; NULL on negative rows     |
 
 Indexes: `idx_credit_ledger_user_expires (userId, expiresAt)` (partial-ish: used by the expiry sweep and the available-balance query).
 Backfill: `remainingCredits = amountCredits` for existing positive rows, then replay existing negative rows in `createdAt` order per user to allocate against buckets (done in the migration as a TypeScript loop — the table is small pre-launch; no SQL window tricks so sqlite and postgres behave the same).
 
 ### 1.2 `billing_profiles` (PR-C)
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `paygEnabled` | bool default false | owner opted in |
-| `paygSubscriptionId` | varchar(128) NULL | Stripe metered subscription |
-| `paygSubscriptionItemId` | varchar(128) NULL | the metered item (for quantity/threshold updates) |
-| `paygStatus` | varchar(32) NULL | `BillingSubscriptionStatus` |
-| `paygPeriodStart` / `paygPeriodEnd` | timestamp NULL | current Stripe cycle, reconciled by webhook |
-| `paygMonthlyCapCredits` | int NULL | user cap; default from catalog |
-| `paygCapNotifiedPercent` | int default 0 | 0 / 80 / 100 — once-per-cycle notification latch, reset when period rolls |
+| Column                              | Type               | Notes                                                                     |
+| ----------------------------------- | ------------------ | ------------------------------------------------------------------------- |
+| `paygEnabled`                       | bool default false | owner opted in                                                            |
+| `paygSubscriptionId`                | varchar(128) NULL  | Stripe metered subscription                                               |
+| `paygSubscriptionItemId`            | varchar(128) NULL  | the metered item (for quantity/threshold updates)                         |
+| `paygStatus`                        | varchar(32) NULL   | `BillingSubscriptionStatus`                                               |
+| `paygPeriodStart` / `paygPeriodEnd` | timestamp NULL     | current Stripe cycle, reconciled by webhook                               |
+| `paygMonthlyCapCredits`             | int NULL           | user cap; default from catalog                                            |
+| `paygCapNotifiedPercent`            | int default 0      | 0 / 80 / 100 — once-per-cycle notification latch, reset when period rolls |
 
 ### 1.3 `credit_meter_events` (new table, PR-C)
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `id` | uuid PK | |
-| `userId`, `organizationId?`, `tenantId?` | uuid | scope (raw refs, EW-654 rule) |
-| `runId` | uuid | `refId` |
-| `identifier` | varchar(128) UNIQUE | `run:{runId}` — Stripe meter-event identifier and our idempotency key |
-| `credits` | int | credits reported to the meter |
-| `writtenOffCredits` | int default 0 | part beyond the cap that was not billed |
-| `costCentsRef` | int NULL | metered provider cost this derived from |
-| `periodStart` / `periodEnd` | timestamp | PAYG cycle at record time |
-| `status` | varchar(16) | `pending` → `sent` / `failed` (terminal after 35 days) |
-| `attempts` | int default 0 | |
-| `lastError` | varchar(256) NULL | never the full provider error |
-| `sentAt` | timestamp NULL | |
-| `createdAt` | timestamp | |
+| Column                                   | Type                | Notes                                                                 |
+| ---------------------------------------- | ------------------- | --------------------------------------------------------------------- |
+| `id`                                     | uuid PK             |                                                                       |
+| `userId`, `organizationId?`, `tenantId?` | uuid                | scope (raw refs, EW-654 rule)                                         |
+| `runId`                                  | uuid                | `refId`                                                               |
+| `identifier`                             | varchar(128) UNIQUE | `run:{runId}` — Stripe meter-event identifier and our idempotency key |
+| `credits`                                | int                 | credits reported to the meter                                         |
+| `writtenOffCredits`                      | int default 0       | part beyond the cap that was not billed                               |
+| `costCentsRef`                           | int NULL            | metered provider cost this derived from                               |
+| `periodStart` / `periodEnd`              | timestamp           | PAYG cycle at record time                                             |
+| `status`                                 | varchar(16)         | `pending` → `sent` / `failed` (terminal after 35 days)                |
+| `attempts`                               | int default 0       |                                                                       |
+| `lastError`                              | varchar(256) NULL   | never the full provider error                                         |
+| `sentAt`                                 | timestamp NULL      |                                                                       |
+| `createdAt`                              | timestamp           |                                                                       |
 
 Indexes: `(userId, periodStart)`, `(status, createdAt)`.
 
 ### 1.4 `user_subscriptions` (PR-D)
 
-| Column | Type | Notes |
-| --- | --- | --- |
-| `seats` | int NULL | total seats (included + additional) on the provider subscription; NULL = unknown/unbounded |
-| `providerSeatItemId` | varchar(128) NULL | Stripe subscription item for the seat price (NULL until first extra seat) |
+| Column               | Type              | Notes                                                                                      |
+| -------------------- | ----------------- | ------------------------------------------------------------------------------------------ |
+| `seats`              | int NULL          | total seats (included + additional) on the provider subscription; NULL = unknown/unbounded |
+| `providerSeatItemId` | varchar(128) NULL | Stripe subscription item for the seat price (NULL until first extra seat)                  |
 
 ### 1.5 `plan_entitlements` seeds (PR-A / PR-C)
 
@@ -115,19 +115,19 @@ Indexes: `(userId, periodStart)`, `(status, createdAt)`.
 ### 3.1 Ledger buckets + expiry (PR-A)
 
 - `CreditLedgerRepository.recordAtomic`:
-  - positive write → `remainingCredits = amount` (after ceiling clamp), `expiresAt = write.expiresAt ?? null`;
-  - negative write → after floor check, allocate `|amount|` across buckets `WHERE userId AND remainingCredits > 0 AND (expiresAt IS NULL OR expiresAt > now) ORDER BY expiresAt ASC NULLS LAST, createdAt ASC` (driver-neutral: `ORDER BY CASE WHEN expiresAt IS NULL THEN 1 ELSE 0 END, expiresAt, createdAt`), decrementing each; unallocated remainder (only possible with `allowNegativeBalance`) is left unallocated.
-  - new `expireDueBuckets(userId, now)`: in one transaction under the user lock, for each due bucket insert an `expiry` row (`idempotencyKey expiry:{entryId}`, `refType credit-ledger-entry`, `refId entryId`) and set `remainingCredits = 0`. Returns count + credits expired.
-  - `getBalance(userId, now)` → available balance (FR-8). `getPeriodTotals` splits `consumedCredits` (kind consumption), `expiredCredits` (kind expiry), `addedCredits` (positive).
+    - positive write → `remainingCredits = amount` (after ceiling clamp), `expiresAt = write.expiresAt ?? null`;
+    - negative write → after floor check, allocate `|amount|` across buckets `WHERE userId AND remainingCredits > 0 AND (expiresAt IS NULL OR expiresAt > now) ORDER BY expiresAt ASC NULLS LAST, createdAt ASC` (driver-neutral: `ORDER BY CASE WHEN expiresAt IS NULL THEN 1 ELSE 0 END, expiresAt, createdAt`), decrementing each; unallocated remainder (only possible with `allowNegativeBalance`) is left unallocated.
+    - new `expireDueBuckets(userId, now)`: in one transaction under the user lock, for each due bucket insert an `expiry` row (`idempotencyKey expiry:{entryId}`, `refType credit-ledger-entry`, `refId entryId`) and set `remainingCredits = 0`. Returns count + credits expired.
+    - `getBalance(userId, now)` → available balance (FR-8). `getPeriodTotals` splits `consumedCredits` (kind consumption), `expiredCredits` (kind expiry), `addedCredits` (positive).
 - `CreditLedgerService`:
-  - `record` accepts `expiresAt`;
-  - `expireDueCredits(userId?)` (one user, or all users with due buckets — repository method `findUsersWithDueBuckets(now, limit)`);
-  - `dispatchDailyGrants`: fallback for every plan code (FR-1);
-  - `grantForToday(userId)` lazy daily grant (FR-3) — same idempotency key as the sweep.
+    - `record` accepts `expiresAt`;
+    - `expireDueCredits(userId?)` (one user, or all users with due buckets — repository method `findUsersWithDueBuckets(now, limit)`);
+    - `dispatchDailyGrants`: fallback for every plan code (FR-1);
+    - `grantForToday(userId)` lazy daily grant (FR-3) — same idempotency key as the sweep.
 - New `PlanCreditGrantService` (`subscriptions/credits/plan-credit-grant.service.ts`):
-  - `allowancePeriodFor(anchor: Date, now: Date) → {start, end}`, pure + unit-tested (month arithmetic clamped);
-  - `grantCurrentAllowance(userId)` — resolves the active `user_subscriptions` row + plan (`monthlyCredits > 0`, hosting `cloud`, status `active|trialing`), writes `grant` with `expiresAt = end`, idempotency `grant:plan:{userId}:{startISODate}`;
-  - `dispatchPlanGrants(now)` — batch over active subscriptions (new `UserSubscriptionRepository.findActiveBatch`).
+    - `allowancePeriodFor(anchor: Date, now: Date) → {start, end}`, pure + unit-tested (month arithmetic clamped);
+    - `grantCurrentAllowance(userId)` — resolves the active `user_subscriptions` row + plan (`monthlyCredits > 0`, hosting `cloud`, status `active|trialing`), writes `grant` with `expiresAt = end`, idempotency `grant:plan:{userId}:{startISODate}`;
+    - `dispatchPlanGrants(now)` — batch over active subscriptions (new `UserSubscriptionRepository.findActiveBatch`).
 - `PlanSubscriptionService.activate` → after the row write, `await planCreditGrantService.grantCurrentAllowance(userId)` (best-effort, logged).
 - Trigger task `credits-daily-grant` → `expireDueCredits()` → `dispatchDailyGrants()` → `dispatchPlanGrants()`; RPC allow-list extended (`trigger-internal-api.client.ts`).
 
@@ -151,7 +151,7 @@ Indexes: `(userId, periodStart)`, `(status, createdAt)`.
 ### 3.4 Seats (PR-D)
 
 - `SeatsService` (`subscriptions/billing/seats.service.ts`): allowance/usage/assert; repositories: `OrganizationMemberRepository.countDistinctMembersForOwner(userId)`, `AgentRepository.countActiveByUserId(userId)` (or reuse existing finders).
-- Seam: `updateSeatQuantity({subscriptionId, seatLookupKey, quantity})` (find-or-create the seat item; `proration_behavior: 'create_prorations'`), `readSubscriptionSeats(subscription)` in normalization → `BillingSubscriptionSnapshot.seats` (sum of quantities of items whose price lookup_key matches `_seat_`) + `seatItemId`.
+- Seam: `updateSeatQuantity({subscriptionId, seatLookupKey, quantity})` (find-or-create the seat item; `proration_behavior: 'create_prorations'`), `readSubscriptionSeats(subscription)` in normalization → `BillingSubscriptionSnapshot.seats` (sum of quantities of items whose price lookup*key matches `\_seat*`) + `seatItemId`.
 - `PlanSubscriptionService.activate/applyWebhook` persist `seats`/`providerSeatItemId`; `SubscriptionService.summarizePlan` exposes `{seatsIncluded, seatsPurchased, seatsUsed}`.
 - Gates: `OrganizationMembershipService` (add/accept) and `AgentsService.create` call `seatsService.assertSeatAvailable(ownerUserId)`; `SeatLimitExceededError` → 402 filter (alongside `InsufficientCreditsError`).
 - API: `GET /billing/seats`, `POST /billing/seats {seats}` (DTO int 0..1000). Web: seats row in the plan card with "Add seats" stepper.
@@ -163,13 +163,13 @@ Indexes: `(userId, periodStart)`, `(status, createdAt)`.
 
 ## 4. PR sequencing (all to `develop`, each self-contained + green)
 
-| PR | Scope | Migration |
-| --- | --- | --- |
-| **A** `feat(billing): plan credit grants, expiring buckets, universal daily grant` | §3.1 | `AddCreditLedgerBuckets` + entitlement seeds |
-| **B** `feat(billing): margin as a catalog value + pricing endpoint` | §3.2 | — |
-| **C** `feat(billing): pay-as-you-go metered billing on Stripe Billing Meters` | §3.3 + enforcement default + docs/runbook + Trigger tasks | `AddPaygAndMeterEvents` + `credit-limited` seeds |
-| **D** `feat(billing): seats persisted, enforced and adjustable` | §3.4 | `AddSubscriptionSeats` |
-| **E** `docs(billing): reconcile billing docs, runbook` (folded into C/D if small) | §3.5 | — |
+| PR                                                                                 | Scope                                                     | Migration                                        |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------ |
+| **A** `feat(billing): plan credit grants, expiring buckets, universal daily grant` | §3.1                                                      | `AddCreditLedgerBuckets` + entitlement seeds     |
+| **B** `feat(billing): margin as a catalog value + pricing endpoint`                | §3.2                                                      | —                                                |
+| **C** `feat(billing): pay-as-you-go metered billing on Stripe Billing Meters`      | §3.3 + enforcement default + docs/runbook + Trigger tasks | `AddPaygAndMeterEvents` + `credit-limited` seeds |
+| **D** `feat(billing): seats persisted, enforced and adjustable`                    | §3.4                                                      | `AddSubscriptionSeats`                           |
+| **E** `docs(billing): reconcile billing docs, runbook` (folded into C/D if small)  | §3.5                                                      | —                                                |
 
 A and B are independent; C depends on A (buckets) and B (pricing endpoint); D is independent of C. Website `/pricing` PAYG row is a separate PR in `ever-works/website` after C merges.
 

--- a/docs/specs/features/billing/spec.md
+++ b/docs/specs/features/billing/spec.md
@@ -22,22 +22,22 @@ Ever Works sells **three things** on one shared Stripe account ("Ever Tech", `ac
 1. **A plan** — Free / Pro / Enterprise (cloud) or Community / Pro / Enterprise Edition (self-hosted). Flat, recurring (monthly/annual) or a one-off perpetual licence on self-hosted Pro.
 2. **Seats** — employees **or** agents, interchangeable. Each paid plan includes 10; additional seats are a per-unit recurring price ($5 Pro / $10 Enterprise per seat per month).
 3. **Credits** — the unit of platform-billed AI usage. **1 credit = 1 cent** of platform-billed usage. Credits come from four places, all landing in one append-only ledger:
-   - the **daily free allowance** (50/day, every plan, non-accumulating),
-   - the **monthly plan allowance** (3,000 Pro / 25,000 Enterprise, expiring at the end of each allowance month),
-   - **prepaid packs** ($10/1,000 · $50/5,500 · $200/25,000, never expire) — bought at checkout or by threshold auto-recharge,
-   - **pay-as-you-go (PAYG)** — when the prepaid balance is exhausted and the owner has opted in, the remainder is **metered to Stripe and invoiced monthly in arrears** at graduated per-credit rates, under a user-set monthly cap.
+    - the **daily free allowance** (50/day, every plan, non-accumulating),
+    - the **monthly plan allowance** (3,000 Pro / 25,000 Enterprise, expiring at the end of each allowance month),
+    - **prepaid packs** ($10/1,000 · $50/5,500 · $200/25,000, never expire) — bought at checkout or by threshold auto-recharge,
+    - **pay-as-you-go (PAYG)** — when the prepaid balance is exhausted and the owner has opted in, the remainder is **metered to Stripe and invoiced monthly in arrears** at graduated per-credit rates, under a user-set monthly cap.
 
 Runs on the customer's **own model keys** (BYOK/BYOS) spend no credits on any plan.
 
 This spec closes the five gaps found in the 2026-08-23 audit:
 
-| Gap | What was wrong | What this spec does |
-| --- | --- | --- |
-| 1 | Paid subscribers received **zero** credits (no monthly grant writer; daily grant was free-plan-only in code while catalog/marketing said universal) | §3.2 monthly allowance grants + expiry; §3.1 universal daily grant |
-| 2 | `CREDITS_MARGIN_PERCENT=0` → packs sold at or below provider list cost | §3.4 margin becomes a catalog value (35 %) with documented economics |
-| 3 | Seats billed to Stripe but neither persisted nor enforced; ledger per user | §3.6 seats persisted, exposed, enforceable, adjustable; org wallets explicitly deferred (§7) |
-| 4 | Docs drift (pack prices, plan names, removed Stripe APIs), ToS promises in-arrears invoicing the code could not do, PRD missing | this spec + `docs/features/credits-and-billing.md` + `docs/advanced/subscription-billing.md` rewritten; §3.5 makes in-arrears invoicing real |
-| 5 | "Pay-as-you-go from your credits balance" on plan cards while no PAYG existed | §3.5 real PAYG; plan-card wording changed to "Usage is billed from your credits balance" |
+| Gap | What was wrong                                                                                                                                      | What this spec does                                                                                                                          |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Paid subscribers received **zero** credits (no monthly grant writer; daily grant was free-plan-only in code while catalog/marketing said universal) | §3.2 monthly allowance grants + expiry; §3.1 universal daily grant                                                                           |
+| 2   | `CREDITS_MARGIN_PERCENT=0` → packs sold at or below provider list cost                                                                              | §3.4 margin becomes a catalog value (35 %) with documented economics                                                                         |
+| 3   | Seats billed to Stripe but neither persisted nor enforced; ledger per user                                                                          | §3.6 seats persisted, exposed, enforceable, adjustable; org wallets explicitly deferred (§7)                                                 |
+| 4   | Docs drift (pack prices, plan names, removed Stripe APIs), ToS promises in-arrears invoicing the code could not do, PRD missing                     | this spec + `docs/features/credits-and-billing.md` + `docs/advanced/subscription-billing.md` rewritten; §3.5 makes in-arrears invoicing real |
+| 5   | "Pay-as-you-go from your credits balance" on plan cards while no PAYG existed                                                                       | §3.5 real PAYG; plan-card wording changed to "Usage is billed from your credits balance"                                                     |
 
 ## 2. User Scenarios
 

--- a/docs/specs/features/billing/tasks.md
+++ b/docs/specs/features/billing/tasks.md
@@ -32,7 +32,7 @@
 - [ ] `BillingService`: overview `payg`, webhook routing (`payg.updated`, PAYG invoices → status)
 - [ ] `RunCostSettlementService`: overflow to PAYG, lazy daily grant in precheck, headroom admission
 - [ ] Config: enforcement default-on-when-configured, `PAYG_MAX_MONTHLY_CAP_CREDITS`, `STRIPE_AUTOMATIC_TAX`
-- [ ] Trigger task `credits-meter-flush` (*/5) + RPC allow-list
+- [ ] Trigger task `credits-meter-flush` (\*/5) + RPC allow-list
 - [ ] API: `payg.controller.ts` (GET/PUT) + DTO + module wiring + specs
 - [ ] Web: `billing.shared.ts` (types, `canConfigurePayg`, `estimatePaygCents`), server action, `BillingSettings` PAYG card, Usage tile, en.json keys, plan-card label fix
 - [ ] Notifications: `notifyPaygCapThreshold`, `notifyPaygPastDue`

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -995,9 +995,14 @@ export class AgentsService {
             }),
         });
         const bySha = new Map(uploads.map((u) => [u.sha256, u]));
-        if (new Set(rows.map((row) => row.uploadId)).size !== bySha.size) {
-            throw new NotFoundException(`Attachment not found`);
-        }
+        // The Agent itself is the authority: it was ownership-validated
+        // above, and each row carries only (agentId, uploadId) where the
+        // uploadId is a hash the caller supplied at attach time. An upload
+        // row that is not visible in the CURRENT scope (legacy rows pre-date
+        // scope stamping; upgrade-from-account backfills `agents` but not
+        // `user_uploads`) must NOT fail the whole list — the row below just
+        // stays un-enriched (`if (!u) return r`), exactly like any other
+        // metadata miss.
         return rows.map((r) => {
             const u = bySha.get(r.uploadId);
             if (!u) return r;

--- a/packages/agent/src/database/repositories/mission-work.repository.organization-scope.spec.ts
+++ b/packages/agent/src/database/repositories/mission-work.repository.organization-scope.spec.ts
@@ -34,14 +34,19 @@ function queryHarness() {
         execute: jest.fn(async () => ({ affected: 1 })),
         getRawMany: jest.fn(async () => []),
     };
+    const deleted: Record<string, unknown>[] = [];
     const repository = {
         createQueryBuilder: jest.fn(() => query),
+        delete: jest.fn(async (criteria: Record<string, unknown>) => {
+            deleted.push(criteria);
+            return { affected: 1 };
+        }),
     } as unknown as Repository<MissionWork>;
-    return { repository, selected, predicates, parameters };
+    return { repository, selected, predicates, parameters, deleted };
 }
 
 describe('MissionWorkRepository Organization scope', () => {
-    it('returns relation ownership and constrains both relation and Work to the active Organization', async () => {
+    it('returns relation ownership, constrains the joined Work to the active Organization, and leaves the edge row to follow its validated Mission endpoint', async () => {
         const harness = queryHarness();
         const repository = new MissionWorkRepository(harness.repository);
 
@@ -53,8 +58,13 @@ describe('MissionWorkRepository Organization scope', () => {
                 'rel.organizationId AS "organizationId"',
             ]),
         );
-        expect(harness.predicates.join('\n')).toContain('rel.tenantId');
-        expect(harness.predicates.join('\n')).toContain('rel.organizationId');
+        // The edge row is a pure join keyed by its validated endpoints;
+        // filtering it by its own STAMP would hide legacy pre-stamping
+        // relations (upgrade-from-account backfills missions/works but not
+        // mission_works) from their own owner.
+        expect(harness.predicates.join('\n')).not.toContain('rel.tenantId');
+        expect(harness.predicates.join('\n')).not.toContain('rel.organizationId IS');
+        expect(harness.predicates.join('\n')).toContain('rel.userId');
         expect(harness.predicates.join('\n')).toContain('work.tenantId');
         expect(harness.predicates.join('\n')).toContain('work.organizationId');
         expect(Object.assign({}, ...harness.parameters)).toMatchObject({
@@ -72,8 +82,8 @@ describe('MissionWorkRepository Organization scope', () => {
             organizationId: null,
         });
 
-        expect(harness.predicates.join('\n')).toContain('rel.organizationId IS NULL');
         expect(harness.predicates.join('\n')).toContain('work.organizationId IS NULL');
+        expect(harness.predicates.join('\n')).not.toContain('rel.organizationId IS NULL');
     });
 
     it('constrains the reverse relation lookup and its Mission parent to the active Organization', async () => {
@@ -90,6 +100,7 @@ describe('MissionWorkRepository Organization scope', () => {
         );
         expect(harness.predicates.join('\n')).toContain('mission.tenantId');
         expect(harness.predicates.join('\n')).toContain('mission.organizationId');
+        expect(harness.predicates.join('\n')).not.toContain('rel.tenantId');
     });
 
     it('uses canonical IS NULL semantics for an Organization whose Tenant is null', async () => {
@@ -103,17 +114,17 @@ describe('MissionWorkRepository Organization scope', () => {
 
         const predicates = harness.predicates.join('\n');
         const parameters = Object.assign({}, ...harness.parameters);
-        expect(predicates).toContain('rel.tenantId IS NULL');
         expect(predicates).toContain('work.tenantId IS NULL');
+        expect(predicates).not.toContain('rel.tenantId IS NULL');
         expect(predicates).not.toContain('tenantId = :scopeTenantId');
         expect(parameters).not.toHaveProperty('scopeTenantId');
     });
 
-    it('builds scoped detach from portable property criteria with no scope object parameter', async () => {
+    it('detaches by the validated endpoint keys alone, never by the edge stamp', async () => {
         const harness = queryHarness();
         const repository = new MissionWorkRepository(harness.repository);
 
-        await repository.detach({
+        const removed = await repository.detach({
             missionId: 'mission-1',
             workId: 'work-1',
             userId: 'user-1',
@@ -121,21 +132,23 @@ describe('MissionWorkRepository Organization scope', () => {
             scope: EVER_SCOPE,
         });
 
-        expect(harness.repository.createQueryBuilder).toHaveBeenCalledWith();
-        expect(
-            (harness.repository.createQueryBuilder as jest.Mock).mock.results[0].value.where,
-        ).toHaveBeenCalledWith([
+        // The calling service already ownership-validated the Mission in the
+        // active scope; a stamp-filtered delete would leave a legacy
+        // (pre-stamping) edge of an in-scope Mission permanently
+        // un-detachable (404 forever).
+        expect(removed).toBe(true);
+        expect(harness.repository.createQueryBuilder).not.toHaveBeenCalled();
+        expect(harness.deleted).toEqual([
             {
                 missionId: 'mission-1',
                 workId: 'work-1',
                 userId: 'user-1',
                 relation: 'created',
-                ...EVER_SCOPE,
             },
         ]);
     });
 
-    it('emits portable quoted PostgreSQL detach SQL with only scalar ownership parameters', async () => {
+    it('issues the real detach as a plain criteria delete with only scalar endpoint keys', async () => {
         const dataSource = new DataSource({
             type: 'postgres',
             host: '127.0.0.1',
@@ -146,17 +159,11 @@ describe('MissionWorkRepository Organization scope', () => {
         });
         await (dataSource as unknown as { buildMetadatas(): Promise<void> }).buildMetadatas();
         const orm = dataSource.getRepository(MissionWork);
-        const query = orm.createQueryBuilder().delete().from(MissionWork);
-        let emitted: [string, unknown[]] | undefined;
-        let namedParameters: Record<string, unknown> | undefined;
-        jest.spyOn(query, 'execute').mockImplementation(async () => {
-            emitted = query.getQueryAndParameters();
-            namedParameters = query.getParameters();
+        const captured: unknown[] = [];
+        jest.spyOn(orm, 'delete').mockImplementation(async (criteria: unknown) => {
+            captured.push(criteria);
             return { affected: 1, raw: [] } as DeleteResult;
         });
-        jest.spyOn(orm, 'createQueryBuilder').mockReturnValue({
-            delete: jest.fn(() => query),
-        } as never);
 
         await new MissionWorkRepository(orm).detach({
             missionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
@@ -166,17 +173,17 @@ describe('MissionWorkRepository Organization scope', () => {
             scope: EVER_SCOPE,
         });
 
-        expect(emitted).toBeDefined();
-        expect(emitted![0]).toContain('"missionId"');
-        expect(emitted![0]).toContain('"workId"');
-        expect(emitted![0]).toContain('"userId"');
-        expect(emitted![0]).toContain('"tenantId"');
-        expect(emitted![0]).toContain('"organizationId"');
-        expect(emitted![1]).toHaveLength(6);
-        expect(Object.values(namedParameters ?? {})).toHaveLength(6);
-        expect(Object.values(namedParameters ?? {})).not.toContainEqual(EVER_SCOPE);
-        expect(
-            Object.values(namedParameters ?? {}).every((value) => typeof value === 'string'),
-        ).toBe(true);
+        expect(captured).toEqual([
+            {
+                missionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                workId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+                relation: 'created',
+            },
+        ]);
+        const criteria = captured[0] as Record<string, unknown>;
+        expect(criteria).not.toHaveProperty('tenantId');
+        expect(criteria).not.toHaveProperty('organizationId');
+        expect(Object.values(criteria).every((value) => typeof value === 'string')).toBe(true);
     });
 });

--- a/packages/agent/src/database/repositories/mission-work.repository.ts
+++ b/packages/agent/src/database/repositories/mission-work.repository.ts
@@ -2,12 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { MissionWork, type MissionWorkRelation } from '../../entities/mission-work.entity';
-import {
-    ownershipSqlPredicate,
-    ownershipWhere,
-    ownershipWhereWith,
-    type OwnershipScope,
-} from '../ownership-scope';
+import { ownershipSqlPredicate, type OwnershipScope } from '../ownership-scope';
 
 /** A mission_works row hydrated with the Work's display fields. */
 export interface MissionWorkWithWork {
@@ -79,20 +74,14 @@ export class MissionWorkRepository {
         relation: MissionWorkRelation;
         scope?: OwnershipScope;
     }): Promise<boolean> {
-        if (input.scope) {
-            const where = ownershipWhereWith<MissionWork>(input.userId, input.scope, {
-                missionId: input.missionId,
-                workId: input.workId,
-                relation: input.relation,
-            });
-            const res = await this.repository
-                .createQueryBuilder()
-                .delete()
-                .from(MissionWork)
-                .where(where)
-                .execute();
-            return (res.affected ?? 0) > 0;
-        }
+        // The edge is a pure join row: the calling service has already
+        // ownership-validated the Mission endpoint in the active scope, and
+        // the delete is confined by userId + both endpoint ids. Filtering by
+        // the edge row STAMP here would make a legacy (pre-stamping) edge of
+        // an in-scope Mission impossible to detach — the row predates scope
+        // stamping (and upgrade-from-account backfills missions/works but
+        // not mission_works), so the scoped delete matches nothing and the
+        // caller 404s forever.
         const res = await this.repository.delete({
             missionId: input.missionId,
             workId: input.workId,
@@ -124,7 +113,11 @@ export class MissionWorkRepository {
             ])
             .where('rel.missionId = :missionId AND rel.userId = :userId', { missionId, userId })
             .orderBy('rel.createdAt', 'DESC');
-        this.applyOwnershipScope(query, ['rel', 'work'], scope);
+        // Scope only the joined Work endpoint (fail-closed non-disclosure of
+        // out-of-scope Works); the edge row itself follows its validated
+        // Mission endpoint — see detach() for why filtering the edge STAMP
+        // hides legacy rows from their own owner.
+        this.applyOwnershipScope(query, ['work'], scope);
         return query.getRawMany<MissionWorkWithWork>();
     }
 
@@ -150,7 +143,8 @@ export class MissionWorkRepository {
             ])
             .where('rel.workId = :workId AND rel.userId = :userId', { workId, userId })
             .orderBy('rel.createdAt', 'DESC');
-        this.applyOwnershipScope(query, ['rel', 'mission'], scope);
+        // Scope only the joined Mission endpoint — same rationale as above.
+        this.applyOwnershipScope(query, ['mission'], scope);
         return query.getRawMany<MissionWorkWithMission>();
     }
 
@@ -160,13 +154,14 @@ export class MissionWorkRepository {
         userId: string,
         scope?: OwnershipScope,
     ): Promise<string[]> {
+        // Edge rows follow their endpoints; the ids returned here feed a
+        // mission query that is itself scope-filtered, so nothing
+        // out-of-scope is disclosed by leaving the edge stamp out of the
+        // predicate (a scoped predicate would hide legacy pre-stamping
+        // edges from the workId filter).
+        void scope;
         const rows = await this.repository.find({
-            where: scope
-                ? ownershipWhere<MissionWork>(userId, scope).map((branch) => ({
-                      ...branch,
-                      workId,
-                  }))
-                : { workId, userId },
+            where: { workId, userId },
             select: { missionId: true },
         });
         return [...new Set(rows.map((r) => r.missionId))];

--- a/packages/agent/src/fleet/__tests__/fleet-agent-node-affinity.repository.integration.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-agent-node-affinity.repository.integration.spec.ts
@@ -203,7 +203,9 @@ describe('fleet agent node affinity — repository integration (better-sqlite3)'
 
         const forA = await jobs.findQueuedForNode(ownerId, NODE_A, 10);
         expect(forA).toHaveLength(7);
-        expect(forA.every((job) => job.targetNodeId === NODE_A || job.targetNodeId === null)).toBe(true);
+        expect(forA.every((job) => job.targetNodeId === NODE_A || job.targetNodeId === null)).toBe(
+            true,
+        );
         expect(forA.some((job) => job.id === strangers.id)).toBe(false);
     });
 });

--- a/packages/agent/src/fleet/__tests__/fleet-agent-node-affinity.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-agent-node-affinity.service.spec.ts
@@ -76,7 +76,11 @@ function makeService(stores: Stores): FleetAgentNodeAffinityService {
             const before = stores.affinities.length;
             stores.affinities = stores.affinities.filter(
                 (row) =>
-                    !(row.userId === userId && row.organizationId === organizationId && row.agentId === agentId),
+                    !(
+                        row.userId === userId &&
+                        row.organizationId === organizationId &&
+                        row.agentId === agentId
+                    ),
             );
             return stores.affinities.length < before;
         }),

--- a/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
@@ -205,7 +205,9 @@ function makeRepos(stores: Stores): {
     const findForAgent = async (userId: string, organizationId: string, agentId: string) =>
         stores.affinities.find(
             (row) =>
-                row.userId === userId && row.organizationId === organizationId && row.agentId === agentId,
+                row.userId === userId &&
+                row.organizationId === organizationId &&
+                row.agentId === agentId,
         ) ?? null;
     const affinities = {
         findForAgent: jest.fn(findForAgent),
@@ -420,7 +422,9 @@ describe('FleetJobService', () => {
             } as FleetAgentNodeAffinity);
 
             await expect(service.resolveAgentTaskTarget('owner-1', AGENT)).resolves.toBe(NODE_B);
-            await expect(service.resolveAgentTaskTarget('owner-1', 'not-a-uuid')).resolves.toBeNull();
+            await expect(
+                service.resolveAgentTaskTarget('owner-1', 'not-a-uuid'),
+            ).resolves.toBeNull();
             await expect(service.resolveAgentTaskTarget('owner-1', undefined)).resolves.toBeNull();
             const job = await service.enqueue({
                 userId: 'owner-1',

--- a/packages/agent/src/fleet/fleet-agent-node-affinity.repository.ts
+++ b/packages/agent/src/fleet/fleet-agent-node-affinity.repository.ts
@@ -41,7 +41,10 @@ export class FleetAgentNodeAffinityRepository {
      * Null when the Agent is not owned by `userId`, has no Organization
      * (personal scope — bindings are never written there), or is unbound.
      */
-    async findForOwnedAgent(userId: string, agentId: string): Promise<FleetAgentNodeAffinity | null> {
+    async findForOwnedAgent(
+        userId: string,
+        agentId: string,
+    ): Promise<FleetAgentNodeAffinity | null> {
         const agent = await this.agents.findOne({
             where: { id: agentId, userId },
             select: { id: true, organizationId: true },

--- a/packages/agent/src/goals/__tests__/goals.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goals.service.spec.ts
@@ -33,12 +33,10 @@ function makeRepo(prefix: string) {
     ) => {
         if (Array.isArray(where)) return where.some((branch) => matches(row, branch));
         return Object.entries(where).every(([k, value]) => {
-            if (
-                typeof value === 'object' &&
-                value !== null &&
-                (value as { _type?: string })._type === 'isNull'
-            ) {
-                return row[k] == null;
+            if (typeof value === 'object' && value !== null) {
+                const op = value as { _type?: string; _value?: unknown };
+                if (op._type === 'isNull') return row[k] == null;
+                if (op._type === 'in') return (op._value as unknown[]).includes(row[k]);
             }
             return row[k] === value;
         });
@@ -367,6 +365,92 @@ describe('GoalsService', () => {
             missionsRepo._rows.push({ id: 'm1', userId: 'u1' });
             goalsRepo._rows.push(makeGoalRow({ id: 'gA', userId: 'u1' }));
             goalsRepo._rows.push(makeGoalRow({ id: 'gB', userId: 'u1' }));
+        });
+
+        it('demotes a legacy (pre-stamping) primary edge when promoting under an Organization scope', async () => {
+            const EVER = { tenantId: 't-ever', organizationId: 'o-ever' };
+            missionsRepo._rows.push({ id: 'm-ever', userId: 'u1', ...EVER });
+            goalsRepo._rows.push(makeGoalRow({ id: 'gEver', userId: 'u1', ...EVER } as never));
+            // Edge created before scope stamping: null/null yet still the
+            // Mission's primary. The one-primary invariant (and the Postgres
+            // partial unique index uq_mission_goals_primary) is per-MISSION
+            // and knows nothing about stamps, so the demotion query must see
+            // this row - a scope-filtered demote would miss it and the new
+            // primary's save would hit the index and 500.
+            missionGoalsRepo._rows.push({
+                id: 'edge-legacy',
+                missionId: 'm-ever',
+                goalId: 'gA',
+                userId: 'u1',
+                isPrimary: true,
+                tenantId: null,
+                organizationId: null,
+                createdAt: new Date('2026-07-19T00:00:00.000Z'),
+            });
+
+            const link = await service.linkToMission('u1', 'm-ever', 'gEver', true, EVER);
+            expect(link.isPrimary).toBe(true);
+            expect(missionGoalsRepo._rows.find((r) => r.id === 'edge-legacy')?.isPrimary).toBe(
+                false,
+            );
+            expect(
+                missionGoalsRepo._rows.filter((r) => r.missionId === 'm-ever' && r.isPrimary),
+            ).toHaveLength(1);
+        });
+
+        it('lists and unlinks a legacy (pre-stamping) edge of an in-scope Mission and Goal', async () => {
+            const EVER = { tenantId: 't-ever', organizationId: 'o-ever' };
+            missionsRepo._rows.push({ id: 'm-ever', userId: 'u1', ...EVER });
+            goalsRepo._rows.push(makeGoalRow({ id: 'gEver', userId: 'u1', ...EVER } as never));
+            missionGoalsRepo._rows.push({
+                id: 'edge-legacy',
+                missionId: 'm-ever',
+                goalId: 'gEver',
+                userId: 'u1',
+                isPrimary: false,
+                tenantId: null,
+                organizationId: null,
+                createdAt: new Date('2026-07-19T00:00:00.000Z'),
+            });
+
+            // Both endpoints are visible in the active scope; the edge is a
+            // pure join row and must follow them, not its own stamp
+            // (upgrade-from-account backfills missions but not
+            // mission_goals).
+            const links = await service.listForMission('u1', 'm-ever', EVER);
+            expect(links).toHaveLength(1);
+            expect(links[0]).toMatchObject({ goalId: 'gEver', missionId: 'm-ever' });
+
+            await expect(service.unlinkFromMission('u1', 'm-ever', 'gEver', EVER)).resolves.toEqual(
+                { deleted: true },
+            );
+            expect(missionGoalsRepo._rows.find((r) => r.id === 'edge-legacy')).toBeUndefined();
+        });
+
+        it('hides a link whose Goal is not visible in the active scope (no goalId disclosure)', async () => {
+            const EVER = { tenantId: 't-ever', organizationId: 'o-ever' };
+            missionsRepo._rows.push({ id: 'm-ever', userId: 'u1', ...EVER });
+            // The linked Goal lives in ANOTHER workspace of the same user.
+            goalsRepo._rows.push(
+                makeGoalRow({
+                    id: 'gYo',
+                    userId: 'u1',
+                    tenantId: 't-ever',
+                    organizationId: 'o-yo',
+                } as never),
+            );
+            missionGoalsRepo._rows.push({
+                id: 'edge-cross',
+                missionId: 'm-ever',
+                goalId: 'gYo',
+                userId: 'u1',
+                isPrimary: false,
+                tenantId: 't-ever',
+                organizationId: 'o-yo',
+                createdAt: new Date('2026-07-19T00:00:00.000Z'),
+            });
+
+            await expect(service.listForMission('u1', 'm-ever', EVER)).resolves.toEqual([]);
         });
 
         it('promoting a second primary demotes the prior primary edge', async () => {

--- a/packages/agent/src/goals/goals.service.ts
+++ b/packages/agent/src/goals/goals.service.ts
@@ -349,8 +349,16 @@ export class GoalsService {
         scope?: OwnershipScope,
     ): Promise<MissionGoalLinkDto[]> {
         await this.findMissionOrThrow(userId, missionId, scope);
+        // The edge row is a pure join keyed by its ownership-validated
+        // endpoints — do NOT re-filter it by its own stamp: edges created
+        // before scope stamping (and edges of an upgraded-from-account
+        // Mission, whose backfill covers `missions` but not `mission_goals`)
+        // would silently vanish from an in-scope Mission and become
+        // impossible to manage. Link visibility instead follows the GOAL
+        // endpoint below: a link whose Goal is not visible in the current
+        // scope is dropped, so out-of-scope goalIds still are not disclosed.
         const links = await this.missionGoals.find({
-            where: ownershipWhereWith<MissionGoal>(userId, scope, { missionId }),
+            where: { userId, missionId },
             order: { createdAt: 'ASC' },
         });
         if (links.length === 0) return [];
@@ -360,7 +368,9 @@ export class GoalsService {
             }),
         });
         const byId = new Map(goalRows.map((g) => [g.id, g]));
-        return links.map((link) => toMissionGoalLinkDto(link, byId.get(link.goalId) ?? null));
+        return links
+            .filter((link) => byId.has(link.goalId))
+            .map((link) => toMissionGoalLinkDto(link, byId.get(link.goalId) ?? null));
     }
 
     /**
@@ -386,12 +396,16 @@ export class GoalsService {
 
         if (isPrimary) {
             // Demote-before-promote so the Postgres partial unique
-            // index never sees two primaries.
+            // index never sees two primaries. The index
+            // (`uq_mission_goals_primary`) is per-MISSION and knows nothing
+            // about scope stamps, so the demotion query must not be
+            // scope-filtered either: a legacy (null/null-stamped) primary
+            // edge that the current scope's filter cannot see would
+            // otherwise survive, and saving the new primary would hit the
+            // index and 500 instead of demoting. The Mission was
+            // ownership-validated above; `userId` confines the write.
             const currentPrimaries = await this.missionGoals.find({
-                where: ownershipWhereWith<MissionGoal>(userId, scope, {
-                    missionId,
-                    isPrimary: true,
-                }),
+                where: { userId, missionId, isPrimary: true },
             });
             await Promise.all(
                 currentPrimaries.map((primary) => {
@@ -401,7 +415,12 @@ export class GoalsService {
             );
         }
 
-        const linkWhere = ownershipWhereWith<MissionGoal>(userId, scope, { missionId, goalId });
+        // Both endpoints were ownership-validated above; the edge itself is
+        // keyed by them. A scope filter here would make a legacy
+        // (pre-stamping) edge invisible, so the create below would hit the
+        // unique (missionId, goalId) index and the duplicate-recovery
+        // re-read would ALSO miss it and rethrow a 500.
+        const linkWhere = { userId, missionId, goalId };
         let link = await this.missionGoals.findOne({ where: linkWhere });
         if (link) {
             if (link.isPrimary !== isPrimary) {
@@ -452,8 +471,11 @@ export class GoalsService {
     ): Promise<{ deleted: true }> {
         await this.findMissionOrThrow(userId, missionId, scope);
         await this.findOrThrow(userId, goalId, scope);
+        // Endpoints validated above; do not scope-filter the edge itself or
+        // a legacy (pre-stamping) link of an in-scope pair becomes
+        // impossible to unlink.
         const link = await this.missionGoals.findOne({
-            where: ownershipWhereWith<MissionGoal>(userId, scope, { missionId, goalId }),
+            where: { userId, missionId, goalId },
         });
         if (!link) {
             throw new NotFoundException(`Goal link not found`);

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -543,17 +543,18 @@ export class MissionsService {
     ): Promise<MissionAttachment[]> {
         await this.findOrThrow(userId, missionId, scope);
         if (!this.missionAttachments) return [];
-        const rows = await this.missionAttachments.findByMissionId(missionId);
-        if (rows.length === 0 || !this.uploadsRepo) return rows;
-        const uploads = await this.uploadsRepo.find({
-            where: ownershipWhereWith<UserUpload>(userId, scope, {
-                sha256: In(rows.map((row) => row.uploadId)),
-            }),
-        });
-        if (new Set(rows.map((row) => row.uploadId)).size !== uploads.length) {
-            throw new NotFoundException(`Attachment not found`);
-        }
-        return rows;
+        // The Mission itself is the authority: it was ownership-validated
+        // above, and an attachment row carries only (missionId, uploadId)
+        // where uploadId is a hash the caller supplied at attach time — no
+        // cross-user or cross-Organization data can leak through it. Do NOT
+        // re-filter (or fail) the list against the caller's `user_uploads`
+        // visibility in the CURRENT scope: legacy rows pre-date scope
+        // stamping (upgrade-from-account backfills `missions` but not
+        // `user_uploads`), and pre-fix rows may be stored uppercase — either
+        // would 404 the owner's entire attachment list of an in-scope
+        // Mission and make individual attachments impossible to discover
+        // and remove.
+        return this.missionAttachments.findByMissionId(missionId);
     }
 
     /**
@@ -572,13 +573,19 @@ export class MissionsService {
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
+        // Canonicalize ONCE and use the canonical value for the ownership
+        // lookup, persistence, and duplicate recovery alike (mirrors
+        // AgentsService.addAttachment). `user_uploads.sha256` is stored
+        // lowercase, so persisting a raw uppercase input would create an
+        // attachment edge the upload join can never resolve again.
+        const canonicalUploadId = uploadId.toLowerCase();
         // Security: the uploadId must reference a real upload owned by the
         // caller (404 — don't leak existence). Closes the dangling/foreign
         // attachment edge the hunt found.
         if (this.uploadsRepo) {
             const owned = await this.uploadsRepo.findOne({
                 where: ownershipWhereWith<UserUpload>(userId, scope, {
-                    sha256: uploadId.toLowerCase(),
+                    sha256: canonicalUploadId,
                 }),
             });
             if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
@@ -589,13 +596,13 @@ export class MissionsService {
             );
         }
         try {
-            return await this.missionAttachments.add(missionId, uploadId);
+            return await this.missionAttachments.add(missionId, canonicalUploadId);
         } catch (err) {
             // Duplicate (missionId, uploadId) — swallow and re-read.
             // Mirrors the idempotency contract on Task attachments.
             if (err instanceof Error && /duplicate key|unique constraint/i.test(err.message)) {
                 const existing = (await this.missionAttachments.findByMissionId(missionId)).find(
-                    (a) => a.uploadId === uploadId,
+                    (a) => a.uploadId === canonicalUploadId,
                 );
                 if (existing) return existing;
             }

--- a/packages/agent/src/organization-ownership-scoping.spec.ts
+++ b/packages/agent/src/organization-ownership-scoping.spec.ts
@@ -277,9 +277,16 @@ describe('Organization ownership scoping', () => {
                 uploads as never,
             );
 
-            await expect(
-                service.listAttachments('user-1', ownedAgent.id, EVER_SCOPE),
-            ).rejects.toBeInstanceOf(NotFoundException);
+            // The Agent endpoint was ownership-validated; the edge row itself
+            // carries only the hash the caller attached. The Yo upload's
+            // metadata must not leak, but the list must not fail either
+            // (legacy pre-stamping uploads would otherwise 404 the owner's
+            // whole list) - the row comes back UN-ENRICHED.
+            const rows = await service.listAttachments('user-1', ownedAgent.id, EVER_SCOPE);
+            expect(rows).toHaveLength(1);
+            expect(rows[0]).toMatchObject({ id: 'edge-1', uploadId: uploadSha });
+            expect(rows[0]).not.toHaveProperty('url');
+            expect(rows[0]).not.toHaveProperty('filename');
         });
 
         it('404s an Ever Mission attachment whose upload hash belongs to Yo', async () => {
@@ -336,9 +343,45 @@ describe('Organization ownership scoping', () => {
                 uploads as never,
             );
 
+            // Same contract as the Agent twin: the validated Mission is the
+            // authority; a same-user upload row that is invisible in the
+            // CURRENT scope neither leaks metadata (none is joined here) nor
+            // fails the owner's whole attachment list.
             await expect(
                 service.listAttachments('user-1', ownedMission.id, EVER_SCOPE),
-            ).rejects.toBeInstanceOf(NotFoundException);
+            ).resolves.toEqual([expect.objectContaining({ id: 'edge-yo', uploadId: uploadSha })]);
+        });
+
+        it('persists a canonical lowercase Mission attachment hash for an uppercase input', async () => {
+            const ownedMission = mission({ id: 'mission-ever', ...EVER_SCOPE });
+            const edge = { id: 'edge-up', missionId: ownedMission.id, uploadId: uploadSha };
+            const attachments = { add: jest.fn(async () => edge) };
+            const ownedUpload = { sha256: uploadSha, userId: 'user-1', ...EVER_SCOPE };
+            const uploads = {
+                findOne: jest.fn(
+                    async (options: { where?: FindOptionsWhere<typeof ownedUpload> }) =>
+                        matchesWhere(ownedUpload, options.where) ? ownedUpload : null,
+                ),
+            };
+            const service = new MissionsService(
+                { findOne: jest.fn(async () => ownedMission) } as never,
+                new TitlerService(),
+                undefined,
+                attachments as never,
+                uploads as never,
+            );
+
+            await service.addAttachment(
+                'user-1',
+                ownedMission.id,
+                uploadSha.toUpperCase(),
+                EVER_SCOPE,
+            );
+
+            // user_uploads.sha256 is stored lowercase; persisting the raw
+            // uppercase input would create an edge the upload join (and the
+            // duplicate-recovery re-read) could never resolve again.
+            expect(attachments.add).toHaveBeenCalledWith(ownedMission.id, uploadSha);
         });
 
         it('keeps legacy personal Agent attachment metadata and URL readable', async () => {

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -1,8 +1,5 @@
 import { Logger } from '@nestjs/common';
-import {
-    CreditLedgerService,
-    InsufficientCreditsError,
-} from './credit-ledger.service';
+import { CreditLedgerService, InsufficientCreditsError } from './credit-ledger.service';
 import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
 
 /**


### PR DESCRIPTION
## What

Follow-up to the merged #2151/#2152 organization-scope work, fixing the three defects that survived a multi-lens adversarial review of the exact merged heads (details in [this #2151 comment](https://github.com/ever-works/ever-works/pull/2151#issuecomment-5388706384)), plus one mechanical commit that unbreaks CI for every branch.

**Commit 1 — `fix(scope)`:** `mission_goals` / `mission_works` edges and the Mission/Agent attachment lists were re-filtered (or whole-list-404'd) by the EDGE row's own tenant/organization stamp. Edge rows predate scope stamping and none of `mission_goals`, `mission_works`, `mission_attachments`, `agent_attachments`, `user_uploads` is in any upgrade-from-account backfill list, so an in-scope Mission's own links/works/attachments vanished, could not be unlinked/detached, and promoting a new primary Goal could 500 against `uq_mission_goals_primary` instead of demoting. Also canonicalizes the Mission attachment hash (the Agent twin was fixed in `01b6b68bd`, the Mission twin was not — an uppercase input persisted an edge the upload join could never resolve again).

Non-disclosure is preserved: link visibility still follows the ownership-validated **endpoints** (an out-of-scope Goal hides its link; the joined Work/Mission alias predicates stay), and attachment rows return un-enriched rather than leaking foreign-scope upload metadata.

**Commit 2 — `style`:** the 2026-08-23 merge sweep landed 9 files failing `format:check`, so `lint-and-test (22.x)` — the only required check — is red on `develop`, `stage`, `main` and every open PR. Pure `prettier --write`.

## Verification

- 11 regression tests run RED against the pre-fix code and GREEN with it (revert-proven)
- full `@ever-works/agent` suite: 545/545 suites, 9,756 passed / 3 skipped
- focused API (organization-ownership, missions, goals, agents, uploads): 16 suites / 278 passed
- agent + API type-checks green

## Safety

Code/tests only — no migration, no schema, no data, no deploy. Rollback = revert the two commits.

@ integration lane `01a02f95`: per the maintenance board, this PR is yours to take into the next cascade — I am not self-merging while you hold the exclusive lane.