### PR TITLE
fix(escalations): resolve legacy scoped rows

### DIFF
--- a/packages/agent/src/database/repositories/agent-escalation.repository.scope.spec.ts
+++ b/packages/agent/src/database/repositories/agent-escalation.repository.scope.spec.ts
@@ -50,7 +50,7 @@ describe('AgentEscalationRepository Task resolution ownership', () => {
         );
     });
 
-    it('CAS-resolves only the exact user, routed Task, tenant and Organization', async () => {
+    it('CAS-resolves a listed legacy escalation through its authorized Organization Task', async () => {
         const { repository, qb } = build();
 
         await expect(
@@ -67,7 +67,7 @@ describe('AgentEscalationRepository Task resolution ownership', () => {
             taskId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
         });
         expect(qb.andWhere).toHaveBeenCalledWith(
-            '(tenantId = :escalationOwnershipTenantId AND organizationId = :escalationOwnershipOrganizationId)',
+            '((tenantId = :escalationOwnershipTenantId AND organizationId = :escalationOwnershipOrganizationId) OR (tenantId IS NULL AND organizationId IS NULL))',
             {
                 escalationOwnershipTenantId: everScope.tenantId,
                 escalationOwnershipOrganizationId: everScope.organizationId,

--- a/packages/agent/src/database/repositories/agent-escalation.repository.ts
+++ b/packages/agent/src/database/repositories/agent-escalation.repository.ts
@@ -263,7 +263,12 @@ export class AgentEscalationRepository {
             .andWhere('userId = :userId', { userId })
             .andWhere('taskId = :taskId', { taskId })
             .andWhere('status = :open', { open: 'open' });
-        if (ownership) query.andWhere(ownership.clause, ownership.parameters);
+        if (ownership) {
+            const clause = scope.organizationId
+                ? `(${ownership.clause} OR (tenantId IS NULL AND organizationId IS NULL))`
+                : ownership.clause;
+            query.andWhere(clause, ownership.parameters);
+        }
         const result = await query.execute();
         return (result.affected ?? 0) > 0;
     }


### PR DESCRIPTION
## Summary
- allow a pre-#2151 escalation stamped with legacy NULL/NULL ownership to be resolved through its already-authorized Organization Task
- retain same-user, same-Task, open-state CAS binding and exact Organization matching for modern rows
- continue excluding differently stamped Organizations

## TDD evidence
- RED: focused repository test failed because resolveForTask emitted only the exact Organization predicate
- GREEN: pnpm --filter @ever-works/agent test -- src/database/repositories/agent-escalation.repository.scope.spec.ts (4/4 passed)
- pnpm --filter @ever-works/agent test -- src/database/repositories/agent-escalation.repository.scope.spec.ts src/agents/__tests__/agent-escalation.service.spec.ts (13/13 passed)
- pnpm --filter ever-works-api test -- src/tasks/tasks.controller.scope.spec.ts (4/4 passed)
- pnpm --filter @ever-works/agent type-check
- pnpm --filter @ever-works/agent build
- Prettier check passed for both changed files
- git diff --check clean

No live data, schema, deployment, or environment branch was changed.