### PR TITLE
fix(migrations): quote plan_entitlements identifiers — two merged migrations fail on Postgres

### DIFF
--- a/apps/api/src/migrations/1783400000000-CreateCreditsLedgerAndEntitlements.ts
+++ b/apps/api/src/migrations/1783400000000-CreateCreditsLedgerAndEntitlements.ts
@@ -177,7 +177,16 @@ export class CreateCreditsLedgerAndEntitlements1783400000000 implements Migratio
                 .createQueryBuilder()
                 .select('pe.id', 'id')
                 .from('plan_entitlements', 'pe')
-                .where('pe.planId = :planId AND pe.key = :key', {
+                // 🛑 DOUBLE-QUOTED on purpose. This builder has no entity metadata
+                // (raw `.from('plan_entitlements', 'pe')`), so TypeORM emits the
+                // reference verbatim — verified against the Postgres driver:
+                // `pe.planId = :planId` comes out unquoted, Postgres folds it to
+                // `pe.planid`, and the migration dies with 42703 on every Postgres
+                // environment. The sqlite suite cannot catch it: sqlite matches
+                // unquoted identifiers case-insensitively, so CI stays green while
+                // a fresh Postgres boot fails. Same fix as the 1786950000000 /
+                // 1786960000000 seeds.
+                .where('pe."planId" = :planId AND pe."key" = :key', {
                     planId: seed.planId,
                     key: seed.key,
                 })

--- a/apps/api/src/migrations/1784300000000-CreateTerminalTranscriptChunks.ts
+++ b/apps/api/src/migrations/1784300000000-CreateTerminalTranscriptChunks.ts
@@ -144,7 +144,16 @@ export class CreateTerminalTranscriptChunks1784300000000 implements MigrationInt
                 .createQueryBuilder()
                 .select('pe.id', 'id')
                 .from('plan_entitlements', 'pe')
-                .where('pe.planId = :planId AND pe.key = :key', {
+                // 🛑 DOUBLE-QUOTED on purpose. This builder has no entity metadata
+                // (raw `.from('plan_entitlements', 'pe')`), so TypeORM emits the
+                // reference verbatim — verified against the Postgres driver:
+                // `pe.planId = :planId` comes out unquoted, Postgres folds it to
+                // `pe.planid`, and the migration dies with 42703 on every Postgres
+                // environment. The sqlite suite cannot catch it: sqlite matches
+                // unquoted identifiers case-insensitively, so CI stays green while
+                // a fresh Postgres boot fails. Same fix as the 1786950000000 /
+                // 1786960000000 seeds.
+                .where('pe."planId" = :planId AND pe."key" = :key', {
                     planId: seed.planId,
                     key: seed.key,
                 })

--- a/packages/agent/src/notifications/notification.service.ts
+++ b/packages/agent/src/notifications/notification.service.ts
@@ -362,7 +362,19 @@ export class NotificationService {
      * Billing spec FR-21 — a pay-as-you-go invoice could not be collected.
      * Overflow is suspended until it is paid (the portal link recovers it).
      */
-    async notifyPaygPastDue(args: { userId: string; amountCents: number | null }): Promise<void> {
+    async notifyPaygPastDue(args: {
+        userId: string;
+        amountCents: number | null;
+        /**
+         * End of the cycle this failure belongs to. Same re-arming reason as
+         * the cap notice above: a PERSISTENT row cannot be dismissed and
+         * `create()` returns the existing row for a live
+         * `(userId, deduplicationKey)` pair, so a FIXED key announces dunning
+         * once per account — ever. A second failed invoice, a month later,
+         * would be silent.
+         */
+        periodEnd?: Date | null;
+    }): Promise<void> {
         const amount =
             typeof args.amountCents === 'number'
                 ? ` ($${(args.amountCents / 100).toFixed(2)})`
@@ -381,7 +393,9 @@ export class NotificationService {
             actionLabel: 'Fix payment',
             isPersistent: true,
             metadata: { amountCents: args.amountCents },
-            deduplicationKey: 'payg_past_due',
+            deduplicationKey: `payg_past_due_${
+                args.periodEnd?.toISOString().slice(0, 10) ?? 'unknown-period'
+            }`,
         });
         await this.dispatchFanout({
             userId: args.userId,

--- a/packages/agent/src/subscriptions/billing/payg.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/payg.service.spec.ts
@@ -609,6 +609,10 @@ describe('PaygService webhooks', () => {
         expect(h.notificationService.notifyPaygPastDue).toHaveBeenCalledWith({
             userId: 'u1',
             amountCents: 380,
+            // Cycle end rides along so the dedup key re-arms next period —
+            // a persistent row under a fixed key would announce dunning once
+            // per account, ever.
+            periodEnd: PERIOD_END,
         });
 
         await h.service.applyInvoice(h.stored(), invoice({ status: 'paid', amountPaidCents: 380 }));

--- a/packages/agent/src/subscriptions/billing/payg.service.ts
+++ b/packages/agent/src/subscriptions/billing/payg.service.ts
@@ -449,6 +449,7 @@ export class PaygService {
                     this.notificationService?.notifyPaygPastDue({
                         userId: profile.userId,
                         amountCents: invoice.totalCents ?? null,
+                        periodEnd: profile.paygPeriodEnd ?? null,
                     }),
                 );
             }


### PR DESCRIPTION
## The bug

Two **already-merged** migrations abort on Postgres with `42703 column pe.planid does not exist`, so a fresh Postgres boot fails at startup:

- `1783400000000-CreateCreditsLedgerAndEntitlements`
- `1784300000000-CreateTerminalTranscriptChunks`

Both seed `plan_entitlements` through a raw query builder:

```ts
.from('plan_entitlements', 'pe')
.where('pe.planId = :planId AND pe.key = :key', { … })
```

That builder has **no entity metadata**, so TypeORM cannot map `planId` to a column and emits the reference verbatim. Verified against the Postgres driver rather than assumed:

```
UNQUOTED → SELECT pe.id AS "id" FROM "plan_entitlements" "pe" WHERE pe.planId = :planId AND pe.key = :key
QUOTED   → SELECT pe.id AS "id" FROM "plan_entitlements" "pe" WHERE pe."planId" = :planId AND pe."key" = :key
```

Postgres folds the unquoted form to `pe.planid`; the column is `"planId"`.

## Why CI never caught it

The migration suite runs on **better-sqlite3**, which matches unquoted identifiers case-insensitively. The specs pass, and the failure only exists on the driver production uses — the same class of blind spot recorded in `credit-ledger.repository.ts` for `getPeriodTotals` (which shipped a 500 on every Postgres environment for the same reason).

Fixed by explicitly double-quoting, with the reasoning in a comment at each site so the next person does not "tidy" the quotes away. The two newer billing migrations (`1786950000000`, `1786960000000`) were already fixed during the pay-as-you-go review.

## Also here

`payg_past_due` still used a **fixed** notification dedup key. #2215 made the *cap* notice cycle-scoped but not this one; a persistent notification cannot be dismissed and `create()` returns the existing row for a live `(userId, deduplicationKey)` pair, so a second failed invoice a month later would have been **silent**. Now keyed by cycle end, like the cap notice.

## Test plan
- [x] `apps/api` migration specs green (122 passed).
- [x] `packages/agent` payg + notification specs green (72 passed).

⚠️ The one red check is pre-existing on `develop`: `migrations-directory-contract` fails because `1787508800000-create-fleet-agent-node-affinity.ts` is kebab-case where the contract requires PascalCase. Not from this branch; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
