### PR TITLE
fix(scope): align mission task and organization access

### DIFF
--- a/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
+++ b/apps/api/src/scope/__tests__/session-scope.guard.spec.ts
@@ -34,24 +34,12 @@ function makeGuard(
         if (organizationId === 'o-resolved') return 't-resolved';
         return 't-1';
     };
-    return new SessionScopeGuard(
-        scopeContext,
-        userRepository,
-        {
-            findById: jest.fn(async (organizationId: string) => ({
-                id: organizationId,
-                tenantId: tenantForOrganization(organizationId),
-            })),
-        } as never,
-        {
-            findByOrgAndUser: jest.fn(async (organizationId: string, userId: string) => ({
-                organizationId,
-                userId,
-                tenantId: tenantForOrganization(organizationId),
-            })),
-        } as never,
-        { findById: jest.fn(async () => ({ ownerUserId: 'tenant-owner' })) } as never,
-    );
+    return new SessionScopeGuard(scopeContext, userRepository, {
+        findById: jest.fn(async (organizationId: string) => ({
+            id: organizationId,
+            tenantId: tenantForOrganization(organizationId),
+        })),
+    } as never);
 }
 
 type FindByIdResult = {
@@ -195,33 +183,36 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
         expect(reqUser.tenantId).toBe('t-1');
     });
 
-    it.each([
-        [
-            'a removed Ever membership while Yo membership keeps the Tenant active',
-            { id: 'o-ever', tenantId: 't-1' },
-        ],
-        ['an Organization that no longer exists', null],
-    ])('returns the same opaque 404 for %s', async (_label, organization) => {
+    it('allows an invited Tenant member to use every Organization returned by the tenant-wide list', async () => {
         findById.mockResolvedValue({
             tenantId: 't-1',
             lastScopeOrganizationId: 'o-yo',
         });
         const organizationRepository = {
-            findById: jest.fn().mockResolvedValue(organization),
+            findById: jest.fn().mockResolvedValue({ id: 'o-ever', tenantId: 't-1' }),
         };
-        const organizationMembers = {
-            // The user still belongs to Yo, but their Ever roster row was revoked.
-            findByOrgAndUser: jest.fn().mockResolvedValue(null),
-        };
-        const tenants = {
-            findById: jest.fn().mockResolvedValue({ ownerUserId: 'tenant-owner' }),
-        };
-        const membershipGuard = new (SessionScopeGuard as any)(
+        // The invitation was nominally for Yo. The roster is audit metadata;
+        // users.tenantId grants access to every Organization listed in t-1.
+        const membershipGuard = new SessionScopeGuard(
             scopeContext,
-            { findById },
-            organizationRepository,
-            organizationMembers,
-            tenants,
+            { findById } as never,
+            organizationRepository as never,
+        );
+        const ctx = makeContext({ user: { userId: 'u-1' } });
+
+        await expect(
+            scopeContext.runWith({ tenantId: 't-1', organizationId: 'o-ever' }, () =>
+                membershipGuard.canActivate(ctx),
+            ),
+        ).resolves.toBe(true);
+    });
+
+    it('returns the opaque 404 when the Organization no longer exists', async () => {
+        findById.mockResolvedValue({ tenantId: 't-1', lastScopeOrganizationId: 'o-yo' });
+        const membershipGuard = new SessionScopeGuard(
+            scopeContext,
+            { findById } as never,
+            { findById: jest.fn().mockResolvedValue(null) } as never,
         );
         const ctx = makeContext({ user: { userId: 'u-1' } });
 
@@ -248,8 +239,6 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
             scopeContext,
             { findById } as never,
             organizationRepository as never,
-            organizationMembers as never,
-            { findById: jest.fn().mockResolvedValue({ ownerUserId: 'tenant-owner' }) } as never,
         );
         const ctx = makeContext({ user: { userId: 'u-1' } });
 
@@ -275,8 +264,6 @@ describe('SessionScopeGuard (EW-664 Phase 12)', () => {
             scopeContext,
             { findById } as never,
             { findById: jest.fn().mockResolvedValue({ id: 'o-ever', tenantId: 't-1' }) } as never,
-            { findByOrgAndUser: jest.fn().mockResolvedValue(null) } as never,
-            { findById: jest.fn().mockResolvedValue({ ownerUserId: 'u-1' }) } as never,
         );
         const ctx = makeContext({ user: { userId: 'u-1' } });
 

--- a/apps/api/src/scope/session-scope.guard.ts
+++ b/apps/api/src/scope/session-scope.guard.ts
@@ -5,12 +5,7 @@ import {
     Logger,
     NotFoundException,
 } from '@nestjs/common';
-import {
-    OrganizationMemberRepository,
-    OrganizationRepository,
-    TenantRepository,
-    UserRepository,
-} from '@ever-works/agent/database';
+import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
 import { ScopeContextService } from './scope-context.service';
 
 /**
@@ -47,9 +42,11 @@ import { ScopeContextService } from './scope-context.service';
  *   - Otherwise: load the user row once and HYDRATE
  *     `req.user.tenantId` (the auth layer never sets it). This happens
  *     on BOTH legacy and slug-prefixed routes — see below.
- *   - An Organization scope must still have an exact roster membership;
- *     the Tenant owner is the sole row-less exception. A revoked/missing
- *     Organization is an opaque 404.
+ *   - An Organization scope uses the same tenant-wide membership semantics
+ *     as `OrganizationService.listForUser` and `OrganizationMembershipService`:
+ *     every user whose `tenantId` matches may use every Organization listed
+ *     in that Tenant. Tenant owners remain authorized without roster rows.
+ *     A missing/cross-Tenant Organization is an opaque 404.
  *   - Then SEED personal scope only if no Organization slug resolved one
  *     (`scope.tenantId === null`) AND the user has a Tenant →
  *     `{ tenantId, organizationId: null }`.
@@ -75,8 +72,6 @@ export class SessionScopeGuard implements CanActivate {
         private readonly scopeContext: ScopeContextService,
         private readonly userRepository: UserRepository,
         private readonly organizationRepository: OrganizationRepository,
-        private readonly organizationMembers: OrganizationMemberRepository,
-        private readonly tenants: TenantRepository,
     ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -123,7 +118,7 @@ export class SessionScopeGuard implements CanActivate {
             scope.tenantId !== null &&
             scope.tenantId === tenantId
         ) {
-            await this.requireActiveOrganization(user.userId, scope.tenantId, scope.organizationId);
+            await this.requireActiveOrganization(scope.tenantId, scope.organizationId);
         }
         if (scope.tenantId === null && tenantId !== null) {
             this.scopeContext.setScope({
@@ -144,7 +139,6 @@ export class SessionScopeGuard implements CanActivate {
      * the same non-enumerating 404.
      */
     private async requireActiveOrganization(
-        userId: string,
         tenantId: string,
         organizationId: string,
     ): Promise<void> {
@@ -153,17 +147,12 @@ export class SessionScopeGuard implements CanActivate {
             throw new NotFoundException('Organization not found');
         }
 
-        const [membership, tenant] = await Promise.all([
-            this.organizationMembers.findByOrgAndUser(organizationId, userId),
-            this.tenants.findById(tenantId),
-        ]);
-        if (
-            tenant?.ownerUserId === userId ||
-            (membership !== null && membership.tenantId === tenantId)
-        ) {
-            return;
-        }
-
-        throw new NotFoundException('Organization not found');
+        // `users.tenantId` is the authorization grant in the current v1
+        // model. organization_members records invitation provenance and a
+        // future per-Organization role seam, but is deliberately not an
+        // authorization input. `canActivate` calls this method only after
+        // proving the resolved scope tenant equals the hydrated user tenant,
+        // so the Organization equality above is sufficient and keeps the
+        // row-less Tenant-owner exception intact.
     }
 }

--- a/packages/agent/src/missions/__tests__/mission-clone.service.spec.ts
+++ b/packages/agent/src/missions/__tests__/mission-clone.service.spec.ts
@@ -396,6 +396,38 @@ describe('MissionCloneService', () => {
             expect(copies).toHaveLength(1);
             expect(copies[0]).toMatchObject({ title: 'Ever idea', ...everScope });
         });
+
+        it('retains an unscoped scheduled-tick Idea for the authorized Mission without cloning another Organization Idea', async () => {
+            const everScope = {
+                tenantId: '11111111-1111-4111-8111-111111111111',
+                organizationId: '22222222-2222-4222-8222-222222222222',
+            };
+            const source = store.seedMission({ userId: 'u1', ...everScope });
+            store.seedProposal({
+                userId: 'u1',
+                missionId: source.id,
+                title: 'Scheduled tick under EMPTY_SCOPE',
+                tenantId: null,
+                organizationId: null,
+            });
+            store.seedProposal({
+                userId: 'u1',
+                missionId: source.id,
+                title: 'Other Organization idea',
+                tenantId: everScope.tenantId,
+                organizationId: '33333333-3333-4333-8333-333333333333',
+            });
+
+            const result = await service.cloneForUser('u1', source.id, {}, everScope);
+            const copies = store.proposals.filter((idea) => idea.missionId === result.mission.id);
+
+            expect(result.ideasCloned).toBe(1);
+            expect(copies).toHaveLength(1);
+            expect(copies[0]).toMatchObject({
+                title: 'Scheduled tick under EMPTY_SCOPE',
+                ...everScope,
+            });
+        });
     });
 
     describe('countClonesOf', () => {

--- a/packages/agent/src/missions/mission-clone.service.ts
+++ b/packages/agent/src/missions/mission-clone.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Not, Repository } from 'typeorm';
+import { IsNull, Not, Repository, type FindOptionsWhere } from 'typeorm';
 import { Mission, MissionGuardrailsOverride, MissionStatus } from '../entities/mission.entity';
 import {
     WorkProposal,
@@ -199,10 +199,28 @@ export class MissionCloneService {
             // ALL non-PENDING source statuses for the "skipped"
             // metric below (just DISMISSED), so the caller can
             // surface a "we skipped N dismissed Ideas" hint.
-            const sourceIdeas = await tx.find(WorkProposal, {
-                where: ownershipWhereWith<WorkProposal>(userId, scope, {
+            const scopedIdeaWhere = ownershipWhereWith<WorkProposal>(userId, scope, {
+                missionId: source.id,
+            });
+            const sourceIdeaWhere: FindOptionsWhere<WorkProposal>[] = Array.isArray(scopedIdeaWhere)
+                ? scopedIdeaWhere
+                : [scopedIdeaWhere];
+            if (scope?.organizationId) {
+                // Scheduled ticks run outside HTTP/ALS under EMPTY_SCOPE, so
+                // their Ideas are stamped NULL/NULL even when the Mission is
+                // Organization-scoped. The already-authorized Mission FK plus
+                // userId makes those rows safe to recover. Keep the exact
+                // Organization branches too, and never admit a differently
+                // stamped Organization row.
+                sourceIdeaWhere.push({
+                    userId,
                     missionId: source.id,
-                }),
+                    tenantId: IsNull(),
+                    organizationId: IsNull(),
+                });
+            }
+            const sourceIdeas = await tx.find(WorkProposal, {
+                where: sourceIdeaWhere,
             });
             const eligible = sourceIdeas.filter(
                 (idea) => idea.status !== WorkProposalStatus.DISMISSED,

--- a/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/tasks.service.spec.ts
@@ -76,6 +76,7 @@ function makeService(overrides: Record<string, any> = {}) {
         },
         works: {
             findById: jest.fn(),
+            findByIds: jest.fn(),
         },
         missions: {
             findOne: jest.fn(),
@@ -353,6 +354,25 @@ describe('TasksService authorization guardrails', () => {
         await expect(
             (service.getOne as any)('user-1', hiddenWorkTask.id, everScope),
         ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('omits a Work-scoped Task from list when detail would 404 for a Work scope mismatch', async () => {
+        const visible = makeTask({ id: 'task-visible', workId: 'work-ever', ...everScope });
+        const hidden = makeTask({ id: 'task-hidden', workId: 'work-yo', ...everScope });
+        const { service, repos } = makeService();
+        repos.tasks.findByUserIdFiltered.mockResolvedValueOnce({
+            rows: [visible, hidden],
+            total: 2,
+        });
+        repos.works.findByIds.mockResolvedValueOnce([
+            { id: 'work-ever', userId: 'user-1', ...everScope },
+            { id: 'work-yo', userId: 'user-1', ...yoScope },
+        ]);
+
+        await expect(service.list('user-1', {}, {}, everScope)).resolves.toEqual({
+            rows: [visible],
+            total: 1,
+        });
     });
 
     it('keeps legacy personal Task and Work rows reachable in personal scope', async () => {

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -370,13 +370,15 @@ export class TasksService {
         opts: { includeRun?: boolean } = {},
         ownershipScope?: OwnershipScope,
     ): Promise<{ rows: TaskWithRun[]; total: number }> {
-        const { rows, total } = await this.tasks.findByUserIdFiltered(
+        const { rows: scopedRows, total } = await this.tasks.findByUserIdFiltered(
             userId,
             filter,
             ownershipScope,
         );
+        const rows = await this.filterTasksByReachableWork(userId, scopedRows, ownershipScope);
+        const reachableTotal = Math.max(0, total - (scopedRows.length - rows.length));
         if (!opts.includeRun || rows.length === 0 || !this.agentRuns) {
-            return { rows, total };
+            return { rows, total: reachableTotal };
         }
         // Kanban run cockpit (Wave 2 M2) — batch-embed the latest AgentRun
         // per returned row via ONE IN query on the denormalized
@@ -397,7 +399,7 @@ export class TasksService {
             ),
         ];
         if (runIds.length === 0) {
-            return { rows, total };
+            return { rows, total: reachableTotal };
         }
         let runsById = new Map<string, TaskRunEmbed>();
         try {
@@ -421,13 +423,40 @@ export class TasksService {
             // Best-effort embed: the list itself must not fail because the
             // runs table hiccuped — rows simply ship without `run`.
             this.logger.warn(`includeRun embed failed (${runIds.length} run ids): ${err}`);
-            return { rows, total };
+            return { rows, total: reachableTotal };
         }
         const withRuns: TaskWithRun[] = rows.map((row) => ({
             ...row,
             run: (row.latestRunId && runsById.get(row.latestRunId)) || null,
         }));
-        return { rows: withRuns, total };
+        return { rows: withRuns, total: reachableTotal };
+    }
+
+    /**
+     * Keep board/list visibility aligned with {@link getOne}: a Task whose
+     * referenced Work is missing, foreign, or in another active scope must
+     * not be listed and then immediately 404 when opened.
+     */
+    private async filterTasksByReachableWork(
+        userId: string,
+        rows: Task[],
+        scope?: OwnershipScope,
+    ): Promise<Task[]> {
+        if (!scope) return rows;
+
+        const workIds = [
+            ...new Set(rows.map((task) => task.workId).filter((id): id is string => Boolean(id))),
+        ];
+        if (workIds.length === 0) return rows;
+        if (!this.works) return rows.filter((task) => !task.workId);
+
+        const works = await this.works.findByIds(workIds).catch(() => []);
+        const reachableWorkIds = new Set(
+            works
+                .filter((work) => work.userId === userId && ownershipScopeMatches(work, scope))
+                .map((work) => work.id),
+        );
+        return rows.filter((task) => !task.workId || reachableWorkIds.has(task.workId));
     }
 
     async getOne(userId: string, id: string, scope?: OwnershipScope): Promise<Task> {


### PR DESCRIPTION
## Summary
- recover scheduled-tick Ideas stamped under EMPTY_SCOPE when cloning an already-authorized Organization Mission, while excluding differently scoped Organization Ideas
- align Task list visibility with Work-backed detail authorization to prevent list-then-404 and preserve cross-Organization isolation
- align session Organization authorization with the tenant-wide membership semantics used by OrganizationService, retaining the row-less Tenant-owner case

## Verification
- pnpm --filter @ever-works/agent test -- src/missions/__tests__/mission-clone.service.spec.ts src/tasks-domain/__tests__/tasks.service.spec.ts (43 passed)
- pnpm --filter ever-works-api test -- src/scope/__tests__/session-scope.guard.spec.ts (15 passed)
- pnpm --filter @ever-works/agent type-check
- pnpm --filter ever-works-api type-check
- git diff --check

No live schema or data writes were performed.