### PR TITLE
fix(auth): preserve upload caller ownership

### DIFF
--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -27,7 +27,13 @@ jest.mock('@ever-works/agent/database', () => ({
     },
 }));
 
-import { BadRequestException, HttpStatus, Logger, NotFoundException } from '@nestjs/common';
+import {
+    BadRequestException,
+    HttpStatus,
+    Logger,
+    NotFoundException,
+    NotImplementedException,
+} from '@nestjs/common';
 import { SELF_DECLARED_DEPS_METADATA } from '@nestjs/common/constants';
 import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
@@ -181,6 +187,7 @@ describe('UploadsController', () => {
             organization?: object | null;
             member?: object | null;
             tenant?: object | null;
+            apiKey?: boolean;
         }) {
             const uploads = {
                 saveImage: jest.fn().mockResolvedValue(fileResult),
@@ -253,6 +260,13 @@ describe('UploadsController', () => {
                             : options.tenant,
                     ),
             };
+            const apiKeys = {
+                validateKey: jest
+                    .fn()
+                    .mockResolvedValue(
+                        options.apiKey ? { id: 'key-1', userId: bearerUserId } : null,
+                    ),
+            };
             const scopedController = new (UploadsController as any)(
                 uploads,
                 anonymousAuth,
@@ -264,10 +278,14 @@ describe('UploadsController', () => {
                 organizations,
                 members,
                 tenants,
+                apiKeys,
             ) as UploadsController;
             const req = {
-                headers:
-                    options.bearer || options.authRejects ? { authorization: 'Bearer token' } : {},
+                headers: options.apiKey
+                    ? { 'x-api-key': 'ew_live_test-key' }
+                    : options.bearer || options.authRejects
+                      ? { authorization: 'Bearer token' }
+                      : {},
             } as never;
             return {
                 controller: scopedController,
@@ -279,6 +297,7 @@ describe('UploadsController', () => {
                 organizations,
                 members,
                 tenants,
+                apiKeys,
                 req,
             };
         }
@@ -355,6 +374,18 @@ describe('UploadsController', () => {
                 bearerUserId,
             );
             expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
+        });
+
+        it('honors an x-api-key caller instead of minting an anonymous upload owner', async () => {
+            const ctx = publicController({ activeScope: everScope, apiKey: true });
+
+            await ctx.controller.uploadAnonymous(mkFile({}), ctx.req, undefined);
+
+            expect(ctx.apiKeys.validateKey).toHaveBeenCalledWith('ew_live_test-key');
+            expect(ctx.anonymousAuth.createAnonymousUser).not.toHaveBeenCalled();
+            expect(ctx.uploads.saveImage).toHaveBeenCalledWith(bearerUserId, expect.anything(), {
+                ownershipScope: everScope,
+            });
         });
 
         it('resolves a headerless bearer to bare personal scope and never reads the persisted Organization pointer', async () => {
@@ -516,6 +547,20 @@ describe('UploadsController', () => {
             });
             expect(ctx.anonymousAuth.createAnonymousUser).toHaveBeenCalledTimes(1);
             expect(ctx.uploads.getBackend).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns 501 for an unsupported backend without minting an anonymous user', async () => {
+            const ctx = publicController({ activeScope: everScope });
+            ctx.uploads.getBackend.mockResolvedValue({});
+
+            await expect(
+                ctx.controller.presign(
+                    { filename: 'direct.png', mimeType: 'image/png', size: 100 },
+                    ctx.req,
+                ),
+            ).rejects.toBeInstanceOf(NotImplementedException);
+
+            expect(ctx.anonymousAuth.createAnonymousUser).not.toHaveBeenCalled();
         });
 
         it('derives an explicit personal scope for a valid bearer', async () => {

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -43,6 +43,7 @@ import { toHeaders } from '../auth/providers/request-headers';
 import { UploadsService } from './uploads.service';
 import { PresignUploadDto } from './dto/presign-upload.dto';
 import { ScopeContextService } from '../scope/scope-context.service';
+import { ApiKeyService } from '../auth/services/api-key.service';
 
 const MAX_UPLOAD_BYTES = Number(process.env.UPLOADS_MAX_BYTES) || 5 * 1024 * 1024;
 
@@ -107,6 +108,7 @@ export class UploadsController {
         @Optional()
         @Inject(TenantRepository)
         private readonly tenantRepository?: TenantRepository,
+        private readonly apiKeyService?: ApiKeyService,
     ) {}
 
     /**
@@ -450,10 +452,14 @@ export class UploadsController {
         description: 'Backend does not support presign — use POST /api/uploads',
     })
     async presign(@Body() body: PresignUploadDto, @Req() req: AnonRequest) {
-        // Authenticate + hydrate ownership before touching even the backend
-        // capability surface. A revoked bearer must not receive a presign
-        // oracle or a key in a fallback personal scope.
-        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
+        // Capability is public and independent of caller identity. Reject an
+        // unsupported backend before creating the otherwise-unused anonymous
+        // User row. Supplied credentials are still validated first so revoked
+        // callers do not gain a capability oracle; only a truly anonymous
+        // request defers identity creation until support is confirmed.
+        let actingUser = this.hasSuppliedCredential(req)
+            ? await this.resolveActingUser(req)
+            : undefined;
         const backend = await this.uploads.getBackend();
         if (!backend.presignPut) {
             throw new NotImplementedException({
@@ -463,6 +469,8 @@ export class UploadsController {
                     'Active storage backend does not support presigned uploads — use POST /api/uploads with multipart form data instead.',
             });
         }
+        actingUser ??= await this.resolveActingUser(req);
+        const { userId, anonAccessToken, anonymousExpiresAt } = actingUser;
 
         const presign = await backend.presignPut({
             filename: body.filename,
@@ -586,15 +594,26 @@ export class UploadsController {
         ownershipScope: OwnershipScope;
     }> {
         const authorization = req.headers?.authorization;
+        const apiKeyHeader = req.headers?.['x-api-key'];
+        const headerApiKey =
+            typeof apiKeyHeader === 'string' && apiKeyHeader.trim().length > 0
+                ? apiKeyHeader.trim()
+                : null;
+        const bearerApiKey = Array.isArray(authorization)
+            ? null
+            : (/^Bearer\s+(ew_live_\S+)$/i.exec(authorization?.trim() ?? '')?.[1] ?? null);
+        const apiKey = headerApiKey ?? bearerApiKey;
         const hasBearer = Array.isArray(authorization)
             ? authorization.some((value) => value.trim().length > 0)
             : typeof authorization === 'string' && authorization.trim().length > 0;
 
-        if (hasBearer) {
+        if (apiKey || hasBearer) {
             // @Public() skips the global session/scope guards, so reproduce
             // their authoritative half here. A supplied-but-invalid bearer
             // is never reinterpreted as an anonymous request.
-            const existing = await this.authenticateBearer(req);
+            const existing = apiKey
+                ? await this.authenticateApiKey(apiKey)
+                : await this.authenticateBearer(req);
             const ownershipScope = await this.hydrateAuthenticatedScope(existing);
             req.user = existing;
             this.scopeContext.setScope(ownershipScope);
@@ -637,6 +656,16 @@ export class UploadsController {
         throw new NotFoundException({ status: 'error', message: 'Resource not found' });
     }
 
+    private hasSuppliedCredential(req: AnonRequest): boolean {
+        const authorization = req.headers?.authorization;
+        const apiKey = req.headers?.['x-api-key'];
+        return [authorization, apiKey].some((value) =>
+            Array.isArray(value)
+                ? value.some((entry) => entry.trim().length > 0)
+                : typeof value === 'string' && value.trim().length > 0,
+        );
+    }
+
     private async authenticateBearer(req: AnonRequest): Promise<AuthenticatedUser> {
         try {
             const authenticated = await this.authProvider.authenticate(
@@ -644,6 +673,29 @@ export class UploadsController {
             );
             if (!authenticated?.userId) this.opaqueScopeNotFound();
             return authenticated;
+        } catch {
+            this.opaqueScopeNotFound();
+        }
+    }
+
+    private async authenticateApiKey(apiKey: string): Promise<AuthenticatedUser> {
+        try {
+            const keyRecord = await this.apiKeyService?.validateKey(apiKey);
+            if (!keyRecord?.userId || !this.userRepository) this.opaqueScopeNotFound();
+            const user = await this.userRepository.findById(keyRecord.userId);
+            if (!user?.isActive) this.opaqueScopeNotFound();
+            return {
+                userId: user.id,
+                email: user.email,
+                username: user.username,
+                provider: user.registrationProvider,
+                emailVerified: user.emailVerified,
+                isActive: user.isActive,
+                avatar: user.avatar || null,
+                iat: Math.floor(Date.now() / 1000),
+                iss: 'ever-works',
+                aud: 'ever-works',
+            };
         } catch {
             this.opaqueScopeNotFound();
         }

--- a/packages/agent/src/database/repositories/user-upload.repository.spec.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.spec.ts
@@ -115,6 +115,26 @@ describe('UserUploadRepository — ownership scope', () => {
         }
     });
 
+    it('uses explicit SQL NULL predicates when deduping a fully anonymous upload', async () => {
+        await uploads.record({
+            userId: null,
+            sha256,
+            tenantId: null,
+            organizationId: null,
+            storageProvider: 'local-fs',
+            storagePath: `anonymous/${sha256}.png`,
+        });
+
+        expect(orm.findOne).toHaveBeenCalledWith({
+            where: {
+                userId: expect.objectContaining({ _type: 'isNull' }),
+                sha256,
+                tenantId: expect.objectContaining({ _type: 'isNull' }),
+                organizationId: expect.objectContaining({ _type: 'isNull' }),
+            },
+        });
+    });
+
     it('normalizes uppercase SHA-256 before scoped lookup and persistence', async () => {
         const uppercaseSha256 = sha256.toUpperCase();
 

--- a/packages/agent/src/database/repositories/user-upload.repository.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { UserUpload } from '../../entities/user-upload.entity';
 import { ownershipWhereWith, type OwnershipScope } from '../ownership-scope';
 
@@ -57,10 +57,11 @@ export class UserUploadRepository {
             where:
                 userId === null
                     ? {
-                          userId: null,
+                          userId: IsNull(),
                           sha256: normalizedInput.sha256,
-                          tenantId: scope.tenantId,
-                          organizationId: scope.organizationId,
+                          tenantId: scope.tenantId === null ? IsNull() : scope.tenantId,
+                          organizationId:
+                              scope.organizationId === null ? IsNull() : scope.organizationId,
                       }
                     : ownershipWhereWith<UserUpload>(userId, scope, {
                           sha256: normalizedInput.sha256,


### PR DESCRIPTION
## Summary
- authenticate public upload callers using x-api-key or an ew_live_ bearer instead of minting an anonymous owner
- use explicit TypeORM IS NULL predicates for fully anonymous upload dedupe
- avoid creating an anonymous User before returning 501 for unsupported presign backends while still validating supplied credentials first

## TDD evidence
Each regression test failed on fac11bfe90e761888598f20c45d9f37a4d709fd8 before its production fix.

## Verification
- pnpm --filter @ever-works/agent exec jest src/database/repositories/user-upload.repository.spec.ts --runInBand: 9 passed
- pnpm --filter ever-works-api exec jest src/uploads/uploads.controller.spec.ts --runInBand: 33 passed
- pnpm --filter @ever-works/agent type-check: passed
- pnpm exec prettier --check on all 4 changed files: passed
- git diff --check: passed

API package typecheck was attempted but initially required unbuilt workspace dependency outputs; no API typecheck success is claimed.