### PR TITLE
fix(scope): preserve legacy relationship lookups

### DIFF
--- a/apps/api/src/agents/sub-agent-delegation.runner.spec.ts
+++ b/apps/api/src/agents/sub-agent-delegation.runner.spec.ts
@@ -172,6 +172,27 @@ describe('SubAgentDelegationRunnerService', () => {
         );
     });
 
+    it('lets a legacy parent reach its same-owner current-tenant child Agent and parent Task', async () => {
+        const legacyScope = { tenantId: null, organizationId: null };
+        agents.findById.mockResolvedValue({ id: PARENT_AGENT, userId: OWNER, ...legacyScope });
+        agents.findByIdAndUser.mockImplementation(
+            async (id: string, _userId: string, scope: unknown) =>
+                scope === undefined ? { id, userId: OWNER, ...EVER_SCOPE } : null,
+        );
+        tasks.getOne.mockImplementation(async (_userId: string, id: string, scope: unknown) =>
+            scope === undefined ? { id, userId: OWNER, ...EVER_SCOPE } : null,
+        );
+        tasks.create.mockResolvedValue({ id: 'task-child', userId: OWNER, ...legacyScope });
+
+        await expect(
+            runner.run(request({ childAgentId: CHILD_AGENT, parentTaskId: 'task-parent' })),
+        ).resolves.toMatchObject({ status: 'completed' });
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(CHILD_AGENT, OWNER, undefined);
+        expect(tasks.getOne).toHaveBeenCalledWith(OWNER, 'task-parent', undefined);
+        expect(tasks.create).toHaveBeenCalledWith(OWNER, expect.any(Object), legacyScope);
+    });
+
     describe("inputs reach the child's brief", () => {
         // The child Task description IS the delegation's only channel into
         // the child's prompt. When `inputs` was left out of it, every

--- a/apps/api/src/agents/sub-agent-delegation.runner.ts
+++ b/apps/api/src/agents/sub-agent-delegation.runner.ts
@@ -10,6 +10,7 @@ import {
     AgentCollaboratorRepository,
     AgentRepository,
     AgentRunRepository,
+    ownershipRelationScopeOf,
     ownershipScopeOf,
 } from '@ever-works/agent/database';
 import { TasksService, TaskTransitionService, type Task } from '@ever-works/agent/tasks-domain';
@@ -99,13 +100,10 @@ export class SubAgentDelegationRunnerService implements SubAgentDelegationRunner
             return this.failure(request, 'parent agent no longer exists');
         }
         const ownershipScope = ownershipScopeOf(parent);
+        const relationScope = ownershipRelationScopeOf(parent);
 
         const childAgentId = request.childAgentId ?? parent.id;
-        const child = await this.agents.findByIdAndUser(
-            childAgentId,
-            parent.userId,
-            ownershipScope,
-        );
+        const child = await this.agents.findByIdAndUser(childAgentId, parent.userId, relationScope);
         if (!child) {
             return this.failure(request, `child agent ${childAgentId} not found`);
         }
@@ -173,7 +171,7 @@ export class SubAgentDelegationRunnerService implements SubAgentDelegationRunner
         const parentTaskId = await this.resolveParentTaskId(request);
         if (parentTaskId) {
             try {
-                await this.tasks.getOne(parent.userId, parentTaskId, ownershipScope);
+                await this.tasks.getOne(parent.userId, parentTaskId, relationScope);
             } catch {
                 return this.failure(request, 'parent Task not found');
             }

--- a/packages/agent/src/database/ownership-scope.ts
+++ b/packages/agent/src/database/ownership-scope.ts
@@ -101,6 +101,19 @@ export function ownershipScopeOf(row: OwnershipScopedRow): OwnershipScope {
 }
 
 /**
+ * Scope to use when following an already-validated relationship pointer.
+ *
+ * A null/null stamp means the source row predates ownership stamping; turning
+ * that stamp into a query scope would mean "legacy targets only" and hide the
+ * same owner's current-tenant target. Scoped source rows remain exact and
+ * therefore keep cross-Organization relationships fail-closed.
+ */
+export function ownershipRelationScopeOf(row: OwnershipScopedRow): OwnershipScope | undefined {
+    const scope = ownershipScopeOf(row);
+    return scope.tenantId === null && scope.organizationId === null ? undefined : scope;
+}
+
+/**
  * QueryBuilder equivalent of {@link ownershipWhere}. The parameter prefix
  * keeps the primitive safe to compose more than once in a single query.
  */

--- a/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
@@ -326,27 +326,28 @@ describe('GoalOrchestratorService — limits', () => {
         });
     });
 
-    it('validates a pin against the persisted legacy Goal scope, not the broader request scope', async () => {
-        const personalRequestScope = { tenantId: everScope.tenantId, organizationId: null };
+    it('lets a legacy Goal pin a same-owner current-tenant Agent without manufacturing a null scope query', async () => {
         const { service, agents, goals } = build({
             goal: { tenantId: null, organizationId: null },
         });
-        agents.findByIdAndUser.mockResolvedValueOnce(null as never);
+        agents.findByIdAndUser.mockImplementationOnce(
+            async (id: string, _userId?: string, scope?: typeof everScope) =>
+                scope === undefined ? ({ id, userId: 'u1', ...everScope } as never) : null,
+        );
 
         await expect(
-            service.updateLimits(
-                'u1',
-                'g1',
-                { assignedAgentId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' },
-                personalRequestScope,
-            ),
-        ).rejects.toBeInstanceOf(NotFoundException);
+            service.updateLimits('u1', 'g1', {
+                assignedAgentId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            }),
+        ).resolves.toMatchObject({
+            assignedAgentId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+        });
         expect(agents.findByIdAndUser).toHaveBeenCalledWith(
             'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
             'u1',
-            { tenantId: null, organizationId: null },
+            undefined,
         );
-        expect(goals.save).not.toHaveBeenCalled();
+        expect(goals.save).toHaveBeenCalled();
     });
 
     it('persists every limit field and logs the change', async () => {
@@ -705,10 +706,28 @@ describe('GoalOrchestratorService — advance', () => {
 
         await service.advance('u1', 'g1');
 
-        expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', {
-            tenantId: null,
-            organizationId: null,
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', undefined);
+        expect(transitions.dispatchAgentRun).toHaveBeenCalled();
+    });
+
+    it('routes a legacy Goal to its same-owner current-tenant pinned Agent', async () => {
+        const assignedAgentId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+        const { service, agents, transitions } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId,
+                tenantId: null,
+                organizationId: null,
+            },
         });
+        agents.findByIdAndUser.mockImplementationOnce(
+            async (id: string, _userId?: string, scope?: typeof everScope) =>
+                scope === undefined ? ({ id, userId: 'u1', ...everScope } as never) : null,
+        );
+
+        await service.advance('u1', 'g1');
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith(assignedAgentId, 'u1', undefined);
         expect(transitions.dispatchAgentRun).toHaveBeenCalled();
     });
 

--- a/packages/agent/src/goals/goal-orchestrator.service.ts
+++ b/packages/agent/src/goals/goal-orchestrator.service.ts
@@ -30,6 +30,7 @@ import { AGENT_RUN_CANCELLER, type AgentRunCanceller } from '../agents/agent-run
 import { TasksService } from '../tasks-domain/tasks.service';
 import { TaskTransitionService } from '../tasks-domain/task-transition.service';
 import {
+    ownershipRelationScopeOf,
     ownershipScopeOf,
     ownershipWhereWith,
     type OwnershipScope,
@@ -215,7 +216,7 @@ export class GoalOrchestratorService {
             goal.assignedAgentId = await this.resolveAssignedAgentId(
                 userId,
                 input.assignedAgentId,
-                ownershipScopeOf(goal),
+                ownershipRelationScopeOf(goal),
             );
         }
 
@@ -1039,7 +1040,7 @@ export class GoalOrchestratorService {
      */
     private async resolveCandidates(goal: Goal): Promise<GoalRoutingCandidate[]> {
         if (goal.assignedAgentId) {
-            const goalScope = ownershipScopeOf(goal);
+            const goalScope = ownershipRelationScopeOf(goal);
             const agent = this.agents
                 ? await this.agents
                       .findByIdAndUser(goal.assignedAgentId, goal.userId, goalScope)
@@ -1063,7 +1064,7 @@ export class GoalOrchestratorService {
         const out = new Map<string, GoalRoutingCandidate>();
         for (const task of tasks) {
             if (!task.agentId || out.has(task.agentId)) continue;
-            const goalScope = ownershipScopeOf(goal);
+            const goalScope = ownershipRelationScopeOf(goal);
             const agent = this.agents
                 ? await this.agents
                       .findByIdAndUser(task.agentId, goal.userId, goalScope)

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -170,6 +170,30 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         expect(dispatcher.enqueue).not.toHaveBeenCalled();
     });
 
+    it('dispatches a legacy Task to its same-owner current-tenant Agent', async () => {
+        const svc = makeSvc();
+        const task = makeTask({ tenantId: null, organizationId: null });
+        agents.findByIdAndUser.mockImplementationOnce(
+            async (id: string, userId: string, scope: unknown) =>
+                scope === undefined
+                    ? {
+                          id,
+                          userId,
+                          tenantId: '11111111-1111-4111-8111-111111111111',
+                          organizationId: '22222222-2222-4222-8222-222222222222',
+                      }
+                    : null,
+        );
+
+        await expect(svc.dispatchAgentRun(task, 'agent-ever')).resolves.toMatchObject({
+            dispatched: true,
+            runId: 'r1',
+        });
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith('agent-ever', 'u1', undefined);
+        expect(dispatcher.enqueue).toHaveBeenCalled();
+    });
+
     it('pre-creates a queued AgentRun row before enqueuing the Trigger.dev run', async () => {
         const svc = makeSvc();
         const task = makeTask({ status: TaskStatus.TODO });

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
@@ -309,6 +309,27 @@ describe('TasksService authorization guardrails', () => {
         expect(repos.reviewers.add).toHaveBeenCalledTimes(1);
     });
 
+    it('lets a legacy Task accept its same-owner current-tenant Agent actor', async () => {
+        const legacy = makeTask({ tenantId: null, organizationId: null, userId: taskOwnerId });
+        const { service, repos } = makeService();
+        repos.tasks.findByIdAndUser.mockResolvedValueOnce(legacy);
+        repos.agents.findByIdAndUser.mockImplementationOnce(
+            async (id: string, userId: string, scope: unknown) =>
+                scope === undefined ? { id, userId, ...everScope } : null,
+        );
+
+        await expect(
+            service.addAssignee(taskOwnerId, legacy.id, 'agent', 'agent-ever'),
+        ).resolves.toBeDefined();
+
+        expect(repos.agents.findByIdAndUser).toHaveBeenCalledWith(
+            'agent-ever',
+            taskOwnerId,
+            undefined,
+        );
+        expect(repos.assignees.add).toHaveBeenCalled();
+    });
+
     it('scopes the includeRun batch lookup instead of trusting a Task latestRunId pointer', async () => {
         const knownRunId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
         const task = makeTask({ latestRunId: knownRunId, ...everScope });

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -18,7 +18,7 @@ import {
 } from '../database/repositories/task-side.repositories';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
 import { AgentRepository } from '../database/repositories/agent.repository';
-import { ownershipScopeOf } from '../database/ownership-scope';
+import { ownershipRelationScopeOf } from '../database/ownership-scope';
 import {
     AGENT_TASK_EXECUTE_DISPATCHER,
     JOB_RUNTIME_NOT_CONFIGURED_REASON,
@@ -373,7 +373,7 @@ export class TaskTransitionService {
             return { runId: null, dispatched: false, parked: false, error: 'no-dispatcher' };
         }
         const agent = await this.agents
-            ?.findByIdAndUser(agentId, task.userId, ownershipScopeOf(task))
+            ?.findByIdAndUser(agentId, task.userId, ownershipRelationScopeOf(task))
             .catch(() => null);
         if (!agent) {
             return {

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -46,6 +46,7 @@ import { WorkKnowledgeUploadRepository } from '../database/repositories/work-kno
 import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkProposalRepository } from '../user-research/work-proposal.repository';
 import {
+    ownershipRelationScopeOf,
     ownershipScopeMatches,
     ownershipScopeOf,
     ownershipStamp,
@@ -321,7 +322,7 @@ export class TasksService {
         const taskScope = ownershipScopeOf(task);
         if (actorType === 'agent' && this.agents) {
             const agent = await this.agents
-                .findByIdAndUser(actorId, userId, taskScope)
+                .findByIdAndUser(actorId, userId, ownershipRelationScopeOf(task))
                 .catch(() => null);
             if (!agent) {
                 throw new BadRequestException('Task actor is not reachable in this Task scope.');


### PR DESCRIPTION
## Summary
- treat a legacy null/null ownership stamp as unscoped only when following an already owner-validated relationship pointer
- keep exact tenant/organization query scope for stamped rows so cross-organization references remain fail-closed
- cover sub-agent delegation, Goal routing/pinning, Task dispatch, and Task actor validation regressions

## TDD evidence
Focused tests failed before implementation because null/null query scopes hid current-tenant Agent/Task rows, then passed after introducing ownershipRelationScopeOf.

## Verification
- API sub-agent delegation suite: 25/25 passed
- Agent Goal/Task/ownership suites: 130/130 passed
- @ever-works/agent build/typecheck: passed
- ever-works-api type-check: passed after building workspace dependency outputs
- Prettier check: passed
- git diff --check: passed

No schema, data, environment, or live deployment changes.