### PR TITLE
fix(subscriptions): "Switch to Free" relabelled the tier while Stripe kept charging

### DIFF
--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -728,6 +728,57 @@ describe('SubscriptionService', () => {
         });
     });
 
+    describe('changePlanSelfService — switching to Free is not a cancellation', () => {
+        // 🛑 `persistDefaultPlan` writes users.defaultPlanId and nothing else — it never
+        // touches the payment provider. So before this guard, a paying customer clicking
+        // "Switch to Free" in the plan switcher had their tier relabelled while Stripe kept
+        // renewing and charging. Cancelling is a different action entirely
+        // (BillingService.cancelSubscription).
+        it('refuses while a LIVE provider subscription exists, and does not touch the plan', async () => {
+            const { service, userRepository } = makeService(
+                { findByCode: jest.fn().mockResolvedValue(FREE_PLAN) },
+                {
+                    findActiveByUser: jest.fn().mockResolvedValue({
+                        id: 'sub-1',
+                        providerSubscriptionId: 'sub_live_123',
+                    }),
+                },
+            );
+
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as never, SubscriptionPlanCode.FREE),
+            ).rejects.toThrow(/active paid subscription/i);
+            expect(userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('allows the switch when the subscription was already cancelled (no active row)', async () => {
+            const { service, userRepository } = makeService(
+                { findByCode: jest.fn().mockResolvedValue(FREE_PLAN) },
+                { findActiveByUser: jest.fn().mockResolvedValue(null) },
+            );
+
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as never, SubscriptionPlanCode.FREE),
+            ).resolves.toBeDefined();
+            expect(userRepository.update).toHaveBeenCalled();
+        });
+
+        it('allows the switch when an active row carries no provider subscription', async () => {
+            const { service, userRepository } = makeService(
+                { findByCode: jest.fn().mockResolvedValue(FREE_PLAN) },
+                {
+                    findActiveByUser: jest
+                        .fn()
+                        .mockResolvedValue({ id: 's', providerSubscriptionId: null }),
+                },
+            );
+
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as never, SubscriptionPlanCode.FREE),
+            ).resolves.toBeDefined();
+            expect(userRepository.update).toHaveBeenCalled();
+        });
+    });
     describe('getDefaultCadence', () => {
         it('returns the LAST entry of plan.allowedCadences (smallest interval = best slot)', () => {
             const { service } = makeService();

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -1,5 +1,6 @@
 import {
     BadRequestException,
+    ConflictException,
     ForbiddenException,
     Injectable,
     Logger,
@@ -588,6 +589,34 @@ export class SubscriptionService implements OnModuleInit {
                 'Self-hosted editions cannot be self-assigned on a hosted deployment.',
             );
         }
+
+        // 🛑 A self-service switch to Free is NOT a cancellation, and must not be
+        // allowed to masquerade as one.
+        //
+        // `persistDefaultPlan` writes `users.defaultPlanId` and nothing else. It does
+        // not touch the provider. So a paying customer who clicks "Switch to Free" in
+        // the plan switcher (`BillingSettings.tsx` -> `changePlanAction`) saw their
+        // plan become Free while their Stripe subscription kept renewing and kept
+        // charging them — with the tier label now saying they get nothing for it.
+        // Cancelling is a different button (`cancelSubscriptionAction` ->
+        // `BillingService.cancelSubscription`), which does cancel at the provider.
+        //
+        // Fail CLOSED rather than cancelling implicitly: silently terminating a paid
+        // subscription from a plan-switcher click would be a worse surprise than an
+        // error. Refuse, and name the action that actually works.
+        //
+        // Scoped to a LIVE provider subscription (`providerSubscriptionId` set on an
+        // active/trialing row), so it cannot block: a user with no subscription, a
+        // user whose subscription is already cancelled, or a deployment with no
+        // billing provider at all — in every one of those cases the switch is exactly
+        // what it appears to be.
+        const live = await this.userSubscriptionRepository.findActiveByUser(user.id);
+        if (live?.providerSubscriptionId) {
+            throw new ConflictException(
+                'You still have an active paid subscription. Cancel it first — switching the plan here would relabel your tier while the provider kept billing you.',
+            );
+        }
+
         return this.persistDefaultPlan(user, plan);
     }
 


### PR DESCRIPTION
## "Switch to Free" relabelled the tier while Stripe kept charging

`changePlanSelfService` ends in `persistDefaultPlan`, which writes `users.defaultPlanId` **and nothing else** — it never touches the payment provider. The plan switcher exposes exactly this as a **"Switch to Free"** button (`BillingSettings.tsx:675` → `changePlanAction` → `POST /api/subscriptions/plan`).

So a paying customer could click it, watch their plan become Free, and **keep being charged by Stripe** on the next renewal — now on a tier that grants them nothing.

Cancelling is a *different* action (`cancelSubscriptionAction` → `BillingService.cancelSubscription`), which does cancel at the provider. Two routes, one of which quietly does not do what its label says.

### Why refuse rather than cancel

Silently terminating a paid subscription from a plan-switcher click would be a worse surprise than an error, so this **fails closed**: a 409 that names the action which actually works.

### Why it cannot over-block

Scoped to a **live** provider subscription — `providerSubscriptionId` set on an active/trialing row. It therefore cannot block:

- a user with no subscription at all,
- a user whose subscription is already cancelled,
- a deployment with no billing provider.

In every one of those the switch means exactly what it appears to. Production currently holds **zero** `user_subscriptions` rows, so the guard is inert until real subscriptions exist — the safe direction to ship in.

### Test plan
- [x] `subscription.service.spec.ts` — 80/80 green.
- [x] **Proven to bite**: reverting the guard turns the refusal case red (1 failed / 80).
- [x] The two "allows the switch…" cases pass with *and* without the guard **by design** — they exist to catch over-blocking, not to prove the fix. Flagging that explicitly so nobody reads them as evidence.
- [x] `prettier --check` clean.

### Provenance
Found by an adversarial audit of the now-live billing paths (24 candidates → 3-lens refutation panel → 13 distinct survivors, written up in `_LOCAL/EVER_WORKS_BILLING_AUDIT_FINDINGS.md` §I) and confirmed by reading the call path myself before fixing.

Deliberately **file-disjoint from #2223** (`feat/billing-seats`), which owns `plan-subscription.service.ts` and `BillingSettings.tsx`. The related and still-open finding — *no active-subscription guard on plan checkout, so a second "Upgrade" click mints a second live Stripe subscription* — lives in #2223's files and is flagged there rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
