### PR TITLE
fix(scope): preserve agent task ownership stamps

### DIFF
--- a/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
@@ -292,7 +292,7 @@ describe('AgentExportService', () => {
             );
         });
 
-        it('does not overwrite the same logical slug in another active Organization', async () => {
+        it('returns a generic conflict instead of overwriting the same database slug in another Organization', async () => {
             const everScope = {
                 tenantId: '11111111-1111-4111-8111-111111111111',
                 organizationId: '22222222-2222-4222-8222-222222222222',
@@ -303,26 +303,49 @@ describe('AgentExportService', () => {
                 tenantId: everScope.tenantId,
                 organizationId: '33333333-3333-4333-8333-333333333333',
             });
-            agents.findByUserIdAndSlug.mockImplementation(async (...args: unknown[]) =>
-                (args[4] as typeof everScope | undefined)?.organizationId ===
-                everScope.organizationId
-                    ? null
-                    : hidden,
-            );
-            agents.findByIdAndUser.mockResolvedValue(hidden);
+            agents.findByUserIdAndSlug.mockResolvedValue(hidden);
+            agents.findByIdAndUser.mockResolvedValue(null);
+
+            await expect(
+                (svc.importOne as any)(
+                    'u1',
+                    baseEnvelope(),
+                    { onConflict: 'overwrite' },
+                    everScope,
+                ),
+            ).rejects.toThrow(ConflictException);
+
+            expect(agents.updateById).not.toHaveBeenCalled();
+            expect(agents.create).not.toHaveBeenCalled();
+            expect(hidden.name).toBe('Yo CEO');
+        });
+
+        it('auto-renames around a hidden same-slug Agent and preserves the active Organization stamp', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            agents.findByUserIdAndSlug
+                .mockResolvedValueOnce(makeAgent({ id: 'hidden-ceo', slug: 'ceo' }))
+                .mockResolvedValueOnce(null);
             agents.create.mockImplementation(async (partial: Partial<Agent>) => makeAgent(partial));
 
             const result = await (svc.importOne as any)(
                 'u1',
                 baseEnvelope(),
-                { onConflict: 'overwrite' },
+                { onConflict: 'rename' },
                 everScope,
             );
 
-            expect(result.conflictResolution).toBe('none');
-            expect(result.created).toMatchObject(everScope);
+            expect(result).toMatchObject({
+                conflictResolution: 'renamed',
+                originalSlug: 'ceo',
+                finalSlug: 'ceo-2',
+            });
+            expect(agents.create).toHaveBeenCalledWith(
+                expect.objectContaining({ ...everScope, slug: 'ceo-2' }),
+            );
             expect(agents.updateById).not.toHaveBeenCalled();
-            expect(hidden.name).toBe('Yo CEO');
         });
 
         it('rejects secret in any file body', async () => {

--- a/packages/agent/src/agents/agent-export.service.ts
+++ b/packages/agent/src/agents/agent-export.service.ts
@@ -28,6 +28,7 @@ import { WorkProposal } from '../entities/work-proposal.entity';
 import { AgentRepository } from '../database/repositories/agent.repository';
 import {
     ownershipStamp,
+    ownershipScopeMatches,
     ownershipWhereWith,
     type OwnershipScope,
 } from '../database/ownership-scope';
@@ -419,6 +420,16 @@ export class AgentExportService {
                     `Agent with slug "${originalSlug}" already exists in this scope — skip mode.`,
                 );
             } else if (mode === 'overwrite') {
+                // The uniqueness probe intentionally sees same-user rows in
+                // every Organization because the durable index does too. An
+                // overwrite, however, is an ownership-sensitive mutation:
+                // re-resolve through the active scope and return the same
+                // generic conflict when the colliding row is hidden.
+                if (!ownershipScopeMatches(conflict, ownershipScope)) {
+                    throw new ConflictException(
+                        `Agent with slug "${originalSlug}" already exists in this scope.`,
+                    );
+                }
                 await this.applyEnvelopeToExisting(conflict, envelope);
                 conflictResolution = 'overwritten';
                 const refreshed = (await this.agents.findByIdAndUser(

--- a/packages/agent/src/database/repositories/__tests__/agent.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/agent.repository.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AgentRepository } from '../agent.repository';
-import { Agent, AgentStatus } from '../../../entities/agent.entity';
+import { Agent, AgentScope, AgentStatus } from '../../../entities/agent.entity';
 
 /**
  * Repository tests for the CAS-claim primitive used by the heartbeat
@@ -72,6 +72,33 @@ describe('AgentRepository', () => {
         }).compile();
 
         repo = module.get(AgentRepository);
+    });
+
+    describe('findByUserIdAndSlug (durable uniqueness)', () => {
+        it('checks the unscoped database key across Organizations without returning a broader catalog', async () => {
+            inner.findOne.mockResolvedValueOnce(null);
+
+            await repo.findByUserIdAndSlug(
+                'user-1',
+                AgentScope.TENANT,
+                'ceo',
+                {},
+                {
+                    tenantId: '11111111-1111-4111-8111-111111111111',
+                    organizationId: '22222222-2222-4222-8222-222222222222',
+                },
+            );
+
+            const [{ where }] = inner.findOne.mock.calls[0];
+            expect(Array.isArray(where)).toBe(false);
+            expect(where).toMatchObject({
+                userId: 'user-1',
+                scope: AgentScope.TENANT,
+                slug: 'ceo',
+            });
+            expect(where).not.toHaveProperty('tenantId');
+            expect(where).not.toHaveProperty('organizationId');
+        });
     });
 
     describe('tryClaimForRun (CAS pattern)', () => {

--- a/packages/agent/src/database/repositories/agent.repository.ts
+++ b/packages/agent/src/database/repositories/agent.repository.ts
@@ -83,16 +83,19 @@ export class AgentRepository {
     }
 
     /**
-     * Uniqueness check used by `AgentService.create`. Honors scope —
-     * a tenant-scoped CEO and a Mission-scoped CEO are distinct rows
-     * (matches `uq_agents_user_scope_slug`).
+     * Uniqueness check used by `AgentService.create`. This intentionally
+     * follows the durable database key, which is global to the user + Agent
+     * scope and does not include Tenant/Organization columns. Catalog and
+     * id lookups remain ownership-scoped; this probe may only drive a generic
+     * conflict/rename decision and must never expose or mutate the found row
+     * without a separate scoped lookup.
      */
     async findByUserIdAndSlug(
         userId: string,
         scope: AgentScope,
         slug: string,
         opts: { missionId?: string | null; ideaId?: string | null; workId?: string | null } = {},
-        ownershipScope?: OwnershipScope,
+        _ownershipScope?: OwnershipScope,
     ): Promise<Agent | null> {
         const common: FindOptionsWhere<Agent> = {
             scope,
@@ -101,14 +104,7 @@ export class AgentRepository {
             ideaId: opts.ideaId ?? IsNull(),
             workId: opts.workId ?? IsNull(),
         };
-        return this.repository.findOne({
-            where: ownershipScope
-                ? ownershipWhere<Agent>(userId, ownershipScope).map((branch) => ({
-                      ...branch,
-                      ...common,
-                  }))
-                : { userId, ...common },
-        });
+        return this.repository.findOne({ where: { userId, ...common } });
     }
 
     async findByUserIdScoped(

--- a/packages/agent/src/tasks-domain/agent-task-tools.spec.ts
+++ b/packages/agent/src/tasks-domain/agent-task-tools.spec.ts
@@ -1,0 +1,43 @@
+import { AgentScope } from '../entities/agent.entity';
+import type { Agent } from '../entities/agent.entity';
+import { buildAgentTaskTools } from './agent-task-tools';
+import type { TasksService } from './tasks.service';
+import type { TaskChatService } from './task-chat.service';
+
+describe('buildAgentTaskTools createTask ownership', () => {
+    it('stamps a Task from the persisted organization-scoped Agent', async () => {
+        const tasksService = {
+            create: jest.fn().mockResolvedValue({ id: 'task-1', slug: 'ship-fix' }),
+        } as unknown as TasksService;
+        const agent = {
+            id: 'agent-1',
+            userId: 'user-1',
+            scope: AgentScope.WORK,
+            workId: 'work-1',
+            tenantId: '11111111-1111-4111-8111-111111111111',
+            organizationId: '22222222-2222-4222-8222-222222222222',
+            permissions: { canAssignTasks: true },
+        } as Agent;
+        const [createTask] = buildAgentTaskTools({
+            agent,
+            tasksService,
+            chatService: {} as TaskChatService,
+        });
+
+        await createTask.invoke({ title: 'Ship fix' });
+
+        expect(tasksService.create).toHaveBeenCalledWith(
+            'user-1',
+            expect.objectContaining({
+                title: 'Ship fix',
+                workId: 'work-1',
+                createdByType: 'agent',
+                createdById: 'agent-1',
+            }),
+            {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            },
+        );
+    });
+});

--- a/packages/agent/src/tasks-domain/agent-task-tools.ts
+++ b/packages/agent/src/tasks-domain/agent-task-tools.ts
@@ -7,6 +7,7 @@ import type {
     TaskApproverRepository,
 } from '../database/repositories/task-side.repositories';
 import type { TaskStatus } from '../entities/task.entity';
+import { ownershipScopeOf } from '../database/ownership-scope';
 
 /**
  * Tasks feature — Phase 16.2 / 16.3 / 16.4.
@@ -109,17 +110,21 @@ export function buildAgentTaskTools(args: {
             invoke: async (raw) => {
                 const a = raw as CreateTaskArgs;
                 try {
-                    const created = await args.tasksService.create(args.agent.userId, {
-                        title: a.title,
-                        description: a.description ?? null,
-                        priority: a.priority as any,
-                        missionId: args.agent.missionId ?? null,
-                        ideaId: args.agent.ideaId ?? null,
-                        workId: args.agent.workId ?? null,
-                        parentTaskId: a.parentTaskId ?? null,
-                        createdByType: 'agent',
-                        createdById: args.agent.id,
-                    });
+                    const created = await args.tasksService.create(
+                        args.agent.userId,
+                        {
+                            title: a.title,
+                            description: a.description ?? null,
+                            priority: a.priority as any,
+                            missionId: args.agent.missionId ?? null,
+                            ideaId: args.agent.ideaId ?? null,
+                            workId: args.agent.workId ?? null,
+                            parentTaskId: a.parentTaskId ?? null,
+                            createdByType: 'agent',
+                            createdById: args.agent.id,
+                        },
+                        ownershipScopeOf(args.agent),
+                    );
                     return { id: created.id, slug: created.slug };
                 } catch (err) {
                     return { error: err instanceof Error ? err.message : String(err) };

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -207,6 +207,8 @@ const OWNER = '11111111-1111-4111-8111-111111111111';
 const AGENT_ID = '22222222-2222-4222-8222-222222222222';
 const OWNED_TASK_ID = '33333333-3333-4333-8333-333333333333';
 const FOREIGN_TASK_ID = '44444444-4444-4444-8444-444444444444';
+const TENANT_ID = '55555555-5555-4555-8555-555555555555';
+const ORGANIZATION_ID = '66666666-6666-4666-8666-666666666666';
 
 describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
     let appContext: {
@@ -362,7 +364,14 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
         // rejected by TasksService.getOne exactly like the real
         // `findByIdAndUser` lookup (throws NotFoundException).
         agents.findByIdAndUser.mockImplementation(async (agentId: string, userId: string) =>
-            agentId === AGENT_ID && userId === OWNER ? { id: AGENT_ID, userId: OWNER } : null,
+            agentId === AGENT_ID && userId === OWNER
+                ? {
+                      id: AGENT_ID,
+                      userId: OWNER,
+                      tenantId: TENANT_ID,
+                      organizationId: ORGANIZATION_ID,
+                  }
+                : null,
         );
         tasks.getOne.mockImplementation(async (userId: string, taskId: string) => {
             if (userId === OWNER && taskId === OWNED_TASK_ID) {
@@ -377,6 +386,8 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                     missionId: null,
                     ideaId: null,
                     workId: null,
+                    tenantId: TENANT_ID,
+                    organizationId: ORGANIZATION_ID,
                 };
             }
             throw new Error(`Task ${taskId} not found.`);
@@ -466,6 +477,8 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 taskId: OWNED_TASK_ID,
                 // Wave 4 M1 — workId denorm at creation (owner-scoped taskRow).
                 workId: null,
+                tenantId: TENANT_ID,
+                organizationId: ORGANIZATION_ID,
             });
             // Null here only because this call omits the Trigger.dev run
             // params; see the ctx test below for the real-runtime path.
@@ -485,6 +498,32 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 taskId: OWNED_TASK_ID,
                 runId: 'run-1',
             });
+        });
+
+        it('does not combine a personal Task tenant stamp with the Agent Organization stamp', async () => {
+            tasks.getOne.mockResolvedValueOnce({
+                id: OWNED_TASK_ID,
+                slug: 'personal-task',
+                title: 'Personal Task',
+                description: null,
+                status: 'in_progress',
+                priority: 'medium',
+                labels: [],
+                missionId: null,
+                ideaId: null,
+                workId: null,
+                tenantId: TENANT_ID,
+                organizationId: null,
+            });
+
+            await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tenantId: TENANT_ID,
+                    organizationId: null,
+                }),
+            );
         });
 
         it('feeds the owned task fields into the agent immediateInput', async () => {
@@ -897,7 +936,9 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
 
                 const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
 
-                expect(runner.checkBudget).toHaveBeenCalledWith({ id: AGENT_ID, userId: OWNER });
+                expect(runner.checkBudget).toHaveBeenCalledWith(
+                    expect.objectContaining({ id: AGENT_ID, userId: OWNER }),
+                );
                 expect(runner.execute).toHaveBeenCalledTimes(1); // no iterate spend
                 expect(gateRunner.runChecks).toHaveBeenCalledTimes(1);
                 expect(taskWorkspace.finalizeRun).not.toHaveBeenCalled();

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -391,6 +391,13 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 // (`TaskTransitionService.dispatchAgentRun`, the drain, or
                 // assign-task); re-admitting here could only refuse work
                 // already in flight and strand it with no run row.
+                // A non-null field means the Task carries an explicit
+                // ownership stamp. Select that stamp as one unit: null
+                // organizationId is meaningful personal scope and must not
+                // be filled from an Organization-scoped Agent. Legacy Tasks
+                // with both columns null inherit the persisted Agent stamp.
+                const runOwnership =
+                    taskRow.tenantId != null || taskRow.organizationId != null ? taskRow : agent;
                 run = await runs.createQueued({
                     agentId: agent.id,
                     userId: agent.userId,
@@ -399,6 +406,11 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     // Wave 4 M1 — workId denorm at creation (owner-scoped
                     // taskRow resolved above).
                     workId: taskRow.workId ?? null,
+                    // Trigger workers have no request ALS. Prefer the
+                    // authoritative persisted Task stamp and fall back to the
+                    // persisted Agent stamp only for legacy unstamped Tasks.
+                    tenantId: runOwnership.tenantId ?? null,
+                    organizationId: runOwnership.organizationId ?? null,
                 });
                 // Kanban run cockpit — on-the-fly creation (dispatcher row was
                 // never found), mirror it exactly like the fan-out path does.


### PR DESCRIPTION
## Summary
- align Agent slug collision probes with the unscoped durable unique key while keeping catalog visibility and overwrite mutations ownership-scoped
- stamp Tasks created by organization-scoped Agents
- stamp fallback AgentRuns atomically from the persisted Task scope, falling back to the Agent only for legacy unstamped Tasks

## Verification
- pnpm --filter @ever-works/agent exec jest src/database/repositories/__tests__/agent.repository.spec.ts src/agents/__tests__/agent-export.service.spec.ts src/tasks-domain/agent-task-tools.spec.ts src/agents/__tests__/agents.service.spec.ts --runInBand (83 passed)
- pnpm --filter @ever-works/trigger-tasks exec vitest run src/__tests__/agent-task-execute.task.spec.ts (46 passed)
- pnpm --filter @ever-works/agent type-check
- pnpm --filter @ever-works/trigger-tasks type-check
- pnpm exec prettier --check on all 8 changed files
- git diff --check