### PR TITLE
fix(billing): block duplicate recurring plan checkout

### DIFF
--- a/apps/api/src/billing/plan-checkout.controller.spec.ts
+++ b/apps/api/src/billing/plan-checkout.controller.spec.ts
@@ -39,6 +39,12 @@ class FakePlanNotPurchasableError extends Error {
         this.name = 'PlanNotPurchasableError';
     }
 }
+class FakeActivePlanSubscriptionError extends Error {
+    constructor() {
+        super('An active provider subscription already exists');
+        this.name = 'ActivePlanSubscriptionError';
+    }
+}
 class FakeCheckoutSessionNotFoundError extends Error {
     constructor() {
         super('Checkout session not found');
@@ -51,6 +57,7 @@ jest.mock('@ever-works/agent/subscriptions', () => ({
     BillingProviderError: FakeBillingProviderError,
     UnknownSubscriptionPlanError: FakeUnknownSubscriptionPlanError,
     PlanNotPurchasableError: FakePlanNotPurchasableError,
+    ActivePlanSubscriptionError: FakeActivePlanSubscriptionError,
     CheckoutSessionNotFoundError: FakeCheckoutSessionNotFoundError,
     PlanSubscriptionService: class PlanSubscriptionService {},
 }));
@@ -286,6 +293,21 @@ describe('POST /api/billing/checkout/plan — owner scoping', () => {
                 startPlanCheckout: jest
                     .fn()
                     .mockRejectedValue(new FakeBillingProviderError('provider said no')),
+            }),
+            makeMembership(),
+        );
+
+        await expect(
+            controller.createPlanCheckout(auth, { planCode: 'standard' } as never),
+        ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('maps an existing active subscription to 409', async () => {
+        const controller = new PlanCheckoutController(
+            makeService({
+                startPlanCheckout: jest
+                    .fn()
+                    .mockRejectedValue(new FakeActivePlanSubscriptionError()),
             }),
             makeMembership(),
         );

--- a/apps/api/src/billing/plan-checkout.controller.ts
+++ b/apps/api/src/billing/plan-checkout.controller.ts
@@ -18,6 +18,7 @@ import { AuthSessionGuard, CurrentUser } from '@src/auth';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
 import { config } from '@src/config/constants';
 import {
+    ActivePlanSubscriptionError,
     BillingProviderError,
     BillingProviderNotConfiguredError,
     CheckoutSessionNotFoundError,
@@ -180,6 +181,9 @@ export function mapPlanBillingError(error: unknown): unknown {
         // Existence-leak contract: "not yours" is indistinguishable from
         // "does not exist".
         return new NotFoundException(error.message);
+    }
+    if (error instanceof ActivePlanSubscriptionError) {
+        return new ConflictException(error.message);
     }
     if (error instanceof BillingProviderError) {
         return new ConflictException(error.message);

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -1,4 +1,5 @@
 import {
+    ActivePlanSubscriptionError,
     CheckoutSessionNotFoundError,
     PlanNotPurchasableError,
     PlanSubscriptionService,
@@ -181,6 +182,43 @@ const checkoutOptions = {
 };
 
 describe('startPlanCheckout — the server prices everything', () => {
+    it('refuses to create a second checkout while a provider subscription is active', async () => {
+        const subscriptionRepository = makeSubscriptionRepository({
+            findActiveByUser: jest.fn().mockResolvedValue({
+                id: 'sub-row-1',
+                providerSubscriptionId: 'sub_live_1',
+            }),
+        });
+        const { service, provider } = build({ subscriptionRepository });
+
+        await expect(service.startPlanCheckout(checkoutOptions)).rejects.toBeInstanceOf(
+            ActivePlanSubscriptionError,
+        );
+        expect(provider.ensureCustomer).not.toHaveBeenCalled();
+        expect(provider.createPlanCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('still permits a one-off lifetime licence alongside an active subscription', async () => {
+        const subscriptionRepository = makeSubscriptionRepository({
+            findActiveByUser: jest.fn().mockResolvedValue({
+                id: 'sub-row-1',
+                providerSubscriptionId: 'sub_live_1',
+            }),
+        });
+        const { service, provider } = build({ subscriptionRepository });
+
+        await expect(
+            service.startPlanCheckout({
+                ...checkoutOptions,
+                planCode: 'selfhosted_pro',
+                interval: 'lifetime',
+            }),
+        ).resolves.toBeDefined();
+        expect(provider.createPlanCheckoutSession).toHaveBeenCalledWith(
+            expect.objectContaining({ plan: expect.objectContaining({ mode: 'payment' }) }),
+        );
+    });
+
     it('prices the checkout from the SERVER plan row', async () => {
         const { service, provider } = build();
 

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -43,6 +43,16 @@ export class PlanNotPurchasableError extends Error {
     }
 }
 
+/** A recurring checkout would create a second live provider subscription. */
+export class ActivePlanSubscriptionError extends Error {
+    constructor() {
+        super(
+            'An active paid subscription already exists. Manage or cancel it before starting another recurring plan checkout.',
+        );
+        this.name = 'ActivePlanSubscriptionError';
+    }
+}
+
 /**
  * The caller asked to finalize a checkout session that is not theirs (or
  * does not exist). Deliberately ONE error for both, so a session id in a
@@ -188,6 +198,17 @@ export class PlanSubscriptionService {
         }
 
         const interval: CatalogInterval = options.interval ?? 'monthly';
+
+        // The local model tracks one provider subscription per owner. A second
+        // recurring checkout can create a second live Stripe subscription while
+        // overwriting that pointer, leaving one renewal unmanaged. One-off
+        // lifetime licences do not create a subscription and remain buyable.
+        if (interval !== 'lifetime') {
+            const active = await this.userSubscriptionRepository.findActiveByUser(options.userId);
+            if (active?.providerSubscriptionId) {
+                throw new ActivePlanSubscriptionError();
+            }
+        }
 
         const plan = await this.resolveSellablePlan(options.planCode, interval);
         const catalogSku = resolveSkuForPlanRow({


### PR DESCRIPTION
## Summary
- refuse recurring plan checkout while the owner already has an active provider subscription
- keep one-off lifetime licence purchases available
- map the conflict to HTTP 409

## Review proof
- PlanSubscriptionService focused suite: 45/45
- PlanCheckoutController focused suite: 25/25
- Agent type-check passed
- Prettier and git diff checks passed

This closes the duplicate-live-subscription finding identified while reviewing #2229. CI may remain queued; the owner directed this rollout not to wait indefinitely on stuck CI.