### PR TITLE
test(scope): pin the ownershipRelationScopeOf contract

### DIFF
--- a/packages/agent/src/database/ownership-scope.spec.ts
+++ b/packages/agent/src/database/ownership-scope.spec.ts
@@ -1,0 +1,64 @@
+import { IsNull } from 'typeorm';
+import {
+    ownershipRelationScopeOf,
+    ownershipScopeOf,
+    ownershipWhere,
+    type OwnershipScope,
+} from './ownership-scope';
+
+const TENANT = '11111111-1111-4111-8111-111111111111';
+const ORG = '22222222-2222-4222-8222-222222222222';
+
+/**
+ * `ownershipRelationScopeOf` exists because a row's PERSISTED scope is not a
+ * usable QUERY scope for its related entities. These tests pin the exact
+ * difference — remove the helper and the legacy case below goes red.
+ */
+describe('ownershipRelationScopeOf', () => {
+    it('keeps an Organization-stamped row confined to its exact Organization', () => {
+        expect(ownershipRelationScopeOf({ tenantId: TENANT, organizationId: ORG })).toEqual({
+            tenantId: TENANT,
+            organizationId: ORG,
+        });
+    });
+
+    it('keeps a personal row on its own Tenant surface', () => {
+        expect(ownershipRelationScopeOf({ tenantId: TENANT, organizationId: null })).toEqual({
+            tenantId: TENANT,
+            organizationId: null,
+        });
+    });
+
+    it('returns owner-scoped (undefined) for a fully legacy row instead of "legacy rows only"', () => {
+        // The regression this prevents: ownershipScopeOf() reports
+        // {null, null}, which ownershipWhere() reads as "tenantId IS NULL AND
+        // organizationId IS NULL" — so a Task/Goal/Agent created before Tenant
+        // stamping would reject every Agent the same user has created since,
+        // and become permanently unrunnable / unassignable.
+        const row = { tenantId: null, organizationId: null };
+        expect(ownershipScopeOf(row)).toEqual({ tenantId: null, organizationId: null });
+        expect(ownershipRelationScopeOf(row)).toBeUndefined();
+    });
+
+    it('proves the difference at the predicate level', () => {
+        const row = { tenantId: null, organizationId: null };
+        const persisted = ownershipWhere('user-1', ownershipScopeOf(row) as OwnershipScope);
+        // Only legacy rows match — a current-Tenant Agent of the same user does not.
+        expect(persisted).toEqual([
+            { userId: 'user-1', organizationId: IsNull(), tenantId: IsNull() },
+        ]);
+
+        const relation = ownershipWhere('user-1', ownershipRelationScopeOf(row));
+        // Owner-scoped: the same user's Agents are reachable again, and no
+        // other user's rows ever are (userId is always in the predicate).
+        expect(relation).toEqual([{ userId: 'user-1' }]);
+    });
+
+    it('never widens an Organization row to another workspace', () => {
+        const relation = ownershipWhere(
+            'user-1',
+            ownershipRelationScopeOf({ tenantId: TENANT, organizationId: ORG }),
+        );
+        expect(relation).toEqual([{ userId: 'user-1', tenantId: TENANT, organizationId: ORG }]);
+    });
+});


### PR DESCRIPTION
`ownershipRelationScopeOf` (added in `49c0fe3ea`, fixing the family I reported in [#2213](https://github.com/ever-works/ever-works/pull/2213#issuecomment-5388897921)) is what stops a row's **persisted** scope being reused as a **query** scope. It shipped with no test of its own — `grep -rl ownershipRelationScopeOf --include='*.spec.ts'` finds nothing on `develop`, so nothing pins the one branch that matters.

The regression it guards: for a fully legacy row `ownershipScopeOf` reports `{tenantId: null, organizationId: null}`, which `ownershipWhere` reads as *legacy rows only* — a Task/Goal/Agent predating Tenant stamping then rejects every Agent the same user has created since, and becomes permanently unrunnable/unassignable while the candidate pickers still offer those Agents.

Five tests, no source change:
- Organization-stamped row → that exact Organization (fail-closed, unchanged)
- personal row with a Tenant → its own Tenant surface
- fully legacy row → owner-scoped (`undefined`), **not** "legacy rows only"
- the same difference proved at the predicate level through `ownershipWhere` (`[{userId}]` vs `[{userId, tenantId: IsNull(), organizationId: IsNull()}]`)
- an Organization row is never widened to another workspace

**Revert-proven:** restoring the pre-fix body (`return ownershipScopeOf(row)`) turns 2 of the 5 red; with the current implementation all 5 pass unmodified.