### PR TITLE
fix(web): preserve public locale proxy authority

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -155,20 +155,30 @@ function alignLocaleRewriteOrigin(req: NextRequest, response: NextResponse): Nex
     const target = new URL(rewrite, 'http://internal.invalid');
     const locale = target.pathname.split('/').filter(Boolean)[0];
     if (locale && LOCALE_SET.has(locale)) {
-        const requestHost = req.headers.get('host')?.trim();
         const requestOrigin = new URL(req.nextUrl.origin);
-        if (requestHost && SAFE_REQUEST_HOST.test(requestHost)) {
+        const forwardedHost = req.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
+        const requestHost = req.headers.get('host')?.trim();
+        const forwardedProto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
+
+        for (const requestAuthority of [forwardedHost, requestHost]) {
+            if (!requestAuthority || !SAFE_REQUEST_HOST.test(requestAuthority)) continue;
             try {
-                const authority = new URL(`${requestOrigin.protocol}//${requestHost}`);
+                const authority = new URL(`${requestOrigin.protocol}//${requestAuthority}`);
                 if (isAllowedRequestHostname(authority.hostname)) {
-                    requestOrigin.host = authority.host;
+                    requestOrigin.hostname = authority.hostname;
+                    requestOrigin.port = authority.port;
+                    break;
                 }
             } catch {
-                // Keep Next's parsed request origin for an invalid authority.
+                // Try the next authority, then keep Next's parsed origin.
             }
         }
+        if (forwardedProto === 'http' || forwardedProto === 'https') {
+            requestOrigin.protocol = `${forwardedProto}:`;
+        }
         target.protocol = requestOrigin.protocol;
-        target.host = requestOrigin.host;
+        target.hostname = requestOrigin.hostname;
+        target.port = requestOrigin.port;
         response.headers.set('x-middleware-rewrite', target.toString());
     }
     return response;

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -84,6 +84,26 @@ describe('canonical Organization workspace proxy', () => {
         );
     });
 
+    it('uses the allowlisted forwarded authority without leaking the internal service port', async () => {
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: { 'x-middleware-rewrite': 'http://localhost:3000/en/login' },
+            }),
+        );
+        const ingressRequest = new NextRequest('https://127.0.0.1:3000/login', {
+            headers: {
+                host: '127.0.0.1:3000',
+                'x-forwarded-host': '127.0.0.1',
+                'x-forwarded-proto': 'https',
+            },
+        });
+
+        const response = await proxy(ingressRequest);
+
+        expect(response.headers.get('x-middleware-rewrite')).toBe('https://127.0.0.1/en/login');
+    });
+
     it('does not align an internal rewrite to a non-allowlisted Host header', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
@@ -98,6 +118,26 @@ describe('canonical Organization workspace proxy', () => {
         const response = await proxy(hostileRequest);
 
         expect(response.headers.get('x-middleware-rewrite')).toBe('http://localhost:3000/en/login');
+    });
+
+    it('ignores an untrusted forwarded authority and falls back to the allowlisted Host', async () => {
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: { 'x-middleware-rewrite': 'http://localhost:3000/en/login' },
+            }),
+        );
+        const requestWithHostFallback = new NextRequest('http://127.0.0.1:3000/login', {
+            headers: {
+                host: '127.0.0.1:3000',
+                'x-forwarded-host': 'malicious.invalid',
+                'x-forwarded-proto': 'javascript',
+            },
+        });
+
+        const response = await proxy(requestWithHostFallback);
+
+        expect(response.headers.get('x-middleware-rewrite')).toBe('http://127.0.0.1:3000/en/login');
     });
 
     it.each(['/settings/dashboard', '/org/dashboard'])(


### PR DESCRIPTION
## Summary
- prefer the validated ingress forwarding authority for next-intl rewrites
- clear the inherited internal service port explicitly
- reject hostile forwarded host/protocol values and preserve the safe Host fallback

## Verification
- pnpm --filter ever-works-web test:unit -- src/proxy.unit.spec.ts (11/11)
- pnpm --filter ever-works-web type-check
- git diff --check

The full web unit command was bounded after several minutes without failures; the focused affected suite and complete type-check passed.