### PR TITLE
fix(billing): wire seats repository for image builds

### DIFF
--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -1,4 +1,5 @@
 import * as subscriptionsBarrel from './index';
+import { AgentRepository } from '../database/repositories/agent.repository';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
 import { SubscriptionsModule } from './subscriptions.module';
 import { SubscriptionService } from './subscription.service';
@@ -22,6 +23,7 @@ import {
     PaymentMethodService,
 } from './billing/payment-method.service';
 import {
+    ActivePlanSubscriptionError,
     CheckoutSessionNotFoundError,
     PlanNotPurchasableError,
     PlanSubscriptionService,
@@ -152,6 +154,9 @@ describe('SubscriptionsModule + barrel re-exports', () => {
 
         it('re-exports the paid-plan purchase path (audit B24)', () => {
             expect(subscriptionsBarrel.PlanSubscriptionService).toBe(PlanSubscriptionService);
+            expect(subscriptionsBarrel.ActivePlanSubscriptionError).toBe(
+                ActivePlanSubscriptionError,
+            );
             expect(subscriptionsBarrel.PaymentMethodService).toBe(PaymentMethodService);
             expect(subscriptionsBarrel.PaymentMethodNotFoundError).toBe(PaymentMethodNotFoundError);
             expect(subscriptionsBarrel.LastPaymentMethodError).toBe(LastPaymentMethodError);
@@ -199,6 +204,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'AutoRechargeService',
                     // Paid-plan purchase (audit B24)
                     'PlanSubscriptionService',
+                    'ActivePlanSubscriptionError',
                     'UnknownSubscriptionPlanError',
                     'PlanNotPurchasableError',
                     'CheckoutSessionNotFoundError',
@@ -294,13 +300,15 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(getMeta('exports')).toContain(CostsSummaryService);
         });
 
-        it('provides AgentRunRepository locally so CostsSummaryService can resolve it', () => {
-            // AgentRunRepository is owned by AgentsModule, not the
-            // DatabaseModule repository inventory — without this local
-            // provider CostsSummaryService fails to instantiate at boot.
+        it('provides agent repositories locally so costs and seats can resolve at boot', () => {
+            // Both repositories are owned by AgentsModule, not the
+            // DatabaseModule repository inventory. Without these local
+            // providers CostsSummaryService / SeatsService fail to instantiate.
+            expect(getMeta('providers')).toContain(AgentRepository);
             expect(getMeta('providers')).toContain(AgentRunRepository);
             // Module-local on purpose: exporting it would hand consumers a
-            // second AgentRunRepository instance beside AgentsModule's.
+            // second repository instance beside AgentsModule's.
+            expect(getMeta('exports')).not.toContain(AgentRepository);
             expect(getMeta('exports')).not.toContain(AgentRunRepository);
         });
 

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '@src/database/database.module';
+import { Agent } from '@src/entities/agent.entity';
 import { AgentRun } from '@src/entities/agent-run.entity';
+import { AgentRepository } from '@src/database/repositories/agent.repository';
 import { AgentRunRepository } from '@src/database/repositories/agent-run.repository';
 import { NotificationsModule } from '@src/notifications/notifications.module';
 import { SubscriptionService } from './subscription.service';
@@ -29,15 +31,13 @@ import { CostsSummaryService } from './credits/costs-summary.service';
         // Wave 9 M2 — RunCostSettlementService emits the balance-exhausted
         // notification through the existing NotificationService.
         NotificationsModule,
-        // Costs dashboard — `AgentRunRepository` is not in the
-        // `_repository-inventory` DatabaseModule exports (it is owned by
-        // AgentsModule), so it is provided locally here. Same pattern,
-        // and same reason, as `TerminalTranscriptModule`: importing
-        // AgentsModule for two read-only aggregations would drag the
-        // whole agent runtime into this module's graph. The local
-        // instance never writes a terminal transition, so it never
-        // exercises the RUN_COST_SETTLER hook.
-        TypeOrmModule.forFeature([AgentRun]),
+        // Costs + seats — AgentRunRepository and AgentRepository are not in
+        // the `_repository-inventory` DatabaseModule exports (both are owned
+        // by AgentsModule), so they are provided locally here. Importing the
+        // whole AgentsModule for read-only aggregations would drag the agent
+        // runtime into this graph. The local AgentRunRepository never writes
+        // a terminal transition, so it never exercises RUN_COST_SETTLER.
+        TypeOrmModule.forFeature([Agent, AgentRun]),
     ],
     providers: [
         SubscriptionService,
@@ -64,6 +64,7 @@ import { CostsSummaryService } from './credits/costs-summary.service';
         // Costs dashboard — the `GET /api/usage/costs/*` aggregations
         // (spend by day/agent/model + top runs). Read-only; derived from
         // the same metering rows the usage summary reads.
+        AgentRepository,
         AgentRunRepository,
         CostsSummaryService,
         // The money path (billing PRD B5) — checkout, webhook, invoices,


### PR DESCRIPTION
## Summary

- provide the read-only `AgentRepository` locally in agent-side `SubscriptionsModule`, alongside its existing local `AgentRunRepository`
- register the `Agent` entity through `TypeOrmModule.forFeature` so Nest can construct that repository
- update the pinned subscription barrel contract for the already-exported `ActivePlanSubscriptionError`

## Root cause

The merged seats feature injects `AgentRepository` into `SeatsService`, but `SubscriptionsModule` did not provide/import that repository. The first full image build after the seats cascade failed in `.deploy/docker/mcp/Dockerfile` during OpenAPI generation with:

`UnknownDependenciesException: Nest can't resolve dependencies of SeatsService ... AgentRepository at index [4]`

Importing the whole `AgentsModule` would enlarge/cycle the runtime graph. The existing module already uses the correct local-provider pattern for `AgentRunRepository`, so this extends that pattern to the read-only seat count.

## Verification

- exact pre-fix MCP/OpenAPI image step: RED with the error above
- focused `subscriptions.module.spec.ts`: 29/29 PASS
- `@ever-works/agent` type-check: PASS
- API dependency closure build: 15/15 packages PASS
- exact `generate-openapi.js`: PASS, 599 paths
- Prettier + `git diff --check`: PASS

No schema/data/secret change. The required environment cascade remains owned by maintenance lane `e173d886`; this PR targets `develop` only.