### PR TITLE
docs(migrations): correct the identifier-quoting rationale — I overstated it as a Postgres failure

### DIFF
--- a/apps/api/src/migrations/1783400000000-CreateCreditsLedgerAndEntitlements.ts
+++ b/apps/api/src/migrations/1783400000000-CreateCreditsLedgerAndEntitlements.ts
@@ -177,15 +177,19 @@ export class CreateCreditsLedgerAndEntitlements1783400000000 implements Migratio
                 .createQueryBuilder()
                 .select('pe.id', 'id')
                 .from('plan_entitlements', 'pe')
-                // 🛑 DOUBLE-QUOTED on purpose. This builder has no entity metadata
-                // (raw `.from('plan_entitlements', 'pe')`), so TypeORM emits the
-                // reference verbatim — verified against the Postgres driver:
-                // `pe.planId = :planId` comes out unquoted, Postgres folds it to
-                // `pe.planid`, and the migration dies with 42703 on every Postgres
-                // environment. The sqlite suite cannot catch it: sqlite matches
-                // unquoted identifiers case-insensitively, so CI stays green while
-                // a fresh Postgres boot fails. Same fix as the 1786950000000 /
-                // 1786960000000 seeds.
+                // Identifiers are double-quoted explicitly so this query does not
+                // depend on TypeORM resolving the raw table name to an entity.
+                //
+                // It normally does: the runtime DataSource registers every entity
+                // (`database.config.ts` → `entities: ENTITIES`) alongside the
+                // migrations glob, so `.from('plan_entitlements', 'pe')` matches
+                // `PlanEntitlement` BY TABLE NAME and the emitted SQL is fully
+                // quoted — which is why this seed has always worked on Postgres.
+                // Quoting here only removes the dependency on that lookup; it is
+                // what makes the query correct for a table with NO entity, where
+                // TypeORM would emit `pe.planId` verbatim and Postgres would fold
+                // it to `pe.planid` (sqlite, which CI runs on, matches unquoted
+                // identifiers case-insensitively and would not catch it).
                 .where('pe."planId" = :planId AND pe."key" = :key', {
                     planId: seed.planId,
                     key: seed.key,

--- a/apps/api/src/migrations/1784300000000-CreateTerminalTranscriptChunks.ts
+++ b/apps/api/src/migrations/1784300000000-CreateTerminalTranscriptChunks.ts
@@ -144,15 +144,19 @@ export class CreateTerminalTranscriptChunks1784300000000 implements MigrationInt
                 .createQueryBuilder()
                 .select('pe.id', 'id')
                 .from('plan_entitlements', 'pe')
-                // 🛑 DOUBLE-QUOTED on purpose. This builder has no entity metadata
-                // (raw `.from('plan_entitlements', 'pe')`), so TypeORM emits the
-                // reference verbatim — verified against the Postgres driver:
-                // `pe.planId = :planId` comes out unquoted, Postgres folds it to
-                // `pe.planid`, and the migration dies with 42703 on every Postgres
-                // environment. The sqlite suite cannot catch it: sqlite matches
-                // unquoted identifiers case-insensitively, so CI stays green while
-                // a fresh Postgres boot fails. Same fix as the 1786950000000 /
-                // 1786960000000 seeds.
+                // Identifiers are double-quoted explicitly so this query does not
+                // depend on TypeORM resolving the raw table name to an entity.
+                //
+                // It normally does: the runtime DataSource registers every entity
+                // (`database.config.ts` → `entities: ENTITIES`) alongside the
+                // migrations glob, so `.from('plan_entitlements', 'pe')` matches
+                // `PlanEntitlement` BY TABLE NAME and the emitted SQL is fully
+                // quoted — which is why this seed has always worked on Postgres.
+                // Quoting here only removes the dependency on that lookup; it is
+                // what makes the query correct for a table with NO entity, where
+                // TypeORM would emit `pe.planId` verbatim and Postgres would fold
+                // it to `pe.planid` (sqlite, which CI runs on, matches unquoted
+                // identifiers case-insensitively and would not catch it).
                 .where('pe."planId" = :planId AND pe."key" = :key', {
                     planId: seed.planId,
                     key: seed.key,


### PR DESCRIPTION
## Correcting my own claim from #2224

In #2224 I wrote — in the PR body, in the commit message, and in code comments now on `main` — that two already-merged migrations *"abort on Postgres with 42703"* and that *"a fresh Postgres boot fails today"*.

**That is wrong.** This PR corrects the comments. It is comments-only: no SQL, no behaviour change.

## What actually happens

TypeORM resolves a raw table-name string to entity metadata **when the entity is registered**, and the runtime DataSource registers all of them (`database.config.ts` → `entities: ENTITIES`) alongside the migrations glob. So `.from('plan_entitlements', 'pe')` matches `PlanEntitlement` *by table name* and the emitted SQL is fully quoted:

```
WITH-ENTITIES → SELECT "pe"."id" AS "id" FROM "plan_entitlements" "pe"
                WHERE "pe"."planId" = :planId AND "pe"."key" = :key
```

Those seeds have therefore always worked on Postgres.

## Where my error came from

My probe built the DataSource with `entities: []`:

```
UNQUOTED (entities: []) → ... WHERE pe.planId = :planId AND pe.key = :key
```

That is not how migrations run. I took a result from an unrepresentative harness and generalised it into a production claim — the same class of mistake as trusting a mocked spec over the real driver, just pointed the other way.

**What caught it:** production is healthy. If the claim had been true the API could not have booted, since migrations self-apply on startup. That contradiction is what made me re-test.

## Why the quoting stays

Explicit quoting is still worth having — it removes the dependency on that metadata lookup, and it is genuinely **required** for a table with no registered entity, where TypeORM does emit `pe.planId` verbatim and Postgres folds it to `pe.planid` (sqlite, which CI runs, matches unquoted identifiers case-insensitively and would not catch it). So the change is kept and only the reasoning is fixed.

I have also corrected the Workspace KB note that recorded this as a trap, including the method lesson: **when testing ORM SQL emission, register the entities the real DataSource has.**

## Test plan
- [x] Comments-only — `git diff` touches no SQL and no logic.
- [x] `apps/api` migrations suite green except the pre-existing kebab-case contract failure fixed in #2231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
