### PR TITLE
fix(uploads): preserve legacy and work-scoped compatibility

### DIFF
--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -728,9 +728,64 @@ describe('UploadsController', () => {
                 stored.id,
                 owner.userId,
                 everScope,
+                null,
             );
             expect(calls.statusCode).toBeUndefined();
             expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
+        });
+
+        it('serves a pre-index legacy upload only when no metadata row exists in any scope', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const userUploads = {
+                findOwnedByUser: jest.fn().mockResolvedValue(null),
+            };
+            const { res, calls } = mkRes();
+
+            await guardedController(userUploads, everScope).serve(
+                owner,
+                owner.userId,
+                stored.filename,
+                res,
+            );
+
+            expect(userUploads.findOwnedByUser).toHaveBeenNthCalledWith(
+                1,
+                stored.id,
+                owner.userId,
+                everScope,
+                null,
+            );
+            expect(userUploads.findOwnedByUser).toHaveBeenNthCalledWith(2, stored.id, owner.userId);
+            expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
+        });
+
+        it('does not treat a differently scoped metadata row as a legacy upload', async () => {
+            const owner = mkAuth();
+            const stored = await controller.upload(owner, mkFile({}));
+            const userUploads = {
+                findOwnedByUser: jest
+                    .fn()
+                    .mockResolvedValueOnce(null)
+                    .mockResolvedValueOnce({
+                        sha256: stored.id,
+                        userId: owner.userId,
+                        workId: null,
+                        ...yoScope,
+                    }),
+            };
+            const readFile = jest.spyOn(service, 'readFile');
+            const { res, calls } = mkRes();
+
+            await guardedController(userUploads, everScope).serve(
+                owner,
+                owner.userId,
+                stored.filename,
+                res,
+            );
+
+            expect(calls.statusCode).toBe(HttpStatus.NOT_FOUND);
+            expect(readFile).not.toHaveBeenCalled();
         });
 
         it('opaque-404s the same-user known hash in Yo before reading bytes from Ever', async () => {
@@ -744,8 +799,10 @@ describe('UploadsController', () => {
             };
             const userUploads = {
                 findOwnedByUser: jest.fn(
-                    async (_sha: string, _userId: string, scope: typeof everScope) =>
-                        scope.organizationId === yoUpload.organizationId ? yoUpload : null,
+                    async (_sha: string, _userId: string, scope?: typeof everScope) =>
+                        !scope || scope.organizationId === yoUpload.organizationId
+                            ? yoUpload
+                            : null,
                 ),
             };
             const readFile = jest.spyOn(service, 'readFile');
@@ -790,6 +847,7 @@ describe('UploadsController', () => {
                 stored.id,
                 owner.userId,
                 personalScope,
+                null,
             );
             expect((calls.sent as Buffer).equals(TINY_PNG)).toBe(true);
         });

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -522,11 +522,26 @@ export class UploadsController {
         // centralized ownership predicate in UserUploadRepository.
         if (this.userUploads) {
             const match = /^([0-9a-f]{64})(?:\.|$)/i.exec(filename);
+            if (!match) {
+                res.status(HttpStatus.NOT_FOUND).json({ status: 'error', message: 'Not found' });
+                return;
+            }
             const scope = this.scopeContext.getScope();
-            const upload = match
-                ? await this.userUploads.findOwnedByUser(match[1].toLowerCase(), userId, scope)
-                : null;
-            if (!upload || (upload.workId ?? null) !== (workId ?? null)) {
+            const sha256 = match[1].toLowerCase();
+            const upload = await this.userUploads.findOwnedByUser(
+                sha256,
+                userId,
+                scope,
+                workId ?? null,
+            );
+            // Pre-user_uploads objects have no metadata row. Preserve their
+            // historical owner-keyed read path only when no row exists in any
+            // scope; a same-user row hidden by the active scope must remain an
+            // opaque 404 rather than being mistaken for legacy storage.
+            const indexedElsewhere = upload
+                ? null
+                : await this.userUploads.findOwnedByUser(sha256, userId);
+            if (indexedElsewhere) {
                 res.status(HttpStatus.NOT_FOUND).json({ status: 'error', message: 'Not found' });
                 return;
             }

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -101,6 +101,19 @@ describe('UploadsService', () => {
             );
         });
 
+        it('keeps uploads compatible when the optional metadata repository is unavailable', async () => {
+            const legacyCompatible = new (UploadsService as any)(backend, undefined, undefined, {
+                getScope: () => everScope,
+            }) as UploadsService;
+
+            await expect(legacyCompatible.saveImage(userId, fakeFile({}))).resolves.toEqual(
+                expect.objectContaining({
+                    id: expect.stringMatching(/^[a-f0-9]{64}$/),
+                    url: expect.stringContaining(`/api/uploads/${userId}/`),
+                }),
+            );
+        });
+
         it.each(['saveImage', 'saveFile'] as const)(
             'uses the explicit ownership scope for %s even when request ALS is stale',
             async (method) => {

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -273,9 +273,9 @@ export class UploadsService {
         @Optional()
         @Inject(WORK_REPO_RESOLVER)
         private readonly workRepoResolver?: WorkRepoResolver,
-        // Authoritative ownership index for plain uploads. Required in the
-        // Nest graph: returning success without this row would create bytes
-        // that no scoped attach/read path can authorize.
+        // Ownership index for plain uploads. Current Nest graphs provide it;
+        // optional construction preserves compatibility with legacy/minimal
+        // deployments that predate user_uploads.
         @Inject(USER_UPLOAD_REPOSITORY)
         private readonly userUploads?: UserUploadRepository,
         // Globally provided in the API. The default keeps direct unit
@@ -304,10 +304,10 @@ export class UploadsService {
     }
 
     /**
-     * Persist the authoritative ownership row before reporting upload success.
+     * Persist the authoritative ownership row when the repository is available.
      * Storage writes happen first because the plugin contract has no shared DB
-     * transaction, but metadata failure is never swallowed: callers receive an
-     * error rather than a URL that every scoped attach/read path must reject.
+     * transaction. A configured repository failure is never swallowed; only a
+     * genuinely absent optional repository keeps the legacy storage-only path.
      */
     private async recordUpload(input: {
         userId: string;
@@ -319,9 +319,7 @@ export class UploadsService {
         workId?: string;
         ownershipScope?: OwnershipScope;
     }): Promise<void> {
-        if (!this.userUploads) {
-            throw new Error('Upload metadata repository is not configured');
-        }
+        if (!this.userUploads) return;
         const scope = input.ownershipScope ?? this.scopeContext.getScope();
         await this.userUploads.record({
             userId: input.userId,

--- a/packages/agent/src/database/repositories/user-upload.repository.spec.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.spec.ts
@@ -11,6 +11,8 @@ describe('UserUploadRepository — ownership scope', () => {
         tenantId: everScope.tenantId,
         organizationId: '33333333-3333-4333-8333-333333333333',
     };
+    const workId = '44444444-4444-4444-8444-444444444444';
+    const otherWorkId = '55555555-5555-4555-8555-555555555555';
 
     let orm: { findOne: jest.Mock; create: jest.Mock; save: jest.Mock };
     let uploads: UserUploadRepository;
@@ -88,12 +90,47 @@ describe('UserUploadRepository — ownership scope', () => {
         });
 
         expect(orm.findOne).toHaveBeenNthCalledWith(1, {
-            where: [{ userId, sha256, ...everScope }],
+            where: [{ userId, sha256, workId: null, ...everScope }],
         });
         expect(orm.findOne).toHaveBeenNthCalledWith(2, {
-            where: [{ userId, sha256, ...yoScope }],
+            where: [{ userId, sha256, workId: null, ...yoScope }],
         });
         expect(orm.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not dedupe identical bytes across different Works in the same scope', async () => {
+        await uploads.record({
+            userId,
+            sha256,
+            workId,
+            ...everScope,
+            storageProvider: 'github-storage',
+            storagePath: `dr:${workId}:${sha256}.png`,
+        });
+        await uploads.record({
+            userId,
+            sha256,
+            workId: otherWorkId,
+            ...everScope,
+            storageProvider: 'github-storage',
+            storagePath: `dr:${otherWorkId}:${sha256}.png`,
+        });
+
+        expect(orm.findOne).toHaveBeenNthCalledWith(1, {
+            where: [{ userId, sha256, workId, ...everScope }],
+        });
+        expect(orm.findOne).toHaveBeenNthCalledWith(2, {
+            where: [{ userId, sha256, workId: otherWorkId, ...everScope }],
+        });
+        expect(orm.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('can resolve the exact Work-associated upload behind a workId URL', async () => {
+        await (uploads.findOwnedByUser as any)(sha256, userId, everScope, workId);
+
+        expect(orm.findOne).toHaveBeenCalledWith({
+            where: [{ sha256, userId, workId, ...everScope }],
+        });
     });
 
     it('dedupes current and legacy personal uploads without matching an Organization row', async () => {
@@ -127,7 +164,7 @@ describe('UserUploadRepository — ownership scope', () => {
         });
 
         expect(orm.findOne).toHaveBeenCalledWith({
-            where: [{ userId, sha256, ...everScope }],
+            where: [{ userId, sha256, workId: null, ...everScope }],
         });
         expect(orm.create).toHaveBeenCalledWith(
             expect.objectContaining({ userId, sha256, ...everScope }),

--- a/packages/agent/src/database/repositories/user-upload.repository.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.ts
@@ -38,8 +38,8 @@ export class UserUploadRepository {
 
     /**
      * Insert the upload-ownership record, deduped within the exact persisted
-     * ownership scope. Organization uploads never collapse into another
-     * Organization merely because their bytes (and therefore sha256) match.
+     * ownership + Work scope. Organization or Work uploads never collapse into
+     * another scope merely because their bytes (and therefore sha256) match.
      * Personal scope deliberately includes legacy null/null rows through the
      * centralized ownership predicate.
      */
@@ -53,17 +53,20 @@ export class UserUploadRepository {
             organizationId: normalizedInput.organizationId ?? null,
         };
         const userId = normalizedInput.userId ?? null;
+        const workId = normalizedInput.workId ?? null;
         const existing = await this.repo.findOne({
             where:
                 userId === null
                     ? {
                           userId: null,
                           sha256: normalizedInput.sha256,
+                          workId,
                           tenantId: scope.tenantId,
                           organizationId: scope.organizationId,
                       }
                     : ownershipWhereWith<UserUpload>(userId, scope, {
                           sha256: normalizedInput.sha256,
+                          workId,
                       }),
         });
         if (existing) return existing;
@@ -71,16 +74,19 @@ export class UserUploadRepository {
         return this.repo.save(entity);
     }
 
-    /** An upload with this `sha256` owned by `userId`, else null. */
+    /** An upload with this `sha256` owned by `userId` (and optional Work), else null. */
     async findOwnedByUser(
         sha256: string,
         userId: string,
         scope?: OwnershipScope,
+        workId?: string | null,
     ): Promise<UserUpload | null> {
+        const relation = {
+            sha256: normalizeUploadSha256(sha256),
+            ...(workId !== undefined ? { workId } : {}),
+        };
         return this.repo.findOne({
-            where: ownershipWhereWith<UserUpload>(userId, scope, {
-                sha256: normalizeUploadSha256(sha256),
-            }),
+            where: ownershipWhereWith<UserUpload>(userId, scope, relation),
         });
     }
 

--- a/packages/agent/src/entities/user-upload.entity.ts
+++ b/packages/agent/src/entities/user-upload.entity.ts
@@ -24,7 +24,7 @@ import { User } from './user.entity';
  * This row makes an upload an OWNABLE, QUERYABLE record:
  *   - `userId` — the owner (NULL for an anonymous upload).
  *   - `sha256` — the content hash returned to clients as the upload id; what
- *     attachments reference. Deduped per `(userId, sha256)`.
+ *     attachments reference. Deduped by repository within ownership + Work scope.
  *   - OPTIONAL scope links — `workId` is stamped today (from `?workId=`); the
  *     `missionId` / `ideaId` / `tenantId` / `organizationId` columns let an
  *     upload also be associated with those scopes as the upload surface grows


### PR DESCRIPTION
## Summary
- preserve storage-only upload compatibility when the optional user_uploads repository is absent
- serve truly pre-index legacy objects only after proving no metadata row exists in any scope
- include workId in upload dedupe and exact URL lookup so identical bytes across Works do not produce mismatched URLs

## Security
- owner identity remains enforced before metadata or storage access
- active-scope metadata lookup remains exact
- a same-user metadata row in another scope blocks legacy fallback with the existing opaque 404
- workId reads still pass the existing Work ownership/scope gate

## TDD evidence
RED reproduced four failures: absent metadata repository rejected upload success; Work dedupe omitted workId; Work URL lookup omitted workId; legacy reads could not distinguish no metadata from cross-scope metadata.

GREEN verification:
- upload service/controller suites: 70/70 passed
- user-upload repository suite: 10/10 passed
- API dependency closure build: passed
- @ever-works/agent type-check: passed
- ever-works-api type-check: passed
- Prettier check: passed
- git diff --check: passed

Base used: fac11bfe90e761888598f20c45d9f37a4d709fd8

No migrations, data, secrets, maintenance, protected branches, or live state were touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads are now correctly isolated by Work, preventing files with identical hashes from being mixed across Works.
  * Invalid file identifiers now return a clear not-found response.
  * File access respects the active ownership scope while preserving supported legacy uploads.
  * Uploads continue to work in configurations without optional metadata storage.
  * Improved handling of uploads hidden by scope restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->