### PR TITLE
fix(web): keep ingress locale rewrites internal

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -159,8 +159,36 @@ function alignLocaleRewriteOrigin(req: NextRequest, response: NextResponse): Nex
         const forwardedHost = req.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
         const requestHost = req.headers.get('host')?.trim();
         const forwardedProto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
+        const runtimeHostname = process.env.HOSTNAME?.trim();
+        const runtimePort = process.env.PORT?.trim();
+        let usedRuntimeOrigin = false;
 
-        for (const requestAuthority of [forwardedHost, requestHost]) {
+        if (forwardedHost && SAFE_REQUEST_HOST.test(forwardedHost)) {
+            try {
+                const forwardedAuthority = new URL(`${requestOrigin.protocol}//${forwardedHost}`);
+                const runtimeAuthority = runtimePort
+                    ? `${runtimeHostname}:${runtimePort}`
+                    : runtimeHostname;
+                if (
+                    isAllowedRequestHostname(forwardedAuthority.hostname) &&
+                    runtimeAuthority &&
+                    SAFE_REQUEST_HOST.test(runtimeAuthority)
+                ) {
+                    // Next's router only treats a middleware rewrite as internal
+                    // when its origin matches the standalone server's init URL.
+                    // Behind ingress that URL is http://$HOSTNAME:$PORT, not the
+                    // browser authority carried by X-Forwarded-Host.
+                    requestOrigin.protocol = 'http:';
+                    requestOrigin.hostname = runtimeHostname!;
+                    requestOrigin.port = runtimePort || '';
+                    usedRuntimeOrigin = true;
+                }
+            } catch {
+                // Fall through to the validated request authority.
+            }
+        }
+
+        for (const requestAuthority of usedRuntimeOrigin ? [] : [forwardedHost, requestHost]) {
             if (!requestAuthority || !SAFE_REQUEST_HOST.test(requestAuthority)) continue;
             try {
                 const authority = new URL(`${requestOrigin.protocol}//${requestAuthority}`);
@@ -173,7 +201,7 @@ function alignLocaleRewriteOrigin(req: NextRequest, response: NextResponse): Nex
                 // Try the next authority, then keep Next's parsed origin.
             }
         }
-        if (forwardedProto === 'http' || forwardedProto === 'https') {
+        if (!usedRuntimeOrigin && (forwardedProto === 'http' || forwardedProto === 'https')) {
             requestOrigin.protocol = `${forwardedProto}:`;
         }
         target.protocol = requestOrigin.protocol;

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { BROWSER_WORKSPACE_SCOPE_HEADER } from './lib/workspace-scope';
 
@@ -22,6 +22,10 @@ describe('canonical Organization workspace proxy', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         getAuthFromRequestMock.mockResolvedValue({ isAuthenticated: true, isExpired: false });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     it.each([
@@ -84,7 +88,9 @@ describe('canonical Organization workspace proxy', () => {
         );
     });
 
-    it('uses the allowlisted forwarded authority without leaking the internal service port', async () => {
+    it('keeps a reverse-proxy locale rewrite on the runtime server origin', async () => {
+        vi.stubEnv('HOSTNAME', 'ever-works-web-pod');
+        vi.stubEnv('PORT', '3000');
         intlMock.mockResolvedValueOnce(
             new Response(null, {
                 status: 200,
@@ -101,7 +107,9 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(ingressRequest);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe('https://127.0.0.1/en/login');
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+            'http://ever-works-web-pod:3000/en/login',
+        );
     });
 
     it('does not align an internal rewrite to a non-allowlisted Host header', async () => {


### PR DESCRIPTION
## Root cause
Next only relativizes middleware rewrites when their origin matches the standalone server init URL. Rewriting to the public forwarded authority caused an external /en/login request, whose legacy-locale redirect looped back to /login.

## Fix
- for validated ingress requests, use the trusted runtime http://HOSTNAME:PORT origin that Next's standalone router uses
- retain validated request-authority fallback outside reverse-proxy runtime
- keep hostile forwarded values rejected

## Verification
- reproduced against the exact production pod: repeated 307 /login with x-middleware-rewrite to the public /en/login URL
- RED then GREEN focused proxy suite (11/11)
- web type-check
- Prettier and git diff checks