### PR TITLE
🔴 fix(credits): the ledger cannot write AT ALL on Postgres — eager relation breaks SELECT FOR UPDATE (prod is live-chargeable)

### DIFF
--- a/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
@@ -170,12 +170,28 @@ describe('CreditLedgerRepository.recordAtomic', () => {
         expect(entryRepo.save).not.toHaveBeenCalled();
     });
 
-    it('takes a pessimistic user-row lock on postgres but skips it on sqlite', async () => {
+    it('locks the user row on postgres WITHOUT joining eager relations, and skips the lock on sqlite', async () => {
         const pg = makeHarness({ driver: 'postgres' });
         await pg.repository.recordAtomic({ ...BASE_WRITE });
+        // 🛑 `loadEagerRelations: false` is the whole point of this assertion.
+        // `User.defaultPlan` is an eager @ManyToOne, so without it TypeORM
+        // LEFT JOINs `subscription_plans` and PostgreSQL rejects the lock with
+        // "FOR UPDATE cannot be applied to the nullable side of an outer join".
+        // That throw escaped every recordAtomic call — the single write path for
+        // the entire ledger — so on Postgres NOTHING could be credited: not the
+        // daily free grant, not a monthly plan allowance, and not a paid credit
+        // pack (the customer was charged, the webhook 500d, Stripe retried).
+        // Measured in production before the fix: the 00:05Z sweep on 2026-08-24
+        // returned granted: 0, scanned: 30, failed: 30 with an empty ledger.
+        //
+        // This asserts the OPTION rather than the behaviour because the suite
+        // runs on sqlite, where the lock is skipped entirely and the broken
+        // statement is never executed. The behaviour was verified separately by
+        // replaying both queries against a real PostgreSQL 16.
         expect(pg.userRepo.findOne).toHaveBeenCalledWith({
             where: { id: 'user-1' },
             lock: { mode: 'pessimistic_write' },
+            loadEagerRelations: false,
         });
 
         const sqlite = makeHarness({ driver: 'better-sqlite3' });

--- a/packages/agent/src/database/repositories/credit-ledger.repository.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.ts
@@ -464,12 +464,45 @@ export class CreditLedgerRepository {
      * throws `LockNotSupportedOnGivenDriverError` AND serializes writes
      * at the connection anyway, so the lock is safely skipped there.
      */
+    /**
+     * Serialise concurrent ledger writes for one user by locking their
+     * `users` row for the rest of the transaction.
+     *
+     * 🛑 `loadEagerRelations: false` is load-bearing, not tidiness.
+     * `User.defaultPlan` is `@ManyToOne(..., { eager: true })`, so a plain
+     * `findOne` LEFT JOINs `subscription_plans` — and PostgreSQL refuses
+     * `SELECT ... FOR UPDATE` over the nullable side of an outer join:
+     *
+     *     FOR UPDATE cannot be applied to the nullable side of an outer join
+     *
+     * That throw propagated out of EVERY `recordAtomic` call, which is the
+     * single write path for the whole credit ledger — daily free grants,
+     * monthly plan allowances, refunds, and a PAID credit-pack purchase
+     * (`BillingService.applyPurchase` -> `record` -> `recordAtomic`). In
+     * production it meant a customer could be charged for a pack and
+     * receive nothing while the webhook 500d and Stripe retried forever.
+     *
+     * Measured before the fix: the 2026-08-24 00:05Z production run of
+     * `credits-daily-grant` returned `granted: 0, scanned: 30, failed: 30`,
+     * and the prod, stage and dev ledgers all held zero rows.
+     *
+     * 🛑 Why no test caught it: the lock is deliberately skipped on sqlite
+     * (below), and sqlite is what the whole suite runs on. The failing
+     * statement is therefore never executed in CI on ANY driver. The
+     * regression test beside this asserts the option is set, because that
+     * is the only thing a sqlite-backed test can observe; the behaviour
+     * itself was verified by replaying both the broken and fixed query
+     * against a real PostgreSQL 16, including a control proving the lock
+     * still blocks a competing `FOR UPDATE`.
+     */
     private async lockUserRow(manager: EntityManager, userId: string): Promise<void> {
         const driver = manager.connection.options.type;
         if (driver === 'postgres' || driver === 'mysql' || driver === 'mariadb') {
             await manager.getRepository(User).findOne({
                 where: { id: userId },
                 lock: { mode: 'pessimistic_write' },
+                // Lock the row, join nothing. See the docblock above.
+                loadEagerRelations: false,
             });
         }
     }


### PR DESCRIPTION
## 🔴 Production is taking live cards and cannot credit anything

`recordAtomic` is the **single write path for the entire credit ledger**, and its first act is `lockUserRow()`:

```ts
findOne(User, { where: { id }, lock: { mode: 'pessimistic_write' } })
```

`User.defaultPlan` is `@ManyToOne(..., { eager: true })`, so TypeORM LEFT JOINs `subscription_plans`, and PostgreSQL refuses:

```
FOR UPDATE cannot be applied to the nullable side of an outer join
```

That throw escapes **every** ledger write on Postgres. Nothing can be credited:

- the advertised **"50 free credits/day on every tier"** — never granted, on prod *or* stage;
- the monthly plan allowance (#2203/#2209) — cannot be granted;
- 💸 **a paid credit pack** — `applyPurchase` → `record` → `recordAtomic`. The customer is charged, the webhook 500s, and **Stripe retries the delivery forever** while they receive nothing. Production has held a **live** Stripe key since 2026-08-24 00:20Z.

### Measured in production, not inferred

The `credits-daily-grant` run at **2026-08-24 00:05Z (PRODUCTION)** completed "successfully" and returned:

```json
{"daily":{"granted":0,"scanned":30,"alreadyGranted":0,"failed":30}, ...}
```

`credit_ledger_entries` holds **0 rows in all three databases** (prod, stage, dev). The `failed` counter that makes this visible is the one added in #2203 — the 2026-08-23 run reported the identical outcome as a silent `skipped: 30`, which is why it went unnoticed.

### Why no test caught it

The lock is **deliberately skipped on sqlite**, and the suite runs on sqlite — so the failing statement is never executed in CI on any driver. The spec here asserts the *option*, because that is the only thing a sqlite-backed test can observe.

The behaviour was verified by replaying both queries against a **real PostgreSQL 16** with the real entities:

| probe | result |
|---|---|
| EAGER relations TypeORM sees on `User` | `defaultPlan` |
| control — same `findOne` **without** the lock | OK |
| `lockUserRow` **as shipped** | **THREW** `FOR UPDATE cannot be applied to the nullable side of an outer join` |
| control — lock on an entity with **no** eager relation | OK |
| with `loadEagerRelations: false` | row locked |
| competing `SELECT … FOR UPDATE` still blocks | **YES** |

That last row is the important one: the fix keeps the lock **real**, it does not quietly disable the concurrency guard.

### Test plan
- [x] `credit-ledger.repository.spec.ts` — 12/12 green.
- [x] **Proven to bite**: reverting the single option turns it red (1 failed / 12).
- [x] `prettier --check` clean.
- [ ] After deploy, confirm the next 00:05Z sweep returns `granted > 0` and `credit_ledger_entries` becomes non-empty. I have a monitor on this.

Please prioritise the cascade — every hour this is live is an hour a customer can pay and get nothing. Board claim: `_LOCAL/MAINTENANCE.md` §3, row `2026-08-24 07:55Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
